### PR TITLE
fix brotli compression, replica round-robin, and README PostgreSQL claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ ePHPm gives you three database strategies. PHP apps keep their existing `pdo_mys
 
 ### 1. Already have a database? Use the built-in proxy
 
-If you have a MySQL or PostgreSQL server, ePHPm's DB proxy sits between PHP and your database with connection pooling, read/write splitting, and health checks. PHP connects to `localhost:3306` — the proxy handles the rest.
+If you have a MySQL server, ePHPm's DB proxy sits between PHP and your database with connection pooling, read/write splitting, and health checks. PHP connects to `localhost:3306` — the proxy handles the rest. PostgreSQL proxy support is planned but not yet implemented.
 
 ```toml
 [db.mysql]

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -29,6 +29,7 @@
 //! ```
 //! Support for `caching_sha2_password` is planned (TODO).
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use sha1::{Digest, Sha1};
@@ -86,6 +87,8 @@ struct ServerMeta {
 pub struct MySqlProxy {
     pool: Pool,
     replica_pools: Vec<Pool>,
+    /// Round-robin counter for distributing reads across replicas.
+    replica_rr: AtomicUsize,
     meta: Arc<ServerMeta>,
     listen: String,
     #[allow(dead_code)]
@@ -181,6 +184,7 @@ impl MySqlProxy {
         Ok(Self {
             pool,
             replica_pools,
+            replica_rr: AtomicUsize::new(0),
             meta,
             listen: listen.to_string(),
             socket,
@@ -243,7 +247,7 @@ impl MySqlProxy {
 
         if needs_routing {
             // Step 4a: per-query routing with dirty tracking.
-            proxy_routing_loop(client, &self.pool, &self.replica_pools, &self.rw_split, self.reset_strategy)
+            proxy_routing_loop(client, &self.pool, &self.replica_pools, &self.replica_rr, &self.rw_split, self.reset_strategy)
                 .await
         } else {
             // Fast path: simple bidirectional copy.
@@ -750,6 +754,7 @@ async fn forward_mysql_response(
 fn select_pool<'a>(
     primary: &'a Pool,
     replicas: &'a [Pool],
+    replica_rr: &AtomicUsize,
     state: &ClientState,
     kind: QueryKind,
     _rw_split: &RwSplitParams,
@@ -771,10 +776,10 @@ fn select_pool<'a>(
         }
     }
 
-    // Read queries can use replicas.
+    // Read queries can use replicas via round-robin.
     if matches!(kind, QueryKind::Read) {
-        // Simple V1: use first replica. TODO: round-robin.
-        &replicas[0]
+        let idx = replica_rr.fetch_add(1, Ordering::Relaxed) % replicas.len();
+        &replicas[idx]
     } else {
         // Write, TxBegin, TxEnd: always primary.
         primary
@@ -786,6 +791,7 @@ async fn proxy_routing_loop(
     mut client: TcpStream,
     pool: &Pool,
     replica_pools: &[Pool],
+    replica_rr: &AtomicUsize,
     rw_split: &RwSplitParams,
     reset_strategy: crate::ResetStrategy,
 ) -> Result<(), DbError> {
@@ -814,7 +820,7 @@ async fn proxy_routing_loop(
                 QueryKind::Write
             };
 
-            let target = select_pool(pool, replica_pools, &state, kind, rw_split);
+            let target = select_pool(pool, replica_pools, replica_rr, &state, kind, rw_split);
             (target, kind)
         } else {
             (pool, QueryKind::Write) // No routing: always primary

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -613,11 +613,15 @@ fn compress_value(data: &[u8], config: CompressionConfig) -> Vec<u8> {
             }
         }
         CompressionAlgo::Brotli => {
-            // The brotli crate (FFI bindings to C library) doesn't expose a simple
-            // high-level compression function like flate2::Compression or zstd::encode_all.
-            // For now, fall back to storing uncompressed. Users should prefer gzip or zstd.
-            // TODO: Implement via raw FFI bindings to BrotliEncoderCompress if needed.
-            data.to_vec()
+            let mut output = Vec::new();
+            {
+                let mut encoder = brotli::CompressorWriter::new(&mut output, 4096, config.level, 22);
+                if encoder.write_all(data).is_err() {
+                    return data.to_vec(); // Fall back to uncompressed
+                }
+                // CompressorWriter flushes remaining data on drop.
+            }
+            output
         }
         CompressionAlgo::Zstd => {
             #[allow(clippy::cast_possible_wrap)]


### PR DESCRIPTION
- implement real brotli compression in KV store (was a no-op fallback)
- add atomic round-robin load balancing for replica read routing
- correct README to reflect PostgreSQL proxy is planned, not implemented