### PR TITLE
ci(release): pin libclang on macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      - name: Pin libclang for bindgen
+        # The runner's system Apple-clang (Xcode 16+) emits CXCallingConv
+        # value 20 (CXCallingConv_PreserveNone, added in clang 18), which
+        # bindgen 0.72 doesn't know how to tokenize — it panics with
+        # "Cannot turn unknown calling convention to tokens: 20".
+        # Pointing bindgen at llvm@17's libclang avoids the new enum value
+        # entirely. Mirrors the same step in nightly.yml — remove from
+        # both once bindgen learns the new CCs or falls back gracefully.
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          brew install llvm@17 || brew upgrade llvm@17 || true
+          LLVM_PREFIX=$(brew --prefix llvm@17)
+          echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+
       - name: Build ephpm
         run: cargo xtask release ${{ matrix.php_minor }}
 


### PR DESCRIPTION
## Summary

Copies the `Pin libclang for bindgen` step from `nightly.yml` (PRs #47 and #49) into `release.yml`'s `build-macos` job. Without this, the Release workflow would hit the same `bindgen` panic on macOS that the nightly was hitting before #47:

```
thread 'main' panicked at bindgen-0.72.1/ir/function.rs:259:34:
Cannot turn unknown calling convention to tokens: 20
```

Cutting a `v*` tag right now would fail on macOS instead of producing `macos-aarch64` archives.

## Change

One step added before `Build ephpm` in the `build-macos` job:

```yaml
- name: Pin libclang for bindgen
  run: |
    export PATH="/opt/homebrew/bin:$PATH"
    brew install llvm@17 || brew upgrade llvm@17 || true
    LLVM_PREFIX=$(brew --prefix llvm@17)
    echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
```

Identical to the nightly version. Same removal criteria too — drop both once `bindgen` is taught the new `CXCallingConv` values.

## Test plan
- [ ] Merge, then cut `v0.0.0-rc1` against current `main`. macOS build cells should produce `ephpm-v0.0.0-rc1+php8.4.21-macos-aarch64.tar.gz` and `+php8.5.6-macos-aarch64.tar.gz`.