### PR TITLE
fix(ephpm-php): force libz whole-archive to resolve gz* in test builds

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -75,6 +75,21 @@ fn link_php(lib_dir: &Path, target_os: &str) {
 
     // Link additional static libraries from the SDK that static-php-cli
     // built. We probe for each library since the set varies by config.
+    //
+    // `libz` is emitted with `+whole-archive` because both libphp's
+    // `zlib_fopen_wrapper.o` and libxml2's `xmlIO.c.o` reference gz*
+    // symbols. Single-pass ld resolves the first set of refs from libz,
+    // then won't re-scan libz for the second set — so debug test builds
+    // fail with `undefined reference to gzread / gzwrite / gzclose / ...`.
+    // (The release build's `--gc-sections` masks this by stripping the
+    // unused PHP zlib wrapper.) `whole-archive` forces every object from
+    // libz into the link output, so all gz* symbols are present regardless
+    // of who references them or when.
+    //
+    // This is the modern rustc-blessed alternative to wrapping the lib
+    // group in `-Wl,--start-group`/`--end-group`, which can't be emitted
+    // from a library crate's build.rs (rustc-link-arg only applies to
+    // binary/cdylib targets).
     println!("cargo::warning=probing for static support libs in {}", lib_dir.display());
     for static_lib in &[
         "ssl", "crypto", "curl", "z", "xml2", "sodium", "iconv", "charset", "png16", "gd", "jpeg",
@@ -89,7 +104,11 @@ fn link_php(lib_dir: &Path, target_os: &str) {
             unix_path.display()
         );
         if found {
-            println!("cargo::rustc-link-lib=static={static_lib}");
+            if *static_lib == "z" {
+                println!("cargo::rustc-link-lib=static:+whole-archive={static_lib}");
+            } else {
+                println!("cargo::rustc-link-lib=static={static_lib}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Stacked on top of #39. The shadowing fix in #39 unblocks the `sessions` test compile; this PR fixes the next failure — a linker error when test binaries link the ephpm-php crate against the musl PHP SDK.

Both libphp's `zlib_fopen_wrapper.o` and libxml2's `xmlIO.c.o` reference `gz*` symbols. With the default single-pass link, ld resolves libphp's refs from libz, then drops libz before xml2's refs arrive — leaving them undefined:

```
undefined reference to gzread / gzwrite / gzclose / gzdopen / gzeof / gzflush / gzdirect
```

The release build masks this via `--gc-sections` (the unused PHP zlib wrapper gets stripped pre-link). Debug test builds keep everything → linker fails.

`static:+whole-archive=z` forces every object from libz into the output, so all `gz*` symbols are present regardless of who references them or when.

## Why not `-Wl,--start-group`/`--end-group`?

That was the original plan, but `cargo::rustc-link-arg` only applies to binary/cdylib targets, not library crates — so it can't be emitted from `ephpm-php`'s build.rs. The `whole-archive` link-lib modifier is the rustc-blessed equivalent for static libs.

## Why only `z`?

The error log only references `gz*` symbols. Other libs (ssl, crypto, xml2, etc.) appear to resolve in the default order. If similar errors surface for another lib later (e.g. `undefined reference to xml*`), this same pattern extends — add another arm to the `if *static_lib == "z"` branch.

## Test plan

- [ ] Trigger Nightly against this branch (`fix/ephpm-php-link-order`) — Linux 8.4 & 8.5 builds should get past `Run ignored integration tests`.
- [ ] Confirm the release build path remains unchanged (no perf/size regression — `whole-archive` only affects the test binary link since release strips via `--gc-sections`).