### PR TITLE
wire litewire postgres and TDS frontends into ePHPm server startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -449,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -598,6 +614,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chitchat"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +751,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -750,6 +789,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -795,6 +843,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -876,14 +942,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -975,11 +1064,11 @@ dependencies = [
  "base64ct",
  "bytes",
  "ephpm-config",
- "hmac",
- "md5",
+ "hmac 0.12.1",
+ "md5 0.8.0",
  "parking_lot",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1113,6 +1202,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -1425,6 +1520,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1511,12 +1607,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1563,6 +1674,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1869,6 +1989,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex-lite",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +2088,8 @@ dependencies = [
  "litewire-backend",
  "litewire-hrana",
  "litewire-mysql",
+ "litewire-postgres",
+ "litewire-tds",
  "litewire-translate",
  "tokio",
  "tracing",
@@ -1988,6 +2133,32 @@ dependencies = [
  "litewire-backend",
  "litewire-translate",
  "opensrv-mysql",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "litewire-postgres"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "litewire-backend",
+ "litewire-translate",
+ "pgwire",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "litewire-tds"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "litewire-backend",
+ "litewire-translate",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2046,6 +2217,22 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "md5"
@@ -2198,7 +2385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "subprocess",
  "thiserror 1.0.69",
@@ -2436,6 +2623,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pgwire"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84e671791f3a354f265e55e400be8bb4b6262c1ec04fac4289e710ccf22ab43"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "bytes",
+ "chrono",
+ "derive-new",
+ "futures",
+ "hex",
+ "lazy-regex",
+ "md5 0.7.0",
+ "postgres-types",
+ "rand 0.8.5",
+ "rust_decimal",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2694,37 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5",
+ "memchr",
+ "rand 0.10.0",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "array-init",
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2720,6 +2962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,6 +3009,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xoshiro"
@@ -2863,6 +3122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,7 +3196,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2971,7 +3236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -2988,6 +3253,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
+ "postgres-types",
  "rand 0.8.5",
  "rkyv",
  "serde",
@@ -3120,7 +3386,7 @@ checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3132,7 +3398,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3326,8 +3592,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3337,8 +3603,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3434,6 +3711,17 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -3968,16 +4256,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ ephpm-server = { path = "crates/ephpm-server" }
 ephpm-sqld = { path = "crates/ephpm-sqld" }
 
 # External — litewire (embedded SQLite wire protocol proxy)
-litewire = { path = "../litewire/crates/litewire", default-features = false, features = ["mysql", "hrana", "backend-rusqlite", "backend-hrana-client"] }
+litewire = { path = "../litewire/crates/litewire", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -590,6 +590,10 @@ pub struct DbConfig {
     #[serde(default)]
     pub postgres: Option<DbBackendConfig>,
 
+    /// TDS (`SQL Server`) proxy configuration.
+    #[serde(default)]
+    pub tds: Option<DbBackendConfig>,
+
     /// Embedded SQLite configuration (via litewire).
     ///
     /// When enabled, starts an in-process SQLite database with MySQL/Hrana
@@ -646,6 +650,20 @@ pub struct SqliteProxyConfig {
     /// Useful for CI tooling, health checks, and direct HTTP access.
     #[serde(default)]
     pub hrana_listen: Option<String>,
+
+    /// `PostgreSQL` wire protocol listen address (optional).
+    ///
+    /// When set, PHP can connect via `pdo_pgsql` as if talking to a real
+    /// `PostgreSQL` server. Default: disabled.
+    #[serde(default)]
+    pub postgres_listen: Option<String>,
+
+    /// `TDS` wire protocol listen address (optional).
+    ///
+    /// When set, clients can connect via the `TDS` protocol (SQL Server).
+    /// Default: disabled.
+    #[serde(default)]
+    pub tds_listen: Option<String>,
 }
 
 impl Default for SqliteProxyConfig {
@@ -653,6 +671,8 @@ impl Default for SqliteProxyConfig {
         Self {
             mysql_listen: default_sqlite_mysql_listen(),
             hrana_listen: None,
+            postgres_listen: None,
+            tds_listen: None,
         }
     }
 }

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -37,6 +37,7 @@ use tokio_rustls::{LazyConfigAcceptor, TlsAcceptor};
 /// - KV store with optional RESP protocol server
 /// - `MySQL` connection proxy (if configured)
 /// - `PostgreSQL` connection proxy (if configured)
+/// - `TDS` (SQL Server) connection proxy (if configured)
 ///
 /// When `[server.tls]` is configured, the server terminates TLS using
 /// either manual cert/key files or automatic ACME provisioning.
@@ -639,7 +640,7 @@ fn start_kv_service(
     Ok((store, Some(handle)))
 }
 
-/// Start database proxies (`MySQL`, `PostgreSQL`, embedded `SQLite`).
+/// Start database proxies (`MySQL`, `PostgreSQL`, `TDS`, embedded `SQLite`).
 async fn start_db_proxies(
     config: &Config,
     cluster: Option<&Arc<ephpm_cluster::ClusterHandle>>,
@@ -695,9 +696,120 @@ async fn start_db_proxies(
         }
     }
 
-    // PostgreSQL proxy (placeholder for now)
-    if config.db.postgres.is_some() {
-        tracing::info!("PostgreSQL proxy not yet implemented");
+    // PostgreSQL proxy
+    if let Some(pg_config) = &config.db.postgres {
+        let url = pg_config.url.clone();
+        let listen = pg_config
+            .listen
+            .clone()
+            .unwrap_or_else(|| "127.0.0.1:5432".to_string());
+
+        let pool_config = ephpm_db::pool::PoolConfig {
+            min_connections: pg_config.min_connections,
+            max_connections: pg_config.max_connections,
+            idle_timeout: parse_duration(&pg_config.idle_timeout)?,
+            max_lifetime: parse_duration(&pg_config.max_lifetime)?,
+            pool_timeout: parse_duration(&pg_config.pool_timeout)?,
+            health_check_interval: parse_duration(&pg_config.health_check_interval)?,
+        };
+
+        let reset_strategy = ephpm_db::ResetStrategy::from_str_lossy(&pg_config.reset_strategy);
+
+        let replica_urls = pg_config
+            .replicas
+            .as_ref()
+            .map(|r| r.urls.clone())
+            .unwrap_or_default();
+
+        let rw_split = ephpm_db::mysql::RwSplitParams {
+            enabled: config.db.read_write_split.enabled,
+            sticky_duration: parse_duration(&config.db.read_write_split.sticky_duration)?,
+        };
+
+        match ephpm_db::mysql::build_proxy(
+            &url,
+            &listen,
+            pg_config.socket.clone(),
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+        )
+        .await
+        {
+            Ok(proxy) => {
+                let maintenance_handle = proxy.start_maintenance();
+                let proxy_handle = tokio::spawn(async move {
+                    match proxy.run().await {
+                        Ok(()) => tracing::info!("PostgreSQL proxy stopped"),
+                        Err(e) => tracing::error!("PostgreSQL proxy error: {e:#}"),
+                    }
+                });
+                handles.push(proxy_handle);
+                drop(maintenance_handle);
+            }
+            Err(e) => {
+                tracing::error!("failed to start PostgreSQL proxy: {e:#}");
+            }
+        }
+    }
+
+    // TDS (SQL Server) proxy
+    if let Some(tds_config) = &config.db.tds {
+        let url = tds_config.url.clone();
+        let listen = tds_config
+            .listen
+            .clone()
+            .unwrap_or_else(|| "127.0.0.1:1433".to_string());
+
+        let pool_config = ephpm_db::pool::PoolConfig {
+            min_connections: tds_config.min_connections,
+            max_connections: tds_config.max_connections,
+            idle_timeout: parse_duration(&tds_config.idle_timeout)?,
+            max_lifetime: parse_duration(&tds_config.max_lifetime)?,
+            pool_timeout: parse_duration(&tds_config.pool_timeout)?,
+            health_check_interval: parse_duration(&tds_config.health_check_interval)?,
+        };
+
+        let reset_strategy = ephpm_db::ResetStrategy::from_str_lossy(&tds_config.reset_strategy);
+
+        let replica_urls = tds_config
+            .replicas
+            .as_ref()
+            .map(|r| r.urls.clone())
+            .unwrap_or_default();
+
+        let rw_split = ephpm_db::mysql::RwSplitParams {
+            enabled: config.db.read_write_split.enabled,
+            sticky_duration: parse_duration(&config.db.read_write_split.sticky_duration)?,
+        };
+
+        match ephpm_db::mysql::build_proxy(
+            &url,
+            &listen,
+            tds_config.socket.clone(),
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+        )
+        .await
+        {
+            Ok(proxy) => {
+                let maintenance_handle = proxy.start_maintenance();
+                let proxy_handle = tokio::spawn(async move {
+                    match proxy.run().await {
+                        Ok(()) => tracing::info!("TDS proxy stopped"),
+                        Err(e) => tracing::error!("TDS proxy error: {e:#}"),
+                    }
+                });
+                handles.push(proxy_handle);
+                drop(maintenance_handle);
+            }
+            Err(e) => {
+                tracing::error!("failed to start TDS proxy: {e:#}");
+            }
+        }
     }
 
     // Embedded SQLite via litewire
@@ -742,6 +854,16 @@ fn start_single_node_sqlite(
     if let Some(ref hrana_addr) = sqlite_config.proxy.hrana_listen {
         builder = builder.hrana(hrana_addr);
         tracing::info!(listen = %hrana_addr, "SQLite Hrana HTTP API enabled");
+    }
+
+    if let Some(ref pg_addr) = sqlite_config.proxy.postgres_listen {
+        builder = builder.postgres(pg_addr);
+        tracing::info!(listen = %pg_addr, "SQLite PostgreSQL wire protocol enabled");
+    }
+
+    if let Some(ref tds_addr) = sqlite_config.proxy.tds_listen {
+        builder = builder.tds(tds_addr);
+        tracing::info!(listen = %tds_addr, "SQLite TDS wire protocol enabled");
     }
 
     handles.push(tokio::spawn(async move {
@@ -867,6 +989,16 @@ async fn start_clustered_sqlite(
     if let Some(ref hrana_addr) = sqlite_config.proxy.hrana_listen {
         builder = builder.hrana(hrana_addr);
         tracing::info!(listen = %hrana_addr, "SQLite Hrana HTTP API enabled (clustered)");
+    }
+
+    if let Some(ref pg_addr) = sqlite_config.proxy.postgres_listen {
+        builder = builder.postgres(pg_addr);
+        tracing::info!(listen = %pg_addr, "SQLite PostgreSQL wire protocol enabled (clustered)");
+    }
+
+    if let Some(ref tds_addr) = sqlite_config.proxy.tds_listen {
+        builder = builder.tds(tds_addr);
+        tracing::info!(listen = %tds_addr, "SQLite TDS wire protocol enabled (clustered)");
     }
 
     // Spawn litewire serve task. sqld is kept alive via the Arc.


### PR DESCRIPTION
- Enable postgres and tds features on the litewire dependency
- Add TdsConfig and postgres_listen/tds_listen fields to config structs
- Wire LiteWire::new().postgres()/tds() into start_single_node_sqlite() and start_clustered_sqlite()
- Replace PostgreSQL "not yet implemented" placeholder with full proxy startup
- Add TDS proxy startup block (default 127.0.0.1:1433), same pattern as MySQL