### PR TITLE
E2E coverage: header limits, compression, connections, KV, Hrana, SQLite, timeouts

### DIFF
--- a/crates/ephpm-e2e/tests/compression_thresholds.rs
+++ b/crates/ephpm-e2e/tests/compression_thresholds.rs
@@ -1,0 +1,84 @@
+//! Compression threshold tests.
+//!
+//! Validates:
+//! - Responses smaller than `compression_min_size` are NOT compressed
+//! - Responses larger than `compression_min_size` ARE compressed
+//!
+//! The test config sets `compression_min_size = 1024` (1 KiB). reqwest is
+//! configured with `default-features = false` so it does NOT auto-decompress,
+//! meaning we receive raw bytes and can inspect `Content-Encoding` directly.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+#[tokio::test]
+async fn small_response_is_not_compressed() {
+    let base_url = required_env("EPHPM_URL");
+    // test.html is a small static file (well under 1 KiB) — should not be compressed.
+    let url = format!("{base_url}/test.html");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("Accept-Encoding", "gzip")
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "expected 200 from /test.html, got {}",
+        resp.status()
+    );
+
+    let encoding = resp
+        .headers()
+        .get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        encoding.is_empty(),
+        "small response (under compression_min_size=1024) must NOT have Content-Encoding, got: {encoding:?}"
+    );
+}
+
+#[tokio::test]
+async fn large_response_is_compressed() {
+    let base_url = required_env("EPHPM_URL");
+    // info.php generates a large phpinfo() page — well above 1 KiB.
+    let url = format!("{base_url}/info.php");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("Accept-Encoding", "gzip")
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "expected 200 from /info.php, got {}",
+        resp.status()
+    );
+
+    let encoding = resp
+        .headers()
+        .get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        encoding.contains("gzip"),
+        "large response (above compression_min_size=1024) must have Content-Encoding: gzip, got: {encoding:?}"
+    );
+
+    let body = resp.bytes().await.expect("failed to read compressed body");
+    assert!(
+        !body.is_empty(),
+        "compressed response body must not be empty"
+    );
+}

--- a/crates/ephpm-e2e/tests/connection_limits.rs
+++ b/crates/ephpm-e2e/tests/connection_limits.rs
@@ -1,0 +1,101 @@
+//! Connection limit smoke tests.
+//!
+//! Validates that the `[server.limits] max_connections` setting is accepted
+//! by the server without breaking normal request handling.
+//!
+//! The test config sets `max_connections = 100` — high enough that normal
+//! traffic never hits the limit, but non-zero so the code path that
+//! initialises the `Limiter` is exercised.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+/// Fire 5 concurrent GET requests and confirm every one succeeds.
+///
+/// With `max_connections = 100` and only 5 in-flight requests, none should
+/// be rejected. This proves the limiter initialises correctly and the
+/// connection-slot bookkeeping (acquire + release) works without leaking
+/// slots on normal request completion.
+#[tokio::test]
+async fn concurrent_requests_under_limit_all_succeed() {
+    let base_url = required_env("EPHPM_URL");
+    let client = reqwest::Client::new();
+
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let url = format!("{base_url}/index.php?conn_test={i}");
+        let c = client.clone();
+        handles.push(tokio::spawn(async move {
+            let resp = c
+                .get(&url)
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+            (i, resp.status().as_u16())
+        }));
+    }
+
+    for handle in handles {
+        let (i, status) = handle.await.expect("task panicked");
+        assert_eq!(
+            status, 200,
+            "request {i} should succeed with 200 under the connection limit, got {status}"
+        );
+    }
+}
+
+/// Verify the server returns standard response headers even when the
+/// connection limiter is active. This catches regressions where the limiter
+/// middleware accidentally strips response headers.
+#[tokio::test]
+async fn response_headers_intact_with_limiter_active() {
+    let base_url = required_env("EPHPM_URL");
+
+    let resp = reqwest::get(format!("{base_url}/test.html"))
+        .await
+        .unwrap_or_else(|e| panic!("GET /test.html failed: {e}"));
+
+    assert_eq!(resp.status().as_u16(), 200);
+
+    // The test config sets X-Frame-Options: DENY in [server.response] headers.
+    // If the limiter interferes with the response pipeline this will be missing.
+    let xfo = resp
+        .headers()
+        .get("x-frame-options")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert_eq!(
+        xfo, "DENY",
+        "X-Frame-Options must still be present when the connection limiter is active"
+    );
+}
+
+/// Sequential requests succeed repeatedly, proving connection slots are
+/// properly released after each response completes.
+#[tokio::test]
+async fn slots_released_after_response() {
+    let base_url = required_env("EPHPM_URL");
+    let client = reqwest::Client::new();
+
+    // 10 sequential requests — if slots leak, a low limit would eventually
+    // reject. With max_connections = 100 we have headroom, but the pattern
+    // still exercises the release path.
+    for i in 0..10 {
+        let url = format!("{base_url}/index.php?seq={i}");
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("GET {url} (seq {i}) failed: {e}"));
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "sequential request {i} must succeed, got {}",
+            resp.status()
+        );
+        // Consume the body so the connection is fully returned to the pool.
+        let _ = resp.bytes().await;
+    }
+}

--- a/crates/ephpm-e2e/tests/header_limits.rs
+++ b/crates/ephpm-e2e/tests/header_limits.rs
@@ -1,0 +1,71 @@
+//! Header size limit tests.
+//!
+//! Validates:
+//! - Requests with headers exceeding `max_header_size` are rejected
+//! - Requests with normal-sized headers succeed
+//!
+//! The test config sets `max_header_size = 4096` (4 KiB). hyper enforces
+//! this via `max_buf_size` and responds with 431 Request Header Fields Too
+//! Large (or drops the connection entirely for extremely large headers).
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+#[tokio::test]
+async fn oversized_header_is_rejected() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/test.html");
+
+    // Build a header value that pushes the total header block well past 4096 bytes.
+    // The request line + Host header already consume ~100 bytes, so an 8 KiB
+    // custom header guarantees we exceed the limit.
+    let large_value = "X".repeat(8 * 1024);
+
+    let client = reqwest::Client::new();
+    let result = client
+        .get(&url)
+        .header("X-Large-Header", &large_value)
+        .send()
+        .await;
+
+    match result {
+        Ok(resp) => {
+            // hyper may return 431 if it can parse enough of the request to
+            // send a response before closing.
+            let status = resp.status().as_u16();
+            assert!(
+                status == 431 || status == 400,
+                "expected 431 Request Header Fields Too Large (or 400) for oversized headers, got {status}"
+            );
+        }
+        Err(_) => {
+            // hyper may also just drop the connection when the buffer
+            // overflows during header parsing — this is acceptable behavior
+            // for an oversized request.
+        }
+    }
+}
+
+#[tokio::test]
+async fn normal_headers_succeed() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/test.html");
+
+    // A modest custom header well under the 4096-byte limit.
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("X-Small-Header", "hello")
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} with small header failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "requests with normal-sized headers must succeed, got {}",
+        resp.status()
+    );
+}

--- a/crates/ephpm-e2e/tests/hidden_files_allow.rs
+++ b/crates/ephpm-e2e/tests/hidden_files_allow.rs
@@ -1,0 +1,71 @@
+//! Hidden file edge-case tests for `.well-known` paths.
+//!
+//! Validates:
+//! - `/.well-known/acme-challenge/test` is blocked by hidden-file rules
+//!   because `.well-known` starts with a dot and ephpm has no special
+//!   exception for it (unlike nginx/Apache which commonly allow it)
+//! - `/.config/settings` is blocked as a hidden directory
+//!
+//! The default `hidden_files` mode is "deny" (403). These tests document
+//! current behavior and verify the deny logic covers common dot-prefixed
+//! paths that other servers sometimes exempt.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+#[tokio::test]
+async fn well_known_path_blocked_by_hidden_files() {
+    let base_url = required_env("EPHPM_URL");
+    // `.well-known` is a dot-prefixed segment. ephpm does NOT have a special
+    // exception for RFC 8615 well-known URIs — they are blocked like any
+    // other hidden path when hidden_files = "deny" (the default).
+    let url = format!("{base_url}/.well-known/acme-challenge/test-token");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "/.well-known/ must be blocked by hidden-file rules (no exception exists), got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn hidden_config_directory_blocked() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/.config/settings");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "/.config/ must be blocked by hidden-file rules, got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn nested_hidden_segment_blocked() {
+    let base_url = required_env("EPHPM_URL");
+    // Hidden segment deep in the path — verifies the check inspects all segments.
+    let url = format!("{base_url}/assets/.secret/logo.png");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "nested hidden segment /assets/.secret/ must be blocked, got {}",
+        resp.status()
+    );
+}

--- a/crates/ephpm-e2e/tests/hrana.rs
+++ b/crates/ephpm-e2e/tests/hrana.rs
@@ -1,0 +1,173 @@
+//! Hrana HTTP API smoke tests.
+//!
+//! Validates that the optional `hrana_listen` configuration under
+//! `[db.sqlite.proxy]` is accepted by the server and that the Hrana
+//! endpoint responds to requests.
+//!
+//! The test config sets `hrana_listen = "0.0.0.0:8081"` so litewire
+//! exposes its HTTP API alongside the MySQL wire protocol frontend.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+//! - `EPHPM_HRANA_URL` — base URL of the Hrana HTTP endpoint (e.g. `http://ephpm:8081`).
+//!   If not set, Hrana-specific endpoint tests are skipped (the server may
+//!   be behind a network boundary that the test runner cannot reach).
+
+use ephpm_e2e::required_env;
+
+/// Verify the main server starts successfully when `hrana_listen` is configured.
+///
+/// If the Hrana listener fails to bind or panics during startup, the
+/// ephpm process will exit and this request will fail to connect.
+#[tokio::test]
+async fn server_starts_with_hrana_configured() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/index.php");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed — server may not have started: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "index.php must return 200 when hrana_listen is configured, got {}",
+        resp.status()
+    );
+    let body = resp.text().await.expect("failed to read body");
+    assert!(
+        body.contains("Hello from ePHPm"),
+        "index.php output must be served normally with Hrana enabled:\n{body}"
+    );
+}
+
+/// Verify PHP can still execute SQL through the MySQL wire protocol while
+/// the Hrana HTTP API is also listening on a separate port. This catches
+/// port-binding conflicts or shared-state corruption between the two
+/// frontends.
+#[tokio::test]
+async fn php_sqlite_query_works_with_hrana_enabled() {
+    let base_url = required_env("EPHPM_URL");
+
+    // The sqlite.rs e2e tests create tables via /db.php — we just need to
+    // confirm a simple query round-trips. Use a standalone CREATE + SELECT
+    // that does not depend on pre-existing state.
+    let client = reqwest::Client::new();
+
+    // Create a throwaway table.
+    let create_url = format!(
+        "{base_url}/db.php?sql={}",
+        urlencoding::encode(
+            "CREATE TABLE IF NOT EXISTS hrana_smoke (id INTEGER PRIMARY KEY, val TEXT)"
+        )
+    );
+    let resp = client
+        .get(&create_url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {create_url} failed: {e}"));
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "CREATE TABLE must succeed, got {}",
+        resp.status()
+    );
+
+    // Insert a row.
+    let insert_url = format!(
+        "{base_url}/db.php?sql={}",
+        urlencoding::encode("INSERT OR IGNORE INTO hrana_smoke (id, val) VALUES (1, 'hrana_ok')")
+    );
+    let resp = client
+        .get(&insert_url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {insert_url} failed: {e}"));
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "INSERT must succeed, got {}",
+        resp.status()
+    );
+
+    // Select it back.
+    let select_url = format!(
+        "{base_url}/db.php?sql={}",
+        urlencoding::encode("SELECT val FROM hrana_smoke WHERE id = 1")
+    );
+    let resp = client
+        .get(&select_url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {select_url} failed: {e}"));
+    assert_eq!(resp.status().as_u16(), 200);
+    let body = resp.text().await.expect("failed to read body");
+    assert!(
+        body.contains("hrana_ok"),
+        "SELECT must return the inserted value when Hrana is co-running:\n{body}"
+    );
+}
+
+/// If the `EPHPM_HRANA_URL` environment variable is set, probe the Hrana
+/// HTTP endpoint directly.
+///
+/// The Hrana v3 protocol responds to `POST /v3/pipeline` but also exposes
+/// a basic health surface. We send a simple pipeline request and check
+/// that the endpoint does not return a connection error or 404.
+#[tokio::test]
+async fn hrana_endpoint_responds() {
+    let base_url = required_env("EPHPM_URL");
+
+    // Ensure the server is up first.
+    let resp = reqwest::get(format!("{base_url}/index.php"))
+        .await
+        .unwrap_or_else(|e| panic!("server health check failed: {e}"));
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let hrana_url = match std::env::var("EPHPM_HRANA_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            // Hrana endpoint not reachable from the test runner — skip.
+            eprintln!("EPHPM_HRANA_URL not set, skipping direct Hrana probe");
+            return;
+        }
+    };
+
+    // Send a minimal Hrana v3 pipeline request.
+    let client = reqwest::Client::new();
+    let pipeline_url = format!("{hrana_url}/v3/pipeline");
+    let body = serde_json::json!({
+        "requests": [
+            {
+                "type": "execute",
+                "stmt": {
+                    "sql": "SELECT 1 AS ping"
+                }
+            },
+            {
+                "type": "close"
+            }
+        ]
+    });
+
+    let resp = client
+        .post(&pipeline_url)
+        .json(&body)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("POST {pipeline_url} failed: {e}"));
+
+    // Accept any 2xx — the exact response format depends on the litewire
+    // Hrana implementation version.
+    assert!(
+        resp.status().is_success(),
+        "Hrana pipeline endpoint must return 2xx, got {}",
+        resp.status()
+    );
+
+    let resp_body = resp.text().await.expect("failed to read Hrana response");
+    assert!(
+        !resp_body.is_empty(),
+        "Hrana pipeline response must not be empty"
+    );
+}

--- a/crates/ephpm-e2e/tests/idle_timeout.rs
+++ b/crates/ephpm-e2e/tests/idle_timeout.rs
@@ -1,0 +1,159 @@
+//! Idle and header-read timeout configuration tests.
+//!
+//! Validates that ephpm accepts and operates correctly with explicit timeout
+//! configuration. Since timing-sensitive tests are unreliable in CI, these
+//! tests take a conservative approach:
+//! - Verify the server starts and serves normally with explicit timeout values
+//! - Verify PHP execution still works within the configured timeouts
+//! - Verify static file serving is unaffected by timeout settings
+//!
+//! The actual timeout enforcement is covered by `timeouts.rs` (request timeout)
+//! and `timeout_edge.rs` (recovery after timeout). This file focuses on the
+//! `[server.timeouts]` idle and header_read config fields.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+/// Verify the server starts and serves static files normally with explicit
+/// idle and header_read timeout values configured in ephpm-test.toml.
+#[tokio::test]
+async fn static_file_served_with_timeout_config() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/test.html");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "static file must be served with explicit timeout config, got {}",
+        resp.status()
+    );
+}
+
+/// Verify PHP execution completes within the configured timeouts.
+/// A fast PHP script should not be affected by idle/header_read timeouts.
+#[tokio::test]
+async fn php_execution_within_timeouts() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/test.php");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "PHP request must succeed within configured timeouts, got {}",
+        resp.status()
+    );
+
+    let body = resp.text().await.expect("failed to read body");
+    assert!(
+        !body.is_empty(),
+        "PHP response must not be empty"
+    );
+}
+
+/// Verify that multiple sequential requests on the same connection succeed.
+/// With idle timeout set to 45s, keep-alive connections should remain open
+/// between rapid sequential requests.
+#[tokio::test]
+async fn sequential_requests_within_idle_timeout() {
+    let base_url = required_env("EPHPM_URL");
+
+    // Use a single client to exercise keep-alive connections.
+    let client = reqwest::Client::builder()
+        .pool_idle_timeout(std::time::Duration::from_secs(30))
+        .build()
+        .expect("failed to build reqwest client");
+
+    for i in 0..5 {
+        let url = format!("{base_url}/test.html");
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("request {i}: GET {url} failed: {e}"));
+
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "request {i}: sequential keep-alive request must succeed, got {}",
+            resp.status()
+        );
+
+        // Consume the body to release the connection back to the pool.
+        let _ = resp.bytes().await;
+    }
+}
+
+/// Verify that a POST request with headers and body completes within the
+/// header_read timeout. The configured header_read timeout (20s) is well
+/// above what a normal request needs.
+#[tokio::test]
+async fn post_request_within_header_read_timeout() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/test.php");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body("timeout_test=yes")
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("POST {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "POST must complete within header_read timeout, got {}",
+        resp.status()
+    );
+
+    let body = resp.text().await.expect("failed to read body");
+    assert!(
+        body.contains("timeout_test = yes"),
+        "POST body must reach PHP within timeout config:\n{body}"
+    );
+}
+
+/// Verify that the server handles concurrent requests correctly with
+/// timeout config active. Timeouts should not interfere with parallel
+/// request processing.
+#[tokio::test]
+async fn concurrent_requests_with_timeout_config() {
+    let base_url = required_env("EPHPM_URL");
+    let client = reqwest::Client::new();
+
+    let mut handles = Vec::new();
+    for i in 0..10 {
+        let url = format!("{base_url}/test.html");
+        let c = client.clone();
+        handles.push(tokio::spawn(async move {
+            let resp = c
+                .get(&url)
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("concurrent request {i}: GET {url} failed: {e}"));
+            (i, resp.status().as_u16())
+        }));
+    }
+
+    for handle in handles {
+        let (i, status) = handle.await.expect("task panicked");
+        assert_eq!(
+            status, 200,
+            "concurrent request {i}: must succeed with timeout config, got {status}"
+        );
+    }
+}

--- a/crates/ephpm-e2e/tests/kv_advanced.rs
+++ b/crates/ephpm-e2e/tests/kv_advanced.rs
@@ -1,0 +1,164 @@
+//! KV store advanced configuration tests.
+//!
+//! Validates that `[kv]` settings (`memory_limit`, `eviction_policy`,
+//! `compression`) are accepted and that the KV store remains functional
+//! under a non-default configuration.
+//!
+//! The test config sets:
+//! - `memory_limit = "64MB"`
+//! - `eviction_policy = "allkeys-lru"`
+//!
+//! These tests do NOT attempt to hit the memory ceiling — that belongs in
+//! nightly stress tests. They verify the config is accepted and basic
+//! operations still work.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+/// Helper: call /kv.php with the given query string, return (status, trimmed body).
+async fn kv(base_url: &str, query: &str) -> (u16, String) {
+    let url = format!("{base_url}/kv.php?{query}");
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    let status = resp.status().as_u16();
+    let body = resp
+        .text()
+        .await
+        .expect("failed to read kv response body")
+        .trim()
+        .to_owned();
+    (status, body)
+}
+
+/// Basic set/get with the custom memory_limit + eviction_policy config.
+///
+/// If the config parsing broke (e.g. unrecognised eviction policy string),
+/// the server would fail to start and this test would not reach 200.
+#[tokio::test]
+async fn kv_set_get_with_custom_config() {
+    let base = required_env("EPHPM_URL");
+
+    let (s, _) = kv(&base, "op=set&key=adv_cfg&val=configured&ttl=0").await;
+    assert_eq!(s, 200, "set must succeed with custom KV config");
+
+    let (s, body) = kv(&base, "op=get&key=adv_cfg").await;
+    assert_eq!(s, 200);
+    assert_eq!(
+        body, "configured",
+        "get must return the stored value under custom KV config"
+    );
+}
+
+/// Write several moderately-sized values and read them back.
+///
+/// This exercises the memory-tracking path (each set updates
+/// `memory_used`) and the LRU bookkeeping (`last_accessed` update on
+/// read) without coming close to the 64 MB ceiling.
+#[tokio::test]
+async fn kv_multiple_keys_with_memory_tracking() {
+    let base = required_env("EPHPM_URL");
+
+    // Write 20 keys, each ~1 KB (well under the 64 MB limit).
+    let value = "V".repeat(1_000);
+    let encoded = urlencoding::encode(&value);
+
+    for i in 0..20 {
+        let (s, _) = kv(
+            &base,
+            &format!("op=set&key=adv_bulk_{i}&val={encoded}&ttl=0"),
+        )
+        .await;
+        assert_eq!(s, 200, "set adv_bulk_{i} must succeed");
+    }
+
+    // Read them all back.
+    for i in 0..20 {
+        let (s, body) = kv(&base, &format!("op=get&key=adv_bulk_{i}")).await;
+        assert_eq!(s, 200);
+        assert_eq!(
+            body.len(),
+            1_000,
+            "adv_bulk_{i} must return 1000-byte value, got {}",
+            body.len()
+        );
+    }
+}
+
+/// Overwrite the same key many times to exercise the memory-accounting
+/// delta path (old entry size subtracted, new entry size added).
+#[tokio::test]
+async fn kv_overwrite_updates_memory_accounting() {
+    let base = required_env("EPHPM_URL");
+
+    // Start with a small value.
+    let (s, _) = kv(&base, "op=set&key=adv_ow&val=small&ttl=0").await;
+    assert_eq!(s, 200);
+
+    // Overwrite with a larger value.
+    let large = "L".repeat(5_000);
+    let encoded = urlencoding::encode(&large);
+    let (s, _) = kv(
+        &base,
+        &format!("op=set&key=adv_ow&val={encoded}&ttl=0"),
+    )
+    .await;
+    assert_eq!(s, 200);
+
+    // Read back — must be the large value.
+    let (s, body) = kv(&base, "op=get&key=adv_ow").await;
+    assert_eq!(s, 200);
+    assert_eq!(
+        body.len(),
+        5_000,
+        "overwritten key must return the latest (larger) value"
+    );
+
+    // Overwrite again with a smaller value.
+    let (s, _) = kv(&base, "op=set&key=adv_ow&val=tiny&ttl=0").await;
+    assert_eq!(s, 200);
+
+    let (s, body) = kv(&base, "op=get&key=adv_ow").await;
+    assert_eq!(s, 200);
+    assert_eq!(
+        body, "tiny",
+        "overwritten key must return the latest (smaller) value"
+    );
+}
+
+/// Delete keys and verify they are removed, exercising the memory
+/// reclamation path.
+#[tokio::test]
+async fn kv_delete_reclaims_memory() {
+    let base = required_env("EPHPM_URL");
+
+    let value = "D".repeat(2_000);
+    let encoded = urlencoding::encode(&value);
+
+    // Set 5 keys.
+    for i in 0..5 {
+        let (s, _) = kv(
+            &base,
+            &format!("op=set&key=adv_del_{i}&val={encoded}&ttl=0"),
+        )
+        .await;
+        assert_eq!(s, 200);
+    }
+
+    // Delete them.
+    for i in 0..5 {
+        let (s, _) = kv(&base, &format!("op=del&key=adv_del_{i}")).await;
+        assert_eq!(s, 200);
+    }
+
+    // Confirm they are gone.
+    for i in 0..5 {
+        let (_, body) = kv(&base, &format!("op=exists&key=adv_del_{i}")).await;
+        assert_eq!(
+            body, "0",
+            "adv_del_{i} must not exist after deletion"
+        );
+    }
+}

--- a/crates/ephpm-e2e/tests/kv_unix_socket.rs
+++ b/crates/ephpm-e2e/tests/kv_unix_socket.rs
@@ -1,0 +1,120 @@
+//! KV Unix socket configuration smoke tests.
+//!
+//! Validates that ephpm starts correctly when a Unix socket path is configured
+//! for the KV RESP listener. Since the e2e runner cannot access the Unix socket
+//! on the ephpm pod, these tests verify:
+//! - The server starts without errors when `[kv.redis_compat] socket` is set
+//! - PHP SAPI KV functions still work (they use in-process DashMap, not the socket)
+//! - Normal HTTP requests are unaffected by the socket configuration
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+/// Helper: call /kv.php with the given query string, return trimmed body.
+async fn kv(base_url: &str, query: &str) -> (u16, String) {
+    let url = format!("{base_url}/kv.php?{query}");
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    let status = resp.status().as_u16();
+    let body = resp
+        .text()
+        .await
+        .expect("failed to read kv response body")
+        .trim()
+        .to_owned();
+    (status, body)
+}
+
+/// Verify the server starts and serves requests normally with a Unix socket
+/// configured for the KV RESP listener. The socket config is in ephpm-test.toml
+/// under `[kv.redis_compat] socket = "/tmp/ephpm-kv.sock"`.
+#[tokio::test]
+async fn server_starts_with_kv_unix_socket_config() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/index.php");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "server must start and serve index.php with KV Unix socket configured, got {}",
+        resp.status()
+    );
+
+    let body = resp.text().await.expect("failed to read body");
+    assert!(
+        body.contains("Hello from ePHPm"),
+        "index.php must produce expected output when KV socket is configured:\n{body}"
+    );
+}
+
+/// Verify that PHP SAPI KV functions (ephpm_kv_set/get) work correctly when
+/// a Unix socket is configured. These functions use the in-process DashMap
+/// directly and should be completely unaffected by the RESP socket config.
+#[tokio::test]
+async fn kv_sapi_functions_work_with_unix_socket_config() {
+    let base_url = required_env("EPHPM_URL");
+
+    // Use a unique key to avoid collisions with other KV tests.
+    let key = "unix_sock_test_key";
+    let val = "socket_config_ok";
+
+    // Set via PHP SAPI function
+    let (status, body) = kv(
+        &base_url,
+        &format!("op=set&key={key}&val={val}&ttl=0"),
+    )
+    .await;
+    assert_eq!(status, 200, "kv set must return 200");
+    assert_eq!(body, "ok", "kv set must return 'ok'");
+
+    // Get via PHP SAPI function
+    let (status, body) = kv(&base_url, &format!("op=get&key={key}")).await;
+    assert_eq!(status, 200, "kv get must return 200");
+    assert_eq!(
+        body, val,
+        "kv get must return the value set via SAPI function"
+    );
+
+    // Verify exists
+    let (status, body) = kv(&base_url, &format!("op=exists&key={key}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "1", "key must exist after set");
+
+    // Cleanup
+    kv(&base_url, &format!("op=del&key={key}")).await;
+}
+
+/// Verify that KV TTL expiry works correctly with a Unix socket configured.
+/// This exercises the DashMap + expiry logic independently of the RESP listener.
+#[tokio::test(flavor = "current_thread")]
+async fn kv_ttl_works_with_unix_socket_config() {
+    let base_url = required_env("EPHPM_URL");
+
+    let key = "unix_sock_ttl_key";
+
+    // Set with a 50 ms TTL
+    let (status, _) = kv(
+        &base_url,
+        &format!("op=set&key={key}&val=ephemeral&ttl=50"),
+    )
+    .await;
+    assert_eq!(status, 200);
+
+    // Wait for expiry
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Key should be gone
+    let (status, body) = kv(&base_url, &format!("op=get&key={key}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        body, "null",
+        "key must expire after TTL even with Unix socket configured"
+    );
+}

--- a/crates/ephpm-e2e/tests/sqlite_advanced.rs
+++ b/crates/ephpm-e2e/tests/sqlite_advanced.rs
@@ -1,0 +1,300 @@
+//! SQLite advanced edge-case tests via litewire.
+//!
+//! Validates:
+//! - Concurrent SQLite writes from parallel HTTP requests
+//! - Large result sets (bulk insert + SELECT all)
+//! - Row count consistency after bulk operations
+//!
+//! Uses `sqlite_advanced_test.php` in docroot, which connects to litewire's
+//! MySQL frontend backed by SQLite.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct AdvancedResponse {
+    status: String,
+    #[serde(default)]
+    count: Option<i64>,
+    #[serde(default)]
+    rows: Vec<serde_json::Value>,
+    #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    id: Option<i64>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Helper to call sqlite_advanced_test.php with an action and optional params.
+async fn advanced_action(action: &str, extra_params: &str) -> AdvancedResponse {
+    let base_url = required_env("EPHPM_URL");
+    let url = if extra_params.is_empty() {
+        format!("{base_url}/sqlite_advanced_test.php?action={action}")
+    } else {
+        format!("{base_url}/sqlite_advanced_test.php?action={action}&{extra_params}")
+    };
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    let status_code = resp.status().as_u16();
+    assert_eq!(
+        status_code, 200,
+        "sqlite_advanced_test.php?action={action} returned {status_code}"
+    );
+
+    resp.json::<AdvancedResponse>()
+        .await
+        .unwrap_or_else(|e| panic!("failed to parse JSON from {url}: {e}"))
+}
+
+/// Bulk insert 50 rows into SQLite, then SELECT all and verify count matches.
+#[tokio::test]
+async fn sqlite_bulk_insert_and_select_all() {
+    // Setup fresh table
+    let resp = advanced_action("setup", "").await;
+    assert_eq!(resp.status, "ok", "setup failed: {:?}", resp.message);
+
+    // Bulk insert 50 rows
+    let resp = advanced_action("bulk_insert", "count=50").await;
+    assert_eq!(resp.status, "ok", "bulk_insert failed: {:?}", resp.message);
+    assert_eq!(
+        resp.count,
+        Some(50),
+        "bulk_insert should report count=50"
+    );
+
+    // Verify count via SELECT COUNT(*)
+    let resp = advanced_action("count", "").await;
+    assert_eq!(resp.status, "ok", "count failed: {:?}", resp.message);
+    assert_eq!(
+        resp.count,
+        Some(50),
+        "expected 50 rows after bulk insert, got {:?}",
+        resp.count
+    );
+
+    // SELECT all rows and verify the result set
+    let resp = advanced_action("select_all", "").await;
+    assert_eq!(resp.status, "ok", "select_all failed: {:?}", resp.message);
+    assert_eq!(
+        resp.rows.len(),
+        50,
+        "expected 50 rows in SELECT result, got {}",
+        resp.rows.len()
+    );
+
+    // Verify ordering and values
+    for (i, row) in resp.rows.iter().enumerate() {
+        let expected_id = (i + 1) as i64;
+        let actual_id = row["id"]
+            .as_i64()
+            .or_else(|| row["id"].as_str().and_then(|s| s.parse().ok()))
+            .unwrap_or_else(|| panic!("row {i}: id must be an integer, got {:?}", row["id"]));
+        assert_eq!(
+            actual_id, expected_id,
+            "row {i}: expected id={expected_id}, got {actual_id}"
+        );
+
+        let expected_val = format!("bulk_value_{}", i + 1);
+        assert_eq!(
+            row["value"].as_str().unwrap_or(""),
+            expected_val,
+            "row {i}: value mismatch"
+        );
+    }
+
+    // Cleanup
+    let resp = advanced_action("cleanup", "").await;
+    assert_eq!(resp.status, "ok", "cleanup failed: {:?}", resp.message);
+}
+
+/// Send 5 parallel INSERT requests to SQLite, then verify all rows exist.
+/// SQLite serializes writes, so all requests should succeed without conflict.
+#[tokio::test]
+async fn sqlite_concurrent_writes() {
+    let base_url = required_env("EPHPM_URL");
+
+    // Setup fresh table
+    let resp = advanced_action("setup", "").await;
+    assert_eq!(resp.status, "ok", "setup failed: {:?}", resp.message);
+
+    // Launch 5 concurrent INSERT requests with distinct IDs (1000..1004)
+    let client = reqwest::Client::new();
+    let mut handles = Vec::new();
+
+    for i in 0..5 {
+        let id = 1000 + i;
+        let url = format!(
+            "{base_url}/sqlite_advanced_test.php?action=concurrent_write&id={id}&value=concurrent_{id}"
+        );
+        let c = client.clone();
+        handles.push(tokio::spawn(async move {
+            let resp = c
+                .get(&url)
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("concurrent write id={id} failed: {e}"));
+
+            let status = resp.status().as_u16();
+            let body: AdvancedResponse = resp
+                .json()
+                .await
+                .unwrap_or_else(|e| panic!("failed to parse response for id={id}: {e}"));
+            (id, status, body)
+        }));
+    }
+
+    // Wait for all concurrent writes to complete
+    for handle in handles {
+        let (id, status, body) = handle.await.expect("task panicked");
+        assert_eq!(
+            status, 200,
+            "concurrent write id={id} returned {status}"
+        );
+        assert_eq!(
+            body.status, "ok",
+            "concurrent write id={id} failed: {:?}",
+            body.message
+        );
+    }
+
+    // Verify all 5 rows exist
+    let resp = advanced_action("count", "").await;
+    assert_eq!(resp.status, "ok", "count failed: {:?}", resp.message);
+    assert_eq!(
+        resp.count,
+        Some(5),
+        "expected 5 rows after concurrent writes, got {:?}",
+        resp.count
+    );
+
+    // Verify each row individually
+    let resp = advanced_action("select_all", "").await;
+    assert_eq!(resp.status, "ok");
+    assert_eq!(resp.rows.len(), 5, "expected 5 rows in result set");
+
+    for i in 0..5 {
+        let expected_id = 1000 + i as i64;
+        let row = &resp.rows[i];
+        let actual_id = row["id"]
+            .as_i64()
+            .or_else(|| row["id"].as_str().and_then(|s| s.parse().ok()))
+            .unwrap_or_else(|| panic!("row {i}: id must be an integer, got {:?}", row["id"]));
+        assert_eq!(
+            actual_id, expected_id,
+            "row {i}: expected id={expected_id}, got {actual_id}"
+        );
+        assert_eq!(
+            row["value"].as_str().unwrap_or(""),
+            format!("concurrent_{expected_id}"),
+            "row {i}: value mismatch"
+        );
+    }
+
+    // Cleanup
+    let resp = advanced_action("cleanup", "").await;
+    assert_eq!(resp.status, "ok", "cleanup failed: {:?}", resp.message);
+}
+
+/// Verify that large result sets are returned correctly through the
+/// litewire MySQL protocol translation layer.
+#[tokio::test]
+async fn sqlite_large_result_set() {
+    // Setup fresh table
+    let resp = advanced_action("setup", "").await;
+    assert_eq!(resp.status, "ok", "setup failed: {:?}", resp.message);
+
+    // Insert 100 rows
+    let resp = advanced_action("bulk_insert", "count=100").await;
+    assert_eq!(resp.status, "ok", "bulk_insert failed: {:?}", resp.message);
+
+    // SELECT all and verify count
+    let resp = advanced_action("select_all", "").await;
+    assert_eq!(resp.status, "ok", "select_all failed: {:?}", resp.message);
+    assert_eq!(
+        resp.rows.len(),
+        100,
+        "expected 100 rows in large result set, got {}",
+        resp.rows.len()
+    );
+
+    // Spot-check first and last rows
+    let first = &resp.rows[0];
+    assert_eq!(
+        first["id"]
+            .as_i64()
+            .or_else(|| first["id"].as_str().and_then(|s| s.parse().ok()))
+            .unwrap_or(-1),
+        1,
+        "first row id must be 1"
+    );
+    assert_eq!(
+        first["value"].as_str().unwrap_or(""),
+        "bulk_value_1",
+        "first row value mismatch"
+    );
+
+    let last = &resp.rows[99];
+    assert_eq!(
+        last["id"]
+            .as_i64()
+            .or_else(|| last["id"].as_str().and_then(|s| s.parse().ok()))
+            .unwrap_or(-1),
+        100,
+        "last row id must be 100"
+    );
+    assert_eq!(
+        last["value"].as_str().unwrap_or(""),
+        "bulk_value_100",
+        "last row value mismatch"
+    );
+
+    // Cleanup
+    let resp = advanced_action("cleanup", "").await;
+    assert_eq!(resp.status, "ok", "cleanup failed: {:?}", resp.message);
+}
+
+/// Verify setup is idempotent — calling setup drops and recreates the table.
+#[tokio::test]
+async fn sqlite_setup_is_idempotent() {
+    // Setup twice in a row should not fail
+    let resp = advanced_action("setup", "").await;
+    assert_eq!(resp.status, "ok", "first setup failed: {:?}", resp.message);
+
+    // Insert some data
+    let resp = advanced_action("bulk_insert", "count=10").await;
+    assert_eq!(resp.status, "ok");
+
+    // Setup again — should drop and recreate, clearing data
+    let resp = advanced_action("setup", "").await;
+    assert_eq!(resp.status, "ok", "second setup failed: {:?}", resp.message);
+
+    // Count should be 0 after fresh setup
+    let resp = advanced_action("count", "").await;
+    assert_eq!(resp.status, "ok");
+    assert_eq!(
+        resp.count,
+        Some(0),
+        "table should be empty after re-setup, got {:?}",
+        resp.count
+    );
+
+    // Cleanup
+    advanced_action("cleanup", "").await;
+}
+
+/// Verify cleanup is idempotent — DROP TABLE IF EXISTS should never fail.
+#[tokio::test]
+async fn sqlite_cleanup_is_idempotent() {
+    let resp = advanced_action("cleanup", "").await;
+    assert_eq!(resp.status, "ok", "first cleanup failed: {:?}", resp.message);
+
+    let resp = advanced_action("cleanup", "").await;
+    assert_eq!(resp.status, "ok", "second cleanup failed: {:?}", resp.message);
+}

--- a/tests/docroot/sqlite_advanced_test.php
+++ b/tests/docroot/sqlite_advanced_test.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * SQLite advanced edge-case tests via litewire MySQL frontend.
+ *
+ * Connects to the litewire MySQL wire protocol frontend using PDO,
+ * exercises concurrent writes, bulk inserts, and large result sets.
+ *
+ * Usage: GET /sqlite_advanced_test.php?action=<action>[&params]
+ *   - setup:            CREATE TABLE for advanced tests
+ *   - bulk_insert:      INSERT N rows (&count=50)
+ *   - count:            SELECT COUNT(*) from test table
+ *   - concurrent_write: INSERT a single row (&id=X)
+ *   - select_all:       SELECT all rows ordered by id
+ *   - cleanup:          DROP TABLE
+ */
+
+header('Content-Type: application/json');
+
+$host   = getenv('DB_HOST') ?: '127.0.0.1';
+$port   = getenv('DB_PORT') ?: '3306';
+$action = $_GET['action'] ?? '';
+
+try {
+    $pdo = new PDO(
+        "mysql:host={$host};port={$port}",
+        'root',
+        '',
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+
+    switch ($action) {
+        case 'setup':
+            $pdo->exec('DROP TABLE IF EXISTS test_advanced');
+            $pdo->exec('CREATE TABLE test_advanced (id INTEGER PRIMARY KEY, value TEXT NOT NULL, created_at TEXT DEFAULT CURRENT_TIMESTAMP)');
+            echo json_encode(['status' => 'ok', 'action' => 'setup']);
+            break;
+
+        case 'bulk_insert':
+            $count = (int) ($_GET['count'] ?? 50);
+            $stmt = $pdo->prepare('INSERT INTO test_advanced (id, value) VALUES (?, ?)');
+            for ($i = 1; $i <= $count; $i++) {
+                $stmt->execute([$i, "bulk_value_{$i}"]);
+            }
+            echo json_encode(['status' => 'ok', 'action' => 'bulk_insert', 'count' => $count]);
+            break;
+
+        case 'count':
+            $stmt = $pdo->query('SELECT COUNT(*) as cnt FROM test_advanced');
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+            echo json_encode(['status' => 'ok', 'count' => (int) $row['cnt']]);
+            break;
+
+        case 'concurrent_write':
+            $id    = (int) ($_GET['id'] ?? 0);
+            $value = $_GET['value'] ?? "concurrent_{$id}";
+            $stmt  = $pdo->prepare('INSERT OR REPLACE INTO test_advanced (id, value) VALUES (?, ?)');
+            $stmt->execute([$id, $value]);
+            echo json_encode(['status' => 'ok', 'action' => 'concurrent_write', 'id' => $id]);
+            break;
+
+        case 'select_all':
+            $stmt = $pdo->query('SELECT id, value FROM test_advanced ORDER BY id');
+            $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            echo json_encode(['status' => 'ok', 'rows' => $rows, 'count' => count($rows)]);
+            break;
+
+        case 'cleanup':
+            $pdo->exec('DROP TABLE IF EXISTS test_advanced');
+            echo json_encode(['status' => 'ok', 'action' => 'cleanup']);
+            break;
+
+        default:
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'message' => "unknown action: {$action}"]);
+    }
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/tests/ephpm-test.toml
+++ b/tests/ephpm-test.toml
@@ -7,6 +7,7 @@ fallback = ["$uri", "$uri/", "=404"]
 
 [server.request]
 max_body_size = 1024
+max_header_size = 4096
 trusted_hosts = [
     "ephpm", "localhost", "127.0.0.1",
     # vhost tests
@@ -25,6 +26,7 @@ trusted_hosts = [
 ]
 
 [server.response]
+compression_min_size = 1024
 headers = [
     ["X-Frame-Options", "DENY"],
     ["X-Content-Type-Options", "nosniff"],
@@ -54,6 +56,7 @@ ini_overrides = [
 ]
 
 [server.limits]
+max_connections = 100
 per_ip_rate = 50.0
 per_ip_burst = 10
 
@@ -62,9 +65,22 @@ path = "/tmp/ephpm-test.db"
 
 [db.sqlite.proxy]
 mysql_listen = "127.0.0.1:3306"
+hrana_listen = "0.0.0.0:8081"
 postgres_listen = "127.0.0.1:5432"
 tds_listen = "127.0.0.1:1433"
+
+[server.timeouts]
+header_read = 20
+idle = 45
 
 [db.read_write_split]
 enabled = true
 sticky_duration = "2s"
+
+[kv]
+memory_limit = "64MB"
+eviction_policy = "allkeys-lru"
+
+[kv.redis_compat]
+enabled = true
+socket = "/tmp/ephpm-kv.sock"


### PR DESCRIPTION
## Summary

30 new e2e tests across 9 test files covering the remaining untested config options and features.

- **header_limits** (2 tests): oversized header rejection, normal headers pass
- **compression_thresholds** (2 tests): small responses not compressed, large ones are
- **hidden_files_allow** (3 tests): .well-known path blocked, hidden dirs, nested hidden segments
- **connection_limits** (3 tests): concurrent requests under limit, headers intact, slot release
- **kv_advanced** (4 tests): memory tracking, overwrite accounting, delete reclamation
- **hrana** (3 tests): Hrana HTTP API config accepted, MySQL coexistence, direct endpoint (opt-in)
- **kv_unix_socket** (3 tests): server starts with socket config, SAPI KV works, TTL works
- **idle_timeout** (5 tests): server operates normally with explicit header_read/idle timeouts
- **sqlite_advanced** (5 tests): bulk insert 50 rows, concurrent writes, large result sets, idempotent setup/cleanup

Also adds `sqlite_advanced_test.php` helper and config for all new features.

## Test plan

- [ ] Run e2e: `cargo xtask e2e`
- [ ] Verify existing tests not broken by new config values

🤖 Generated with [Claude Code](https://claude.com/claude-code)