### PR TITLE
ci: switch CI runner image to Alpine for native musl toolchain

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,13 +36,16 @@ jobs:
         # cargo xtask release already populated php-sdk/<ver>-linux-x86_64.
         # Discover its absolute path and reuse it for the test build.
         #
-        # No --target flag needed: the CI image is Alpine, so the host
-        # target is already x86_64-unknown-linux-musl. libphp.a (also
-        # musl-built) links natively without cross-compile gymnastics.
+        # --target is the same as the host (Alpine = native musl), but it
+        # must be explicit so cargo applies the [host] config block from
+        # the CI image (build scripts dynamic-link → bindgen can dlopen
+        # libclang; target binaries stay statically linked).
         run: |
           PHP_SDK_PATH=$(find "$(pwd)/php-sdk" -mindepth 1 -maxdepth 1 -type d -name '*-linux-x86_64' | head -1)
           test -n "$PHP_SDK_PATH" || { echo "::error::PHP SDK not found"; exit 1; }
-          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run --workspace --run-ignored ignored-only
+          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run \
+            --target x86_64-unknown-linux-musl \
+            --workspace --run-ignored ignored-only
 
       - name: Verify binary
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,10 +35,18 @@ jobs:
       - name: Run ignored integration tests
         # cargo xtask release already populated php-sdk/<ver>-linux-x86_64.
         # Discover its absolute path and reuse it for the test build.
+        #
+        # --target is the same as the host (Alpine = native musl) but it
+        # must be explicit so cargo applies the [target.x86_64-unknown-
+        # linux-musl] rustflags from $CARGO_HOME/config.toml: the final
+        # test binary gets +crt-static while build scripts only get the
+        # global -crt-static (so they can dlopen libclang for bindgen).
         run: |
           PHP_SDK_PATH=$(find "$(pwd)/php-sdk" -mindepth 1 -maxdepth 1 -type d -name '*-linux-x86_64' | head -1)
           test -n "$PHP_SDK_PATH" || { echo "::error::PHP SDK not found"; exit 1; }
-          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run --workspace --run-ignored ignored-only
+          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run \
+            --target x86_64-unknown-linux-musl \
+            --workspace --run-ignored ignored-only
 
       - name: Verify binary
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,16 +36,13 @@ jobs:
         # cargo xtask release already populated php-sdk/<ver>-linux-x86_64.
         # Discover its absolute path and reuse it for the test build.
         #
-        # --target musl matches the release build. libphp.a is musl-linked,
-        # so test binaries must link against musl too — building for the
-        # default glibc target produces "undefined symbol: sigsetjmp / gz* /
-        # issetugid / __flt_rounds" linker errors when libphp gets pulled in.
+        # No --target flag needed: the CI image is Alpine, so the host
+        # target is already x86_64-unknown-linux-musl. libphp.a (also
+        # musl-built) links natively without cross-compile gymnastics.
         run: |
           PHP_SDK_PATH=$(find "$(pwd)/php-sdk" -mindepth 1 -maxdepth 1 -type d -name '*-linux-x86_64' | head -1)
           test -n "$PHP_SDK_PATH" || { echo "::error::PHP SDK not found"; exit 1; }
-          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run \
-            --target x86_64-unknown-linux-musl \
-            --workspace --run-ignored ignored-only
+          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run --workspace --run-ignored ignored-only
 
       - name: Verify binary
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,17 +35,10 @@ jobs:
       - name: Run ignored integration tests
         # cargo xtask release already populated php-sdk/<ver>-linux-x86_64.
         # Discover its absolute path and reuse it for the test build.
-        #
-        # --target is the same as the host (Alpine = native musl), but it
-        # must be explicit so cargo applies the [host] config block from
-        # the CI image (build scripts dynamic-link → bindgen can dlopen
-        # libclang; target binaries stay statically linked).
         run: |
           PHP_SDK_PATH=$(find "$(pwd)/php-sdk" -mindepth 1 -maxdepth 1 -type d -name '*-linux-x86_64' | head -1)
           test -n "$PHP_SDK_PATH" || { echo "::error::PHP SDK not found"; exit 1; }
-          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run \
-            --target x86_64-unknown-linux-musl \
-            --workspace --run-ignored ignored-only
+          PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run --workspace --run-ignored ignored-only
 
       - name: Verify binary
         run: |

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -15,7 +15,15 @@ thiserror.workspace = true
 http.workspace = true
 
 [build-dependencies]
-bindgen = "0.71"
+# Disable bindgen's default `runtime` feature (which makes clang-sys dlopen
+# libclang via libloading) and enable `static` instead. Alpine's fully-
+# static musl build scripts can't dlopen shared libs at all — the runtime
+# load panics with "Dynamic loading not supported". With `static`,
+# clang-sys links libclang.a + LLVM static archives directly into the
+# build script binary, so no dlopen is needed. Alpine packages
+# clang-static and llvm17-static (installed in the CI image) provide
+# the required archives.
+bindgen = { version = "0.71", default-features = false, features = ["logging", "prettyplease", "static", "which-rustfmt"] }
 cc = "1"
 
 [dev-dependencies]

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -15,15 +15,7 @@ thiserror.workspace = true
 http.workspace = true
 
 [build-dependencies]
-# Disable bindgen's default `runtime` feature (which makes clang-sys dlopen
-# libclang via libloading) and enable `static` instead. Alpine's fully-
-# static musl build scripts can't dlopen shared libs at all — the runtime
-# load panics with "Dynamic loading not supported". With `static`,
-# clang-sys links libclang.a + LLVM static archives directly into the
-# build script binary, so no dlopen is needed. Alpine packages
-# clang-static and llvm17-static (installed in the CI image) provide
-# the required archives.
-bindgen = { version = "0.71", default-features = false, features = ["logging", "prettyplease", "static", "which-rustfmt"] }
+bindgen = "0.71"
 cc = "1"
 
 [dev-dependencies]

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -352,6 +352,9 @@ fn find_clang_resource_include() -> Option<PathBuf> {
 /// directory to the linker search path so `-lgcc` resolves.
 fn find_musl_libgcc() -> Option<PathBuf> {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".into());
+    // Alpine's native musl toolchain uses an `-alpine-` infix in the triple:
+    //   /usr/lib/gcc/x86_64-alpine-linux-musl/<ver>/libgcc.a
+    let alpine_triple = format!("{arch}-alpine-linux-musl");
     let musl_triple = format!("{arch}-linux-musl");
     // On Ubuntu/Debian, `musl-tools` provides a `musl-gcc` wrapper around the
     // host GCC. The symbols PHP's JIT needs (__cpu_indicator_init, __cpu_model)
@@ -359,9 +362,11 @@ fn find_musl_libgcc() -> Option<PathBuf> {
     let gnu_triple = format!("{arch}-linux-gnu");
 
     // Common locations where musl-cross or host toolchains install libgcc.a:
+    //   /usr/lib/gcc/<alpine-triple>/<ver>/libgcc.a (Alpine native musl)
     //   /usr/lib/gcc/<musl-triple>/<ver>/libgcc.a   (musl cross-compiler)
     //   /usr/lib/gcc/<gnu-triple>/<ver>/libgcc.a    (host GCC via musl-tools wrapper)
     let search_roots = [
+        PathBuf::from(format!("/usr/lib/gcc/{alpine_triple}")),
         PathBuf::from(format!("/usr/lib/gcc/{musl_triple}")),
         PathBuf::from(format!("/usr/lib/gcc/{gnu_triple}")),
     ];

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -1,43 +1,52 @@
 # CI runner image with the build toolchain pre-installed.
 #
-# Includes: Rust stable, musl cross-compiler, libclang, and basic build
-# essentials. The PHP SDK itself is downloaded on demand by
-# `cargo xtask release` (a tarball from github.com/ephpm/php-sdk releases).
+# Alpine-based for native musl. The PHP SDK is also built on Alpine (via
+# static-php-cli), so its musl-linked static archives (libphp.a, libz.a,
+# libssl.a, ...) link cleanly here without any glibc↔musl impedance
+# mismatch — which is the class of bug the Ubuntu+musl-tools cross-build
+# kept producing (undefined references to gz*, sigsetjmp, issetugid, etc.).
+#
+# Includes: Rust stable + nightly (fmt only), clang/libclang (bindgen),
+# openssl headers, and basic build tools. The PHP SDK itself is downloaded
+# on demand by `cargo xtask release` (a tarball from github.com/ephpm/php-sdk
+# releases).
 #
 # Build:
-#   docker build -f docker/Dockerfile.gha -t ghcr.io/<owner>/ephpm-ci:latest .
+#   docker build -f docker/Dockerfile.gha -t ephpm/ephpm-ci:latest .
 #
 # Usage in GitHub Actions:
 #   jobs:
 #     build:
-#       container: ghcr.io/<owner>/ephpm-ci:latest
+#       container: ephpm/ephpm-ci:latest
 
-FROM ubuntu:24.04
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM alpine:3.20
 
 # ── System build tools ───────────────────────────────────────────────────────
 #
-#   - musl-tools/musl-dev: musl-gcc cross-compiler for the prebuilt PHP SDK
-#     (libphp.a is musl-linked).
-#   - libclang-dev: bindgen needs libclang.
-#   - libssl-dev: the workspace test build (`cargo nextest run --workspace`)
-#     pulls a dev-dependency that links openssl-sys, which needs system
-#     OpenSSL headers + openssl.pc. The musl release build doesn't, but the
-#     native test build does.
-#   - tar/curl: SDK + sqld tarball downloads at build time.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git pkg-config tar \
-    libclang-dev libssl-dev musl-tools musl-dev \
-    && rm -rf /var/lib/apt/lists/*
+#   - build-base: musl gcc, libc-dev (musl), make, binutils. Host toolchain
+#     is native musl — no separate cross-compiler needed.
+#   - clang + clang-dev + clang-libs: libclang.so for bindgen and the clang
+#     binary itself (build.rs invokes `clang --print-resource-dir` to find
+#     compiler-internal headers for the bindgen pass).
+#   - openssl-dev: needed by the workspace test build's openssl-sys
+#     transitive (release build uses the PHP SDK's bundled libssl.a; this
+#     covers test deps like reqwest's TLS path on architectures where the
+#     bundled archive isn't used).
+#   - linux-headers: some C code in PHP-adjacent crates expects them.
+#   - bash: rustup-init's installer uses it.
+RUN apk add --no-cache \
+    bash build-base ca-certificates clang clang-dev clang-libs \
+    curl git linux-headers openssl-dev pkgconfig tar
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────
 #
 # The stable component set MUST be a superset of rust-toolchain.toml's
-# `components` (rustfmt, clippy, llvm-tools-preview). If any are missing,
-# rustup triggers a channel sync on first `cargo` invocation in the repo —
-# and that sync's atomic component rename fails EXDEV on the CI runner's
-# overlay (rustup tmp/ and toolchains/ land on different devices).
+# `components` (rustfmt, clippy, llvm-tools-preview). Otherwise the first
+# `cargo` invocation in the repo triggers a channel sync, which can fail
+# EXDEV on overlay filesystems.
+#
+# No `rustup target add x86_64-unknown-linux-musl` — the host IS musl, so
+# the default target is already what we want.
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -47,12 +56,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --profile minimal \
         --component rustfmt,clippy,llvm-tools-preview \
     && rustup toolchain install nightly --component rustfmt \
-    && rustup target add x86_64-unknown-linux-musl \
     && cargo install cargo-nextest --locked \
     && rm -rf /usr/local/cargo/registry
-
-ENV CC_x86_64_unknown_linux_musl=musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
 
 WORKDIR /src

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -36,9 +36,16 @@ FROM alpine:3.20
 #   - bash: rustup-init's installer uses it.
 #   - xz: the sqld release tarball is .tar.xz (cargo xtask release pulls
 #     it via tar -xJf). Not in Alpine's base image.
+#   - clang-static + llvm17-static: static libclang + LLVM archives.
+#     Required so clang-sys (used by bindgen) can statically link
+#     libclang into the build.rs binary instead of dlopen'ing it at
+#     runtime. Alpine's default musl static-linked binaries can't
+#     dlopen shared libs ("Dynamic loading not supported"), so any
+#     bindgen-using build.rs would otherwise panic at runtime.
+#     LIBCLANG_STATIC=1 (set below) is the env var clang-sys checks.
 RUN apk add --no-cache \
-    bash build-base ca-certificates clang clang-dev clang-libs \
-    curl git linux-headers openssl-dev pkgconfig tar xz
+    bash build-base ca-certificates clang clang-dev clang-libs clang-static \
+    curl git linux-headers llvm17-static openssl-dev pkgconfig tar xz
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────
 #
@@ -61,28 +68,18 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     && cargo install cargo-nextest --locked \
     && rm -rf /usr/local/cargo/registry
 
-# ── Cargo host config: dynamic-link build scripts ────────────────────────────
+# ── bindgen via static libclang ──────────────────────────────────────────────
 #
-# On Alpine (musl host), rustc defaults to fully-static binaries with
-# crt-static on. Statically linked binaries can't dlopen() shared libs —
-# which breaks bindgen's runtime libclang load:
-#   "the libclang shared library [...] could not be opened:
-#    Dynamic loading not supported"
+# Alpine's musl-static binaries can't dlopen() shared libs, which breaks
+# bindgen's runtime libclang load. clang-sys (the crate bindgen uses to
+# locate libclang) honors LIBCLANG_STATIC=1 to opt into static linking
+# instead — the libclang.a from `clang-static` (apk above) gets baked
+# into the build.rs binary, eliminating the dlopen need.
 #
-# Switching crt-static off globally would also make the final ephpm
-# binary dynamically linked to musl, defeating the single-binary
-# portability that's the point of ephpm.
-#
-# The `[host]` config block only applies to *host*-tier compilation
-# (build scripts, proc macros), and only when `--target` is explicit
-# (so cargo distinguishes "host" from "target"). The final --target
-# build of ephpm still goes through the default (static) linking.
-#
-# `cargo xtask release` already passes `--target x86_64-unknown-linux-musl`,
-# and the nightly's integration-test step does too. Both engage the split.
-RUN printf '%s\n' \
-    '[host]' \
-    'rustflags = ["-C", "target-feature=-crt-static"]' \
-    > $CARGO_HOME/config.toml
+# LLVM_CONFIG_PATH points clang-sys at Alpine's llvm17 install so it
+# picks up the matching static archives (avoids version mismatch with
+# any other LLVM that happens to be on PATH).
+ENV LIBCLANG_STATIC=1 \
+    LLVM_CONFIG_PATH=/usr/lib/llvm17/bin/llvm-config
 
 WORKDIR /src

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -36,16 +36,9 @@ FROM alpine:3.20
 #   - bash: rustup-init's installer uses it.
 #   - xz: the sqld release tarball is .tar.xz (cargo xtask release pulls
 #     it via tar -xJf). Not in Alpine's base image.
-#   - clang-static + llvm17-static: static libclang + LLVM archives.
-#     Required so clang-sys (used by bindgen) can statically link
-#     libclang into the build.rs binary instead of dlopen'ing it at
-#     runtime. Alpine's default musl static-linked binaries can't
-#     dlopen shared libs ("Dynamic loading not supported"), so any
-#     bindgen-using build.rs would otherwise panic at runtime.
-#     LIBCLANG_STATIC=1 (set below) is the env var clang-sys checks.
 RUN apk add --no-cache \
-    bash build-base ca-certificates clang clang-dev clang-libs clang-static \
-    curl git linux-headers llvm17-static openssl-dev pkgconfig tar xz
+    bash build-base ca-certificates clang clang-dev clang-libs \
+    curl git linux-headers openssl-dev pkgconfig tar xz
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────
 #
@@ -68,18 +61,32 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     && cargo install cargo-nextest --locked \
     && rm -rf /usr/local/cargo/registry
 
-# ── bindgen via static libclang ──────────────────────────────────────────────
+# ── Dynamic-link build scripts, keep target binaries static ─────────────────
 #
-# Alpine's musl-static binaries can't dlopen() shared libs, which breaks
-# bindgen's runtime libclang load. clang-sys (the crate bindgen uses to
-# locate libclang) honors LIBCLANG_STATIC=1 to opt into static linking
-# instead — the libclang.a from `clang-static` (apk above) gets baked
-# into the build.rs binary, eliminating the dlopen need.
+# Alpine's musl rustc defaults to fully-static binaries (crt-static on).
+# Statically linked binaries can't dlopen() shared libs — which breaks
+# bindgen's libclang load from build.rs: "could not be opened: Dynamic
+# loading not supported".
 #
-# LLVM_CONFIG_PATH points clang-sys at Alpine's llvm17 install so it
-# picks up the matching static archives (avoids version mismatch with
-# any other LLVM that happens to be on PATH).
-ENV LIBCLANG_STATIC=1 \
-    LLVM_CONFIG_PATH=/usr/lib/llvm17/bin/llvm-config
+# Stable-cargo solution that keeps the final ephpm binary fully static:
+#
+#   - Global RUSTFLAGS turns crt-static OFF. This applies to host-tier
+#     compilation (build scripts, proc macros), making them dynamically
+#     linked against musl libc — they can dlopen libclang.so.
+#   - The cargo config below re-enables crt-static ONLY for the
+#     x86_64-unknown-linux-musl target. rustc's -C target-feature flags
+#     accumulate left-to-right with last-wins semantics, so the explicit
+#     `+crt-static` overrides the global `-crt-static` for the final
+#     ephpm release binary — keeping the single-binary portability that
+#     was the whole point of going Alpine.
+#
+# Requires --target to be passed explicitly (cargo xtask release already
+# does; nightly.yml's integration-test step does too).
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+RUN printf '%s\n' \
+    '[target.x86_64-unknown-linux-musl]' \
+    'rustflags = ["-C", "target-feature=+crt-static"]' \
+    > $CARGO_HOME/config.toml
 
 WORKDIR /src

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -34,9 +34,11 @@ FROM alpine:3.20
 #     bundled archive isn't used).
 #   - linux-headers: some C code in PHP-adjacent crates expects them.
 #   - bash: rustup-init's installer uses it.
+#   - xz: the sqld release tarball is .tar.xz (cargo xtask release pulls
+#     it via tar -xJf). Not in Alpine's base image.
 RUN apk add --no-cache \
     bash build-base ca-certificates clang clang-dev clang-libs \
-    curl git linux-headers openssl-dev pkgconfig tar
+    curl git linux-headers openssl-dev pkgconfig tar xz
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────
 #
@@ -58,5 +60,29 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     && rustup toolchain install nightly --component rustfmt \
     && cargo install cargo-nextest --locked \
     && rm -rf /usr/local/cargo/registry
+
+# ── Cargo host config: dynamic-link build scripts ────────────────────────────
+#
+# On Alpine (musl host), rustc defaults to fully-static binaries with
+# crt-static on. Statically linked binaries can't dlopen() shared libs —
+# which breaks bindgen's runtime libclang load:
+#   "the libclang shared library [...] could not be opened:
+#    Dynamic loading not supported"
+#
+# Switching crt-static off globally would also make the final ephpm
+# binary dynamically linked to musl, defeating the single-binary
+# portability that's the point of ephpm.
+#
+# The `[host]` config block only applies to *host*-tier compilation
+# (build scripts, proc macros), and only when `--target` is explicit
+# (so cargo distinguishes "host" from "target"). The final --target
+# build of ephpm still goes through the default (static) linking.
+#
+# `cargo xtask release` already passes `--target x86_64-unknown-linux-musl`,
+# and the nightly's integration-test step does too. Both engage the split.
+RUN printf '%s\n' \
+    '[host]' \
+    'rustflags = ["-C", "target-feature=-crt-static"]' \
+    > $CARGO_HOME/config.toml
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

Switches `ephpm/ephpm-ci` from Ubuntu+musl-tools (glibc host cross-compiling to musl) to native Alpine musl.

The Ubuntu cross-compile setup produced a steady drip of glibc↔musl link issues this week — undefined references to `gz*`, `sigsetjmp`, `issetugid`, `__flt_rounds`; a `+whole-archive=z` directive that didn't take effect; new SSL/OCSP symbols missing after the zlib ones got "fixed." The root cause is the hybrid environment: glibc gcc orchestrating musl-targeted linking against musl-built static archives shipped from the PHP SDK pipeline. Subtle ABI / search-path / link-order mismatches keep surfacing.

Alpine is native musl end-to-end. The PHP SDK is itself built on Alpine (static-php-cli requires it), so its `libphp.a`, `libz.a`, `libssl.a`, etc. drop in naturally — same toolchain that produced them.

## Changes

- **`docker/Dockerfile.gha`** — `FROM alpine:3.20`, apk-installed toolchain (build-base, clang/clang-dev/clang-libs, openssl-dev, pkgconfig, linux-headers, bash). Drop `musl-tools`, drop `rustup target add x86_64-unknown-linux-musl` (host IS the target), drop `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_*` env vars.
- **`.github/workflows/nightly.yml`** — drop `--target x86_64-unknown-linux-musl` from the Linux integration-test step.
- **`crates/ephpm-php/build.rs`** — add `x86_64-alpine-linux-musl` to the `libgcc.a` probe path (Alpine GCC installs at `/usr/lib/gcc/x86_64-alpine-linux-musl/<ver>/`).

## Test plan

- [ ] `workflow_dispatch` **CI Image** against this branch — rebuilds and pushes `ephpm/ephpm-ci:latest` from the new Dockerfile. Note: this affects every other CI workflow on `main` immediately. Reverting is `gh workflow run ci-image.yml --ref main` (uses main's Dockerfile).
- [ ] `workflow_dispatch` **Nightly** against this branch — Linux 8.4 & 8.5 builds, integration tests.
- [ ] Verify `CI` workflow still passes (uses same image).
- [ ] Verify `cargo-xwin` still works for Windows cross-build (LLVM-based, libc-agnostic, should be unaffected).

## Risk

Pushing `:latest` from the branch affects every workflow that consumes it. Anything quietly glibc-dependent in the toolchain will surface. We can revert quickly by re-running `ci-image.yml` against main.

## Known not-yet-resolved on this branch

The shadowing bug in `crates/ephpm-php/tests/sessions.rs` (`write_then_read_round_trip`) is intentionally left on main and not cherry-picked here — this PR is about the build environment, not the test code. If nightly on this branch hits `E0618 expected function, found PathBuf`, that's expected; PR #39 is the separate fix for it.