### PR TITLE
build(ephpm-php): support newly-bundled SDK libs + GCC 14 cpu init symbol

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -76,6 +76,16 @@ fn link_php(lib_dir: &Path, target_os: &str) {
     // Link additional static libraries from the SDK that static-php-cli
     // built. We probe for each library since the set varies by config.
     //
+    // Order matters because rustc emits these to the linker in sequence
+    // and ld is single-pass. Dependencies must come AFTER the libraries
+    // that need them:
+    //   - extension libs (curl, xml2, intl, etc.) reference symbols in
+    //     the lower-level libs (ssl/crypto, z, icudata, …)
+    //   - libicui18n needs libicuuc which needs libicudata
+    //   - libstdc++ has to be last on Linux because ICU is C++ — its
+    //     archives reference std::__throw_bad_alloc, __cxa_begin_catch,
+    //     etc., which only libstdc++.a provides
+    //
     // `libz` is emitted with `+whole-archive` because both libphp's
     // `zlib_fopen_wrapper.o` and libxml2's `xmlIO.c.o` reference gz*
     // symbols. Single-pass ld resolves the first set of refs from libz,
@@ -92,8 +102,26 @@ fn link_php(lib_dir: &Path, target_os: &str) {
     // binary/cdylib targets).
     println!("cargo::warning=probing for static support libs in {}", lib_dir.display());
     for static_lib in &[
-        "ssl", "crypto", "curl", "z", "xml2", "sodium", "iconv", "charset", "png16", "gd", "jpeg",
-        "freetype", "onig", "zip", "bz2", "xslt", "exslt",
+        // High-level extension support libs first; they reference the
+        // lower-level libs below.
+        "ssl", "crypto", "curl", "z", "xml2", "xslt", "exslt", "lzma",
+        "sodium", "iconv", "charset", "intl",
+        "png16", "gd", "jpeg", "freetype",
+        "onig", "zip", "bz2",
+        "gmp", "sqlite3",
+        // PostgreSQL libs (pdo_pgsql). Order: libpq depends on pgcommon
+        // and pgport.
+        "pq", "pgcommon", "pgport",
+        // Readline / line-editing ecosystem (pulled in by pdo_sqlite and
+        // a few CLI-facing extensions on the embed build).
+        "edit", "ncurses", "menu", "form", "panel", "tic",
+        // ICU — needed by the intl extension. Order matters: i18n →
+        // uc → data, with io/tu as auxiliary modules that may pull
+        // from any of them.
+        "icui18n", "icuuc", "icudata", "icuio", "icutu",
+        // libstdc++ last: ICU is C++ and references std::* / __cxa_*
+        // symbols that only the C++ runtime provides.
+        "stdc++",
     ] {
         // Unix uses libfoo.a, Windows uses foo.lib
         let unix_path = lib_dir.join(format!("lib{static_lib}.a"));
@@ -213,6 +241,10 @@ fn compile_wrapper(include_dir: &Path, target_os: &str) {
     let mut build = cc::Build::new();
     build
         .file("ephpm_wrapper.c")
+        // Bundles the __cpu_indicator_init_local → __cpu_indicator_init
+        // thunk for GCC 13.x hosts linking against an SDK compiled with
+        // GCC 14+. See cpu_compat.c for the full rationale.
+        .file("cpu_compat.c")
         .include(include_dir)
         .include(&include_main)
         .include(&include_zend)

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -104,11 +104,8 @@ fn link_php(lib_dir: &Path, target_os: &str) {
     for static_lib in &[
         // High-level extension support libs first; they reference the
         // lower-level libs below.
-        "ssl", "crypto", "curl", "z", "xml2", "xslt", "exslt", "lzma",
-        "sodium", "iconv", "charset", "intl",
-        "png16", "gd", "jpeg", "freetype",
-        "onig", "zip", "bz2",
-        "gmp", "sqlite3",
+        "ssl", "crypto", "curl", "z", "xml2", "xslt", "exslt", "lzma", "sodium", "iconv", "charset",
+        "intl", "png16", "gd", "jpeg", "freetype", "onig", "zip", "bz2", "gmp", "sqlite3",
         // PostgreSQL libs (pdo_pgsql). Order: libpq depends on pgcommon
         // and pgport.
         "pq", "pgcommon", "pgport",

--- a/crates/ephpm-php/cpu_compat.c
+++ b/crates/ephpm-php/cpu_compat.c
@@ -1,0 +1,28 @@
+/*
+ * Compatibility shim for GCC __cpu_indicator_init_local.
+ *
+ * static-php-cli builds libphp.a inside an Alpine container with GCC 14+,
+ * whose __builtin_cpu_supports() / __builtin_cpu_init() expand to a call
+ * to __cpu_indicator_init_local — a no-PLT, static-link-friendly variant
+ * of __cpu_indicator_init introduced in GCC 14. Older host toolchains
+ * (notably Ubuntu 24.04's GCC 13.2, which the ephpm CI image uses) ship
+ * a libgcc.a that only provides __cpu_indicator_init.
+ *
+ * libphp.a's zend_jit_startup references __cpu_indicator_init_local from
+ * its precompiled object code, so we can't change PHP's emitted symbol.
+ * Define a thunk that forwards to __cpu_indicator_init — same semantics,
+ * different linkage. Functionally a no-op once GCC's libgcc catches up.
+ *
+ * Compiled into the ephpm_wrapper static archive by build.rs's cc::Build
+ * step.
+ */
+
+#if defined(__linux__) && defined(__GNUC__)
+
+extern void __cpu_indicator_init(void);
+
+void __cpu_indicator_init_local(void) {
+    __cpu_indicator_init();
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adapts `crates/ephpm-php/build.rs` to the post-#50 php-sdk releases (`v8.3.31`, `v8.4.21`, `v8.5.6`), which bundle a much larger static-lib set than the original probe knew about.

## Two concrete changes

### 1. Extended static-lib probe list

The previous loop iterated `ssl/crypto/curl/z/xml2/sodium/iconv/charset/png16/gd/jpeg/freetype/onig/zip/bz2/xslt/exslt`. The new SDK adds:

- `intl`, `gmp`, `sqlite3` — single-extension support libs
- `pq`, `pgcommon`, `pgport` — PostgreSQL (pdo_pgsql)
- `edit`, `ncurses`, `menu`, `form`, `panel`, `tic` — readline/edit/curses ecosystem
- `icui18n`, `icuuc`, `icudata`, `icuio`, `icutu` — ICU (intl)
- `lzma` — xz
- `stdc++` — C++ runtime (ICU references `std::__throw_bad_alloc`, `__cxa_begin_catch`, etc.)

Order matters because `rustc` emits these to `ld` in sequence and single-pass `ld` only resolves forward references. Extension libs first, then PostgreSQL group, then readline/curses group, then ICU group (`i18n` → `uc` → `data`), then `libstdc++` last.

### 2. `cpu_compat.c` shim for GCC 14's `__cpu_indicator_init_local`

`libphp.a` is now compiled in an Alpine container with GCC 14+, whose `__builtin_cpu_supports()` (used in `zend_jit_startup`) expands to the no-PLT `_local` variant. The host CI image (`ephpm/ephpm-ci:latest`, Ubuntu 24.04 + GCC 13.2) provides `libgcc.a` containing only `__cpu_indicator_init` without the `_local` suffix.

Same function, different linkage:

```c
extern void __cpu_indicator_init(void);
void __cpu_indicator_init_local(void) {
    __cpu_indicator_init();
}
```

Compiled into the existing `ephpm_wrapper` static archive by `build.rs`'s `cc::Build` step.

## Local verification

Built Linux 8.4 against v8.4.21 SDK via podman + `ephpm/ephpm-ci:latest`:

```
$ podman run --rm -v $(pwd):/src -w /src ephpm/ephpm-ci:latest cargo xtask release 8.4
...
Finished `release` profile [optimized] target(s) in 4m 58s
==> Binary ready: target/x86_64-unknown-linux-musl/release/ephpm

$ file target/.../ephpm
ELF 64-bit LSB pie executable, x86-64, static-pie linked, not stripped (151MB)

$ target/.../ephpm --version
ephpm 0.1.0
```

## Test plan

- [ ] After merge, trigger nightly. Linux 8.4 + 8.5 should both build green (8.3 not in nightly matrix). macOS 8.4 + 8.5 should also build green — the macOS SDK has all the same libs, the probe list extension applies uniformly.
- [ ] Optional: cut a `v0.0.0-rc1` tag to exercise the Release workflow end-to-end against the three fixed SDKs.