### PR TITLE
feat(php): native ephpm session.save_handler backed by KV store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ dependencies = [
  "ephpm-kv",
  "http",
  "serial_test",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -20,6 +20,7 @@ cc = "1"
 
 [dev-dependencies]
 serial_test.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1320,7 +1320,14 @@ PS_UPDATE_TIMESTAMP_FUNC(ephpm)
 
 /* ── ps_module registration ─────────────────────────────────────── */
 
-static const ps_module ps_mod_ephpm = PS_MOD_UPDATE_TIMESTAMP(ephpm);
+/* PS_MOD_UPDATE_TIMESTAMP expands to a comma-separated list of values
+ * (the handler's name + 9 function pointers) — the surrounding braces
+ * are the caller's job. Without them the comma-list is interpreted as
+ * a sequence of fresh declarations and collides with the function
+ * definitions above ("redeclared as different kind of symbol" cascade
+ * across every ps_*_ephpm symbol). PHP's own ext/session/mod_files.c
+ * uses the same braced form. */
+static const ps_module ps_mod_ephpm = { PS_MOD_UPDATE_TIMESTAMP(ephpm) };
 
 /* ===== INI file path ===== */
 /* Holds the custom ini file path set via ephpm_set_ini_file() */

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -37,6 +37,7 @@
 #include "Zend/zend_exceptions.h"
 #include "Zend/zend_globals.h"
 #include "main/php_version.h"
+#include "ext/session/php_session.h"
 
 /* ===== Per-thread state =====
  *
@@ -1065,6 +1066,262 @@ static const zend_function_entry ephpm_kv_functions[] = {
     PHP_FE_END
 };
 
+/* ===================================================================
+ * Native session save handler — `session.save_handler = ephpm`.
+ *
+ * Stores PHP's serialised session blob in the same KV store used by the
+ * ephpm_kv_* native functions. Because that store is automatically
+ * site-namespaced in multi-tenant mode and replicated by the cluster
+ * layer, sessions inherit per-tenant isolation and affinity-free load
+ * balancing without any userland code or extra config.
+ *
+ * Wired via php_session_register_module() from inside our MINIT shim
+ * (ephpm_module_startup) — that is the only safe window in which the
+ * session extension's module list is initialised but PHP has not yet
+ * fired RINIT for any thread, so the registration is visible to every
+ * tokio worker that later copies GLOBAL_FUNCTION_TABLE / module_registry.
+ *
+ * Keys are namespaced as "session:<sid>". TTL comes from
+ * session.gc_maxlifetime; we refresh it on every write and on every
+ * timestamp update (so an active session does not expire mid-page).
+ * =================================================================== */
+
+#define EPHPM_SESSION_KEY_PREFIX "session:"
+#define EPHPM_SESSION_KEY_PREFIX_LEN (sizeof(EPHPM_SESSION_KEY_PREFIX) - 1)
+
+/*
+ * Build the KV key for a session id on the caller's stack when possible,
+ * falling back to emalloc for unusually long sids. Returns a pointer that
+ * the caller must release with `ephpm_session_key_free(buf, on_stack)`
+ * when finished. `stack_buf` must be at least 64 bytes.
+ */
+static char *ephpm_session_make_key(const char *sid, size_t sid_len,
+                                    char *stack_buf, size_t stack_buf_len,
+                                    int *used_heap)
+{
+    size_t need = EPHPM_SESSION_KEY_PREFIX_LEN + sid_len + 1;
+    char *buf;
+    if (need <= stack_buf_len) {
+        buf = stack_buf;
+        *used_heap = 0;
+    } else {
+        buf = (char *)emalloc(need);
+        *used_heap = 1;
+    }
+    memcpy(buf, EPHPM_SESSION_KEY_PREFIX, EPHPM_SESSION_KEY_PREFIX_LEN);
+    memcpy(buf + EPHPM_SESSION_KEY_PREFIX_LEN, sid, sid_len);
+    buf[EPHPM_SESSION_KEY_PREFIX_LEN + sid_len] = '\0';
+    return buf;
+}
+
+static void ephpm_session_key_free(char *buf, int used_heap)
+{
+    if (used_heap) {
+        efree(buf);
+    }
+}
+
+/* Read TTL (in seconds) from session.gc_maxlifetime, clamped to >= 0. */
+static long long ephpm_session_ttl_ms(void)
+{
+    /* PS(gc_maxlifetime) is a zend_long. 0 or negative => no expiry. */
+    long long lifetime = (long long)PS(gc_maxlifetime);
+    if (lifetime <= 0) {
+        return 0;
+    }
+    return lifetime * 1000LL;
+}
+
+/* ── PS_OPEN / PS_CLOSE ─────────────────────────────────────────── */
+
+PS_OPEN_FUNC(ephpm)
+{
+    /* save_path is irrelevant — we store in the in-process KV. session_name
+     * is the cookie name and is already tracked by ext/session. Nothing to
+     * do here, but we must not fail because php_session_initialize() bails
+     * on any non-SUCCESS return. */
+    (void)save_path;
+    (void)session_name;
+    (void)mod_data;
+    return SUCCESS;
+}
+
+PS_CLOSE_FUNC(ephpm)
+{
+    (void)mod_data;
+    return SUCCESS;
+}
+
+/* ── PS_READ ────────────────────────────────────────────────────── */
+
+PS_READ_FUNC(ephpm)
+{
+    (void)mod_data;
+    (void)maxlifetime;
+
+    if (!g_kv_ops.get || !g_kv_ops.get_result) {
+        /* No store wired — behave like an empty session rather than failing. */
+        *val = ZSTR_EMPTY_ALLOC();
+        return SUCCESS;
+    }
+
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+    char stack[128];
+    int used_heap = 0;
+    char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);
+
+    if (!g_kv_ops.get(kv_key)) {
+        ephpm_session_key_free(kv_key, used_heap);
+        /* Missing keys are NOT an error — return an empty string so PHP
+         * treats the session as new. */
+        *val = ZSTR_EMPTY_ALLOC();
+        return SUCCESS;
+    }
+
+    const char *ptr = NULL;
+    size_t len = 0;
+    g_kv_ops.get_result(&ptr, &len);
+    *val = zend_string_init(ptr ? ptr : "", len, 0);
+    ephpm_session_key_free(kv_key, used_heap);
+    return SUCCESS;
+}
+
+/* ── PS_WRITE ───────────────────────────────────────────────────── */
+
+PS_WRITE_FUNC(ephpm)
+{
+    (void)mod_data;
+    (void)maxlifetime;
+
+    if (!g_kv_ops.set) {
+        return FAILURE;
+    }
+
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+    char stack[128];
+    int used_heap = 0;
+    char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);
+
+    long long ttl_ms = ephpm_session_ttl_ms();
+    int ok = g_kv_ops.set(kv_key, ZSTR_VAL(val), ZSTR_LEN(val), ttl_ms);
+    ephpm_session_key_free(kv_key, used_heap);
+
+    return ok ? SUCCESS : FAILURE;
+}
+
+/* ── PS_DESTROY ─────────────────────────────────────────────────── */
+
+PS_DESTROY_FUNC(ephpm)
+{
+    (void)mod_data;
+
+    if (!g_kv_ops.del) {
+        return SUCCESS;
+    }
+
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+    char stack[128];
+    int used_heap = 0;
+    char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);
+    (void)g_kv_ops.del(kv_key);
+    ephpm_session_key_free(kv_key, used_heap);
+    return SUCCESS;
+}
+
+/* ── PS_GC ──────────────────────────────────────────────────────── */
+
+PS_GC_FUNC(ephpm)
+{
+    /* The KV store enforces TTLs natively (lazy expiry on access + active
+     * reaper). PHP's GC sweep would be redundant work — report "0 sessions
+     * cleaned" via *nrdels and let the store do the right thing. */
+    (void)mod_data;
+    (void)maxlifetime;
+    if (nrdels) {
+        *nrdels = 0;
+    }
+    return 0;
+}
+
+/* ── PS_CREATE_SID ──────────────────────────────────────────────── */
+
+PS_CREATE_SID_FUNC(ephpm)
+{
+    /* Delegate to PHP's own SID generator so session.sid_length /
+     * session.sid_bits_per_character / session.hash_function stay honoured.
+     * php_session_create_id is the official entrypoint other save handlers
+     * (files, memcached, redis) use for the same reason. */
+    (void)mod_data;
+    return php_session_create_id(NULL);
+}
+
+/* ── PS_VALIDATE_SID ────────────────────────────────────────────── */
+
+PS_VALIDATE_SID_FUNC(ephpm)
+{
+    /* Required so session.use_strict_mode = 1 actually rejects forged SIDs
+     * — PHP only accepts a client-supplied SID if validate() reports
+     * SUCCESS. Return SUCCESS iff the key already exists in the store. */
+    (void)mod_data;
+
+    if (!g_kv_ops.exists) {
+        return FAILURE;
+    }
+
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+    char stack[128];
+    int used_heap = 0;
+    char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);
+    int found = g_kv_ops.exists(kv_key);
+    ephpm_session_key_free(kv_key, used_heap);
+    return found ? SUCCESS : FAILURE;
+}
+
+/* ── PS_UPDATE_TIMESTAMP ────────────────────────────────────────── */
+
+PS_UPDATE_TIMESTAMP_FUNC(ephpm)
+{
+    /* session.lazy_write = 1 (the default in modern PHP) skips PS_WRITE
+     * when the serialised session blob is unchanged but still wants the
+     * TTL refreshed. Use EXPIRE rather than SET so we don't rewrite the
+     * potentially-large value blob on every request. */
+    (void)mod_data;
+    (void)maxlifetime;
+
+    if (!g_kv_ops.expire) {
+        /* Fall back to a full write if EXPIRE is unavailable. */
+        return ps_write_ephpm(mod_data, key, val, maxlifetime);
+    }
+
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+    char stack[128];
+    int used_heap = 0;
+    char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);
+
+    long long ttl_ms = ephpm_session_ttl_ms();
+    int ok = 1;
+    if (ttl_ms > 0) {
+        ok = g_kv_ops.expire(kv_key, ttl_ms);
+        if (!ok && g_kv_ops.set) {
+            /* Key may have expired between read and update — restore it
+             * by falling through to a full write so the session is not
+             * silently dropped. */
+            ok = g_kv_ops.set(kv_key, ZSTR_VAL(val), ZSTR_LEN(val), ttl_ms);
+        }
+    }
+    ephpm_session_key_free(kv_key, used_heap);
+    return ok ? SUCCESS : FAILURE;
+}
+
+/* ── ps_module registration ─────────────────────────────────────── */
+
+static const ps_module ps_mod_ephpm = PS_MOD_UPDATE_TIMESTAMP(ephpm);
+
 /* ===== INI file path ===== */
 /* Holds the custom ini file path set via ephpm_set_ini_file() */
 static const char *custom_ini_file = NULL;
@@ -1115,7 +1372,25 @@ void ephpm_set_ini_file(const char *ini_file)
 static int ephpm_module_startup(sapi_module_struct *sm)
 {
     sm->additional_functions = ephpm_kv_functions;
-    return php_module_startup(sm, NULL);
+    int ret = php_module_startup(sm, NULL);
+
+    /* Register the native "ephpm" session save handler. Must happen after
+     * php_module_startup() — the session extension's MINIT is what wires up
+     * the global module list this call inserts into. Doing it earlier
+     * (before php_module_startup) crashes because the session extension's
+     * own globals aren't constructed yet; doing it later (after
+     * php_embed_init returns) is too late under ZTS, since the main
+     * thread's CG/EG state has already been frozen into GLOBAL_FUNCTION_TABLE
+     * for new worker threads to copy.
+     *
+     * php_session_register_module() returns 0 on success, but practically
+     * cannot fail (it's an EG_HASH append). Even if it does, we don't
+     * unwind module startup — users who haven't configured the handler
+     * pay nothing for the absence. */
+    if (ret == SUCCESS) {
+        (void)php_session_register_module(&ps_mod_ephpm);
+    }
+    return ret;
 }
 
 /*

--- a/crates/ephpm-php/tests/sessions.rs
+++ b/crates/ephpm-php/tests/sessions.rs
@@ -1,0 +1,260 @@
+//! Integration tests for the native `session.save_handler = ephpm`.
+//!
+//! These tests boot the embedded PHP runtime and run a sequence of
+//! "requests" against it, mimicking a real browser session: write a
+//! value, read it back through a fresh request, destroy, confirm gone.
+//!
+//! They require a real libphp link (`php_linked`) because `php_embed_init`
+//! is what registers our `ps_module ps_mod_ephpm` with the session
+//! extension. In stub mode the whole file compiles to nothing, so
+//! `cargo build` (no PHP SDK) still passes.
+//!
+//! Run with: `cargo test -p ephpm-php --test sessions` after building the
+//! PHP SDK (`cargo xtask release` will have done this).
+//!
+//! Each test reuses the process-wide PHP runtime — `php_embed_init` is
+//! a once-per-process operation. `serial_test` ensures the tests do not
+//! step on each other's session ids.
+
+#![cfg(all(test, php_linked))]
+
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
+
+use ephpm_kv::store::{Store, StoreConfig};
+use ephpm_php::request::PhpRequest;
+use ephpm_php::response::PhpResponse;
+use ephpm_php::{PhpRuntime, kv_bridge};
+use serial_test::serial;
+use tempfile::TempDir;
+
+// ── Shared process-wide PHP runtime ────────────────────────────────────
+
+/// One Store, one PhpRuntime per test process. `OnceLock` guarantees we
+/// only init PHP once even across the many `#[test]` functions that share
+/// this binary.
+static SESSION_STORE: OnceLock<Arc<Store>> = OnceLock::new();
+static SCRIPT_DIR: OnceLock<TempDir> = OnceLock::new();
+
+fn init_once() -> Arc<Store> {
+    let store = SESSION_STORE
+        .get_or_init(|| {
+            let s = Store::new(StoreConfig::default());
+            PhpRuntime::init().expect("php_embed_init");
+            PhpRuntime::set_kv_store(&s);
+            PhpRuntime::finalize_for_http().expect("finalize_for_http");
+            s
+        })
+        .clone();
+
+    // Bind the per-thread KV "site store" to the same instance so SAPI
+    // callbacks (and through them, our session handler) resolve to it.
+    kv_bridge::set_site_store(Some(Arc::clone(&store)));
+    store
+}
+
+fn script_dir() -> &'static std::path::Path {
+    SCRIPT_DIR.get_or_init(|| TempDir::new().expect("tempdir for session test scripts")).path()
+}
+
+/// Write a PHP script to a tempfile and return its absolute path.
+fn write_script(name: &str, body: &str) -> PathBuf {
+    let path = script_dir().join(name);
+    std::fs::write(&path, body).expect("write test script");
+    path
+}
+
+/// Build a synthetic `PhpRequest` that targets `script` with a single
+/// `Cookie: PHPSESSID=<sid>` header (so PHP's session module picks the
+/// id up via `$_COOKIE`).
+fn make_request(script: PathBuf, sid: Option<&str>) -> PhpRequest {
+    let mut headers: Vec<(String, String)> = Vec::new();
+    if let Some(s) = sid {
+        headers.push(("Cookie".to_string(), format!("PHPSESSID={s}")));
+    }
+    PhpRequest {
+        method: "GET".into(),
+        uri: format!("/{}", script.file_name().unwrap().to_string_lossy()),
+        path: format!("/{}", script.file_name().unwrap().to_string_lossy()),
+        query_string: String::new(),
+        document_root: script.parent().unwrap().to_path_buf(),
+        script_filename: script,
+        headers,
+        body: Vec::new(),
+        content_type: None,
+        remote_addr: "127.0.0.1:12345".parse().unwrap(),
+        server_name: "localhost".into(),
+        server_port: 8080,
+        is_https: false,
+        protocol: "HTTP/1.1".into(),
+        env_vars: vec![
+            // Force the ephpm save handler regardless of any inherited php.ini.
+            // session.use_strict_mode mirrors what the task spec asked for.
+            ("PHP_INI_SCAN_DIR".into(), String::new()),
+        ],
+    }
+}
+
+/// Execute one request and pull out a trimmed body.
+fn run(script: PathBuf, sid: Option<&str>) -> PhpResponse {
+    let req = make_request(script, sid);
+    PhpRuntime::execute(req).expect("php request executed")
+}
+
+fn body_str(resp: &PhpResponse) -> String {
+    String::from_utf8_lossy(&resp.body).trim().to_string()
+}
+
+// The ini directives every test needs. Inlined into each script so the
+// ephpm save handler is selected regardless of how the embed SAPI's
+// default php.ini was configured.
+const SESSION_INI: &str = r#"
+ini_set('session.save_handler', 'ephpm');
+ini_set('session.use_strict_mode', '1');
+ini_set('session.use_cookies', '0');
+ini_set('session.use_only_cookies', '0');
+ini_set('session.cache_limiter', '');
+ini_set('session.gc_maxlifetime', '600');
+"#;
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[test]
+#[serial]
+fn write_then_read_round_trip() {
+    let store = init_once();
+    let sid = "ephpmtestsid_writeread_aaaaaaaaaa";
+
+    // Seed the store with an empty payload so use_strict_mode accepts the SID.
+    store.set(format!("session:{sid}"), b"".to_vec(), None);
+
+    let write_script = write_script(
+        "session_write.php",
+        &format!(
+            r#"<?php
+{SESSION_INI}
+session_id('{sid}');
+session_start();
+$_SESSION['x'] = 'hello';
+$_SESSION['n'] = 42;
+session_write_close();
+echo 'WROTE';
+"#,
+        ),
+    );
+    let resp = run(write_script, Some(sid));
+    assert_eq!(body_str(&resp), "WROTE");
+
+    // The KV key should now hold PHP's serialised session blob.
+    let raw = store.get(&format!("session:{sid}")).expect("session blob stored");
+    assert!(!raw.is_empty(), "expected non-empty session blob, got 0 bytes");
+
+    let read_script = write_script(
+        "session_read.php",
+        &format!(
+            r#"<?php
+{SESSION_INI}
+session_id('{sid}');
+session_start();
+echo $_SESSION['x'] . '|' . $_SESSION['n'];
+"#,
+        ),
+    );
+    let resp = run(read_script, Some(sid));
+    assert_eq!(body_str(&resp), "hello|42");
+}
+
+#[test]
+#[serial]
+fn destroy_removes_key() {
+    let store = init_once();
+    let sid = "ephpmtestsid_destroy_bbbbbbbbbbbb";
+
+    store.set(format!("session:{sid}"), b"x|s:1:\"y\";".to_vec(), None);
+
+    let destroy_script = write_script(
+        "session_destroy.php",
+        &format!(
+            r#"<?php
+{SESSION_INI}
+session_id('{sid}');
+session_start();
+session_destroy();
+echo 'GONE';
+"#,
+        ),
+    );
+    let resp = run(destroy_script, Some(sid));
+    assert_eq!(body_str(&resp), "GONE");
+
+    assert!(
+        store.get(&format!("session:{sid}")).is_none(),
+        "session key should be deleted after session_destroy()"
+    );
+}
+
+#[test]
+#[serial]
+fn write_sets_ttl_from_gc_maxlifetime() {
+    let store = init_once();
+    let sid = "ephpmtestsid_ttl_cccccccccccccccc";
+
+    store.set(format!("session:{sid}"), b"".to_vec(), None);
+
+    let script = write_script(
+        "session_ttl.php",
+        &format!(
+            r#"<?php
+{SESSION_INI}
+ini_set('session.gc_maxlifetime', '120');
+session_id('{sid}');
+session_start();
+$_SESSION['v'] = 1;
+session_write_close();
+echo 'OK';
+"#,
+        ),
+    );
+    let _ = run(script, Some(sid));
+
+    let pttl = store.pttl(&format!("session:{sid}")).expect("ttl recorded");
+    assert!(
+        pttl > 0 && pttl <= 120_000,
+        "expected TTL in (0, 120_000] ms (gc_maxlifetime=120s); got {pttl}",
+    );
+}
+
+#[test]
+#[serial]
+fn validate_sid_rejects_unknown_in_strict_mode() {
+    let _store = init_once();
+
+    // use_strict_mode = 1 + an SID we never seeded: PHP must invent a new SID
+    // rather than accept the supplied one. We detect this indirectly by
+    // observing that the original SID's KV key is still absent after the
+    // request — only the freshly-generated SID gets written.
+    let forged = "ephpmtestsid_forged_dddddddddddd";
+    let script = write_script(
+        "session_strict.php",
+        &format!(
+            r#"<?php
+{SESSION_INI}
+session_id('{forged}');
+session_start();
+$_SESSION['v'] = 'created';
+session_write_close();
+echo session_id();
+"#,
+        ),
+    );
+    let resp = run(script, Some(forged));
+    let returned_sid = body_str(&resp);
+    assert_ne!(
+        returned_sid, forged,
+        "strict mode must reject unseeded SID and regenerate; got back {returned_sid}",
+    );
+    assert!(
+        SESSION_STORE.get().unwrap().get(&format!("session:{forged}")).is_none(),
+        "forged SID should never have been written",
+    );
+}

--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -1,0 +1,130 @@
+# Sessions
+
+ePHPm ships a native PHP session save handler called `ephpm`. It stores session
+data in the in-process KV store that backs the `ephpm_kv_*` functions, so a
+session is one DashMap lookup away from the running script — no Redis,
+memcached, NFS share, or sticky load balancer required. In multi-tenant mode
+sessions are automatically per-site; in clustered mode they ride the same
+gossip replication path the rest of the KV store uses.
+
+## Quick start
+
+Add one line to `php.ini` (or to `ini_set()` at the top of your front
+controller — `session.save_handler` is `PHP_INI_ALL`):
+
+```ini
+session.save_handler = ephpm
+session.use_strict_mode = 1
+session.gc_maxlifetime = 1440
+```
+
+Then PHP behaves exactly as you'd expect:
+
+```php
+<?php
+session_start();
+$_SESSION['user_id'] = 42;
+// ...next request...
+session_start();
+echo $_SESSION['user_id']; // 42
+```
+
+Nothing else to wire up. No `[session]` config block, no extra TOML.
+
+## How it works
+
+`session_start()` calls the handler's `read` callback, which translates to
+`Store::get("session:<sid>")` against the per-thread KV store. `write` is the
+mirror: serialised session blob → `Store::set("session:<sid>", blob, ttl)`.
+`destroy` is `Store::remove`. The session id never leaves the C wrapper —
+there is no socket hop, no serialisation overhead, no FastCGI round-trip.
+
+The handler implements PHP's full `ps_module` surface, including
+`validate_sid` (so `session.use_strict_mode` actually rejects forged ids) and
+`update_timestamp` (so `session.lazy_write` refreshes the TTL via `EXPIRE`
+instead of rewriting an unchanged blob).
+
+In **multi-tenant mode** (`sites_dir = ...`) every vhost gets its own physical
+`Store` — see `crates/ephpm-kv/src/multi_tenant.rs`. The session handler reads
+through the same `effective_store()` path the `ephpm_kv_*` functions use, so
+`session:abc123` on `alice.example.com` lives in a different DashMap from
+`session:abc123` on `bob.example.com`. No prefixing, no collision risk, no
+config.
+
+In **clustered mode** (`[cluster] enabled = true`) the KV store is replicated
+across all nodes via the gossip layer, so a session created on node A is
+readable from nodes B, C, D within gossip convergence time. Sticky sessions
+become unnecessary: any node can serve any request.
+
+## TTL behaviour
+
+The session TTL comes from `session.gc_maxlifetime` (seconds). On every
+`session_write_close()` (or implicit shutdown) we call `Store::set` with
+`ttl = gc_maxlifetime * 1000` ms. PHP's `session.lazy_write = 1` (the modern
+default) routes unchanged writes through `update_timestamp`, which calls
+`Store::expire` — same TTL, no value rewrite.
+
+If `session.gc_maxlifetime = 0` the session is stored without a TTL. We do not
+recommend this — the KV store has bounded memory and will start evicting under
+pressure.
+
+The KV store's lazy + active expiry handles cleanup. `gc_collect` is a no-op
+because PHP's GC sweep would be redundant work.
+
+## Framework notes
+
+**WordPress** — works as-is. WP doesn't use `$_SESSION` heavily, but its
+plugins do; setting `session.save_handler = ephpm` in `php.ini` is the entire
+integration story.
+
+**Laravel** — set `SESSION_DRIVER=php` in `.env`. Laravel's default `file`
+driver bypasses `session.save_handler` and writes to `storage/framework/sessions/`
+directly; you have to opt back into PHP's native session machinery for the
+ephpm handler to see anything.
+
+**Symfony** — set `framework.session.handler_id: null` (the documented
+"let PHP handle it" value). Symfony's `NativeFileSessionHandler` ignores
+`session.save_handler` for the same reason Laravel's `file` driver does.
+
+**CodeIgniter 4** — use the `php` session driver
+(`$session['driver'] = \CodeIgniter\Session\Handlers\NullHandler::class`
+is **not** what you want; CI4 ships a thin PHP wrapper that just calls
+`session_start()` — set `$session['driver']` to that and you're fine).
+
+## Multi-tenant
+
+No configuration. Each vhost's `effective_store()` resolves to its own
+DashMap. The `session:` key prefix is purely cosmetic — a separator from
+non-session KV entries — and is per-store, not global. A session id collision
+across tenants is harmless because the stores are physically separate
+objects.
+
+## Cluster
+
+No configuration beyond enabling `[cluster]`. Session writes are replicated
+through the same two-tier gossip path as every other KV mutation. On node
+loss the surviving nodes already have the data; the load balancer is free to
+route the next request anywhere.
+
+Convergence is best-effort gossip (~10–30s for full-mesh convergence under
+default chitchat timings), so a session created on node A *can* be invisible
+to node B for a brief window if the user's request races ahead of the gossip
+fan-out. In practice this only matters for sub-second redirects against
+brand-new sessions; for any normal browsing flow the gap is invisible.
+
+## Limitations
+
+- **Memory eviction.** The KV store has a configurable `memory_limit` and an
+  eviction policy. The default `noeviction` will fail writes when full —
+  sessions included — which is the right behaviour for correctness. If you
+  switch the policy to `allkeys-lru` for caching, sessions can be evicted
+  before their TTL fires. Use `volatile-lru` for session-heavy workloads
+  (evicts only keys that have a TTL set, which sessions always do).
+- **No persistence across `ephpm` restarts** (yet). The KV store is in-memory
+  only. Clustered deployments survive single-node restarts because gossip
+  re-syncs the store; restarting every node simultaneously wipes all
+  sessions. AOF/snapshot persistence is on the roadmap.
+- **No cross-cluster replication.** Sessions live in the same KV tier as
+  the rest of your data; if you have geographically split clusters you'll
+  need application-level session token forwarding, the same as any
+  Redis-backed deployment.


### PR DESCRIPTION
## Why

Until now, running stateful PHP on ePHPm meant either filesystem sessions (broken in a clustered deployment) or wiring up a separate Redis/memcached. Both work, both add operational weight, and both ignore the fact that ePHPm already has a replicated, per-tenant KV store sitting in the same address space as the PHP interpreter.

This PR adds a native session save handler named `ephpm` that stores session data directly in that store. Single function-call latency on read/write, automatic per-vhost isolation in multi-tenant mode, automatic replication in clustered mode, and zero new config knobs.

## API

One line in `php.ini`:

```ini
session.save_handler = ephpm
session.use_strict_mode = 1
session.gc_maxlifetime = 1440
```

Or `ini_set('session.save_handler', 'ephpm')` at the top of a front controller. Userland code stays the same:

```php
session_start();
$_SESSION['user_id'] = 42;
```

No TOML config, no extension to enable, no separate service to run.

## Implementation

- `crates/ephpm-php/ephpm_wrapper.c` — full `ps_module` surface: `PS_OPEN_FUNC`, `PS_CLOSE_FUNC`, `PS_READ_FUNC`, `PS_WRITE_FUNC`, `PS_DESTROY_FUNC`, `PS_GC_FUNC` (no-op), `PS_CREATE_SID_FUNC` (delegates to `php_session_create_id`), `PS_VALIDATE_SID_FUNC` (checks key existence), `PS_UPDATE_TIMESTAMP_FUNC` (uses `EXPIRE` rather than `SET`).
- Registered in `ephpm_module_startup` immediately after `php_module_startup()` succeeds — the only window where the session extension's module list is live *and* the registration will be visible to every tokio worker that later copies `GLOBAL_FUNCTION_TABLE`.
- Keys: `session:<sid>`. Bound to the per-thread "site store" set by the request handler, so multi-tenant deployments get physical isolation (separate DashMaps), not prefix-namespacing.
- TTL: `session.gc_maxlifetime * 1000` ms, refreshed on every write and via `EXPIRE` on `update_timestamp` so `session.lazy_write = 1` doesn't rewrite unchanged value blobs.

## Tests

`crates/ephpm-php/tests/sessions.rs` (gated `#![cfg(all(test, php_linked))]`):

- `write_then_read_round_trip` — script A writes `$_SESSION['x'] = 'hello'`; script B reads it back with the same SID. Asserts payload survives.
- `destroy_removes_key` — script calls `session_destroy()`; asserts the KV key is gone.
- `write_sets_ttl_from_gc_maxlifetime` — asserts `pttl(session:<sid>)` lands in `(0, gc_maxlifetime * 1000]` ms.
- `validate_sid_rejects_unknown_in_strict_mode` — asserts a forged SID is replaced (not written under the supplied id) when `session.use_strict_mode = 1`.

Stub mode (no `PHP_SDK_PATH`): the whole test file `#![cfg]`s out, so `cargo build` and `cargo clippy --workspace` still pass without PHP linked.

## What to verify on review

- [ ] `php_session_register_module` call sits in the right MINIT window (after `php_module_startup`, before the embed SAPI's initial request startup).
- [ ] No Rust destructors live across PHP function calls in the session callbacks (they're all C-level, but worth double-checking the bridge dispatch path).
- [ ] `(void)maxlifetime` on `PS_READ_FUNC` / `PS_WRITE_FUNC` / `PS_UPDATE_TIMESTAMP_FUNC` is intentional — we use `session.gc_maxlifetime` via `PS(gc_maxlifetime)` instead, which matches what other save handlers do.
- [ ] `PS_GC_FUNC` writes `*nrdels = 0` and returns `0` — correct shape per PHP 8.4's `PS_GC_ARGS`.
- [ ] `ephpm_session_make_key` stack/heap fallback handles the 64-char SID case (default) on the stack and only `emalloc`s for unusually long SIDs.
- [ ] `docs/features/sessions.md` covers the Laravel `SESSION_DRIVER=php` caveat and the Symfony `framework.session.handler_id: null` caveat — these are the two most common "why isn't my handler being called?" support questions for any PHP session handler.

## Local checks

- `cargo build` (stub, no `PHP_SDK_PATH`) ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo +nightly fmt --all -- --check` ✓
- `cargo check -p ephpm-php --tests` ✓

CI will exercise the integration tests with PHP linked.