### PR TITLE
ci(nightly): pragmatic cleanup — pin libclang, drop upstream-blocked jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        # 8.4 temporarily disabled — the 8.4.19 php-sdk linux-x86_64
+        # release tarball is missing libphp.a. Tracked upstream at
+        # github.com/ephpm/php-sdk; re-add "8.4" here once a new SDK
+        # release ships with the static lib present.
+        php: ["8.5"]
     steps:
       - uses: actions/checkout@v4
 
@@ -77,12 +81,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        # 8.4 temporarily disabled — the 8.4.19 php-sdk macos-aarch64
+        # release tarball is missing libphp.a (same upstream gap as the
+        # linux-x86_64 build). Re-add "8.4" once a new SDK release ships.
+        php: ["8.5"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
+      - name: Pin libclang for bindgen
+        # The runner's system Apple-clang (Xcode 16+) emits CXCallingConv
+        # value 20 (CXCallingConv_PreserveNone, added in clang 18), which
+        # bindgen 0.72 doesn't know how to tokenize — it panics with
+        # "Cannot turn unknown calling convention to tokens: 20".
+        # Pinning bindgen to llvm@17's libclang avoids the new enum value
+        # entirely. Tracked at github.com/rust-lang/rust-bindgen.
+        run: |
+          brew install llvm@17 || brew upgrade llvm@17 || true
+          LLVM_PREFIX=$(brew --prefix llvm@17)
+          echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
 
       - name: Build ephpm
         # Pulls libphp.a from github.com/ephpm/php-sdk; no system PHP/spc
@@ -116,6 +135,14 @@ jobs:
     name: Build (PHP ${{ matrix.php }}, windows-x86_64)
     runs-on: [self-hosted, linux, x64]
     container: ephpm/ephpm-ci:latest
+    # Temporarily disabled — the php-sdk windows-x86_64 release tarball
+    # is missing PHP's win32/* headers (e.g. win32/ioutil.h, referenced by
+    # Zend/zend_stream.h), so ephpm_wrapper.c fails to compile. The
+    # cargo-xwin toolchain itself is working (PR #44 added clang+lld);
+    # this is purely an upstream packaging gap. Re-enable once
+    # github.com/ephpm/php-sdk ships a windows tarball that includes the
+    # full PHP source-tree win32/ headers.
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -29,8 +29,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 #     OpenSSL headers + openssl.pc. The musl release build doesn't, but the
 #     native test build does.
 #   - tar/curl: SDK + sqld tarball downloads at build time.
+#   - file: nightly's `Verify binary` step uses /usr/bin/file to print the
+#     artifact's ELF metadata as a sanity check.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git pkg-config tar \
+    build-essential ca-certificates curl file git pkg-config tar \
     libclang-dev clang lld libssl-dev musl-tools musl-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

After three iterations (#42, #43, #44, #45) we have a clear picture of what's fixable here vs. blocked on the **github.com/ephpm/php-sdk** upstream. This PR cleans up the remaining items:

| Issue | Layer | Action |
|---|---|---|
| Linux 8.5 \`Verify binary\` fails with \`file: not found\` | CI image gap | Install \`file\` in Dockerfile.gha |
| Linux 8.4 \`Build ephpm\` panics: PHP static library not found | upstream php-sdk 8.4.19 tarball missing libphp.a | Drop \"8.4\" from build-linux matrix until fixed upstream |
| macOS bindgen panic: \"Cannot turn unknown calling convention to tokens: 20\" | Apple-clang 18+ emits \`CXCallingConv_PreserveNone\`, bindgen 0.72 doesn't recognize it | Install \`brew llvm@17\` on the macOS runner and point \`LIBCLANG_PATH\` at it |
| macOS 8.4 | Same upstream php-sdk packaging gap as Linux | Drop \"8.4\" from build-macos matrix |
| Windows \`Build .exe\` fails: \`win32/ioutil.h\` not found | upstream php-sdk windows tarball missing PHP's win32/* headers | Disable the build-windows job (\`if: false\`) — toolchain is fine, PR #44's clang+lld stays |

After this PR + CI image rebuild, the nightly should produce: **Linux 8.5 ✅, macOS 8.5 ✅, Windows skipped**.

## Why each thing is the right call

- **Pinning macOS libclang to llvm@17**: bindgen needs to add support for new \`CXCallingConv\` enum values upstream; until they do, pinning libclang is the only ePHPm-side workaround. The alternative (\`blocklist_function\` on whichever PHP/system header function uses PreserveNone) requires identifying the symbol per release.
- **Dropping 8.4 from the matrix instead of \`continue-on-error\`**: there's no value running a known-broken job every night — it just adds noise. Easy to re-add once the SDK ships.
- **\`if: false\` on Windows instead of removing the job**: keeps the configuration around so re-enabling is one-line.

## Test plan
- [ ] After merge, trigger CI Image rebuild (\`gh workflow run ci-image.yml --ref main\`) to publish image with \`file\` baked in
- [ ] Trigger nightly (\`gh workflow run nightly.yml --ref main\`) — Linux 8.5 and macOS 8.5 should both go green; Windows should show as skipped; Nightly Summary should pass