### PR TITLE
ci(release): publish Docker images, archive binaries, write SHA256SUMS

### DIFF
--- a/.github/release-readme.txt
+++ b/.github/release-readme.txt
@@ -1,0 +1,62 @@
+ePHPm — Embedded PHP Manager
+============================
+
+All-in-one PHP application server in a single binary. Embeds PHP via FFI,
+includes an HTTP server, MySQL connection pool, embedded SQLite, KV store,
+clustering, and TLS / ACME.
+
+This archive contains:
+  ephpm        the binary (use `ephpm.exe` on Windows)
+  LICENSE      MIT
+  README.txt   this file
+
+Quick start
+-----------
+
+Linux / macOS:
+
+    sudo ./ephpm install
+
+Installs the binary to /usr/local/bin/ephpm, drops a default config in
+/etc/ephpm/ephpm.toml, registers a systemd unit (Linux) or launchd plist
+(macOS), and starts the service. The HTTP listener comes up on port 8080.
+
+Windows (Administrator PowerShell):
+
+    .\ephpm.exe install
+
+Installs into "C:\Program Files\ephpm\", adds itself to PATH, registers
+a Windows service, and starts.
+
+Docker
+------
+
+If you'd rather not install anything:
+
+    docker run -p 8080:8080 ephpm/ephpm:latest
+
+Tag scheme:
+  ephpm/ephpm:<release>-php<phpver>   pinned ePHPm release × pinned PHP patch
+  ephpm/ephpm:<release>-php<minor>    pinned ePHPm release × rolling PHP minor
+  ephpm/ephpm:<minor>                 rolling latest release × rolling PHP minor
+  ephpm/ephpm:latest                  rolling latest release, default PHP minor
+
+Manage the service
+------------------
+
+The same subcommands work on every platform — they wrap systemd /
+launchd / the Windows service controller:
+
+    sudo ephpm start       # start the service
+    sudo ephpm stop        # stop the service
+    sudo ephpm restart     # restart
+    sudo ephpm status      # show status
+    sudo ephpm uninstall   # remove the service + binary
+
+Documentation
+-------------
+
+  Homepage:        https://ephpm.dev
+  Source:          https://github.com/ephpm/ephpm
+  Releases:        https://github.com/ephpm/ephpm/releases
+  Issue tracker:   https://github.com/ephpm/ephpm/issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,26 @@
 name: Release
 
+# Release artifacts produced per tag:
+#
+#   * Per-platform binary archives uploaded to the GitHub release:
+#       ephpm-vX.Y.Z+php<PHP_FULL>-<os>-<arch>.tar.gz   (one per PHP minor × OS/arch)
+#       SHA256SUMS                                       (covers all archives)
+#
+#   * Docker images pushed to Docker Hub at docker.io/ephpm/ephpm:
+#       :vX.Y.Z-php<PHP_FULL>     pinned ephpm release × pinned PHP patch
+#       :vX.Y.Z-php<PHP_MINOR>    pinned ephpm release × rolling PHP minor
+#       :<PHP_MINOR>              rolling latest release × rolling PHP minor
+#       :vX.Y.Z (default PHP)     pinned ephpm release × default PHP minor
+#       :latest (default PHP)     rolling latest release × default PHP minor
+#
+# The "+" in artifact names is real SemVer build metadata. OCI tag regex
+# rejects "+", so every Docker tag substitutes "-" for "+" — the same
+# trade-off k3s and rke2 make. The real SemVer string is preserved on each
+# image via the org.opencontainers.image.version label.
+#
+# PHP version pins must match xtask::PHP_SDK_VERSIONS — keep the matrix
+# entries below in sync if you bump a pin.
+
 on:
   push:
     tags: ["v*"]
@@ -8,33 +29,59 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── Linux binaries ─────────────────────────────────────────────────────────
   build-linux:
-    name: Build (PHP ${{ matrix.php }}, linux-x86_64)
+    name: Build (PHP ${{ matrix.php_full }}, linux-x86_64)
     runs-on: [self-hosted, linux, x64]
     container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        include:
+          - php_minor: "8.4"
+            php_full: "8.4.19"
+          - php_minor: "8.5"
+            php_full: "8.5.2"
     steps:
       - uses: actions/checkout@v4
 
       - name: Build ephpm
-        run: cargo xtask release ${{ matrix.php }}
+        run: cargo xtask release ${{ matrix.php_minor }}
 
-      - name: Upload artifact
+      - name: Package archive
+        id: pkg
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php_full }}
+        run: |
+          set -eu
+          name="ephpm-${VERSION}+php${PHP_FULL}-linux-x86_64"
+          mkdir -p "dist/${name}"
+          cp target/release/ephpm "dist/${name}/ephpm"
+          cp LICENSE "dist/${name}/LICENSE"
+          cp .github/release-readme.txt "dist/${name}/README.txt"
+          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
+          rm -rf "dist/${name}"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-php${{ matrix.php }}-linux-x86_64
-          path: target/release/ephpm
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-linux-x86_64
+          path: ${{ steps.pkg.outputs.archive }}
 
+  # ── macOS binaries ─────────────────────────────────────────────────────────
   build-macos:
-    name: Build (PHP ${{ matrix.php }}, macos-aarch64)
+    name: Build (PHP ${{ matrix.php_full }}, macos-aarch64)
     runs-on: [self-hosted, macos, arm64]
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        include:
+          - php_minor: "8.4"
+            php_full: "8.4.19"
+          - php_minor: "8.5"
+            php_full: "8.5.2"
     steps:
       - uses: actions/checkout@v4
 
@@ -42,22 +89,43 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build ephpm
-        run: cargo xtask release ${{ matrix.php }}
+        run: cargo xtask release ${{ matrix.php_minor }}
 
-      - name: Upload artifact
+      - name: Package archive
+        id: pkg
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php_full }}
+        run: |
+          set -eu
+          name="ephpm-${VERSION}+php${PHP_FULL}-macos-aarch64"
+          mkdir -p "dist/${name}"
+          cp target/release/ephpm "dist/${name}/ephpm"
+          cp LICENSE "dist/${name}/LICENSE"
+          cp .github/release-readme.txt "dist/${name}/README.txt"
+          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
+          rm -rf "dist/${name}"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-php${{ matrix.php }}-macos-aarch64
-          path: target/release/ephpm
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-macos-aarch64
+          path: ${{ steps.pkg.outputs.archive }}
 
+  # ── Windows binaries (cross-compiled from Linux via cargo-xwin) ────────────
   build-windows:
-    name: Build (PHP ${{ matrix.php }}, windows-x86_64)
+    name: Build (PHP ${{ matrix.php_full }}, windows-x86_64)
     runs-on: [self-hosted, linux, x64]
     container: ghcr.io/${{ github.repository }}/ephpm-ci:latest
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        include:
+          - php_minor: "8.4"
+            php_full: "8.4.19"
+          - php_minor: "8.5"
+            php_full: "8.5.2"
     steps:
       - uses: actions/checkout@v4
 
@@ -65,17 +133,103 @@ jobs:
         run: cargo install cargo-xwin --locked || true
 
       - name: Build Windows .exe
-        run: cargo xtask release ${{ matrix.php }} --target windows --no-sqld
+        run: cargo xtask release ${{ matrix.php_minor }} --target windows --no-sqld
 
-      - name: Upload artifact
+      - name: Package archive
+        id: pkg
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php_full }}
+        run: |
+          set -eu
+          name="ephpm-${VERSION}+php${PHP_FULL}-windows-x86_64"
+          mkdir -p "dist/${name}"
+          cp target/x86_64-pc-windows-msvc/release/ephpm.exe "dist/${name}/ephpm.exe"
+          cp LICENSE "dist/${name}/LICENSE"
+          cp .github/release-readme.txt "dist/${name}/README.txt"
+          # tar.gz on Windows too: built-in `tar` (bsdtar) on Win10/11 1809+
+          # unpacks .tar.gz natively, so we don't need a separate .zip path.
+          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
+          rm -rf "dist/${name}"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-php${{ matrix.php }}-windows-x86_64
-          path: target/x86_64-pc-windows-msvc/release/ephpm.exe
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-windows-x86_64
+          path: ${{ steps.pkg.outputs.archive }}
 
+  # ── Docker images on Docker Hub ────────────────────────────────────────────
+  docker-image:
+    name: Docker (PHP ${{ matrix.php_full }})
+    runs-on: [self-hosted, linux, x64]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php_minor: "8.4"
+            php_full: "8.4.19"
+            default: false
+          - php_minor: "8.5"
+            php_full: "8.5.2"
+            default: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_MINOR: ${{ matrix.php_minor }}
+          PHP_FULL: ${{ matrix.php_full }}
+          IS_DEFAULT: ${{ matrix.default }}
+        run: |
+          set -eu
+          # All tags substitute "+" → "-" because OCI tag regex rejects "+".
+          # The real SemVer string lives in the OCI label (see --label below).
+          tags="ephpm/ephpm:${VERSION}-php${PHP_FULL}"
+          tags="${tags},ephpm/ephpm:${VERSION}-php${PHP_MINOR}"
+          tags="${tags},ephpm/ephpm:${PHP_MINOR}"
+          if [ "${IS_DEFAULT}" = "true" ]; then
+            tags="${tags},ephpm/ephpm:${VERSION}"
+            tags="${tags},ephpm/ephpm:latest"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+          echo "semver=${VERSION}+php${PHP_FULL}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          build-args: |
+            PHP_SDK_VERSION=${{ matrix.php_full }}
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=ephpm
+            org.opencontainers.image.description=All-in-one PHP application server in a single binary
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tags.outputs.semver }}
+            org.opencontainers.image.licenses=MIT
+
+  # ── Release: gather archives, hash them, attach to the GitHub release ──────
   release:
     name: Create Release
-    needs: [build-linux, build-macos, build-windows]
+    needs: [build-linux, build-macos, build-windows, docker-image]
     runs-on: [self-hosted, linux, x64]
     permissions:
       contents: write
@@ -84,8 +238,20 @@ jobs:
         with:
           path: artifacts
 
-      - name: Create release
+      - name: Collect archives and write SHA256SUMS
+        id: collect
+        run: |
+          set -eu
+          mkdir -p release
+          # Each upload-artifact produces a per-name directory; flatten the
+          # actual archive files into one place so the sums file lives next
+          # to the things it sums.
+          find artifacts -type f -name '*.tar.gz' -exec cp {} release/ \;
+          (cd release && sha256sum *.tar.gz | sort > SHA256SUMS)
+          ls -lh release/
+
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/**/*
+          files: release/*
           generate_release_notes: true


### PR DESCRIPTION
Brings the release pipeline up to "a stranger could plausibly install this" by layering three things onto the existing per-PHP-version matrix.

## What ships per release tag

**Per-platform binary archives** uploaded to the GitHub release page:

```
ephpm-vX.Y.Z+php8.4.19-linux-x86_64.tar.gz
ephpm-vX.Y.Z+php8.4.19-macos-aarch64.tar.gz
ephpm-vX.Y.Z+php8.4.19-windows-x86_64.tar.gz
ephpm-vX.Y.Z+php8.5.2-linux-x86_64.tar.gz
ephpm-vX.Y.Z+php8.5.2-macos-aarch64.tar.gz
ephpm-vX.Y.Z+php8.5.2-windows-x86_64.tar.gz
SHA256SUMS
```

Each archive contains the binary, `LICENSE`, and a one-page `README.txt` with install + service-management + Docker instructions. `.tar.gz` is used for Windows too — built-in `tar` (bsdtar) on Win10/11 1809+ unpacks it natively, no separate `.zip` path needed.

**Docker images** pushed to `docker.io/ephpm/ephpm` for both PHP 8.4 and 8.5:

| Tag                              | What it is                                          |
|----------------------------------|-----------------------------------------------------|
| `vX.Y.Z-php8.5.2`                | pinned ePHPm release × pinned PHP patch             |
| `vX.Y.Z-php8.5`                  | pinned ePHPm release × rolling PHP minor            |
| `8.5`                            | rolling latest release × rolling PHP minor          |
| `vX.Y.Z` (default PHP only)      | pinned ePHPm release, default PHP minor             |
| `latest` (default PHP only)      | rolling latest release, default PHP minor           |

PHP 8.5 is the default, so it gets the `:vX.Y.Z` and `:latest` aliases.

## The "+" vs "-" thing

Real SemVer build metadata uses `+`, so artifact filenames and OCI image labels keep it: `v0.0.1+php8.5.2`. OCI tag regex rejects `+`, so every Docker tag substitutes `-`: `v0.0.1-php8.5.2`. Same trade-off [k3s](https://github.com/k3s-io/k3s/releases) and [rke2](https://github.com/rancher/rke2/releases) make — release tag is `v1.30.4+k3s1` but the Docker tag is `rancher/k3s:v1.30.4-k3s1`.

The real SemVer string is preserved on each image via the `org.opencontainers.image.version` label, so `docker inspect` round-trips it.

## Required setup before the next tag push

This PR will fail at the Docker login step until two repo (or org) secrets exist:

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` — a Docker Hub personal access token with **Read, Write, Delete** scope on the `ephpm/ephpm` repository

The `ephpm/ephpm` Docker Hub repository should also exist before the first push (an empty repo is fine — the first push populates it).

## Test plan

- [ ] Add `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` org secrets
- [ ] Confirm `ephpm/ephpm` exists on Docker Hub
- [ ] Tag `v0.0.1` and push; verify all six `.tar.gz` archives + `SHA256SUMS` land on the release
- [ ] `docker pull ephpm/ephpm:latest` works and `docker run -p 8080:8080 ephpm/ephpm:latest` serves on `:8080`
- [ ] `docker inspect ephpm/ephpm:v0.0.1-php8.5.2 | jq '.[0].Config.Labels."org.opencontainers.image.version"'` returns `v0.0.1+php8.5.2`
