### PR TITLE
docs: post-PR-22 audit sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,12 @@ Three database modes, all transparent to PHP (`pdo_mysql` connects to `127.0.0.1
 2. **Single-node SQLite** (`[db.sqlite]`) — litewire + rusqlite in-process, no external database
 3. **Clustered SQLite** (`[db.sqlite]` + `[cluster]`) — litewire + sqld sidecar, WAL frame replication via gRPC
 
-Mode detection:
+Mode detection (`is_clustered_sqlite()` in `crates/ephpm-server/src/lib.rs`):
 - If `replication.role = "primary"` or `"replica"` → clustered
 - If `replication.role = "auto"` AND `cluster.enabled = true` → clustered (election via gossip)
 - Otherwise → single-node (rusqlite in-process)
+
+Note that `replication.role` defaults to `"auto"`. So omitting `[db.sqlite.replication]` entirely is identical to setting `role = "auto"` — clustered mode if `[cluster].enabled = true`, single-node otherwise. To force single-node even with clustering on, set `replication.role` to anything other than `"primary"`, `"replica"`, or `"auto"` (e.g. `"single"`).
 
 Clustered mode spawns sqld as a child process. Primary election uses the gossip KV tier (`kv:sqlite:primary`). On failover, the role-change watcher restarts sqld in the new mode.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ How ePHPm compares to other ways of running PHP with a webserver.
 
 ePHPm is a single self-managing binary — it registers and controls its own system service. There is no install script.
 
+> Prefer containers? `docker run -p 8080:8080 ephpm/ephpm:latest`. See the [Docker section of the install docs](https://ephpm.dev/getting-started/install/#docker) for the full tag scheme.
+
 ### Linux / macOS
 
 Download the latest binary from [Releases](https://github.com/ephpm/ephpm/releases), unpack, then:

--- a/site/content/architecture/http.md
+++ b/site/content/architecture/http.md
@@ -97,6 +97,18 @@ PHP installs a `SIGPROF` handler for `max_execution_time`. This signal is proces
 
 PHP uses `setjmp`/`longjmp` for error handling. All PHP calls go through `ephpm_wrapper.c` which wraps execution in `zend_try`/`zend_catch`. PHP 8.x `exit()`/`die()` throws an unwind exit exception, which we detect and treat as a normal response (with captured output).
 
+### PHP Fatal → HTTP 500
+
+A PHP fatal error must surface as an HTTP 500 even though the embed SAPI gives us several different ways for one to happen. `ephpm_execute_request()` in `ephpm_wrapper.c` covers two distinct detection paths:
+
+1. **`zend_bailout()` longjmp.** Out-of-memory, max-execution-time, and the older fatal-class errors call `zend_bailout()`, which longjmps out of `php_execute_script`. The `SETJMP(__bailout) == 0` guard in the wrapper catches that case and sets `fatal_bailout = 1`.
+
+2. **PHP 8.x uncaught `Throwable`.** When a script throws and nothing catches it, `zend_exception_error()` formats the message via `zend_error_va(... | E_DONT_BAIL ...)` and lets `php_execute_script` return normally. `SETJMP` sees nothing — no longjmp ever happens. To catch this path the wrapper also checks `PG(last_error_type)` against a fatal-class mask (`E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE`). Without that second check, "Fatal error: Uncaught Error: Call to undefined function …" comes back as `200 OK`.
+
+`PG(last_error_type)` is reset to `0` before each request so a fatal from a previous reuse of the embed request can't leak into the next one.
+
+Once a fatal has been detected by either path, the wrapper only overrides the status when it is still the default `200`. Anything the script set explicitly via `http_response_code()` or `exit($status)` is preserved — the contract is "200 → 500 on fatal", not "always 500 on fatal".
+
 ## SAPI Callbacks
 
 | Callback | Purpose |
@@ -147,6 +159,22 @@ PHP must be initialized **before** the tokio runtime to avoid signal conflicts:
 - Gzip compression for compressible content types above minimum size
 - `Cache-Control` header when configured
 - `ETag` generation (weak, hash-based) + `If-None-Match` → 304 Not Modified
+
+### Percent-Decoding of URI Paths
+
+hyper hands the router the raw URI path, so `/test%2Ehtml` would otherwise be looked up as the literal name `test%2Ehtml`. Before any routing or filesystem lookup happens, the request path is run through `percent_decode_path()` (in `crates/ephpm-server/src/router.rs`) so `%XX` escapes resolve to their bytes — `/test%2Ehtml` becomes `/test.html` and matches the file on disk.
+
+The decoder is deliberately strict:
+
+| Input | Result |
+|-------|--------|
+| `%XX` with valid hex | decoded to the byte |
+| Truncated `%`, `%X` (one digit) | 400 Bad Request |
+| Non-hex digits (`%ZZ`, `%G1`) | 400 Bad Request |
+| Encoded slash (`%2F`) or backslash (`%5C`) | 400 Bad Request |
+| Decoded byte stream not valid UTF-8 | 400 Bad Request |
+
+Rejecting `%2F` / `%5C` is what keeps percent encoding from being used to sneak past path-traversal protection or prefix-based blocks like `/vendor/*` — a request such as `/vendor%2Fconfig.php` cannot decode into a `/`-containing path that bypasses the glob check. UTF-8 validation on the decoded bytes lets non-ASCII paths work normally while still rejecting malformed escape sequences.
 
 ## PHP Response Cache (Phase 2 — requires KV store)
 

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -3,7 +3,36 @@ title = "Install"
 weight = 1
 +++
 
-ePHPm ships as a single binary that manages itself. There's no install script — the binary registers and controls its own system service.
+ePHPm ships as a single binary that manages itself. There's no install script — the binary registers and controls its own system service. For trying it out without touching the host, a Docker image is also published.
+
+## Docker
+
+```bash
+docker run -p 8080:8080 ephpm/ephpm:latest
+```
+
+That starts ePHPm with default settings on `http://localhost:8080`. Mount your document root at `/var/www/html` and your config at `/etc/ephpm/ephpm.toml` to serve a real site:
+
+```bash
+docker run -p 8080:8080 \
+  -v /path/to/site:/var/www/html \
+  -v /path/to/ephpm.toml:/etc/ephpm/ephpm.toml \
+  ephpm/ephpm:latest
+```
+
+### Tags
+
+| Tag | What it tracks |
+|-----|----------------|
+| `ephpm/ephpm:latest` | Rolling latest release with the default PHP minor |
+| `ephpm/ephpm:8.5` / `ephpm/ephpm:8.4` | Rolling latest release pinned to a PHP minor |
+| `ephpm/ephpm:vX.Y.Z` | Pinned ePHPm release with the default PHP minor |
+| `ephpm/ephpm:vX.Y.Z-php8.5` | Pinned release × rolling PHP minor |
+| `ephpm/ephpm:vX.Y.Z-php8.5.2` | Pinned release × pinned PHP patch (fully reproducible) |
+
+Real SemVer build metadata uses `+` (`v0.0.1+php8.5.2`), but OCI tags reject `+`, so Docker tags substitute `-` while the upstream `+` form is preserved on each image's `org.opencontainers.image.version` label — the same trade-off k3s and rke2 make.
+
+For the standalone binary install path (single-binary, self-installing, no container runtime needed), grab an archive from [Releases](https://github.com/ephpm/ephpm/releases) and continue with the Linux / macOS or Windows section below.
 
 ## Linux / macOS
 

--- a/site/content/guides/kv-from-php.md
+++ b/site/content/guides/kv-from-php.md
@@ -75,7 +75,35 @@ Not implemented: hashes, lists, sets, transactions, `SCAN`, pub/sub. ePHPm targe
 
 ### Multi-tenant note
 
-The RESP listener exposes the **whole** store with no per-vhost filtering. In multi-tenant deployments (`[server] sites_dir = ...`) keep `[kv.redis_compat] enabled = false` and use the SAPI functions, which are automatically namespaced per virtual host. ePHPm derives a per-site password from the master `[kv] secret` and injects it into PHP's `$_ENV` as `EPHPM_REDIS_PASSWORD`.
+The RESP listener can be shared across virtual hosts — each site is isolated by AUTH. When both `[kv] secret` and `[server] sites_dir` are set, ePHPm derives a per-site password as `HMAC-SHA256(secret, hostname)` (lowercase hex, 64 chars) and injects four env vars into every PHP request so the site's code can connect without any per-vhost configuration:
+
+```
+EPHPM_REDIS_HOST       # from [kv.redis_compat] listen
+EPHPM_REDIS_PORT
+EPHPM_REDIS_USERNAME   # the vhost hostname (e.g. alice-blog.com)
+EPHPM_REDIS_PASSWORD   # HMAC-SHA256(secret, hostname) hex
+```
+
+The RESP server validates the incoming `AUTH <username> <password>` against the same derivation, so requests authenticated as `alice-blog.com` only see alice's `DashMap`. Bob's connection sees a separate one even though both hit the same TCP port.
+
+A PHP app consumes them like any other Redis credentials — Predis, phpredis, or the `ephpm_kv_*` SAPI functions all work without code changes:
+
+```php
+$redis = new Predis\Client([
+    'scheme'   => 'tcp',
+    'host'     => $_SERVER['EPHPM_REDIS_HOST'],
+    'port'     => (int) $_SERVER['EPHPM_REDIS_PORT'],
+    'username' => $_SERVER['EPHPM_REDIS_USERNAME'],
+    'password' => $_SERVER['EPHPM_REDIS_PASSWORD'],
+]);
+$redis->set('cache:page:home', $html);
+```
+
+If `[kv] secret` is unset, no env vars are injected and the RESP listener treats the connection as the global store — fine for single-site mode, never use that combination with `sites_dir` set.
+
+### Automatic value compression
+
+`ephpm_kv_set()` (and the RESP `SET` family) auto-compress values according to the global `[kv]` block — `compression = "gzip" | "brotli" | "zstd"` plus `compression_level` and `compression_min_size`. Values smaller than `compression_min_size` are stored raw. `ephpm_kv_get()` transparently decompresses, so PHP code only ever sees the original bytes regardless of how the value was stored. Mixed compression settings during the lifetime of a store are safe — each entry remembers whether it was compressed when it was written. See [Configuration reference](/reference/config/) for the exact knobs.
 
 ## Common patterns
 

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -60,12 +60,17 @@ Most sites need zero configuration — they inherit PHP settings, timeouts, and 
 # site.toml — only set what you want to override
 [php]
 memory_limit = "256M"             # this site needs more memory
+max_execution_time = 120          # long-running admin import scripts
+ini_overrides = [
+    ["display_errors", "On"],     # staging vhost — surface errors in-page
+    ["upload_max_filesize", "32M"],
+]
 
 [db.sqlite]
 path = "/mnt/fast-ssd/alice.db"   # custom database location
 ```
 
-Everything not specified in `site.toml` falls through to the global `ephpm.toml`.
+The `[php]` block in `site.toml` has the same shape as the global `[php]` block in `ephpm.toml` — every key documented for `PhpConfig` (`memory_limit`, `max_execution_time`, `ini_file`, `ini_overrides`, `workers`) is overridable per site. Everything not specified in `site.toml` falls through to the global `ephpm.toml`. Lists like `ini_overrides` are replaced wholesale, not merged element-wise — if you set `ini_overrides` per site you take ownership of the full list for that site.
 
 ### SQLite Database Location
 


### PR DESCRIPTION
A focused docs-only sweep covering the 8 documentation gaps surfaced by the post-PR-22 audit. Each item is grounded in the actual implementation (`router.rs`, `ephpm_wrapper.c`, `ephpm-kv`, `ephpm-server/src/lib.rs`, etc.) — no speculative or aspirational claims beyond what is already documented as Phase 2.

## What this fixes

- **`site/content/architecture/http.md`**
  - Adds a "Percent-Decoding of URI Paths" subsection under Static File Serving — covers `%XX` decoding, malformed-escape rejection (truncated `%`, non-hex), encoded-slash rejection (`%2F`, `%5C`) as the path-traversal / prefix-block bypass mitigation, and UTF-8 validation on the decoded byte stream.
  - Adds a "PHP Fatal → HTTP 500" subsection — documents both detection paths (`zend_bailout` longjmp via `SETJMP`, and PHP 8.x uncaught `Throwable`s that travel the `E_DONT_BAIL` path through `zend_exception_error`, requiring the secondary `PG(last_error_type)` mask check). Explicitly notes the wrapper only overrides 200 → 500 so `http_response_code()` and `exit($status)` are preserved.

- **`site/content/guides/virtual-hosts.md`**
  - Extends the existing `site.toml` per-site override example with `ini_overrides` and `max_execution_time` — verified that the `[php]` block in `site.toml` mirrors the global `PhpConfig` shape; calls out that list-typed overrides like `ini_overrides` are replaced wholesale rather than element-merged.

- **`site/content/guides/kv-from-php.md`**
  - Replaces the terse "Multi-tenant note" with a full subsection on per-site RESP password derivation: `HMAC-SHA256(secret, hostname)` (lowercase hex, 64 chars), the four `EPHPM_REDIS_HOST/PORT/USERNAME/PASSWORD` env vars injected into PHP, RESP-side AUTH validation against the same derivation, and a Predis usage snippet.
  - Adds an "Automatic value compression" subsection covering the gzip/brotli/zstd behaviour of `ephpm_kv_set` / `ephpm_kv_get`, the `compression_min_size` gate, and forward-compatibility of mixed-compression entries — links to `reference/config.md` for the knobs.

- **`CLAUDE.md`**
  - Clarifies the database mode-detection bullet list: omitting `[db.sqlite.replication]` is identical to setting `role = "auto"` (because that's the serde default), so it stays clustered if `[cluster].enabled = true`. To force single-node with clustering on, set `role` to anything outside `"primary"`/`"replica"`/`"auto"`.

- **`site/content/getting-started/install.md` + `README.md`**
  - Adds a top-level "Docker" section to install.md with quickstart (`docker run -p 8080:8080 ephpm/ephpm:latest`), tag-scheme table (`:latest`, `:8.5`, `:vX.Y.Z`, `:vX.Y.Z-php8.5.2`), one-sentence `+`-vs-`-` SemVer note (matches PR #29's framing), and a pointer to the binary install path below.
  - README install section gets a single-line pointer to the Docker section so README-only readers know it exists. No table duplication.

## Sequencing note for reviewer

**Gap 8 (Docker docs) assumes PR #29 lands first.** The image tag scheme documented here matches the one introduced by `release/docker-images-and-archives` (PR #29). The docs are written and accurate, but `ephpm/ephpm:latest` etc. won't actually exist on Docker Hub until #29 is merged AND a `v*` tag is pushed (the Docker push job only runs on tag pushes). Recommend merging #29 first, then this PR — or at least not advertising the install docs publicly until both are in.

The other seven gaps are purely about behaviour that already ships on `main`, so they can land independently.
