### PR TITLE
fix: correct repository URL and document OpenSSL prerequisite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ cargo xtask release --target windows       # → target/x86_64-pc-windows-msvc/r
 # Note: Windows builds never include sqld (no Windows binary available from Turso)
 ```
 
-Prerequisites for `cargo xtask release`: php CLI 8.2+, composer, git, and C build tools (autoconf, cmake, make, etc.). The xtask handles static-php-cli and sqld downloads automatically.
+Prerequisites for `cargo xtask release`: php CLI 8.2+, composer, git, OpenSSL dev headers (`libssl-dev` on Debian/Ubuntu, `openssl-devel` on Fedora/RHEL), and C build tools (autoconf, cmake, make, etc.). The xtask handles static-php-cli and sqld downloads automatically.
 
 ## Testing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"
-repository = "https://github.com/user/ephpm"
+repository = "https://github.com/ephpm/ephpm"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cargo build
 cargo run -- --config ephpm.toml
 
 # Release binary with PHP embedded
-# Prerequisites: php-cli, composer, git, build-essential, autoconf, cmake, pkg-config, re2c
+# Prerequisites: php-cli, composer, git, build-essential, autoconf, cmake, pkg-config, re2c, libssl-dev
 cargo xtask release       # → target/release/ephpm
 ```
 


### PR DESCRIPTION
## Summary

- Fix workspace `repository` URL from `github.com/user/ephpm` to `github.com/ephpm/ephpm` (would publish incorrect metadata to crates.io)
- Document `libssl-dev` as build prerequisite in README and CLAUDE.md (`cargo clippy --all-targets` fails without it)

## Test plan

- [ ] `cargo metadata` shows correct repository URL
- [ ] Fresh clone on Ubuntu can build after installing listed prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)