### PR TITLE
ci(nightly): install file in CI image + pin libclang on macOS runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,6 +84,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      - name: Pin libclang for bindgen
+        # The runner's system Apple-clang (Xcode 16+) emits CXCallingConv
+        # value 20 (CXCallingConv_PreserveNone, added in clang 18), which
+        # bindgen 0.72 doesn't know how to tokenize — it panics with
+        # "Cannot turn unknown calling convention to tokens: 20".
+        # Pointing bindgen at llvm@17's libclang avoids the new enum value
+        # entirely. Tracked at github.com/rust-lang/rust-bindgen — remove
+        # this step once bindgen learns the new CCs (or falls back
+        # gracefully instead of panicking).
+        run: |
+          brew install llvm@17 || brew upgrade llvm@17 || true
+          LLVM_PREFIX=$(brew --prefix llvm@17)
+          echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+
       - name: Build ephpm
         # Pulls libphp.a from github.com/ephpm/php-sdk; no system PHP/spc
         # toolchain required.

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -29,8 +29,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 #     OpenSSL headers + openssl.pc. The musl release build doesn't, but the
 #     native test build does.
 #   - tar/curl: SDK + sqld tarball downloads at build time.
+#   - file: nightly's `Verify binary` step uses /usr/bin/file to print the
+#     artifact's ELF metadata as a sanity check.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git pkg-config tar \
+    build-essential ca-certificates curl file git pkg-config tar \
     libclang-dev clang lld libssl-dev musl-tools musl-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Narrow replacement for #46. Keeps two orthogonal fixes; drops the matrix-changes / Windows-disable strategy in favor of bumping \`PHP_SDK_VERSIONS\` to a freshly-released SDK (separate PR, pending a php-sdk rebuild that includes the Linux libphp.a path fix and the Windows \`win32/*\` headers).

1. **\`docker/Dockerfile.gha\`** — install \`file\` so the Linux \`Verify binary\` step (which calls \`/usr/bin/file <artifact>\`) stops exiting 127 with \`file: not found\`. Last gap blocking a green Linux 8.5 nightly once the path was fixed in #43.

2. **\`.github/workflows/nightly.yml\` build-macos** — install \`brew llvm@17\` and point bindgen at its libclang via \`LIBCLANG_PATH\`. The runner's stock Apple-clang (Xcode 16+) emits \`CXCallingConv\` value 20 (\`CXCallingConv_PreserveNone\`, added in clang 18). bindgen 0.72 panics on unknown calling conventions in its \`ToTokens\` impl with \"Cannot turn unknown calling convention to tokens: 20\". Bumping bindgen further doesn't help — the panic site is unchanged in master. Feeding it an older libclang that never emits the new enum value is the cleanest workaround.

## Test plan
- [ ] After merge, trigger CI Image rebuild (\`gh workflow run ci-image.yml --ref main\`) so the new image with \`file\` is published
- [ ] Trigger nightly — Linux 8.5 \`Verify binary\` should pass; macOS 8.5 \`Build ephpm\` should pass once libclang is pinned. Linux 8.4 / macOS 8.4 / Windows still red pending the SDK bump.

## Removal criteria
- Linux: drop the Dockerfile comment line if \`file\` is no longer used.
- macOS: drop the libclang pin step once \`bindgen\` learns the new \`CXCallingConv\` values or falls back gracefully instead of panicking. Tracked at github.com/rust-lang/rust-bindgen.