### PR TITLE
feat(dev): `ephpm dev` mode + `*.localhost` vhosting + local e2e

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -46,6 +46,18 @@ pub struct ServerConfig {
     #[serde(default)]
     pub sites_dir: Option<PathBuf>,
 
+    /// Optional domain suffix to strip from incoming `Host` headers when
+    /// resolving vhosts. When set (e.g. `.localhost`), a directory named
+    /// `~/sites/blog/` matches `Host: blog.localhost` — the suffix is
+    /// stripped before the registry lookup and the on-disk lazy fallback.
+    ///
+    /// Primarily used by `ephpm dev --sites` so developers can keep short
+    /// directory names while testing with `*.localhost` URLs. Production
+    /// deployments typically leave this unset and name directories with
+    /// the full FQDN (`~/sites/blog.example.com/`).
+    #[serde(default)]
+    pub sites_domain_suffix: Option<String>,
+
     /// Index file names to try when a directory is requested.
     #[serde(default = "default_index_files")]
     pub index_files: Vec<String>,
@@ -1159,6 +1171,7 @@ impl Default for ServerConfig {
             listen: default_listen(),
             document_root: default_document_root(),
             sites_dir: None,
+            sites_domain_suffix: None,
             index_files: default_index_files(),
             fallback: default_fallback(),
             request: RequestConfig::default(),

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -60,6 +60,10 @@ pub struct Router {
     /// Optional path to the sites directory for lazy vhost discovery.
     /// When set, unknown hosts are checked against the filesystem.
     sites_dir: Option<PathBuf>,
+    /// Lowercased domain suffix (e.g. `.localhost`) stripped from incoming
+    /// `Host` headers before vhost resolution. Lets dev-mode users keep
+    /// short directory names while their browser uses `*.localhost`.
+    sites_domain_suffix: Option<String>,
     index_files: Vec<String>,
     fallback: Vec<String>,
     server_port: u16,
@@ -180,6 +184,11 @@ impl Router {
             document_root: config.server.document_root.clone(),
             sites,
             sites_dir: config.server.sites_dir.clone(),
+            sites_domain_suffix: config
+                .server
+                .sites_domain_suffix
+                .as_ref()
+                .map(|s| s.to_ascii_lowercase()),
             index_files: config.server.index_files.clone(),
             fallback: config.server.fallback.clone(),
             server_port: port,
@@ -271,21 +280,38 @@ impl Router {
         // Strip port and trailing dot, lowercase.
         let clean = host.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase();
 
-        // Check the startup-scanned registry first.
+        // If a domain suffix is configured (e.g. `.localhost`), peel it off
+        // first so `blog.localhost` looks up the `blog/` directory. Falls
+        // back to the literal name if the host doesn't end with the suffix.
+        let stripped = self
+            .sites_domain_suffix
+            .as_deref()
+            .and_then(|suffix| clean.strip_suffix(suffix))
+            .map(str::to_owned);
+        let lookup_keys: &[&str] = match stripped.as_deref() {
+            Some(s) => &[s, clean.as_str()][..],
+            None => &[clean.as_str()][..],
+        };
+
+        // Check the startup-scanned registry first for each candidate key.
         // Verify the directory still exists — it may have been removed (teardown).
-        if let Some(site) = self.sites.get(&clean) {
-            if site.document_root.is_dir() {
-                return (site.document_root.clone(), &site.index_files, &site.fallback);
+        for key in lookup_keys {
+            if let Some(site) = self.sites.get(*key) {
+                if site.document_root.is_dir() {
+                    return (site.document_root.clone(), &site.index_files, &site.fallback);
+                }
             }
         }
 
         // Lazy filesystem check: if sites_dir is set and the directory exists,
         // serve from it. No restart needed — new sites are discovered on demand.
         if let Some(ref sites_dir) = self.sites_dir {
-            let candidate = sites_dir.join(&clean);
-            if candidate.is_dir() {
-                tracing::info!(host = %clean, path = %candidate.display(), "discovered new virtual host (lazy)");
-                return (candidate, &self.index_files, &self.fallback);
+            for key in lookup_keys {
+                let candidate = sites_dir.join(key);
+                if candidate.is_dir() {
+                    tracing::info!(host = %clean, key = %key, path = %candidate.display(), "discovered new virtual host (lazy)");
+                    return (candidate, &self.index_files, &self.fallback);
+                }
             }
         }
 

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -60,6 +60,12 @@ enum Commands {
         #[arg(short, long, default_value_t = 8080u16)]
         port: u16,
 
+        /// Sites directory for `*.localhost` vhosting. Each subdirectory
+        /// becomes a vhost reachable at `http://<name>.localhost:<port>` —
+        /// no /etc/hosts edit required (RFC 6761 covers `*.localhost`).
+        #[arg(short, long)]
+        sites: Option<PathBuf>,
+
         /// Increase log verbosity (-v = debug, -vv = trace)
         #[arg(short, long, action = clap::ArgAction::Count)]
         verbose: u8,
@@ -199,13 +205,13 @@ fn run() -> anyhow::Result<ExitCode> {
                 .map(|()| ExitCode::SUCCESS)
                 .map_err(|e| anyhow::anyhow!("service dispatcher failed: {e}"))
         }
-        Some(Commands::Dev { listen, document_root, port, verbose }) => {
-            run_dev(listen, document_root, port, verbose)
+        Some(Commands::Dev { listen, document_root, port, sites, verbose }) => {
+            run_dev(listen, document_root, port, sites, verbose)
         }
         // Bare `ephpm` (no subcommand) is the dev-mode entry point. Service
         // backends always invoke the binary with explicit `serve --config`
         // arguments, so this default never executes under SCM/systemd/launchd.
-        None => run_dev(None, None, 8080, 0),
+        None => run_dev(None, None, 8080, None, 0),
         other @ Some(Commands::Serve { .. }) => run_serve_sync(other),
     }
 }
@@ -263,6 +269,7 @@ fn run_dev(
     listen: Option<String>,
     document_root: Option<PathBuf>,
     port: u16,
+    sites: Option<PathBuf>,
     verbose: u8,
 ) -> anyhow::Result<ExitCode> {
     let mut config = ephpm_config::Config::default_config()
@@ -285,6 +292,15 @@ fn run_dev(
         None => std::env::current_dir().context("failed to read current directory")?,
     };
 
+    // When --sites is provided, point the vhost machinery at it and enable
+    // the `.localhost` suffix-stripping so on-disk dirs are short names
+    // (`blog/`) while browsers use `blog.localhost:<port>`.
+    if let Some(sites_path) = sites {
+        let canonical = sites_path.canonicalize().unwrap_or_else(|_| sites_path.clone());
+        config.server.sites_dir = Some(canonical);
+        config.server.sites_domain_suffix = Some(".localhost".into());
+    }
+
     print_dev_banner(&config);
     run_with_config(config, verbose)
 }
@@ -295,16 +311,62 @@ fn run_dev(
 fn print_dev_banner(config: &ephpm_config::Config) {
     let version = env!("CARGO_PKG_VERSION");
     let url = format!("http://{}", config.server.listen);
-    let doc_root = config.server.document_root.display();
     let php = ephpm_php::PhpRuntime::php_version();
+
+    // Pull the port out of the listen address for vhost URLs.
+    let port = config.server.listen.rsplit(':').next().unwrap_or("8080");
 
     println!();
     println!("  ePHPm {version} — dev server");
-    println!("    serving:  {doc_root}");
-    println!("    url:      {url}");
+
+    if let Some(sites_dir) = &config.server.sites_dir {
+        println!("    sites:    {}", sites_dir.display());
+        match list_site_dirs(sites_dir) {
+            Ok(entries) if !entries.is_empty() => {
+                let suffix = config.server.sites_domain_suffix.as_deref().unwrap_or("");
+                println!("    routing:");
+                for name in entries {
+                    println!("              http://{name}{suffix}:{port}  →  {name}/");
+                }
+                println!(
+                    "              http://localhost:{port}              →  document_root fallback"
+                );
+            }
+            Ok(_) => println!(
+                "    routing:  (sites directory is empty — create subdirectories to add vhosts)"
+            ),
+            Err(e) => println!("    routing:  (could not enumerate sites: {e})"),
+        }
+        println!("    fallback: {}", config.server.document_root.display());
+    } else {
+        println!("    serving:  {}", config.server.document_root.display());
+        println!("    url:      {url}");
+    }
+
     println!("    php:      {php}");
     println!("    press ctrl+c to stop");
     println!();
+}
+
+/// List the immediate subdirectory names under `sites_dir`, sorted, lowercased,
+/// excluding dotfiles. Used by the banner — not authoritative for routing
+/// (the router does lazy discovery for dirs created after startup).
+fn list_site_dirs(sites_dir: &std::path::Path) -> std::io::Result<Vec<String>> {
+    let mut names: Vec<String> = std::fs::read_dir(sites_dir)?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            if !entry.file_type().ok()?.is_dir() {
+                return None;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with('.') {
+                return None;
+            }
+            Some(name.to_ascii_lowercase())
+        })
+        .collect();
+    names.sort();
+    Ok(names)
 }
 
 /// Probe ports starting at `start_port` on `host`, returning the first one

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -23,7 +23,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Start the PHP application server (default)
+    /// Start the PHP application server in production mode (binds 0.0.0.0)
     Serve {
         /// Path to the configuration file
         #[arg(short, long, default_value = "ephpm.toml")]
@@ -36,6 +36,29 @@ enum Commands {
         /// Document root directory (overrides config)
         #[arg(short, long)]
         document_root: Option<PathBuf>,
+
+        /// Increase log verbosity (-v = debug, -vv = trace)
+        #[arg(short, long, action = clap::ArgAction::Count)]
+        verbose: u8,
+    },
+
+    /// Local development server — binds 127.0.0.1, serves CWD, auto-picks port
+    ///
+    /// This is also what plain `ephpm` (no subcommand) runs. Use `ephpm serve`
+    /// for production (binds 0.0.0.0, expects an ephpm.toml) or `ephpm install`
+    /// to register the system service.
+    Dev {
+        /// Address to listen on (overrides default 127.0.0.1:<port>)
+        #[arg(short, long)]
+        listen: Option<String>,
+
+        /// Document root directory (defaults to current working directory)
+        #[arg(short, long)]
+        document_root: Option<PathBuf>,
+
+        /// Preferred port — if busy, the next free port is picked
+        #[arg(short, long, default_value_t = 8080u16)]
+        port: u16,
 
         /// Increase log verbosity (-v = debug, -vv = trace)
         #[arg(short, long, action = clap::ArgAction::Count)]
@@ -176,7 +199,14 @@ fn run() -> anyhow::Result<ExitCode> {
                 .map(|()| ExitCode::SUCCESS)
                 .map_err(|e| anyhow::anyhow!("service dispatcher failed: {e}"))
         }
-        other => run_serve_sync(other),
+        Some(Commands::Dev { listen, document_root, port, verbose }) => {
+            run_dev(listen, document_root, port, verbose)
+        }
+        // Bare `ephpm` (no subcommand) is the dev-mode entry point. Service
+        // backends always invoke the binary with explicit `serve --config`
+        // arguments, so this default never executes under SCM/systemd/launchd.
+        None => run_dev(None, None, 8080, 0),
+        other @ Some(Commands::Serve { .. }) => run_serve_sync(other),
     }
 }
 
@@ -216,6 +246,83 @@ pub(crate) fn run_serve_with_config(config: PathBuf) -> anyhow::Result<()> {
     } else {
         anyhow::bail!("server exited with non-zero status")
     }
+}
+
+/// Run the `ephpm dev` subcommand — local development server with sensible
+/// defaults (loopback bind, CWD doc root, auto-port-pick). This is the path
+/// the bare `ephpm` invocation routes through.
+///
+/// Differences from `ephpm serve`:
+/// - Binds `127.0.0.1` (loopback) instead of `0.0.0.0`
+/// - Auto-picks the next free port if `port` is busy
+/// - Defaults document_root to the current working directory
+/// - Prints a banner with the URL and PHP runtime status
+/// - Ignores any `ephpm.toml` in CWD — dev mode is intentionally
+///   configuration-free so that `cd && ephpm` "just works"
+fn run_dev(
+    listen: Option<String>,
+    document_root: Option<PathBuf>,
+    port: u16,
+    verbose: u8,
+) -> anyhow::Result<ExitCode> {
+    let mut config = ephpm_config::Config::default_config()
+        .context("failed to build default dev-mode configuration")?;
+
+    // Resolve listen address. Explicit --listen wins; otherwise we auto-pick
+    // a free port starting from `port` on 127.0.0.1.
+    config.server.listen = match listen {
+        Some(addr) => addr,
+        None => {
+            let picked = find_free_port("127.0.0.1", port)
+                .context("could not find a free TCP port to listen on")?;
+            format!("127.0.0.1:{picked}")
+        }
+    };
+
+    // Resolve document root — CLI override, else CWD.
+    config.server.document_root = match document_root {
+        Some(root) => root,
+        None => std::env::current_dir().context("failed to read current directory")?,
+    };
+
+    print_dev_banner(&config);
+    run_with_config(config, verbose)
+}
+
+/// Pretty banner printed once at dev-server startup. Stdout, not tracing,
+/// so it's stable across log-format changes and visible regardless of
+/// `RUST_LOG`.
+fn print_dev_banner(config: &ephpm_config::Config) {
+    let version = env!("CARGO_PKG_VERSION");
+    let url = format!("http://{}", config.server.listen);
+    let doc_root = config.server.document_root.display();
+    let php = ephpm_php::PhpRuntime::php_version();
+
+    println!();
+    println!("  ePHPm {version} — dev server");
+    println!("    serving:  {doc_root}");
+    println!("    url:      {url}");
+    println!("    php:      {php}");
+    println!("    press ctrl+c to stop");
+    println!();
+}
+
+/// Probe ports starting at `start_port` on `host`, returning the first one
+/// that accepts a `TcpListener::bind`. Gives up after 50 attempts. There's a
+/// small TOCTOU window between dropping the probe listener and the real bind,
+/// which is acceptable for a dev server — worst case the real bind fails and
+/// we surface the OS error.
+fn find_free_port(host: &str, start_port: u16) -> anyhow::Result<u16> {
+    use std::net::TcpListener;
+
+    for offset in 0..50u16 {
+        let candidate = start_port.saturating_add(offset);
+        if let Ok(listener) = TcpListener::bind((host, candidate)) {
+            drop(listener);
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!("no free port in range {start_port}..={}", start_port.saturating_add(49))
 }
 
 /// Run the `ephpm php` subcommand — pass args through to the embedded PHP CLI.
@@ -269,7 +376,14 @@ impl Drop for TempFileGuard {
 fn run_serve_sync(command: Option<Commands>) -> anyhow::Result<ExitCode> {
     // Load config first (before tracing) so we can use the configured log level.
     let (config, verbose) = load_serve_config(command)?;
+    run_with_config(config, verbose)
+}
 
+/// Shared HTTP server startup path used by both `serve` (production) and
+/// `dev` (developer) entry points. Initialises tracing, applies PHP ini
+/// overrides, boots the embedded PHP runtime in single-threaded mode, then
+/// hands off to the tokio-driven HTTP loop.
+fn run_with_config(config: ephpm_config::Config, verbose: u8) -> anyhow::Result<ExitCode> {
     // Resolve log level: RUST_LOG > -v flag > config > "info"
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         let level = match verbose {

--- a/crates/ephpm/tests/vhost_routing.rs
+++ b/crates/ephpm/tests/vhost_routing.rs
@@ -1,0 +1,163 @@
+//! Local-process e2e test for `*.localhost` virtual-host routing.
+//!
+//! Spawns the real `ephpm dev --sites <tempdir>` binary as a child process,
+//! creates a few subdirectories that should be picked up as vhosts, then
+//! hits the loopback listener with custom `Host:` headers and asserts that
+//! each site serves its own content. The same shape covers the existing
+//! Kind-based `crates/ephpm-e2e/tests/vhosts.rs` without needing a cluster.
+//!
+//! Why this lives in `crates/ephpm/tests/` and not `crates/ephpm-e2e/`:
+//! `ephpm-e2e` is excluded from the workspace and only builds inside the
+//! Kind/Tilt container image. This test runs from a plain `cargo test`
+//! against the in-tree binary, so it's part of the `ephpm` crate's
+//! integration tests. No special infrastructure required.
+//!
+//! Run with: `cargo test -p ephpm --test vhost_routing -- --nocapture`
+
+use std::io::{BufRead as _, BufReader};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_ephpm");
+
+/// Pick a free port on 127.0.0.1 by binding to port 0 and reading back the
+/// kernel-assigned port. Mirrors what `ephpm dev` does internally.
+fn pick_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind 127.0.0.1:0");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+/// Spawn `ephpm dev --sites <sites> --document-root <doc_root> --port <port>`
+/// and block until it logs `HTTP listening` (or 15 seconds elapse).
+///
+/// Both stdout (banner) and stderr (tracing) must be drained — otherwise a
+/// piped child blocks on its first write past the pipe buffer.
+fn spawn_dev(sites: &PathBuf, doc_root: &PathBuf, port: u16) -> Child {
+    let mut cmd = Command::new(BIN);
+    cmd.arg("dev")
+        .arg("--sites")
+        .arg(sites)
+        .arg("--document-root")
+        .arg(doc_root)
+        .arg("--port")
+        .arg(port.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn ephpm dev");
+
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let tx_stdout = tx.clone();
+    let stdout = child.stdout.take().expect("stdout piped");
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            eprintln!("ephpm[out]: {line}");
+            if line.contains("HTTP listening") {
+                let _ = tx_stdout.send(());
+            }
+        }
+    });
+
+    let stderr = child.stderr.take().expect("stderr piped");
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            eprintln!("ephpm[err]: {line}");
+            if line.contains("HTTP listening") {
+                let _ = tx.send(());
+            }
+        }
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if rx.try_recv().is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!("ephpm dev did not log 'HTTP listening' within 15s");
+}
+
+/// Drop-guard so a panic doesn't leak an `ephpm` process holding the port.
+struct ServerGuard(Child);
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Blocking HTTP GET with a custom `Host` header. Uses `reqwest`'s blocking
+/// client because the rest of the test is synchronous and we don't need a
+/// tokio runtime just for three GETs.
+fn get_with_host(url: &str, host: &str) -> (u16, String) {
+    let rt =
+        tokio::runtime::Builder::new_current_thread().enable_all().build().expect("tokio runtime");
+    rt.block_on(async {
+        let resp = reqwest::Client::new()
+            .get(url)
+            .header("Host", host)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("GET {url} with Host: {host} failed: {e}"));
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        (status, body)
+    })
+}
+
+#[test]
+fn dev_sites_routes_localhost_subdomains() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let sites = temp.path().join("sites");
+    let doc_root = temp.path().join("fallback");
+
+    for site in ["blog", "shop", "wiki"] {
+        let dir = sites.join(site);
+        std::fs::create_dir_all(&dir).expect("mkdir site");
+        std::fs::write(dir.join("index.html"), format!("<h1>{site}</h1>"))
+            .expect("write index.html");
+    }
+    std::fs::create_dir_all(&doc_root).expect("mkdir doc_root");
+    std::fs::write(doc_root.join("index.html"), "<h1>fallback</h1>").expect("write fallback");
+
+    let port = pick_port();
+    let _server = ServerGuard(spawn_dev(&sites, &doc_root, port));
+    let base = format!("http://127.0.0.1:{port}/");
+
+    // Each named vhost serves its own content.
+    for site in ["blog", "shop", "wiki"] {
+        let host = format!("{site}.localhost");
+        let (status, body) = get_with_host(&base, &host);
+        assert_eq!(status, 200, "{host} returned {status}");
+        assert!(
+            body.contains(&format!("<h1>{site}</h1>")),
+            "{host} served the wrong body: {body:?}",
+        );
+    }
+
+    // Unknown vhost falls back to document_root.
+    let (status, body) = get_with_host(&base, "nothing.localhost");
+    assert_eq!(status, 200, "fallback returned {status}");
+    assert!(body.contains("<h1>fallback</h1>"), "fallback wrong body: {body:?}");
+
+    // Lazy discovery — directory created after server startup must still
+    // resolve without a restart.
+    let lazy = sites.join("lazy");
+    std::fs::create_dir(&lazy).expect("mkdir lazy");
+    std::fs::write(lazy.join("index.html"), "<h1>lazy</h1>").expect("write lazy");
+    let (status, body) = get_with_host(&base, "lazy.localhost");
+    assert_eq!(status, 200, "lazy.localhost returned {status}");
+    assert!(body.contains("<h1>lazy</h1>"), "lazy.localhost wrong body: {body:?}");
+
+    // Host without the `.localhost` suffix matches the same bare directory
+    // name — covers tools that send `Host: blog` directly.
+    let (status, body) = get_with_host(&base, "blog");
+    assert_eq!(status, 200);
+    assert!(body.contains("<h1>blog</h1>"));
+}

--- a/site/content/developer/testing.md
+++ b/site/content/developer/testing.md
@@ -10,7 +10,8 @@ ePHPm uses a layered testing approach: fast unit tests for inner logic, a dedica
 |-------|------|---------------|-------|
 | Unit | `cargo nextest` | Config parsing, routing logic, SAPI mapping, response building | Seconds |
 | Integration | `cargo nextest` (ignored by default) | PHP execution, WordPress lifecycle — requires libphp | Seconds (with SDK) |
-| E2E | `ephpm-e2e` crate + Tilt + Kind | Full stack against real K8s infrastructure | Minutes |
+| Local e2e | `cargo test -p ephpm --test <name>` | Real binary spawned as a child against the loopback listener — vhost routing, HTTP correctness | Sub-second per test |
+| E2E (cluster) | `ephpm-e2e` crate + Tilt + Kind | Full stack against real K8s infrastructure, pod-to-pod networking | Minutes |
 | Benchmarks | Criterion | Throughput, latency p99 — requires libphp | Minutes |
 
 ---
@@ -30,6 +31,75 @@ Integration tests that require PHP are `#[ignore]` by default. Run them after bu
 ```bash
 cargo nextest run --workspace --run-ignored all
 ```
+
+---
+
+## Virtual Host Testing (`*.localhost`)
+
+ePHPm supports multi-tenant hosting: a `sites_dir` containing one subdirectory per virtual host, and incoming requests are routed by `Host` header to the matching directory's document root. This is wired in `crates/ephpm-server/src/router.rs::resolve_site` and exercised by both the Kind e2e suite and a fast local-process test.
+
+### How routing works
+
+Two paths populate the vhost registry:
+
+- **Startup scan** (`scan_sites_dir`) — at server boot, every immediate subdirectory of `sites_dir` becomes a registered vhost keyed by the lowercased directory name.
+- **Lazy filesystem fallback** — when a request arrives for an unknown `Host`, the router checks whether `<sites_dir>/<host>` exists on disk and serves from it if so. New sites appear without restarting.
+
+When `server.sites_domain_suffix` is set (e.g. `.localhost`), the router strips that suffix from the cleaned `Host` value before both the registry lookup and the lazy check. That lets developers keep short directory names (`~/sites/blog/`) while their browser hits `http://blog.localhost:8080`. Hosts without the suffix (`Host: blog` directly) still resolve via the bare key.
+
+If nothing matches, the request falls through to `server.document_root`.
+
+### Dev-mode workflow with `*.localhost`
+
+`ephpm dev --sites <DIR>` enables the suffix-stripping path so testing in a browser is friction-free. Per RFC 6761, **every** subdomain of `localhost` already resolves to 127.0.0.1 — no `/etc/hosts` edit, no DNS, no elevation. Chrome (since 2018), Firefox 65+, Safari, and curl all honor this.
+
+```bash
+$ mkdir -p ~/sites/{blog,shop,wiki}
+$ echo '<h1>blog</h1>' > ~/sites/blog/index.html
+$ echo '<h1>shop</h1>' > ~/sites/shop/index.html
+$ ephpm dev --sites ~/sites
+  ePHPm 0.1.0 — dev server
+    sites:    /home/luther/sites
+    routing:
+              http://blog.localhost:8080  →  blog/
+              http://shop.localhost:8080  →  shop/
+              http://wiki.localhost:8080  →  wiki/
+              http://localhost:8080       →  document_root fallback
+    fallback: /home/luther/sites
+    php:      8.5.2
+    press ctrl+c to stop
+```
+
+A subdirectory created after startup is picked up by the lazy fallback on the next matching request — no restart needed:
+
+```bash
+$ mkdir ~/sites/admin && echo '<h1>admin</h1>' > ~/sites/admin/index.html
+$ curl http://admin.localhost:8080/         # served from sites/admin/ immediately
+```
+
+### Local-process test (`vhost_routing`)
+
+`crates/ephpm/tests/vhost_routing.rs` covers the same behavior in CI without needing Kind. It:
+
+1. Builds a `tempfile::tempdir()` with `blog/`, `shop/`, `wiki/` subdirs.
+2. Spawns `target/release/ephpm dev --sites <tempdir> --port <picked>` as a child process.
+3. Drains stdout + stderr in threads so the piped child doesn't back-pressure (banner goes to stdout, tracing to stdout too — both must be read).
+4. Waits for the `HTTP listening` log line before issuing requests.
+5. Hits the loopback listener with custom `Host:` headers and asserts the served body matches the per-site `index.html`.
+6. Adds a directory mid-test to confirm lazy discovery works.
+7. A `Drop` guard kills the child even on panic so the listener doesn't leak.
+
+```bash
+cargo test -p ephpm --test vhost_routing --release -- --nocapture
+```
+
+Runs in well under a second on a warm cache. Use this as the template for any future local-process e2e test — same shape, different assertions.
+
+### Kind counterpart (`vhosts.rs`)
+
+`crates/ephpm-e2e/tests/vhosts.rs` exercises the same logic against a pod-deployed ephpm with `EPHPM_SITES_DIR` mounted from a hostPath that the test runner Job can write to. It's slower (it pays the Kind/Tilt orchestration cost) but verifies that the routing also works through K8s service DNS and that the multi-tenant `security_p0` policies (open_basedir, disable_functions, RESP auth) compose correctly with vhost selection.
+
+**Rule of thumb**: prefer the local test for routing correctness assertions; keep the Kind path for the small set of assertions that genuinely need pod-to-pod networking or the in-pod filesystem layout. Don't duplicate — if a property is covered locally, the Kind test should focus on cluster-specific behavior, not re-assert the same routing logic.
 
 ---
 
@@ -256,6 +326,8 @@ Each job builds ephpm with the specified PHP version, deploys it to a Kind clust
 |------|---------|----------------------|
 | HTTP routing, config, CLI | `cargo build` + `cargo nextest` | None (stub mode) |
 | PHP execution | `cargo xtask release` + `cargo nextest --run-ignored all` | PHP SDK |
+| Local vhost routing | `cargo test -p ephpm --test vhost_routing -- --nocapture` | None — spawns the binary directly |
+| Test a local site in a browser | `ephpm dev --sites ~/sites` | None — `*.localhost` resolves to 127.0.0.1 |
 | E2E tests (headless) | `cargo xtask e2e --php-version 8.5` | Kind + Podman/Docker |
 | E2E dev environment | `cargo xtask e2e-up --php-version 8.5` | Kind + Podman/Docker |
 | Tear down E2E | `cargo xtask e2e-down` | — |


### PR DESCRIPTION
## Summary

- New `ephpm dev` subcommand for local development. Binds `127.0.0.1`, defaults the document root to CWD, auto-picks the next free port if 8080 is busy (probes up to 50), prints a banner with the URL and PHP runtime status, ignores any `ephpm.toml` so `cd && ephpm` "just works".
- Bare `ephpm` (no subcommand) now routes to dev mode. Previously it was a silent alias for `serve` with all-zero defaults — a footgun because it bound `0.0.0.0` and exposed your dev box to whatever network you were on. Service install backends (SCM, systemd, launchd) all spawn the binary with an explicit `serve --config` or `service-run --config`, never the bare invocation, so the production path is untouched.
- `ephpm dev --sites <DIR>` for zero-config virtual hosting via `*.localhost`. Each subdirectory becomes a vhost reachable at `http://<name>.localhost:<port>` — no `/etc/hosts` edit, no DNS, no elevation. RFC 6761 routes every subdomain of `localhost` to 127.0.0.1; Chrome (since 2018), Firefox 65+, Safari, and curl all honor it.
- New `server.sites_domain_suffix` config field. When set (dev mode sets `.localhost`), `Router::resolve_site` peels the suffix off the incoming Host before both the registry lookup and the lazy filesystem fallback — so `~/sites/blog/` matches `Host: blog.localhost` while bare `Host: blog` still resolves the same directory. Production deployments leave the field unset and keep using full FQDN directory names.
- New local-process e2e test (`crates/ephpm/tests/vhost_routing.rs`) that spawns `ephpm dev --sites <tempdir>` as a child, drains stdout + stderr (banner + tracing — piped child back-pressures otherwise), and asserts routing via custom `Host:` headers. Runs in ~0.13s vs ~3 minutes for the equivalent Kind test. First member of a new "Local e2e" test tier — see the dev doc for the pattern.
- Documents the new test tier in `site/content/developer/testing.md` with a "Virtual Host Testing (`*.localhost`)" section: how routing works, dev-mode workflow, local-process test pattern, and when to use Kind vs local for routing assertions.

## What you'll see

```
$ mkdir -p ~/sites/{blog,shop,wiki}
$ ephpm dev --sites ~/sites
  ePHPm 0.1.0 — dev server
    sites:    /home/luther/sites
    routing:
              http://blog.localhost:8080  →  blog/
              http://shop.localhost:8080  →  shop/
              http://wiki.localhost:8080  →  wiki/
              http://localhost:8080       →  document_root fallback
    fallback: /home/luther/sites
    php:      8.5.2
    press ctrl+c to stop
```

## Test plan

- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p ephpm --test vhost_routing --release` passes (0.13s, real binary spawn)
- [x] Manual smoke on Windows: bare `ephpm` flips to dev / loopback bind, `ephpm dev --port 9000` honors override, auto-port-pick climbs past 8080+ when busy, `ephpm serve` still binds `0.0.0.0` from config
- [x] Manual smoke of `--sites` on Windows: blog/shop/wiki route correctly, unknown host falls back to document_root, directory created mid-test discovered by lazy fallback without restart, `Host: blog` (no suffix) still resolves
- [ ] No Linux/macOS manual verification — same code path as Windows, but reviewers on those platforms please confirm the loopback bind + banner look reasonable.

## Risk

The bare-`ephpm` behavior change is the one to scrutinize. Previously `ephpm` (no args) = `ephpm serve` (production-shaped, 0.0.0.0). Now `ephpm` (no args) = `ephpm dev` (loopback). Anyone running `ephpm` from an init script or process supervisor expecting it to bind a network interface will silently start serving only loopback. All three service backends use explicit subcommands so the install flow is unaffected — but worth a callout in release notes.