### PR TITLE
feat: use pre-built PHP SDK from ephpm/php-sdk releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 target/
-php-sdk/
+# php-sdk/*.tar.gz are needed by Dockerfile for pre-built SDK
+php-sdk/static-php-cli/
+php-sdk/windows/
 .git/
 bin/
 docs/

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Build CI Image
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
       - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
+          apt-get update -qq
+          apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -66,8 +66,8 @@ jobs:
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
       - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
+          apt-get update -qq
+          apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -86,8 +86,7 @@ jobs:
           token: ${{ secrets.PHP_SDK_TOKEN }}
       - name: Symlink litewire for Cargo path dependency
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked || true
+      - run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # macOS disabled until self-hosted runner is available
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Checkout litewire (path dependency)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ephpm/litewire
-          path: ../litewire
+          path: litewire
           token: ${{ secrets.PHP_SDK_TOKEN }}
-          token: ${{ secrets.PHP_SDK_TOKEN }}
+      - name: Symlink litewire for Cargo path dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -36,8 +37,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ephpm/litewire
-          path: ../litewire
+          path: litewire
           token: ${{ secrets.PHP_SDK_TOKEN }}
+      - name: Symlink litewire for Cargo path dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -53,8 +56,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ephpm/litewire
-          path: ../litewire
+          path: litewire
           token: ${{ secrets.PHP_SDK_TOKEN }}
+      - name: Symlink litewire for Cargo path dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -69,6 +74,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ephpm/litewire
-          path: ../litewire
+          path: litewire
           token: ${{ secrets.PHP_SDK_TOKEN }}
+      - name: Symlink litewire for Cargo path dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
       - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -22,7 +22,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       - name: Checkout litewire (path dependency)
@@ -57,7 +57,7 @@ jobs:
 
   deny:
     name: Cargo Deny
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       - name: Checkout litewire (path dependency)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout litewire (path dependency)
+        uses: actions/checkout@v4
+        with:
+          repository: ephpm/litewire
+          path: ../litewire
+          token: ${{ secrets.PHP_SDK_TOKEN }}
+          token: ${{ secrets.PHP_SDK_TOKEN }}
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -30,6 +37,7 @@ jobs:
         with:
           repository: ephpm/litewire
           path: ../litewire
+          token: ${{ secrets.PHP_SDK_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -46,6 +54,7 @@ jobs:
         with:
           repository: ephpm/litewire
           path: ../litewire
+          token: ${{ secrets.PHP_SDK_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -61,4 +70,5 @@ jobs:
         with:
           repository: ephpm/litewire
           path: ../litewire
+          token: ${{ secrets.PHP_SDK_TOKEN }}
       - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # macOS disabled until self-hosted runner is available
-        os: [ubuntu-latest]
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       - name: Checkout litewire (path dependency)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo +nightly fmt --all -- --check
+      # --all includes local path deps (litewire), so list workspace packages explicitly
+      - run: |
+          cargo +nightly fmt -p ephpm -p ephpm-server -p ephpm-config -p ephpm-php \
+            -p ephpm-db -p ephpm-kv -p ephpm-cluster -p ephpm-sqld \
+            -p ephpm-query-stats -p xtask -- --check
 
   clippy:
     name: Clippy
@@ -86,7 +90,11 @@ jobs:
           token: ${{ secrets.PHP_SDK_TOKEN }}
       - name: Symlink litewire for Cargo path dependency
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
+      - name: Install build dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
-        run: cargo install cargo-deny --locked || true
+        run: cargo install cargo-deny --locked
       - run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
           token: ${{ secrets.PHP_SDK_TOKEN }}
       - name: Symlink litewire for Cargo path dependency
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -60,6 +64,10 @@ jobs:
           token: ${{ secrets.PHP_SDK_TOKEN }}
       - name: Symlink litewire for Cargo path dependency
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -78,4 +86,8 @@ jobs:
           token: ${{ secrets.PHP_SDK_TOKEN }}
       - name: Symlink litewire for Cargo path dependency
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
       - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,8 +32,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ephpm/litewire
-          path: ../litewire
+          path: litewire
           token: ${{ secrets.PHP_SDK_TOKEN }}
+      - name: Symlink litewire for Cargo path dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout litewire (path dependency)
+        uses: actions/checkout@v4
+        with:
+          repository: ephpm/litewire
+          path: ../litewire
+          token: ${{ secrets.PHP_SDK_TOKEN }}
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install E2E tools (kind, tilt, kubectl)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
+          apt-get update -qq
+          apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Symlink litewire for Cargo path dependency
         run: ln -sfn "$GITHUB_WORKSPACE/litewire" ../litewire
 
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq build-essential pkg-config libclang-dev libssl-dev
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install E2E tools (kind, tilt, kubectl)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Run E2E tests
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PHP_SDK_TOKEN }}
         run: cargo xtask e2e --php-version ${{ matrix.php_sdk_version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   e2e:
     name: E2E (PHP ${{ matrix.php }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,8 @@
 # E2E tests — build ephpm with PHP, deploy to Kind, run phpinfo validation.
 #
-# Matrix: PHP 8.4 and 8.5. Each job builds a release binary with the
-# specified PHP version and asserts that the running server reports it.
+# Matrix: PHP 8.4 and 8.5. Each job builds a release binary using a
+# pre-built PHP SDK from ephpm/php-sdk releases, deploys to Kind, and
+# asserts that the running server reports the correct PHP version.
 
 name: E2E Tests
 
@@ -18,7 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        include:
+          - php: "8.4"
+            php_sdk_version: "8.4.7"
+          - php: "8.5"
+            php_sdk_version: "8.5.2"
 
     steps:
       - uses: actions/checkout@v4
@@ -29,4 +34,6 @@ jobs:
         run: cargo xtask e2e-install
 
       - name: Run E2E tests
-        run: cargo xtask e2e --php-version ${{ matrix.php }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo xtask e2e --php-version ${{ matrix.php_sdk_version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,8 +20,7 @@ jobs:
 
   build-linux:
     name: Build (PHP ${{ matrix.php }}, linux-x86_64)
-    runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -51,59 +50,40 @@ jobs:
           name: ephpm-php${{ matrix.php }}-linux-x86_64
           path: target/*/release/ephpm
 
-  build-macos:
-    name: Build (PHP ${{ matrix.php }}, ${{ matrix.artifact_suffix }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ["8.4", "8.5"]
-        include:
-          - os: macos-latest
-            artifact_suffix: macos-aarch64
-          - os: macos-13
-            artifact_suffix: macos-x86_64
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-
-      - name: Install system dependencies
-        run: |
-          brew install autoconf automake bison cmake flex libtool \
-            make pkg-config re2c
-
-      - name: Build ephpm
-        run: cargo xtask release ${{ matrix.php }}
-
-      - name: Run ignored integration tests
-        run: |
-          cargo install cargo-nextest --locked || true
-          cargo nextest run --workspace --run-ignored ignored-only
-
-      - name: Verify binary
-        run: |
-          FILE="target/release/ephpm"
-          test -f "$FILE" || { echo "::error::Binary not found at $FILE"; exit 1; }
-          file "$FILE"
-          ls -lh "$FILE"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ephpm-php${{ matrix.php }}-${{ matrix.artifact_suffix }}
-          path: target/release/ephpm
+  # macOS disabled until self-hosted runner is available
+  # build-macos:
+  #   name: Build (PHP ${{ matrix.php }}, ${{ matrix.artifact_suffix }})
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       php: ["8.4", "8.5"]
+  #       include:
+  #         - os: macos-latest
+  #           artifact_suffix: macos-aarch64
+  #         - os: macos-13
+  #           artifact_suffix: macos-x86_64
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: Swatinem/rust-cache@v2
+  #     - name: Set up PHP
+  #       uses: shivammathur/setup-php@v2
+  #       with:
+  #         php-version: "8.4"
+  #     - name: Install system dependencies
+  #       run: brew install autoconf automake bison cmake flex libtool make pkg-config re2c
+  #     - name: Build ephpm
+  #       run: cargo xtask release ${{ matrix.php }}
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ephpm-php${{ matrix.php }}-${{ matrix.artifact_suffix }}
+  #         path: target/release/ephpm
 
   build-windows:
     name: Build (PHP ${{ matrix.php }}, windows-x86_64)
-    runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -134,7 +114,7 @@ jobs:
 
   fuzz:
     name: Fuzz (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -179,7 +159,7 @@ jobs:
   e2e:
     name: E2E (PHP ${{ matrix.php }})
     needs: [build-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -200,7 +180,7 @@ jobs:
   smoke-tests:
     name: Smoke Tests (PHP ${{ matrix.php }})
     needs: [build-linux]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -291,7 +271,7 @@ jobs:
 
   audit:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
 
@@ -320,8 +300,8 @@ jobs:
   nightly-summary:
     name: Nightly Summary
     if: always()
-    needs: [build-linux, build-macos, build-windows, fuzz, e2e, smoke-tests, audit]
-    runs-on: ubuntu-latest
+    needs: [build-linux, build-windows, fuzz, e2e, smoke-tests, audit]
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Check results
         run: |
@@ -330,7 +310,7 @@ jobs:
           echo "| Job | Status |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Linux builds | ${{ needs.build-linux.result }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| macOS builds | ${{ needs.build-macos.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| macOS builds | disabled |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Windows builds | ${{ needs.build-windows.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Fuzz testing | ${{ needs.fuzz.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| E2E tests | ${{ needs.e2e.result }} |" >> "$GITHUB_STEP_SUMMARY"
@@ -339,7 +319,6 @@ jobs:
 
           # Fail if any required job failed
           if [[ "${{ needs.build-linux.result }}" == "failure" ]] || \
-             [[ "${{ needs.build-macos.result }}" == "failure" ]] || \
              [[ "${{ needs.fuzz.result }}" == "failure" ]] || \
              [[ "${{ needs.e2e.result }}" == "failure" ]] || \
              [[ "${{ needs.smoke-tests.result }}" == "failure" ]]; then

--- a/.github/workflows/php-sdk.yml
+++ b/.github/workflows/php-sdk.yml
@@ -36,15 +36,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64]
         php:
           - ${{ inputs.php_version || '8.5' }}
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: [self-hosted, linux, x64]
             platform: linux/amd64
-          - arch: arm64
-            runner: ubuntu-24.04-arm
+          # arm64 disabled until self-hosted runner is available
+          # - arch: arm64
+          #   runner: ubuntu-24.04-arm
             platform: linux/arm64
     steps:
       - uses: actions/checkout@v4
@@ -196,7 +197,7 @@ jobs:
 
   windows:
     name: Windows (x86_64, PHP ${{ matrix.php }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -293,7 +294,7 @@ jobs:
     name: Upload to Release
     if: startsWith(github.ref, 'refs/tags/')
     needs: [linux, windows]  # Add macos back when runner is available
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/php-sdk.yml
+++ b/.github/workflows/php-sdk.yml
@@ -1,0 +1,339 @@
+# Build and push PHP SDK base images for each supported platform/arch.
+#
+# These images contain a pre-built libphp.a + headers via static-php-cli,
+# so release builds can skip the ~15 min PHP compilation step.
+#
+# Trigger: manual dispatch with PHP version param, or on tag push.
+# Matrix: linux/amd64, linux/arm64, macOS x86_64, macOS arm64, Windows x86_64.
+
+name: PHP SDK Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      php_version:
+        description: "PHP version to build (e.g., 8.4, 8.5)"
+        required: true
+        default: "8.5"
+        type: string
+  push:
+    tags: ["v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ghcr.io/${{ github.repository }}/php-sdk
+
+jobs:
+  # ── Linux container images (amd64 + arm64) ─────────────────────────────────
+
+  linux:
+    name: Linux (${{ matrix.arch }}, PHP ${{ matrix.php }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        php:
+          - ${{ inputs.php_version || '8.5' }}
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # - name: Log in to GHCR
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build PHP SDK image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.php-sdk
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+          push: false  # Set to true once registry is configured
+          tags: |
+            ${{ env.IMAGE_BASE }}:${{ matrix.php }}-linux-${{ matrix.arch }}
+            ${{ env.IMAGE_BASE }}:${{ matrix.php }}-linux-${{ matrix.arch }}-${{ github.sha }}
+          cache-from: type=gha,scope=php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}
+          load: true
+
+      - name: Verify SDK contents
+        run: |
+          docker create --name sdk-check ${{ env.IMAGE_BASE }}:${{ matrix.php }}-linux-${{ matrix.arch }}
+          docker cp sdk-check:/opt/php-sdk /tmp/php-sdk
+          docker rm sdk-check
+
+          echo "==> Checking libphp.a..."
+          test -f /tmp/php-sdk/lib/libphp.a || { echo "::error::libphp.a not found"; exit 1; }
+          ls -lh /tmp/php-sdk/lib/libphp.a
+
+          echo "==> Checking headers..."
+          test -d /tmp/php-sdk/include/php/main || { echo "::error::PHP headers not found"; exit 1; }
+          ls /tmp/php-sdk/include/php/
+
+          echo "==> Checking ZTS..."
+          grep -r "ZTS" /tmp/php-sdk/include/php/main/php_config.h | head -5 || true
+
+      - name: Export SDK tarball
+        run: |
+          docker create --name sdk-export ${{ env.IMAGE_BASE }}:${{ matrix.php }}-linux-${{ matrix.arch }}
+          docker cp sdk-export:/opt/php-sdk - | gzip > php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}.tar.gz
+          docker rm sdk-export
+          ls -lh php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}.tar.gz
+
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}
+          path: php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}.tar.gz
+
+  # ── macOS native builds (no container — spc runs natively) ─────────────────
+
+  macos:
+    name: macOS (${{ matrix.arch }}, PHP ${{ matrix.php }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, x86_64]
+        php:
+          - ${{ inputs.php_version || '8.5' }}
+        include:
+          - arch: arm64
+            runner: macos-latest      # Apple Silicon
+            spc_arch: aarch64
+          - arch: x86_64
+            runner: macos-13          # Intel
+            spc_arch: x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          brew install autoconf automake bison cmake flex libtool \
+            make pkg-config re2c
+
+      - name: Build PHP SDK via spc
+        env:
+          SPC_VERSION: "2.8.3"
+          PHP_EXTENSIONS: "bcmath,calendar,ctype,curl,dom,exif,fileinfo,filter,gd,hash,iconv,mbstring,mysqli,mysqlnd,openssl,pcntl,pcre,pdo,pdo_mysql,phar,posix,session,simplexml,sodium,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
+        run: |
+          mkdir -p spc-build && cd spc-build
+
+          echo "==> Downloading spc v${SPC_VERSION}..."
+          curl -fSL "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/spc-macos-${{ matrix.spc_arch }}.tar.gz" \
+            | tar xz
+          chmod +x spc
+
+          echo "==> Running spc doctor..."
+          ./spc doctor --auto-fix || true
+
+          echo "==> Downloading PHP ${{ matrix.php }} sources..."
+          ./spc download \
+            --with-php=${{ matrix.php }} \
+            --for-extensions=${PHP_EXTENSIONS} \
+            --prefer-pre-built
+
+          mkdir -p buildroot/bin
+          ln -sf "$(which pkg-config)" buildroot/bin/pkg-config
+
+          echo "==> Building libphp.a with ZTS..."
+          ./spc build \
+            ${PHP_EXTENSIONS} \
+            --build-embed \
+            --no-strip \
+            --enable-zts
+
+      - name: Verify SDK contents
+        run: |
+          SDK=spc-build/buildroot
+          echo "==> Checking libphp.a..."
+          test -f ${SDK}/lib/libphp.a || { echo "::error::libphp.a not found"; exit 1; }
+          ls -lh ${SDK}/lib/libphp.a
+          file ${SDK}/lib/libphp.a
+
+          echo "==> Checking headers..."
+          test -d ${SDK}/include/php/main || { echo "::error::PHP headers not found"; exit 1; }
+
+      - name: Package SDK tarball
+        run: |
+          tar czf php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz \
+            -C spc-build/buildroot \
+            lib/libphp.a \
+            include/php/
+          ls -lh php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz
+
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}
+          path: php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz
+
+  # ── Windows SDK (pre-built from windows.php.net) ───────────────────────────
+  #
+  # Windows uses the official PHP SDK (headers + php8embed.lib + php8embed.dll)
+  # from windows.php.net, NOT static-php-cli. This is NTS (ZTS=0) because
+  # the PHP Windows DLL is not built with thread safety.
+
+  windows:
+    name: Windows (x86_64, PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - ${{ inputs.php_version || '8.5' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download PHP Windows SDK
+        run: |
+          PHP_VERSION="${{ matrix.php }}"
+          BASE_URL="https://windows.php.net/downloads/releases/latest"
+          QA_URL="https://windows.php.net/downloads/qa"
+
+          mkdir -p php-sdk-win/lib php-sdk-win/include/php _tmp
+
+          # 1. Download NTS package (contains php8embed.dll)
+          NTS_ZIP="php-${PHP_VERSION}-nts-Win32-vs17-x64-latest.zip"
+          echo "==> Downloading NTS package (for php8embed.dll)..."
+          if ! curl -fSL -o _tmp/nts.zip "${BASE_URL}/${NTS_ZIP}" 2>/dev/null; then
+            echo "==> Trying QA builds..."
+            curl -fSL -o _tmp/nts.zip "${QA_URL}/${NTS_ZIP}" || {
+              echo "::error::Could not download NTS package for PHP ${PHP_VERSION}"
+              exit 1
+            }
+          fi
+          unzip -q _tmp/nts.zip -d _tmp/nts
+
+          # Find and copy php8embed.dll
+          DLL=$(find _tmp/nts -name "php8embed.dll" | head -1)
+          if [ -z "${DLL}" ]; then
+            echo "::error::php8embed.dll not found in NTS package"
+            exit 1
+          fi
+          cp "${DLL}" php-sdk-win/lib/
+          echo "==> Found php8embed.dll ($(stat -c%s "${DLL}" | numfmt --to=iec))"
+
+          # 2. Download devel pack (contains php8embed.lib + headers)
+          DEVEL_ZIP="php-devel-pack-${PHP_VERSION}-nts-Win32-vs17-x64-latest.zip"
+          echo "==> Downloading devel pack (for headers + import lib)..."
+          if ! curl -fSL -o _tmp/devel.zip "${BASE_URL}/${DEVEL_ZIP}" 2>/dev/null; then
+            echo "==> Trying QA builds..."
+            curl -fSL -o _tmp/devel.zip "${QA_URL}/${DEVEL_ZIP}" || {
+              echo "::error::Could not download devel pack for PHP ${PHP_VERSION}"
+              exit 1
+            }
+          fi
+          unzip -q _tmp/devel.zip -d _tmp/devel
+
+          # Find and copy php8embed.lib
+          LIB=$(find _tmp/devel -name "php8embed.lib" | head -1)
+          if [ -z "${LIB}" ]; then
+            echo "::error::php8embed.lib not found in devel pack"
+            exit 1
+          fi
+          cp "${LIB}" php-sdk-win/lib/
+          echo "==> Found php8embed.lib"
+
+          # Copy headers (main, Zend, TSRM, sapi, ext)
+          INCLUDE_DIR=$(find _tmp/devel -type d -name "include" | head -1)
+          for subdir in main Zend TSRM sapi ext; do
+            if [ -d "${INCLUDE_DIR}/${subdir}" ]; then
+              cp -r "${INCLUDE_DIR}/${subdir}" php-sdk-win/include/php/
+            fi
+          done
+
+          rm -rf _tmp
+
+      - name: Verify SDK contents
+        run: |
+          echo "==> Checking lib..."
+          ls -la php-sdk-win/lib/
+          test -f php-sdk-win/lib/php8embed.dll || { echo "::error::php8embed.dll missing"; exit 1; }
+          test -f php-sdk-win/lib/php8embed.lib || { echo "::error::php8embed.lib missing"; exit 1; }
+          echo "==> Checking headers..."
+          ls php-sdk-win/include/php/
+
+      - name: Package SDK tarball
+        run: |
+          tar czf php-sdk-${{ matrix.php }}-windows-x86_64.tar.gz \
+            -C php-sdk-win \
+            .
+          ls -lh php-sdk-${{ matrix.php }}-windows-x86_64.tar.gz
+
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-sdk-${{ matrix.php }}-windows-x86_64
+          path: php-sdk-${{ matrix.php }}-windows-x86_64.tar.gz
+
+  # ── Attach SDK tarballs to GitHub Release ──────────────────────────────────
+
+  release:
+    name: Upload to Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [linux, macos, windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: php-sdk-*
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -lh artifacts/
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*.tar.gz
+
+  # ── Multi-arch manifest (Linux only — macOS/Windows are tarballs) ──────────
+  #
+  # Creates a multi-arch manifest so `docker pull php-sdk:8.5-linux` resolves
+  # to the correct arch automatically.
+
+  # manifest:
+  #   name: Create multi-arch manifest (PHP ${{ needs.linux.strategy.matrix.php }})
+  #   needs: [linux]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     packages: write
+  #   steps:
+  #     - name: Log in to GHCR
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #
+  #     - name: Create and push manifest
+  #       env:
+  #         PHP: ${{ inputs.php_version || '8.5' }}
+  #       run: |
+  #         docker manifest create ${{ env.IMAGE_BASE }}:${PHP}-linux \
+  #           ${{ env.IMAGE_BASE }}:${PHP}-linux-amd64 \
+  #           ${{ env.IMAGE_BASE }}:${PHP}-linux-arm64
+  #         docker manifest push ${{ env.IMAGE_BASE }}:${PHP}-linux

--- a/.github/workflows/php-sdk.yml
+++ b/.github/workflows/php-sdk.yml
@@ -105,87 +105,88 @@ jobs:
           name: php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}
           path: php-sdk-${{ matrix.php }}-linux-${{ matrix.arch }}.tar.gz
 
-  # ── macOS native builds (no container — spc runs natively) ─────────────────
+  # ── macOS native builds (disabled until self-hosted runner is available) ─────
+  # Uncomment when Mac mini runner is set up.
 
-  macos:
-    name: macOS (${{ matrix.arch }}, PHP ${{ matrix.php }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [arm64, x86_64]
-        php:
-          - ${{ inputs.php_version || '8.5' }}
-        include:
-          - arch: arm64
-            runner: macos-latest      # Apple Silicon
-            spc_arch: aarch64
-          - arch: x86_64
-            runner: macos-13          # Intel
-            spc_arch: x86_64
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install system dependencies
-        run: |
-          brew install autoconf automake bison cmake flex libtool \
-            make pkg-config re2c
-
-      - name: Build PHP SDK via spc
-        env:
-          SPC_VERSION: "2.8.3"
-          PHP_EXTENSIONS: "bcmath,calendar,ctype,curl,dom,exif,fileinfo,filter,gd,hash,iconv,mbstring,mysqli,mysqlnd,openssl,pcntl,pcre,pdo,pdo_mysql,phar,posix,session,simplexml,sodium,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
-        run: |
-          mkdir -p spc-build && cd spc-build
-
-          echo "==> Downloading spc v${SPC_VERSION}..."
-          curl -fSL "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/spc-macos-${{ matrix.spc_arch }}.tar.gz" \
-            | tar xz
-          chmod +x spc
-
-          echo "==> Running spc doctor..."
-          ./spc doctor --auto-fix || true
-
-          echo "==> Downloading PHP ${{ matrix.php }} sources..."
-          ./spc download \
-            --with-php=${{ matrix.php }} \
-            --for-extensions=${PHP_EXTENSIONS} \
-            --prefer-pre-built
-
-          mkdir -p buildroot/bin
-          ln -sf "$(which pkg-config)" buildroot/bin/pkg-config
-
-          echo "==> Building libphp.a with ZTS..."
-          ./spc build \
-            ${PHP_EXTENSIONS} \
-            --build-embed \
-            --no-strip \
-            --enable-zts
-
-      - name: Verify SDK contents
-        run: |
-          SDK=spc-build/buildroot
-          echo "==> Checking libphp.a..."
-          test -f ${SDK}/lib/libphp.a || { echo "::error::libphp.a not found"; exit 1; }
-          ls -lh ${SDK}/lib/libphp.a
-          file ${SDK}/lib/libphp.a
-
-          echo "==> Checking headers..."
-          test -d ${SDK}/include/php/main || { echo "::error::PHP headers not found"; exit 1; }
-
-      - name: Package SDK tarball
-        run: |
-          tar czf php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz \
-            -C spc-build/buildroot \
-            lib/libphp.a \
-            include/php/
-          ls -lh php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz
-
-      - name: Upload SDK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}
-          path: php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz
+  # macos:
+  #   name: macOS (${{ matrix.arch }}, PHP ${{ matrix.php }})
+  #   runs-on: ${{ matrix.runner }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       arch: [arm64, x86_64]
+  #       php:
+  #         - ${{ inputs.php_version || '8.5' }}
+  #       include:
+  #         - arch: arm64
+  #           runner: macos-latest      # Apple Silicon
+  #           spc_arch: aarch64
+  #         - arch: x86_64
+  #           runner: macos-13          # Intel
+  #           spc_arch: x86_64
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - name: Install system dependencies
+  #       run: |
+  #         brew install autoconf automake bison cmake flex libtool \
+  #           make pkg-config re2c
+  #
+  #     - name: Build PHP SDK via spc
+  #       env:
+  #         SPC_VERSION: "2.8.3"
+  #         PHP_EXTENSIONS: "bcmath,calendar,ctype,curl,dom,exif,fileinfo,filter,gd,hash,iconv,mbstring,mysqli,mysqlnd,openssl,pcntl,pcre,pdo,pdo_mysql,phar,posix,session,simplexml,sodium,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
+  #       run: |
+  #         mkdir -p spc-build && cd spc-build
+  #
+  #         echo "==> Downloading spc v${SPC_VERSION}..."
+  #         curl -fSL "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/spc-macos-${{ matrix.spc_arch }}.tar.gz" \
+  #           | tar xz
+  #         chmod +x spc
+  #
+  #         echo "==> Running spc doctor..."
+  #         ./spc doctor --auto-fix || true
+  #
+  #         echo "==> Downloading PHP ${{ matrix.php }} sources..."
+  #         ./spc download \
+  #           --with-php=${{ matrix.php }} \
+  #           --for-extensions=${PHP_EXTENSIONS} \
+  #           --prefer-pre-built
+  #
+  #         mkdir -p buildroot/bin
+  #         ln -sf "$(which pkg-config)" buildroot/bin/pkg-config
+  #
+  #         echo "==> Building libphp.a with ZTS..."
+  #         ./spc build \
+  #           ${PHP_EXTENSIONS} \
+  #           --build-embed \
+  #           --no-strip \
+  #           --enable-zts
+  #
+  #     - name: Verify SDK contents
+  #       run: |
+  #         SDK=spc-build/buildroot
+  #         echo "==> Checking libphp.a..."
+  #         test -f ${SDK}/lib/libphp.a || { echo "::error::libphp.a not found"; exit 1; }
+  #         ls -lh ${SDK}/lib/libphp.a
+  #         file ${SDK}/lib/libphp.a
+  #
+  #         echo "==> Checking headers..."
+  #         test -d ${SDK}/include/php/main || { echo "::error::PHP headers not found"; exit 1; }
+  #
+  #     - name: Package SDK tarball
+  #       run: |
+  #         tar czf php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz \
+  #           -C spc-build/buildroot \
+  #           lib/libphp.a \
+  #           include/php/
+  #         ls -lh php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz
+  #
+  #     - name: Upload SDK artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}
+  #         path: php-sdk-${{ matrix.php }}-macos-${{ matrix.arch }}.tar.gz
 
   # ── Windows SDK (pre-built from windows.php.net) ───────────────────────────
   #
@@ -291,7 +292,7 @@ jobs:
   release:
     name: Upload to Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [linux, macos, windows]
+    needs: [linux, windows]  # Add macos back when runner is available
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,7 @@ env:
 jobs:
   build-linux:
     name: Build (PHP ${{ matrix.php }}, linux-x86_64)
-    runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -28,47 +27,47 @@ jobs:
           name: ephpm-php${{ matrix.php }}-linux-x86_64
           path: target/release/ephpm
 
-  build-macos:
-    name: Build (PHP ${{ matrix.php }}, ${{ matrix.artifact_suffix }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ["8.4", "8.5"]
-        include:
-          - os: macos-latest
-            artifact_suffix: macos-aarch64
-          - os: macos-13
-            artifact_suffix: macos-x86_64
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-
-      - name: Install system dependencies
-        run: |
-          brew install autoconf automake bison cmake flex libtool \
-            make pkg-config re2c
-
-      - name: Build ephpm
-        run: cargo xtask release ${{ matrix.php }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ephpm-php${{ matrix.php }}-${{ matrix.artifact_suffix }}
-          path: target/release/ephpm
+  # macOS disabled until self-hosted runner is available
+  # build-macos:
+  #   name: Build (PHP ${{ matrix.php }}, ${{ matrix.artifact_suffix }})
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       php: ["8.4", "8.5"]
+  #       include:
+  #         - os: macos-latest
+  #           artifact_suffix: macos-aarch64
+  #         - os: macos-13
+  #           artifact_suffix: macos-x86_64
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: Swatinem/rust-cache@v2
+  #
+  #     - name: Set up PHP
+  #       uses: shivammathur/setup-php@v2
+  #       with:
+  #         php-version: "8.4"
+  #
+  #     - name: Install system dependencies
+  #       run: |
+  #         brew install autoconf automake bison cmake flex libtool \
+  #           make pkg-config re2c
+  #
+  #     - name: Build ephpm
+  #       run: cargo xtask release ${{ matrix.php }}
+  #
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ephpm-php${{ matrix.php }}-${{ matrix.artifact_suffix }}
+  #         path: target/release/ephpm
 
   build-windows:
     name: Build (PHP ${{ matrix.php }}, windows-x86_64)
-    runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
+    runs-on: [self-hosted, linux, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -90,8 +89,8 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build-linux, build-macos, build-windows]
-    runs-on: ubuntu-latest
+    needs: [build-linux, build-windows]
+    runs-on: [self-hosted, linux, x64]
     permissions:
       contents: write
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Build artifacts
 target/
 
-# PHP SDK (built by cargo xtask via static-php-cli)
-/php-sdk/
+# PHP SDK (built by cargo xtask via static-php-cli, or downloaded tarballs)
+/php-sdk/*
+!/php-sdk/.gitkeep
 
 # sqld binary cache (downloaded by cargo xtask release)
 /sqld-cache/

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -20,8 +20,8 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
@@ -96,9 +96,7 @@ impl ClusteredStore {
     /// events for hot-key version changes so local caches are
     /// invalidated promptly.
     pub async fn init_hot_key_watcher(self: &Arc<Self>) {
-        if !self.config.hot_key_cache
-            || self.subscribed.swap(true, Ordering::SeqCst)
-        {
+        if !self.config.hot_key_cache || self.subscribed.swap(true, Ordering::SeqCst) {
             return;
         }
 
@@ -120,8 +118,7 @@ impl ClusteredStore {
                         let mem = entry.data.len() + entry.key.len() + 64;
                         drop(entry);
                         this.hot_cache.remove(&key_hash);
-                        this.hot_cache_mem
-                            .fetch_sub(mem as u64, Ordering::Relaxed);
+                        this.hot_cache_mem.fetch_sub(mem as u64, Ordering::Relaxed);
                         tracing::debug!(
                             key_hash,
                             old_version = new_version - 1,
@@ -158,8 +155,7 @@ impl ClusteredStore {
                 let mem = cached.data.len() + cached.key.len() + 64;
                 drop(cached);
                 self.hot_cache.remove(&key_hash);
-                self.hot_cache_mem
-                    .fetch_sub(mem as u64, Ordering::Relaxed);
+                self.hot_cache_mem.fetch_sub(mem as u64, Ordering::Relaxed);
             }
         }
 
@@ -186,12 +182,7 @@ impl ClusteredStore {
     ///
     /// Returns `true` on success, `false` if the local store rejected the
     /// write (e.g., memory limit with `NoEviction` policy).
-    pub async fn set(
-        &self,
-        key: String,
-        value: Vec<u8>,
-        ttl: Option<Duration>,
-    ) -> bool {
+    pub async fn set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
         if value.len() <= self.config.small_key_threshold {
             // Gossip tier: replicate to all nodes.
             self.cluster.gossip_set(&key, &value, ttl).await;
@@ -205,12 +196,8 @@ impl ClusteredStore {
             true
         } else {
             // Large value — route to the owner node via TCP data plane.
-            let ok = if let Some(owner_addr) =
-                self.resolve_owner_data_addr(&key).await
-            {
-                match crate::kv_data_plane::store_remote(owner_addr, &key, &value)
-                    .await
-                {
+            let ok = if let Some(owner_addr) = self.resolve_owner_data_addr(&key).await {
+                match crate::kv_data_plane::store_remote(owner_addr, &key, &value).await {
                     Ok(accepted) => accepted,
                     Err(e) => {
                         tracing::warn!(
@@ -249,8 +236,7 @@ impl ClusteredStore {
             let key_hash = hash_key(key);
             if let Some((_, entry)) = self.hot_cache.remove(&key_hash) {
                 let mem = entry.data.len() + entry.key.len() + 64;
-                self.hot_cache_mem
-                    .fetch_sub(mem as u64, Ordering::Relaxed);
+                self.hot_cache_mem.fetch_sub(mem as u64, Ordering::Relaxed);
             }
         }
 
@@ -297,10 +283,7 @@ impl ClusteredStore {
     /// (already checked local store) or no remote nodes are alive.
     async fn resolve_owner_data_addr(&self, key: &str) -> Option<SocketAddr> {
         let nodes = self.cluster.nodes().await;
-        let alive: Vec<_> = nodes
-            .iter()
-            .filter(|n| n.state == crate::NodeState::Alive)
-            .collect();
+        let alive: Vec<_> = nodes.iter().filter(|n| n.state == crate::NodeState::Alive).collect();
 
         if alive.len() <= 1 {
             return None; // Only this node is alive.
@@ -343,10 +326,7 @@ impl ClusteredStore {
             let mut counter = self
                 .hit_counters
                 .entry(key_hash)
-                .or_insert_with(|| HitCounter {
-                    count: 0,
-                    window_start: now,
-                });
+                .or_insert_with(|| HitCounter { count: 0, window_start: now });
 
             // Reset window if expired.
             if counter.window_start.elapsed() > window {
@@ -392,18 +372,11 @@ impl ClusteredStore {
         // Adjust memory accounting.
         if let Some(old_entry) = old {
             let old_mem = (old_entry.data.len() + old_entry.key.len() + 64) as u64;
-            self.hot_cache_mem
-                .fetch_sub(old_mem, Ordering::Relaxed);
+            self.hot_cache_mem.fetch_sub(old_mem, Ordering::Relaxed);
         }
-        self.hot_cache_mem
-            .fetch_add(entry_mem, Ordering::Relaxed);
+        self.hot_cache_mem.fetch_add(entry_mem, Ordering::Relaxed);
 
-        tracing::debug!(
-            key,
-            key_hash,
-            value_len = value.len(),
-            "promoted to hot key cache",
-        );
+        tracing::debug!(key, key_hash, value_len = value.len(), "promoted to hot key cache",);
     }
 
     /// If a key is tracked as hot, bump its version in chitchat so
@@ -412,8 +385,8 @@ impl ClusteredStore {
         let key_hash = hash_key(key);
         // Only bump if we've seen this key in the hit counters (it's hot
         // somewhere) or it's in our own hot cache.
-        let is_tracked = self.hit_counters.contains_key(&key_hash)
-            || self.hot_cache.contains_key(&key_hash);
+        let is_tracked =
+            self.hit_counters.contains_key(&key_hash) || self.hot_cache.contains_key(&key_hash);
         if !is_tracked {
             return;
         }
@@ -437,12 +410,7 @@ impl ClusteredStore {
             )
             .await;
 
-        tracing::debug!(
-            key,
-            key_hash,
-            new_version,
-            "bumped hot key version via gossip",
-        );
+        tracing::debug!(key, key_hash, new_version, "bumped hot key version via gossip",);
     }
 
     /// Periodic maintenance: evict expired hot cache entries and stale
@@ -455,8 +423,7 @@ impl ClusteredStore {
         self.hot_cache.retain(|_, entry| {
             if entry.cached_at.elapsed() >= ttl {
                 let mem = (entry.data.len() + entry.key.len() + 64) as u64;
-                self.hot_cache_mem
-                    .fetch_sub(mem, Ordering::Relaxed);
+                self.hot_cache_mem.fetch_sub(mem, Ordering::Relaxed);
                 false
             } else {
                 true
@@ -464,8 +431,7 @@ impl ClusteredStore {
         });
 
         // Evict stale hit counters (windows that have expired).
-        self.hit_counters
-            .retain(|_, counter| counter.window_start.elapsed() < window * 2);
+        self.hit_counters.retain(|_, counter| counter.window_start.elapsed() < window * 2);
     }
 
     /// Current hot cache memory usage in bytes.
@@ -518,13 +484,10 @@ fn hash_key(key: &str) -> u64 {
 /// Returns an error for unrecognized unit suffixes.
 fn parse_memory_size(s: &str) -> Result<u64, ParseMemoryError> {
     let s = s.trim();
-    let (num, unit) = s
-        .find(|c: char| !c.is_ascii_digit() && c != '.')
-        .map_or((s, ""), |i| s.split_at(i));
+    let (num, unit) =
+        s.find(|c: char| !c.is_ascii_digit() && c != '.').map_or((s, ""), |i| s.split_at(i));
 
-    let base: f64 = num
-        .parse()
-        .map_err(|_| ParseMemoryError::InvalidNumber(s.to_string()))?;
+    let base: f64 = num.parse().map_err(|_| ParseMemoryError::InvalidNumber(s.to_string()))?;
 
     let multiplier = match unit.trim().to_uppercase().as_str() {
         "B" | "" => 1.0,

--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -95,15 +95,13 @@ async fn handle_connection(mut stream: TcpStream, store: &Store) -> anyhow::Resu
     // Read key bytes.
     let mut key_buf = vec![0u8; key_len as usize];
     stream.read_exact(&mut key_buf).await?;
-    let key = String::from_utf8(key_buf)
-        .map_err(|_| anyhow::anyhow!("invalid UTF-8 key"))?;
+    let key = String::from_utf8(key_buf).map_err(|_| anyhow::anyhow!("invalid UTF-8 key"))?;
 
     match op {
         OP_GET => {
             // Look up in local store and write response.
             if let Some(value) = store.get(&key) {
-                let len = u32::try_from(value.len())
-                    .unwrap_or(NOT_FOUND_SENTINEL - 1);
+                let len = u32::try_from(value.len()).unwrap_or(NOT_FOUND_SENTINEL - 1);
                 stream.write_u32(len).await?;
                 stream.write_all(&value).await?;
             } else {
@@ -145,8 +143,7 @@ pub async fn fetch_remote(addr: SocketAddr, key: &str) -> anyhow::Result<Option<
     // Send GET op + key.
     stream.write_u8(OP_GET).await?;
     let key_bytes = key.as_bytes();
-    let key_len = u32::try_from(key_bytes.len())
-        .map_err(|_| anyhow::anyhow!("key too long"))?;
+    let key_len = u32::try_from(key_bytes.len()).map_err(|_| anyhow::anyhow!("key too long"))?;
     stream.write_u32(key_len).await?;
     stream.write_all(key_bytes).await?;
     stream.flush().await?;
@@ -177,8 +174,7 @@ pub async fn store_remote(addr: SocketAddr, key: &str, value: &[u8]) -> anyhow::
     // Send SET op + key + value.
     stream.write_u8(OP_SET).await?;
     let key_bytes = key.as_bytes();
-    let key_len = u32::try_from(key_bytes.len())
-        .map_err(|_| anyhow::anyhow!("key too long"))?;
+    let key_len = u32::try_from(key_bytes.len()).map_err(|_| anyhow::anyhow!("key too long"))?;
     stream.write_u32(key_len).await?;
     stream.write_all(key_bytes).await?;
     let value_len = u32::try_from(value.len())
@@ -286,9 +282,7 @@ mod tests {
         let mut handles = Vec::new();
         for i in 0..10 {
             let key = format!("k{i}");
-            handles.push(tokio::spawn(async move {
-                fetch_remote(addr, &key).await
-            }));
+            handles.push(tokio::spawn(async move { fetch_remote(addr, &key).await }));
         }
 
         for (i, handle) in handles.into_iter().enumerate() {

--- a/crates/ephpm-cluster/src/lib.rs
+++ b/crates/ephpm-cluster/src/lib.rs
@@ -21,5 +21,5 @@ pub mod sqlite_election;
 
 pub use clustered_store::ClusteredStore;
 pub use kv_data_plane as data_plane;
-pub use node::{start_gossip, ClusterHandle, NodeInfo, NodeState};
+pub use node::{ClusterHandle, NodeInfo, NodeState, start_gossip};
 pub use sqlite_election::{ElectedRole, SqliteElection};

--- a/crates/ephpm-cluster/src/node.rs
+++ b/crates/ephpm-cluster/src/node.rs
@@ -9,9 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use chitchat::transport::UdpTransport;
-use chitchat::{
-    ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, spawn_chitchat,
-};
+use chitchat::{ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, spawn_chitchat};
 use ephpm_config::ClusterConfig;
 
 /// Information about a single cluster node.
@@ -84,12 +82,8 @@ impl ClusterHandle {
         }
 
         // Include self if not already in live/dead sets (always alive).
-        let self_in_live = live_ids
-            .iter()
-            .any(|id| id.node_id == self.self_id);
-        let self_in_dead = dead_ids
-            .iter()
-            .any(|id| id.node_id == self.self_id);
+        let self_in_live = live_ids.iter().any(|id| id.node_id == self.self_id);
+        let self_in_dead = dead_ids.iter().any(|id| id.node_id == self.self_id);
         if !self_in_live && !self_in_dead {
             nodes.push(NodeInfo {
                 id: self.self_id.clone(),
@@ -145,11 +139,8 @@ impl ClusterHandle {
 ///
 /// Panics if the system clock is before the UNIX epoch.
 pub async fn start_gossip(config: &ClusterConfig) -> anyhow::Result<ClusterHandle> {
-    let node_id = if config.node_id.is_empty() {
-        generate_node_id()
-    } else {
-        config.node_id.clone()
-    };
+    let node_id =
+        if config.node_id.is_empty() { generate_node_id() } else { config.node_id.clone() };
 
     let listen_addr: SocketAddr = config
         .bind
@@ -197,9 +188,7 @@ pub async fn start_gossip(config: &ClusterConfig) -> anyhow::Result<ClusterHandl
 
 /// Generate a unique node ID from the hostname and a random suffix.
 fn generate_node_id() -> String {
-    let hostname = std::env::var("HOSTNAME")
-        .ok()
-        .unwrap_or_else(|| "unknown".to_string());
+    let hostname = std::env::var("HOSTNAME").ok().unwrap_or_else(|| "unknown".to_string());
 
     let suffix: u32 = rand_suffix();
     format!("{hostname}-{suffix:08x}")

--- a/crates/ephpm-cluster/src/sqlite_election.rs
+++ b/crates/ephpm-cluster/src/sqlite_election.rs
@@ -51,10 +51,7 @@ impl PrimaryClaim {
     fn decode(bytes: &[u8]) -> Option<Self> {
         let s = std::str::from_utf8(bytes).ok()?;
         let (node_id, grpc_addr) = s.split_once('|')?;
-        Some(Self {
-            node_id: node_id.to_string(),
-            grpc_addr: grpc_addr.to_string(),
-        })
+        Some(Self { node_id: node_id.to_string(), grpc_addr: grpc_addr.to_string() })
     }
 }
 
@@ -77,16 +74,10 @@ impl SqliteElection {
     #[must_use]
     pub fn new(cluster: Arc<ClusterHandle>, grpc_listen: String) -> Self {
         // Start as replica with empty URL — will be resolved on first tick.
-        let (role_tx, role_rx) = watch::channel(ElectedRole::Replica {
-            primary_grpc_url: String::new(),
-        });
+        let (role_tx, role_rx) =
+            watch::channel(ElectedRole::Replica { primary_grpc_url: String::new() });
 
-        Self {
-            cluster,
-            grpc_listen,
-            role_tx,
-            role_rx,
-        }
+        Self { cluster, grpc_listen, role_tx, role_rx }
     }
 
     /// Get a receiver for role changes.
@@ -118,9 +109,7 @@ impl SqliteElection {
             ElectedRole::Primary
         } else {
             // No primary yet and we're not lowest ordinal — wait.
-            ElectedRole::Replica {
-                primary_grpc_url: String::new(),
-            }
+            ElectedRole::Replica { primary_grpc_url: String::new() }
         }
     }
 
@@ -165,9 +154,8 @@ impl SqliteElection {
 
                 // Someone else claims primary — check if they're alive.
                 let nodes = self.cluster.nodes().await;
-                let primary_alive = nodes
-                    .iter()
-                    .any(|n| n.id == claim.node_id && n.state == NodeState::Alive);
+                let primary_alive =
+                    nodes.iter().any(|n| n.id == claim.node_id && n.state == NodeState::Alive);
 
                 if primary_alive {
                     return ElectedRole::Replica {
@@ -193,9 +181,7 @@ impl SqliteElection {
             ElectedRole::Primary
         } else {
             // Not our turn — wait for the rightful primary to claim.
-            ElectedRole::Replica {
-                primary_grpc_url: String::new(),
-            }
+            ElectedRole::Replica { primary_grpc_url: String::new() }
         }
     }
 
@@ -204,10 +190,8 @@ impl SqliteElection {
         let self_id = &self.cluster.self_node().id;
         let nodes = self.cluster.nodes().await;
 
-        let lowest_alive = nodes
-            .iter()
-            .filter(|n| n.state == NodeState::Alive)
-            .min_by(|a, b| a.id.cmp(&b.id));
+        let lowest_alive =
+            nodes.iter().filter(|n| n.state == NodeState::Alive).min_by(|a, b| a.id.cmp(&b.id));
 
         lowest_alive.is_some_and(|n| &n.id == self_id)
     }
@@ -218,9 +202,7 @@ impl SqliteElection {
             node_id: self.cluster.self_node().id.clone(),
             grpc_addr: self.grpc_listen.clone(),
         };
-        self.cluster
-            .gossip_set(PRIMARY_KEY, &claim.encode(), Some(PRIMARY_TTL))
-            .await;
+        self.cluster.gossip_set(PRIMARY_KEY, &claim.encode(), Some(PRIMARY_TTL)).await;
     }
 }
 
@@ -230,10 +212,7 @@ mod tests {
 
     #[test]
     fn primary_claim_roundtrip() {
-        let claim = PrimaryClaim {
-            node_id: "ephpm-0".into(),
-            grpc_addr: "10.0.1.2:5001".into(),
-        };
+        let claim = PrimaryClaim { node_id: "ephpm-0".into(), grpc_addr: "10.0.1.2:5001".into() };
         let encoded = claim.encode();
         let decoded = PrimaryClaim::decode(&encoded).unwrap();
         assert_eq!(decoded.node_id, "ephpm-0");
@@ -248,15 +227,9 @@ mod tests {
 
     #[test]
     fn primary_claim_encode_format() {
-        let claim = PrimaryClaim {
-            node_id: "node-1".into(),
-            grpc_addr: "0.0.0.0:5001".into(),
-        };
+        let claim = PrimaryClaim { node_id: "node-1".into(), grpc_addr: "0.0.0.0:5001".into() };
         let bytes = claim.encode();
-        assert_eq!(
-            std::str::from_utf8(&bytes).unwrap(),
-            "node-1|0.0.0.0:5001"
-        );
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "node-1|0.0.0.0:5001");
     }
 
     #[test]
@@ -264,38 +237,25 @@ mod tests {
         assert_eq!(ElectedRole::Primary, ElectedRole::Primary);
         assert_ne!(
             ElectedRole::Primary,
-            ElectedRole::Replica {
-                primary_grpc_url: "http://x:5001".into(),
-            }
+            ElectedRole::Replica { primary_grpc_url: "http://x:5001".into() }
         );
         assert_eq!(
-            ElectedRole::Replica {
-                primary_grpc_url: "http://x:5001".into(),
-            },
-            ElectedRole::Replica {
-                primary_grpc_url: "http://x:5001".into(),
-            }
+            ElectedRole::Replica { primary_grpc_url: "http://x:5001".into() },
+            ElectedRole::Replica { primary_grpc_url: "http://x:5001".into() }
         );
     }
 
     #[test]
     fn elected_role_different_replicas_not_equal() {
         assert_ne!(
-            ElectedRole::Replica {
-                primary_grpc_url: "http://a:5001".into(),
-            },
-            ElectedRole::Replica {
-                primary_grpc_url: "http://b:5001".into(),
-            }
+            ElectedRole::Replica { primary_grpc_url: "http://a:5001".into() },
+            ElectedRole::Replica { primary_grpc_url: "http://b:5001".into() }
         );
     }
 
     #[test]
     fn primary_claim_with_ipv6() {
-        let claim = PrimaryClaim {
-            node_id: "node-v6".into(),
-            grpc_addr: "[::1]:5001".into(),
-        };
+        let claim = PrimaryClaim { node_id: "node-v6".into(), grpc_addr: "[::1]:5001".into() };
         let encoded = claim.encode();
         let decoded = PrimaryClaim::decode(&encoded).unwrap();
         assert_eq!(decoded.node_id, "node-v6");
@@ -313,12 +273,8 @@ mod tests {
     #[test]
     fn primary_claim_with_long_node_id() {
         let long_id = "ephpm-".to_string() + &"x".repeat(200);
-        let claim = PrimaryClaim {
-            node_id: long_id.clone(),
-            grpc_addr: "10.0.1.2:5001".into(),
-        };
-        let roundtripped =
-            PrimaryClaim::decode(&claim.encode()).unwrap();
+        let claim = PrimaryClaim { node_id: long_id.clone(), grpc_addr: "10.0.1.2:5001".into() };
+        let roundtripped = PrimaryClaim::decode(&claim.encode()).unwrap();
         assert_eq!(roundtripped.node_id, long_id);
     }
 
@@ -334,11 +290,8 @@ mod tests {
             ("ephpm-d", true),
         ];
 
-        let lowest_alive = nodes
-            .iter()
-            .filter(|(_, alive)| *alive)
-            .min_by(|a, b| a.0.cmp(b.0))
-            .map(|(id, _)| *id);
+        let lowest_alive =
+            nodes.iter().filter(|(_, alive)| *alive).min_by(|a, b| a.0.cmp(b.0)).map(|(id, _)| *id);
 
         assert_eq!(lowest_alive, Some("ephpm-a"));
     }
@@ -352,11 +305,8 @@ mod tests {
             ("ephpm-c", true),
         ];
 
-        let lowest_alive = nodes
-            .iter()
-            .filter(|(_, alive)| *alive)
-            .min_by(|a, b| a.0.cmp(b.0))
-            .map(|(id, _)| *id);
+        let lowest_alive =
+            nodes.iter().filter(|(_, alive)| *alive).min_by(|a, b| a.0.cmp(b.0)).map(|(id, _)| *id);
 
         assert_eq!(lowest_alive, Some("ephpm-b"));
     }

--- a/crates/ephpm-cluster/tests/clustered_store.rs
+++ b/crates/ephpm-cluster/tests/clustered_store.rs
@@ -3,16 +3,14 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use ephpm_cluster::node::{start_gossip, ClusterHandle, NodeState};
 use ephpm_cluster::ClusteredStore;
+use ephpm_cluster::node::{ClusterHandle, NodeState, start_gossip};
 use ephpm_config::{ClusterConfig, ClusterKvConfig};
 use ephpm_kv::store::{Store, StoreConfig};
 
 /// Allocate a random UDP port by binding to :0 and immediately closing.
 async fn random_udp_port() -> u16 {
-    let sock = tokio::net::UdpSocket::bind("127.0.0.1:0")
-        .await
-        .expect("bind failed");
+    let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.expect("bind failed");
     sock.local_addr().expect("local_addr failed").port()
 }
 
@@ -27,9 +25,7 @@ async fn start_node(port: u16, seeds: Vec<String>, node_id: &str) -> ClusterHand
         cluster_id: "test-cluster".to_string(),
         kv: ClusterKvConfig::default(),
     };
-    start_gossip(&config)
-        .await
-        .unwrap_or_else(|e| panic!("gossip start failed for {node_id}: {e}"))
+    start_gossip(&config).await.unwrap_or_else(|e| panic!("gossip start failed for {node_id}: {e}"))
 }
 
 /// Create a local KV store with defaults.
@@ -51,12 +47,7 @@ async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeo
     loop {
         let mut all_ok = true;
         for h in handles {
-            let alive = h
-                .nodes()
-                .await
-                .iter()
-                .filter(|n| n.state == NodeState::Alive)
-                .count();
+            let alive = h.nodes().await.iter().filter(|n| n.state == NodeState::Alive).count();
             if alive != expected {
                 all_ok = false;
                 break;
@@ -65,10 +56,7 @@ async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeo
         if all_ok {
             return;
         }
-        assert!(
-            start.elapsed() <= timeout,
-            "convergence timeout after {timeout:?}",
-        );
+        assert!(start.elapsed() <= timeout, "convergence timeout after {timeout:?}",);
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 }
@@ -82,10 +70,7 @@ async fn small_value_routes_via_gossip() {
     let port = random_udp_port().await;
     let handle = Arc::new(start_node(port, vec![], "route-small").await);
     let store = local_store();
-    let config = ClusterKvConfig {
-        small_key_threshold: 64,
-        ..ClusterKvConfig::default()
-    };
+    let config = ClusterKvConfig { small_key_threshold: 64, ..ClusterKvConfig::default() };
 
     let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
 
@@ -112,10 +97,7 @@ async fn large_value_routes_to_local_store() {
     let port = random_udp_port().await;
     let handle = Arc::new(start_node(port, vec![], "route-large").await);
     let store = local_store();
-    let config = ClusterKvConfig {
-        small_key_threshold: 8,
-        ..ClusterKvConfig::default()
-    };
+    let config = ClusterKvConfig { small_key_threshold: 8, ..ClusterKvConfig::default() };
 
     let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
 
@@ -151,8 +133,7 @@ async fn small_value_replicates_via_clustered_store() {
     let cs2 = ClusteredStore::new(local_store(), Arc::clone(&h2), ClusterKvConfig::default());
 
     // Set on node1's clustered store.
-    cs1.set("replicated".to_string(), b"data".to_vec(), None)
-        .await;
+    cs1.set("replicated".to_string(), b"data".to_vec(), None).await;
 
     // Wait for node2 to see it via gossip.
     let start = Instant::now();
@@ -161,10 +142,7 @@ async fn small_value_replicates_via_clustered_store() {
             assert_eq!(val, b"data");
             break;
         }
-        assert!(
-            start.elapsed() <= Duration::from_secs(10),
-            "replication timeout",
-        );
+        assert!(start.elapsed() <= Duration::from_secs(10), "replication timeout",);
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
@@ -179,10 +157,7 @@ async fn exists_checks_both_tiers() {
     let port = random_udp_port().await;
     let handle = Arc::new(start_node(port, vec![], "exists-test").await);
     let store = local_store();
-    let config = ClusterKvConfig {
-        small_key_threshold: 16,
-        ..ClusterKvConfig::default()
-    };
+    let config = ClusterKvConfig { small_key_threshold: 16, ..ClusterKvConfig::default() };
 
     let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
 
@@ -204,10 +179,7 @@ async fn remove_from_both_tiers() {
     let port = random_udp_port().await;
     let handle = Arc::new(start_node(port, vec![], "rm-test").await);
     let store = local_store();
-    let config = ClusterKvConfig {
-        small_key_threshold: 16,
-        ..ClusterKvConfig::default()
-    };
+    let config = ClusterKvConfig { small_key_threshold: 16, ..ClusterKvConfig::default() };
 
     let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
 
@@ -384,20 +356,12 @@ async fn pttl_gossip_tier_key() {
     let port = random_udp_port().await;
     let handle = Arc::new(start_node(port, vec![], "pttl-gossip").await);
     let store = local_store();
-    let config = ClusterKvConfig {
-        small_key_threshold: 64,
-        ..ClusterKvConfig::default()
-    };
+    let config = ClusterKvConfig { small_key_threshold: 64, ..ClusterKvConfig::default() };
 
     let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
 
     // Small key with TTL → gossip tier
-    cs.set(
-        "tiny-ttl".to_string(),
-        b"val".to_vec(),
-        Some(Duration::from_secs(60)),
-    )
-    .await;
+    cs.set("tiny-ttl".to_string(), b"val".to_vec(), Some(Duration::from_secs(60))).await;
 
     let pttl = cs.pttl("tiny-ttl").await;
     assert!(pttl.is_some(), "gossip key with TTL should have pttl");
@@ -413,17 +377,13 @@ async fn pttl_local_store_key() {
     let port = random_udp_port().await;
     let handle = Arc::new(start_node(port, vec![], "pttl-local").await);
     let store = local_store();
-    let config = ClusterKvConfig {
-        small_key_threshold: 8,
-        ..ClusterKvConfig::default()
-    };
+    let config = ClusterKvConfig { small_key_threshold: 8, ..ClusterKvConfig::default() };
 
     let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
 
     // Large key with TTL → local store
     let big = vec![0u8; 100];
-    cs.set("big-ttl".to_string(), big, Some(Duration::from_secs(120)))
-        .await;
+    cs.set("big-ttl".to_string(), big, Some(Duration::from_secs(120))).await;
 
     let pttl = cs.pttl("big-ttl").await;
     assert!(pttl.is_some(), "local key with TTL should have pttl");
@@ -440,11 +400,8 @@ async fn pttl_missing_key_returns_none() {
     let handle = Arc::new(start_node(port, vec![], "pttl-miss").await);
     let store = local_store();
 
-    let cs = ClusteredStore::new(
-        Arc::clone(&store),
-        Arc::clone(&handle),
-        ClusterKvConfig::default(),
-    );
+    let cs =
+        ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
 
     // pttl for non-existent key should return None (or -2 via local store).
     // The ClusteredStore checks gossip first (returns None), then local store.
@@ -469,7 +426,8 @@ async fn local_store_accessor_returns_correct_store() {
     let handle = Arc::new(start_node(port, vec![], "accessor").await);
     let store = local_store();
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
+    let cs =
+        ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
 
     // Write directly to local store, verify via accessor.
     store.set("direct".to_string(), b"value".to_vec(), None);
@@ -485,7 +443,8 @@ async fn set_returns_true_on_success() {
     let handle = Arc::new(start_node(port, vec![], "set-ok").await);
     let store = local_store();
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
+    let cs =
+        ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
 
     // Both small and large values should succeed.
     let small_ok = cs.set("s".to_string(), b"x".to_vec(), None).await;

--- a/crates/ephpm-cluster/tests/gossip.rs
+++ b/crates/ephpm-cluster/tests/gossip.rs
@@ -5,7 +5,7 @@
 
 use std::time::{Duration, Instant};
 
-use ephpm_cluster::node::{start_gossip, ClusterHandle, NodeState};
+use ephpm_cluster::node::{ClusterHandle, NodeState, start_gossip};
 use ephpm_config::{ClusterConfig, ClusterKvConfig};
 
 /// Allocate a random UDP port by binding to :0 and immediately closing.
@@ -13,9 +13,7 @@ async fn random_udp_port() -> u16 {
     let sock = tokio::net::UdpSocket::bind("127.0.0.1:0")
         .await
         .expect("failed to bind UDP socket for port allocation");
-    sock.local_addr()
-        .expect("failed to get local addr")
-        .port()
+    sock.local_addr().expect("failed to get local addr").port()
 }
 
 /// Start a gossip node on the given port with the given seeds.
@@ -35,20 +33,13 @@ async fn start_node(port: u16, seeds: Vec<String>, node_id: &str) -> ClusterHand
 }
 
 /// Poll until all handles see `expected` alive nodes, or panic after `timeout`.
-async fn wait_for_convergence(
-    handles: &[&ClusterHandle],
-    expected: usize,
-    timeout: Duration,
-) {
+async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeout: Duration) {
     let start = Instant::now();
     loop {
         let mut all_converged = true;
         for handle in handles {
             let nodes = handle.nodes().await;
-            let alive_count = nodes
-                .iter()
-                .filter(|n| n.state == NodeState::Alive)
-                .count();
+            let alive_count = nodes.iter().filter(|n| n.state == NodeState::Alive).count();
             if alive_count != expected {
                 all_converged = false;
                 break;
@@ -68,9 +59,7 @@ async fn wait_for_convergence(
                     nodes,
                 );
             }
-            panic!(
-                "gossip did not converge to {expected} alive nodes within {timeout:?}"
-            );
+            panic!("gossip did not converge to {expected} alive nodes within {timeout:?}");
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
@@ -108,22 +97,12 @@ async fn three_nodes_discover_each_other() {
     let node3 = start_node(port3, vec![seed], "node-3").await;
 
     // Wait for all three to see each other.
-    wait_for_convergence(
-        &[&node1, &node2, &node3],
-        3,
-        Duration::from_secs(10),
-    )
-    .await;
+    wait_for_convergence(&[&node1, &node2, &node3], 3, Duration::from_secs(10)).await;
 
     // Verify all nodes are alive.
     for handle in [&node1, &node2, &node3] {
         let members = handle.nodes().await;
-        assert_eq!(
-            members.len(),
-            3,
-            "{} sees wrong count: {members:?}",
-            handle.self_node().id,
-        );
+        assert_eq!(members.len(), 3, "{} sees wrong count: {members:?}", handle.self_node().id,);
         assert!(
             members.iter().all(|n| n.state == NodeState::Alive),
             "all nodes should be alive: {members:?}",
@@ -209,8 +188,7 @@ async fn gossip_kv_ttl_expiry() {
     let node = start_node(port, vec![], "kv-ttl").await;
 
     // Set with a very short TTL.
-    node.gossip_set("ephemeral", b"data", Some(Duration::from_millis(200)))
-        .await;
+    node.gossip_set("ephemeral", b"data", Some(Duration::from_millis(200))).await;
 
     // Should be readable immediately.
     assert!(node.gossip_get("ephemeral").await.is_some());
@@ -301,10 +279,7 @@ async fn gossip_kv_delete_not_owned_returns_false() {
         if node2.gossip_get("owned-by-1").await.is_some() {
             break;
         }
-        assert!(
-            start.elapsed() <= Duration::from_secs(10),
-            "key did not replicate",
-        );
+        assert!(start.elapsed() <= Duration::from_secs(10), "key did not replicate",);
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
@@ -338,8 +313,7 @@ async fn gossip_kv_pttl_returns_remaining_ms() {
     let node = start_node(port, vec![], "pttl-test").await;
 
     // Key with TTL
-    node.gossip_set("ttl-key", b"val", Some(Duration::from_secs(60)))
-        .await;
+    node.gossip_set("ttl-key", b"val", Some(Duration::from_secs(60))).await;
     let pttl = node.gossip_pttl("ttl-key").await;
     assert!(pttl.is_some(), "TTL key should have pttl");
     let ms = pttl.unwrap();
@@ -347,16 +321,10 @@ async fn gossip_kv_pttl_returns_remaining_ms() {
 
     // Key without TTL
     node.gossip_set("no-ttl", b"val", None).await;
-    assert!(
-        node.gossip_pttl("no-ttl").await.is_none(),
-        "key without TTL should return None"
-    );
+    assert!(node.gossip_pttl("no-ttl").await.is_none(), "key without TTL should return None");
 
     // Missing key
-    assert!(
-        node.gossip_pttl("missing").await.is_none(),
-        "missing key should return None"
-    );
+    assert!(node.gossip_pttl("missing").await.is_none(), "missing key should return None");
 
     node.shutdown().await;
 }
@@ -388,10 +356,7 @@ async fn gossip_kv_exists_false_after_delete() {
     assert!(node.gossip_exists("ephemeral").await);
 
     node.gossip_del("ephemeral").await;
-    assert!(
-        !node.gossip_exists("ephemeral").await,
-        "deleted key should not exist"
-    );
+    assert!(!node.gossip_exists("ephemeral").await, "deleted key should not exist");
 
     node.shutdown().await;
 }

--- a/crates/ephpm-cluster/tests/gossip_formation.rs
+++ b/crates/ephpm-cluster/tests/gossip_formation.rs
@@ -6,7 +6,7 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use ephpm_cluster::{start_gossip, NodeState};
+use ephpm_cluster::{NodeState, start_gossip};
 use ephpm_config::ClusterConfig;
 
 /// Find a free UDP port by binding to port 0 and returning the address.
@@ -19,7 +19,12 @@ fn free_udp_addr() -> SocketAddr {
 }
 
 /// Helper: create a cluster config bound to a specific address on localhost.
-fn node_config(node_id: &str, cluster_id: &str, bind: SocketAddr, seeds: Vec<String>) -> ClusterConfig {
+fn node_config(
+    node_id: &str,
+    cluster_id: &str,
+    bind: SocketAddr,
+    seeds: Vec<String>,
+) -> ClusterConfig {
     ClusterConfig {
         enabled: true,
         bind: bind.to_string(),
@@ -78,10 +83,8 @@ async fn two_nodes_discover_each_other() {
 
     // Verify node-b also sees node-a.
     let nodes_from_b = handle2.nodes().await;
-    let alive_from_b: Vec<_> = nodes_from_b
-        .iter()
-        .filter(|n| n.state == NodeState::Alive)
-        .collect();
+    let alive_from_b: Vec<_> =
+        nodes_from_b.iter().filter(|n| n.state == NodeState::Alive).collect();
     assert!(
         alive_from_b.len() >= 2,
         "node-b should see at least 2 alive nodes, got {}",
@@ -113,9 +116,7 @@ async fn gossip_kv_propagates_between_nodes() {
     }
 
     // Set a KV entry on node-1.
-    handle1
-        .gossip_set("test-key", b"test-value", None)
-        .await;
+    handle1.gossip_set("test-key", b"test-value", None).await;
 
     // Wait for it to propagate to node-2.
     let mut found = false;
@@ -149,9 +150,7 @@ async fn gossip_kv_with_ttl() {
     let handle = start_gossip(&config).await.unwrap();
 
     // Set with a long TTL.
-    handle
-        .gossip_set("ttl-key", b"data", Some(Duration::from_secs(3600)))
-        .await;
+    handle.gossip_set("ttl-key", b"data", Some(Duration::from_secs(3600))).await;
 
     let value = handle.gossip_get("ttl-key").await;
     assert!(value.is_some(), "key with future TTL should be readable");
@@ -203,10 +202,7 @@ async fn node_departure_detected() {
             break;
         }
     }
-    assert!(
-        handle1.live_node_count().await >= 2,
-        "should have 2 live nodes before departure"
-    );
+    assert!(handle1.live_node_count().await >= 2, "should have 2 live nodes before departure");
 
     // Shut down the departing node.
     handle2.shutdown().await;

--- a/crates/ephpm-cluster/tests/stress.rs
+++ b/crates/ephpm-cluster/tests/stress.rs
@@ -9,7 +9,7 @@
 use std::fmt::Write;
 use std::time::{Duration, Instant};
 
-use ephpm_cluster::node::{start_gossip, ClusterHandle, NodeState};
+use ephpm_cluster::node::{ClusterHandle, NodeState, start_gossip};
 use ephpm_config::{ClusterConfig, ClusterKvConfig};
 
 /// Allocate a random UDP port by binding to :0 and immediately closing.
@@ -17,9 +17,7 @@ async fn random_udp_port() -> u16 {
     let sock = tokio::net::UdpSocket::bind("127.0.0.1:0")
         .await
         .expect("failed to bind UDP socket for port allocation");
-    sock.local_addr()
-        .expect("failed to get local addr")
-        .port()
+    sock.local_addr().expect("failed to get local addr").port()
 }
 
 /// Start a gossip node on the given port with the given seeds.
@@ -39,20 +37,13 @@ async fn start_node(port: u16, seeds: Vec<String>, node_id: &str) -> ClusterHand
 }
 
 /// Poll until all handles see `expected` alive nodes, or panic after `timeout`.
-async fn wait_for_convergence(
-    handles: &[&ClusterHandle],
-    expected: usize,
-    timeout: Duration,
-) {
+async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeout: Duration) {
     let start = Instant::now();
     loop {
         let mut all_converged = true;
         for handle in handles {
             let nodes = handle.nodes().await;
-            let alive_count = nodes
-                .iter()
-                .filter(|n| n.state == NodeState::Alive)
-                .count();
+            let alive_count = nodes.iter().filter(|n| n.state == NodeState::Alive).count();
             if alive_count != expected {
                 all_converged = false;
                 break;
@@ -65,10 +56,7 @@ async fn wait_for_convergence(
             // Print diagnostics before panicking.
             for (i, handle) in handles.iter().enumerate() {
                 let nodes = handle.nodes().await;
-                let alive = nodes
-                    .iter()
-                    .filter(|n| n.state == NodeState::Alive)
-                    .count();
+                let alive = nodes.iter().filter(|n| n.state == NodeState::Alive).count();
                 eprintln!(
                     "  node {i} ({}) sees {alive}/{} alive nodes: {:?}",
                     handle.self_node().id,
@@ -76,9 +64,7 @@ async fn wait_for_convergence(
                     nodes,
                 );
             }
-            panic!(
-                "gossip did not converge to {expected} alive nodes within {timeout:?}"
-            );
+            panic!("gossip did not converge to {expected} alive nodes within {timeout:?}");
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
@@ -102,11 +88,7 @@ async fn multi_node_convergence() {
     // node N seeds on node N-1.
     let mut handles = Vec::with_capacity(NODE_COUNT);
     for (i, &port) in ports.iter().enumerate() {
-        let seeds = if i == 0 {
-            vec![]
-        } else {
-            vec![format!("127.0.0.1:{}", ports[i - 1])]
-        };
+        let seeds = if i == 0 { vec![] } else { vec![format!("127.0.0.1:{}", ports[i - 1])] };
         let node_id = format!("stress-{i}");
         handles.push(start_node(port, seeds, &node_id).await);
     }
@@ -116,9 +98,7 @@ async fn multi_node_convergence() {
     wait_for_convergence(&refs, NODE_COUNT, TIMEOUT).await;
 
     // Verify each node sees exactly the right set of node IDs.
-    let mut expected_ids: Vec<String> = (0..NODE_COUNT)
-        .map(|i| format!("stress-{i}"))
-        .collect();
+    let mut expected_ids: Vec<String> = (0..NODE_COUNT).map(|i| format!("stress-{i}")).collect();
     expected_ids.sort();
 
     for handle in &handles {
@@ -137,11 +117,7 @@ async fn multi_node_convergence() {
         );
         let mut ids: Vec<String> = nodes.iter().map(|n| n.id.clone()).collect();
         ids.sort();
-        assert_eq!(
-            ids, expected_ids,
-            "{} sees wrong node IDs",
-            handle.self_node().id,
-        );
+        assert_eq!(ids, expected_ids, "{} sees wrong node IDs", handle.self_node().id,);
     }
 
     // Clean shutdown.
@@ -168,12 +144,7 @@ async fn node_failure_detection() {
     let node2 = start_node(port2, vec![seed], "fail-2").await;
 
     // Wait for all 3 to see each other.
-    wait_for_convergence(
-        &[&node0, &node1, &node2],
-        3,
-        TIMEOUT_CONVERGE,
-    )
-    .await;
+    wait_for_convergence(&[&node0, &node1, &node2], 3, TIMEOUT_CONVERGE).await;
 
     // Drop node2 — this shuts down its gossip listener, simulating a crash.
     drop(node2);
@@ -182,18 +153,8 @@ async fn node_failure_detection() {
     // from their live nodes list (either absent or marked Dead).
     let start = Instant::now();
     loop {
-        let n0_alive = node0
-            .nodes()
-            .await
-            .iter()
-            .filter(|n| n.state == NodeState::Alive)
-            .count();
-        let n1_alive = node1
-            .nodes()
-            .await
-            .iter()
-            .filter(|n| n.state == NodeState::Alive)
-            .count();
+        let n0_alive = node0.nodes().await.iter().filter(|n| n.state == NodeState::Alive).count();
+        let n1_alive = node1.nodes().await.iter().filter(|n| n.state == NodeState::Alive).count();
 
         // Both survivors should see exactly 2 alive nodes (themselves + the
         // other survivor). Node2 should be dead or gone.
@@ -306,15 +267,9 @@ async fn kv_replication() {
         for i in 0..KEY_COUNT {
             let key = format!("stress-key-{i:03}");
             let expected = format!("value-{i:03}");
-            let actual = handle
-                .gossip_get(&key)
-                .await
-                .unwrap_or_else(|| {
-                    panic!(
-                        "{} missing key {key} after replication",
-                        handle.self_node().id,
-                    )
-                });
+            let actual = handle.gossip_get(&key).await.unwrap_or_else(|| {
+                panic!("{} missing key {key} after replication", handle.self_node().id,)
+            });
             assert_eq!(
                 actual,
                 expected.as_bytes(),
@@ -335,11 +290,7 @@ async fn kv_replication() {
         );
         for i in 0..KEY_COUNT {
             let key = format!("stress-key-{i:03}");
-            assert!(
-                keys.contains(&key),
-                "{} gossip_keys() missing {key}",
-                handle.self_node().id,
-            );
+            assert!(keys.contains(&key), "{} gossip_keys() missing {key}", handle.self_node().id,);
         }
     }
 

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -389,10 +389,7 @@ pub struct MetricsConfig {
 
 impl Default for MetricsConfig {
     fn default() -> Self {
-        Self {
-            enabled: false,
-            path: default_metrics_path(),
-        }
+        Self { enabled: false, path: default_metrics_path() }
     }
 }
 
@@ -732,10 +729,7 @@ pub struct SqldConfig {
 
 impl Default for SqldConfig {
     fn default() -> Self {
-        Self {
-            http_listen: default_sqld_http_listen(),
-            grpc_listen: default_sqld_grpc_listen(),
-        }
+        Self { http_listen: default_sqld_http_listen(), grpc_listen: default_sqld_grpc_listen() }
     }
 }
 
@@ -761,10 +755,7 @@ pub struct ReplicationConfig {
 
 impl Default for ReplicationConfig {
     fn default() -> Self {
-        Self {
-            role: default_replication_role(),
-            primary_grpc_url: String::new(),
-        }
+        Self { role: default_replication_role(), primary_grpc_url: String::new() }
     }
 }
 
@@ -1085,12 +1076,7 @@ pub struct KvRedisCompatConfig {
 
 impl Default for KvRedisCompatConfig {
     fn default() -> Self {
-        Self {
-            enabled: false,
-            listen: default_kv_listen(),
-            socket: None,
-            password: None,
-        }
+        Self { enabled: false, listen: default_kv_listen(), socket: None, password: None }
     }
 }
 
@@ -1159,8 +1145,10 @@ impl Config {
     ///
     /// Returns `ConfigError::Load` if environment variables contain invalid values.
     pub fn default_config() -> Result<Self, ConfigError> {
-        let config =
-            Figment::new().merge(Env::prefixed("EPHPM_").split("__")).extract().map_err(Box::new)?;
+        let config = Figment::new()
+            .merge(Env::prefixed("EPHPM_").split("__"))
+            .extract()
+            .map_err(Box::new)?;
         Ok(config)
     }
 }
@@ -1230,13 +1218,9 @@ impl Default for StaticConfig {
     }
 }
 
-
 impl Default for LoggingConfig {
     fn default() -> Self {
-        Self {
-            access: String::new(),
-            level: default_log_level(),
-        }
+        Self { access: String::new(), level: default_log_level() }
     }
 }
 
@@ -1442,11 +1426,7 @@ fn default_index_files() -> Vec<String> {
 }
 
 fn default_fallback() -> Vec<String> {
-    vec![
-        "$uri".to_string(),
-        "$uri/".to_string(),
-        "/index.php?$query_string".to_string(),
-    ]
+    vec!["$uri".to_string(), "$uri/".to_string(), "/index.php?$query_string".to_string()]
 }
 
 fn default_max_body_size() -> u64 {
@@ -1722,10 +1702,7 @@ ini_overrides = [
         let config = Config::load(&file).unwrap();
         assert_eq!(config.php.ini_overrides.len(), 2);
         assert_eq!(config.php.ini_overrides[0], ["display_errors", "Off"]);
-        assert_eq!(
-            config.php.ini_overrides[1],
-            ["error_reporting", "E_ALL"]
-        );
+        assert_eq!(config.php.ini_overrides[1], ["error_reporting", "E_ALL"]);
     }
 
     #[test]
@@ -1989,10 +1966,7 @@ primary_grpc_url = "http://10.0.1.2:5001"
         assert_eq!(sqlite.sqld.http_listen, "127.0.0.1:9081");
         assert_eq!(sqlite.sqld.grpc_listen, "0.0.0.0:6001");
         assert_eq!(sqlite.replication.role, "replica");
-        assert_eq!(
-            sqlite.replication.primary_grpc_url,
-            "http://10.0.1.2:5001"
-        );
+        assert_eq!(sqlite.replication.primary_grpc_url, "http://10.0.1.2:5001");
     }
 
     #[test]
@@ -2014,14 +1988,10 @@ path = "test.db"
         )
         .unwrap();
 
-        temp_env::with_var(
-            "EPHPM_DB__SQLITE__REPLICATION__ROLE",
-            Some("primary"),
-            || {
-                let config = Config::load(&file).unwrap();
-                let sqlite = config.db.sqlite.expect("sqlite should be present");
-                assert_eq!(sqlite.replication.role, "primary");
-            },
-        );
+        temp_env::with_var("EPHPM_DB__SQLITE__REPLICATION__ROLE", Some("primary"), || {
+            let config = Config::load(&file).unwrap();
+            let sqlite = config.db.sqlite.expect("sqlite should be present");
+            assert_eq!(sqlite.replication.role, "primary");
+        });
     }
 }

--- a/crates/ephpm-db/src/lib.rs
+++ b/crates/ephpm-db/src/lib.rs
@@ -10,33 +10,33 @@ pub mod url;
 /// Strategy for resetting backend connections when returning to the pool.
 #[derive(Clone, Copy, Debug, Default)]
 pub enum ResetStrategy {
-	/// Always send `COM_RESET_CONNECTION` on return.
-	Always,
-	/// Never reset (fastest, use only in trusted dev environments).
-	Never,
-	/// Reset only when session may be dirty (tracks dirty bit per connection).
-	#[default]
-	Smart,
+    /// Always send `COM_RESET_CONNECTION` on return.
+    Always,
+    /// Never reset (fastest, use only in trusted dev environments).
+    Never,
+    /// Reset only when session may be dirty (tracks dirty bit per connection).
+    #[default]
+    Smart,
 }
 
 impl ResetStrategy {
-	/// Parse a reset strategy from a string (case-insensitive).
-	///
-	/// Returns [`ResetStrategy::Smart`] for unrecognised values.
-	#[must_use]
-	pub fn from_str_lossy(s: &str) -> Self {
-		match s.to_ascii_lowercase().as_str() {
-			"never" => Self::Never,
-			"always" => Self::Always,
-			_ => Self::Smart,
-		}
-	}
+    /// Parse a reset strategy from a string (case-insensitive).
+    ///
+    /// Returns [`ResetStrategy::Smart`] for unrecognised values.
+    #[must_use]
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "never" => Self::Never,
+            "always" => Self::Always,
+            _ => Self::Smart,
+        }
+    }
 }
 
 impl std::str::FromStr for ResetStrategy {
-	type Err = std::convert::Infallible;
+    type Err = std::convert::Infallible;
 
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Ok(Self::from_str_lossy(s))
-	}
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from_str_lossy(s))
+    }
 }

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -29,8 +29,8 @@
 //! path (RSA public key exchange over non-TLS connections).
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use sha1::{Digest as _, Sha1};
 use sha2::Sha256;
@@ -376,13 +376,8 @@ async fn connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, ServerMeta), D
                     let mut new_challenge = [0u8; 20];
                     let copy_len = switch_data.len().min(20);
                     new_challenge[..copy_len].copy_from_slice(&switch_data[..copy_len]);
-                    handle_caching_sha2(
-                        &mut stream,
-                        &url.password,
-                        &new_challenge,
-                        seq + 1,
-                    )
-                    .await?;
+                    handle_caching_sha2(&mut stream, &url.password, &new_challenge, seq + 1)
+                        .await?;
                 }
                 other => {
                     return Err(DbError::Auth(format!(
@@ -602,9 +597,7 @@ async fn handle_caching_sha2(
         Some(0x01) => {
             handle_caching_sha2_more_data(stream, password, challenge, &resp, next_seq).await
         }
-        _ => Err(DbError::Protocol(
-            "unexpected response during caching_sha2 auth".into(),
-        )),
+        _ => Err(DbError::Protocol("unexpected response during caching_sha2 auth".into())),
     }
 }
 
@@ -643,9 +636,7 @@ async fn handle_caching_sha2_more_data(
 
             if key_resp.first() == Some(&0xFF) {
                 let msg = parse_error_packet(&key_resp);
-                return Err(DbError::Auth(format!(
-                    "failed to get RSA public key: {msg}"
-                )));
+                return Err(DbError::Auth(format!("failed to get RSA public key: {msg}")));
             }
 
             // The response is the public key in PEM format (0x01 prefix + PEM data).
@@ -661,18 +652,16 @@ async fn handle_caching_sha2_more_data(
                 Some(0x00) => Ok(()),
                 Some(0xFF) => {
                     let msg = parse_error_packet(&final_resp);
-                    Err(DbError::Auth(format!(
-                        "caching_sha2 full auth error: {msg}"
-                    )))
+                    Err(DbError::Auth(format!("caching_sha2 full auth error: {msg}")))
                 }
                 _ => Err(DbError::Protocol(
                     "unexpected response after caching_sha2 full auth".into(),
                 )),
             }
         }
-        other => Err(DbError::Protocol(format!(
-            "unexpected caching_sha2 more-data flag: {other:#x}"
-        ))),
+        other => {
+            Err(DbError::Protocol(format!("unexpected caching_sha2 more-data flag: {other:#x}")))
+        }
     }
 }
 
@@ -1161,8 +1150,15 @@ async fn proxy_routing_loop(
             break;
         }
 
-        let (target_pool, query_kind) =
-            route_command(&payload, pool, replica_pools, &state, rw_split, &stmt_pool_map, replica_rr);
+        let (target_pool, query_kind) = route_command(
+            &payload,
+            pool,
+            replica_pools,
+            &state,
+            rw_split,
+            &stmt_pool_map,
+            replica_rr,
+        );
         track_dirty(&mut state, &payload, query_kind);
 
         // Acquire backend and forward the command.
@@ -1175,10 +1171,8 @@ async fn proxy_routing_loop(
                 PoolTarget::Primary
             } else {
                 // Find which replica index was selected.
-                let idx = replica_pools
-                    .iter()
-                    .position(|r| std::ptr::eq(target_pool, r))
-                    .unwrap_or(0);
+                let idx =
+                    replica_pools.iter().position(|r| std::ptr::eq(target_pool, r)).unwrap_or(0);
                 PoolTarget::Replica(idx)
             };
             if let Some(stmt_id) = forward_prepare_response(&mut backend, &mut client).await? {

--- a/crates/ephpm-db/src/pool.rs
+++ b/crates/ephpm-db/src/pool.rs
@@ -88,7 +88,10 @@ impl Pool {
         config: PoolConfig,
         connect: impl Fn() -> BoxFuture<Result<TcpStream, DbError>> + Send + Sync + 'static,
         reset: impl Fn(TcpStream) -> BoxFuture<Result<TcpStream, DbError>> + Send + Sync + 'static,
-        ping: impl Fn(TcpStream) -> BoxFuture<Result<(TcpStream, bool), DbError>> + Send + Sync + 'static,
+        ping: impl Fn(TcpStream) -> BoxFuture<Result<(TcpStream, bool), DbError>>
+        + Send
+        + Sync
+        + 'static,
     ) -> Self {
         let max = config.max_connections as usize;
         Self {
@@ -186,13 +189,13 @@ impl Pool {
     ///
     /// The caller must run the protocol-level reset (`COM_RESET_CONNECTION` /
     /// `DISCARD ALL`) before calling this. Pass the post-reset stream.
-    pub(crate) fn recycle(&self, stream: TcpStream, created_at: Instant, permit: OwnedSemaphorePermit) {
-        let slot = Slot {
-            stream,
-            created_at,
-            last_used: Instant::now(),
-            permit,
-        };
+    pub(crate) fn recycle(
+        &self,
+        stream: TcpStream,
+        created_at: Instant,
+        permit: OwnedSemaphorePermit,
+    ) {
+        let slot = Slot { stream, created_at, last_used: Instant::now(), permit };
         self.state.idle.lock().push_back(slot);
     }
 
@@ -348,9 +351,7 @@ impl Checkout {
     /// discarded and the pool slot is freed.
     pub async fn return_with_reset(mut self, stream: TcpStream) {
         if let Some(permit) = self.permit.take() {
-            self.pool
-                .recycle_with_reset(stream, self.created_at, permit)
-                .await;
+            self.pool.recycle_with_reset(stream, self.created_at, permit).await;
         }
     }
 

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -19,8 +19,8 @@
 //! Supports `trust`, `md5`, and `scram-sha-256` for backend authentication.
 //! Client-facing auth is always `AuthenticationOk` (loopback only).
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use base64ct::Encoding;
 use sha2::{Digest as _, Sha256};
@@ -28,10 +28,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, info, warn};
 
+use crate::ResetStrategy;
 use crate::error::DbError;
 use crate::pool::{Checkout, Pool, PoolConfig};
 use crate::url::DbUrl;
-use crate::ResetStrategy;
 
 // ── PG message tags ──────────────────────────────────────────────────────────
 //
@@ -146,9 +146,7 @@ impl PgProxy {
         let mut checkout = Checkout {
             stream: Some(probe_stream),
             permit: Some(
-                Arc::clone(&pool.semaphore)
-                    .try_acquire_owned()
-                    .map_err(|_| DbError::PoolClosed)?,
+                Arc::clone(&pool.semaphore).try_acquire_owned().map_err(|_| DbError::PoolClosed)?,
             ),
             created_at: std::time::Instant::now(),
             pool: pool.clone(),
@@ -253,9 +251,8 @@ impl PgProxy {
         send_ready_for_query(&mut client, b'I').await?;
 
         // Determine if we need query-level routing or just simple proxying.
-        let needs_routing =
-            matches!(self.reset_strategy, ResetStrategy::Smart)
-                || (self.rw_split.enabled && !self.replica_pools.is_empty());
+        let needs_routing = matches!(self.reset_strategy, ResetStrategy::Smart)
+            || (self.rw_split.enabled && !self.replica_pools.is_empty());
 
         if needs_routing {
             pg_proxy_routing_loop(
@@ -275,19 +272,17 @@ impl PgProxy {
             let result = pg_proxy_bidirectional(client, backend).await;
 
             match result {
-                Ok(backend) => {
-                    match self.reset_strategy {
-                        ResetStrategy::Never => {
-                            checkout.return_to_pool(backend);
-                        }
-                        ResetStrategy::Always => {
-                            checkout.return_with_reset(backend).await;
-                        }
-                        ResetStrategy::Smart => {
-                            unreachable!()
-                        }
+                Ok(backend) => match self.reset_strategy {
+                    ResetStrategy::Never => {
+                        checkout.return_to_pool(backend);
                     }
-                }
+                    ResetStrategy::Always => {
+                        checkout.return_with_reset(backend).await;
+                    }
+                    ResetStrategy::Smart => {
+                        unreachable!()
+                    }
+                },
                 Err(e) => {
                     debug!("proxy session error, discarding backend connection: {e}");
                     checkout.retire();
@@ -324,8 +319,8 @@ async fn pg_connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, PgServerMet
     startup.push(0);
 
     // The StartupMessage has no tag byte, just: [length: 4BE][payload].
-    let total_len = i32::try_from(4 + startup.len())
-        .expect("startup message too large for i32 length field");
+    let total_len =
+        i32::try_from(4 + startup.len()).expect("startup message too large for i32 length field");
     stream.write_all(&total_len.to_be_bytes()).await?;
     stream.write_all(&startup).await?;
 
@@ -347,12 +342,10 @@ async fn pg_connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, PgServerMet
             }
             MSG_BACKEND_KEY_DATA => {
                 if payload.len() >= 8 {
-                    process_id = i32::from_be_bytes([
-                        payload[0], payload[1], payload[2], payload[3],
-                    ]);
-                    secret_key = i32::from_be_bytes([
-                        payload[4], payload[5], payload[6], payload[7],
-                    ]);
+                    process_id =
+                        i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    secret_key =
+                        i32::from_be_bytes([payload[4], payload[5], payload[6], payload[7]]);
                 }
             }
             MSG_READY_FOR_QUERY => {
@@ -369,14 +362,7 @@ async fn pg_connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, PgServerMet
         }
     }
 
-    Ok((
-        stream,
-        PgServerMeta {
-            parameters,
-            process_id,
-            secret_key,
-        },
-    ))
+    Ok((stream, PgServerMeta { parameters, process_id, secret_key }))
 }
 
 /// Handle the backend authentication exchange.
@@ -394,17 +380,13 @@ async fn handle_backend_auth(
             return Err(DbError::Auth(format!("backend auth error: {msg}")));
         }
         if tag != MSG_AUTH {
-            return Err(DbError::Protocol(format!(
-                "expected auth request, got '{}'",
-                tag as char
-            )));
+            return Err(DbError::Protocol(format!("expected auth request, got '{}'", tag as char)));
         }
         if payload.len() < 4 {
             return Err(DbError::Protocol("auth message too short".into()));
         }
 
-        let auth_type =
-            i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+        let auth_type = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
 
         match auth_type {
             AUTH_OK => return Ok(()),
@@ -420,9 +402,7 @@ async fn handle_backend_auth(
                 // SCRAM-SHA-256 negotiation.
                 let mechanisms = parse_sasl_mechanisms(&payload[4..]);
                 if !mechanisms.iter().any(|m| m == "SCRAM-SHA-256") {
-                    return Err(DbError::Auth(
-                        "server requires unsupported SASL mechanism".into(),
-                    ));
+                    return Err(DbError::Auth("server requires unsupported SASL mechanism".into()));
                 }
                 scram_sha256_exchange(stream, username, password).await?;
             }
@@ -433,9 +413,7 @@ async fn handle_backend_auth(
                 ));
             }
             other => {
-                return Err(DbError::Auth(format!(
-                    "unsupported auth method: {other}"
-                )));
+                return Err(DbError::Auth(format!("unsupported auth method: {other}")));
             }
         }
     }
@@ -466,8 +444,8 @@ async fn scram_sha256_exchange(
     let msg_bytes = client_first.as_bytes();
     let mut sasl_init = Vec::with_capacity(mechanism.len() + 4 + msg_bytes.len());
     sasl_init.extend_from_slice(mechanism);
-    let msg_len = i32::try_from(msg_bytes.len())
-        .expect("SASL message too large for i32 length field");
+    let msg_len =
+        i32::try_from(msg_bytes.len()).expect("SASL message too large for i32 length field");
     sasl_init.extend_from_slice(&msg_len.to_be_bytes());
     sasl_init.extend_from_slice(msg_bytes);
 
@@ -484,9 +462,7 @@ async fn scram_sha256_exchange(
     }
     let auth_type = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
     if auth_type != AUTH_SASL_CONTINUE {
-        return Err(DbError::Protocol(format!(
-            "expected SASL continue (11), got {auth_type}"
-        )));
+        return Err(DbError::Protocol(format!("expected SASL continue (11), got {auth_type}")));
     }
     let server_first = String::from_utf8_lossy(&payload[4..]).to_string();
 
@@ -507,15 +483,11 @@ async fn scram_sha256_exchange(
     let stored_key = Sha256::digest(&client_key);
 
     let client_final_without_proof = format!("c=biws,r={server_nonce}");
-    let auth_message =
-        format!("{client_first_bare},{server_first},{client_final_without_proof}");
+    let auth_message = format!("{client_first_bare},{server_first},{client_final_without_proof}");
 
     let client_signature = hmac_sha256(&stored_key, auth_message.as_bytes());
-    let client_proof: Vec<u8> = client_key
-        .iter()
-        .zip(client_signature.iter())
-        .map(|(a, b)| a ^ b)
-        .collect();
+    let client_proof: Vec<u8> =
+        client_key.iter().zip(client_signature.iter()).map(|(a, b)| a ^ b).collect();
 
     let proof_b64 = base64ct::Base64::encode_string(&client_proof);
     let client_final = format!("{client_final_without_proof},p={proof_b64}");
@@ -533,9 +505,7 @@ async fn scram_sha256_exchange(
     }
     let auth_type = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
     if auth_type != AUTH_SASL_FINAL {
-        return Err(DbError::Protocol(format!(
-            "expected SASL final (12), got {auth_type}"
-        )));
+        return Err(DbError::Protocol(format!("expected SASL final (12), got {auth_type}")));
     }
     // We could verify the server signature here, but for a proxy it's not
     // strictly necessary — we trust the backend.
@@ -551,9 +521,7 @@ async fn scram_sha256_exchange(
     }
     let auth_type = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
     if auth_type != AUTH_OK {
-        return Err(DbError::Auth(format!(
-            "expected AUTH_OK after SCRAM, got {auth_type}"
-        )));
+        return Err(DbError::Auth(format!("expected AUTH_OK after SCRAM, got {auth_type}")));
     }
 
     Ok(())
@@ -592,8 +560,7 @@ fn parse_server_first(msg: &str) -> Result<(String, String, u32), DbError> {
     Ok((
         nonce.ok_or_else(|| DbError::Protocol("missing nonce in server-first".into()))?,
         salt.ok_or_else(|| DbError::Protocol("missing salt in server-first".into()))?,
-        iterations
-            .ok_or_else(|| DbError::Protocol("missing iterations in server-first".into()))?,
+        iterations.ok_or_else(|| DbError::Protocol("missing iterations in server-first".into()))?,
     ))
 }
 
@@ -601,8 +568,7 @@ fn parse_server_first(msg: &str) -> Result<(String, String, u32), DbError> {
 fn hmac_sha256(key: &[u8], msg: &[u8]) -> Vec<u8> {
     use hmac::{Hmac, Mac};
     type HmacSha256 = Hmac<Sha256>;
-    let mut mac =
-        HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
     mac.update(msg);
     mac.finalize().into_bytes().to_vec()
 }
@@ -613,16 +579,14 @@ fn hi(password: &[u8], salt: &[u8], iterations: u32) -> Vec<u8> {
     type HmacSha256 = Hmac<Sha256>;
 
     // U1 = HMAC(password, salt || 0x00000001)
-    let mut mac =
-        HmacSha256::new_from_slice(password).expect("HMAC can take key of any size");
+    let mut mac = HmacSha256::new_from_slice(password).expect("HMAC can take key of any size");
     mac.update(salt);
     mac.update(&1_u32.to_be_bytes());
     let mut u_prev = mac.finalize().into_bytes().to_vec();
     let mut result = u_prev.clone();
 
     for _ in 1..iterations {
-        let mut mac =
-            HmacSha256::new_from_slice(password).expect("HMAC can take key of any size");
+        let mut mac = HmacSha256::new_from_slice(password).expect("HMAC can take key of any size");
         mac.update(&u_prev);
         u_prev = mac.finalize().into_bytes().to_vec();
         for (r, u) in result.iter_mut().zip(u_prev.iter()) {
@@ -636,9 +600,7 @@ fn hi(password: &[u8], salt: &[u8], iterations: u32) -> Vec<u8> {
 /// Generate a random nonce for SCRAM.
 fn generate_nonce() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
     let ptr = Arc::as_ptr(&Arc::new(())) as usize;
     format!("{:x}{:x}{:x}", ts.as_secs(), ts.subsec_nanos(), ptr)
 }
@@ -652,9 +614,7 @@ async fn read_pg_message(stream: &mut TcpStream) -> Result<(u8, Vec<u8>), DbErro
     let tag = stream.read_u8().await?;
     let len = stream.read_i32().await?;
     if len < 4 {
-        return Err(DbError::Protocol(format!(
-            "invalid PG message length: {len}"
-        )));
+        return Err(DbError::Protocol(format!("invalid PG message length: {len}")));
     }
     let payload_len = usize::try_from(len - 4)
         .map_err(|_| DbError::Protocol("negative PG payload length".into()))?;
@@ -666,11 +626,7 @@ async fn read_pg_message(stream: &mut TcpStream) -> Result<(u8, Vec<u8>), DbErro
 }
 
 /// Write one PG message: `[tag: 1][length: 4BE][payload]`.
-async fn write_pg_message(
-    stream: &mut TcpStream,
-    tag: u8,
-    payload: &[u8],
-) -> Result<(), DbError> {
+async fn write_pg_message(stream: &mut TcpStream, tag: u8, payload: &[u8]) -> Result<(), DbError> {
     let len = i32::try_from(payload.len() + 4)
         .expect("PG message payload too large for i32 length field");
     stream.write_u8(tag).await?;
@@ -680,17 +636,10 @@ async fn write_pg_message(
 }
 
 /// Forward a raw PG message from one stream to another.
-async fn forward_pg_message(
-    from: &mut TcpStream,
-    to: &mut TcpStream,
-) -> Result<u8, DbError> {
+async fn forward_pg_message(from: &mut TcpStream, to: &mut TcpStream) -> Result<u8, DbError> {
     let tag = from.read_u8().await?;
     let len = from.read_i32().await?;
-    let payload_len = if len >= 4 {
-        usize::try_from(len - 4).unwrap_or(0)
-    } else {
-        0
-    };
+    let payload_len = if len >= 4 { usize::try_from(len - 4).unwrap_or(0) } else { 0 };
 
     // Write tag + length.
     to.write_u8(tag).await?;
@@ -717,9 +666,7 @@ async fn forward_pg_message(
 async fn read_startup_message(stream: &mut TcpStream) -> Result<Vec<u8>, DbError> {
     let len = stream.read_i32().await?;
     if !(8..=10240).contains(&len) {
-        return Err(DbError::Protocol(format!(
-            "invalid startup message length: {len}"
-        )));
+        return Err(DbError::Protocol(format!("invalid startup message length: {len}")));
     }
     let payload_len = usize::try_from(len - 4)
         .map_err(|_| DbError::Protocol("negative startup payload length".into()))?;
@@ -728,8 +675,7 @@ async fn read_startup_message(stream: &mut TcpStream) -> Result<Vec<u8>, DbError
 
     // Check protocol version (first 4 bytes of payload).
     if payload.len() >= 4 {
-        let version =
-            i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+        let version = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
         // SSL request (80877103) or cancel request (80877102): not handled.
         if version == 80_877_103 {
             // SSL request: send 'N' (no SSL) and read the real startup.
@@ -810,11 +756,7 @@ fn parse_pg_error(payload: &[u8]) -> String {
         }
         i += end + 1;
     }
-    if message.is_empty() {
-        "(unknown error)".to_string()
-    } else {
-        message
-    }
+    if message.is_empty() { "(unknown error)".to_string() } else { message }
 }
 
 // ── Reset & health check ────────────────────────────────────────────────────
@@ -907,11 +849,7 @@ enum PgQueryKind {
 /// Classify a SQL query based on its first keyword.
 fn classify_pg_query(sql: &str) -> PgQueryKind {
     let s = sql.trim_start();
-    let tok = s
-        .split_ascii_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_ascii_uppercase();
+    let tok = s.split_ascii_whitespace().next().unwrap_or("").to_ascii_uppercase();
 
     match tok.as_str() {
         "SELECT" | "SHOW" | "EXPLAIN" | "TABLE" => {
@@ -1096,10 +1034,7 @@ mod tests {
 
     #[test]
     fn classify_select_for_update_as_write() {
-        assert_eq!(
-            classify_pg_query("SELECT * FROM users FOR UPDATE"),
-            PgQueryKind::Write
-        );
+        assert_eq!(classify_pg_query("SELECT * FROM users FOR UPDATE"), PgQueryKind::Write);
     }
 
     #[test]
@@ -1109,10 +1044,7 @@ mod tests {
 
     #[test]
     fn classify_insert_as_write() {
-        assert_eq!(
-            classify_pg_query("INSERT INTO users VALUES (1)"),
-            PgQueryKind::Write
-        );
+        assert_eq!(classify_pg_query("INSERT INTO users VALUES (1)"), PgQueryKind::Write);
     }
 
     #[test]
@@ -1137,18 +1069,12 @@ mod tests {
 
     #[test]
     fn classify_unknown_as_write() {
-        assert_eq!(
-            classify_pg_query("TRUNCATE TABLE users"),
-            PgQueryKind::Write
-        );
+        assert_eq!(classify_pg_query("TRUNCATE TABLE users"), PgQueryKind::Write);
     }
 
     #[test]
     fn classify_explain_as_read() {
-        assert_eq!(
-            classify_pg_query("EXPLAIN SELECT * FROM users"),
-            PgQueryKind::Read
-        );
+        assert_eq!(classify_pg_query("EXPLAIN SELECT * FROM users"), PgQueryKind::Read);
     }
 
     // ── md5_password ────────────────────────────────────────────────
@@ -1231,26 +1157,21 @@ mod tests {
 
     #[test]
     fn select_routes_read_to_replica() {
-        let rw_split = PgRwSplitParams {
-            enabled: true,
-            sticky_duration: std::time::Duration::from_secs(1),
-        };
+        let rw_split =
+            PgRwSplitParams { enabled: true, sticky_duration: std::time::Duration::from_secs(1) };
         let primary = pool_stub();
         let replicas = vec![pool_stub()];
         let state = PgClientState::default();
         let rr = AtomicUsize::new(0);
 
-        let target =
-            pg_select_pool(&primary, &replicas, &rr, &state, PgQueryKind::Read, &rw_split);
+        let target = pg_select_pool(&primary, &replicas, &rr, &state, PgQueryKind::Read, &rw_split);
         assert!(std::ptr::eq(target, &raw const replicas[0]));
     }
 
     #[test]
     fn select_routes_write_to_primary() {
-        let rw_split = PgRwSplitParams {
-            enabled: true,
-            sticky_duration: std::time::Duration::from_secs(1),
-        };
+        let rw_split =
+            PgRwSplitParams { enabled: true, sticky_duration: std::time::Duration::from_secs(1) };
         let primary = pool_stub();
         let replicas = vec![pool_stub()];
         let state = PgClientState::default();
@@ -1263,20 +1184,14 @@ mod tests {
 
     #[test]
     fn select_routes_to_primary_in_transaction() {
-        let rw_split = PgRwSplitParams {
-            enabled: true,
-            sticky_duration: std::time::Duration::from_secs(1),
-        };
+        let rw_split =
+            PgRwSplitParams { enabled: true, sticky_duration: std::time::Duration::from_secs(1) };
         let primary = pool_stub();
         let replicas = vec![pool_stub()];
-        let state = PgClientState {
-            in_transaction: true,
-            ..PgClientState::default()
-        };
+        let state = PgClientState { in_transaction: true, ..PgClientState::default() };
         let rr = AtomicUsize::new(0);
 
-        let target =
-            pg_select_pool(&primary, &replicas, &rr, &state, PgQueryKind::Read, &rw_split);
+        let target = pg_select_pool(&primary, &replicas, &rr, &state, PgQueryKind::Read, &rw_split);
         assert!(std::ptr::eq(target, &raw const primary));
     }
 
@@ -1301,14 +1216,10 @@ mod tests {
         let (mut dst_writer, mut dst_reader) = make_tcp_pair().await;
 
         let payload = b"test payload";
-        write_pg_message(&mut src_writer, b'T', payload)
-            .await
-            .unwrap();
+        write_pg_message(&mut src_writer, b'T', payload).await.unwrap();
         drop(src_writer);
 
-        let tag = forward_pg_message(&mut src_reader, &mut dst_writer)
-            .await
-            .unwrap();
+        let tag = forward_pg_message(&mut src_reader, &mut dst_writer).await.unwrap();
         assert_eq!(tag, b'T');
         drop(dst_writer);
 

--- a/crates/ephpm-db/src/url.rs
+++ b/crates/ephpm-db/src/url.rs
@@ -46,24 +46,21 @@ impl DbUrl {
         let default_port: u16 = if scheme == "mysql" { 3306 } else { 5432 };
 
         // Split user:pass@host:port/db
-        let (auth, host_path) = rest
-            .split_once('@')
-            .ok_or_else(|| DbError::InvalidUrl("missing '@' in URL".into()))?;
+        let (auth, host_path) =
+            rest.split_once('@').ok_or_else(|| DbError::InvalidUrl("missing '@' in URL".into()))?;
 
         let (username, password) = auth.split_once(':').unwrap_or((auth, ""));
 
         let (host_port, database) = host_path.split_once('/').unwrap_or((host_path, ""));
 
-        let (host, port_str) = host_port
-            .rsplit_once(':')
-            .unwrap_or((host_port, ""));
+        let (host, port_str) = host_port.rsplit_once(':').unwrap_or((host_port, ""));
 
         let port: u16 = if port_str.is_empty() {
             default_port
         } else {
-            port_str.parse().map_err(|_| {
-                DbError::InvalidUrl(format!("invalid port '{port_str}'"))
-            })?
+            port_str
+                .parse()
+                .map_err(|_| DbError::InvalidUrl(format!("invalid port '{port_str}'")))?
         };
 
         let host = if host.is_empty() { "127.0.0.1" } else { host };

--- a/crates/ephpm-db/tests/pool_lifecycle.rs
+++ b/crates/ephpm-db/tests/pool_lifecycle.rs
@@ -78,10 +78,7 @@ async fn pool_timeout_when_exhausted() {
 
     assert!(result.is_err(), "second acquire should fail");
     let err = result.err().unwrap();
-    assert!(
-        matches!(err, DbError::PoolTimeout { .. }),
-        "error should be PoolTimeout, got: {err}"
-    );
+    assert!(matches!(err, DbError::PoolTimeout { .. }), "error should be PoolTimeout, got: {err}");
     assert!(elapsed >= Duration::from_millis(150), "should have waited near pool_timeout");
 
     drop(checkout);
@@ -134,8 +131,5 @@ async fn close_rejects_new_acquires() {
     let result = pool.acquire().await;
     assert!(result.is_err(), "acquire after close should fail");
     let err = result.err().unwrap();
-    assert!(
-        matches!(err, DbError::PoolClosed),
-        "error should be PoolClosed, got: {err}"
-    );
+    assert!(matches!(err, DbError::PoolClosed), "error should be PoolClosed, got: {err}");
 }

--- a/crates/ephpm-db/tests/proxy_integration.rs
+++ b/crates/ephpm-db/tests/proxy_integration.rs
@@ -113,18 +113,14 @@ async fn basic_query_roundtrip() {
         .await
         .unwrap();
 
-    let rows: Vec<(i32, String)> = conn
-        .query("SELECT id, val FROM _ephpm_test_roundtrip WHERE id = 1")
-        .await
-        .unwrap();
+    let rows: Vec<(i32, String)> =
+        conn.query("SELECT id, val FROM _ephpm_test_roundtrip WHERE id = 1").await.unwrap();
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].0, 1);
     assert_eq!(rows[0].1, "hello");
 
-    conn.query_drop("DROP TABLE IF EXISTS _ephpm_test_roundtrip")
-        .await
-        .unwrap();
+    conn.query_drop("DROP TABLE IF EXISTS _ephpm_test_roundtrip").await.unwrap();
 
     drop(conn);
     pool.disconnect().await.unwrap();
@@ -226,30 +222,22 @@ async fn transaction_integrity() {
 
     // Begin transaction, insert, verify visible within txn.
     conn.query_drop("BEGIN").await.unwrap();
-    conn.query_drop("INSERT INTO _ephpm_test_txn (id, val) VALUES (1, 'txn_data')")
-        .await
-        .unwrap();
+    conn.query_drop("INSERT INTO _ephpm_test_txn (id, val) VALUES (1, 'txn_data')").await.unwrap();
 
-    let rows: Vec<(i32, String)> = conn
-        .query("SELECT id, val FROM _ephpm_test_txn WHERE id = 1")
-        .await
-        .unwrap();
+    let rows: Vec<(i32, String)> =
+        conn.query("SELECT id, val FROM _ephpm_test_txn WHERE id = 1").await.unwrap();
     assert_eq!(rows.len(), 1, "row should be visible inside transaction");
     assert_eq!(rows[0].1, "txn_data");
 
     // Rollback — row should vanish.
     conn.query_drop("ROLLBACK").await.unwrap();
 
-    let rows: Vec<(i32,)> = conn
-        .query("SELECT id FROM _ephpm_test_txn WHERE id = 1")
-        .await
-        .unwrap();
+    let rows: Vec<(i32,)> =
+        conn.query("SELECT id FROM _ephpm_test_txn WHERE id = 1").await.unwrap();
     assert!(rows.is_empty(), "row should not exist after ROLLBACK");
 
     // Cleanup.
-    conn.query_drop("DROP TABLE IF EXISTS _ephpm_test_txn")
-        .await
-        .unwrap();
+    conn.query_drop("DROP TABLE IF EXISTS _ephpm_test_txn").await.unwrap();
 
     drop(conn);
     pool.disconnect().await.unwrap();
@@ -279,10 +267,7 @@ async fn prepared_statement_lifecycle() {
         .unwrap();
 
     // Prepare, execute with parameter, verify result.
-    let stmt = conn
-        .prep("SELECT id, name FROM _ephpm_test_ps WHERE id = ?")
-        .await
-        .unwrap();
+    let stmt = conn.prep("SELECT id, name FROM _ephpm_test_ps WHERE id = ?").await.unwrap();
 
     let rows: Vec<(i32, String)> = conn.exec(&stmt, (1,)).await.unwrap();
     assert_eq!(rows.len(), 1);
@@ -297,9 +282,7 @@ async fn prepared_statement_lifecycle() {
     conn.close(stmt).await.unwrap();
 
     // Cleanup.
-    conn.query_drop("DROP TABLE IF EXISTS _ephpm_test_ps")
-        .await
-        .unwrap();
+    conn.query_drop("DROP TABLE IF EXISTS _ephpm_test_ps").await.unwrap();
 
     drop(conn);
     pool.disconnect().await.unwrap();

--- a/crates/ephpm-kv/src/auth.rs
+++ b/crates/ephpm-kv/src/auth.rs
@@ -108,11 +108,7 @@ mod tests {
 
     #[test]
     fn validate_wrong_password() {
-        assert!(!validate_site_password(
-            "secret",
-            "example.com",
-            "wrong-password"
-        ));
+        assert!(!validate_site_password("secret", "example.com", "wrong-password"));
     }
 
     #[test]

--- a/crates/ephpm-kv/src/command.rs
+++ b/crates/ephpm-kv/src/command.rs
@@ -86,11 +86,7 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
         "SELECT" => {
             // Single-server: only DB 0 supported.
             let db = str_arg(argv, 0).unwrap_or_default();
-            if db == "0" {
-                Frame::ok()
-            } else {
-                Frame::error("ERR DB index is out of range")
-            }
+            if db == "0" { Frame::ok() } else { Frame::error("ERR DB index is out of range") }
         }
         "QUIT" => Frame::ok(),
         "COMMAND" => {
@@ -516,17 +512,14 @@ fn str_arg(argv: &[&[u8]], idx: usize) -> Option<String> {
 /// Parse a byte slice as i64.
 fn parse_i64(b: &[u8]) -> Result<i64, Frame> {
     let s = str_from(b);
-    s.parse::<i64>()
-        .map_err(|_| Frame::error("ERR value is not an integer or out of range"))
+    s.parse::<i64>().map_err(|_| Frame::error("ERR value is not an integer or out of range"))
 }
 
 /// Return an error frame if `argv` doesn't have at least `n` elements.
 /// Uses the `?` operator trick — returns `Frame` on error.
 fn require_args(cmd: &str, argv: &[&[u8]], n: usize) -> Result<(), Frame> {
     if argv.len() < n {
-        Err(Frame::error(format!(
-            "ERR wrong number of arguments for '{cmd}' command"
-        )))
+        Err(Frame::error(format!("ERR wrong number of arguments for '{cmd}' command")))
     } else {
         Ok(())
     }
@@ -545,20 +538,12 @@ mod tests {
 
     /// Build a command frame and dispatch it.
     fn cmd(store: &Arc<Store>, args: &[&str]) -> Frame {
-        let frame = Frame::Array(
-            args.iter()
-                .map(|s| Frame::bulk(s.as_bytes().to_vec()))
-                .collect(),
-        );
+        let frame = Frame::Array(args.iter().map(|s| Frame::bulk(s.as_bytes().to_vec())).collect());
         dispatch(store, &frame)
     }
 
     fn bulk_str(f: &Frame) -> Option<&str> {
-        if let Frame::Bulk(b) = f {
-            std::str::from_utf8(b).ok()
-        } else {
-            None
-        }
+        if let Frame::Bulk(b) = f { std::str::from_utf8(b).ok() } else { None }
     }
 
     fn int(f: &Frame) -> Option<i64> {
@@ -685,10 +670,7 @@ mod tests {
 
     #[test]
     fn set_nx_and_xx_together_is_error() {
-        assert!(matches!(
-            cmd(&store(), &["SET", "k", "v", "NX", "XX"]),
-            Frame::Error(_)
-        ));
+        assert!(matches!(cmd(&store(), &["SET", "k", "v", "NX", "XX"]), Frame::Error(_)));
     }
 
     #[test]
@@ -702,10 +684,7 @@ mod tests {
 
     #[test]
     fn setex_invalid_ttl_is_error() {
-        assert!(matches!(
-            cmd(&store(), &["SETEX", "k", "-1", "v"]),
-            Frame::Error(_)
-        ));
+        assert!(matches!(cmd(&store(), &["SETEX", "k", "-1", "v"]), Frame::Error(_)));
     }
 
     #[test]
@@ -920,10 +899,7 @@ mod tests {
 
     #[test]
     fn type_missing_key_is_none() {
-        assert_eq!(
-            cmd(&store(), &["TYPE", "nope"]),
-            Frame::Simple("none".into())
-        );
+        assert_eq!(cmd(&store(), &["TYPE", "nope"]), Frame::Simple("none".into()));
     }
 
     #[test]
@@ -937,10 +913,7 @@ mod tests {
 
     #[test]
     fn rename_missing_key_is_error() {
-        assert!(matches!(
-            cmd(&store(), &["RENAME", "nope", "new"]),
-            Frame::Error(_)
-        ));
+        assert!(matches!(cmd(&store(), &["RENAME", "nope", "new"]), Frame::Error(_)));
     }
 
     #[test]
@@ -958,9 +931,7 @@ mod tests {
     fn keys_wildcard_returns_all() {
         let s = store();
         cmd(&s, &["MSET", "a", "1", "b", "2"]);
-        let Frame::Array(keys) = cmd(&s, &["KEYS", "*"]) else {
-            panic!("expected array")
-        };
+        let Frame::Array(keys) = cmd(&s, &["KEYS", "*"]) else { panic!("expected array") };
         assert!(keys.len() >= 2);
     }
 
@@ -968,9 +939,7 @@ mod tests {
     fn keys_pattern_filters() {
         let s = store();
         cmd(&s, &["MSET", "user:1", "a", "user:2", "b", "post:1", "c"]);
-        let Frame::Array(keys) = cmd(&s, &["KEYS", "user:*"]) else {
-            panic!("expected array")
-        };
+        let Frame::Array(keys) = cmd(&s, &["KEYS", "user:*"]) else { panic!("expected array") };
         assert_eq!(keys.len(), 2);
     }
 
@@ -1050,10 +1019,7 @@ mod tests {
 
     #[test]
     fn incrby_non_integer_delta_is_error() {
-        assert!(matches!(
-            cmd(&store(), &["INCRBY", "k", "notanint"]),
-            Frame::Error(_)
-        ));
+        assert!(matches!(cmd(&store(), &["INCRBY", "k", "notanint"]), Frame::Error(_)));
     }
 
     // ── Case insensitivity ───────────────────────────────────────────────

--- a/crates/ephpm-kv/src/multi_tenant.rs
+++ b/crates/ephpm-kv/src/multi_tenant.rs
@@ -32,11 +32,7 @@ impl MultiTenantStore {
     /// `site_config` is the template for creating per-site stores.
     #[must_use]
     pub fn new(default_store: Arc<Store>, site_config: StoreConfig) -> Self {
-        Self {
-            sites: Arc::new(DashMap::new()),
-            site_config,
-            default_store,
-        }
+        Self { sites: Arc::new(DashMap::new()), site_config, default_store }
     }
 
     /// Get or create a store for the given hostname.

--- a/crates/ephpm-kv/src/resp/frame.rs
+++ b/crates/ephpm-kv/src/resp/frame.rs
@@ -3,8 +3,9 @@
 //! Implements the Redis Serialization Protocol as described in
 //! <https://redis.io/docs/reference/protocol-spec/>.
 
-use bytes::{BufMut, BytesMut};
 use std::fmt;
+
+use bytes::{BufMut, BytesMut};
 
 /// A single RESP protocol frame.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,10 +168,7 @@ mod tests {
 
     #[test]
     fn serialize_array() {
-        let f = Frame::Array(vec![
-            Frame::bulk("GET"),
-            Frame::bulk("key"),
-        ]);
+        let f = Frame::Array(vec![Frame::bulk("GET"), Frame::bulk("key")]);
         assert_eq!(&f.to_bytes()[..], b"*2\r\n$3\r\nGET\r\n$3\r\nkey\r\n");
     }
 

--- a/crates/ephpm-kv/src/resp/mod.rs
+++ b/crates/ephpm-kv/src/resp/mod.rs
@@ -8,4 +8,4 @@ mod frame;
 mod parse;
 
 pub use frame::Frame;
-pub use parse::{parse_frame, ParseError};
+pub use parse::{ParseError, parse_frame};

--- a/crates/ephpm-kv/src/resp/parse.rs
+++ b/crates/ephpm-kv/src/resp/parse.rs
@@ -39,9 +39,7 @@ pub fn parse_frame(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
         b':' => parse_integer(buf),
         b'$' => parse_bulk(buf),
         b'*' => parse_array(buf),
-        byte => Err(ParseError::Protocol(format!(
-            "unexpected type byte: {byte:#04x}"
-        ))),
+        byte => Err(ParseError::Protocol(format!("unexpected type byte: {byte:#04x}"))),
     }
 }
 
@@ -68,8 +66,7 @@ fn read_line(buf: &[u8], start: usize) -> Result<(usize, &[u8]), ParseError> {
 fn parse_line_int(line: &[u8]) -> Result<i64, ParseError> {
     let s = std::str::from_utf8(line)
         .map_err(|_| ParseError::Protocol("non-UTF-8 integer line".into()))?;
-    s.parse::<i64>()
-        .map_err(|_| ParseError::Protocol(format!("invalid integer: {s}")))
+    s.parse::<i64>().map_err(|_| ParseError::Protocol(format!("invalid integer: {s}")))
 }
 
 fn parse_simple(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
@@ -231,10 +228,7 @@ mod tests {
         let frame = parse(b"*2\r\n$3\r\nGET\r\n$3\r\nkey\r\n").unwrap().unwrap();
         assert_eq!(
             frame,
-            Frame::Array(vec![
-                Frame::Bulk(b"GET".to_vec()),
-                Frame::Bulk(b"key".to_vec()),
-            ])
+            Frame::Array(vec![Frame::Bulk(b"GET".to_vec()), Frame::Bulk(b"key".to_vec()),])
         );
     }
 

--- a/crates/ephpm-kv/src/server.rs
+++ b/crates/ephpm-kv/src/server.rs
@@ -15,11 +15,10 @@ use tokio::net::TcpListener;
 use tokio::signal;
 use tracing::{debug, error, info, trace};
 
-use crate::auth;
-use crate::command;
 use crate::multi_tenant::MultiTenantStore;
 use crate::resp::{self, Frame};
 use crate::store::Store;
+use crate::{auth, command};
 
 /// Configuration for the KV TCP server.
 #[derive(Debug, Clone)]
@@ -230,21 +229,15 @@ fn handle_auth(
             (Some(hostname), Some(password)) => {
                 if auth::validate_site_password(secret_val, &hostname, &password) {
                     let store = mt.get_site_store(&hostname);
-                    (
-                        Frame::ok(),
-                        true,
-                        Some(HmacAuthResult { store }),
-                    )
+                    (Frame::ok(), true, Some(HmacAuthResult { store }))
                 } else {
                     (Frame::error("ERR invalid password"), false, None)
                 }
             }
             // Missing hostname or password argument.
-            (Some(_), None) | (None, _) => (
-                Frame::error("ERR wrong number of arguments for 'auth' command"),
-                false,
-                None,
-            ),
+            (Some(_), None) | (None, _) => {
+                (Frame::error("ERR wrong number of arguments for 'auth' command"), false, None)
+            }
         }
     } else {
         // Legacy single-password mode.
@@ -257,11 +250,9 @@ fn handle_auth(
             // Password configured but client provided wrong one.
             (Some(_), Some(_)) => (Frame::error("ERR invalid password"), false, None),
             // Password configured but client sent AUTH with no argument.
-            (Some(_), None) => (
-                Frame::error("ERR wrong number of arguments for 'auth' command"),
-                false,
-                None,
-            ),
+            (Some(_), None) => {
+                (Frame::error("ERR wrong number of arguments for 'auth' command"), false, None)
+            }
             // No password configured — AUTH is a no-op, always succeeds.
             (None, _) => (Frame::ok(), true, None),
         }
@@ -373,16 +364,13 @@ async fn handle_connection(
 /// Wait for Ctrl-C / SIGTERM.
 async fn shutdown_signal() {
     let ctrl_c = async {
-        signal::ctrl_c()
-            .await
-            .expect("failed to install Ctrl+C handler");
+        signal::ctrl_c().await.expect("failed to install Ctrl+C handler");
     };
 
     #[cfg(unix)]
     {
-        let mut sigterm =
-            signal::unix::signal(signal::unix::SignalKind::terminate())
-                .expect("failed to install SIGTERM handler");
+        let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
         tokio::select! {
             () = ctrl_c => {}
             _ = sigterm.recv() => {}

--- a/crates/ephpm-kv/src/store/entry.rs
+++ b/crates/ephpm-kv/src/store/entry.rs
@@ -22,18 +22,17 @@ impl Entry {
     #[must_use]
     pub fn new(data: Vec<u8>, key_len: usize, compressed: bool) -> Self {
         let mem_size = Self::estimate_size(key_len, data.len());
-        Self {
-            data,
-            compressed,
-            expires_at: None,
-            last_accessed: Instant::now(),
-            mem_size,
-        }
+        Self { data, compressed, expires_at: None, last_accessed: Instant::now(), mem_size }
     }
 
     /// Create a new entry with an absolute expiry.
     #[must_use]
-    pub fn with_expiry(data: Vec<u8>, key_len: usize, compressed: bool, expires_at: Instant) -> Self {
+    pub fn with_expiry(
+        data: Vec<u8>,
+        key_len: usize,
+        compressed: bool,
+        expires_at: Instant,
+    ) -> Self {
         let mem_size = Self::estimate_size(key_len, data.len());
         Self {
             data,
@@ -47,8 +46,7 @@ impl Entry {
     /// Returns `true` if this entry has expired.
     #[must_use]
     pub fn is_expired(&self) -> bool {
-        self.expires_at
-            .is_some_and(|exp| Instant::now() >= exp)
+        self.expires_at.is_some_and(|exp| Instant::now() >= exp)
     }
 
     /// Touch the entry, updating its last-access time for LRU.

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -8,14 +8,13 @@ mod entry;
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
-use tracing::{debug, trace};
-
 pub use entry::Entry;
+use tracing::{debug, trace};
 
 /// Eviction policy when the memory limit is reached.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -84,11 +83,7 @@ pub struct CompressionConfig {
 
 impl Default for CompressionConfig {
     fn default() -> Self {
-        Self {
-            algo: CompressionAlgo::None,
-            level: 6,
-            min_size: 1024,
-        }
+        Self { algo: CompressionAlgo::None, level: 6, min_size: 1024 }
     }
 }
 
@@ -129,11 +124,7 @@ impl HashEntry {
 
     /// Rough memory estimate.
     fn mem_size(&self) -> usize {
-        self.fields
-            .iter()
-            .map(|(k, v)| k.len() + v.len() + 64)
-            .sum::<usize>()
-            + 64
+        self.fields.iter().map(|(k, v)| k.len() + v.len() + 64).sum::<usize>() + 64
     }
 }
 
@@ -268,19 +259,18 @@ impl Store {
     /// the `NoEviction` policy when the memory limit is reached.
     pub fn set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
         // Try compression if configured and size is above threshold.
-        let (data, compressed) =
-            if self.config.compression.algo != CompressionAlgo::None
-                && value.len() >= self.config.compression.min_size
-            {
-                let compressed_data = compress_value(&value, self.config.compression);
-                if compressed_data.len() < value.len() {
-                    (compressed_data, true)
-                } else {
-                    (value, false)
-                }
+        let (data, compressed) = if self.config.compression.algo != CompressionAlgo::None
+            && value.len() >= self.config.compression.min_size
+        {
+            let compressed_data = compress_value(&value, self.config.compression);
+            if compressed_data.len() < value.len() {
+                (compressed_data, true)
             } else {
                 (value, false)
-            };
+            }
+        } else {
+            (value, false)
+        };
 
         let entry = match ttl {
             Some(dur) => Entry::with_expiry(data, key.len(), compressed, Instant::now() + dur),
@@ -373,25 +363,25 @@ impl Store {
                 };
 
                 let current = parse_int_value(&data)?;
-                let new_val = current.checked_add(delta).ok_or_else(|| {
-                    "ERR increment or decrement would overflow".to_string()
-                })?;
+                let new_val = current
+                    .checked_add(delta)
+                    .ok_or_else(|| "ERR increment or decrement would overflow".to_string())?;
                 let new_bytes = new_val.to_string().into_bytes();
 
                 // Try compression again if configured.
-                let (stored_data, compressed) =
-                    if self.config.compression.algo != CompressionAlgo::None
-                        && new_bytes.len() >= self.config.compression.min_size
-                    {
-                        let compressed_data = compress_value(&new_bytes, self.config.compression);
-                        if compressed_data.len() < new_bytes.len() {
-                            (compressed_data, true)
-                        } else {
-                            (new_bytes, false)
-                        }
+                let (stored_data, compressed) = if self.config.compression.algo
+                    != CompressionAlgo::None
+                    && new_bytes.len() >= self.config.compression.min_size
+                {
+                    let compressed_data = compress_value(&new_bytes, self.config.compression);
+                    if compressed_data.len() < new_bytes.len() {
+                        (compressed_data, true)
                     } else {
                         (new_bytes, false)
-                    };
+                    }
+                } else {
+                    (new_bytes, false)
+                };
 
                 let old_mem = entry.mem_size;
                 entry.data = stored_data;
@@ -437,19 +427,19 @@ impl Store {
                 data.extend_from_slice(value);
 
                 // Try compression again if configured.
-                let (stored_data, compressed) =
-                    if self.config.compression.algo != CompressionAlgo::None
-                        && data.len() >= self.config.compression.min_size
-                    {
-                        let compressed_data = compress_value(&data, self.config.compression);
-                        if compressed_data.len() < data.len() {
-                            (compressed_data, true)
-                        } else {
-                            (data.clone(), false)
-                        }
+                let (stored_data, compressed) = if self.config.compression.algo
+                    != CompressionAlgo::None
+                    && data.len() >= self.config.compression.min_size
+                {
+                    let compressed_data = compress_value(&data, self.config.compression);
+                    if compressed_data.len() < data.len() {
+                        (compressed_data, true)
                     } else {
                         (data.clone(), false)
-                    };
+                    }
+                } else {
+                    (data.clone(), false)
+                };
 
                 let old_mem = entry.mem_size;
                 entry.data = stored_data;
@@ -482,10 +472,7 @@ impl Store {
         let field_mem = field.len() + value.len() + 64;
         let mut entry = self.hashes.entry(key.to_string()).or_insert_with(|| {
             self.mem_add(64); // base hash overhead
-            HashEntry {
-                fields: HashMap::new(),
-                expires_at: None,
-            }
+            HashEntry { fields: HashMap::new(), expires_at: None }
         });
         if entry.is_expired() {
             let old_mem = entry.mem_size();
@@ -555,11 +542,7 @@ impl Store {
             self.hash_remove(key);
             return Vec::new();
         }
-        entry
-            .fields
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
+        entry.fields.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
     }
 
     /// Get all field names from a hash.
@@ -812,8 +795,7 @@ impl Store {
 fn parse_int_value(data: &[u8]) -> Result<i64, String> {
     let s = std::str::from_utf8(data)
         .map_err(|_| "ERR value is not an integer or out of range".to_string())?;
-    s.parse::<i64>()
-        .map_err(|_| "ERR value is not an integer or out of range".to_string())
+    s.parse::<i64>().map_err(|_| "ERR value is not an integer or out of range".to_string())
 }
 
 /// Simple glob matching supporting `*` (any chars) and `?` (single char).
@@ -843,7 +825,8 @@ fn compress_value(data: &[u8], config: CompressionConfig) -> Vec<u8> {
     match config.algo {
         CompressionAlgo::None => unreachable!(),
         CompressionAlgo::Gzip => {
-            let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::new(config.level));
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::new(config.level));
             if encoder.write_all(data).is_err() {
                 return data.to_vec(); // Fall back to uncompressed
             }
@@ -855,7 +838,8 @@ fn compress_value(data: &[u8], config: CompressionConfig) -> Vec<u8> {
         CompressionAlgo::Brotli => {
             let mut output = Vec::new();
             {
-                let mut encoder = brotli::CompressorWriter::new(&mut output, 4096, config.level, 22);
+                let mut encoder =
+                    brotli::CompressorWriter::new(&mut output, 4096, config.level, 22);
                 if encoder.write_all(data).is_err() {
                     return data.to_vec(); // Fall back to uncompressed
                 }
@@ -863,7 +847,8 @@ fn compress_value(data: &[u8], config: CompressionConfig) -> Vec<u8> {
             }
             output
         }
-        CompressionAlgo::Zstd => {
+        CompressionAlgo::Zstd =>
+        {
             #[allow(clippy::cast_possible_wrap)]
             match zstd::encode_all(data, config.level as i32) {
                 Ok(compressed) => compressed,
@@ -890,11 +875,7 @@ fn decompress_value(data: &[u8], algo: CompressionAlgo) -> Option<Vec<u8>> {
         CompressionAlgo::Brotli => {
             let mut decompressor = brotli::Decompressor::new(data, 4096);
             let mut output = Vec::new();
-            if decompressor.read_to_end(&mut output).is_ok() {
-                Some(output)
-            } else {
-                None
-            }
+            if decompressor.read_to_end(&mut output).is_ok() { Some(output) } else { None }
         }
         CompressionAlgo::Zstd => zstd::decode_all(data).ok(),
     }
@@ -1068,11 +1049,7 @@ mod tests {
         let s = Store::new(StoreConfig {
             memory_limit: 0,
             eviction_policy: EvictionPolicy::AllKeysLru,
-            compression: CompressionConfig {
-                algo: CompressionAlgo::Gzip,
-                level: 6,
-                min_size: 10,
-            },
+            compression: CompressionConfig { algo: CompressionAlgo::Gzip, level: 6, min_size: 10 },
         });
         let data = b"hello world this is a test string that should compress well";
         s.set("key".into(), data.to_vec(), None);
@@ -1102,11 +1079,7 @@ mod tests {
         let s = Store::new(StoreConfig {
             memory_limit: 0,
             eviction_policy: EvictionPolicy::AllKeysLru,
-            compression: CompressionConfig {
-                algo: CompressionAlgo::Zstd,
-                level: 6,
-                min_size: 10,
-            },
+            compression: CompressionConfig { algo: CompressionAlgo::Zstd, level: 6, min_size: 10 },
         });
         let data = b"hello world this is yet another test string for zstd";
         s.set("key".into(), data.to_vec(), None);
@@ -1142,11 +1115,7 @@ mod tests {
         let s = Store::new(StoreConfig {
             memory_limit: 0,
             eviction_policy: EvictionPolicy::AllKeysLru,
-            compression: CompressionConfig {
-                algo: CompressionAlgo::Gzip,
-                level: 6,
-                min_size: 1,
-            },
+            compression: CompressionConfig { algo: CompressionAlgo::Gzip, level: 6, min_size: 1 },
         });
         assert_eq!(s.incr_by("counter", 1), Ok(1));
         assert_eq!(s.incr_by("counter", 5), Ok(6));
@@ -1159,11 +1128,7 @@ mod tests {
         let s = Store::new(StoreConfig {
             memory_limit: 0,
             eviction_policy: EvictionPolicy::AllKeysLru,
-            compression: CompressionConfig {
-                algo: CompressionAlgo::Zstd,
-                level: 6,
-                min_size: 1,
-            },
+            compression: CompressionConfig { algo: CompressionAlgo::Zstd, level: 6, min_size: 1 },
         });
         assert_eq!(s.append("key", b"hello"), 5);
         assert_eq!(s.append("key", b" world"), 11);
@@ -1464,10 +1429,10 @@ mod tests {
         s.hset("h", "b", b"2".to_vec());
         let mut pairs = s.hgetall("h");
         pairs.sort_by(|a, b| a.0.cmp(&b.0));
-        assert_eq!(pairs, vec![
-            ("a".to_string(), b"1".to_vec()),
-            ("b".to_string(), b"2".to_vec()),
-        ]);
+        assert_eq!(
+            pairs,
+            vec![("a".to_string(), b"1".to_vec()), ("b".to_string(), b"2".to_vec()),]
+        );
     }
 
     #[test]

--- a/crates/ephpm-kv/tests/resp_compat.rs
+++ b/crates/ephpm-kv/tests/resp_compat.rs
@@ -22,19 +22,13 @@ struct TestServer {
 
 impl TestServer {
     async fn start() -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind test listener");
-        let addr = listener
-            .local_addr()
-            .expect("failed to get local addr")
-            .to_string();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("failed to bind test listener");
+        let addr = listener.local_addr().expect("failed to get local addr").to_string();
 
         let store = Store::new(StoreConfig::default());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, None, None)
-                .await
-                .ok();
+            server::serve_on(store, listener, 64 * 1024 * 1024, None, None, None).await.ok();
         });
 
         // Give the accept loop a moment to become ready.
@@ -73,11 +67,7 @@ async fn ping_returns_pong() {
 async fn ping_with_message_echoes_back() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
-    let resp: String = redis::cmd("PING")
-        .arg("hello world")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let resp: String = redis::cmd("PING").arg("hello world").query_async(&mut con).await.unwrap();
     assert_eq!(resp, "hello world");
 }
 
@@ -85,11 +75,7 @@ async fn ping_with_message_echoes_back() {
 async fn echo_returns_argument() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
-    let resp: String = redis::cmd("ECHO")
-        .arg("testing 123")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let resp: String = redis::cmd("ECHO").arg("testing 123").query_async(&mut con).await.unwrap();
     assert_eq!(resp, "testing 123");
 }
 
@@ -130,14 +116,8 @@ async fn set_with_ex_applies_ttl_seconds() {
     let mut con = srv.con().await;
 
     // Use SET ... EX rather than SETEX (we don't implement the SETEX alias).
-    let _: () = redis::cmd("SET")
-        .arg("k")
-        .arg("v")
-        .arg("EX")
-        .arg(30)
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let _: () =
+        redis::cmd("SET").arg("k").arg("v").arg("EX").arg(30).query_async(&mut con).await.unwrap();
     let ttl: i64 = con.ttl("k").await.unwrap();
     assert!(ttl > 0 && ttl <= 30, "expected TTL in (0, 30], got {ttl}");
 }
@@ -157,10 +137,7 @@ async fn set_with_px_applies_ttl_millis() {
         .await
         .unwrap();
     let pttl: i64 = con.pttl("k").await.unwrap();
-    assert!(
-        pttl > 0 && pttl <= 30_000,
-        "expected PTTL in (0, 30000], got {pttl}"
-    );
+    assert!(pttl > 0 && pttl <= 30_000, "expected PTTL in (0, 30000], got {pttl}");
 }
 
 #[tokio::test]
@@ -184,24 +161,14 @@ async fn set_xx_only_when_key_present() {
     let mut con = srv.con().await;
 
     // XX on absent key → Null (redis crate returns false/None).
-    let absent: Option<String> = redis::cmd("SET")
-        .arg("k")
-        .arg("v")
-        .arg("XX")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let absent: Option<String> =
+        redis::cmd("SET").arg("k").arg("v").arg("XX").query_async(&mut con).await.unwrap();
     assert!(absent.is_none(), "SET XX on absent key should return nil");
 
     let _: () = con.set("k", "original").await.unwrap();
 
-    let _present: Option<String> = redis::cmd("SET")
-        .arg("k")
-        .arg("updated")
-        .arg("XX")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let _present: Option<String> =
+        redis::cmd("SET").arg("k").arg("updated").arg("XX").query_async(&mut con).await.unwrap();
 
     let got: String = con.get("k").await.unwrap();
     assert_eq!(got, "updated");
@@ -214,13 +181,8 @@ async fn set_get_option_returns_previous_value() {
 
     let _: () = con.set("k", "old").await.unwrap();
 
-    let prev: Option<String> = redis::cmd("SET")
-        .arg("k")
-        .arg("new")
-        .arg("GET")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let prev: Option<String> =
+        redis::cmd("SET").arg("k").arg("new").arg("GET").query_async(&mut con).await.unwrap();
     assert_eq!(prev.as_deref(), Some("old"));
 
     let got: String = con.get("k").await.unwrap();
@@ -234,10 +196,7 @@ async fn mset_and_mget_multiple_keys() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
 
-    let _: () = con
-        .mset(&[("a", "1"), ("b", "2"), ("c", "3")])
-        .await
-        .unwrap();
+    let _: () = con.mset(&[("a", "1"), ("b", "2"), ("c", "3")]).await.unwrap();
 
     let got: Vec<Option<String>> = con.mget(&["a", "b", "c", "missing"]).await.unwrap();
     assert_eq!(got[0].as_deref(), Some("1"));
@@ -251,20 +210,11 @@ async fn setnx_via_set_nx() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
 
-    let first: i64 = redis::cmd("SETNX")
-        .arg("k")
-        .arg("v")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let first: i64 = redis::cmd("SETNX").arg("k").arg("v").query_async(&mut con).await.unwrap();
     assert_eq!(first, 1);
 
-    let second: i64 = redis::cmd("SETNX")
-        .arg("k")
-        .arg("other")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let second: i64 =
+        redis::cmd("SETNX").arg("k").arg("other").query_async(&mut con).await.unwrap();
     assert_eq!(second, 0);
 
     let got: String = con.get("k").await.unwrap();
@@ -410,11 +360,7 @@ async fn strlen_returns_byte_length() {
     let mut con = srv.con().await;
 
     let _: () = con.set("k", "hello").await.unwrap();
-    let len: i64 = redis::cmd("STRLEN")
-        .arg("k")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let len: i64 = redis::cmd("STRLEN").arg("k").query_async(&mut con).await.unwrap();
     assert_eq!(len, 5);
 }
 
@@ -422,11 +368,7 @@ async fn strlen_returns_byte_length() {
 async fn strlen_missing_key_is_zero() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
-    let len: i64 = redis::cmd("STRLEN")
-        .arg("nope")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let len: i64 = redis::cmd("STRLEN").arg("nope").query_async(&mut con).await.unwrap();
     assert_eq!(len, 0);
 }
 
@@ -436,12 +378,8 @@ async fn getset_returns_old_value_and_sets_new() {
     let mut con = srv.con().await;
 
     let _: () = con.set("k", "old").await.unwrap();
-    let prev: String = redis::cmd("GETSET")
-        .arg("k")
-        .arg("new")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let prev: String =
+        redis::cmd("GETSET").arg("k").arg("new").query_async(&mut con).await.unwrap();
     assert_eq!(prev, "old");
 
     let got: String = con.get("k").await.unwrap();
@@ -499,10 +437,7 @@ async fn pexpire_sets_millisecond_ttl() {
     assert!(set);
 
     let pttl: i64 = con.pttl("k").await.unwrap();
-    assert!(
-        pttl > 0 && pttl <= 30_000,
-        "expected PTTL in (0, 30000], got {pttl}"
-    );
+    assert!(pttl > 0 && pttl <= 30_000, "expected PTTL in (0, 30000], got {pttl}");
 }
 
 #[tokio::test]
@@ -510,14 +445,8 @@ async fn persist_removes_expiry() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
 
-    let _: () = redis::cmd("SET")
-        .arg("k")
-        .arg("v")
-        .arg("EX")
-        .arg(30)
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let _: () =
+        redis::cmd("SET").arg("k").arg("v").arg("EX").arg(30).query_async(&mut con).await.unwrap();
     let removed: bool = con.persist("k").await.unwrap();
     assert!(removed);
 
@@ -541,11 +470,7 @@ async fn type_string_key() {
     let mut con = srv.con().await;
 
     let _: () = con.set("k", "v").await.unwrap();
-    let t: String = redis::cmd("TYPE")
-        .arg("k")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let t: String = redis::cmd("TYPE").arg("k").query_async(&mut con).await.unwrap();
     assert_eq!(t, "string");
 }
 
@@ -553,11 +478,7 @@ async fn type_string_key() {
 async fn type_missing_key_returns_none_string() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
-    let t: String = redis::cmd("TYPE")
-        .arg("nope")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let t: String = redis::cmd("TYPE").arg("nope").query_async(&mut con).await.unwrap();
     assert_eq!(t, "none");
 }
 
@@ -579,10 +500,7 @@ async fn keys_prefix_pattern_filters() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
 
-    let _: () = con
-        .mset(&[("user:1", "a"), ("user:2", "b"), ("post:1", "c")])
-        .await
-        .unwrap();
+    let _: () = con.mset(&[("user:1", "a"), ("user:2", "b"), ("post:1", "c")]).await.unwrap();
 
     let mut keys: Vec<String> = con.keys("user:*").await.unwrap();
     keys.sort();
@@ -669,9 +587,16 @@ async fn pipeline_set_then_get() {
     // Pipeline: SET pk pv  (ignored), GET pk, SET pk2 pv2 (ignored).
     // Non-ignored responses are collected in order: just GET pk → "pv".
     let (got,): (String,) = redis::pipe()
-        .cmd("SET").arg("pk").arg("pv").ignore()
-        .cmd("GET").arg("pk")
-        .cmd("SET").arg("pk2").arg("pv2").ignore()
+        .cmd("SET")
+        .arg("pk")
+        .arg("pv")
+        .ignore()
+        .cmd("GET")
+        .arg("pk")
+        .cmd("SET")
+        .arg("pk2")
+        .arg("pv2")
+        .ignore()
         .query_async(&mut con)
         .await
         .unwrap();
@@ -685,15 +610,10 @@ async fn pipeline_set_then_get() {
 async fn unknown_command_returns_error() {
     let srv = TestServer::start().await;
     let mut con = srv.con().await;
-    let err = redis::cmd("NOTACOMMAND")
-        .query_async::<String>(&mut con)
-        .await;
+    let err = redis::cmd("NOTACOMMAND").query_async::<String>(&mut con).await;
     assert!(err.is_err(), "unknown command should return an error");
     let msg = err.unwrap_err().to_string();
-    assert!(
-        msg.contains("NOTACOMMAND"),
-        "error message should name the command, got: {msg}"
-    );
+    assert!(msg.contains("NOTACOMMAND"), "error message should name the command, got: {msg}");
 }
 
 #[tokio::test]
@@ -714,20 +634,14 @@ struct AuthTestServer {
 
 impl AuthTestServer {
     async fn start(password: &str) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind test listener");
-        let addr = listener
-            .local_addr()
-            .expect("failed to get local addr")
-            .to_string();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("failed to bind test listener");
+        let addr = listener.local_addr().expect("failed to get local addr").to_string();
 
         let store = Store::new(StoreConfig::default());
         let pw = Some(password.to_string());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, pw, None, None)
-                .await
-                .ok();
+            server::serve_on(store, listener, 64 * 1024 * 1024, pw, None, None).await.ok();
         });
 
         tokio::time::sleep(Duration::from_millis(5)).await;
@@ -753,10 +667,7 @@ async fn auth_required_blocks_commands() {
     let err = redis::cmd("PING").query_async::<String>(&mut con).await;
     assert!(err.is_err(), "PING without AUTH should fail");
     let msg = err.unwrap_err().to_string();
-    assert!(
-        msg.contains("NOAUTH"),
-        "expected NOAUTH error, got: {msg}"
-    );
+    assert!(msg.contains("NOAUTH"), "expected NOAUTH error, got: {msg}");
 }
 
 #[tokio::test]
@@ -791,11 +702,7 @@ async fn auth_no_password_configured_accepts_anything() {
 
     // AUTH with any password should succeed when no password is configured.
     let mut con = srv.con().await;
-    let resp: String = redis::cmd("AUTH")
-        .arg("anything")
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let resp: String = redis::cmd("AUTH").arg("anything").query_async(&mut con).await.unwrap();
     assert_eq!(resp, "OK");
 }
 
@@ -812,33 +719,20 @@ impl HmacTestServer {
     async fn start(secret: &str) -> Self {
         use ephpm_kv::multi_tenant::MultiTenantStore;
 
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind test listener");
-        let addr = listener
-            .local_addr()
-            .expect("failed to get local addr")
-            .to_string();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("failed to bind test listener");
+        let addr = listener.local_addr().expect("failed to get local addr").to_string();
 
         let store = Store::new(StoreConfig::default());
-        let mt = MultiTenantStore::new(
-            std::sync::Arc::clone(&store),
-            StoreConfig::default(),
-        );
+        let mt = MultiTenantStore::new(std::sync::Arc::clone(&store), StoreConfig::default());
         let sec = Some(secret.to_string());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, sec, Some(mt))
-                .await
-                .ok();
+            server::serve_on(store, listener, 64 * 1024 * 1024, None, sec, Some(mt)).await.ok();
         });
 
         tokio::time::sleep(Duration::from_millis(5)).await;
 
-        Self {
-            addr,
-            handle,
-            secret: secret.to_string(),
-        }
+        Self { addr, handle, secret: secret.to_string() }
     }
 }
 
@@ -867,12 +761,8 @@ async fn hmac_auth_correct_password_succeeds() {
     assert!(msg.contains("NOAUTH"), "expected NOAUTH, got: {msg}");
 
     // Now AUTH with the correct hostname + password.
-    let resp: String = redis::cmd("AUTH")
-        .arg(hostname)
-        .arg(&password)
-        .query_async(&mut con)
-        .await
-        .unwrap();
+    let resp: String =
+        redis::cmd("AUTH").arg(hostname).arg(&password).query_async(&mut con).await.unwrap();
     assert_eq!(resp, "OK");
 
     // Commands should now work.
@@ -894,10 +784,7 @@ async fn hmac_auth_wrong_password_rejected() {
         .await;
     assert!(err.is_err());
     let msg = err.unwrap_err().to_string();
-    assert!(
-        msg.contains("invalid password"),
-        "expected invalid password error, got: {msg}"
-    );
+    assert!(msg.contains("invalid password"), "expected invalid password error, got: {msg}");
 }
 
 #[tokio::test]
@@ -921,12 +808,8 @@ async fn hmac_auth_site_isolation() {
     let pw_bob = derive_site_password(&srv.secret, "bob.com");
     let client_bob = redis::Client::open(format!("redis://{}/", srv.addr)).unwrap();
     let mut con_bob = client_bob.get_multiplexed_async_connection().await.unwrap();
-    let _: String = redis::cmd("AUTH")
-        .arg("bob.com")
-        .arg(&pw_bob)
-        .query_async(&mut con_bob)
-        .await
-        .unwrap();
+    let _: String =
+        redis::cmd("AUTH").arg("bob.com").arg(&pw_bob).query_async(&mut con_bob).await.unwrap();
 
     // Alice sets a key.
     let _: () = redis::cmd("SET")
@@ -937,22 +820,13 @@ async fn hmac_auth_site_isolation() {
         .unwrap();
 
     // Bob should not see Alice's key (isolated stores).
-    let bob_val: Option<String> = redis::cmd("GET")
-        .arg("shared_key")
-        .query_async(&mut con_bob)
-        .await
-        .unwrap();
-    assert!(
-        bob_val.is_none(),
-        "bob should not see alice's data, got: {bob_val:?}"
-    );
+    let bob_val: Option<String> =
+        redis::cmd("GET").arg("shared_key").query_async(&mut con_bob).await.unwrap();
+    assert!(bob_val.is_none(), "bob should not see alice's data, got: {bob_val:?}");
 
     // Alice should see her own key.
-    let alice_val: String = redis::cmd("GET")
-        .arg("shared_key")
-        .query_async(&mut con_alice)
-        .await
-        .unwrap();
+    let alice_val: String =
+        redis::cmd("GET").arg("shared_key").query_async(&mut con_alice).await.unwrap();
     assert_eq!(alice_val, "alice-data");
 }
 
@@ -964,10 +838,7 @@ async fn hmac_auth_missing_password_arg_rejected() {
     let mut con = client.get_multiplexed_async_connection().await.unwrap();
 
     // AUTH with only hostname (missing password) should fail.
-    let err = redis::cmd("AUTH")
-        .arg("alice.com")
-        .query_async::<String>(&mut con)
-        .await;
+    let err = redis::cmd("AUTH").arg("alice.com").query_async::<String>(&mut con).await;
     assert!(err.is_err());
     let msg = err.unwrap_err().to_string();
     assert!(

--- a/crates/ephpm-kv/tests/stress.rs
+++ b/crates/ephpm-kv/tests/stress.rs
@@ -41,19 +41,13 @@ impl TestServer {
     }
 
     async fn start_with_config(config: StoreConfig) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind test listener");
-        let addr = listener
-            .local_addr()
-            .expect("failed to get local addr")
-            .to_string();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("failed to bind test listener");
+        let addr = listener.local_addr().expect("failed to get local addr").to_string();
 
         let store = Store::new(config);
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, None, None)
-                .await
-                .ok();
+            server::serve_on(store, listener, 64 * 1024 * 1024, None, None, None).await.ok();
         });
 
         // Give the accept loop a moment to become ready.
@@ -86,30 +80,20 @@ struct HmacTestServer {
 
 impl HmacTestServer {
     async fn start(secret: &str) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind test listener");
-        let addr = listener
-            .local_addr()
-            .expect("failed to get local addr")
-            .to_string();
+        let listener =
+            TcpListener::bind("127.0.0.1:0").await.expect("failed to bind test listener");
+        let addr = listener.local_addr().expect("failed to get local addr").to_string();
 
         let store = Store::new(StoreConfig::default());
         let mt = MultiTenantStore::new(Arc::clone(&store), StoreConfig::default());
         let sec = Some(secret.to_string());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, sec, Some(mt))
-                .await
-                .ok();
+            server::serve_on(store, listener, 64 * 1024 * 1024, None, sec, Some(mt)).await.ok();
         });
 
         tokio::time::sleep(Duration::from_millis(10)).await;
 
-        Self {
-            addr,
-            handle,
-            secret: secret.to_string(),
-        }
+        Self { addr, handle, secret: secret.to_string() }
     }
 
     /// Open a raw (unauthenticated) connection to be manually AUTH'd.
@@ -143,10 +127,8 @@ async fn concurrent_writer_storm() {
         let url = format!("redis://{addr}/");
         handles.push(tokio::spawn(async move {
             let client = redis::Client::open(url).expect("invalid redis URL");
-            let mut con = client
-                .get_multiplexed_async_connection()
-                .await
-                .expect("failed to connect");
+            let mut con =
+                client.get_multiplexed_async_connection().await.expect("failed to connect");
 
             for i in 0..OPS_PER_WRITER {
                 let key = format!("w{writer_id}:k{i}");
@@ -250,8 +232,7 @@ async fn compression_round_trip_at_scale() {
     let mut con = srv.con().await;
 
     // Build compressible values: repeated patterns of varying lengths.
-    let mut expected_values: Vec<(String, Vec<u8>)> =
-        Vec::with_capacity(COMPRESSION_KEY_COUNT);
+    let mut expected_values: Vec<(String, Vec<u8>)> = Vec::with_capacity(COMPRESSION_KEY_COUNT);
     for i in 0..COMPRESSION_KEY_COUNT {
         let key = format!("cmp:{i}");
         // Create a value with repeated patterns that compresses well.
@@ -291,9 +272,7 @@ async fn compression_round_trip_at_scale() {
 async fn multi_tenant_isolation() {
     let srv = HmacTestServer::start("stress-test-secret").await;
 
-    let hostnames: Vec<String> = (0..TENANTS)
-        .map(|i| format!("tenant{i}.example.com"))
-        .collect();
+    let hostnames: Vec<String> = (0..TENANTS).map(|i| format!("tenant{i}.example.com")).collect();
 
     // Each tenant writes 200 keys via its own authenticated connection.
     let mut handles = Vec::with_capacity(TENANTS);
@@ -305,10 +284,8 @@ async fn multi_tenant_isolation() {
             let password = derive_site_password(&secret, &hostname);
             let client =
                 redis::Client::open(format!("redis://{addr}/")).expect("invalid redis URL");
-            let mut con = client
-                .get_multiplexed_async_connection()
-                .await
-                .expect("failed to connect");
+            let mut con =
+                client.get_multiplexed_async_connection().await.expect("failed to connect");
 
             // Authenticate.
             let _: String = redis::cmd("AUTH")
@@ -330,10 +307,7 @@ async fn multi_tenant_isolation() {
                 let key = format!("key:{i}");
                 let expected = format!("tenant{tenant_idx}:val{i}");
                 let got: String = con.get(&key).await.expect("GET failed");
-                assert_eq!(
-                    got, expected,
-                    "tenant {hostname} read-back mismatch for {key}",
-                );
+                assert_eq!(got, expected, "tenant {hostname} read-back mismatch for {key}",);
             }
 
             // DBSIZE should reflect only this tenant's keys.

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -71,8 +71,8 @@ fn link_php(lib_dir: &Path, target_os: &str) {
     // Link additional static libraries from the SDK that static-php-cli
     // built. We probe for each library since the set varies by config.
     for static_lib in &[
-        "ssl", "crypto", "curl", "z", "xml2", "sodium", "iconv", "charset",
-        "png16", "gd", "jpeg", "freetype", "onig", "zip", "bz2", "xslt", "exslt",
+        "ssl", "crypto", "curl", "z", "xml2", "sodium", "iconv", "charset", "png16", "gd", "jpeg",
+        "freetype", "onig", "zip", "bz2", "xslt", "exslt",
     ] {
         // Unix uses libfoo.a, Windows uses foo.lib
         let found = lib_dir.join(format!("lib{static_lib}.a")).exists()
@@ -219,15 +219,13 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
     let include_tsrm = include_dir.join("TSRM");
     let include_sapi = include_dir.join("sapi");
 
-    let mut builder = bindgen::Builder::default()
-        .header("wrapper.h")
-        .clang_args([
-            format!("-I{}", include_dir.display()),
-            format!("-I{}", include_main.display()),
-            format!("-I{}", include_zend.display()),
-            format!("-I{}", include_tsrm.display()),
-            format!("-I{}", include_sapi.display()),
-        ]);
+    let mut builder = bindgen::Builder::default().header("wrapper.h").clang_args([
+        format!("-I{}", include_dir.display()),
+        format!("-I{}", include_main.display()),
+        format!("-I{}", include_zend.display()),
+        format!("-I{}", include_tsrm.display()),
+        format!("-I{}", include_sapi.display()),
+    ]);
 
     // When targeting musl, libclang defaults to glibc headers in /usr/include/
     // which then fail to find stddef.h. We need to:
@@ -236,9 +234,7 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
     //  3. Add clang's internal headers for stddef.h, stdarg.h, etc.
     //  4. Define _GNU_SOURCE for memrchr/mempcpy declarations
     if target_env == "musl" {
-        builder = builder
-            .clang_arg("-D_GNU_SOURCE")
-            .clang_arg("-nostdlibinc");
+        builder = builder.clang_arg("-D_GNU_SOURCE").clang_arg("-nostdlibinc");
 
         // Add clang's resource directory (contains stddef.h, stdarg.h, etc.)
         if let Some(clang_include) = find_clang_resource_include() {
@@ -259,9 +255,7 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
         builder = builder.clang_arg("--target=x86_64-pc-windows-msvc");
     } else {
         // ZTS builds: define ZTS for bindgen so PHP headers use thread-safe macros.
-        builder = builder
-            .clang_arg("-DZTS=1")
-            .clang_arg("-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+        builder = builder.clang_arg("-DZTS=1").clang_arg("-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
     }
 
     let bindings = builder
@@ -304,9 +298,7 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
         .expect("failed to generate PHP bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("php_bindings.rs"))
-        .expect("failed to write PHP bindings");
+    bindings.write_to_file(out_path.join("php_bindings.rs")).expect("failed to write PHP bindings");
 }
 
 /// Find clang's resource directory containing compiler-internal headers

--- a/crates/ephpm-php/src/kv_bridge.rs
+++ b/crates/ephpm-php/src/kv_bridge.rs
@@ -57,11 +57,7 @@ pub fn set_site_store(_store: Option<std::sync::Arc<ephpm_kv::store::Store>>) {}
 fn effective_store() -> Option<Arc<Store>> {
     KV_SITE_STORE.with(|s| {
         let site = s.borrow();
-        if let Some(ref store) = *site {
-            Some(Arc::clone(store))
-        } else {
-            KV_STORE.get().cloned()
-        }
+        if let Some(ref store) = *site { Some(Arc::clone(store)) } else { KV_STORE.get().cloned() }
     })
 }
 
@@ -78,12 +74,8 @@ pub struct EphpmKvOps {
     pub get: Option<unsafe extern "C" fn(key: *const std::os::raw::c_char) -> std::os::raw::c_int>,
 
     /// Retrieve the pointer and length of the last `get` result.
-    pub get_result: Option<
-        unsafe extern "C" fn(
-            ptr: *mut *const std::os::raw::c_char,
-            len: *mut usize,
-        ),
-    >,
+    pub get_result:
+        Option<unsafe extern "C" fn(ptr: *mut *const std::os::raw::c_char, len: *mut usize)>,
 
     /// Set a key to a value. `ttl_ms` of 0 means no expiry.
     /// Returns 1 on success, 0 on failure (e.g. OOM with noeviction).
@@ -97,8 +89,7 @@ pub struct EphpmKvOps {
     >,
 
     /// Delete a key. Returns 1 if it existed, 0 if not.
-    pub del:
-        Option<unsafe extern "C" fn(key: *const std::os::raw::c_char) -> std::os::raw::c_long>,
+    pub del: Option<unsafe extern "C" fn(key: *const std::os::raw::c_char) -> std::os::raw::c_long>,
 
     /// Check if a key exists. Returns 1 if yes, 0 if no.
     pub exists:
@@ -125,9 +116,8 @@ pub struct EphpmKvOps {
 
     /// Get remaining TTL in milliseconds. Returns -1 for no expiry,
     /// -2 for missing key.
-    pub pttl: Option<
-        unsafe extern "C" fn(key: *const std::os::raw::c_char) -> std::os::raw::c_longlong,
-    >,
+    pub pttl:
+        Option<unsafe extern "C" fn(key: *const std::os::raw::c_char) -> std::os::raw::c_longlong>,
 }
 
 // ── Callback implementations ────────────────────────────────────────────
@@ -158,10 +148,7 @@ unsafe extern "C" fn kv_get(key: *const std::os::raw::c_char) -> std::os::raw::c
 }
 
 #[cfg(php_linked)]
-unsafe extern "C" fn kv_get_result(
-    ptr: *mut *const std::os::raw::c_char,
-    len: *mut usize,
-) {
+unsafe extern "C" fn kv_get_result(ptr: *mut *const std::os::raw::c_char, len: *mut usize) {
     // Safety: `ptr` and `len` are valid pointers provided by our own C code
     // in `PHP_FUNCTION(ephpm_kv_get)`. The buffer remains valid because this
     // is called on the same thread immediately after `kv_get`, and the
@@ -284,9 +271,7 @@ unsafe extern "C" fn kv_expire(
 }
 
 #[cfg(php_linked)]
-unsafe extern "C" fn kv_pttl(
-    key: *const std::os::raw::c_char,
-) -> std::os::raw::c_longlong {
+unsafe extern "C" fn kv_pttl(key: *const std::os::raw::c_char) -> std::os::raw::c_longlong {
     // Safety: `key` is a null-terminated C string from PHP.
     let key_str = unsafe { CStr::from_ptr(key) };
     let Ok(key_str) = key_str.to_str() else {
@@ -350,8 +335,8 @@ pub fn set_store(_store: std::sync::Arc<ephpm_kv::store::Store>) {
 mod tests {
     use std::ffi::CString;
     use std::sync::{Arc, OnceLock};
-    use std::time::Duration;
     use std::thread;
+    use std::time::Duration;
 
     use ephpm_kv::store::{Store, StoreConfig};
     use serial_test::serial;
@@ -631,11 +616,7 @@ mod tests {
     #[serial]
     fn pttl_with_expiry_returns_positive() {
         let store = init_store();
-        store.set(
-            "bridge_pttl_exp".into(),
-            b"v".to_vec(),
-            Some(Duration::from_secs(60)),
-        );
+        store.set("bridge_pttl_exp".into(), b"v".to_vec(), Some(Duration::from_secs(60)));
         let key = cstr("bridge_pttl_exp");
         // Safety: key is a valid C string.
         let ms = unsafe { kv_pttl(key.as_ptr()) };

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -9,8 +9,8 @@ pub mod sapi;
 #[cfg(all(php_linked, target_os = "windows"))]
 pub mod windows_dll;
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use request::PhpRequest;
 use response::PhpResponse;
@@ -79,18 +79,14 @@ mod ffi {
         ) -> ::std::os::raw::c_int;
 
         /// Get the captured output buffer. Sets `*out_len` to the length.
-        pub fn ephpm_get_output_buf(
-            out_len: *mut usize,
-        ) -> *const ::std::os::raw::c_char;
+        pub fn ephpm_get_output_buf(out_len: *mut usize) -> *const ::std::os::raw::c_char;
 
         /// Get the HTTP response status code.
         pub fn ephpm_get_response_code() -> ::std::os::raw::c_int;
 
         /// Get the captured response headers ("Name: Value\n" lines).
         /// Sets `*out_len` to the length.
-        pub fn ephpm_get_response_headers(
-            out_len: *mut usize,
-        ) -> *const ::std::os::raw::c_char;
+        pub fn ephpm_get_response_headers(out_len: *mut usize) -> *const ::std::os::raw::c_char;
 
         // ── ZTS thread lifecycle ────────────────────────────────────
 
@@ -117,9 +113,7 @@ mod ffi {
 
         /// Set the KV ops function pointer table. Can be called after
         /// `php_embed_init()`, before any PHP scripts execute.
-        pub fn ephpm_set_kv_ops(
-            ops: *const crate::kv_bridge::EphpmKvOps,
-        );
+        pub fn ephpm_set_kv_ops(ops: *const crate::kv_bridge::EphpmKvOps);
 
         /// Get the PHP version string (compile-time constant).
         /// Safe to call before `php_embed_init()`.
@@ -358,9 +352,7 @@ impl PhpRuntime {
         // PHP_VERSION string constant, which is valid for the entire process.
         let ptr = unsafe { ffi::ephpm_get_php_version() };
         // Safety: PHP_VERSION is a valid UTF-8 C string literal.
-        unsafe { std::ffi::CStr::from_ptr(ptr) }
-            .to_str()
-            .unwrap_or("unknown")
+        unsafe { std::ffi::CStr::from_ptr(ptr) }.to_str().unwrap_or("unknown")
     }
 
     /// Get the embedded PHP version string (stub mode).
@@ -398,9 +390,10 @@ impl PhpRuntime {
             let mut c_args: Vec<CString> = Vec::with_capacity(args.len() + 1);
             c_args.push(CString::new("ephpm").unwrap());
             for arg in args {
-                c_args.push(CString::new(arg.as_str()).map_err(|e| {
-                    PhpError::ExecutionFailed(format!("invalid argument: {e}"))
-                })?);
+                c_args
+                    .push(CString::new(arg.as_str()).map_err(|e| {
+                        PhpError::ExecutionFailed(format!("invalid argument: {e}"))
+                    })?);
             }
 
             let mut argv_ptrs: Vec<*mut std::os::raw::c_char> =
@@ -541,11 +534,8 @@ impl PhpRuntime {
             .map_err(|e| PhpError::ExecutionFailed(format!("invalid script path: {e}")))?;
 
         // Pass POST body — use null pointer for empty bodies
-        let post_data_ptr = if request.body.is_empty() {
-            std::ptr::null()
-        } else {
-            request.body.as_ptr().cast()
-        };
+        let post_data_ptr =
+            if request.body.is_empty() { std::ptr::null() } else { request.body.as_ptr().cast() };
 
         // Set core request info in C
         // Safety: All CString pointers are valid and will stay alive.
@@ -624,15 +614,11 @@ impl PhpRuntime {
 
         match ret {
             0 => Ok(PhpResponse { status, headers, body }),
-            -1 => Err(PhpError::ExecutionFailed(
-                "php_request_startup failed".into(),
-            )),
+            -1 => Err(PhpError::ExecutionFailed("php_request_startup failed".into())),
             _ => {
                 // Bailout (exit/die/fatal): return whatever output was captured
                 if body.is_empty() {
-                    Err(PhpError::ExecutionFailed(
-                        "PHP bailout (fatal error or exit)".into(),
-                    ))
+                    Err(PhpError::ExecutionFailed("PHP bailout (fatal error or exit)".into()))
                 } else {
                     // exit() and die() are common in PHP — return the output
                     Ok(PhpResponse { status, headers, body })
@@ -771,10 +757,7 @@ mod tests {
 
         let response = PhpRuntime::execute(make_test_request()).unwrap();
         assert_eq!(response.status, 200);
-        assert!(response
-            .headers
-            .iter()
-            .any(|(k, v)| k == "Content-Type" && v == "text/html"));
+        assert!(response.headers.iter().any(|(k, v)| k == "Content-Type" && v == "text/html"));
         let body = String::from_utf8(response.body).unwrap();
         assert!(body.contains("ePHPm Stub"));
         assert!(body.contains("test.php"));
@@ -788,9 +771,6 @@ mod tests {
         let _ = PhpRuntime::shutdown();
 
         let err = PhpRuntime::execute(make_test_request()).unwrap_err();
-        assert!(
-            matches!(err, PhpError::NotInitialized),
-            "expected NotInitialized, got {err}"
-        );
+        assert!(matches!(err, PhpError::NotInitialized), "expected NotInitialized, got {err}");
     }
 }

--- a/crates/ephpm-php/src/request.rs
+++ b/crates/ephpm-php/src/request.rs
@@ -226,10 +226,7 @@ mod tests {
         let req = make_request();
         let vars = req.server_variables();
 
-        assert_eq!(
-            find_var(&vars, "HTTP_ACCEPT_ENCODING"),
-            Some("gzip, deflate")
-        );
+        assert_eq!(find_var(&vars, "HTTP_ACCEPT_ENCODING"), Some("gzip, deflate"));
     }
 
     #[test]
@@ -245,8 +242,7 @@ mod tests {
     #[test]
     fn test_server_variables_content_type_no_http_prefix() {
         let mut req = make_request();
-        req.headers
-            .push(("content-type".into(), "application/json".into()));
+        req.headers.push(("content-type".into(), "application/json".into()));
         let vars = req.server_variables();
 
         assert_eq!(find_var(&vars, "CONTENT_TYPE"), Some("application/json"));
@@ -284,8 +280,7 @@ mod tests {
     #[test]
     fn test_cookie_string_found() {
         let mut req = make_request();
-        req.headers
-            .push(("Cookie".into(), "session=abc123".into()));
+        req.headers.push(("Cookie".into(), "session=abc123".into()));
         assert_eq!(req.cookie_string(), "session=abc123");
     }
 
@@ -298,8 +293,7 @@ mod tests {
     #[test]
     fn test_cookie_string_case_insensitive() {
         let mut req = make_request();
-        req.headers
-            .push(("COOKIE".into(), "token=xyz".into()));
+        req.headers.push(("COOKIE".into(), "token=xyz".into()));
         assert_eq!(req.cookie_string(), "token=xyz");
     }
 

--- a/crates/ephpm-php/src/windows_dll.rs
+++ b/crates/ephpm-php/src/windows_dll.rs
@@ -71,11 +71,7 @@ pub fn extract_php_dll() -> std::io::Result<PhpDllGuard> {
     std::fs::write(dir.join("php8embed.dll"), PHP_EMBED_DLL)?;
 
     // Build a null-terminated UTF-16 path for the Win32 API.
-    let wide: Vec<u16> = dir
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0u16))
-        .collect();
+    let wide: Vec<u16> = dir.as_os_str().encode_wide().chain(std::iter::once(0u16)).collect();
 
     // Safety: `wide` is a valid null-terminated UTF-16 string pointing to
     // an existing directory. SetDllDirectoryW only reads the string; it does

--- a/crates/ephpm-query-stats/src/digest.rs
+++ b/crates/ephpm-query-stats/src/digest.rs
@@ -85,9 +85,7 @@ pub fn normalize(sql: &str) -> String {
 
 /// Returns `true` if the last character in `out` is alphanumeric or `_`.
 fn prev_is_identifier(out: &str) -> bool {
-    out.chars()
-        .next_back()
-        .is_some_and(|p| p.is_alphanumeric() || p == '_')
+    out.chars().next_back().is_some_and(|p| p.is_alphanumeric() || p == '_')
 }
 
 /// Handle a character in `Normal` state. Returns the new index.
@@ -119,9 +117,7 @@ fn handle_normal(
         i + 2
     } else if c == '0' && i + 1 < len && (chars[i + 1] == 'x' || chars[i + 1] == 'X') {
         handle_hex_literal(i, chars, len, out)
-    } else if c.is_ascii_digit()
-        || (c == '.' && i + 1 < len && chars[i + 1].is_ascii_digit())
-    {
+    } else if c.is_ascii_digit() || (c == '.' && i + 1 < len && chars[i + 1].is_ascii_digit()) {
         handle_numeric_literal(c, i, out, state)
     } else if c.is_ascii_whitespace() {
         if !out.ends_with(' ') && !out.is_empty() {
@@ -195,8 +191,7 @@ fn collapse_in_lists(sql: &mut String) {
         let mut end = after_in;
         let chars: Vec<char> = rest.chars().collect();
         let mut j = 0;
-        while j + 2 < chars.len() && chars[j] == ',' && chars[j + 1] == ' ' && chars[j + 2] == '?'
-        {
+        while j + 2 < chars.len() && chars[j] == ',' && chars[j + 1] == ' ' && chars[j + 2] == '?' {
             j += 3;
         }
         end += j;
@@ -258,51 +253,33 @@ mod tests {
 
     #[test]
     fn normalize_float() {
-        assert_eq!(
-            normalize("WHERE price > 9.99"),
-            "WHERE price > ?"
-        );
+        assert_eq!(normalize("WHERE price > 9.99"), "WHERE price > ?");
     }
 
     #[test]
     fn normalize_escaped_quote() {
-        assert_eq!(
-            normalize("WHERE name = 'it''s'"),
-            "WHERE name = ?"
-        );
+        assert_eq!(normalize("WHERE name = 'it''s'"), "WHERE name = ?");
     }
 
     #[test]
     fn normalize_backslash_escape() {
-        assert_eq!(
-            normalize(r"WHERE name = 'it\'s'"),
-            "WHERE name = ?"
-        );
+        assert_eq!(normalize(r"WHERE name = 'it\'s'"), "WHERE name = ?");
     }
 
     #[test]
     fn normalize_in_list() {
-        assert_eq!(
-            normalize("WHERE id IN (1, 2, 3, 4, 5)"),
-            "WHERE id IN (?, ...)"
-        );
+        assert_eq!(normalize("WHERE id IN (1, 2, 3, 4, 5)"), "WHERE id IN (?, ...)");
     }
 
     #[test]
     fn normalize_in_list_single() {
         // Single value — no collapse
-        assert_eq!(
-            normalize("WHERE id IN (1)"),
-            "WHERE id IN (?)"
-        );
+        assert_eq!(normalize("WHERE id IN (1)"), "WHERE id IN (?)");
     }
 
     #[test]
     fn normalize_preserves_identifiers() {
-        assert_eq!(
-            normalize("SELECT col1, col2 FROM table1"),
-            "SELECT col1, col2 FROM table1"
-        );
+        assert_eq!(normalize("SELECT col1, col2 FROM table1"), "SELECT col1, col2 FROM table1");
     }
 
     #[test]
@@ -315,18 +292,12 @@ mod tests {
 
     #[test]
     fn normalize_strips_line_comment() {
-        assert_eq!(
-            normalize("SELECT 1 -- this is a comment\nFROM t"),
-            "SELECT ? FROM t"
-        );
+        assert_eq!(normalize("SELECT 1 -- this is a comment\nFROM t"), "SELECT ? FROM t");
     }
 
     #[test]
     fn normalize_strips_block_comment() {
-        assert_eq!(
-            normalize("SELECT /* comment */ 1 FROM t"),
-            "SELECT ? FROM t"
-        );
+        assert_eq!(normalize("SELECT /* comment */ 1 FROM t"), "SELECT ? FROM t");
     }
 
     #[test]
@@ -339,18 +310,12 @@ mod tests {
 
     #[test]
     fn normalize_preserves_null_keyword() {
-        assert_eq!(
-            normalize("WHERE val IS NULL"),
-            "WHERE val IS NULL"
-        );
+        assert_eq!(normalize("WHERE val IS NULL"), "WHERE val IS NULL");
     }
 
     #[test]
     fn normalize_hex_literal() {
-        assert_eq!(
-            normalize("WHERE data = 0xDEADBEEF"),
-            "WHERE data = ?"
-        );
+        assert_eq!(normalize("WHERE data = 0xDEADBEEF"), "WHERE data = ?");
     }
 
     #[test]
@@ -370,17 +335,11 @@ mod tests {
     #[test]
     fn normalize_negative_number() {
         // -42 is unary minus + number literal
-        assert_eq!(
-            normalize("WHERE val = -42"),
-            "WHERE val = -?"
-        );
+        assert_eq!(normalize("WHERE val = -42"), "WHERE val = -?");
     }
 
     #[test]
     fn normalize_double_quoted_string() {
-        assert_eq!(
-            normalize(r#"WHERE name = "Alice""#),
-            "WHERE name = ?"
-        );
+        assert_eq!(normalize(r#"WHERE name = "Alice""#), "WHERE name = ?");
     }
 }

--- a/crates/ephpm-query-stats/src/lib.rs
+++ b/crates/ephpm-query-stats/src/lib.rs
@@ -30,11 +30,7 @@ pub struct StatsConfig {
 
 impl Default for StatsConfig {
     fn default() -> Self {
-        Self {
-            enabled: true,
-            slow_query_threshold: Duration::from_secs(1),
-            max_digests: 100_000,
-        }
+        Self { enabled: true, slow_query_threshold: Duration::from_secs(1), max_digests: 100_000 }
     }
 }
 
@@ -97,10 +93,7 @@ impl QueryStats {
     /// Create a new stats collector with the given configuration.
     #[must_use]
     pub fn new(config: StatsConfig) -> Self {
-        Self {
-            entries: Arc::new(DashMap::new()),
-            config,
-        }
+        Self { entries: Arc::new(DashMap::new()), config }
     }
 
     /// Record a completed query (SELECT, SHOW, etc.).
@@ -122,11 +115,8 @@ impl QueryStats {
     /// Snapshot of all tracked digests, sorted by total time descending.
     #[must_use]
     pub fn top_queries(&self, limit: usize) -> Vec<DigestEntry> {
-        let mut entries: Vec<DigestEntry> = self
-            .entries
-            .iter()
-            .map(|r| r.value().clone())
-            .collect();
+        let mut entries: Vec<DigestEntry> =
+            self.entries.iter().map(|r| r.value().clone()).collect();
         entries.sort_by(|a, b| b.total_time.cmp(&a.total_time));
         entries.truncate(limit);
         entries
@@ -274,7 +264,12 @@ mod tests {
     fn separate_digests_for_different_queries() {
         let stats = QueryStats::new(StatsConfig::default());
         stats.record_query("SELECT * FROM users WHERE id = 1", Duration::from_millis(1), true, 1);
-        stats.record_mutation("INSERT INTO users VALUES (1, 'a')", Duration::from_millis(2), true, 1);
+        stats.record_mutation(
+            "INSERT INTO users VALUES (1, 'a')",
+            Duration::from_millis(2),
+            true,
+            1,
+        );
 
         assert_eq!(stats.digest_count(), 2);
     }
@@ -306,10 +301,7 @@ mod tests {
 
     #[test]
     fn max_digests_enforced() {
-        let config = StatsConfig {
-            max_digests: 3,
-            ..Default::default()
-        };
+        let config = StatsConfig { max_digests: 3, ..Default::default() };
         let stats = QueryStats::new(config);
 
         for i in 0..10 {
@@ -385,10 +377,7 @@ mod tests {
 
     #[test]
     fn disabled_stats_records_nothing() {
-        let config = StatsConfig {
-            enabled: false,
-            ..Default::default()
-        };
+        let config = StatsConfig { enabled: false, ..Default::default() };
         let stats = QueryStats::new(config);
         stats.record_query("SELECT * FROM t WHERE id = 1", Duration::from_millis(5), true, 1);
         stats.record_mutation("INSERT INTO t VALUES (1)", Duration::from_millis(2), true, 1);

--- a/crates/ephpm-query-stats/tests/stress.rs
+++ b/crates/ephpm-query-stats/tests/stress.rs
@@ -18,10 +18,7 @@ fn sql_patterns() -> Vec<String> {
     (0..20)
         .map(|i| match i % 4 {
             0 => format!("SELECT * FROM table_{i} WHERE id = {}", i * 100),
-            1 => format!(
-                "INSERT INTO table_{i} (col_a, col_b) VALUES ({}, 'value_{i}')",
-                i * 10
-            ),
+            1 => format!("INSERT INTO table_{i} (col_a, col_b) VALUES ({}, 'value_{i}')", i * 10),
             2 => format!("UPDATE table_{i} SET col_a = {} WHERE id = {}", i * 5, i),
             _ => format!("DELETE FROM table_{i} WHERE created_at < '{i}-01-01'"),
         })
@@ -64,12 +61,7 @@ fn concurrent_recording_accuracy() {
                 barrier.wait();
                 for q in 0..queries_per_thread {
                     let idx = (t * queries_per_thread + q) % patterns.len();
-                    stats.record(
-                        &patterns[idx],
-                        Duration::from_micros(100),
-                        true,
-                        1,
-                    );
+                    stats.record(&patterns[idx], Duration::from_micros(100), true, 1);
                 }
             })
         })
@@ -97,8 +89,7 @@ fn concurrent_recording_accuracy() {
     );
 
     // Each of the 20 patterns is hit 1 (seed) + 2,500 (concurrent) = 2,501 times.
-    let expected_per_digest =
-        1 + (num_threads * queries_per_thread / patterns.len()) as u64;
+    let expected_per_digest = 1 + (num_threads * queries_per_thread / patterns.len()) as u64;
     for entry in &top {
         assert_eq!(
             entry.count, expected_per_digest,
@@ -174,10 +165,7 @@ fn normalization_throughput() {
 #[test]
 #[ignore = "nightly CI only — tests digest cap enforcement"]
 fn max_digests_cap() {
-    let config = StatsConfig {
-        max_digests: 50,
-        ..Default::default()
-    };
+    let config = StatsConfig { max_digests: 50, ..Default::default() };
     let stats = QueryStats::new(config);
 
     for i in 0..200 {
@@ -223,12 +211,7 @@ fn reset_under_concurrent_load() {
                 let mut i: usize = 0;
                 while running.load(Ordering::Relaxed) {
                     let idx = (t as usize * 1000 + i) % patterns.len();
-                    stats.record(
-                        &patterns[idx],
-                        Duration::from_micros(10),
-                        true,
-                        1,
-                    );
+                    stats.record(&patterns[idx], Duration::from_micros(10), true, 1);
                     i = i.wrapping_add(1);
                 }
             })

--- a/crates/ephpm-server/src/acme.rs
+++ b/crates/ephpm-server/src/acme.rs
@@ -99,19 +99,14 @@ pub fn start_acme(tls_config: &TlsConfig, store: Option<Arc<Store>>) -> anyhow::
         "ACME auto-TLS enabled"
     );
 
-    Ok(AcmeSetup {
-        challenge_config,
-        default_config,
-    })
+    Ok(AcmeSetup { challenge_config, default_config })
 }
 
 /// Poll the ACME state stream, logging events and errors.
 ///
 /// This task runs for the lifetime of the server. It drives certificate
 /// ordering, renewal, and cache operations.
-async fn drive_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
-    mut state: AcmeState<EC, EA>,
-) {
+async fn drive_acme_events<EC: Debug + 'static, EA: Debug + 'static>(mut state: AcmeState<EC, EA>) {
     loop {
         match state.next().await {
             Some(Ok(event)) => {
@@ -144,9 +139,7 @@ const ACME_CERT_PREFIX: &str = "acme:cert:";
 /// Generate a unique node identifier for ACME leader election.
 fn acme_node_id() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
     let pid = std::process::id();
     format!("{}-{}-{}", ts.as_millis(), pid, ts.subsec_nanos())
 }

--- a/crates/ephpm-server/src/file_cache.rs
+++ b/crates/ephpm-server/src/file_cache.rs
@@ -182,10 +182,7 @@ impl FileCache {
 /// Format: `W/"{mtime_secs:x}-{size:x}"`. This avoids reading file
 /// content for ETag generation — a significant win for large files.
 fn compute_mtime_etag(mtime: SystemTime, size: u64) -> String {
-    let secs = mtime
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let secs = mtime.duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
     format!("W/\"{secs:x}-{size:x}\"")
 }
 
@@ -205,11 +202,7 @@ mod tests {
     }
 
     fn test_compression() -> CompressionSettings {
-        CompressionSettings {
-            enabled: true,
-            level: 1,
-            min_size: 1024,
-        }
+        CompressionSettings { enabled: true, level: 1, min_size: 1024 }
     }
 
     #[test]
@@ -254,7 +247,8 @@ mod tests {
         let content = vec![0u8; 2048];
         let mtime = SystemTime::now();
 
-        let entry = cache.insert(&path, &content, mtime, "application/octet-stream", test_compression());
+        let entry =
+            cache.insert(&path, &content, mtime, "application/octet-stream", test_compression());
         assert!(entry.content.is_none(), "files above inline_threshold should not cache content");
         assert_eq!(entry.size, 2048);
     }

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -103,10 +103,7 @@ enum TlsMode {
     /// Manual TLS with a static cert/key loaded at startup.
     Manual(TlsAcceptor),
     /// Automatic ACME certificate provisioning (Let's Encrypt).
-    Acme {
-        challenge_config: Arc<ServerConfig>,
-        default_config: Arc<ServerConfig>,
-    },
+    Acme { challenge_config: Arc<ServerConfig>, default_config: Arc<ServerConfig> },
 }
 
 /// Resolved listener state after binding.
@@ -178,11 +175,8 @@ async fn bind_listeners(
             TlsMode::Manual(acceptor)
         }
         Some(tls_config) if tls_config.is_acme() => {
-            let acme_store = if config.cluster.enabled {
-                Some(Arc::clone(&kv_store))
-            } else {
-                None
-            };
+            let acme_store =
+                if config.cluster.enabled { Some(Arc::clone(&kv_store)) } else { None };
             let setup = acme::start_acme(tls_config, acme_store)?;
             TlsMode::Acme {
                 challenge_config: setup.challenge_config,
@@ -190,14 +184,18 @@ async fn bind_listeners(
             }
         }
         Some(tls_config) if tls_config.cert.is_some() || tls_config.key.is_some() => {
-            anyhow::bail!(
-                "TLS config must provide both cert and key, or neither (for ACME mode)"
-            );
+            anyhow::bail!("TLS config must provide both cert and key, or neither (for ACME mode)");
         }
         _ => TlsMode::None,
     };
 
-    let router = Arc::new(Router::new(config, kv_store, metrics_handle, limiter.clone(), file_cache.clone()));
+    let router = Arc::new(Router::new(
+        config,
+        kv_store,
+        metrics_handle,
+        limiter.clone(),
+        file_cache.clone(),
+    ));
 
     let has_tls = !matches!(tls_mode, TlsMode::None);
 
@@ -211,27 +209,17 @@ async fn bind_listeners(
         .transpose()?;
 
     let redirect_http = has_tls
-        && config
-            .server
-            .tls
-            .as_ref()
-            .is_some_and(|t| t.redirect_http && t.listen.is_some());
+        && config.server.tls.as_ref().is_some_and(|t| t.redirect_http && t.listen.is_some());
 
-    if config
-        .server
-        .tls
-        .as_ref()
-        .is_some_and(|t| t.redirect_http && t.listen.is_none())
-    {
+    if config.server.tls.as_ref().is_some_and(|t| t.redirect_http && t.listen.is_none()) {
         tracing::warn!(
             "tls.redirect_http is set but tls.listen is not — \
              redirect has no effect without a separate HTTP listener"
         );
     }
 
-    let main = TcpListener::bind(addr)
-        .await
-        .with_context(|| format!("failed to bind to {addr}"))?;
+    let main =
+        TcpListener::bind(addr).await.with_context(|| format!("failed to bind to {addr}"))?;
 
     let tls_listener = match tls_listen_addr {
         Some(tls_addr) if has_tls => {
@@ -448,10 +436,7 @@ fn dispatch_main_connection(
                 serve_manual_tls(stream, acceptor, router, remote_addr, conn).await;
             });
         }
-        TlsMode::Acme {
-            challenge_config,
-            default_config,
-        } => {
+        TlsMode::Acme { challenge_config, default_config } => {
             let challenge = Arc::clone(challenge_config);
             let default = Arc::clone(default_config);
             let router = Arc::clone(router);
@@ -495,10 +480,7 @@ fn dispatch_tls_connection(
                 serve_manual_tls(stream, acceptor, router, remote_addr, conn).await;
             });
         }
-        TlsMode::Acme {
-            challenge_config,
-            default_config,
-        } => {
+        TlsMode::Acme { challenge_config, default_config } => {
             let challenge = Arc::clone(challenge_config);
             let default = Arc::clone(default_config);
             let router = Arc::clone(router);
@@ -622,9 +604,8 @@ async fn serve_connection<I>(
     if let Err(err) = builder.serve_connection_with_upgrades(io, service).await {
         // Downcast to hyper::Error to suppress noisy "connection closed before
         // message was completed" errors (clients disconnecting mid-request).
-        let is_incomplete = err
-            .downcast_ref::<hyper::Error>()
-            .is_some_and(hyper::Error::is_incomplete_message);
+        let is_incomplete =
+            err.downcast_ref::<hyper::Error>().is_some_and(hyper::Error::is_incomplete_message);
         if !is_incomplete {
             tracing::debug!(%remote_addr, %err, "connection error");
         }
@@ -641,11 +622,8 @@ async fn serve_http_redirect(stream: TcpStream, remote_addr: SocketAddr, setting
             .and_then(|h| h.to_str().ok())
             .unwrap_or("localhost")
             .to_owned();
-        let path_and_query = req
-            .uri()
-            .path_and_query()
-            .map_or("/", http::uri::PathAndQuery::as_str)
-            .to_owned();
+        let path_and_query =
+            req.uri().path_and_query().map_or("/", http::uri::PathAndQuery::as_str).to_owned();
 
         async move {
             let location = format!("https://{host}{path_and_query}");
@@ -704,7 +682,9 @@ fn start_kv_service(
     // Create the KV store
     let store_config = ephpm_kv::store::StoreConfig {
         memory_limit: parse_memory_size(&config.kv.memory_limit)?,
-        eviction_policy: ephpm_kv::store::EvictionPolicy::from_str_lossy(&config.kv.eviction_policy),
+        eviction_policy: ephpm_kv::store::EvictionPolicy::from_str_lossy(
+            &config.kv.eviction_policy,
+        ),
         compression: ephpm_kv::store::CompressionConfig {
             algo: ephpm_kv::store::CompressionAlgo::from_str_lossy(&config.kv.compression),
             level: config.kv.compression_level,
@@ -764,10 +744,7 @@ async fn start_db_proxies(
     // MySQL proxy
     if let Some(mysql_config) = &config.db.mysql {
         let url = mysql_config.url.clone();
-        let listen = mysql_config
-            .listen
-            .clone()
-            .unwrap_or_else(|| "127.0.0.1:3306".to_string());
+        let listen = mysql_config.listen.clone().unwrap_or_else(|| "127.0.0.1:3306".to_string());
 
         let pool_config = ephpm_db::pool::PoolConfig {
             min_connections: mysql_config.min_connections,
@@ -780,17 +757,25 @@ async fn start_db_proxies(
 
         let reset_strategy = ephpm_db::ResetStrategy::from_str_lossy(&mysql_config.reset_strategy);
 
-        let replica_urls = mysql_config.replicas
-            .as_ref()
-            .map(|r| r.urls.clone())
-            .unwrap_or_default();
+        let replica_urls =
+            mysql_config.replicas.as_ref().map(|r| r.urls.clone()).unwrap_or_default();
 
         let rw_split = ephpm_db::mysql::RwSplitParams {
             enabled: config.db.read_write_split.enabled,
             sticky_duration: parse_duration(&config.db.read_write_split.sticky_duration)?,
         };
 
-        match ephpm_db::mysql::build_proxy(&url, &listen, mysql_config.socket.clone(), pool_config, reset_strategy, replica_urls, rw_split).await {
+        match ephpm_db::mysql::build_proxy(
+            &url,
+            &listen,
+            mysql_config.socket.clone(),
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+        )
+        .await
+        {
             Ok(proxy) => {
                 let maintenance_handle = proxy.start_maintenance();
                 let proxy_handle = tokio::spawn(async move {
@@ -812,10 +797,7 @@ async fn start_db_proxies(
     // PostgreSQL proxy
     if let Some(pg_config) = &config.db.postgres {
         let url = pg_config.url.clone();
-        let listen = pg_config
-            .listen
-            .clone()
-            .unwrap_or_else(|| "127.0.0.1:5432".to_string());
+        let listen = pg_config.listen.clone().unwrap_or_else(|| "127.0.0.1:5432".to_string());
 
         let pool_config = ephpm_db::pool::PoolConfig {
             min_connections: pg_config.min_connections,
@@ -828,11 +810,7 @@ async fn start_db_proxies(
 
         let reset_strategy = ephpm_db::ResetStrategy::from_str_lossy(&pg_config.reset_strategy);
 
-        let replica_urls = pg_config
-            .replicas
-            .as_ref()
-            .map(|r| r.urls.clone())
-            .unwrap_or_default();
+        let replica_urls = pg_config.replicas.as_ref().map(|r| r.urls.clone()).unwrap_or_default();
 
         let rw_split = ephpm_db::postgres::PgRwSplitParams {
             enabled: config.db.read_write_split.enabled,
@@ -969,17 +947,12 @@ async fn start_clustered_sqlite(
                 "replication.primary_grpc_url is required when role = \"replica\""
             );
             tracing::info!(primary = %url, "SQLite replication role forced to replica");
-            (
-                ephpm_sqld::SqldRole::Replica {
-                    primary_grpc_url: url.clone(),
-                },
-                None,
-            )
+            (ephpm_sqld::SqldRole::Replica { primary_grpc_url: url.clone() }, None)
         }
         _ => {
             // "auto" — use gossip election
-            let cluster_handle = cluster
-                .context("cluster must be enabled for auto SQLite replication")?;
+            let cluster_handle =
+                cluster.context("cluster must be enabled for auto SQLite replication")?;
             let election = ephpm_cluster::SqliteElection::new(
                 Arc::clone(cluster_handle),
                 sqlite_config.sqld.grpc_listen.clone(),
@@ -1006,9 +979,7 @@ async fn start_clustered_sqlite(
         .context("failed to start sqld")?;
 
     // Wait for sqld to become healthy.
-    sqld.wait_healthy(Duration::from_secs(30))
-        .await
-        .context("sqld did not become healthy")?;
+    sqld.wait_healthy(Duration::from_secs(30)).await.context("sqld did not become healthy")?;
 
     let sqld_http_url = sqld.http_url();
     tracing::info!(url = %sqld_http_url, "sqld is healthy, starting litewire with Hrana backend");
@@ -1084,9 +1055,7 @@ fn elected_to_sqld_role(elected: &ephpm_cluster::ElectedRole) -> ephpm_sqld::Sql
     match elected {
         ephpm_cluster::ElectedRole::Primary => ephpm_sqld::SqldRole::Primary,
         ephpm_cluster::ElectedRole::Replica { primary_grpc_url } => {
-            ephpm_sqld::SqldRole::Replica {
-                primary_grpc_url: primary_grpc_url.clone(),
-            }
+            ephpm_sqld::SqldRole::Replica { primary_grpc_url: primary_grpc_url.clone() }
         }
     }
 }
@@ -1105,17 +1074,14 @@ fn parse_memory_size(s: &str) -> anyhow::Result<usize> {
         (s.as_str(), 1)
     };
 
-    let num: usize = num_str.trim().parse()
-        .with_context(|| format!("invalid memory size: {s}"))?;
+    let num: usize = num_str.trim().parse().with_context(|| format!("invalid memory size: {s}"))?;
     Ok(num.saturating_mul(multiplier))
 }
 
 /// Parse a duration string (e.g. "30s", "5m", "1h") to `std::time::Duration`.
 fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
-    ephpm_db::duration::parse_duration(s)
-        .map_err(|e| anyhow::anyhow!("{e}"))
+    ephpm_db::duration::parse_duration(s).map_err(|e| anyhow::anyhow!("{e}"))
 }
-
 
 #[cfg(test)]
 mod lib_tests {

--- a/crates/ephpm-server/src/metrics.rs
+++ b/crates/ephpm-server/src/metrics.rs
@@ -6,11 +6,11 @@
 //! Call [`init`] once at startup. Pass the returned [`PrometheusHandle`] into
 //! [`Router`](crate::router::Router) so the `/metrics` endpoint can serve it.
 
+use ::metrics::gauge;
 use anyhow::Context;
 use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::{Response, StatusCode};
-use ::metrics::gauge;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 
 /// Duration histogram buckets tuned for PHP workloads.
@@ -27,7 +27,14 @@ const MUTEX_WAIT_BUCKETS: &[f64] =
 /// Body size buckets in bytes: 100B to 10MB. Covers typical HTML (5-50KB),
 /// API JSON (1-100KB), and larger asset responses.
 const BODY_BYTES_BUCKETS: &[f64] = &[
-    100.0, 1_000.0, 10_000.0, 50_000.0, 100_000.0, 500_000.0, 1_000_000.0, 5_000_000.0,
+    100.0,
+    1_000.0,
+    10_000.0,
+    50_000.0,
+    100_000.0,
+    500_000.0,
+    1_000_000.0,
+    5_000_000.0,
     10_000_000.0,
 ];
 

--- a/crates/ephpm-server/src/rate_limit.rs
+++ b/crates/ephpm-server/src/rate_limit.rs
@@ -110,10 +110,7 @@ impl Limiter {
             state.connections.fetch_add(1, Ordering::Relaxed);
         }
 
-        Some(ConnectionGuard {
-            limiter: std::sync::Arc::clone(self),
-            ip,
-        })
+        Some(ConnectionGuard { limiter: std::sync::Arc::clone(self), ip })
     }
 
     /// Check if a request from the given IP is allowed under the rate limit.
@@ -248,10 +245,7 @@ mod tests {
 
     #[test]
     fn connection_limit_enforced() {
-        let config = LimitsConfig {
-            max_connections: 2,
-            ..LimitsConfig::default()
-        };
+        let config = LimitsConfig { max_connections: 2, ..LimitsConfig::default() };
         let limiter = std::sync::Arc::new(Limiter::new(config));
         let ip: IpAddr = "1.2.3.4".parse().unwrap();
 

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+#[allow(unused_imports)]
+use ::metrics::{counter, gauge, histogram};
 use ephpm_config::Config;
 use ephpm_kv::store::Store;
 use ephpm_php::PhpRuntime;
@@ -25,9 +27,6 @@ use ipnet::IpNet;
 
 use crate::body::{self, ServerBody};
 use crate::{metrics, static_files};
-
-#[allow(unused_imports)]
-use ::metrics::{counter, gauge, histogram};
 
 /// Result of resolving a request through `fallback`.
 enum Resolved {
@@ -256,10 +255,7 @@ impl Router {
         let password = ephpm_kv::auth::derive_site_password(secret, hostname);
 
         // Parse host:port from the listen address.
-        let (host, port) = self
-            .kv_listen
-            .rsplit_once(':')
-            .unwrap_or(("127.0.0.1", "6379"));
+        let (host, port) = self.kv_listen.rsplit_once(':').unwrap_or(("127.0.0.1", "6379"));
 
         vec![
             ("EPHPM_REDIS_HOST".into(), host.into()),
@@ -275,12 +271,7 @@ impl Router {
         }
 
         // Strip port and trailing dot, lowercase.
-        let clean = host
-            .split(':')
-            .next()
-            .unwrap_or("")
-            .trim_end_matches('.')
-            .to_ascii_lowercase();
+        let clean = host.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase();
 
         // Check the startup-scanned registry first.
         // Verify the directory still exists — it may have been removed (teardown).
@@ -325,21 +316,16 @@ impl Router {
             let (effective_addr, _) = self.resolve_proxy_info(&req, remote_addr, is_tls);
             if !limiter.check_rate(effective_addr.ip()) {
                 counter!("ephpm_rate_limited_total").increment(1);
-                return Ok(error_response(
-                    StatusCode::TOO_MANY_REQUESTS,
-                    "429 Too Many Requests",
-                ));
+                return Ok(error_response(StatusCode::TOO_MANY_REQUESTS, "429 Too Many Requests"));
             }
         }
 
         gauge!("ephpm_http_requests_in_flight").increment(1.0);
         let start = std::time::Instant::now();
 
-        let (result, handler) = if let Ok(result) = tokio::time::timeout(
-            self.request_timeout,
-            self.handle_inner(req, remote_addr, is_tls),
-        )
-        .await
+        let (result, handler) = if let Ok(result) =
+            tokio::time::timeout(self.request_timeout, self.handle_inner(req, remote_addr, is_tls))
+                .await
         {
             let handler = result.as_ref().map_or("error", |(_, h)| *h);
             (result.map(|(resp, _)| resp), handler)
@@ -443,48 +429,78 @@ impl Router {
 
         // Extract If-None-Match for ETag support before consuming the request.
         let if_none_match = if self.etag {
-            req.headers()
-                .get("if-none-match")
-                .and_then(|v| v.to_str().ok())
-                .map(String::from)
+            req.headers().get("if-none-match").and_then(|v| v.to_str().ok()).map(String::from)
         } else {
             None
         };
 
-        let (mut response, handler) = match self.resolve_fallback(&uri_path, &query_string, &site_root, site_index, site_fallback) {
+        let (mut response, handler) = match self.resolve_fallback(
+            &uri_path,
+            &query_string,
+            &site_root,
+            site_index,
+            site_fallback,
+        ) {
             Resolved::File(fs_path) => {
                 if is_php_file(&fs_path) {
                     if self.is_php_allowed(&uri_path) {
-                        let is_cacheable = (method == "GET" || method == "HEAD") && self.php_etag_cache_config.enabled;
+                        let is_cacheable = (method == "GET" || method == "HEAD")
+                            && self.php_etag_cache_config.enabled;
 
                         // Pre-check: bypass PHP if client's ETag matches stored value.
                         if is_cacheable {
                             if let Some(client_tag) = &if_none_match {
-                                let key = php_etag_cache_key(&self.php_etag_cache_config.key_prefix, &method, &uri_path, &query_string);
+                                let key = php_etag_cache_key(
+                                    &self.php_etag_cache_config.key_prefix,
+                                    &method,
+                                    &uri_path,
+                                    &query_string,
+                                );
                                 if let Some(stored) = self.store.get(&key) {
                                     let stored_etag = String::from_utf8_lossy(&stored);
                                     if etag_matches_value(&stored_etag, client_tag) {
-                                        return Ok((Response::builder()
-                                            .status(StatusCode::NOT_MODIFIED)
-                                            .header("etag", stored_etag.as_ref())
-                                            .body(body::buffered(Full::new(Bytes::new())))
-                                            .expect("304 builder"), "php"));
+                                        return Ok((
+                                            Response::builder()
+                                                .status(StatusCode::NOT_MODIFIED)
+                                                .header("etag", stored_etag.as_ref())
+                                                .body(body::buffered(Full::new(Bytes::new())))
+                                                .expect("304 builder"),
+                                            "php",
+                                        ));
                                     }
                                 }
                             }
                         }
 
                         // Execute PHP
-                        let resp = self.handle_php(req, effective_addr, is_https, fs_path, accepts_gzip, accepts_br, site_root.clone())
+                        let resp = self
+                            .handle_php(
+                                req,
+                                effective_addr,
+                                is_https,
+                                fs_path,
+                                accepts_gzip,
+                                accepts_br,
+                                site_root.clone(),
+                            )
                             .await;
 
                         // Post-store: cache any ETag PHP set in the response.
                         if is_cacheable {
-                            if let Some(etag_val) = resp.headers().get("etag").and_then(|v| v.to_str().ok()) {
-                                let key = php_etag_cache_key(&self.php_etag_cache_config.key_prefix, &method, &uri_path, &query_string);
+                            if let Some(etag_val) =
+                                resp.headers().get("etag").and_then(|v| v.to_str().ok())
+                            {
+                                let key = php_etag_cache_key(
+                                    &self.php_etag_cache_config.key_prefix,
+                                    &method,
+                                    &uri_path,
+                                    &query_string,
+                                );
                                 #[allow(clippy::cast_sign_loss)]
                                 let ttl = if self.php_etag_cache_config.ttl_secs > 0 {
-                                    Some(Duration::from_secs(self.php_etag_cache_config.ttl_secs as u64))
+                                    Some(Duration::from_secs(
+                                        self.php_etag_cache_config.ttl_secs as u64,
+                                    ))
                                 } else {
                                     None
                                 };
@@ -497,23 +513,32 @@ impl Router {
                         (error_response(StatusCode::FORBIDDEN, "403 Forbidden"), "error")
                     }
                 } else {
-                    (static_files::serve_file(
-                        &site_root,
-                        &fs_path,
-                        accepts_gzip,
-                        accepts_br,
-                        &self.cache_control,
-                        self.compression,
-                        self.etag,
-                        if_none_match.as_deref(),
-                        self.file_cache.as_deref(),
+                    (
+                        static_files::serve_file(
+                            &site_root,
+                            &fs_path,
+                            accepts_gzip,
+                            accepts_br,
+                            &self.cache_control,
+                            self.compression,
+                            self.etag,
+                            if_none_match.as_deref(),
+                            self.file_cache.as_deref(),
+                        )
+                        .await,
+                        "static",
                     )
-                    .await, "static")
                 }
             }
             Resolved::Status(code) => {
                 let status = StatusCode::from_u16(code).unwrap_or(StatusCode::NOT_FOUND);
-                (error_response(status, &format!("{code} {}", status.canonical_reason().unwrap_or("Error"))), "error")
+                (
+                    error_response(
+                        status,
+                        &format!("{code} {}", status.canonical_reason().unwrap_or("Error")),
+                    ),
+                    "error",
+                )
             }
         };
 
@@ -566,7 +591,12 @@ impl Router {
     }
 
     /// Probe a single `fallback` entry against the filesystem.
-    fn probe_path(&self, expanded: &str, doc_root: &Path, index_files: &[String]) -> Option<PathBuf> {
+    fn probe_path(
+        &self,
+        expanded: &str,
+        doc_root: &Path,
+        index_files: &[String],
+    ) -> Option<PathBuf> {
         let (path_part, _) = split_path_query(expanded);
 
         if path_part.ends_with('/') {
@@ -582,11 +612,7 @@ impl Router {
             None
         } else {
             let fs_path = doc_root.join(path_part.trim_start_matches('/'));
-            if fs_path.is_file() {
-                Some(fs_path)
-            } else {
-                None
-            }
+            if fs_path.is_file() { Some(fs_path) } else { None }
         }
     }
 
@@ -639,7 +665,7 @@ impl Router {
         let result = tokio::task::spawn_blocking(move || {
             // Scope KV store to this virtual host for multi-tenant isolation.
             ephpm_php::kv_bridge::set_site_store(
-                multi_tenant_kv.as_ref().map(|mt| mt.get_site_store(&server_name))
+                multi_tenant_kv.as_ref().map(|mt| mt.get_site_store(&server_name)),
             );
 
             // Apply per-request PHP sandbox for multi-tenant isolation.
@@ -655,9 +681,21 @@ impl Router {
             }
 
             PhpRuntime::execute(PhpRequest {
-                method, uri, path, query_string, script_filename,
-                document_root, headers, body, content_type, remote_addr,
-                server_name, server_port, is_https, protocol, env_vars,
+                method,
+                uri,
+                path,
+                query_string,
+                script_filename,
+                document_root,
+                headers,
+                body,
+                content_type,
+                remote_addr,
+                server_name,
+                server_port,
+                is_https,
+                protocol,
+                env_vars,
             })
         })
         .await;
@@ -678,7 +716,9 @@ impl Router {
         if self.max_body_size == 0 {
             return None;
         }
-        let len: u64 = req.headers().get("content-length")
+        let len: u64 = req
+            .headers()
+            .get("content-length")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
@@ -700,7 +740,10 @@ impl Router {
             } else {
                 StatusCode::FORBIDDEN
             };
-            Some(error_response(status, &format!("{} {}", status.as_u16(), status.canonical_reason().unwrap_or("Error"))))
+            Some(error_response(
+                status,
+                &format!("{} {}", status.as_u16(), status.canonical_reason().unwrap_or("Error")),
+            ))
         } else {
             None
         }
@@ -754,11 +797,7 @@ impl Router {
         if self.trusted_hosts.is_empty() {
             return None;
         }
-        let host = req
-            .headers()
-            .get("host")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
+        let host = req.headers().get("host").and_then(|v| v.to_str().ok()).unwrap_or("");
         // Compare with and without port.
         let host_no_port = host.split(':').next().unwrap_or(host);
         let is_trusted = self.trusted_hosts.iter().any(|trusted| {
@@ -768,10 +807,7 @@ impl Router {
             None
         } else {
             tracing::debug!(host, "rejected untrusted host");
-            Some(error_response(
-                StatusCode::MISDIRECTED_REQUEST,
-                "421 Misdirected Request",
-            ))
+            Some(error_response(StatusCode::MISDIRECTED_REQUEST, "421 Misdirected Request"))
         }
     }
 
@@ -928,19 +964,13 @@ fn build_db_env_vars(config: &Config) -> Vec<(String, String)> {
     // MySQL takes precedence (most common for PHP).
     if let Some(ref mysql) = config.db.mysql {
         if mysql.inject_env {
-            let listen = mysql
-                .listen
-                .as_deref()
-                .unwrap_or("127.0.0.1:3306");
+            let listen = mysql.listen.as_deref().unwrap_or("127.0.0.1:3306");
             return db_env_from_url(listen, &mysql.url, "mysql");
         }
     }
     if let Some(ref pg) = config.db.postgres {
         if pg.inject_env {
-            let listen = pg
-                .listen
-                .as_deref()
-                .unwrap_or("127.0.0.1:5432");
+            let listen = pg.listen.as_deref().unwrap_or("127.0.0.1:5432");
             return db_env_from_url(listen, &pg.url, "pgsql");
         }
     }
@@ -952,17 +982,10 @@ fn db_env_from_url(listen: &str, backend_url: &str, driver: &str) -> Vec<(String
     let (host, port) = listen.rsplit_once(':').unwrap_or((listen, "3306"));
 
     // Parse: scheme://user:password@host:port/dbname
-    let rest = backend_url
-        .find("://")
-        .map_or(backend_url, |i| &backend_url[i + 3..]);
+    let rest = backend_url.find("://").map_or(backend_url, |i| &backend_url[i + 3..]);
     let (creds, host_db) = rest.split_once('@').unwrap_or(("", rest));
     let (user, password) = creds.split_once(':').unwrap_or((creds, ""));
-    let db_name = host_db
-        .split_once('/')
-        .map_or("", |(_, db)| db)
-        .split('?')
-        .next()
-        .unwrap_or("");
+    let db_name = host_db.split_once('/').map_or("", |(_, db)| db).split('?').next().unwrap_or("");
 
     vec![
         ("DB_HOST".into(), host.into()),
@@ -971,10 +994,7 @@ fn db_env_from_url(listen: &str, backend_url: &str, driver: &str) -> Vec<(String
         ("DB_USER".into(), user.into()),
         ("DB_PASSWORD".into(), password.into()),
         ("DB_CONNECTION".into(), driver.into()),
-        (
-            "DATABASE_URL".into(),
-            format!("{driver}://{user}:{password}@{host}:{port}/{db_name}"),
-        ),
+        ("DATABASE_URL".into(), format!("{driver}://{user}:{password}@{host}:{port}/{db_name}")),
     ]
 }
 
@@ -991,7 +1011,10 @@ fn error_response(status: StatusCode, body: &str) -> Response<ServerBody> {
 ///
 /// Prefers Brotli (`br`) over gzip when the client supports it.
 fn build_php_response(
-    result: Result<Result<ephpm_php::response::PhpResponse, ephpm_php::PhpError>, tokio::task::JoinError>,
+    result: Result<
+        Result<ephpm_php::response::PhpResponse, ephpm_php::PhpError>,
+        tokio::task::JoinError,
+    >,
     accepts_gzip: bool,
     accepts_br: bool,
     compression: CompressionSettings,
@@ -999,7 +1022,9 @@ fn build_php_response(
     match result {
         Ok(Ok(php_response)) => {
             let status = StatusCode::from_u16(php_response.status).unwrap_or(StatusCode::OK);
-            let ct = php_response.headers.iter()
+            let ct = php_response
+                .headers
+                .iter()
                 .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
                 .map_or("", |(_, v)| v.as_str());
 
@@ -1014,16 +1039,10 @@ fn build_php_response(
             // Try Brotli first (better ratio), then fall back to gzip.
             let (body_bytes, encoding) = if accepts_br {
                 brotli_compress(&php_response.body, ct, compression)
-                    .map_or_else(
-                        || (php_response.body, None),
-                        |c| (c, Some("br")),
-                    )
+                    .map_or_else(|| (php_response.body, None), |c| (c, Some("br")))
             } else if accepts_gzip {
                 gzip_compress(&php_response.body, ct, compression)
-                    .map_or_else(
-                        || (php_response.body, None),
-                        |c| (c, Some("gzip")),
-                    )
+                    .map_or_else(|| (php_response.body, None), |c| (c, Some("gzip")))
             } else {
                 (php_response.body, None)
             };
@@ -1049,7 +1068,10 @@ fn build_php_response(
         }
         Ok(Err(err)) => {
             tracing::error!(%err, "PHP execution failed");
-            error_response(StatusCode::INTERNAL_SERVER_ERROR, &format!("PHP execution error: {err}"))
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("PHP execution error: {err}"),
+            )
         }
         Err(err) => {
             tracing::error!(%err, "spawn_blocking task failed");
@@ -1092,7 +1114,11 @@ fn is_compressible(content_type: &str) -> bool {
 
 /// Try to gzip-compress a body. Returns `None` if not worth compressing.
 #[must_use]
-pub fn gzip_compress(data: &[u8], content_type: &str, settings: CompressionSettings) -> Option<Vec<u8>> {
+pub fn gzip_compress(
+    data: &[u8],
+    content_type: &str,
+    settings: CompressionSettings,
+) -> Option<Vec<u8>> {
     if data.len() < settings.min_size || !is_compressible(content_type) {
         return None;
     }
@@ -1100,11 +1126,7 @@ pub fn gzip_compress(data: &[u8], content_type: &str, settings: CompressionSetti
     let mut encoder = GzEncoder::new(Vec::new(), level);
     encoder.write_all(data).ok()?;
     let compressed = encoder.finish().ok()?;
-    if compressed.len() < data.len() {
-        Some(compressed)
-    } else {
-        None
-    }
+    if compressed.len() < data.len() { Some(compressed) } else { None }
 }
 
 /// Try to Brotli-compress a body. Returns `None` if not worth compressing.
@@ -1112,7 +1134,11 @@ pub fn gzip_compress(data: &[u8], content_type: &str, settings: CompressionSetti
 /// Brotli typically achieves 15-25% better compression than gzip on text
 /// content, making it the preferred choice when the client supports it.
 #[must_use]
-pub fn brotli_compress(data: &[u8], content_type: &str, settings: CompressionSettings) -> Option<Vec<u8>> {
+pub fn brotli_compress(
+    data: &[u8],
+    content_type: &str,
+    settings: CompressionSettings,
+) -> Option<Vec<u8>> {
     if data.len() < settings.min_size || !is_compressible(content_type) {
         return None;
     }
@@ -1131,11 +1157,7 @@ pub fn brotli_compress(data: &[u8], content_type: &str, settings: CompressionSet
         // CompressorWriter flushes on drop, but we need to handle errors.
         // Drop triggers the final flush.
     }
-    if compressed.len() < data.len() {
-        Some(compressed)
-    } else {
-        None
-    }
+    if compressed.len() < data.len() { Some(compressed) } else { None }
 }
 
 /// Build the KV store key for caching a PHP response's `ETag`.
@@ -1239,16 +1261,18 @@ mod tests {
     }
 
     fn default_compression() -> CompressionSettings {
-        CompressionSettings {
-            enabled: true,
-            level: 1,
-            min_size: 1024,
-        }
+        CompressionSettings { enabled: true, level: 1, min_size: 1024 }
     }
 
     /// Test helper: call resolve_fallback with the router's own defaults.
     fn resolve_fb(router: &Router, uri: &str, qs: &str) -> Resolved {
-        router.resolve_fallback(uri, qs, &router.document_root, &router.index_files, &router.fallback)
+        router.resolve_fallback(
+            uri,
+            qs,
+            &router.document_root,
+            &router.index_files,
+            &router.fallback,
+        )
     }
 
     // ── fallback resolution ─────────────────────────────────────────
@@ -1548,10 +1572,8 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        config.server.security.allowed_php_paths = vec![
-            "/index.php".to_string(),
-            "/wp-login.php".to_string(),
-        ];
+        config.server.security.allowed_php_paths =
+            vec!["/index.php".to_string(), "/wp-login.php".to_string()];
         let router = Router::new(&config, test_store(), None, None, None);
         assert!(router.is_php_allowed("/index.php"));
         assert!(router.is_php_allowed("/wp-login.php"));
@@ -1571,10 +1593,8 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        config.server.security.allowed_php_paths = vec![
-            "/index.php".to_string(),
-            "/wp-admin/*.php".to_string(),
-        ];
+        config.server.security.allowed_php_paths =
+            vec!["/index.php".to_string(), "/wp-admin/*.php".to_string()];
         let router = Router::new(&config, test_store(), None, None, None);
         assert!(router.is_php_allowed("/index.php"));
         assert!(router.is_php_allowed("/wp-admin/admin.php"));
@@ -1781,11 +1801,8 @@ mod tests {
 
     #[test]
     fn blocked_multiple_patterns() {
-        let blocked = vec![
-            "/wp-config.php".to_string(),
-            "/vendor/*".to_string(),
-            "/.env".to_string(),
-        ];
+        let blocked =
+            vec!["/wp-config.php".to_string(), "/vendor/*".to_string(), "/.env".to_string()];
         assert!(is_path_blocked("/wp-config.php", &blocked));
         assert!(is_path_blocked("/vendor/autoload.php", &blocked));
         assert!(is_path_blocked("/.env", &blocked));
@@ -2022,9 +2039,9 @@ mod tests {
     #[allow(unexpected_cfgs)]
     #[cfg(all(test, php_linked))]
     mod php_etag_tests {
-        use hyper::body::Empty;
-        use http_body_util::BodyExt;
         use ephpm_php::PhpRuntime;
+        use http_body_util::BodyExt;
+        use hyper::body::Empty;
         use serial_test::serial;
 
         use super::*;

--- a/crates/ephpm-server/src/static_files.rs
+++ b/crates/ephpm-server/src/static_files.rs
@@ -49,9 +49,9 @@ pub async fn serve_file(
     // (large files without inlined content) so we fall through to streaming.
     if let Some(cache) = file_cache {
         if let Some(entry) = cache.lookup(&canonical_file).await {
-            if let Some(resp) = serve_cached_entry(
-                entry, accepts_gzip, cache_control, if_none_match,
-            ) {
+            if let Some(resp) =
+                serve_cached_entry(entry, accepts_gzip, cache_control, if_none_match)
+            {
                 return resp;
             }
         }
@@ -70,14 +70,8 @@ pub async fn serve_file(
     const STREAM_THRESHOLD: u64 = 1_048_576;
 
     if metadata.len() > STREAM_THRESHOLD {
-        return serve_streamed(
-            &canonical_file,
-            &metadata,
-            mime,
-            cache_control,
-            if_none_match,
-        )
-        .await;
+        return serve_streamed(&canonical_file, &metadata, mime, cache_control, if_none_match)
+            .await;
     }
 
     let Ok(content) = tokio::fs::read(&canonical_file).await else {
@@ -89,9 +83,9 @@ pub async fn serve_file(
     if let Some(cache) = file_cache {
         if let Ok(mtime) = metadata.modified() {
             let entry = cache.insert(&canonical_file, &content, mtime, mime, compression);
-            if let Some(resp) = serve_cached_entry(
-                entry, accepts_gzip, cache_control, if_none_match,
-            ) {
+            if let Some(resp) =
+                serve_cached_entry(entry, accepts_gzip, cache_control, if_none_match)
+            {
                 return resp;
             }
         }
@@ -257,10 +251,8 @@ async fn serve_streamed(
 
     // Compute metadata-based ETag.
     let etag_value = modified_time.map(|mt| {
-        let secs = mt
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let secs =
+            mt.duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
         format!("W/\"{secs:x}-{size:x}\"")
     });
 
@@ -292,9 +284,7 @@ async fn serve_streamed(
     if let Some(ref tag) = etag_value {
         builder = builder.header("ETag", tag.as_str());
     }
-    builder
-        .body(body::streamed(file))
-        .unwrap_or_else(|_| internal_error())
+    builder.body(body::streamed(file)).unwrap_or_else(|_| internal_error())
 }
 
 /// Compute a weak `ETag` from file content using a fast hash.
@@ -348,11 +338,7 @@ mod tests {
 
     /// Default compression settings (disabled) for tests.
     fn no_compression() -> crate::router::CompressionSettings {
-        crate::router::CompressionSettings {
-            enabled: false,
-            level: 6,
-            min_size: 1024,
-        }
+        crate::router::CompressionSettings { enabled: false, level: 6, min_size: 1024 }
     }
 
     /// Collect a response body into a `Vec<u8>`.
@@ -363,18 +349,7 @@ mod tests {
     /// Helper: serve a file using `serve_file` with default settings.
     async fn serve_test(docroot: &Path, filename: &str) -> Response<ServerBody> {
         let file_path = docroot.join(filename);
-        serve_file(
-            docroot,
-            &file_path,
-            false,
-            false,
-            "",
-            no_compression(),
-            false,
-            None,
-            None,
-        )
-        .await
+        serve_file(docroot, &file_path, false, false, "", no_compression(), false, None, None).await
     }
 
     #[tokio::test]
@@ -406,10 +381,7 @@ mod tests {
 
         let resp = serve_test(dir.path(), "test.txt").await;
         assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(
-            resp.headers()["content-length"],
-            content.len().to_string().as_str()
-        );
+        assert_eq!(resp.headers()["content-length"], content.len().to_string().as_str());
     }
 
     #[tokio::test]
@@ -419,10 +391,7 @@ mod tests {
 
         let resp = serve_test(dir.path(), "data.ephpmtest").await;
         assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(
-            resp.headers()["content-type"],
-            "application/octet-stream"
-        );
+        assert_eq!(resp.headers()["content-type"], "application/octet-stream");
     }
 
     #[tokio::test]
@@ -442,18 +411,9 @@ mod tests {
         fs::write(parent.path().join("secret.txt"), "secret").unwrap();
 
         let file_path = docroot.join("..").join("secret.txt");
-        let resp = serve_file(
-            &docroot,
-            &file_path,
-            false,
-            false,
-            "",
-            no_compression(),
-            false,
-            None,
-            None,
-        )
-        .await;
+        let resp =
+            serve_file(&docroot, &file_path, false, false, "", no_compression(), false, None, None)
+                .await;
         // Should be 403 (path resolves outside docroot) or 404 (canonicalize fails)
         let status = resp.status();
         assert!(
@@ -469,10 +429,7 @@ mod tests {
         let resp = serve_test(dir.path(), "app.js").await;
         assert_eq!(resp.status(), StatusCode::OK);
         let ct = resp.headers()["content-type"].to_str().unwrap();
-        assert!(
-            ct.contains("javascript"),
-            "expected javascript content-type, got {ct}"
-        );
+        assert!(ct.contains("javascript"), "expected javascript content-type, got {ct}");
     }
 
     #[tokio::test]

--- a/crates/ephpm-server/src/tls.rs
+++ b/crates/ephpm-server/src/tls.rs
@@ -81,9 +81,7 @@ mod tests {
         let cert = dir.join("cert.pem");
         let key = dir.join("key.pem");
         let status = std::process::Command::new("openssl")
-            .args([
-                "req", "-x509", "-newkey", "rsa:2048", "-keyout",
-            ])
+            .args(["req", "-x509", "-newkey", "rsa:2048", "-keyout"])
             .arg(&key)
             .args(["-out"])
             .arg(&cert)
@@ -100,7 +98,12 @@ mod tests {
         let key = dir.join("ec-key.pem");
         let status = std::process::Command::new("openssl")
             .args([
-                "req", "-x509", "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:prime256v1",
+                "req",
+                "-x509",
+                "-newkey",
+                "ec",
+                "-pkeyopt",
+                "ec_paramgen_curve:prime256v1",
                 "-keyout",
             ])
             .arg(&key)
@@ -160,12 +163,12 @@ mod tests {
         let cert = dir.path().join("bad-cert.pem");
         let (_, key) = generate_rsa_cert(dir.path());
         std::fs::write(&cert, "not a real PEM certificate").unwrap();
-        let err = build_tls_acceptor(&cert, &key)
-            .err()
-            .expect("should fail with invalid cert");
+        let err = build_tls_acceptor(&cert, &key).err().expect("should fail with invalid cert");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("invalid TLS") || msg.contains("no private key") || msg.contains("certificate"),
+            msg.contains("invalid TLS")
+                || msg.contains("no private key")
+                || msg.contains("certificate"),
             "unexpected error: {msg}"
         );
     }
@@ -177,9 +180,7 @@ mod tests {
         let (cert, _) = generate_rsa_cert(dir.path());
         let key = dir.path().join("bad-key.pem");
         std::fs::write(&key, "not a real PEM key").unwrap();
-        let err = build_tls_acceptor(&cert, &key)
-            .err()
-            .expect("should fail with invalid key");
+        let err = build_tls_acceptor(&cert, &key).err().expect("should fail with invalid key");
         let msg = format!("{err:#}");
         assert!(msg.contains("no private key"), "unexpected error: {msg}");
     }

--- a/crates/ephpm-server/src/tracked_backend.rs
+++ b/crates/ephpm-server/src/tracked_backend.rs
@@ -48,8 +48,9 @@ impl<B: Backend> Backend for TrackedBackend<B> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::time::Duration;
+
+    use super::*;
 
     /// A minimal test backend that always succeeds.
     struct StubBackend;
@@ -57,10 +58,7 @@ mod tests {
     #[async_trait::async_trait]
     impl Backend for StubBackend {
         async fn query(&self, _sql: &str, _params: &[Value]) -> Result<ResultSet, BackendError> {
-            Ok(ResultSet {
-                columns: vec![],
-                rows: vec![vec![Value::Integer(1)]],
-            })
+            Ok(ResultSet { columns: vec![], rows: vec![vec![Value::Integer(1)]] })
         }
 
         async fn execute(
@@ -68,10 +66,7 @@ mod tests {
             _sql: &str,
             _params: &[Value],
         ) -> Result<ExecuteResult, BackendError> {
-            Ok(ExecuteResult {
-                affected_rows: 1,
-                last_insert_rowid: Some(1),
-            })
+            Ok(ExecuteResult { affected_rows: 1, last_insert_rowid: Some(1) })
         }
     }
 
@@ -94,10 +89,7 @@ mod tests {
         let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
         let backend = TrackedBackend::new(StubBackend, stats.clone());
 
-        backend
-            .execute("INSERT INTO t VALUES (1, 'hello')", &[])
-            .await
-            .unwrap();
+        backend.execute("INSERT INTO t VALUES (1, 'hello')", &[]).await.unwrap();
 
         assert_eq!(stats.digest_count(), 1);
         let top = stats.top_queries(1);

--- a/crates/ephpm-sqld/build.rs
+++ b/crates/ephpm-sqld/build.rs
@@ -13,10 +13,7 @@ fn main() {
         std::fs::copy(src, &dest).expect("failed to copy sqld binary to OUT_DIR");
 
         println!("cargo::rustc-cfg=sqld_embedded");
-        println!(
-            "cargo::rustc-env=SQLD_BINARY_PATH={}",
-            dest.display()
-        );
+        println!("cargo::rustc-env=SQLD_BINARY_PATH={}", dest.display());
         println!("cargo::warning=sqld binary embedded from {path}");
     } else {
         println!("cargo::warning=SQLD_BINARY_PATH not set — building without embedded sqld");

--- a/crates/ephpm-sqld/src/lib.rs
+++ b/crates/ephpm-sqld/src/lib.rs
@@ -72,13 +72,7 @@ impl SqldProcess {
             "sqld process spawned"
         );
 
-        Ok(Self {
-            child,
-            temp_path,
-            config,
-            role,
-            http_client: reqwest::Client::new(),
-        })
+        Ok(Self { child, temp_path, config, role, http_client: reqwest::Client::new() })
     }
 
     /// Poll the sqld health endpoint until it responds or the timeout expires.
@@ -92,10 +86,7 @@ impl SqldProcess {
 
         loop {
             if tokio::time::Instant::now() >= deadline {
-                anyhow::bail!(
-                    "sqld did not become healthy within {}s",
-                    timeout.as_secs()
-                );
+                anyhow::bail!("sqld did not become healthy within {}s", timeout.as_secs());
             }
 
             match self.http_client.get(&health_url).send().await {
@@ -240,9 +231,7 @@ async fn extract_binary() -> anyhow::Result<PathBuf> {
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
-        tokio::fs::set_permissions(&path, perms)
-            .await
-            .context("failed to set sqld permissions")?;
+        tokio::fs::set_permissions(&path, perms).await.context("failed to set sqld permissions")?;
     }
 
     tracing::debug!(path = %path.display(), "extracted sqld binary");
@@ -276,11 +265,9 @@ fn spawn_child(
     }
 
     // Inherit stdout/stderr so sqld logs appear in ephpm's output.
-    cmd.stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit());
+    cmd.stdout(std::process::Stdio::inherit()).stderr(std::process::Stdio::inherit());
 
-    cmd.spawn()
-        .context("failed to spawn sqld child process")
+    cmd.spawn().context("failed to spawn sqld child process")
 }
 
 #[cfg(test)]
@@ -300,29 +287,19 @@ mod tests {
         assert_eq!(SqldRole::Primary, SqldRole::Primary);
         assert_ne!(
             SqldRole::Primary,
-            SqldRole::Replica {
-                primary_grpc_url: "http://x:5001".into(),
-            }
+            SqldRole::Replica { primary_grpc_url: "http://x:5001".into() }
         );
     }
 
     #[test]
     fn sqld_role_replica_equality() {
         assert_eq!(
-            SqldRole::Replica {
-                primary_grpc_url: "http://x:5001".into(),
-            },
-            SqldRole::Replica {
-                primary_grpc_url: "http://x:5001".into(),
-            }
+            SqldRole::Replica { primary_grpc_url: "http://x:5001".into() },
+            SqldRole::Replica { primary_grpc_url: "http://x:5001".into() }
         );
         assert_ne!(
-            SqldRole::Replica {
-                primary_grpc_url: "http://a:5001".into(),
-            },
-            SqldRole::Replica {
-                primary_grpc_url: "http://b:5001".into(),
-            }
+            SqldRole::Replica { primary_grpc_url: "http://a:5001".into() },
+            SqldRole::Replica { primary_grpc_url: "http://b:5001".into() }
         );
     }
 
@@ -343,10 +320,7 @@ mod tests {
             Ok(_) => panic!("should fail without embedded binary"),
             Err(e) => {
                 let err = e.to_string();
-                assert!(
-                    err.contains("not embedded"),
-                    "unexpected error: {err}"
-                );
+                assert!(err.contains("not embedded"), "unexpected error: {err}");
             }
         }
     }
@@ -355,9 +329,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_fails_as_replica_too() {
         let config = test_config();
-        let role = SqldRole::Replica {
-            primary_grpc_url: "http://10.0.1.2:5001".into(),
-        };
+        let role = SqldRole::Replica { primary_grpc_url: "http://10.0.1.2:5001".into() };
         match SqldProcess::spawn(config, role).await {
             Ok(_) => panic!("should fail without embedded binary"),
             Err(e) => {
@@ -406,9 +378,7 @@ mod tests {
     fn spawn_child_args_replica() {
         let config = test_config();
         let binary = PathBuf::from("/fake/sqld");
-        let role = SqldRole::Replica {
-            primary_grpc_url: "http://10.0.1.2:5001".into(),
-        };
+        let role = SqldRole::Replica { primary_grpc_url: "http://10.0.1.2:5001".into() };
         let result = spawn_child(&binary, &config, &role);
         assert!(result.is_err());
     }
@@ -418,12 +388,8 @@ mod tests {
         let primary_dbg = format!("{:?}", SqldRole::Primary);
         assert_eq!(primary_dbg, "Primary");
 
-        let replica_dbg = format!(
-            "{:?}",
-            SqldRole::Replica {
-                primary_grpc_url: "http://host:5001".into()
-            }
-        );
+        let replica_dbg =
+            format!("{:?}", SqldRole::Replica { primary_grpc_url: "http://host:5001".into() });
         assert!(replica_dbg.contains("Replica"));
         assert!(replica_dbg.contains("host:5001"));
     }
@@ -436,10 +402,7 @@ mod tests {
         let result = rt.block_on(extract_binary());
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("not embedded"),
-            "expected 'not embedded', got: {err}"
-        );
+        assert!(err.contains("not embedded"), "expected 'not embedded', got: {err}");
     }
 
     #[test]
@@ -447,12 +410,7 @@ mod tests {
         let expected_prefix = format!("ephpm-sqld-{}", std::process::id());
         let temp_path = std::env::temp_dir().join(&expected_prefix);
         assert!(
-            temp_path
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .starts_with("ephpm-sqld-"),
+            temp_path.file_name().unwrap().to_str().unwrap().starts_with("ephpm-sqld-"),
             "temp path should include ephpm-sqld prefix"
         );
     }

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -7,10 +7,9 @@ use clap::{Parser, Subcommand};
 use ephpm_kv::resp::{Frame, parse_frame};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
 
 /// ePHPm — All-in-one PHP application server
 #[derive(Parser, Debug)]
@@ -115,8 +114,7 @@ fn run() -> anyhow::Result<ExitCode> {
     match cli.command {
         Some(Commands::Php { args }) => run_php(&args),
         Some(Commands::Kv { host, port, subcommand }) => {
-            let rt = tokio::runtime::Runtime::new()
-                .context("failed to create tokio runtime")?;
+            let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
             rt.block_on(run_kv(&host, port, subcommand))
         }
         other => run_serve_sync(other),
@@ -131,19 +129,14 @@ fn run_php(args: &[String]) -> anyhow::Result<ExitCode> {
     let _dll_guard = ephpm_php::windows_dll::extract_php_dll()
         .context("failed to extract embedded php8embed.dll")?;
 
-    let exit_code = ephpm_php::PhpRuntime::cli_main(args)
-        .context("PHP CLI failed")?;
+    let exit_code = ephpm_php::PhpRuntime::cli_main(args).context("PHP CLI failed")?;
     let _ = ephpm_php::PhpRuntime::shutdown();
     Ok(exit_code_from(exit_code))
 }
 
 /// Convert a PHP exit code (i32) to a Rust `ExitCode`.
 fn exit_code_from(code: i32) -> ExitCode {
-    if code == 0 {
-        ExitCode::SUCCESS
-    } else {
-        ExitCode::from(u8::try_from(code).unwrap_or(1))
-    }
+    if code == 0 { ExitCode::SUCCESS } else { ExitCode::from(u8::try_from(code).unwrap_or(1)) }
 }
 
 /// Initialize PHP and start the HTTP server.
@@ -176,27 +169,22 @@ fn run_serve_sync(command: Option<Commands>) -> anyhow::Result<ExitCode> {
 
     // Set up access log file writer if configured.
     let _access_guard = if config.server.logging.access.is_empty() {
-        tracing_subscriber::registry()
-            .with(env_filter)
-            .with(fmt_layer)
-            .init();
+        tracing_subscriber::registry().with(env_filter).with(fmt_layer).init();
         None
     } else {
         let access_path = PathBuf::from(&config.server.logging.access);
         let access_dir = access_path.parent().unwrap_or_else(|| std::path::Path::new("."));
-        let access_file = access_path.file_name()
+        let access_file = access_path
+            .file_name()
             .map_or_else(|| "access.log".to_string(), |f| f.to_string_lossy().into_owned());
-        let (access_writer, guard) =
-            tracing_appender::non_blocking(tracing_appender::rolling::never(access_dir, access_file));
+        let (access_writer, guard) = tracing_appender::non_blocking(
+            tracing_appender::rolling::never(access_dir, access_file),
+        );
         let access_layer = tracing_subscriber::fmt::layer()
             .with_writer(access_writer)
             .with_target(true)
             .with_filter(EnvFilter::new("access_log=info"));
-        tracing_subscriber::registry()
-            .with(env_filter)
-            .with(fmt_layer)
-            .with(access_layer)
-            .init();
+        tracing_subscriber::registry().with(env_filter).with(fmt_layer).with(access_layer).init();
         Some(guard)
     };
 
@@ -223,9 +211,7 @@ fn run_serve_sync(command: Option<Commands>) -> anyhow::Result<ExitCode> {
 
     // Now safe to create the multi-threaded tokio runtime
     let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-    let result = rt.block_on(async {
-        ephpm_server::serve(config).await
-    });
+    let result = rt.block_on(async { ephpm_server::serve(config).await });
 
     // Shutdown PHP runtime
     ephpm_php::PhpRuntime::shutdown().context("failed to shutdown PHP runtime")?;
@@ -238,17 +224,14 @@ fn run_serve_sync(command: Option<Commands>) -> anyhow::Result<ExitCode> {
 /// Called before tracing is initialized, so no logging here.
 /// Returns `(config, verbose_level)`.
 fn load_serve_config(command: Option<Commands>) -> anyhow::Result<(ephpm_config::Config, u8)> {
-    let Commands::Serve {
-        config,
-        listen,
-        document_root,
-        verbose,
-    } = command.unwrap_or(Commands::Serve {
-        config: PathBuf::from("ephpm.toml"),
-        listen: None,
-        document_root: None,
-        verbose: 0,
-    }) else {
+    let Commands::Serve { config, listen, document_root, verbose } =
+        command.unwrap_or(Commands::Serve {
+            config: PathBuf::from("ephpm.toml"),
+            listen: None,
+            document_root: None,
+            verbose: 0,
+        })
+    else {
         unreachable!("load_serve_config called with non-Serve command");
     };
 
@@ -299,10 +282,7 @@ async fn kv_connect(host: &str, port: u16) -> anyhow::Result<TcpStream> {
 /// Send a RESP frame to the server.
 async fn kv_send(stream: &mut TcpStream, frame: &Frame) -> anyhow::Result<()> {
     let bytes = frame.to_bytes();
-    stream
-        .write_all(&bytes)
-        .await
-        .context("failed to write command to KV server")
+    stream.write_all(&bytes).await.context("failed to write command to KV server")
 }
 
 /// Receive a RESP frame from the server.
@@ -310,16 +290,11 @@ async fn kv_recv(stream: &mut TcpStream) -> anyhow::Result<Frame> {
     let mut buf = BytesMut::with_capacity(4096);
     loop {
         buf.reserve(512);
-        let n = stream
-            .read_buf(&mut buf)
-            .await
-            .context("failed to read from KV server")?;
+        let n = stream.read_buf(&mut buf).await.context("failed to read from KV server")?;
         if n == 0 {
             anyhow::bail!("KV server closed connection unexpectedly");
         }
-        if let Some(frame) = parse_frame(&mut buf)
-            .context("invalid RESP data from KV server")?
-        {
+        if let Some(frame) = parse_frame(&mut buf).context("invalid RESP data from KV server")? {
             return Ok(frame);
         }
     }
@@ -350,10 +325,8 @@ async fn kv_ping(host: &str, port: u16) -> anyhow::Result<ExitCode> {
 
 /// KEYS command.
 async fn kv_keys(host: &str, port: u16, pattern: &str) -> anyhow::Result<ExitCode> {
-    let cmd = Frame::Array(vec![
-        Frame::bulk(b"KEYS".to_vec()),
-        Frame::bulk(pattern.as_bytes().to_vec()),
-    ]);
+    let cmd =
+        Frame::Array(vec![Frame::bulk(b"KEYS".to_vec()), Frame::bulk(pattern.as_bytes().to_vec())]);
     match kv_roundtrip(host, port, cmd).await? {
         Frame::Array(items) => {
             if items.is_empty() {
@@ -378,10 +351,8 @@ async fn kv_keys(host: &str, port: u16, pattern: &str) -> anyhow::Result<ExitCod
 
 /// GET command.
 async fn kv_get(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
-    let cmd = Frame::Array(vec![
-        Frame::bulk(b"GET".to_vec()),
-        Frame::bulk(key.as_bytes().to_vec()),
-    ]);
+    let cmd =
+        Frame::Array(vec![Frame::bulk(b"GET".to_vec()), Frame::bulk(key.as_bytes().to_vec())]);
     match kv_roundtrip(host, port, cmd).await? {
         Frame::Bulk(data) => {
             match std::str::from_utf8(&data) {
@@ -460,10 +431,7 @@ async fn kv_del(host: &str, port: u16, keys: &[String]) -> anyhow::Result<ExitCo
 /// INCR command.
 async fn kv_incr(host: &str, port: u16, key: &str, by: i64) -> anyhow::Result<ExitCode> {
     let cmd = if by == 1 {
-        Frame::Array(vec![
-            Frame::bulk(b"INCR".to_vec()),
-            Frame::bulk(key.as_bytes().to_vec()),
-        ])
+        Frame::Array(vec![Frame::bulk(b"INCR".to_vec()), Frame::bulk(key.as_bytes().to_vec())])
     } else {
         Frame::Array(vec![
             Frame::bulk(b"INCRBY".to_vec()),
@@ -491,10 +459,7 @@ async fn kv_ttl(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
     // Send TTL
     kv_send(
         &mut stream,
-        &Frame::Array(vec![
-            Frame::bulk(b"TTL".to_vec()),
-            Frame::bulk(key.as_bytes().to_vec()),
-        ]),
+        &Frame::Array(vec![Frame::bulk(b"TTL".to_vec()), Frame::bulk(key.as_bytes().to_vec())]),
     )
     .await?;
     let ttl_frame = kv_recv(&mut stream).await?;
@@ -502,10 +467,7 @@ async fn kv_ttl(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
     // Send PTTL on the same connection
     kv_send(
         &mut stream,
-        &Frame::Array(vec![
-            Frame::bulk(b"PTTL".to_vec()),
-            Frame::bulk(key.as_bytes().to_vec()),
-        ]),
+        &Frame::Array(vec![Frame::bulk(b"PTTL".to_vec()), Frame::bulk(key.as_bytes().to_vec())]),
     )
     .await?;
     let pttl_frame = kv_recv(&mut stream).await?;

--- a/crates/ephpm/tests/kv_sapi_integration.rs
+++ b/crates/ephpm/tests/kv_sapi_integration.rs
@@ -7,11 +7,10 @@
 //!
 //! Run with: cargo nextest run -p ephpm --run-ignored all
 
-use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::thread;
 use std::time::Duration;
+use std::{fs, thread};
 
 /// Helper to wait for a port to be listening.
 fn wait_for_port(port: u16, timeout_secs: u64) -> bool {
@@ -61,8 +60,7 @@ listen = "127.0.0.1:6379"
     );
 
     let mut f = tempfile::NamedTempFile::new().expect("failed to create temp config");
-    f.write_all(config_content.as_bytes())
-        .expect("failed to write config");
+    f.write_all(config_content.as_bytes()).expect("failed to write config");
     f.flush().expect("failed to flush config");
 
     (f, config_content)
@@ -83,10 +81,7 @@ fn find_ephpm_binary() -> PathBuf {
         }
     }
 
-    panic!(
-        "ephpm binary not found. Run `cargo xtask release` first. Checked: {:?}",
-        candidates
-    );
+    panic!("ephpm binary not found. Run `cargo xtask release` first. Checked: {:?}", candidates);
 }
 
 #[tokio::test]
@@ -108,11 +103,7 @@ async fn kv_sapi_set_get() {
         .expect("failed to spawn ephpm");
 
     // Wait for server to start
-    assert!(
-        wait_for_port(port as u16, 5),
-        "ephpm server failed to start on port {}",
-        port
-    );
+    assert!(wait_for_port(port as u16, 5), "ephpm server failed to start on port {}", port);
 
     // Run test and clean up
     let result = get_json(&format!("http://127.0.0.1:{}/kv_sapi_test.php?test=set_get", port))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,17 @@
 #
 # Cache strategy:
 #   base:    System deps + Rust toolchain — changes rarely
-#   php-sdk: PHP SDK via spc — only rebuilds when PHP_VERSION or xtask changes
+#   php-sdk: Pre-built tarball from build context, or built from source via spc
 #   builder: Cargo manifest fetch (cached until Cargo.lock changes) → full source build
 #
-# Build:
+# Fast build (pre-built SDK, download it first):
+#   gh release download 8.5.2 -R ephpm/php-sdk -p 'php-sdk-*-linux-x86_64.tar.gz' -D php-sdk/
+#   podman build -f docker/Dockerfile --build-arg PHP_VERSION=8.5.2 -t ephpm:dev .
+#
+# Source build (no pre-built SDK, ~15 min longer):
 #   podman build -f docker/Dockerfile --build-arg PHP_VERSION=8.5 -t ephpm:dev .
 
-# Global ARG so it can be referenced in FROM lines (each stage re-declares it to use it)
-ARG PHP_VERSION=8.5
+ARG PHP_VERSION=8.5.2
 
 # ── Stage 1: base — system deps + Rust toolchain ─────────────────────────────
 
@@ -18,19 +21,6 @@ FROM ubuntu:24.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 
 # System build tools for static-php-cli (spc) and musl cross-compilation.
-#
-# The standalone spc binary bundles its own PHP — no system PHP or Composer
-# is needed. `spc doctor --auto-fix` may install additional packages, so we
-# keep apt metadata around (no `rm -rf /var/lib/apt/lists/*`).
-#
-# Key packages:
-#   unzip           — required by spc for extracting downloads
-#   gettext         — provides `autopoint`, checked by spc doctor
-#   musl-tools      — provides musl-gcc cross-compiler
-#   musl-dev        — musl development files and static libraries
-#   gcc-multilib    — 32-bit support for cross-compilation
-#   libstdc++-12-dev — needed for C++ standard library (musl)
-#   libgcc-12-dev   — GCC runtime library (musl)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential ca-certificates curl git pkg-config sudo \
     autoconf automake bison cmake flex gettext libtool make re2c unzip \
@@ -52,7 +42,11 @@ ENV CC_x86_64_unknown_linux_musl=musl-gcc \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=musl-gcc \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
 
-# ── Stage 2: php-sdk — rebuilt only when PHP_VERSION or xtask source changes ──
+# ── Stage 2: php-sdk — use pre-built tarball or build from source ────────────
+#
+# If php-sdk/*.tar.gz exists in the build context (downloaded by the workflow
+# or manually via `gh release download`), extract it. Otherwise build from
+# source via `cargo xtask php-sdk` (~15 min).
 
 FROM base AS php-sdk
 
@@ -60,9 +54,29 @@ ARG PHP_VERSION
 
 WORKDIR /src
 
-# Workspace manifest + lock + xtask source (the only things needed to run
-# `cargo xtask php-sdk`). Stub Cargo.toml files for every other workspace
-# member keep the resolver happy without pulling in real source.
+# Copy any pre-downloaded SDK tarballs from the build context.
+# The directory may be empty — that's fine, we check in the RUN step.
+COPY php-sdk/ /tmp/php-sdk-dl/
+
+# Layout that cargo xtask release expects:
+#   php-sdk/static-php-cli/buildroot/lib/libphp.a
+#   php-sdk/static-php-cli/buildroot/include/php/
+
+# Try to find a matching tarball; if none, fall through to source build.
+RUN ARCH=$(uname -m) && \
+    TARBALL=$(find /tmp/php-sdk-dl -name "php-sdk-*-linux-${ARCH}.tar.gz" 2>/dev/null | head -1) && \
+    if [ -n "${TARBALL}" ]; then \
+        echo "==> Extracting pre-built PHP SDK from ${TARBALL}..." && \
+        mkdir -p php-sdk/static-php-cli/buildroot && \
+        tar xzf "${TARBALL}" -C php-sdk/static-php-cli/buildroot && \
+        ls -lh php-sdk/static-php-cli/buildroot/lib/libphp.a && \
+        echo "==> PHP SDK ready (pre-built)"; \
+    else \
+        echo "==> No pre-built SDK tarball found, will build from source..."; \
+    fi && \
+    rm -rf /tmp/php-sdk-dl
+
+# Source build fallback — only runs if libphp.a doesn't exist yet.
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo/ .cargo/
 COPY xtask/ xtask/
@@ -73,20 +87,20 @@ COPY crates/ephpm-php/Cargo.toml      crates/ephpm-php/Cargo.toml
 COPY crates/ephpm-db/Cargo.toml       crates/ephpm-db/Cargo.toml
 COPY crates/ephpm-kv/Cargo.toml       crates/ephpm-kv/Cargo.toml
 
-# Minimal stub src so cargo can parse (but not compile) workspace members
-RUN mkdir -p \
-        crates/ephpm/src \
-        crates/ephpm-config/src \
-        crates/ephpm-server/src \
-        crates/ephpm-php/src \
-        crates/ephpm-db/src \
-        crates/ephpm-kv/src && \
-    printf 'fn main() {}\n' > crates/ephpm/src/main.rs && \
-    for d in ephpm-config ephpm-server ephpm-php ephpm-db ephpm-kv; do \
-        touch crates/$d/src/lib.rs; \
-    done
-
-RUN cargo xtask php-sdk ${PHP_VERSION}
+RUN if [ ! -f php-sdk/static-php-cli/buildroot/lib/libphp.a ]; then \
+        mkdir -p \
+            crates/ephpm/src \
+            crates/ephpm-config/src \
+            crates/ephpm-server/src \
+            crates/ephpm-php/src \
+            crates/ephpm-db/src \
+            crates/ephpm-kv/src && \
+        printf 'fn main() {}\n' > crates/ephpm/src/main.rs && \
+        for d in ephpm-config ephpm-server ephpm-php ephpm-db ephpm-kv; do \
+            touch crates/$d/src/lib.rs; \
+        done && \
+        cargo xtask php-sdk ${PHP_VERSION}; \
+    fi
 
 # ── Stage 3: builder — dep fetch layer then full source build ─────────────────
 

--- a/docker/Dockerfile.php-sdk
+++ b/docker/Dockerfile.php-sdk
@@ -1,0 +1,74 @@
+# PHP SDK base image — pre-built libphp.a + headers for a given PHP version.
+#
+# Contains the complete PHP SDK (static libphp.a, headers, pkg-config files)
+# built via static-php-cli with ZTS enabled. Used as a cache layer so release
+# builds skip the ~15 min PHP compilation step.
+#
+# Build args:
+#   PHP_VERSION  — PHP version to build (e.g., 8.4, 8.5)
+#   SPC_VERSION  — static-php-cli release version
+#
+# Build:
+#   docker build -f docker/Dockerfile.php-sdk \
+#     --build-arg PHP_VERSION=8.5 \
+#     -t ghcr.io/ephpm/php-sdk:8.5-linux-x86_64 .
+#
+# The SDK output lives at /opt/php-sdk/ containing:
+#   lib/libphp.a        — static PHP library (ZTS, embed SAPI)
+#   include/php/        — all PHP/Zend/TSRM/SAPI headers
+#   lib/pkgconfig/      — pkg-config files
+
+ARG BASE_IMAGE=ubuntu:24.04
+
+FROM ${BASE_IMAGE} AS builder
+
+ARG PHP_VERSION=8.5
+ARG SPC_VERSION=2.8.3
+ARG PHP_EXTENSIONS="bcmath,calendar,ctype,curl,dom,exif,fileinfo,filter,gd,hash,iconv,mbstring,mysqli,mysqlnd,openssl,pcntl,pcre,pdo,pdo_mysql,phar,posix,session,simplexml,sodium,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System build tools required by static-php-cli
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential ca-certificates curl git pkg-config sudo \
+    autoconf automake bison cmake flex gettext libtool make re2c unzip \
+    libclang-dev musl-tools musl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Download the standalone spc binary (self-contained, no system PHP needed)
+RUN ARCH=$(uname -m) && \
+    curl -fSL "https://github.com/crazywhalecc/static-php-cli/releases/download/${SPC_VERSION}/spc-linux-${ARCH}.tar.gz" \
+    | tar xz && \
+    chmod +x spc
+
+# Let spc check/fix build environment
+RUN ./spc doctor --auto-fix
+
+# Download PHP source + extension dependencies
+RUN ./spc download \
+    --with-php=${PHP_VERSION} \
+    --for-extensions=${PHP_EXTENSIONS} \
+    --prefer-pre-built
+
+# Ensure pkg-config is discoverable by spc
+RUN mkdir -p buildroot/bin && \
+    ln -sf /usr/bin/pkg-config buildroot/bin/pkg-config
+
+# Build libphp.a with ZTS (embed SAPI, no stripping for debug info)
+RUN ./spc build \
+    ${PHP_EXTENSIONS} \
+    --build-embed \
+    --no-strip \
+    --enable-zts
+
+# ── Output stage — just the SDK artifacts ────────────────────────────────────
+
+FROM scratch
+
+COPY --from=builder /build/buildroot/lib/          /opt/php-sdk/lib/
+COPY --from=builder /build/buildroot/include/php/  /opt/php-sdk/include/php/
+
+LABEL org.opencontainers.image.title="ephpm PHP SDK"
+LABEL org.opencontainers.image.description="Pre-built PHP SDK (libphp.a + headers) for ephpm release builds"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -147,9 +147,7 @@ fn release_linux(args: &[String]) -> ExitCode {
 
     // Ensure the musl target is installed
     eprintln!("==> Ensuring Rust target {target} is installed...");
-    let status = Command::new("rustup")
-        .args(["target", "add", &target])
-        .status();
+    let status = Command::new("rustup").args(["target", "add", &target]).status();
     if !ran_ok(&status) {
         eprintln!("error: failed to add Rust target {target}");
         return ExitCode::FAILURE;
@@ -252,9 +250,7 @@ fn release_windows(args: &[String]) -> ExitCode {
 
     // 3. Ensure the MSVC target is installed
     eprintln!("==> Ensuring Rust target {target} is installed...");
-    let status = Command::new("rustup")
-        .args(["target", "add", target])
-        .status();
+    let status = Command::new("rustup").args(["target", "add", target]).status();
     if !ran_ok(&status) {
         eprintln!("error: failed to add Rust target {target}");
         return ExitCode::FAILURE;
@@ -263,15 +259,7 @@ fn release_windows(args: &[String]) -> ExitCode {
     // 4. Build with cargo-xwin
     eprintln!("==> Building ephpm.exe (release, target: {target})...");
     let status = Command::new("cargo")
-        .args([
-            "xwin",
-            "build",
-            "--release",
-            "--package",
-            "ephpm",
-            "--target",
-            target,
-        ])
+        .args(["xwin", "build", "--release", "--package", "ephpm", "--target", target])
         .env("PHP_SDK_PATH", &sdk_dir)
         .status();
 
@@ -281,10 +269,7 @@ fn release_windows(args: &[String]) -> ExitCode {
     }
 
     // 5. Copy php8embed.dll next to the .exe
-    let exe_dir = workspace_root()
-        .join("target")
-        .join(target)
-        .join("release");
+    let exe_dir = workspace_root().join("target").join(target).join("release");
     let dll_dest = exe_dir.join("php8embed.dll");
     let dll_src = sdk_dir.join("lib").join("php8embed.dll");
     if dll_src.exists() {
@@ -408,32 +393,20 @@ fn download_php_windows_sdk(php_version: &str, sdk_dir: &Path) -> ExitCode {
     }
 
     cleanup_dir(&tmp_dir);
-    eprintln!(
-        "==> PHP Windows SDK ready at {}",
-        sdk_dir.display()
-    );
+    eprintln!("==> PHP Windows SDK ready at {}", sdk_dir.display());
     ExitCode::SUCCESS
 }
 
 /// Download a file via curl.
 fn download_file(url: &str, dest: &Path) -> bool {
-    let status = Command::new("curl")
-        .args(["-fSL", "-o"])
-        .arg(dest)
-        .arg(url)
-        .status();
+    let status = Command::new("curl").args(["-fSL", "-o"]).arg(dest).arg(url).status();
     ran_ok(&status)
 }
 
 /// Extract a ZIP file to a directory.
 fn unzip_file(zip: &Path, dest: &Path) -> bool {
     fs::create_dir_all(dest).ok();
-    let status = Command::new("unzip")
-        .args(["-q", "-o"])
-        .arg(zip)
-        .arg("-d")
-        .arg(dest)
-        .status();
+    let status = Command::new("unzip").args(["-q", "-o"]).arg(zip).arg("-d").arg(dest).status();
     ran_ok(&status)
 }
 
@@ -521,16 +494,8 @@ fn php_sdk(args: &[String]) -> ExitCode {
     // Download the standalone spc binary if not present.
     let spc_bin = spc_dir.join("spc");
     if !spc_bin.exists() {
-        let spc_arch = if cfg!(target_arch = "aarch64") {
-            "aarch64"
-        } else {
-            "x86_64"
-        };
-        let spc_os = if cfg!(target_os = "macos") {
-            "macos"
-        } else {
-            "linux"
-        };
+        let spc_arch = if cfg!(target_arch = "aarch64") { "aarch64" } else { "x86_64" };
+        let spc_os = if cfg!(target_os = "macos") { "macos" } else { "linux" };
         let url = format!(
             "https://github.com/crazywhalecc/static-php-cli/releases/download/{SPC_VERSION}/spc-{spc_os}-{spc_arch}.tar.gz"
         );
@@ -546,10 +511,7 @@ fn php_sdk(args: &[String]) -> ExitCode {
     // Let spc install its own toolchain (musl cross-compiler, missing system
     // packages, etc.). This may prompt for sudo password.
     eprintln!("==> Checking build environment (may prompt for sudo)...");
-    let status = Command::new(spc)
-        .args(["doctor", "--auto-fix"])
-        .current_dir(&spc_dir)
-        .status();
+    let status = Command::new(spc).args(["doctor", "--auto-fix"]).current_dir(&spc_dir).status();
 
     if !ran_ok(&status) {
         eprintln!("error: spc doctor failed — check output above");
@@ -587,13 +549,7 @@ fn php_sdk(args: &[String]) -> ExitCode {
     // Build libphp.a with embed SAPI (ZTS enabled for thread-safe embedding)
     eprintln!("==> Building libphp.a with ZTS (this takes ~15 min the first time)...");
     let status = Command::new(spc)
-        .args([
-            "build",
-            PHP_EXTENSIONS,
-            "--build-embed",
-            "--no-strip",
-            "--enable-zts",
-        ])
+        .args(["build", PHP_EXTENSIONS, "--build-embed", "--no-strip", "--enable-zts"])
         .current_dir(&spc_dir)
         .status();
 
@@ -638,10 +594,7 @@ fn has_e2e_tool(name: &str) -> bool {
     if local.exists() {
         return true;
     }
-    Command::new(name)
-        .arg("--version")
-        .output()
-        .is_ok_and(|o| o.status.success())
+    Command::new(name).arg("--version").output().is_ok_and(|o| o.status.success())
 }
 
 /// Detect OS and architecture for download URLs.
@@ -654,11 +607,7 @@ fn platform() -> (&'static str, &'static str) {
         "linux"
     };
 
-    let arch = if cfg!(target_arch = "aarch64") {
-        "arm64"
-    } else {
-        "amd64"
-    };
+    let arch = if cfg!(target_arch = "aarch64") { "arm64" } else { "amd64" };
 
     (os, arch)
 }
@@ -693,9 +642,7 @@ fn e2e_install() -> ExitCode {
     if kubectl_path.exists() {
         eprintln!("==> kubectl already installed, skipping (delete bin/kubectl to reinstall)");
     } else {
-        let url = format!(
-            "https://dl.k8s.io/release/v{KUBECTL_VERSION}/bin/{os}/{arch}/kubectl"
-        );
+        let url = format!("https://dl.k8s.io/release/v{KUBECTL_VERSION}/bin/{os}/{arch}/kubectl");
         eprintln!("==> Downloading kubectl v{KUBECTL_VERSION}...");
         if !download_binary(&url, &kubectl_path) {
             eprintln!("error: failed to download kubectl");
@@ -732,11 +679,7 @@ fn e2e_install() -> ExitCode {
 
 /// Download a single binary file via curl.
 fn download_binary(url: &str, dest: &PathBuf) -> bool {
-    let status = Command::new("curl")
-        .args(["-fSL", "-o"])
-        .arg(dest)
-        .arg(url)
-        .status();
+    let status = Command::new("curl").args(["-fSL", "-o"]).arg(dest).arg(url).status();
 
     if !ran_ok(&status) {
         return false;
@@ -749,10 +692,8 @@ fn download_binary(url: &str, dest: &PathBuf) -> bool {
 /// Download a tarball via curl, pipe through tar, extract a specific binary.
 fn download_and_extract_tarball(url: &str, dest_dir: &PathBuf, binary_name: &str) -> bool {
     // curl -fSL <url> | tar xz -C <dest_dir> <binary_name>
-    let curl = Command::new("curl")
-        .args(["-fSL", url])
-        .stdout(std::process::Stdio::piped())
-        .spawn();
+    let curl =
+        Command::new("curl").args(["-fSL", url]).stdout(std::process::Stdio::piped()).spawn();
 
     let Ok(curl) = curl else {
         return false;
@@ -775,10 +716,8 @@ fn download_and_extract_tarball(url: &str, dest_dir: &PathBuf, binary_name: &str
 
 /// Download a `.tar.xz` archive via curl, extract a specific binary.
 fn download_and_extract_tar_xz(url: &str, dest_dir: &Path, binary_name: &str) -> bool {
-    let curl = Command::new("curl")
-        .args(["-fSL", url])
-        .stdout(std::process::Stdio::piped())
-        .spawn();
+    let curl =
+        Command::new("curl").args(["-fSL", url]).stdout(std::process::Stdio::piped()).spawn();
 
     let Ok(curl) = curl else {
         eprintln!("error: failed to run curl");
@@ -941,11 +880,7 @@ fn e2e_up(args: &[String]) -> ExitCode {
         .current_dir(&k8s_dir)
         .status();
 
-    if ran_ok(&status) {
-        ExitCode::SUCCESS
-    } else {
-        ExitCode::FAILURE
-    }
+    if ran_ok(&status) { ExitCode::SUCCESS } else { ExitCode::FAILURE }
 }
 
 /// Tear down Tilt resources and delete the Kind cluster.
@@ -955,11 +890,7 @@ fn e2e_down() -> ExitCode {
     // tilt down (ignore errors — cluster may already be gone)
     if has_e2e_tool("tilt") {
         eprintln!("==> Removing Tilt resources...");
-        Command::new(find_tool("tilt"))
-            .args(["down"])
-            .current_dir(&k8s_dir)
-            .status()
-            .ok();
+        Command::new(find_tool("tilt")).args(["down"]).current_dir(&k8s_dir).status().ok();
     }
 
     if has_e2e_tool("kind") {
@@ -982,9 +913,7 @@ fn ensure_kind_cluster() -> ExitCode {
     let kind = find_tool("kind");
 
     // Check if cluster already exists
-    let output = Command::new(&kind)
-        .args(["get", "clusters"])
-        .output();
+    let output = Command::new(&kind).args(["get", "clusters"]).output();
 
     if let Ok(output) = output {
         let clusters = String::from_utf8_lossy(&output.stdout);
@@ -1028,11 +957,7 @@ fn build_and_load_images(ce: &str, php_version: &str) -> ExitCode {
     // Uses `gh release download` which authenticates via GITHUB_TOKEN env var.
     let sdk_dir = root.join("php-sdk");
     fs::create_dir_all(&sdk_dir).ok();
-    let arch = if cfg!(target_arch = "aarch64") {
-        "aarch64"
-    } else {
-        "x86_64"
-    };
+    let arch = if cfg!(target_arch = "aarch64") { "aarch64" } else { "x86_64" };
     let tarball_name = format!("php-sdk-{php_version}-linux-{arch}.tar.gz");
     let tarball_path = sdk_dir.join(&tarball_name);
     if !tarball_path.exists() && has_command("gh") {
@@ -1059,11 +984,8 @@ fn build_and_load_images(ce: &str, php_version: &str) -> ExitCode {
 
     // docker uses "buildx build --load" (BuildKit, result written to local
     // daemon); podman uses plain "build" (already BuildKit-equivalent).
-    let build_args: &[&str] = if ce == "docker" {
-        &["buildx", "build", "--load"]
-    } else {
-        &["build"]
-    };
+    let build_args: &[&str] =
+        if ce == "docker" { &["buildx", "build", "--load"] } else { &["build"] };
 
     // Build ephpm image with the specified PHP version
     if dockerfile.exists() {
@@ -1072,13 +994,7 @@ fn build_and_load_images(ce: &str, php_version: &str) -> ExitCode {
             .args(build_args)
             .args(["-f"])
             .arg(&dockerfile)
-            .args([
-                "--build-arg",
-                &format!("PHP_VERSION={php_version}"),
-                "-t",
-                "ephpm:dev",
-                ".",
-            ])
+            .args(["--build-arg", &format!("PHP_VERSION={php_version}"), "-t", "ephpm:dev", "."])
             .current_dir(&root)
             .status();
 
@@ -1129,33 +1045,19 @@ fn dump_pod_logs() {
     let kubectl = find_tool("kubectl");
 
     eprintln!("--- ephpm pod logs ---");
-    Command::new(&kubectl)
-        .args(["logs", "-l", "app=ephpm", "--tail=100"])
-        .status()
-        .ok();
+    Command::new(&kubectl).args(["logs", "-l", "app=ephpm", "--tail=100"]).status().ok();
 
     eprintln!("--- e2e job logs ---");
-    Command::new(&kubectl)
-        .args(["logs", "job/ephpm-e2e", "--tail=200"])
-        .status()
-        .ok();
+    Command::new(&kubectl).args(["logs", "job/ephpm-e2e", "--tail=200"]).status().ok();
 
     eprintln!("--- pod status ---");
-    Command::new(&kubectl)
-        .args(["get", "pods", "-o", "wide"])
-        .status()
-        .ok();
+    Command::new(&kubectl).args(["get", "pods", "-o", "wide"]).status().ok();
 }
 
 /// Determine which container engine to use (podman or docker).
 fn container_engine() -> String {
-    env::var("CONTAINER_ENGINE").unwrap_or_else(|_| {
-        if has_command("podman") {
-            "podman".into()
-        } else {
-            "docker".into()
-        }
-    })
+    env::var("CONTAINER_ENGINE")
+        .unwrap_or_else(|_| if has_command("podman") { "podman".into() } else { "docker".into() })
 }
 
 // ── PHP SDK ─────────────────────────────────────────────────────────────────
@@ -1202,32 +1104,29 @@ fn require_unix(f: impl FnOnce() -> ExitCode) -> ExitCode {
     // WSL auto-maps the Windows CWD to /mnt/c/... so no path conversion needed.
     let args: Vec<String> = env::args().skip(1).collect();
     // Source cargo env since bash -c doesn't run login profile
-    let xtask_cmd = format!(
-        "source \"$HOME/.cargo/env\" 2>/dev/null; cargo xtask {}",
-        args.join(" "),
-    );
+    let xtask_cmd =
+        format!("source \"$HOME/.cargo/env\" 2>/dev/null; cargo xtask {}", args.join(" "),);
 
     eprintln!("==> Windows detected, running via WSL...");
-    let status = Command::new("wsl")
-        .args(["--", "bash", "-c", &xtask_cmd])
-        .status();
+    let status = Command::new("wsl").args(["--", "bash", "-c", &xtask_cmd]).status();
 
     if ran_ok(&status) {
         ExitCode::SUCCESS
     } else {
         eprintln!();
         eprintln!("WSL build failed. Make sure WSL has the required tools:");
-        eprintln!("  wsl -- bash -c 'curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh'");
-        eprintln!("  wsl -- bash -c 'sudo apt update && sudo apt install -y build-essential autoconf cmake pkg-config re2c libclang-dev musl-tools curl git'");
+        eprintln!(
+            "  wsl -- bash -c 'curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh'"
+        );
+        eprintln!(
+            "  wsl -- bash -c 'sudo apt update && sudo apt install -y build-essential autoconf cmake pkg-config re2c libclang-dev musl-tools curl git'"
+        );
         ExitCode::FAILURE
     }
 }
 
 fn has_command(name: &str) -> bool {
-    Command::new(name)
-        .arg("--version")
-        .output()
-        .is_ok_and(|o| o.status.success())
+    Command::new(name).arg("--version").output().is_ok_and(|o| o.status.success())
 }
 
 fn ran_ok(result: &Result<std::process::ExitStatus, std::io::Error>) -> bool {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1024,6 +1024,39 @@ fn build_and_load_images(ce: &str, php_version: &str) -> ExitCode {
     let dockerfile = root.join("docker").join("Dockerfile");
     let dockerfile_e2e = root.join("docker").join("Dockerfile.e2e");
 
+    // Download pre-built PHP SDK tarball if not already present.
+    // Uses `gh release download` which authenticates via GITHUB_TOKEN env var.
+    let sdk_dir = root.join("php-sdk");
+    fs::create_dir_all(&sdk_dir).ok();
+    let arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+    let tarball_name = format!("php-sdk-{php_version}-linux-{arch}.tar.gz");
+    let tarball_path = sdk_dir.join(&tarball_name);
+    if !tarball_path.exists() && has_command("gh") {
+        eprintln!("==> Downloading pre-built PHP SDK ({tarball_name})...");
+        let status = Command::new("gh")
+            .args([
+                "release",
+                "download",
+                php_version,
+                "--repo",
+                "ephpm/php-sdk",
+                "--pattern",
+                &tarball_name,
+                "--dir",
+            ])
+            .arg(&sdk_dir)
+            .status();
+        if ran_ok(&status) {
+            eprintln!("==> PHP SDK tarball ready");
+        } else {
+            eprintln!("warning: could not download pre-built SDK, will build from source");
+        }
+    }
+
     // docker uses "buildx build --load" (BuildKit, result written to local
     // daemon); podman uses plain "build" (already BuildKit-equivalent).
     let build_args: &[&str] = if ce == "docker" {


### PR DESCRIPTION
## Summary

- **Dockerfile**: Stage 2 checks `php-sdk/` for a pre-downloaded tarball and extracts it (~1 sec) instead of building via spc from source (~15 min). Falls back to source build if no tarball found.
- **xtask**: `build_and_load_images()` auto-downloads the SDK tarball via `gh release download` before docker build. Uses `GITHUB_TOKEN` for private repo auth (works in CI and locally via `gh` login).
- **E2E workflow**: Passes `GITHUB_TOKEN` to xtask. Matrix maps PHP versions to SDK release tags (`8.4` → `8.4.7`, `8.5` → `8.5.2`).
- **php-sdk.yml**: New workflow for building SDK images across Linux (amd64/arm64), macOS (arm64/x86_64), and Windows. Uploads tarballs to GitHub Release on tag push.
- **Dockerfile.php-sdk**: Standalone multi-stage Dockerfile for building the SDK image.

### Flow

```
CI:  GITHUB_TOKEN -> xtask -> gh release download -> php-sdk/*.tar.gz -> Dockerfile COPY -> extract
Local: gh auth -> xtask -> same flow, no extra steps
No gh: skip download -> Dockerfile builds from source (15 min fallback)
```

When ephpm/php-sdk goes public, GITHUB_TOKEN becomes unnecessary but harmless.

## Test plan

- [ ] `cargo xtask e2e --php-version 8.5.2` downloads SDK and builds image
- [ ] Docker build without tarball in `php-sdk/` falls back to source build
- [ ] `php-sdk.yml` workflow builds SDK for all platforms on manual dispatch