### PR TITLE
fix(service): Windows install/uninstall correctness + cross-platform elevated e2e

### DIFF
--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -280,7 +280,29 @@ fn run_serve_sync(command: Option<Commands>) -> anyhow::Result<ExitCode> {
         EnvFilter::new(level)
     });
 
-    let fmt_layer = tracing_subscriber::fmt::layer();
+    // If a service backend launched us (e.g. Windows SCM), it sets
+    // EPHPM_SERVICE_LOG_FILE so the main tracing layer can be routed to disk
+    // — without that, SCM-detached stdout swallows every event and `ephpm
+    // logs` has nothing to read. Unix backends rely on systemd/launchd's
+    // built-in stdout redirection, so this branch is effectively Windows-only.
+    let (fmt_layer, _service_log_guard) = match std::env::var_os("EPHPM_SERVICE_LOG_FILE") {
+        Some(raw) if !raw.is_empty() => {
+            let path = PathBuf::from(raw);
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let dir = path.parent().map_or_else(|| PathBuf::from("."), PathBuf::from);
+            let file_name = path
+                .file_name()
+                .map_or_else(|| "ephpm.log".to_string(), |f| f.to_string_lossy().into_owned());
+            let (writer, guard) =
+                tracing_appender::non_blocking(tracing_appender::rolling::never(dir, file_name));
+            let layer =
+                tracing_subscriber::fmt::layer().with_writer(writer).with_ansi(false).boxed();
+            (layer, Some(guard))
+        }
+        _ => (tracing_subscriber::fmt::layer().boxed(), None),
+    };
 
     // Set up access log file writer if configured.
     let _access_guard = if config.server.logging.access.is_empty() {

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -316,13 +316,54 @@ pub fn uninstall(keep_data: bool) -> Result<()> {
             std::fs::remove_dir_all(&paths.data_dir)
                 .map_err(|e| ServiceError::io(&paths.data_dir, e))?;
         }
+        // Clear out the log dir + any shared parent (`C:\ProgramData\ephpm`,
+        // `/var/log/ephpm`) that the install created. `remove_dir_all` on the
+        // log dir handles open log files; the parent removal is best-effort
+        // (only succeeds when empty).
+        if let Some(log_dir) = paths.log_file.parent()
+            && log_dir.exists()
+        {
+            let _ = std::fs::remove_dir_all(log_dir);
+        }
+        if let Some(config_parent) = paths.config.parent() {
+            let _ = std::fs::remove_dir(config_parent);
+        }
     }
 
     if paths.binary.exists() {
-        std::fs::remove_file(&paths.binary).map_err(|e| ServiceError::io(&paths.binary, e))?;
+        remove_with_retry(&paths.binary)?;
+    }
+    // Best-effort: drop the install directory if it's now empty. The Unix
+    // backends install into /usr/local/bin which is shared; `remove_dir` only
+    // succeeds when empty, so this is safe.
+    if let Some(parent) = paths.binary.parent() {
+        let _ = std::fs::remove_dir(parent);
     }
     tracing::info!("ephpm service uninstalled");
     Ok(())
+}
+
+/// Try to delete `path` up to ~3 seconds, sleeping 100ms between attempts.
+/// On Windows the SCM may still hold a handle to a just-exited service
+/// binary for a brief moment after `query_status` reports Stopped, so a
+/// naive `remove_file` races against the kernel releasing the lock.
+fn remove_with_retry(path: &Path) -> Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        match std::fs::remove_file(path) {
+            Ok(()) => return Ok(()),
+            Err(e) if std::time::Instant::now() < deadline => {
+                let kind = e.kind();
+                // On Windows the locked-file error surfaces as PermissionDenied.
+                // Anything else (NotFound, etc.) we surface immediately.
+                if kind != std::io::ErrorKind::PermissionDenied {
+                    return Err(ServiceError::io(path, e));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(e) => return Err(ServiceError::io(path, e)),
+        }
+    }
 }
 
 /// Start the installed service.

--- a/crates/ephpm/src/service/windows.rs
+++ b/crates/ephpm/src/service/windows.rs
@@ -119,7 +119,7 @@ pub(super) fn register(paths: &Paths) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn deregister(_paths: &Paths) -> Result<()> {
+pub(super) fn deregister(paths: &Paths) -> Result<()> {
     let manager = ServiceManager::local_computer(None::<&OsStr>, ServiceManagerAccess::CONNECT)
         .map_err(scm_err)?;
     match manager.open_service(SERVICE_NAME, ServiceAccess::DELETE | ServiceAccess::QUERY_STATUS) {
@@ -127,6 +127,11 @@ pub(super) fn deregister(_paths: &Paths) -> Result<()> {
         Err(windows_service::Error::Winapi(e))
             if e.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST) => {}
         Err(e) => return Err(scm_err(e)),
+    }
+    // Best-effort PATH cleanup — leave the SCM cleanup intact even if we can't
+    // mutate the registry for some reason.
+    if let Err(e) = remove_from_system_path(paths) {
+        tracing::warn!(error = %e, "failed to remove install dir from system PATH");
     }
     Ok(())
 }
@@ -151,18 +156,44 @@ pub(super) fn stop(_paths: &Paths) -> Result<()> {
         .open_service(SERVICE_NAME, ServiceAccess::STOP | ServiceAccess::QUERY_STATUS)
         .map_err(scm_err)?;
     let status = svc.query_status().map_err(scm_err)?;
-    if matches!(status.current_state, ServiceState::Stopped | ServiceState::StopPending) {
-        return Ok(());
+    match status.current_state {
+        ServiceState::Stopped => return Ok(()),
+        ServiceState::StopPending => {}
+        _ => {
+            svc.stop().map_err(scm_err)?;
+        }
     }
-    svc.stop().map_err(scm_err)?;
-    Ok(())
+    wait_for_state(&svc, ServiceState::Stopped, Duration::from_secs(30))
 }
 
 pub(super) fn restart(paths: &Paths) -> Result<()> {
-    stop(paths).ok();
-    // Wait briefly for the service to fully stop before starting again.
-    std::thread::sleep(Duration::from_millis(500));
+    stop(paths)?;
     start(paths)
+}
+
+/// Poll `svc` until it reaches `target` state or `timeout` elapses. Returns an
+/// error only on SCM query failure or timeout. Used by `stop` and `uninstall`
+/// so callers can be sure the service has fully transitioned before they touch
+/// the binary file on disk.
+fn wait_for_state(
+    svc: &windows_service::service::Service,
+    target: ServiceState,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let s = svc.query_status().map_err(scm_err)?;
+        if s.current_state == target {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(ServiceError::command(
+                "Windows SCM",
+                format!("timed out waiting for service to reach {target:?}"),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
 }
 
 pub(super) fn status(_paths: &Paths) -> Result<StatusReport> {
@@ -244,25 +275,7 @@ fn add_to_system_path(paths: &Paths) -> Result<()> {
     let install_str = install_dir.display().to_string();
 
     let key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
-    // Query existing PATH via `reg query` to avoid a winreg dep.
-    let current = std::process::Command::new("reg").args(["query", key, "/v", "Path"]).output();
-    let existing = match current {
-        Ok(out) if out.status.success() => {
-            let text = String::from_utf8_lossy(&out.stdout);
-            text.lines()
-                .find_map(|l| {
-                    let l = l.trim();
-                    let mut parts = l.splitn(3, char::is_whitespace).filter(|s| !s.is_empty());
-                    if parts.next()? != "Path" {
-                        return None;
-                    }
-                    parts.next()?; // type field (REG_SZ / REG_EXPAND_SZ)
-                    Some(parts.next().unwrap_or("").to_string())
-                })
-                .unwrap_or_default()
-        }
-        _ => String::new(),
-    };
+    let existing = query_registry_path(key).unwrap_or_default();
 
     let already_present = existing
         .split(';')
@@ -284,6 +297,72 @@ fn add_to_system_path(paths: &Paths) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Remove the install directory from the system `Path` environment variable.
+/// Idempotent: a no-op when the entry is not present.
+fn remove_from_system_path(paths: &Paths) -> Result<()> {
+    let Some(install_dir) = paths.binary.parent() else {
+        return Ok(());
+    };
+    let install_path = Path::new(install_dir);
+
+    let key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+    let Some(existing) = query_registry_path(key) else { return Ok(()) };
+
+    let filtered: Vec<&str> = existing
+        .split(';')
+        .filter(|p| !Path::new(p.trim()).eq_ignore_ascii_case_path(install_path))
+        .collect();
+    if filtered.len() == existing.split(';').count() {
+        // Install dir wasn't present — nothing to do.
+        return Ok(());
+    }
+    let new_value = filtered.join(";");
+
+    let out = std::process::Command::new("reg")
+        .args(["add", key, "/v", "Path", "/t", "REG_EXPAND_SZ", "/d", &new_value, "/f"])
+        .output()
+        .map_err(|e| ServiceError::command("reg add", e.to_string()))?;
+    if !out.status.success() {
+        return Err(ServiceError::command(
+            "reg add",
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// Read a `REG_SZ` / `REG_EXPAND_SZ` value named `Path` from `key` via the
+/// `reg` CLI. Returns `None` when the key/value is missing or the shell-out
+/// fails. Returns `Some("")` for an empty value.
+///
+/// `reg query` prints lines like `    Path    REG_EXPAND_SZ    <value>` with
+/// multiple spaces between fields. Anything that simply splits on whitespace
+/// chokes on paths containing spaces (e.g. `C:\Program Files\ephpm`), so we
+/// strip the name + known type prefixes off the front instead.
+fn query_registry_path(key: &str) -> Option<String> {
+    let out = std::process::Command::new("reg").args(["query", key, "/v", "Path"]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    for line in text.lines() {
+        let l = line.trim_start();
+        let Some(rest) = l.strip_prefix("Path") else { continue };
+        // Ensure "Path" was a whole word (next char is whitespace) so we don't
+        // match value names like "PathExt".
+        if !rest.starts_with(char::is_whitespace) {
+            continue;
+        }
+        let after_name = rest.trim_start();
+        for ty in ["REG_EXPAND_SZ", "REG_SZ", "REG_MULTI_SZ"] {
+            if let Some(after_type) = after_name.strip_prefix(ty) {
+                return Some(after_type.trim_end_matches(['\r', '\n']).trim().to_string());
+            }
+        }
+    }
+    None
 }
 
 /// Map `windows_service::Error` into our typed error.
@@ -316,7 +395,8 @@ fn service_main_inner(
     arguments: &[OsString],
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Default to the canonical install path if SCM did not pass --config.
-    let mut config_path: PathBuf = Paths::for_current_platform().config;
+    let paths = Paths::for_current_platform();
+    let mut config_path: PathBuf = paths.config.clone();
     let mut iter = arguments.iter().skip(1);
     while let Some(arg) = iter.next() {
         if arg == OsStr::new("--config") {
@@ -324,6 +404,22 @@ fn service_main_inner(
                 config_path = PathBuf::from(v);
             }
         }
+    }
+
+    // SCM detaches stdout/stderr from the service process, so tracing output
+    // would otherwise vanish. Make sure the log directory exists and tell
+    // `run_serve_sync` (via env var) to route the main tracing layer to that
+    // file instead of stderr. The Unix backends rely on systemd/launchd's
+    // built-in stdout redirection so this only matters on Windows.
+    if let Some(parent) = paths.log_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // SAFETY: `set_var` is sound here because no other threads have been
+    // spawned yet — SCM has just invoked our service-main and tokio / tracing
+    // initialization has not started. Setting the env var before any reader
+    // races us is the documented safe pattern.
+    unsafe {
+        std::env::set_var("EPHPM_SERVICE_LOG_FILE", &paths.log_file);
     }
 
     let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel::<()>();

--- a/crates/ephpm/tests/service_lifecycle.rs
+++ b/crates/ephpm/tests/service_lifecycle.rs
@@ -1,0 +1,218 @@
+//! Elevated end-to-end test for the `ephpm` service-management CLI.
+//!
+//! Exercises the full `install → status → stop → start → restart → logs
+//! → uninstall --keep-data → install → uninstall` flow against the real
+//! platform service manager (SCM on Windows, systemd on Linux, launchd on
+//! macOS). All of those mutate system state in production locations, so the
+//! test is double-gated:
+//!
+//! 1. `#[ignore]` keeps it out of `cargo test` by default.
+//! 2. `EPHPM_ELEVATED_E2E=1` must be set, even with `--ignored`, as a tripwire
+//!    against running it by accident in CI or on a dev machine that already
+//!    has a real ephpm install.
+//!
+//! ## Running
+//!
+//! ```bash
+//! # Linux  (systemd required)
+//! sudo EPHPM_ELEVATED_E2E=1 cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture
+//!
+//! # macOS
+//! sudo EPHPM_ELEVATED_E2E=1 cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture
+//!
+//! # Windows  (elevated PowerShell — Administrator)
+//! $env:EPHPM_ELEVATED_E2E="1"; cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture
+//! ```
+//!
+//! Before running, the test refuses to proceed if the canonical install
+//! binary already exists — that's almost certainly a real production install
+//! the developer doesn't want clobbered.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::thread::sleep;
+use std::time::Duration;
+
+const GATE_ENV: &str = "EPHPM_ELEVATED_E2E";
+const BIN: &str = env!("CARGO_BIN_EXE_ephpm");
+
+fn canonical_install_binary() -> PathBuf {
+    if cfg!(windows) {
+        PathBuf::from(r"C:\Program Files\ephpm\ephpm.exe")
+    } else {
+        PathBuf::from("/usr/local/bin/ephpm")
+    }
+}
+
+fn canonical_config() -> PathBuf {
+    if cfg!(windows) {
+        PathBuf::from(r"C:\ProgramData\ephpm\ephpm.toml")
+    } else {
+        PathBuf::from("/etc/ephpm/ephpm.toml")
+    }
+}
+
+/// Run `ephpm <args>` (the test-built binary), capturing stdout+stderr.
+fn ephpm(args: &[&str]) -> Output {
+    Command::new(BIN)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `{BIN} {args:?}`: {e}"))
+}
+
+/// Run and assert success. Panic with stdout+stderr if the command failed.
+fn ephpm_ok(args: &[&str]) -> String {
+    let out = ephpm(args);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "`ephpm {args:?}` failed (exit {:?})\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        out.status.code(),
+    );
+    format!("{stdout}{stderr}")
+}
+
+/// Parse the numeric pid from a `status` output. `None` when the pid line says
+/// "-" (service stopped).
+fn pid_from_status(s: &str) -> Option<u32> {
+    s.lines().find_map(|l| {
+        let trimmed = l.trim_start();
+        let rest = trimmed.strip_prefix("pid:")?;
+        let value = rest.trim();
+        if value == "-" { None } else { value.parse::<u32>().ok() }
+    })
+}
+
+#[test]
+#[ignore = "elevated end-to-end — set EPHPM_ELEVATED_E2E=1 and run as root/Administrator"]
+fn service_full_lifecycle() {
+    // ─── pre-flight gates ────────────────────────────────────────────────
+    if std::env::var_os(GATE_ENV).is_none() {
+        eprintln!(
+            "SKIP: {GATE_ENV} not set. Re-run with `{GATE_ENV}=1` to opt into mutating system state."
+        );
+        return;
+    }
+    let install_binary = canonical_install_binary();
+    assert!(
+        !install_binary.exists(),
+        "refusing to run: {} already exists — looks like a real ephpm install. \
+         Uninstall it first before running this test.",
+        install_binary.display(),
+    );
+
+    // On Linux the systemd backend shells out to `systemctl`; if it's not on
+    // PATH (e.g. inside a non-systemd container), skip rather than fail.
+    #[cfg(target_os = "linux")]
+    {
+        if Command::new("systemctl").arg("--version").output().is_err() {
+            eprintln!("SKIP: systemctl not available — Linux backend needs systemd.");
+            return;
+        }
+    }
+
+    // RAII guard guarantees we run `uninstall` even if the test panics.
+    let _guard = CleanupGuard;
+
+    // ─── install ─────────────────────────────────────────────────────────
+    ephpm_ok(&["install"]);
+    assert!(install_binary.exists(), "binary should exist after install");
+    assert!(canonical_config().exists(), "config should exist after install");
+
+    // Give the service backend a moment to flip into the running state.
+    sleep(Duration::from_secs(2));
+
+    // ─── status (running) ───────────────────────────────────────────────
+    let status_running = ephpm_ok(&["status"]);
+    let running_pid = pid_from_status(&status_running).unwrap_or_else(|| {
+        panic!("status after install reports no pid:\n{status_running}");
+    });
+
+    // ─── stop ───────────────────────────────────────────────────────────
+    ephpm_ok(&["stop"]);
+    let status_stopped = ephpm_ok(&["status"]);
+    assert!(
+        pid_from_status(&status_stopped).is_none(),
+        "expected no pid after stop, got:\n{status_stopped}",
+    );
+
+    // ─── start ──────────────────────────────────────────────────────────
+    ephpm_ok(&["start"]);
+    sleep(Duration::from_secs(1));
+    let status_started = ephpm_ok(&["status"]);
+    let started_pid = pid_from_status(&status_started)
+        .unwrap_or_else(|| panic!("status after start reports no pid:\n{status_started}"));
+
+    // ─── restart ────────────────────────────────────────────────────────
+    ephpm_ok(&["restart"]);
+    sleep(Duration::from_secs(1));
+    let status_restarted = ephpm_ok(&["status"]);
+    let restarted_pid = pid_from_status(&status_restarted)
+        .unwrap_or_else(|| panic!("status after restart reports no pid:\n{status_restarted}"));
+    assert_ne!(
+        restarted_pid, started_pid,
+        "restart should produce a new pid (was {started_pid}, still {restarted_pid})",
+    );
+    // running_pid is from the very first start; sanity check we've cycled at
+    // least twice in this sequence.
+    let _ = running_pid;
+
+    // ─── logs (may need a moment for the async appender to flush) ───────
+    sleep(Duration::from_secs(1));
+    let logs = ephpm_ok(&["logs"]);
+    assert!(
+        !logs.trim().is_empty(),
+        "logs subcommand returned no output — the service either isn't writing or the path is wrong",
+    );
+
+    // ─── uninstall --keep-data ──────────────────────────────────────────
+    ephpm_ok(&["uninstall", "--keep-data"]);
+    assert!(!install_binary.exists(), "binary should be gone after uninstall");
+    assert!(canonical_config().exists(), "config should survive --keep-data uninstall");
+
+    // ─── reinstall on top of preserved data ─────────────────────────────
+    ephpm_ok(&["install"]);
+    sleep(Duration::from_secs(2));
+    let after_reinstall = ephpm_ok(&["status"]);
+    assert!(
+        pid_from_status(&after_reinstall).is_some(),
+        "reinstall should leave the service running:\n{after_reinstall}",
+    );
+
+    // ─── full uninstall ────────────────────────────────────────────────
+    ephpm_ok(&["uninstall"]);
+    assert!(!install_binary.exists(), "binary should be gone after full uninstall");
+    assert!(!canonical_config().exists(), "config should be gone after full uninstall");
+
+    // ─── idempotent uninstall (no-op should not error) ──────────────────
+    let out = ephpm(&["uninstall"]);
+    assert!(
+        out.status.success() || cfg!(target_os = "macos"),
+        "second uninstall should be idempotent\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// Drop-guard that best-effort uninstalls so a panic mid-test doesn't leave
+/// the developer's machine with a stuck service. Errors are swallowed
+/// intentionally — we already know `uninstall` is idempotent.
+struct CleanupGuard;
+
+impl Drop for CleanupGuard {
+    fn drop(&mut self) {
+        let _ = Command::new(BIN).args(["uninstall"]).output();
+    }
+}
+
+#[test]
+fn pid_parser_handles_numeric() {
+    let s = "service: running\n   pid: 1234\nuptime: -\nlisten: 0.0.0.0:8080\nconfig: x\n";
+    assert_eq!(pid_from_status(s), Some(1234));
+}
+
+#[test]
+fn pid_parser_handles_dash() {
+    let s = "service: stopped\n   pid: -\nuptime: -\nlisten: 0.0.0.0:8080\nconfig: x\n";
+    assert_eq!(pid_from_status(s), None);
+}

--- a/site/content/developer/testing.md
+++ b/site/content/developer/testing.md
@@ -10,6 +10,7 @@ ePHPm uses a layered testing approach: fast unit tests for inner logic, a dedica
 |-------|------|---------------|-------|
 | Unit | `cargo nextest` | Config parsing, routing logic, SAPI mapping, response building | Seconds |
 | Integration | `cargo nextest` (ignored by default) | PHP execution, WordPress lifecycle — requires libphp | Seconds (with SDK) |
+| Elevated lifecycle | `cargo test --ignored` (env-gated, root/Administrator) | Real SCM / systemd / launchd install → uninstall flow | ~15s per platform |
 | E2E | `ephpm-e2e` crate + Tilt + Kind | Full stack against real K8s infrastructure | Minutes |
 | Benchmarks | Criterion | Throughput, latency p99 — requires libphp | Minutes |
 
@@ -30,6 +31,56 @@ Integration tests that require PHP are `#[ignore]` by default. Run them after bu
 ```bash
 cargo nextest run --workspace --run-ignored all
 ```
+
+---
+
+## Elevated Service Lifecycle Tests
+
+The `ephpm install / start / stop / restart / status / logs / uninstall` subcommands drive the real platform service manager — SCM on Windows, systemd on Linux, launchd on macOS. None of those can be meaningfully mocked, so the tests that cover them mutate real system state and are kept out of every default run.
+
+The single test lives at `crates/ephpm/tests/service_lifecycle.rs` and walks the full lifecycle: install → status (verify pid) → stop → status (verify no pid) → start → restart (verify pid changed) → logs (verify non-empty) → `uninstall --keep-data` → reinstall on preserved data → full uninstall → idempotent re-uninstall.
+
+### Safety gates
+
+The test will only run when **both** gates are satisfied:
+
+1. `#[ignore]` keeps it out of `cargo test` and CI by default.
+2. `EPHPM_ELEVATED_E2E=1` must be set in the environment — even when passing `--ignored`. This is a tripwire against running it by accident on a machine that already cares about its `ephpm` install.
+
+Additionally, the test refuses to run if the canonical install binary already exists at `C:\Program Files\ephpm\ephpm.exe` (Windows) or `/usr/local/bin/ephpm` (Unix). That's almost certainly a production install the developer doesn't want clobbered.
+
+A `Drop` guard runs `ephpm uninstall` on the way out so a panicking test still tears the service down rather than leaving the developer's machine with a stuck SCM entry or systemd unit.
+
+### Running
+
+**Windows** (elevated PowerShell — Administrator):
+
+```powershell
+$env:EPHPM_ELEVATED_E2E="1"
+cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture
+```
+
+**Linux** (needs systemd as PID 1 — Docker containers without systemd skip automatically):
+
+```bash
+sudo EPHPM_ELEVATED_E2E=1 cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture
+```
+
+**macOS**:
+
+```bash
+sudo EPHPM_ELEVATED_E2E=1 cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture
+```
+
+### Writing a new elevated test
+
+If you add another test that needs root / Administrator and mutates system paths, follow the same pattern:
+
+1. **Gate on both `#[ignore]` and the env var.** The env var carries a short reason describing what gets mutated, e.g. `EPHPM_ELEVATED_E2E`. Don't reuse it for a test that touches a different subsystem — define a new gate so a developer running one doesn't accidentally trigger the others.
+2. **Refuse if the canonical paths already exist.** Treat any pre-existing install as "production state, hands off". Abort the test with a clear message — don't try to clean up or coexist.
+3. **Install a `Drop` guard that performs the inverse operation.** Best-effort, swallowing errors — the cleanup is a safety net, not a correctness assertion. `uninstall` already had to be idempotent for the production flow, so the guard composes naturally.
+4. **Don't assert on platform-specific state strings.** `running` (Windows) vs `active` (systemd) vs `loaded` (launchd) all mean the same thing. Assert on the structural fields that ePHPm itself normalizes — the `pid:` line in `status` output is `<numeric>` when the service is up and `-` when it's down, regardless of backend. There's a `pid_from_status` helper in `service_lifecycle.rs` that's worth copying.
+5. **On Linux, skip cleanly when `systemctl` is absent.** WSL without systemd, Docker without systemd, and similar environments are common — let the test print a `SKIP:` message and return rather than failing on a missing binary.
 
 ---
 
@@ -256,6 +307,7 @@ Each job builds ephpm with the specified PHP version, deploys it to a Kind clust
 |------|---------|----------------------|
 | HTTP routing, config, CLI | `cargo build` + `cargo nextest` | None (stub mode) |
 | PHP execution | `cargo xtask release` + `cargo nextest --run-ignored all` | PHP SDK |
+| Service install lifecycle | `EPHPM_ELEVATED_E2E=1 cargo test -p ephpm --test service_lifecycle -- --ignored` | Root/Administrator + real service manager |
 | E2E tests (headless) | `cargo xtask e2e --php-version 8.5` | Kind + Podman/Docker |
 | E2E dev environment | `cargo xtask e2e-up --php-version 8.5` | Kind + Podman/Docker |
 | Tear down E2E | `cargo xtask e2e-down` | — |


### PR DESCRIPTION
## Summary

- Fixes four bugs in the `ephpm install / uninstall / start / stop / restart / status / logs` lifecycle that only surface on real SCM/systemd/launchd backends (the existing unit tests cover the pure functions, not the OS round-trip).
- Adds `crates/ephpm/tests/service_lifecycle.rs` — a cross-platform integration test that walks the full lifecycle against the real platform service manager, double-gated on `#[ignore]` and `EPHPM_ELEVATED_E2E=1`, with a pre-flight refusal if a real install is already present and a `Drop` guard that runs `uninstall` so a panicking test still tears the service down.
- Documents the new test tier in `site/content/developer/testing.md` (new "Elevated Service Lifecycle Tests" section + a "Writing a new elevated test" subsection so future root-level subsystem tests follow the same shape).

## What broke and how it's fixed

| Bug | Fix |
|---|---|
| `uninstall` race: SCM stop is async, so the binary file was still locked when `remove_file` ran | `stop` now polls `query_status` until `Stopped` (30s timeout); binary delete retries for ~3s on `PermissionDenied` |
| `logs` was a dead end on Windows: SCM detaches stdout so the log file never got written | `service_main_inner` sets `EPHPM_SERVICE_LOG_FILE`; `run_serve_sync` routes the main fmt layer through `tracing_appender::rolling::never` when that var is set. Unix backends still rely on systemd's `StandardOutput=append:` and launchd's `StandardOutPath` |
| `uninstall` left the install directory in HKLM `Path` | Added symmetric `remove_from_system_path`. Also fixed a latent parser bug — `splitn(3, char::is_whitespace)` mishandled multi-space `reg query` output so `existing` was always empty (add worked by coincidence; remove was a silent no-op). Replaced with `query_registry_path` helper |
| `uninstall` left empty install dir + log dir + ProgramData parent | Best-effort `remove_dir_all` on the log dir and `remove_dir` on the install / ProgramData parents (the latter only succeeds if empty, so it's safe on shared `/usr/local/bin`) |

## Test plan

- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy -p ephpm --all-targets -- -D warnings` clean
- [x] `cargo test -p ephpm service::` passes (9 existing unit tests)
- [x] Elevated e2e — Windows (real SCM): `test service_full_lifecycle ... ok` (12.4s)
- [x] Elevated e2e — Linux/systemd in WSL Ubuntu 24.04: `test service_full_lifecycle ... ok` (16.1s)
- [ ] Elevated e2e — macOS/launchd: pending on a Mac. Code path is structurally identical to systemd but unverified in this branch.

Reviewers: please run on macOS before merge — `sudo EPHPM_ELEVATED_E2E=1 cargo test -p ephpm --test service_lifecycle -- --ignored --nocapture`. The test refuses to run if `/usr/local/bin/ephpm` already exists, so it won't trample an existing dev install.