### PR TITLE
ci(nightly): prepend /opt/homebrew/bin to PATH for macOS libclang pin

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,7 +93,12 @@ jobs:
         # entirely. Tracked at github.com/rust-lang/rust-bindgen — remove
         # this step once bindgen learns the new CCs (or falls back
         # gracefully instead of panicking).
+        #
+        # /opt/homebrew/bin isn't on the runner's default PATH for
+        # non-login shells, so prepend it before calling brew (same
+        # pattern php-sdk's macOS job uses).
         run: |
+          export PATH="/opt/homebrew/bin:$PATH"
           brew install llvm@17 || brew upgrade llvm@17 || true
           LLVM_PREFIX=$(brew --prefix llvm@17)
           echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Quick follow-up to #47: the Pin libclang for bindgen step fails on the macOS runner with \`brew: command not found\`. Homebrew isn't on the runner agent's default PATH for non-login shells. Prepending \`/opt/homebrew/bin\` before invoking \`brew\` fixes it — same pattern \`php-sdk\`'s macOS build job already uses successfully.

Reproduced in nightly run [26921432535](https://github.com/ephpm/ephpm/actions/runs/26921432535):

\`\`\`
/Users/admin/actions-runner/_work/_temp/xxx.sh: line 1: brew: command not found
##[error]Process completed with exit code 127.
\`\`\`

## Test plan
- [ ] After merge, trigger nightly — macOS 8.5 \`Build ephpm\` should now succeed (libclang pin step runs cleanly, bindgen no longer hits the CXCallingConv panic)