### PR TITLE
deps: bump PHP_SDK to 8.3.31 / 8.4.21 / 8.5.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.19"
+            php_full: "8.4.21"
           - php_minor: "8.5"
-            php_full: "8.5.2"
+            php_full: "8.5.6"
     steps:
       - uses: actions/checkout@v4
 
@@ -79,9 +79,9 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.19"
+            php_full: "8.4.21"
           - php_minor: "8.5"
-            php_full: "8.5.2"
+            php_full: "8.5.6"
     steps:
       - uses: actions/checkout@v4
 
@@ -123,9 +123,9 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.19"
+            php_full: "8.4.21"
           - php_minor: "8.5"
-            php_full: "8.5.2"
+            php_full: "8.5.6"
     steps:
       - uses: actions/checkout@v4
 
@@ -170,10 +170,10 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.19"
+            php_full: "8.4.21"
             default: false
           - php_minor: "8.5"
-            php_full: "8.5.2"
+            php_full: "8.5.6"
             default: true
     steps:
       - uses: actions/checkout@v4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,9 @@
 # version via xtask::PHP_SDK_VERSIONS and passes it as PHP_SDK_VERSION.
 
 # Pinned full version of the PHP SDK to download. Must match a release tag
-# at github.com/ephpm/php-sdk/releases (e.g., v8.5.2). The default mirrors
+# at github.com/ephpm/php-sdk/releases (e.g., v8.5.6). The default mirrors
 # xtask::PHP_SDK_VERSIONS — keep them in sync if you bump.
-ARG PHP_SDK_VERSION=8.5.2
+ARG PHP_SDK_VERSION=8.5.6
 
 # ── Stage 1: base — system deps + Rust toolchain ─────────────────────────────
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,9 +7,9 @@ use std::{env, fs};
 /// The build flow downloads pre-built `libphp.a` archives from
 /// `github.com/ephpm/php-sdk` releases. Each entry maps a minor-version
 /// shorthand (e.g. "8.5") to the specific patch release we publish SDKs for.
-/// Users may also pass a full version explicitly (e.g. "8.5.2") and the
+/// Users may also pass a full version explicitly (e.g. "8.5.6") and the
 /// resolver will accept it as-is.
-const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.29"), ("8.4", "8.4.19"), ("8.5", "8.5.2")];
+const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.21"), ("8.5", "8.5.6")];
 
 /// Default PHP minor when no version is specified on the command line.
 const DEFAULT_PHP_MINOR: &str = "8.5";


### PR DESCRIPTION
## Summary

Bumps ePHPm's pinned PHP SDK versions to the freshly-released artifacts that include the upstream php-sdk Linux \`libphp.a\` packaging fix.

| Minor | Old | New |
|---|---|---|
| 8.3 | 8.3.29 | **8.3.31** |
| 8.4 | 8.4.19 | **8.4.21** |
| 8.5 | 8.5.2  | **8.5.6**  |

All 9 release tarballs (3 versions × Linux/macOS/Windows) verified locally before push — critical files at expected paths:

| | Linux | macOS | Windows |
|---|---|---|---|
| 8.3.31 | \`./lib/libphp.a\` ✅ | \`./lib/libphp.a\` ✅ | \`./lib/php8embed.lib\` + \`win32/ioutil.h\` ✅ |
| 8.4.21 | \`./lib/libphp.a\` ✅ | \`./lib/libphp.a\` ✅ | \`./lib/php8embed.lib\` + \`win32/ioutil.h\` ✅ |
| 8.5.6  | \`./lib/libphp.a\` ✅ | \`./lib/libphp.a\` ✅ | \`./lib/php8embed.lib\` + \`win32/ioutil.h\` ✅ |

## What changes
- \`xtask/src/main.rs::PHP_SDK_VERSIONS\` — all three minors advance
- \`docker/Dockerfile::ARG PHP_SDK_VERSION\` default — 8.5.2 → 8.5.6 (mirrors xtask)
- \`.github/workflows/release.yml\` matrix entries — 8 occurrences updated across \`build-linux\`, \`build-macos\`, \`build-windows\`, \`docker-image\`

## Why now

Three upstream gaps blocked the release path through this session:
1. Linux \`libphp.a\` nested at \`./lib/lib/\` instead of \`./lib/\` — fixed in php-sdk build.yml + new releases cut
2. Windows tarball missing PHP's \`win32/*\` headers — fixed in v8.5.6, present in the new 8.3.31 and 8.4.21
3. macOS bindgen calling-convention panic — sidestepped by the brew llvm@17 pin merged in #47/#49

With this PR plus the prior CI image rebuilds, every Linux/macOS/Windows × 8.3/8.4/8.5 build cell should turn green.

## Test plan
- [ ] After merge, trigger nightly (\`gh workflow run nightly.yml --ref main\`) — expect all 6 build cells (8.4+8.5 × linux+macos+windows) green for the first time this cycle
- [ ] Then cut a \`v0.0.0-rc1\` tag to exercise the Release workflow end-to-end (matrix produces tarballs + Docker Hub images)