### PR TITLE
ci: add clang+lld to CI image for cargo-xwin Windows builds

### DIFF
--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -21,6 +21,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   - musl-tools/musl-dev: musl-gcc cross-compiler for the prebuilt PHP SDK
 #     (libphp.a is musl-linked).
 #   - libclang-dev: bindgen needs libclang.
+#   - clang/lld: cargo-xwin's Windows cross-build needs `clang-cl` (MSVC-
+#     compatible clang driver) + lld-link to compile cc-rs-driven crates
+#     like `ring` against the xwin MSVC headers.
 #   - libssl-dev: the workspace test build (`cargo nextest run --workspace`)
 #     pulls a dev-dependency that links openssl-sys, which needs system
 #     OpenSSL headers + openssl.pc. The musl release build doesn't, but the
@@ -28,7 +31,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   - tar/curl: SDK + sqld tarball downloads at build time.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential ca-certificates curl git pkg-config tar \
-    libclang-dev libssl-dev musl-tools musl-dev \
+    libclang-dev clang lld libssl-dev musl-tools musl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

cargo-xwin handles MSVC headers/libs/lib paths for cross-compiling to `x86_64-pc-windows-msvc` from Linux, but `cc-rs`-driven crates (notably **ring** via rustls) need an MSVC-compatible compiler driver to build their C/asm sources. `clang-cl` (shipped by Ubuntu's \`clang\` package) is the standard choice. \`lld\` provides \`lld-link\` as the matching MSVC-style linker.

Without these, the nightly Windows build (see run [26855081757](https://github.com/ephpm/ephpm/actions/runs/26855081757)) errors out at:

\`\`\`
cargo:warning=Compiler family detection failed: ToolNotFound: failed to find tool "clang-cl"
error occurred in cc-rs: failed to find tool "clang-cl": No such file or directory
\`\`\`

## Test plan
- [ ] After merge, manually trigger \`CI Image\` workflow on \`main\` to publish the new image
- [ ] Confirm new image has \`clang\` and \`lld\` available (\`docker run --rm ephpm/ephpm-ci:latest which clang-cl lld-link\`)
- [ ] Trigger nightly on \`main\`; \`Build (PHP X.Y, windows-x86_64)\` should advance past the cc-rs probe