### PR TITLE
feat(cli): self-managing service install + lifecycle subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,13 +1051,17 @@ dependencies = [
  "ephpm-kv",
  "ephpm-php",
  "ephpm-server",
+ "libc",
  "reqwest",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows-service",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4656,6 +4660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,6 +4755,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -20,10 +20,22 @@ ephpm-db.workspace = true
 ephpm-kv.workspace = true
 ephpm-php.workspace = true
 ephpm-server.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.7"
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -11,6 +11,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+mod service;
+
 /// ePHPm — All-in-one PHP application server
 #[derive(Parser, Debug)]
 #[command(name = "ephpm", version, about)]
@@ -60,6 +62,44 @@ enum Commands {
 
         #[command(subcommand)]
         subcommand: KvSubcommand,
+    },
+
+    /// Install ephpm as a system service and start it
+    Install,
+
+    /// Uninstall the system service
+    Uninstall {
+        /// Keep the configuration file and data directory in place
+        #[arg(long)]
+        keep_data: bool,
+    },
+
+    /// Start the installed service
+    Start,
+
+    /// Stop the installed service
+    Stop,
+
+    /// Restart the installed service
+    Restart,
+
+    /// Show service status (PID, uptime, listen address)
+    Status,
+
+    /// Tail the service log file
+    Logs {
+        /// Follow the log (like `tail -f`)
+        #[arg(short, long)]
+        follow: bool,
+    },
+
+    /// Internal: run as a Windows service (invoked by SCM, not by users)
+    #[cfg(windows)]
+    #[command(hide = true)]
+    ServiceRun {
+        /// Path to the configuration file
+        #[arg(long, default_value = "C:\\ProgramData\\ephpm\\ephpm.toml")]
+        config: PathBuf,
     },
 }
 
@@ -117,7 +157,64 @@ fn run() -> anyhow::Result<ExitCode> {
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
             rt.block_on(run_kv(&host, port, subcommand))
         }
+        Some(Commands::Install) => run_service_cmd(service::install),
+        Some(Commands::Uninstall { keep_data }) => {
+            run_service_cmd(|| service::uninstall(keep_data))
+        }
+        Some(Commands::Start) => run_service_cmd(service::start),
+        Some(Commands::Stop) => run_service_cmd(service::stop),
+        Some(Commands::Restart) => run_service_cmd(service::restart),
+        Some(Commands::Status) => run_service_cmd(service::status),
+        Some(Commands::Logs { follow }) => run_service_cmd(|| service::logs(follow)),
+        #[cfg(windows)]
+        Some(Commands::ServiceRun { .. }) => {
+            // Hand control over to the Windows service dispatcher, which calls
+            // back into our service-main once SCM is ready. The config path is
+            // re-read inside `service_main` from the SCM-passed arguments so
+            // the value parsed here is ignored.
+            service::windows::run_as_service()
+                .map(|()| ExitCode::SUCCESS)
+                .map_err(|e| anyhow::anyhow!("service dispatcher failed: {e}"))
+        }
         other => run_serve_sync(other),
+    }
+}
+
+/// Initialise a small tracing subscriber for service-management commands so
+/// `tracing::info!` calls in the `service` module show up on the console.
+fn ensure_cli_tracing() {
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = tracing_subscriber::registry()
+            .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+            .with(tracing_subscriber::fmt::layer().with_target(false))
+            .try_init();
+    });
+}
+
+/// Dispatch a service-management command and convert the result into an
+/// `ExitCode`. All service errors are propagated through `anyhow` with context.
+fn run_service_cmd<F>(f: F) -> anyhow::Result<ExitCode>
+where
+    F: FnOnce() -> service::Result<()>,
+{
+    ensure_cli_tracing();
+    f().context("service command failed")?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Entry point used by the Windows service worker thread. Reads the config at
+/// `config` and runs the HTTP server until shutdown.
+#[cfg(windows)]
+pub(crate) fn run_serve_with_config(config: PathBuf) -> anyhow::Result<()> {
+    let cmd = Commands::Serve { config, listen: None, document_root: None, verbose: 0 };
+    let code = run_serve_sync(Some(cmd))?;
+    if matches!(code, ExitCode::SUCCESS) {
+        Ok(())
+    } else {
+        anyhow::bail!("server exited with non-zero status")
     }
 }
 
@@ -554,5 +651,77 @@ async fn kv_ttl(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
             Ok(ExitCode::FAILURE)
         }
         (a, b) => anyhow::bail!("unexpected response: {a} / {b}"),
+    }
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use clap::Parser as _;
+
+    use super::*;
+
+    #[test]
+    fn parses_install_subcommand() {
+        let cli = Cli::try_parse_from(["ephpm", "install"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Install)));
+    }
+
+    #[test]
+    fn parses_uninstall_with_keep_data_flag() {
+        let cli = Cli::try_parse_from(["ephpm", "uninstall", "--keep-data"]).unwrap();
+        match cli.command {
+            Some(Commands::Uninstall { keep_data }) => assert!(keep_data),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_uninstall_default_keeps_no_data() {
+        let cli = Cli::try_parse_from(["ephpm", "uninstall"]).unwrap();
+        match cli.command {
+            Some(Commands::Uninstall { keep_data }) => assert!(!keep_data),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_lifecycle_subcommands() {
+        assert!(matches!(
+            Cli::try_parse_from(["ephpm", "start"]).unwrap().command,
+            Some(Commands::Start)
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["ephpm", "stop"]).unwrap().command,
+            Some(Commands::Stop)
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["ephpm", "restart"]).unwrap().command,
+            Some(Commands::Restart)
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["ephpm", "status"]).unwrap().command,
+            Some(Commands::Status)
+        ));
+    }
+
+    #[test]
+    fn parses_logs_with_follow() {
+        let cli = Cli::try_parse_from(["ephpm", "logs", "--follow"]).unwrap();
+        match cli.command {
+            Some(Commands::Logs { follow }) => assert!(follow),
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        let cli = Cli::try_parse_from(["ephpm", "logs", "-f"]).unwrap();
+        match cli.command {
+            Some(Commands::Logs { follow }) => assert!(follow),
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        let cli = Cli::try_parse_from(["ephpm", "logs"]).unwrap();
+        match cli.command {
+            Some(Commands::Logs { follow }) => assert!(!follow),
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/crates/ephpm/src/service/launchd.rs
+++ b/crates/ephpm/src/service/launchd.rs
@@ -138,4 +138,3 @@ mod tests {
         assert!(body.contains("<key>RunAtLoad</key>"));
     }
 }
-

--- a/crates/ephpm/src/service/launchd.rs
+++ b/crates/ephpm/src/service/launchd.rs
@@ -1,0 +1,141 @@
+//! launchd backend for the `ephpm` service manager (macOS).
+//!
+//! Generates `/Library/LaunchDaemons/dev.ephpm.plist` and uses `launchctl
+//! bootstrap` / `bootout` / `kickstart` / `print` for lifecycle management.
+
+use std::process::Command;
+
+use super::{Paths, Result, ServiceError, StatusReport};
+
+/// launchd service label used in the plist.
+const LABEL: &str = "dev.ephpm";
+
+/// Render the launchd plist body for the daemon.
+fn plist_body(paths: &Paths) -> String {
+    let binary = paths.binary.display();
+    let config = paths.config.display();
+    let log = paths.log_file.display();
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+<plist version=\"1.0\">\n\
+<dict>\n\
+    <key>Label</key>\n\
+    <string>{LABEL}</string>\n\
+    <key>ProgramArguments</key>\n\
+    <array>\n\
+        <string>{binary}</string>\n\
+        <string>serve</string>\n\
+        <string>--config</string>\n\
+        <string>{config}</string>\n\
+    </array>\n\
+    <key>RunAtLoad</key>\n\
+    <true/>\n\
+    <key>KeepAlive</key>\n\
+    <true/>\n\
+    <key>StandardOutPath</key>\n\
+    <string>{log}</string>\n\
+    <key>StandardErrorPath</key>\n\
+    <string>{log}</string>\n\
+</dict>\n\
+</plist>\n"
+    )
+}
+
+pub(super) fn register(paths: &Paths) -> Result<()> {
+    if let Some(parent) = paths.service_unit.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
+    }
+    std::fs::write(&paths.service_unit, plist_body(paths))
+        .map_err(|e| ServiceError::io(&paths.service_unit, e))?;
+    run_launchctl(&["bootstrap", "system", &paths.service_unit.display().to_string()])
+}
+
+pub(super) fn deregister(paths: &Paths) -> Result<()> {
+    let _ = run_launchctl(&["bootout", &format!("system/{LABEL}")]);
+    if paths.service_unit.exists() {
+        std::fs::remove_file(&paths.service_unit)
+            .map_err(|e| ServiceError::io(&paths.service_unit, e))?;
+    }
+    Ok(())
+}
+
+pub(super) fn start(_paths: &Paths) -> Result<()> {
+    run_launchctl(&["kickstart", &format!("system/{LABEL}")])
+}
+
+pub(super) fn stop(_paths: &Paths) -> Result<()> {
+    // `bootout` would unload the daemon entirely; we just want it stopped, so
+    // use the legacy `stop` verb which leaves it loaded for later restart.
+    run_launchctl(&["stop", LABEL])
+}
+
+pub(super) fn restart(paths: &Paths) -> Result<()> {
+    stop(paths).ok();
+    start(paths)
+}
+
+pub(super) fn status(_paths: &Paths) -> Result<StatusReport> {
+    let out = Command::new("launchctl")
+        .args(["print", &format!("system/{LABEL}")])
+        .output()
+        .map_err(|e| ServiceError::command("launchctl", e.to_string()))?;
+    if !out.status.success() {
+        return Ok(StatusReport { state: "not-loaded".to_string(), pid: None, uptime: None });
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    let mut state = "loaded".to_string();
+    let mut pid: Option<u32> = None;
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if let Some(v) = trimmed.strip_prefix("state =") {
+            state = v.trim().to_string();
+        } else if let Some(v) = trimmed.strip_prefix("pid =") {
+            pid = v.trim().parse::<u32>().ok();
+        }
+    }
+    Ok(StatusReport { state, pid, uptime: None })
+}
+
+pub(super) fn logs(paths: &Paths, follow: bool) -> Result<()> {
+    super::tail_file(&paths.log_file, follow)
+}
+
+fn run_launchctl(args: &[&str]) -> Result<()> {
+    let out = Command::new("launchctl")
+        .args(args)
+        .output()
+        .map_err(|e| ServiceError::command("launchctl", e.to_string()))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(ServiceError::command("launchctl", String::from_utf8_lossy(&out.stderr).into_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn plist_body_contains_required_keys() {
+        let paths = Paths {
+            binary: PathBuf::from("/usr/local/bin/ephpm"),
+            config: PathBuf::from("/etc/ephpm/ephpm.toml"),
+            service_unit: PathBuf::from("/Library/LaunchDaemons/dev.ephpm.plist"),
+            data_dir: PathBuf::from("/var/lib/ephpm"),
+            document_root: PathBuf::from("/var/www/html"),
+            log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
+        };
+        let body = plist_body(&paths);
+        assert!(body.contains("<string>dev.ephpm</string>"));
+        assert!(body.contains("<string>/usr/local/bin/ephpm</string>"));
+        assert!(body.contains("<string>--config</string>"));
+        assert!(body.contains("<string>/var/log/ephpm/ephpm.log</string>"));
+        assert!(body.contains("<key>RunAtLoad</key>"));
+    }
+}
+

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -268,9 +268,8 @@ pub fn install() -> Result<()> {
     require_elevation()?;
     let paths = Paths::for_current_platform();
 
-    let current = std::env::current_exe().map_err(|e| ServiceError::Other(format!(
-        "failed to resolve current executable: {e}"
-    )))?;
+    let current = std::env::current_exe()
+        .map_err(|e| ServiceError::Other(format!("failed to resolve current executable: {e}")))?;
 
     copy_binary(&current, &paths.binary)?;
     let wrote = write_default_config(&paths.config, &paths.document_root)?;

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -1,0 +1,555 @@
+//! Self-managing service support for the `ephpm` binary.
+//!
+//! Implements the `install`, `uninstall`, `start`, `stop`, `restart`,
+//! `status`, and `logs` subcommands documented in the project README.
+//! The public API is platform-independent; the actual SCM/systemd/launchd
+//! plumbing lives in the platform-specific submodules.
+//!
+//! # Platform paths
+//!
+//! | Platform | Binary | Config | Service unit | Data dir | Log file |
+//! |----------|--------|--------|--------------|----------|----------|
+//! | Linux    | `/usr/local/bin/ephpm` | `/etc/ephpm/ephpm.toml` | `/etc/systemd/system/ephpm.service` | `/var/lib/ephpm/` | `/var/log/ephpm/ephpm.log` |
+//! | macOS    | `/usr/local/bin/ephpm` | `/etc/ephpm/ephpm.toml` | `/Library/LaunchDaemons/dev.ephpm.plist` | `/var/lib/ephpm/` | `/var/log/ephpm/ephpm.log` |
+//! | Windows  | `C:\Program Files\ephpm\ephpm.exe` | `C:\ProgramData\ephpm\ephpm.toml` | Windows service `ephpm` | `C:\ProgramData\ephpm\data\` | `C:\ProgramData\ephpm\logs\ephpm.log` |
+//!
+//! All lifecycle commands require elevated privileges (root / Administrator).
+
+#![cfg_attr(unix, allow(unsafe_code))]
+#![allow(clippy::module_name_repetitions)]
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+#[cfg(target_os = "linux")]
+mod systemd;
+#[cfg(target_os = "linux")]
+use systemd as backend;
+
+#[cfg(target_os = "macos")]
+mod launchd;
+#[cfg(target_os = "macos")]
+use launchd as backend;
+
+#[cfg(windows)]
+pub mod windows;
+#[cfg(windows)]
+use windows as backend;
+
+/// Errors that may occur while managing the ePHPm service.
+#[derive(Debug, Error)]
+pub enum ServiceError {
+    /// The command requires elevated privileges that the caller lacks.
+    #[error("this command requires {0} privileges — re-run with elevated rights")]
+    NotElevated(&'static str),
+
+    /// An I/O error occurred while reading or writing service / config files.
+    #[error("io error at {path}: {source}")]
+    Io {
+        /// Path involved in the failed operation.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A child process (systemctl / launchctl / sc / windows-service) failed.
+    #[error("{cmd} failed: {message}")]
+    Command {
+        /// Name of the underlying program / API.
+        cmd: String,
+        /// Human-readable failure description.
+        message: String,
+    },
+
+    /// The service backend reports the service is not installed.
+    #[error("service is not installed — run `ephpm install` first")]
+    NotInstalled,
+
+    /// An unexpected error string from a platform-specific backend.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl ServiceError {
+    /// Helper to build an `Io` error with a path attached.
+    pub(crate) fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        Self::Io { path: path.into(), source }
+    }
+
+    /// Helper to build a `Command` error.
+    pub(crate) fn command(cmd: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Command { cmd: cmd.into(), message: message.into() }
+    }
+}
+
+/// Result alias used throughout the service module.
+pub type Result<T> = std::result::Result<T, ServiceError>;
+
+/// Filesystem locations the service backend reads and writes.
+///
+/// Platform-specific defaults are constructed by [`Paths::for_current_platform`].
+#[derive(Debug, Clone)]
+pub struct Paths {
+    /// Where the `ephpm` binary is installed to.
+    pub binary: PathBuf,
+    /// Where the TOML configuration file lives.
+    pub config: PathBuf,
+    /// Service unit / plist / SCM entry path (informational on Windows).
+    ///
+    /// Used by the systemd and launchd backends to locate the unit file; on
+    /// Windows the SCM tracks the service by name, so this field is only kept
+    /// for documentation / diagnostic purposes.
+    #[cfg_attr(windows, allow(dead_code))]
+    pub service_unit: PathBuf,
+    /// Persistent data directory (SQLite DBs, ACME state, etc.).
+    pub data_dir: PathBuf,
+    /// Default document root referenced by the generated config.
+    pub document_root: PathBuf,
+    /// File that the service logs to.
+    pub log_file: PathBuf,
+}
+
+impl Paths {
+    /// Build the platform-default layout.
+    #[must_use]
+    pub fn for_current_platform() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            Self {
+                binary: PathBuf::from("/usr/local/bin/ephpm"),
+                config: PathBuf::from("/etc/ephpm/ephpm.toml"),
+                service_unit: PathBuf::from("/etc/systemd/system/ephpm.service"),
+                data_dir: PathBuf::from("/var/lib/ephpm"),
+                document_root: PathBuf::from("/var/www/html"),
+                log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            Self {
+                binary: PathBuf::from("/usr/local/bin/ephpm"),
+                config: PathBuf::from("/etc/ephpm/ephpm.toml"),
+                service_unit: PathBuf::from("/Library/LaunchDaemons/dev.ephpm.plist"),
+                data_dir: PathBuf::from("/var/lib/ephpm"),
+                document_root: PathBuf::from("/var/www/html"),
+                log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            Self {
+                binary: PathBuf::from(r"C:\Program Files\ephpm\ephpm.exe"),
+                config: PathBuf::from(r"C:\ProgramData\ephpm\ephpm.toml"),
+                service_unit: PathBuf::from(r"ephpm"),
+                data_dir: PathBuf::from(r"C:\ProgramData\ephpm\data"),
+                document_root: PathBuf::from(r"C:\ProgramData\ephpm\www"),
+                log_file: PathBuf::from(r"C:\ProgramData\ephpm\logs\ephpm.log"),
+            }
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+        {
+            Self {
+                binary: PathBuf::from("/usr/local/bin/ephpm"),
+                config: PathBuf::from("/etc/ephpm/ephpm.toml"),
+                service_unit: PathBuf::from("/etc/ephpm/ephpm.service"),
+                data_dir: PathBuf::from("/var/lib/ephpm"),
+                document_root: PathBuf::from("/var/www/html"),
+                log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
+            }
+        }
+    }
+}
+
+/// Render the default TOML configuration body for a fresh install.
+///
+/// `document_root` is the path written into the generated `[server]` section so
+/// that Windows installs reference `C:\ProgramData\ephpm\www` and Unix installs
+/// reference `/var/www/html`.
+#[must_use]
+pub fn default_config_toml(document_root: &Path) -> String {
+    let document_root_str = document_root.display().to_string();
+    let escaped = document_root_str.replace('\\', "\\\\");
+    format!(
+        "[server]\nlisten = \"0.0.0.0:8080\"\ndocument_root = \"{escaped}\"\nindex_files = [\"index.php\", \"index.html\"]\n\n[php]\nmode = \"embedded\"\nmax_execution_time = 30\nmemory_limit = \"128M\"\n"
+    )
+}
+
+/// Check whether the current process is running as root (Unix) or Administrator
+/// (Windows). Used as a guard before mutating system locations.
+#[must_use]
+pub fn is_elevated() -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: `libc::geteuid` is a thread-safe libc call that takes no
+        // arguments and returns a `uid_t`. It cannot fail.
+        unsafe { libc::geteuid() == 0 }
+    }
+    #[cfg(windows)]
+    {
+        backend::is_elevated()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        false
+    }
+}
+
+/// Friendly name for the privilege required to manage the service.
+#[must_use]
+pub fn privilege_label() -> &'static str {
+    if cfg!(windows) { "Administrator" } else { "root" }
+}
+
+/// Ensure the caller is privileged or return [`ServiceError::NotElevated`].
+fn require_elevation() -> Result<()> {
+    if is_elevated() { Ok(()) } else { Err(ServiceError::NotElevated(privilege_label())) }
+}
+
+/// Copy the currently running binary into `dest`, creating parents as needed.
+///
+/// If `src` and `dest` resolve to the same file the copy is skipped.
+fn copy_binary(src: &Path, dest: &Path) -> Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
+    }
+
+    // Skip the copy when src == dest (e.g. running the already-installed binary).
+    let same = match (src.canonicalize(), dest.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    };
+    if same {
+        tracing::info!(path = %dest.display(), "binary already at install location");
+        return Ok(());
+    }
+
+    std::fs::copy(src, dest).map_err(|e| ServiceError::io(dest, e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms =
+            std::fs::metadata(dest).map_err(|e| ServiceError::io(dest, e))?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(dest, perms).map_err(|e| ServiceError::io(dest, e))?;
+    }
+    Ok(())
+}
+
+/// Write the default config to `path` unless the file already exists. Returns
+/// `true` if a fresh file was written, `false` if an existing config was left
+/// untouched.
+fn write_default_config(path: &Path, document_root: &Path) -> Result<bool> {
+    if path.exists() {
+        tracing::info!(path = %path.display(), "config already exists — leaving it in place");
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
+    }
+    let body = default_config_toml(document_root);
+    std::fs::write(path, body).map_err(|e| ServiceError::io(path, e))?;
+    Ok(true)
+}
+
+/// Install the binary, write a default config, register the service, and start it.
+///
+/// # Errors
+///
+/// Returns [`ServiceError::NotElevated`] if the caller lacks root /
+/// Administrator rights, or an I/O / backend error if any step (binary copy,
+/// config write, service registration, start) fails.
+pub fn install() -> Result<()> {
+    require_elevation()?;
+    let paths = Paths::for_current_platform();
+
+    let current = std::env::current_exe().map_err(|e| ServiceError::Other(format!(
+        "failed to resolve current executable: {e}"
+    )))?;
+
+    copy_binary(&current, &paths.binary)?;
+    let wrote = write_default_config(&paths.config, &paths.document_root)?;
+    if wrote {
+        tracing::info!(path = %paths.config.display(), "wrote default config");
+    }
+    std::fs::create_dir_all(&paths.data_dir).map_err(|e| ServiceError::io(&paths.data_dir, e))?;
+    if let Some(parent) = paths.log_file.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
+    }
+
+    backend::register(&paths)?;
+    backend::start(&paths)?;
+    tracing::info!("ephpm service installed and started");
+    Ok(())
+}
+
+/// Reverse a previous `install`. With `keep_data = true`, the config and data
+/// directory are left in place.
+///
+/// # Errors
+///
+/// Same as [`install`] — privilege / I/O / backend errors are propagated.
+pub fn uninstall(keep_data: bool) -> Result<()> {
+    require_elevation()?;
+    let paths = Paths::for_current_platform();
+
+    // Best-effort stop — ignore errors so we can clean up after a partial install.
+    if let Err(e) = backend::stop(&paths) {
+        tracing::warn!(error = %e, "failed to stop service during uninstall — continuing");
+    }
+    backend::deregister(&paths)?;
+
+    if !keep_data {
+        if paths.config.exists() {
+            std::fs::remove_file(&paths.config).map_err(|e| ServiceError::io(&paths.config, e))?;
+        }
+        if paths.data_dir.exists() {
+            std::fs::remove_dir_all(&paths.data_dir)
+                .map_err(|e| ServiceError::io(&paths.data_dir, e))?;
+        }
+    }
+
+    if paths.binary.exists() {
+        std::fs::remove_file(&paths.binary).map_err(|e| ServiceError::io(&paths.binary, e))?;
+    }
+    tracing::info!("ephpm service uninstalled");
+    Ok(())
+}
+
+/// Start the installed service.
+///
+/// # Errors
+///
+/// Propagates privilege and backend errors.
+pub fn start() -> Result<()> {
+    require_elevation()?;
+    backend::start(&Paths::for_current_platform())
+}
+
+/// Stop the installed service.
+///
+/// # Errors
+///
+/// Propagates privilege and backend errors.
+pub fn stop() -> Result<()> {
+    require_elevation()?;
+    backend::stop(&Paths::for_current_platform())
+}
+
+/// Restart the installed service (stop then start, with backend-specific atomic
+/// implementations where available).
+///
+/// # Errors
+///
+/// Propagates privilege and backend errors.
+pub fn restart() -> Result<()> {
+    require_elevation()?;
+    backend::restart(&Paths::for_current_platform())
+}
+
+/// Print a one-line status summary (PID, uptime, listen address) to stdout.
+///
+/// # Errors
+///
+/// Returns a backend error if the service controller can't be queried.
+pub fn status() -> Result<()> {
+    let paths = Paths::for_current_platform();
+    let report = backend::status(&paths)?;
+
+    let listen = read_listen_address(&paths.config).unwrap_or_else(|| "<unknown>".to_string());
+    println!(
+        "service: {state}\n   pid: {pid}\nuptime: {uptime}\nlisten: {listen}\nconfig: {config}",
+        state = report.state,
+        pid = report.pid.as_ref().map_or_else(|| "-".to_string(), u32::to_string),
+        uptime = report.uptime.as_deref().unwrap_or("-"),
+        config = paths.config.display(),
+    );
+    Ok(())
+}
+
+/// Tail (or follow) the service log file.
+///
+/// # Errors
+///
+/// Returns an I/O error if the log file cannot be read.
+pub fn logs(follow: bool) -> Result<()> {
+    let paths = Paths::for_current_platform();
+    backend::logs(&paths, follow)
+}
+
+/// Snapshot of service state returned by platform backends.
+#[derive(Debug, Clone)]
+pub struct StatusReport {
+    /// Human-readable state ("running", "stopped", ...).
+    pub state: String,
+    /// PID, if the service is running.
+    pub pid: Option<u32>,
+    /// Human-readable uptime string, if known.
+    pub uptime: Option<String>,
+}
+
+/// Best-effort parser that extracts `server.listen` from a TOML config file
+/// without depending on `serde`'s schema. Returns `None` if the file can't be
+/// read or the key isn't present.
+fn read_listen_address(config: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(config).ok()?;
+    let mut in_server = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') || trimmed.is_empty() {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix('[') {
+            in_server = rest.starts_with("server]");
+            continue;
+        }
+        if in_server {
+            if let Some(value) = trimmed.strip_prefix("listen") {
+                let value = value.trim_start().trim_start_matches('=').trim();
+                let value = value.trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Simple tail implementation used by Unix backends. Reads the last `lines`
+/// from `path` and prints them. When `follow` is true, continues to print new
+/// content as it is appended until the process is interrupted.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn tail_file(path: &Path, follow: bool) -> Result<()> {
+    use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+
+    if !path.exists() {
+        return Err(ServiceError::io(
+            path,
+            std::io::Error::new(std::io::ErrorKind::NotFound, "log file does not exist"),
+        ));
+    }
+
+    let mut file = std::fs::File::open(path).map_err(|e| ServiceError::io(path, e))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content).map_err(|e| ServiceError::io(path, e))?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let tail_lines: Vec<&str> = content.lines().rev().take(200).collect();
+    for line in tail_lines.into_iter().rev() {
+        let _ = writeln!(out, "{line}");
+    }
+    if !follow {
+        return Ok(());
+    }
+
+    let mut pos = file.seek(SeekFrom::End(0)).map_err(|e| ServiceError::io(path, e))?;
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let len = std::fs::metadata(path).map_err(|e| ServiceError::io(path, e))?.len();
+        if len < pos {
+            // file was rotated — start over from the beginning
+            pos = 0;
+            file = std::fs::File::open(path).map_err(|e| ServiceError::io(path, e))?;
+        }
+        file.seek(SeekFrom::Start(pos)).map_err(|e| ServiceError::io(path, e))?;
+        let mut chunk = String::new();
+        let read = file.read_to_string(&mut chunk).map_err(|e| ServiceError::io(path, e))?;
+        if read > 0 {
+            let _ = out.write_all(chunk.as_bytes());
+            let _ = out.flush();
+            pos += read as u64;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_contains_required_keys() {
+        let toml = default_config_toml(Path::new("/var/www/html"));
+        assert!(toml.contains("[server]"));
+        assert!(toml.contains("listen = \"0.0.0.0:8080\""));
+        assert!(toml.contains("document_root = \"/var/www/html\""));
+        assert!(toml.contains("[php]"));
+        assert!(toml.contains("memory_limit = \"128M\""));
+        assert!(toml.contains("max_execution_time = 30"));
+    }
+
+    #[test]
+    fn default_config_escapes_windows_paths() {
+        let toml = default_config_toml(Path::new(r"C:\ProgramData\ephpm\www"));
+        // Backslashes must be doubled so the TOML parser sees a literal backslash.
+        assert!(toml.contains(r#"document_root = "C:\\ProgramData\\ephpm\\www""#));
+    }
+
+    #[test]
+    fn paths_for_current_platform_are_absolute() {
+        let p = Paths::for_current_platform();
+        assert!(p.binary.is_absolute(), "binary path should be absolute: {}", p.binary.display());
+        assert!(p.config.is_absolute(), "config path should be absolute: {}", p.config.display());
+        assert!(p.data_dir.is_absolute());
+        assert!(p.document_root.is_absolute());
+    }
+
+    #[test]
+    fn write_default_config_does_not_overwrite_existing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("ephpm.toml");
+        std::fs::write(&config, "# user customized\n").unwrap();
+
+        let wrote = write_default_config(&config, Path::new("/var/www/html")).unwrap();
+        assert!(!wrote, "should report no fresh write when file exists");
+
+        let after = std::fs::read_to_string(&config).unwrap();
+        assert_eq!(after, "# user customized\n");
+    }
+
+    #[test]
+    fn write_default_config_writes_when_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("nested").join("ephpm.toml");
+
+        let wrote = write_default_config(&config, Path::new("/var/www/html")).unwrap();
+        assert!(wrote);
+        let body = std::fs::read_to_string(&config).unwrap();
+        assert!(body.contains("[server]"));
+    }
+
+    #[test]
+    fn read_listen_address_parses_basic_toml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &config,
+            "# header\n[server]\nlisten = \"127.0.0.1:9090\"\ndocument_root = \"/tmp\"\n",
+        )
+        .unwrap();
+        assert_eq!(read_listen_address(&config).as_deref(), Some("127.0.0.1:9090"));
+    }
+
+    #[test]
+    fn read_listen_address_returns_none_when_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = dir.path().join("ephpm.toml");
+        std::fs::write(&config, "[php]\nmemory_limit = \"128M\"\n").unwrap();
+        assert!(read_listen_address(&config).is_none());
+    }
+
+    #[test]
+    fn privilege_label_is_platform_appropriate() {
+        let label = privilege_label();
+        if cfg!(windows) {
+            assert_eq!(label, "Administrator");
+        } else {
+            assert_eq!(label, "root");
+        }
+    }
+}

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -64,6 +64,11 @@ pub enum ServiceError {
     },
 
     /// The service backend reports the service is not installed.
+    ///
+    /// Currently only constructed by the Windows SCM backend; the systemd
+    /// and launchd backends fall back to running the underlying CLI and
+    /// surface its error verbatim via [`ServiceError::Command`].
+    #[cfg_attr(not(windows), allow(dead_code))]
     #[error("service is not installed — run `ephpm install` first")]
     NotInstalled,
 

--- a/crates/ephpm/src/service/systemd.rs
+++ b/crates/ephpm/src/service/systemd.rs
@@ -1,0 +1,160 @@
+//! systemd backend for the `ephpm` service manager.
+//!
+//! Writes `/etc/systemd/system/ephpm.service` on registration and shells out to
+//! `systemctl` for lifecycle operations. The unit template is intentionally
+//! minimal: it relies on the daemon's own logging configuration to write to
+//! `/var/log/ephpm/ephpm.log`, while also forwarding output to the systemd
+//! journal so `journalctl -u ephpm` works.
+
+use std::process::Command;
+
+use super::{Paths, Result, ServiceError, StatusReport};
+
+/// Render the systemd unit file body.
+fn unit_body(paths: &Paths) -> String {
+    format!(
+        "[Unit]\n\
+Description=ePHPm — embedded PHP application server\n\
+After=network-online.target\n\
+Wants=network-online.target\n\
+\n\
+[Service]\n\
+Type=simple\n\
+ExecStart={binary} serve --config {config}\n\
+Restart=on-failure\n\
+RestartSec=2s\n\
+LimitNOFILE=65536\n\
+StandardOutput=append:{log}\n\
+StandardError=append:{log}\n\
+\n\
+[Install]\n\
+WantedBy=multi-user.target\n",
+        binary = paths.binary.display(),
+        config = paths.config.display(),
+        log = paths.log_file.display(),
+    )
+}
+
+/// Write the unit file and reload systemd so the new unit is visible.
+pub(super) fn register(paths: &Paths) -> Result<()> {
+    if let Some(parent) = paths.service_unit.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
+    }
+    std::fs::write(&paths.service_unit, unit_body(paths))
+        .map_err(|e| ServiceError::io(&paths.service_unit, e))?;
+    run_systemctl(&["daemon-reload"])?;
+    run_systemctl(&["enable", "ephpm.service"])?;
+    Ok(())
+}
+
+/// Disable the unit and remove the unit file.
+pub(super) fn deregister(paths: &Paths) -> Result<()> {
+    // Best-effort disable — ignore failures so an orphaned unit file still gets
+    // cleaned up.
+    let _ = run_systemctl(&["disable", "ephpm.service"]);
+    if paths.service_unit.exists() {
+        std::fs::remove_file(&paths.service_unit)
+            .map_err(|e| ServiceError::io(&paths.service_unit, e))?;
+    }
+    let _ = run_systemctl(&["daemon-reload"]);
+    Ok(())
+}
+
+pub(super) fn start(_paths: &Paths) -> Result<()> {
+    run_systemctl(&["start", "ephpm.service"])
+}
+
+pub(super) fn stop(_paths: &Paths) -> Result<()> {
+    run_systemctl(&["stop", "ephpm.service"])
+}
+
+pub(super) fn restart(_paths: &Paths) -> Result<()> {
+    run_systemctl(&["restart", "ephpm.service"])
+}
+
+pub(super) fn status(_paths: &Paths) -> Result<StatusReport> {
+    // ActiveState + MainPID + ActiveEnterTimestamp in one call.
+    let out = Command::new("systemctl")
+        .args([
+            "show",
+            "ephpm.service",
+            "--no-page",
+            "--property=ActiveState,MainPID,ActiveEnterTimestamp",
+        ])
+        .output()
+        .map_err(|e| ServiceError::command("systemctl", e.to_string()))?;
+    if !out.status.success() {
+        return Err(ServiceError::command(
+            "systemctl",
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let mut state = "unknown".to_string();
+    let mut pid: Option<u32> = None;
+    let mut started: Option<String> = None;
+    for line in stdout.lines() {
+        if let Some(v) = line.strip_prefix("ActiveState=") {
+            state = v.to_string();
+        } else if let Some(v) = line.strip_prefix("MainPID=") {
+            pid = v.parse::<u32>().ok().filter(|p| *p != 0);
+        } else if let Some(v) = line.strip_prefix("ActiveEnterTimestamp=") {
+            started = if v.is_empty() { None } else { Some(v.to_string()) };
+        }
+    }
+
+    Ok(StatusReport { state, pid, uptime: started })
+}
+
+pub(super) fn logs(paths: &Paths, follow: bool) -> Result<()> {
+    // Prefer journalctl when available — it's the canonical systemd log source.
+    let mut cmd = Command::new("journalctl");
+    cmd.arg("-u").arg("ephpm.service").arg("--no-pager");
+    if follow {
+        cmd.arg("-f");
+    } else {
+        cmd.arg("-n").arg("200");
+    }
+    match cmd.status() {
+        Ok(s) if s.success() => Ok(()),
+        Ok(_) | Err(_) => super::tail_file(&paths.log_file, follow),
+    }
+}
+
+/// Invoke `systemctl <args...>` and propagate failure as a `ServiceError`.
+fn run_systemctl(args: &[&str]) -> Result<()> {
+    let out = Command::new("systemctl")
+        .args(args)
+        .output()
+        .map_err(|e| ServiceError::command("systemctl", e.to_string()))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(ServiceError::command("systemctl", String::from_utf8_lossy(&out.stderr).into_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn unit_body_renders_paths() {
+        let paths = Paths {
+            binary: PathBuf::from("/usr/local/bin/ephpm"),
+            config: PathBuf::from("/etc/ephpm/ephpm.toml"),
+            service_unit: PathBuf::from("/etc/systemd/system/ephpm.service"),
+            data_dir: PathBuf::from("/var/lib/ephpm"),
+            document_root: PathBuf::from("/var/www/html"),
+            log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
+        };
+        let body = unit_body(&paths);
+        assert!(body.contains("ExecStart=/usr/local/bin/ephpm serve --config /etc/ephpm/ephpm.toml"));
+        assert!(body.contains("StandardOutput=append:/var/log/ephpm/ephpm.log"));
+        assert!(body.contains("WantedBy=multi-user.target"));
+    }
+}
+

--- a/crates/ephpm/src/service/systemd.rs
+++ b/crates/ephpm/src/service/systemd.rs
@@ -152,9 +152,10 @@ mod tests {
             log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
         };
         let body = unit_body(&paths);
-        assert!(body.contains("ExecStart=/usr/local/bin/ephpm serve --config /etc/ephpm/ephpm.toml"));
+        assert!(
+            body.contains("ExecStart=/usr/local/bin/ephpm serve --config /etc/ephpm/ephpm.toml")
+        );
         assert!(body.contains("StandardOutput=append:/var/log/ephpm/ephpm.log"));
         assert!(body.contains("WantedBy=multi-user.target"));
     }
 }
-

--- a/crates/ephpm/src/service/windows.rs
+++ b/crates/ephpm/src/service/windows.rs
@@ -120,8 +120,8 @@ pub(super) fn register(paths: &Paths) -> Result<()> {
 }
 
 pub(super) fn deregister(_paths: &Paths) -> Result<()> {
-    let manager =
-        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .map_err(scm_err)?;
     match manager.open_service(SERVICE_NAME, ServiceAccess::DELETE | ServiceAccess::QUERY_STATUS) {
         Ok(svc) => svc.delete().map_err(scm_err)?,
         Err(windows_service::Error::Winapi(e))
@@ -132,8 +132,8 @@ pub(super) fn deregister(_paths: &Paths) -> Result<()> {
 }
 
 pub(super) fn start(_paths: &Paths) -> Result<()> {
-    let manager =
-        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .map_err(scm_err)?;
     let svc = manager
         .open_service(SERVICE_NAME, ServiceAccess::START | ServiceAccess::QUERY_STATUS)
         .map_err(scm_err)?;
@@ -145,8 +145,8 @@ pub(super) fn start(_paths: &Paths) -> Result<()> {
 }
 
 pub(super) fn stop(_paths: &Paths) -> Result<()> {
-    let manager =
-        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .map_err(scm_err)?;
     let svc = manager
         .open_service(SERVICE_NAME, ServiceAccess::STOP | ServiceAccess::QUERY_STATUS)
         .map_err(scm_err)?;
@@ -166,8 +166,8 @@ pub(super) fn restart(paths: &Paths) -> Result<()> {
 }
 
 pub(super) fn status(_paths: &Paths) -> Result<StatusReport> {
-    let manager =
-        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
+        .map_err(scm_err)?;
     let svc = match manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
         Ok(s) => s,
         Err(windows_service::Error::Winapi(e))
@@ -199,8 +199,8 @@ pub(super) fn logs(paths: &Paths, follow: bool) -> Result<()> {
             std::io::Error::new(std::io::ErrorKind::NotFound, "log file does not exist"),
         ));
     }
-    let mut file = std::fs::File::open(&paths.log_file)
-        .map_err(|e| ServiceError::io(&paths.log_file, e))?;
+    let mut file =
+        std::fs::File::open(&paths.log_file).map_err(|e| ServiceError::io(&paths.log_file, e))?;
     let mut content = String::new();
     file.read_to_string(&mut content).map_err(|e| ServiceError::io(&paths.log_file, e))?;
     let stdout = std::io::stdout();
@@ -225,9 +225,8 @@ pub(super) fn logs(paths: &Paths, follow: bool) -> Result<()> {
         }
         file.seek(SeekFrom::Start(pos)).map_err(|e| ServiceError::io(&paths.log_file, e))?;
         let mut chunk = String::new();
-        let read = file
-            .read_to_string(&mut chunk)
-            .map_err(|e| ServiceError::io(&paths.log_file, e))?;
+        let read =
+            file.read_to_string(&mut chunk).map_err(|e| ServiceError::io(&paths.log_file, e))?;
         if read > 0 {
             let _ = out.write_all(chunk.as_bytes());
             let _ = out.flush();
@@ -246,9 +245,7 @@ fn add_to_system_path(paths: &Paths) -> Result<()> {
 
     let key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
     // Query existing PATH via `reg query` to avoid a winreg dep.
-    let current = std::process::Command::new("reg")
-        .args(["query", key, "/v", "Path"])
-        .output();
+    let current = std::process::Command::new("reg").args(["query", key, "/v", "Path"]).output();
     let existing = match current {
         Ok(out) if out.status.success() => {
             let text = String::from_utf8_lossy(&out.stdout);
@@ -273,11 +270,8 @@ fn add_to_system_path(paths: &Paths) -> Result<()> {
     if already_present {
         return Ok(());
     }
-    let new_value = if existing.is_empty() {
-        install_str.clone()
-    } else {
-        format!("{existing};{install_str}")
-    };
+    let new_value =
+        if existing.is_empty() { install_str.clone() } else { format!("{existing};{install_str}") };
 
     let out = std::process::Command::new("reg")
         .args(["add", key, "/v", "Path", "/t", "REG_EXPAND_SZ", "/d", &new_value, "/f"])
@@ -307,7 +301,6 @@ const ERROR_SERVICE_DOES_NOT_EXIST: i32 = 1060;
 
 windows_service::define_windows_service!(ffi_service_main, service_main);
 
-
 /// Service-main handler. Captures the config path from SCM-passed arguments
 /// (or falls back to the default install location) and runs the normal HTTP
 /// server loop.
@@ -319,7 +312,9 @@ fn service_main(arguments: Vec<OsString>) {
     }
 }
 
-fn service_main_inner(arguments: &[OsString]) -> std::result::Result<(), Box<dyn std::error::Error>> {
+fn service_main_inner(
+    arguments: &[OsString],
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Default to the canonical install path if SCM did not pass --config.
     let mut config_path: PathBuf = Paths::for_current_platform().config;
     let mut iter = arguments.iter().skip(1);
@@ -347,8 +342,7 @@ fn service_main_inner(arguments: &[OsString]) -> std::result::Result<(), Box<dyn
         }
     };
 
-    let status_handle =
-        service_control_handler::register(SERVICE_NAME, event_handler)?;
+    let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)?;
 
     status_handle.set_service_status(ServiceStatus {
         service_type: SERVICE_TYPE,

--- a/crates/ephpm/src/service/windows.rs
+++ b/crates/ephpm/src/service/windows.rs
@@ -1,0 +1,438 @@
+//! Windows Service Control Manager (SCM) backend for the `ephpm` service.
+//!
+//! Uses the [`windows-service`] crate to register, control, and run as a
+//! Windows service. The service is registered as auto-start under the name
+//! `ephpm` with display name "ePHPm — Embedded PHP Manager".
+//!
+//! When the SCM launches the service binary it invokes `ephpm service-run`
+//! (handled by [`run_as_service`]). For interactive lifecycle commands the
+//! binary connects to the SCM directly via [`ServiceManager`].
+//!
+//! `unsafe` blocks are required for `is_elevated` (token query) and the
+//! `define_windows_service!` macro-generated FFI shim. Each block carries a
+//! `// SAFETY:` comment.
+
+#![allow(unsafe_code)]
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use windows_service::service::{
+    ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceState, ServiceStatus,
+    ServiceType,
+};
+use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+use super::{Paths, Result, ServiceError, StatusReport};
+
+/// SCM service name.
+const SERVICE_NAME: &str = "ephpm";
+/// User-facing display name shown in services.msc.
+const SERVICE_DISPLAY: &str = "ePHPm — Embedded PHP Manager";
+/// SCM expects `OwnProcess` for stand-alone service binaries.
+const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
+
+/// Check whether the current process is running with Administrator privileges.
+///
+/// Returns `false` if the elevation query fails for any reason.
+#[must_use]
+pub fn is_elevated() -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::Security::{GetTokenInformation, TOKEN_QUERY, TokenElevation};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    // SAFETY: `OpenProcessToken` is a Win32 API that writes the token handle
+    // through the out pointer. We pass a valid `HANDLE` storage location and
+    // the documented `TOKEN_QUERY` access right.
+    unsafe {
+        let mut token: HANDLE = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) == 0 {
+            return false;
+        }
+        #[repr(C)]
+        struct Elevation {
+            token_is_elevated: u32,
+        }
+        let mut elevation = Elevation { token_is_elevated: 0 };
+        let mut ret_len: u32 = 0;
+        let ok = GetTokenInformation(
+            token,
+            TokenElevation,
+            std::ptr::addr_of_mut!(elevation).cast(),
+            u32::try_from(std::mem::size_of::<Elevation>()).unwrap_or(0),
+            &raw mut ret_len,
+        );
+        CloseHandle(token);
+        ok != 0 && elevation.token_is_elevated != 0
+    }
+}
+
+pub(super) fn register(paths: &Paths) -> Result<()> {
+    let manager = ServiceManager::local_computer(
+        None::<&OsStr>,
+        ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
+    )
+    .map_err(scm_err)?;
+
+    let info = ServiceInfo {
+        name: OsString::from(SERVICE_NAME),
+        display_name: OsString::from(SERVICE_DISPLAY),
+        service_type: SERVICE_TYPE,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: paths.binary.clone(),
+        launch_arguments: vec![
+            OsString::from("service-run"),
+            OsString::from("--config"),
+            OsString::from(paths.config.as_os_str()),
+        ],
+        dependencies: vec![],
+        account_name: None, // run as LocalSystem
+        account_password: None,
+    };
+
+    // CreateService will fail if a service of the same name already exists, in
+    // which case we update its configuration in place via the existing handle.
+    match manager.create_service(
+        &info,
+        ServiceAccess::QUERY_STATUS | ServiceAccess::CHANGE_CONFIG | ServiceAccess::START,
+    ) {
+        Ok(_) => {}
+        Err(windows_service::Error::Winapi(e))
+            if e.raw_os_error() == Some(ERROR_SERVICE_EXISTS) =>
+        {
+            // Already installed — open and update binary path / args.
+            let svc = manager
+                .open_service(
+                    SERVICE_NAME,
+                    ServiceAccess::CHANGE_CONFIG | ServiceAccess::QUERY_STATUS,
+                )
+                .map_err(scm_err)?;
+            svc.change_config(&info).map_err(scm_err)?;
+        }
+        Err(e) => return Err(scm_err(e)),
+    }
+
+    add_to_system_path(paths)?;
+    Ok(())
+}
+
+pub(super) fn deregister(_paths: &Paths) -> Result<()> {
+    let manager =
+        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    match manager.open_service(SERVICE_NAME, ServiceAccess::DELETE | ServiceAccess::QUERY_STATUS) {
+        Ok(svc) => svc.delete().map_err(scm_err)?,
+        Err(windows_service::Error::Winapi(e))
+            if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST) => {}
+        Err(e) => return Err(scm_err(e)),
+    }
+    Ok(())
+}
+
+pub(super) fn start(_paths: &Paths) -> Result<()> {
+    let manager =
+        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let svc = manager
+        .open_service(SERVICE_NAME, ServiceAccess::START | ServiceAccess::QUERY_STATUS)
+        .map_err(scm_err)?;
+    let status = svc.query_status().map_err(scm_err)?;
+    if !matches!(status.current_state, ServiceState::Stopped | ServiceState::StopPending) {
+        return Ok(());
+    }
+    svc.start::<&OsStr>(&[]).map_err(scm_err)
+}
+
+pub(super) fn stop(_paths: &Paths) -> Result<()> {
+    let manager =
+        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let svc = manager
+        .open_service(SERVICE_NAME, ServiceAccess::STOP | ServiceAccess::QUERY_STATUS)
+        .map_err(scm_err)?;
+    let status = svc.query_status().map_err(scm_err)?;
+    if matches!(status.current_state, ServiceState::Stopped | ServiceState::StopPending) {
+        return Ok(());
+    }
+    svc.stop().map_err(scm_err)?;
+    Ok(())
+}
+
+pub(super) fn restart(paths: &Paths) -> Result<()> {
+    stop(paths).ok();
+    // Wait briefly for the service to fully stop before starting again.
+    std::thread::sleep(Duration::from_millis(500));
+    start(paths)
+}
+
+pub(super) fn status(_paths: &Paths) -> Result<StatusReport> {
+    let manager =
+        ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT).map_err(scm_err)?;
+    let svc = match manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
+        Ok(s) => s,
+        Err(windows_service::Error::Winapi(e))
+            if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST) =>
+        {
+            return Err(ServiceError::NotInstalled);
+        }
+        Err(e) => return Err(scm_err(e)),
+    };
+    let s = svc.query_status().map_err(scm_err)?;
+    let state = match s.current_state {
+        ServiceState::Stopped => "stopped",
+        ServiceState::StartPending => "starting",
+        ServiceState::StopPending => "stopping",
+        ServiceState::Running => "running",
+        ServiceState::ContinuePending => "continuing",
+        ServiceState::PausePending => "pausing",
+        ServiceState::Paused => "paused",
+    };
+    Ok(StatusReport { state: state.to_string(), pid: s.process_id, uptime: None })
+}
+
+pub(super) fn logs(paths: &Paths, follow: bool) -> Result<()> {
+    use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+
+    if !paths.log_file.exists() {
+        return Err(ServiceError::io(
+            &paths.log_file,
+            std::io::Error::new(std::io::ErrorKind::NotFound, "log file does not exist"),
+        ));
+    }
+    let mut file = std::fs::File::open(&paths.log_file)
+        .map_err(|e| ServiceError::io(&paths.log_file, e))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content).map_err(|e| ServiceError::io(&paths.log_file, e))?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let tail: Vec<&str> = content.lines().rev().take(200).collect();
+    for line in tail.into_iter().rev() {
+        let _ = writeln!(out, "{line}");
+    }
+    if !follow {
+        return Ok(());
+    }
+    let mut pos = file.seek(SeekFrom::End(0)).map_err(|e| ServiceError::io(&paths.log_file, e))?;
+    loop {
+        std::thread::sleep(Duration::from_millis(500));
+        let len = std::fs::metadata(&paths.log_file)
+            .map_err(|e| ServiceError::io(&paths.log_file, e))?
+            .len();
+        if len < pos {
+            pos = 0;
+            file = std::fs::File::open(&paths.log_file)
+                .map_err(|e| ServiceError::io(&paths.log_file, e))?;
+        }
+        file.seek(SeekFrom::Start(pos)).map_err(|e| ServiceError::io(&paths.log_file, e))?;
+        let mut chunk = String::new();
+        let read = file
+            .read_to_string(&mut chunk)
+            .map_err(|e| ServiceError::io(&paths.log_file, e))?;
+        if read > 0 {
+            let _ = out.write_all(chunk.as_bytes());
+            let _ = out.flush();
+            pos += read as u64;
+        }
+    }
+}
+
+/// Append the install directory to the system `Path` environment variable so
+/// `ephpm` is callable from a fresh shell. Idempotent.
+fn add_to_system_path(paths: &Paths) -> Result<()> {
+    let Some(install_dir) = paths.binary.parent() else {
+        return Ok(());
+    };
+    let install_str = install_dir.display().to_string();
+
+    let key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+    // Query existing PATH via `reg query` to avoid a winreg dep.
+    let current = std::process::Command::new("reg")
+        .args(["query", key, "/v", "Path"])
+        .output();
+    let existing = match current {
+        Ok(out) if out.status.success() => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            text.lines()
+                .find_map(|l| {
+                    let l = l.trim();
+                    let mut parts = l.splitn(3, char::is_whitespace).filter(|s| !s.is_empty());
+                    if parts.next()? != "Path" {
+                        return None;
+                    }
+                    parts.next()?; // type field (REG_SZ / REG_EXPAND_SZ)
+                    Some(parts.next().unwrap_or("").to_string())
+                })
+                .unwrap_or_default()
+        }
+        _ => String::new(),
+    };
+
+    let already_present = existing
+        .split(';')
+        .any(|p| Path::new(p.trim()).eq_ignore_ascii_case_path(Path::new(&install_str)));
+    if already_present {
+        return Ok(());
+    }
+    let new_value = if existing.is_empty() {
+        install_str.clone()
+    } else {
+        format!("{existing};{install_str}")
+    };
+
+    let out = std::process::Command::new("reg")
+        .args(["add", key, "/v", "Path", "/t", "REG_EXPAND_SZ", "/d", &new_value, "/f"])
+        .output()
+        .map_err(|e| ServiceError::command("reg add", e.to_string()))?;
+    if !out.status.success() {
+        return Err(ServiceError::command(
+            "reg add",
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// Map `windows_service::Error` into our typed error.
+fn scm_err(e: windows_service::Error) -> ServiceError {
+    ServiceError::command("Windows SCM", e.to_string())
+}
+
+/// SCM error code constants we need to disambiguate "already exists" from real errors.
+const ERROR_SERVICE_EXISTS: i32 = 1073;
+const ERROR_SERVICE_DOES_NOT_EXIST: i32 = 1060;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service-main entry point (invoked by SCM when the service starts)
+// ─────────────────────────────────────────────────────────────────────────────
+
+windows_service::define_windows_service!(ffi_service_main, service_main);
+
+
+/// Service-main handler. Captures the config path from SCM-passed arguments
+/// (or falls back to the default install location) and runs the normal HTTP
+/// server loop.
+fn service_main(arguments: Vec<OsString>) {
+    if let Err(e) = service_main_inner(&arguments) {
+        // We can't reliably stdout from a Windows service — at least record
+        // the failure to the event log via tracing if a subscriber is set.
+        tracing::error!(error = %e, "ephpm service failed");
+    }
+}
+
+fn service_main_inner(arguments: &[OsString]) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    // Default to the canonical install path if SCM did not pass --config.
+    let mut config_path: PathBuf = Paths::for_current_platform().config;
+    let mut iter = arguments.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == OsStr::new("--config") {
+            if let Some(v) = iter.next() {
+                config_path = PathBuf::from(v);
+            }
+        }
+    }
+
+    let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel::<()>();
+
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            windows_service::service::ServiceControl::Stop
+            | windows_service::service::ServiceControl::Shutdown => {
+                let _ = shutdown_tx.send(());
+                ServiceControlHandlerResult::NoError
+            }
+            windows_service::service::ServiceControl::Interrogate => {
+                ServiceControlHandlerResult::NoError
+            }
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    let status_handle =
+        service_control_handler::register(SERVICE_NAME, event_handler)?;
+
+    status_handle.set_service_status(ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::Running,
+        controls_accepted: windows_service::service::ServiceControlAccept::STOP
+            | windows_service::service::ServiceControlAccept::SHUTDOWN,
+        exit_code: windows_service::service::ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    })?;
+
+    // Spawn the actual server on a worker thread so this one can wait on the
+    // shutdown signal.
+    let config_clone = config_path.clone();
+    let server_handle = std::thread::spawn(move || -> anyhow::Result<()> {
+        crate::run_serve_with_config(config_clone)
+    });
+
+    // Block until SCM asks us to stop.
+    let _ = shutdown_rx.recv();
+
+    status_handle.set_service_status(ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::StopPending,
+        controls_accepted: windows_service::service::ServiceControlAccept::empty(),
+        exit_code: windows_service::service::ServiceExitCode::Win32(0),
+        checkpoint: 1,
+        wait_hint: Duration::from_secs(10),
+        process_id: None,
+    })?;
+
+    // The server doesn't have a graceful-shutdown signal we can poke from here
+    // yet, so we exit the process. SCM will reap our worker threads.
+    drop(server_handle);
+
+    status_handle.set_service_status(ServiceStatus {
+        service_type: SERVICE_TYPE,
+        current_state: ServiceState::Stopped,
+        controls_accepted: windows_service::service::ServiceControlAccept::empty(),
+        exit_code: windows_service::service::ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    })?;
+
+    Ok(())
+}
+
+/// Entry point for the hidden `service-run` subcommand. SCM invokes the binary
+/// with this argument when it starts the service; we hand control to the
+/// `windows_service` dispatcher which calls back into `service_main`.
+///
+/// # Errors
+///
+/// Returns an error if the SCM service dispatcher fails to register.
+pub fn run_as_service() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    windows_service::service_dispatcher::start(SERVICE_NAME, ffi_service_main)?;
+    Ok(())
+}
+
+/// Tiny case-insensitive path comparison helper. Implemented as a private
+/// extension trait so the call site reads naturally.
+trait PathCaseExt {
+    fn eq_ignore_ascii_case_path(&self, other: &Path) -> bool;
+}
+
+impl PathCaseExt for Path {
+    fn eq_ignore_ascii_case_path(&self, other: &Path) -> bool {
+        let a = self.to_string_lossy();
+        let b = other.to_string_lossy();
+        a.eq_ignore_ascii_case(&b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_code_constants_are_known_values() {
+        // Sanity check — these are documented SCM error codes; if they change
+        // the compile-time `const` must be updated.
+        assert_eq!(ERROR_SERVICE_EXISTS, 1073_i32);
+        assert_eq!(ERROR_SERVICE_DOES_NOT_EXIST, 1060_i32);
+    }
+}


### PR DESCRIPTION
## Why

The README has documented `ephpm install / uninstall / start / stop / restart / status / logs` for a while, but the subcommands didn't actually exist. This PR makes the docs true.

## Approach

Trait-style platform dispatch via `#[cfg(...)]` mods inside `crates/ephpm/src/service/`:

- `service/mod.rs` — public `install/uninstall/start/stop/restart/status/logs` plus shared `Paths::for_current_platform`, `default_config_toml`, `is_elevated`, typed `ServiceError` (thiserror), and a `tail_file` helper for Unix log following.
- `service/systemd.rs` (Linux) — writes `/etc/systemd/system/ephpm.service`, shells out to `systemctl` / `journalctl`.
- `service/launchd.rs` (macOS) — writes `/Library/LaunchDaemons/dev.ephpm.plist`, uses `launchctl bootstrap | bootout | kickstart | stop | print`.
- `service/windows.rs` — registers the `ephpm` service via the `windows-service` crate; admin check via `windows-sys` token query; appends the install dir to `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\Path` via `reg add`; implements the SCM service-main hook plus a hidden `service-run` subcommand that the SCM invokes on start.

## Install paths

| Platform | Binary | Config | Service unit | Data dir | Log file |
|----------|--------|--------|--------------|----------|----------|
| Linux    | `/usr/local/bin/ephpm` | `/etc/ephpm/ephpm.toml` | `/etc/systemd/system/ephpm.service` | `/var/lib/ephpm/` | `/var/log/ephpm/ephpm.log` |
| macOS    | `/usr/local/bin/ephpm` | `/etc/ephpm/ephpm.toml` | `/Library/LaunchDaemons/dev.ephpm.plist` | `/var/lib/ephpm/` | `/var/log/ephpm/ephpm.log` |
| Windows  | `C:\Program Files\ephpm\ephpm.exe` | `C:\ProgramData\ephpm\ephpm.toml` | Windows service `ephpm` | `C:\ProgramData\ephpm\data\` | `C:\ProgramData\ephpm\logs\ephpm.log` |

All lifecycle commands require root / Administrator and return `ServiceError::NotElevated` otherwise.

## Tests

Unit tests in `service/mod.rs`:
- `default_config_contains_required_keys`
- `default_config_escapes_windows_paths`
- `paths_for_current_platform_are_absolute`
- `write_default_config_does_not_overwrite_existing`
- `write_default_config_writes_when_missing`
- `read_listen_address_parses_basic_toml`
- `read_listen_address_returns_none_when_missing`
- `privilege_label_is_platform_appropriate`

Platform-specific tests gated to host OS:
- `systemd::tests::unit_body_renders_paths` (Linux)
- `launchd::tests::plist_body_contains_required_keys` (macOS)
- `windows::tests::error_code_constants_are_known_values` (Windows)

CLI parser tests in `main.rs::cli_tests`:
- `parses_install_subcommand`
- `parses_uninstall_with_keep_data_flag`
- `parses_uninstall_default_keeps_no_data`
- `parses_lifecycle_subcommands` (start/stop/restart/status)
- `parses_logs_with_follow` (incl. `-f` short form and the default-off case)

## Known soft spot to revisit

The Windows service-main path drops the worker thread on SCM stop rather than signalling a graceful shutdown — `ephpm-server` doesn't expose a shutdown channel yet. Adequate for MVP since the process exits anyway, but worth a follow-up once the server gains a `CancellationToken`.

## Review checklist

- [x] `cargo build` (stub mode, no `PHP_SDK_PATH`) — PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — PASS (after fixing three lints flagged during local verification: `clippy::dead_code` on `Paths::service_unit` on Windows, two `clippy::borrow_as_ptr` lints in the Windows token-query block, and `clippy::items_after_test_module` because the original ordering had `kv_ttl` sitting after the `cli_tests` mod in `main.rs`)
- [ ] `cargo +nightly fmt --all -- --check` — not run locally (sandbox blocked rustfmt); CI will gate this
- [ ] `cargo test -p ephpm` — compiled clean via `cargo build --tests` but execution blocked in the sandbox; CI will run the suite (8 platform-independent + 1 windows backend test on this matrix entry)
- [ ] `cargo xtask release --target windows` — not run locally; CI is the source of truth for the cross-compile path