### PR TITLE
fix: switch litewire from sibling path dep to pinned git dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "anyhow",
  "futures",
@@ -2143,6 +2144,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2159,6 +2161,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2173,6 +2176,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2186,6 +2190,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "async-trait",
  "futures",
@@ -2200,6 +2205,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2212,6 +2218,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
 dependencies = [
  "sqlparser",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,16 @@ ephpm-server = { path = "crates/ephpm-server" }
 ephpm-sqld = { path = "crates/ephpm-sqld" }
 
 # External — litewire (embedded SQLite wire protocol proxy)
-litewire = { path = "../litewire/crates/litewire", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
+#
+# Pinned to a specific commit so builds are reproducible. To bump, replace `rev`
+# with the new commit hash and run `cargo update -p litewire`.
+#
+# For local development against a sibling litewire checkout, add to your local
+# (gitignored) .cargo/config.toml:
+#
+#   [patch."https://github.com/ephpm/litewire.git"]
+#   litewire = { path = "../litewire/crates/litewire" }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "33e24a3e6fe664b1be499a0147c9cae5756eb733", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"


### PR DESCRIPTION
## Summary

- Replaces the `litewire = { path = \"../litewire/crates/litewire\" }` dependency with a pinned git dep at `github.com/ephpm/litewire@33e24a3`.
- The path dep only resolved cleanly when the repo was checked out as a sibling of a local litewire clone — it broke for git worktrees under `.claude/worktrees/`, fresh clones, and CI runs that didn't co-checkout the sibling repo.
- litewire is now public, so a pinned git dep gives reproducible builds with no extra setup.
- Local development against a sibling litewire checkout still works via a gitignored `.cargo/config.toml` `[patch]` block; the new comment on the dep documents how.

## Test plan

- [ ] \`cargo build\` from a fresh clone (no sibling litewire) succeeds
- [ ] \`cargo build\` inside a git worktree under \`.claude/worktrees/\` succeeds
- [ ] \`cargo test --workspace\` passes
- [ ] CI green