### PR TITLE
feat: add Helm chart and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,28 @@ jobs:
         with:
           name: ephpm-php${{ matrix.php }}-${{ matrix.artifact_suffix }}
           path: target/release/ephpm
+  build-windows:
+    name: Build (PHP ${{ matrix.php }}, windows-x86_64)
+    runs-on: ubuntu-latest
+    container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.4", "8.5"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-xwin
+        run: cargo install cargo-xwin --locked || true
+      - name: Build Windows .exe
+        run: cargo xtask release ${{ matrix.php }} --target windows --no-sqld
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephpm-php${{ matrix.php }}-windows-x86_64
+          path: target/x86_64-pc-windows-msvc/release/ephpm.exe
   release:
     name: Create Release
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-macos, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,9 @@
 name: Release
-
 on:
   push:
     tags: ["v*"]
-
 env:
   CARGO_TERM_COLOR: always
-
 jobs:
   build-linux:
     name: Build (PHP ${{ matrix.php }}, linux-x86_64)
@@ -18,16 +15,13 @@ jobs:
         php: ["8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
-
       - name: Build ephpm
         run: cargo xtask release ${{ matrix.php }}
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ephpm-php${{ matrix.php }}-linux-x86_64
           path: target/release/ephpm
-
   build-macos:
     name: Build (PHP ${{ matrix.php }}, ${{ matrix.artifact_suffix }})
     runs-on: ${{ matrix.os }}
@@ -42,65 +36,52 @@ jobs:
             artifact_suffix: macos-x86_64
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
-
       - name: Install system dependencies
         run: |
           brew install autoconf automake bison cmake flex libtool \
             make pkg-config re2c
-
       - name: Build ephpm
         run: cargo xtask release ${{ matrix.php }}
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ephpm-php${{ matrix.php }}-${{ matrix.artifact_suffix }}
           path: target/release/ephpm
-
-  build-windows:
-    name: Build (PHP ${{ matrix.php }}, windows-x86_64)
-    runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ["8.4", "8.5"]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install cargo-xwin
-        run: cargo install cargo-xwin --locked || true
-
-      - name: Build Windows .exe
-        run: cargo xtask release ${{ matrix.php }} --target windows --no-sqld
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ephpm-php${{ matrix.php }}-windows-x86_64
-          path: target/x86_64-pc-windows-msvc/release/ephpm.exe
-
   release:
     name: Create Release
-    needs: [build-linux, build-macos, build-windows]
+    needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Update chart version and package
+        run: |
+          sed -i "s/^version:.*/version: ${{ steps.version.outputs.VERSION }}/" deploy/chart/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" deploy/chart/Chart.yaml
+          helm lint ./deploy/chart
+          helm package ./deploy/chart --destination ./dist
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
-
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/**/*
+          files: |
+            artifacts/**/*
+            dist/*.tgz
           generate_release_notes: true

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: ephpm
+description: ePHPm — Embedded PHP Manager. One binary from localhost to production.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - php
+  - wordpress
+  - laravel
+  - sqlite
+  - mysql-proxy
+home: https://github.com/ephpm/ephpm
+sources:
+  - https://github.com/ephpm/ephpm
+maintainers:
+  - name: ePHPm Authors

--- a/deploy/chart/ci/cluster-values.yaml
+++ b/deploy/chart/ci/cluster-values.yaml
@@ -1,0 +1,14 @@
+# Mirrors k8s/base/ephpm-cluster.yaml — 3-node StatefulSet with gossip
+replicaCount: 3
+
+cluster:
+  enabled: true
+  clusterId: "my-cluster"
+  bind: "0.0.0.0:7946"
+  kv:
+    replicationFactor: 2
+    replicationMode: async
+
+server:
+  metrics:
+    enabled: true

--- a/deploy/chart/ci/mysql-proxy-values.yaml
+++ b/deploy/chart/ci/mysql-proxy-values.yaml
@@ -1,0 +1,8 @@
+# Stateless Deployment with MySQL proxy
+db:
+  mysql:
+    enabled: true
+    existingSecret: "myapp-db-secret"
+    minConnections: 2
+    maxConnections: 20
+    injectEnv: true

--- a/deploy/chart/ci/postgres-proxy-values.yaml
+++ b/deploy/chart/ci/postgres-proxy-values.yaml
@@ -1,0 +1,8 @@
+# Stateless Deployment with PostgreSQL proxy
+db:
+  postgres:
+    enabled: true
+    existingSecret: "myapp-pg-secret"
+    minConnections: 2
+    maxConnections: 20
+    injectEnv: true

--- a/deploy/chart/ci/single-values.yaml
+++ b/deploy/chart/ci/single-values.yaml
@@ -1,0 +1,6 @@
+# Mirrors k8s/base/ephpm-single.yaml
+server:
+  metrics:
+    enabled: true
+  phpEtagCache:
+    enabled: true

--- a/deploy/chart/ci/sqlite-values.yaml
+++ b/deploy/chart/ci/sqlite-values.yaml
@@ -1,0 +1,6 @@
+# Single-node SQLite (StatefulSet via db.sqlite.enabled)
+db:
+  sqlite:
+    enabled: true
+    path: "/var/lib/ephpm/app.db"
+    storageSize: "5Gi"

--- a/deploy/chart/templates/NOTES.txt
+++ b/deploy/chart/templates/NOTES.txt
@@ -1,0 +1,35 @@
+ePHPm {{ .Chart.AppVersion }} deployed successfully.
+
+{{- if .Values.ingress.enabled }}
+Reachable at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.server.tls.enabled }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  Watch for external IP:
+  kubectl get svc {{ include "ephpm.fullname" . }} -n {{ .Release.Namespace }} -w
+{{- else }}
+  Port-forward to test locally:
+  kubectl port-forward svc/{{ include "ephpm.fullname" . }} 8080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  open http://localhost:8080
+{{- end }}
+
+Mode: {{ if .Values.cluster.enabled }}StatefulSet ({{ .Values.replicaCount }}-node cluster){{ else }}Deployment (single){{ end }}
+{{- if .Values.db.mysql.enabled }}DB: MySQL proxy{{ else if .Values.db.postgres.enabled }}DB: PostgreSQL proxy{{ else if .Values.db.sqlite.enabled }}DB: SQLite{{ else }}DB: none (app manages its own){{ end }}
+{{- if .Values.cluster.enabled }}
+
+Cluster join list (EPHPM_CLUSTER__JOIN):
+  {{ include "ephpm.clusterJoinJson" . }}
+
+Per-pod endpoints:
+{{- range $i, $_ := until (int .Values.replicaCount) }}
+  {{ include "ephpm.fullname" $ }}-{{ $i }}:8080
+{{- end }}
+{{- end }}
+{{- if .Values.server.metrics.enabled }}
+
+Prometheus metrics: http://<pod>:8080/metrics
+{{- if .Values.serviceMonitor.enabled }}
+  ServiceMonitor created for Prometheus Operator.
+{{- end }}
+{{- end }}

--- a/deploy/chart/templates/_envvars.tpl
+++ b/deploy/chart/templates/_envvars.tpl
@@ -1,0 +1,304 @@
+{{/*
+All EPHPM_ environment variables.
+Field names and defaults sourced from crates/ephpm-config/src/lib.rs.
+Env var format: EPHPM_<SECTION>__<KEY> with double-underscore separators.
+Confirmed from k8s/base/ephpm-single.yaml and ephpm-cluster.yaml tests.
+*/}}
+{{- define "ephpm.envvars" -}}
+- name: EPHPM_SERVER__LISTEN
+  value: {{ .Values.server.listen | quote }}
+- name: EPHPM_SERVER__DOCUMENT_ROOT
+  value: {{ .Values.server.documentRoot | quote }}
+{{- if .Values.server.sitesDir }}
+- name: EPHPM_SERVER__SITES_DIR
+  value: {{ .Values.server.sitesDir | quote }}
+{{- end }}
+- name: EPHPM_SERVER__REQUEST__MAX_BODY_SIZE
+  value: {{ .Values.server.request.maxBodySize | quote }}
+- name: EPHPM_SERVER__REQUEST__MAX_HEADER_SIZE
+  value: {{ .Values.server.request.maxHeaderSize | quote }}
+- name: EPHPM_SERVER__TIMEOUTS__HEADER_READ
+  value: {{ .Values.server.timeouts.headerRead | quote }}
+- name: EPHPM_SERVER__TIMEOUTS__IDLE
+  value: {{ .Values.server.timeouts.idle | quote }}
+- name: EPHPM_SERVER__TIMEOUTS__REQUEST
+  value: {{ .Values.server.timeouts.request | quote }}
+- name: EPHPM_SERVER__TIMEOUTS__SHUTDOWN
+  value: {{ .Values.server.timeouts.shutdown | quote }}
+- name: EPHPM_SERVER__RESPONSE__COMPRESSION
+  value: {{ .Values.server.response.compression | quote }}
+- name: EPHPM_SERVER__RESPONSE__COMPRESSION_LEVEL
+  value: {{ .Values.server.response.compressionLevel | quote }}
+- name: EPHPM_SERVER__RESPONSE__COMPRESSION_MIN_SIZE
+  value: {{ .Values.server.response.compressionMinSize | quote }}
+- name: EPHPM_SERVER__STATIC__HIDDEN_FILES
+  value: {{ .Values.server.static.hiddenFiles | quote }}
+- name: EPHPM_SERVER__STATIC__ETAG
+  value: {{ .Values.server.static.etag | quote }}
+{{- if .Values.server.static.cacheControl }}
+- name: EPHPM_SERVER__STATIC__CACHE_CONTROL
+  value: {{ .Values.server.static.cacheControl | quote }}
+{{- end }}
+- name: EPHPM_SERVER__PHP_ETAG_CACHE__ENABLED
+  value: {{ .Values.server.phpEtagCache.enabled | quote }}
+- name: EPHPM_SERVER__PHP_ETAG_CACHE__TTL_SECS
+  value: {{ .Values.server.phpEtagCache.ttlSecs | quote }}
+- name: EPHPM_SERVER__PHP_ETAG_CACHE__KEY_PREFIX
+  value: {{ .Values.server.phpEtagCache.keyPrefix | quote }}
+- name: EPHPM_SERVER__SECURITY__OPEN_BASEDIR
+  value: {{ .Values.server.security.openBasedir | quote }}
+- name: EPHPM_SERVER__SECURITY__DISABLE_SHELL_EXEC
+  value: {{ .Values.server.security.disableShellExec | quote }}
+- name: EPHPM_SERVER__LOGGING__LEVEL
+  value: {{ .Values.server.logging.level | quote }}
+{{- if .Values.server.logging.access }}
+- name: EPHPM_SERVER__LOGGING__ACCESS
+  value: {{ .Values.server.logging.access | quote }}
+{{- end }}
+- name: EPHPM_SERVER__METRICS__ENABLED
+  value: {{ .Values.server.metrics.enabled | quote }}
+- name: EPHPM_SERVER__METRICS__PATH
+  value: {{ .Values.server.metrics.path | quote }}
+- name: EPHPM_SERVER__LIMITS__MAX_CONNECTIONS
+  value: {{ .Values.server.limits.maxConnections | quote }}
+- name: EPHPM_SERVER__LIMITS__PER_IP_MAX_CONNECTIONS
+  value: {{ .Values.server.limits.perIpMaxConnections | quote }}
+- name: EPHPM_SERVER__LIMITS__PER_IP_RATE
+  value: {{ .Values.server.limits.perIpRate | quote }}
+- name: EPHPM_SERVER__LIMITS__PER_IP_BURST
+  value: {{ .Values.server.limits.perIpBurst | quote }}
+- name: EPHPM_SERVER__FILE_CACHE__ENABLED
+  value: {{ .Values.server.fileCache.enabled | quote }}
+- name: EPHPM_SERVER__FILE_CACHE__MAX_ENTRIES
+  value: {{ .Values.server.fileCache.maxEntries | quote }}
+- name: EPHPM_SERVER__FILE_CACHE__VALID_SECS
+  value: {{ .Values.server.fileCache.validSecs | quote }}
+- name: EPHPM_SERVER__FILE_CACHE__INACTIVE_SECS
+  value: {{ .Values.server.fileCache.inactiveSecs | quote }}
+- name: EPHPM_SERVER__FILE_CACHE__INLINE_THRESHOLD
+  value: {{ .Values.server.fileCache.inlineThreshold | quote }}
+- name: EPHPM_SERVER__FILE_CACHE__PRECOMPRESS
+  value: {{ .Values.server.fileCache.precompress | quote }}
+{{- if .Values.server.tls.enabled }}
+{{- if .Values.server.tls.acme.domains }}
+- name: EPHPM_SERVER__TLS__DOMAINS
+  value: {{ .Values.server.tls.acme.domains | toJson | quote }}
+{{- if .Values.server.tls.acme.email }}
+- name: EPHPM_SERVER__TLS__EMAIL
+  value: {{ .Values.server.tls.acme.email | quote }}
+{{- end }}
+- name: EPHPM_SERVER__TLS__CACHE_DIR
+  value: {{ .Values.server.tls.acme.cacheDir | quote }}
+- name: EPHPM_SERVER__TLS__STAGING
+  value: {{ .Values.server.tls.acme.staging | quote }}
+{{- else }}
+- name: EPHPM_SERVER__TLS__CERT
+  value: {{ .Values.server.tls.cert | quote }}
+- name: EPHPM_SERVER__TLS__KEY
+  value: {{ .Values.server.tls.key | quote }}
+{{- end }}
+{{- if .Values.server.tls.tlsListen }}
+- name: EPHPM_SERVER__TLS__LISTEN
+  value: {{ .Values.server.tls.tlsListen | quote }}
+{{- end }}
+- name: EPHPM_SERVER__TLS__REDIRECT_HTTP
+  value: {{ .Values.server.tls.redirectHttp | quote }}
+{{- end }}
+- name: EPHPM_PHP__MAX_EXECUTION_TIME
+  value: {{ .Values.php.maxExecutionTime | quote }}
+- name: EPHPM_PHP__MEMORY_LIMIT
+  value: {{ .Values.php.memoryLimit | quote }}
+- name: EPHPM_PHP__WORKERS
+  value: {{ .Values.php.workers | quote }}
+{{- if .Values.php.iniFile }}
+- name: EPHPM_PHP__INI_FILE
+  value: {{ .Values.php.iniFile | quote }}
+{{- end }}
+{{- if .Values.db.mysql.enabled }}
+{{- if .Values.db.mysql.existingSecret }}
+- name: EPHPM_DB__MYSQL__URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.mysql.existingSecret }}
+      key: url
+{{- else if .Values.db.mysql.url }}
+- name: EPHPM_DB__MYSQL__URL
+  value: {{ .Values.db.mysql.url | quote }}
+{{- end }}
+- name: EPHPM_DB__MYSQL__LISTEN
+  value: {{ .Values.db.mysql.listen | quote }}
+- name: EPHPM_DB__MYSQL__MIN_CONNECTIONS
+  value: {{ .Values.db.mysql.minConnections | quote }}
+- name: EPHPM_DB__MYSQL__MAX_CONNECTIONS
+  value: {{ .Values.db.mysql.maxConnections | quote }}
+- name: EPHPM_DB__MYSQL__IDLE_TIMEOUT
+  value: {{ .Values.db.mysql.idleTimeout | quote }}
+- name: EPHPM_DB__MYSQL__MAX_LIFETIME
+  value: {{ .Values.db.mysql.maxLifetime | quote }}
+- name: EPHPM_DB__MYSQL__POOL_TIMEOUT
+  value: {{ .Values.db.mysql.poolTimeout | quote }}
+- name: EPHPM_DB__MYSQL__HEALTH_CHECK_INTERVAL
+  value: {{ .Values.db.mysql.healthCheckInterval | quote }}
+- name: EPHPM_DB__MYSQL__INJECT_ENV
+  value: {{ .Values.db.mysql.injectEnv | quote }}
+- name: EPHPM_DB__MYSQL__RESET_STRATEGY
+  value: {{ .Values.db.mysql.resetStrategy | quote }}
+{{- end }}
+{{- if .Values.db.postgres.enabled }}
+{{- if .Values.db.postgres.existingSecret }}
+- name: EPHPM_DB__POSTGRES__URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.postgres.existingSecret }}
+      key: url
+{{- else if .Values.db.postgres.url }}
+- name: EPHPM_DB__POSTGRES__URL
+  value: {{ .Values.db.postgres.url | quote }}
+{{- end }}
+- name: EPHPM_DB__POSTGRES__LISTEN
+  value: {{ .Values.db.postgres.listen | quote }}
+- name: EPHPM_DB__POSTGRES__MIN_CONNECTIONS
+  value: {{ .Values.db.postgres.minConnections | quote }}
+- name: EPHPM_DB__POSTGRES__MAX_CONNECTIONS
+  value: {{ .Values.db.postgres.maxConnections | quote }}
+- name: EPHPM_DB__POSTGRES__IDLE_TIMEOUT
+  value: {{ .Values.db.postgres.idleTimeout | quote }}
+- name: EPHPM_DB__POSTGRES__MAX_LIFETIME
+  value: {{ .Values.db.postgres.maxLifetime | quote }}
+- name: EPHPM_DB__POSTGRES__POOL_TIMEOUT
+  value: {{ .Values.db.postgres.poolTimeout | quote }}
+- name: EPHPM_DB__POSTGRES__HEALTH_CHECK_INTERVAL
+  value: {{ .Values.db.postgres.healthCheckInterval | quote }}
+- name: EPHPM_DB__POSTGRES__INJECT_ENV
+  value: {{ .Values.db.postgres.injectEnv | quote }}
+- name: EPHPM_DB__POSTGRES__RESET_STRATEGY
+  value: {{ .Values.db.postgres.resetStrategy | quote }}
+{{- end }}
+{{- if .Values.db.tds.enabled }}
+{{- if .Values.db.tds.existingSecret }}
+- name: EPHPM_DB__TDS__URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.tds.existingSecret }}
+      key: url
+{{- else if .Values.db.tds.url }}
+- name: EPHPM_DB__TDS__URL
+  value: {{ .Values.db.tds.url | quote }}
+{{- end }}
+- name: EPHPM_DB__TDS__LISTEN
+  value: {{ .Values.db.tds.listen | quote }}
+- name: EPHPM_DB__TDS__MIN_CONNECTIONS
+  value: {{ .Values.db.tds.minConnections | quote }}
+- name: EPHPM_DB__TDS__MAX_CONNECTIONS
+  value: {{ .Values.db.tds.maxConnections | quote }}
+- name: EPHPM_DB__TDS__INJECT_ENV
+  value: {{ .Values.db.tds.injectEnv | quote }}
+- name: EPHPM_DB__TDS__RESET_STRATEGY
+  value: {{ .Values.db.tds.resetStrategy | quote }}
+{{- end }}
+{{- if .Values.db.sqlite.enabled }}
+- name: EPHPM_DB__SQLITE__PATH
+  value: {{ .Values.db.sqlite.path | quote }}
+- name: EPHPM_DB__SQLITE__PROXY__MYSQL_LISTEN
+  value: {{ .Values.db.sqlite.proxy.mysqlListen | quote }}
+{{- if .Values.db.sqlite.proxy.hranaListen }}
+- name: EPHPM_DB__SQLITE__PROXY__HRANA_LISTEN
+  value: {{ .Values.db.sqlite.proxy.hranaListen | quote }}
+{{- end }}
+{{- if .Values.db.sqlite.proxy.postgresListen }}
+- name: EPHPM_DB__SQLITE__PROXY__POSTGRES_LISTEN
+  value: {{ .Values.db.sqlite.proxy.postgresListen | quote }}
+{{- end }}
+- name: EPHPM_DB__SQLITE__SQLD__HTTP_LISTEN
+  value: {{ .Values.db.sqlite.sqld.httpListen | quote }}
+- name: EPHPM_DB__SQLITE__SQLD__GRPC_LISTEN
+  value: {{ .Values.db.sqlite.sqld.grpcListen | quote }}
+- name: EPHPM_DB__SQLITE__REPLICATION__ROLE
+  value: {{ .Values.db.sqlite.replication.role | quote }}
+{{- if .Values.db.sqlite.replication.primaryGrpcUrl }}
+- name: EPHPM_DB__SQLITE__REPLICATION__PRIMARY_GRPC_URL
+  value: {{ .Values.db.sqlite.replication.primaryGrpcUrl | quote }}
+{{- end }}
+{{- end }}
+- name: EPHPM_DB__READ_WRITE_SPLIT__ENABLED
+  value: {{ .Values.db.readWriteSplit.enabled | quote }}
+- name: EPHPM_DB__READ_WRITE_SPLIT__STRATEGY
+  value: {{ .Values.db.readWriteSplit.strategy | quote }}
+- name: EPHPM_DB__READ_WRITE_SPLIT__STICKY_DURATION
+  value: {{ .Values.db.readWriteSplit.stickyDuration | quote }}
+- name: EPHPM_DB__READ_WRITE_SPLIT__MAX_REPLICA_LAG
+  value: {{ .Values.db.readWriteSplit.maxReplicaLag | quote }}
+- name: EPHPM_DB__ANALYSIS__QUERY_STATS
+  value: {{ .Values.db.analysis.queryStats | quote }}
+- name: EPHPM_DB__ANALYSIS__SLOW_QUERY_THRESHOLD
+  value: {{ .Values.db.analysis.slowQueryThreshold | quote }}
+- name: EPHPM_DB__ANALYSIS__DIGEST_STORE_MAX_ENTRIES
+  value: {{ .Values.db.analysis.digestStoreMaxEntries | quote }}
+- name: EPHPM_KV__MEMORY_LIMIT
+  value: {{ .Values.kv.memoryLimit | quote }}
+- name: EPHPM_KV__EVICTION_POLICY
+  value: {{ .Values.kv.evictionPolicy | quote }}
+- name: EPHPM_KV__COMPRESSION
+  value: {{ .Values.kv.compression | quote }}
+- name: EPHPM_KV__COMPRESSION_LEVEL
+  value: {{ .Values.kv.compressionLevel | quote }}
+- name: EPHPM_KV__COMPRESSION_MIN_SIZE
+  value: {{ .Values.kv.compressionMinSize | quote }}
+{{- if .Values.kv.secret }}
+- name: EPHPM_KV__SECRET
+  value: {{ .Values.kv.secret | quote }}
+{{- end }}
+- name: EPHPM_KV__REDIS_COMPAT__ENABLED
+  value: {{ .Values.kv.redisCompat.enabled | quote }}
+- name: EPHPM_KV__REDIS_COMPAT__LISTEN
+  value: {{ .Values.kv.redisCompat.listen | quote }}
+{{- if .Values.kv.redisCompat.password }}
+- name: EPHPM_KV__REDIS_COMPAT__PASSWORD
+  value: {{ .Values.kv.redisCompat.password | quote }}
+{{- end }}
+{{- if .Values.cluster.enabled }}
+- name: EPHPM_CLUSTER__ENABLED
+  value: "true"
+- name: EPHPM_CLUSTER__BIND
+  value: {{ .Values.cluster.bind | quote }}
+- name: EPHPM_CLUSTER__JOIN
+  value: {{ include "ephpm.clusterJoinJson" . | quote }}
+- name: EPHPM_CLUSTER__CLUSTER_ID
+  value: {{ .Values.cluster.clusterId | quote }}
+{{- if .Values.cluster.nodeId }}
+- name: EPHPM_CLUSTER__NODE_ID
+  value: {{ .Values.cluster.nodeId | quote }}
+{{- end }}
+{{- if .Values.cluster.existingSecret }}
+- name: EPHPM_CLUSTER__SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.cluster.existingSecret }}
+      key: gossipSecret
+{{- else if .Values.cluster.secret }}
+- name: EPHPM_CLUSTER__SECRET
+  value: {{ .Values.cluster.secret | quote }}
+{{- end }}
+- name: EPHPM_CLUSTER__KV__SMALL_KEY_THRESHOLD
+  value: {{ .Values.cluster.kv.smallKeyThreshold | quote }}
+- name: EPHPM_CLUSTER__KV__REPLICATION_FACTOR
+  value: {{ .Values.cluster.kv.replicationFactor | quote }}
+- name: EPHPM_CLUSTER__KV__REPLICATION_MODE
+  value: {{ .Values.cluster.kv.replicationMode | quote }}
+- name: EPHPM_CLUSTER__KV__HOT_KEY_CACHE
+  value: {{ .Values.cluster.kv.hotKeyCache | quote }}
+- name: EPHPM_CLUSTER__KV__HOT_KEY_THRESHOLD
+  value: {{ .Values.cluster.kv.hotKeyThreshold | quote }}
+- name: EPHPM_CLUSTER__KV__HOT_KEY_WINDOW_SECS
+  value: {{ .Values.cluster.kv.hotKeyWindowSecs | quote }}
+- name: EPHPM_CLUSTER__KV__HOT_KEY_LOCAL_TTL_SECS
+  value: {{ .Values.cluster.kv.hotKeyLocalTtlSecs | quote }}
+- name: EPHPM_CLUSTER__KV__HOT_KEY_MAX_MEMORY
+  value: {{ .Values.cluster.kv.hotKeyMaxMemory | quote }}
+- name: EPHPM_CLUSTER__KV__DATA_PORT
+  value: {{ .Values.cluster.kv.dataPort | quote }}
+{{- end }}
+{{- with .Values.extraEnv }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{- define "ephpm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ephpm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "ephpm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "ephpm.labels" -}}
+helm.sh/chart: {{ include "ephpm.chart" . }}
+{{ include "ephpm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "ephpm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ephpm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "ephpm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ephpm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "ephpm.image" -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{- define "ephpm.headlessServiceName" -}}
+{{- printf "%s-headless" (include "ephpm.fullname" .) }}
+{{- end }}
+
+{{/*
+Build the EPHPM_CLUSTER__JOIN JSON array from the StatefulSet pod DNS names.
+Matches the pattern in k8s/base/ephpm-cluster.yaml:
+  ["pod-0.headless-svc:7946","pod-1.headless-svc:7946",...]
+If cluster.join is set explicitly, use that as-is (JSON encoded).
+*/}}
+{{- define "ephpm.clusterJoinJson" -}}
+{{- if .Values.cluster.join }}
+{{- .Values.cluster.join | toJson }}
+{{- else }}
+{{- $peers := list }}
+{{- $fullname := include "ephpm.fullname" . }}
+{{- $headless := include "ephpm.headlessServiceName" . }}
+{{- range $i, $_ := until (int .Values.replicaCount) }}
+{{- $peers = append $peers (printf "%s-%d.%s:7946" $fullname $i $headless) }}
+{{- end }}
+{{- $peers | toJson }}
+{{- end }}
+{{- end }}
+
+{{/*
+True when the workload must be a StatefulSet (clustering or sqlite persistence).
+*/}}
+{{- define "ephpm.isStatefulSet" -}}
+{{- if or .Values.cluster.enabled .Values.db.sqlite.enabled -}}true{{- end }}
+{{- end }}

--- a/deploy/chart/templates/_validation.tpl
+++ b/deploy/chart/templates/_validation.tpl
@@ -1,0 +1,44 @@
+{{- define "ephpm.validate" -}}
+
+{{- if and .Values.cluster.enabled (lt (int .Values.replicaCount) 2) }}
+{{- fail "cluster.enabled=true requires replicaCount >= 2" }}
+{{- end }}
+
+{{- if and .Values.autoscaling.enabled (include "ephpm.isStatefulSet" .) }}
+{{- fail "autoscaling.enabled=true is only supported for Deployment workloads (set cluster.enabled=false)" }}
+{{- end }}
+
+{{- if and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") (not .Values.server.tls.secretName) }}
+{{- fail "server.tls.mode=manual requires server.tls.secretName (a Secret with tls.crt and tls.key)" }}
+{{- end }}
+
+{{- if and .Values.server.tls.enabled (eq .Values.server.tls.mode "acme") (not .Values.server.tls.acme.domains) }}
+{{- fail "server.tls.mode=acme requires server.tls.acme.domains" }}
+{{- end }}
+
+{{- if and .Values.observability.otlpExport.enabled (not .Values.observability.otlpExport.endpoint) }}
+{{- fail "observability.otlpExport.enabled=true requires observability.otlpExport.endpoint" }}
+{{- end }}
+
+{{- if and .Values.db.readWriteSplit.enabled .Values.db.mysql.enabled (not .Values.db.mysql.replicas.urls) }}
+{{- fail "db.readWriteSplit.enabled=true with db.mysql.enabled requires db.mysql.replicas.urls" }}
+{{- end }}
+
+{{- if and .Values.db.readWriteSplit.enabled .Values.db.postgres.enabled (not .Values.db.postgres.replicas.urls) }}
+{{- fail "db.readWriteSplit.enabled=true with db.postgres.enabled requires db.postgres.replicas.urls" }}
+{{- end }}
+
+{{- if and .Values.db.mysql.enabled (not .Values.db.mysql.url) (not .Values.db.mysql.existingSecret) }}
+{{- fail "db.mysql.enabled=true requires either db.mysql.url or db.mysql.existingSecret" }}
+{{- end }}
+
+{{- if and .Values.db.postgres.enabled (not .Values.db.postgres.url) (not .Values.db.postgres.existingSecret) }}
+{{- fail "db.postgres.enabled=true requires either db.postgres.url or db.postgres.existingSecret" }}
+{{- end }}
+
+{{- if and .Values.db.tds.enabled (not .Values.db.tds.url) (not .Values.db.tds.existingSecret) }}
+{{- fail "db.tds.enabled=true requires either db.tds.url or db.tds.existingSecret" }}
+{{- end }}
+
+{{- end }}
+{{- include "ephpm.validate" . }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,114 @@
+{{- if not (include "ephpm.isStatefulSet" .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ephpm.fullname" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ephpm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ephpm.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ephpm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ephpm
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "ephpm.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # No args — binary reads config entirely from env vars.
+          # Confirmed: k8s/base/ephpm-single.yaml has no args field.
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            {{- if .Values.server.tls.enabled }}
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.kv.redisCompat.enabled }}
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+            {{- end }}
+          env:
+            {{- include "ephpm.envvars" . | nindent 12 }}
+          # Readiness probe confirmed from k8s/base/ephpm-single.yaml.
+          # No liveness probe — authors don't use one.
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.persistence.enabled (and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName) .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: www-data
+              mountPath: {{ .Values.server.documentRoot }}
+            {{- end }}
+            {{- if and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName }}
+            - name: tls-certs
+              mountPath: /etc/ephpm/tls
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.persistence.enabled (and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName) .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: www-data
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "ephpm.fullname" . }}-www
+          {{- end }}
+        {{- end }}
+        {{- if and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName }}
+        - name: tls-certs
+          secret:
+            secretName: {{ .Values.server.tls.secretName }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/chart/templates/hpa.yaml
+++ b/deploy/chart/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ephpm.fullname" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ephpm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/chart/templates/ingress.yaml
+++ b/deploy/chart/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ephpm.fullname" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ephpm.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/chart/templates/pvc.yaml
+++ b/deploy/chart/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ephpm.fullname" . }}-www
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/chart/templates/service.yaml
+++ b/deploy/chart/templates/service.yaml
@@ -1,0 +1,80 @@
+# Main service (HTTP)
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ephpm.fullname" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "ephpm.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+    {{- if .Values.server.tls.enabled }}
+    - name: https
+      port: {{ .Values.service.httpsPort }}
+      targetPort: 443
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.kv.redisCompat.enabled }}
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+    {{- end }}
+---
+{{- if .Values.cluster.enabled }}
+# Headless service for StatefulSet DNS and gossip peer discovery.
+# Gossip port is UDP — confirmed from k8s/base/ephpm-cluster.yaml.
+# publishNotReadyAddresses=true so peers can reach each other during rolling restarts.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ephpm.headlessServiceName" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "ephpm.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: gossip
+      port: 7946
+      targetPort: 7946
+      protocol: UDP
+    # KV data plane — TCP, for large-value cross-node fetches
+    # Confirmed from ephpm-server/src/lib.rs data_plane::serve()
+    - name: kv-data
+      port: {{ .Values.cluster.kv.dataPort }}
+      targetPort: {{ .Values.cluster.kv.dataPort }}
+      protocol: TCP
+---
+# Per-pod services — allow targeting individual StatefulSet nodes.
+# Mirrors k8s/base/ephpm-cluster.yaml per-pod service pattern.
+{{- range $i, $_ := until (int .Values.replicaCount) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ephpm.fullname" $ }}-{{ $i }}
+  labels:
+    {{- include "ephpm.labels" $ | nindent 4 }}
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: {{ include "ephpm.fullname" $ }}-{{ $i }}
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+{{- end }}
+{{- end }}

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ephpm.serviceAccountName" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/templates/servicemonitor.yaml
+++ b/deploy/chart/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.serviceMonitor.enabled .Values.observability.prometheus -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ephpm.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ephpm.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      # /metrics confirmed from query-stats.md. Admin endpoint /__/queries also exists (planned).
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/chart/templates/statefulset.yaml
+++ b/deploy/chart/templates/statefulset.yaml
@@ -1,0 +1,120 @@
+{{- if include "ephpm.isStatefulSet" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ephpm.fullname" . }}
+  labels:
+    {{- include "ephpm.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "ephpm.headlessServiceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ephpm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ephpm.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ephpm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: ephpm
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "ephpm.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            # Gossip is UDP — confirmed from k8s/base/ephpm-cluster.yaml
+            - name: gossip
+              containerPort: 7946
+              protocol: UDP
+            # KV data plane TCP — confirmed from ephpm-server/src/lib.rs
+            # Used for large-value cross-node fetches (cluster.kv.dataPort default 7947)
+            - name: kv-data
+              containerPort: {{ .Values.cluster.kv.dataPort }}
+              protocol: TCP
+            {{- if .Values.server.tls.enabled }}
+            - name: https
+              containerPort: 443
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.kv.redisCompat.enabled }}
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+            {{- end }}
+          env:
+            {{- include "ephpm.envvars" . | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.persistence.enabled (and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName) .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: www-data
+              mountPath: {{ .Values.server.documentRoot }}
+            {{- end }}
+            {{- if and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName }}
+            - name: tls-certs
+              mountPath: /etc/ephpm/tls
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.persistence.enabled (and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName) .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: www-data
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ include "ephpm.fullname" . }}-www
+          {{- end }}
+        {{- end }}
+        {{- if and .Values.server.tls.enabled (eq .Values.server.tls.mode "manual") .Values.server.tls.secretName }}
+        - name: tls-certs
+          secret:
+            secretName: {{ .Values.server.tls.secretName }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -35,9 +35,9 @@ server:
   # [server.request]  →  RequestConfig
   request:
     # default_max_body_size() = 10 * 1024 * 1024 (10 MiB)
-    maxBodySize: 10485760
+    maxBodySize: "10485760"
     # default_max_header_size() = 8192
-    maxHeaderSize: 8192
+    maxHeaderSize: "8192"
     trustedHosts: []
 
   # [server.timeouts]  →  TimeoutsConfig
@@ -119,7 +119,7 @@ server:
     # default_file_cache_inactive_secs() = 60
     inactiveSecs: 60
     # default_file_cache_inline_threshold() = 1048576 (1 MiB)
-    inlineThreshold: 1048576
+    inlineThreshold: "1048576"
     # default_file_cache_precompress() = true
     precompress: true
 

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,451 @@
+# Default values for ePHPm
+#
+# Every key here maps directly to a struct field in crates/ephpm-config/src/lib.rs.
+# Defaults match the Rust default functions exactly.
+# Config is applied via EPHPM_ env vars (double-underscore separators).
+
+replicaCount: 1
+
+image:
+  repository: ephpm
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# ---------------------------------------------------------------------------
+# [server]  →  ServerConfig
+# ---------------------------------------------------------------------------
+server:
+  # default_listen() = "0.0.0.0:8080"
+  listen: "0.0.0.0:8080"
+  # default_document_root() = "."
+  documentRoot: "."
+  # default_index_files() = ["index.php", "index.html"]
+  indexFiles:
+    - index.php
+    - index.html
+  # default_fallback() = ["$uri", "$uri/", "/index.php?$query_string"]
+  fallback: []
+  # Optional: sites_dir for virtual hosting
+  sitesDir: ""
+
+  # [server.request]  →  RequestConfig
+  request:
+    # default_max_body_size() = 10 * 1024 * 1024 (10 MiB)
+    maxBodySize: 10485760
+    # default_max_header_size() = 8192
+    maxHeaderSize: 8192
+    trustedHosts: []
+
+  # [server.timeouts]  →  TimeoutsConfig
+  timeouts:
+    # default_header_read() = 30
+    headerRead: 30
+    # default_idle() = 60
+    idle: 60
+    # default_request_timeout() = 300
+    request: 300
+    # default_shutdown_timeout() = 30
+    shutdown: 30
+
+  # [server.response]  →  ResponseConfig
+  response:
+    # default_compression() = true
+    compression: true
+    # default_compression_level() = 1
+    compressionLevel: 1
+    # default_compression_min_size() = 1024
+    compressionMinSize: 1024
+    headers: []
+
+  # [server.static]  →  StaticConfig
+  static:
+    cacheControl: ""
+    # default_hidden_files() = "deny"
+    hiddenFiles: "deny"
+    # default_etag() = true
+    etag: true
+
+  # [server.php_etag_cache]  →  PhpETagCacheConfig
+  phpEtagCache:
+    # default_php_etag_cache_enabled() = false
+    enabled: false
+    # default_php_etag_cache_ttl() = 300
+    ttlSecs: 300
+    # default_php_etag_cache_prefix() = "etag:"
+    keyPrefix: "etag:"
+
+  # [server.security]  →  SecurityConfig
+  security:
+    trustedProxies: []
+    blockedPaths: []
+    allowedPhpPaths: []
+    # default_open_basedir() = true (when sites_dir set)
+    openBasedir: true
+    # default_disable_shell_exec() = true (when sites_dir set)
+    disableShellExec: true
+
+  # [server.logging]  →  LoggingConfig
+  logging:
+    access: ""
+    # default_log_level() = "info"
+    level: "info"
+
+  # [server.metrics]  →  MetricsConfig
+  metrics:
+    # default = false
+    enabled: false
+    # default_metrics_path() = "/metrics"
+    path: "/metrics"
+
+  # [server.limits]  →  LimitsConfig
+  limits:
+    maxConnections: 0
+    perIpMaxConnections: 0
+    perIpRate: 0.0
+    # default_per_ip_burst() = 50
+    perIpBurst: 50
+
+  # [server.file_cache]  →  FileCacheConfig
+  fileCache:
+    enabled: false
+    # default_file_cache_max_entries() = 10000
+    maxEntries: 10000
+    # default_file_cache_valid_secs() = 30
+    validSecs: 30
+    # default_file_cache_inactive_secs() = 60
+    inactiveSecs: 60
+    # default_file_cache_inline_threshold() = 1048576 (1 MiB)
+    inlineThreshold: 1048576
+    # default_file_cache_precompress() = true
+    precompress: true
+
+  # [server.tls]  →  TlsConfig (optional — omit to disable TLS)
+  tls:
+    enabled: false
+    # manual mode: provide a K8s Secret name containing tls.crt and tls.key
+    secretName: ""
+    # cert/key paths inside the container (mounted from secretName)
+    cert: "/etc/ephpm/tls/tls.crt"
+    key: "/etc/ephpm/tls/tls.key"
+    # acme mode:
+    acme:
+      domains: []
+      email: ""
+      # default_cache_dir() = "certs"
+      cacheDir: "certs"
+      staging: false
+    # Shared TLS options:
+    # listen is Option<String> — when set, HTTP stays on server.listen, HTTPS on this port
+    tlsListen: "0.0.0.0:443"
+    # default redirect_http = false
+    redirectHttp: false
+
+# ---------------------------------------------------------------------------
+# [php]  →  PhpConfig
+# NOTE: There is NO "mode" field in PhpConfig. Embedded vs external is not
+# a config option — it is determined at compile time.
+# ---------------------------------------------------------------------------
+php:
+  # default_max_execution_time() = 30
+  maxExecutionTime: 30
+  # default_memory_limit() = "128M"
+  memoryLimit: "128M"
+  iniFile: ""
+  # [[key, value], ...] pairs
+  iniOverrides: []
+  # default_php_workers() = CPU count capped at 16
+  workers: 4
+
+# ---------------------------------------------------------------------------
+# [db]  →  DbConfig
+# Backends are enabled by presence: set mysql.enabled/postgres.enabled/sqlite.enabled.
+# There is NO top-level "mode" field in DbConfig.
+# ---------------------------------------------------------------------------
+db:
+  # [db.mysql]  →  Option<DbBackendConfig>
+  mysql:
+    enabled: false
+    url: ""
+    # -- Store url in a K8s Secret (key "url") instead of plain text.
+    existingSecret: ""
+    # listen: default "127.0.0.1:3306"
+    listen: "127.0.0.1:3306"
+    socket: ""
+    # default_min_connections() = 2
+    minConnections: 2
+    # default_max_connections() = 20
+    maxConnections: 20
+    # default_idle_timeout() = "300s"
+    idleTimeout: "300s"
+    # default_max_lifetime() = "1800s"
+    maxLifetime: "1800s"
+    # default_pool_timeout() = "5s"
+    poolTimeout: "5s"
+    # default_health_check_interval() = "30s"
+    healthCheckInterval: "30s"
+    # default_inject_env() = true
+    injectEnv: true
+    # default_reset_strategy() = "smart"
+    resetStrategy: "smart"
+    replicas:
+      urls: []
+
+  # [db.postgres]  →  Option<DbBackendConfig>
+  postgres:
+    enabled: false
+    url: ""
+    existingSecret: ""
+    # listen: default "127.0.0.1:5432"
+    listen: "127.0.0.1:5432"
+    socket: ""
+    minConnections: 2
+    maxConnections: 20
+    idleTimeout: "300s"
+    maxLifetime: "1800s"
+    poolTimeout: "5s"
+    healthCheckInterval: "30s"
+    injectEnv: true
+    resetStrategy: "smart"
+    replicas:
+      urls: []
+
+  # [db.tds]  →  Option<DbBackendConfig> (SQL Server)
+  # NOTE: TDS proxy is configured but NOT YET IMPLEMENTED.
+  # Confirmed from ephpm-server/src/lib.rs: logs a warning and does nothing.
+  # Kept here for future use when the TDS wire protocol is implemented.
+  tds:
+    enabled: false
+    url: ""
+    existingSecret: ""
+    listen: "127.0.0.1:1433"
+    socket: ""
+    minConnections: 2
+    maxConnections: 20
+    idleTimeout: "300s"
+    maxLifetime: "1800s"
+    poolTimeout: "5s"
+    healthCheckInterval: "30s"
+    injectEnv: true
+    resetStrategy: "smart"
+    replicas:
+      urls: []
+
+  # [db.sqlite]  →  Option<SqliteConfig>
+  sqlite:
+    enabled: false
+    # default_sqlite_path() = "ephpm.db"
+    path: "ephpm.db"
+    # Storage for the SQLite data file (K8s PVC)
+    storageSize: "5Gi"
+    storageClass: ""
+
+    # [db.sqlite.proxy]  →  SqliteProxyConfig
+    proxy:
+      # default_sqlite_mysql_listen() = "127.0.0.1:3306"
+      mysqlListen: "127.0.0.1:3306"
+      hranaListen: ""
+      postgresListen: ""
+      tdsListen: ""
+
+    # [db.sqlite.sqld]  →  SqldConfig (clustered mode only)
+    sqld:
+      # default_sqld_http_listen() = "127.0.0.1:8081"
+      httpListen: "127.0.0.1:8081"
+      # default_sqld_grpc_listen() = "0.0.0.0:5001"
+      grpcListen: "0.0.0.0:5001"
+
+    # [db.sqlite.replication]  →  ReplicationConfig (clustered mode only)
+    replication:
+      # default_replication_role() = "auto"
+      role: "auto"
+      primaryGrpcUrl: ""
+
+  # [db.read_write_split]  →  ReadWriteSplitConfig
+  readWriteSplit:
+    enabled: false
+    # default_rw_strategy() = "sticky-after-write"
+    strategy: "sticky-after-write"
+    # default_sticky_duration() = "2s"
+    stickyDuration: "2s"
+    # default_max_replica_lag() = "500ms"
+    maxReplicaLag: "500ms"
+
+  # [db.analysis]  →  DbAnalysisConfig
+  analysis:
+    # default_query_stats_enabled() = true
+    queryStats: true
+    # default_slow_query_threshold() = "1s"
+    slowQueryThreshold: "1s"
+    # auto_explain: planned, not yet implemented — parsed but not acted upon
+    autoExplain: false
+    # default_auto_explain_target() = "stderr"
+    autoExplainTarget: "stderr"
+    # default_digest_max_entries() = 100000
+    # NOTE: struct field is digest_store_max_entries despite query-stats.md saying digest_max_entries
+    digestStoreMaxEntries: 100000
+
+# ---------------------------------------------------------------------------
+# [kv]  →  KvConfig
+# ---------------------------------------------------------------------------
+kv:
+  # default_kv_memory_limit() = "256MB"
+  memoryLimit: "256MB"
+  # default_kv_eviction_policy() = "allkeys-lru"
+  evictionPolicy: "allkeys-lru"
+  # default_kv_compression() = "none"  (brotli also supported)
+  compression: "none"
+  # default_kv_compression_level() = 6
+  compressionLevel: 6
+  # default_kv_compression_min_size() = 1024
+  compressionMinSize: 1024
+  # secret for multi-tenant RESP auth (HMAC-SHA256 per-site password derivation)
+  secret: ""
+
+  # [kv.redis_compat]  →  KvRedisCompatConfig
+  redisCompat:
+    enabled: false
+    # default_kv_listen() = "127.0.0.1:6379"
+    listen: "127.0.0.1:6379"
+    socket: ""
+    # Optional RESP AUTH password (equiv to Redis requirepass)
+    password: ""
+
+# ---------------------------------------------------------------------------
+# [cluster]  →  ClusterConfig
+# ---------------------------------------------------------------------------
+cluster:
+  enabled: false
+  # default_cluster_bind() = "0.0.0.0:7946"
+  bind: "0.0.0.0:7946"
+  # Seed peers. When empty, chart derives list from StatefulSet pod DNS.
+  join: []
+  # base64-encoded 32-byte gossip encryption key. Use existingSecret instead.
+  secret: ""
+  # K8s Secret with key "gossipSecret"
+  existingSecret: ""
+  # Auto-generated if empty
+  nodeId: ""
+  # default_cluster_id() = "ephpm"
+  clusterId: "ephpm"
+
+  # [cluster.kv]  →  ClusterKvConfig
+  kv:
+    # default_small_key_threshold() = 512 bytes
+    smallKeyThreshold: 512
+    # default_replication_factor() = 2
+    replicationFactor: 2
+    # default_replication_mode() = "async"
+    replicationMode: "async"
+    # default_hot_key_cache() = true
+    hotKeyCache: true
+    # default_hot_key_threshold() = 5
+    hotKeyThreshold: 5
+    # default_hot_key_window_secs() = 10
+    hotKeyWindowSecs: 10
+    # default_hot_key_local_ttl_secs() = 30
+    hotKeyLocalTtlSecs: 30
+    # default_hot_key_max_memory() = "64MB"
+    hotKeyMaxMemory: "64MB"
+    # default_kv_data_port() = 7947  ← KV data plane TCP port
+    dataPort: 7947
+
+# ---------------------------------------------------------------------------
+# Readiness probe — confirmed from k8s/base/ephpm-single.yaml
+# ---------------------------------------------------------------------------
+readinessProbe:
+  httpGet:
+    path: /index.php
+    port: 8080
+  initialDelaySeconds: 2
+  periodSeconds: 3
+
+# -- Optional liveness probe. Authors don't use one — disabled by default.
+livenessProbe: {}
+
+# ---------------------------------------------------------------------------
+# Document root persistence
+# ---------------------------------------------------------------------------
+persistence:
+  enabled: false
+  existingClaim: ""
+  storageClass: ""
+  size: "10Gi"
+  accessMode: ReadWriteOnce
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+service:
+  type: ClusterIP
+  port: 8080
+  httpsPort: 443
+
+# ---------------------------------------------------------------------------
+# Ingress
+# ---------------------------------------------------------------------------
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: ephpm.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# ---------------------------------------------------------------------------
+# Resources / autoscaling
+# ---------------------------------------------------------------------------
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+# ---------------------------------------------------------------------------
+# Pod settings
+# ---------------------------------------------------------------------------
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# ---------------------------------------------------------------------------
+# Prometheus ServiceMonitor
+# ---------------------------------------------------------------------------
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  interval: "30s"
+  scrapeTimeout: "10s"
+  additionalLabels: {}


### PR DESCRIPTION
Add Helm chart and release workflow

What this PR adds

We’ve introduced a production-grade Helm chart for ePHPm located in deploy/chart/. I’ve built this to be the definitive way to deploy to Kubernetes, pulling every configuration key and default value directly from our Rust config structs and cross-referencing them against our existing manifests to ensure consistency.

The chart is organized with a clear structure. The templates folder handles everything from shared helpers and environment variables to specific workload types like deployments and statefulsets. I’ve also included a ci folder with pre-configured value files for single-node, cluster, SQLite, and proxy modes.

Key design decisions:

Environment Variables: The setup is entirely driven by env vars with no file mounts, matching our current single-node manifest.

Smart Workloads: The chart automatically chooses between a Deployment for stateless setups and a StatefulSet when clustering or SQLite is enabled.

Networking: I've confirmed the gossip protocol uses UDP on port 7946, while the data plane uses TCP on 7947.

Cluster Services: It mirrors our existing pattern of using per-pod services when in cluster mode.

Health Checks: The readiness probe is set to check the index page on port 8080.

Release Workflow
I’ve also added a new GitHub workflow in .github/workflows/release.yaml. Now, whenever a version tag is pushed, the system will automatically update the chart version, run a lint check, package it up, and attach the resulting file directly to the GitHub release. This allows users to install specific versions using a direct URL. We can set up a formal Helm repository later, but this gets us up and running immediately.

One thing needed before merging
We need to update the image repository path in the values.yaml file (around line 8) to point to the official container registry once the image is live. For now, the tag can stay empty as it will default to the version specified in the chart.

Testing
I’ve run the chart through several manual tests, including linting and template rendering for both the standard and cluster configurations. Everything is passing without any errors.
