### PR TITLE
ci(nightly): point Verify binary at musl target on Linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,9 +55,11 @@ jobs:
             --workspace --run-ignored ignored-only
 
       - name: Verify binary
+        # cargo xtask release on Linux always targets musl (libphp.a is
+        # musl-linked), so the artifact lives under the musl triple, not
+        # the host triple.
         run: |
-          TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
-          FILE="target/${TRIPLE}/release/ephpm"
+          FILE="target/x86_64-unknown-linux-musl/release/ephpm"
           test -f "$FILE" || { echo "::error::Binary not found at $FILE"; exit 1; }
           file "$FILE"
           ls -lh "$FILE"
@@ -66,7 +68,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ephpm-php${{ matrix.php }}-linux-x86_64
-          path: target/*/release/ephpm
+          path: target/x86_64-unknown-linux-musl/release/ephpm
 
   build-macos:
     name: Build (PHP ${{ matrix.php }}, macos-aarch64)


### PR DESCRIPTION
## Summary

`cargo xtask release` on Linux always cross-compiles to `x86_64-unknown-linux-musl` (the prebuilt `libphp.a` is musl-linked, per commit 11a7112), but the nightly's `Verify binary` step derived the artifact path from `rustc -vV` host triple (`x86_64-unknown-linux-gnu`) and failed with **"Binary not found at target/x86_64-unknown-linux-gnu/release/ephpm"** — see nightly run [26855081757](https://github.com/ephpm/ephpm/actions/runs/26855081757).

Fix: hardcode the musl triple in both `Verify binary` and `Upload artifact` paths in `build-linux`.

`build-macos` and `build-windows` already hardcode their triples correctly (no change needed).

## Test plan
- [ ] Trigger nightly on this branch via `gh workflow run nightly.yml --ref ci/fix-nightly-verify-binary-path` after merge — `Build (PHP 8.5, linux-x86_64)` should pass the Verify binary step
- [ ] Confirm `Upload artifact` succeeds and the artifact is downloadable