### PR TITLE
ci(windows): switch from cargo-xwin cross-compile to native Windows runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -133,8 +133,11 @@ jobs:
 
   build-windows:
     name: Build (PHP ${{ matrix.php }}, windows-x86_64)
-    runs-on: [self-hosted, linux, x64]
-    container: ephpm/ephpm-ci:latest
+    # Native Windows build on the self-hosted Windows runner (same fleet as
+    # php-sdk). Replaces the previous cargo-xwin cross-compile-from-Linux
+    # path, which kept hitting case-sensitivity / transitive-include gaps
+    # between xwin's lowercased SDK headers and PHP source assumptions.
+    runs-on: [self-hosted, windows, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -142,18 +145,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install cargo-xwin
-        run: cargo install cargo-xwin --locked || true
+      - name: Install Rust toolchain
+        shell: powershell
+        run: |
+          $rustcPath = (Get-Command rustc -ErrorAction SilentlyContinue).Source
+          if (-not $rustcPath) {
+            Write-Host "Installing rustup..."
+            Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+            .\rustup-init.exe -y --default-toolchain stable --profile minimal
+            Remove-Item rustup-init.exe
+            "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          }
+          rustup show
 
-      - name: Build Windows .exe
+      - name: Enter MSVC developer environment
+        # Imports vcvars64.bat into the workflow environment so cl.exe,
+        # link.exe, and the Windows SDK includes/libs are on PATH for the
+        # cargo build below (and for cc-rs crates like ring that compile
+        # their own C). Assumes VS Build Tools are pre-installed on the
+        # runner (php-sdk's build.yml installs them on first use and the
+        # install persists across ephemerd-managed runner sessions).
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Build ephpm.exe
+        shell: powershell
         run: cargo xtask release ${{ matrix.php }} --target windows --no-sqld
 
       - name: Verify binary
+        shell: powershell
         run: |
-          FILE="target/x86_64-pc-windows-msvc/release/ephpm.exe"
-          test -f "$FILE" || { echo "::error::Binary not found at $FILE"; exit 1; }
-          file "$FILE"
-          ls -lh "$FILE"
+          $bin = "target\x86_64-pc-windows-msvc\release\ephpm.exe"
+          if (-not (Test-Path $bin)) {
+            Write-Error "Binary not found at $bin"
+            exit 1
+          }
+          Get-Item $bin | Format-List Name, Length, LastWriteTime
+          Write-Host "==> Linker metadata:"
+          & dumpbin /headers $bin | Select-String -Pattern 'machine|subsystem'
+          Write-Host "==> Linked DLL dependencies:"
+          & dumpbin /dependents $bin
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,16 +158,52 @@ jobs:
           }
           rustup show
 
+      - name: Install Visual Studio Build Tools
+        shell: powershell
+        # Mirrors php-sdk's install block (we share the same Windows
+        # runner image: mcr.microsoft.com/windows/servercore:ltsc2025).
+        # The runner is bare — no compiler — so each job installs VS
+        # Build Tools fresh via the official bootstrapper. Bootstrapper
+        # exit on Server Core is unreliable, so we poll for MSBuild.exe.
+        # Long-term: ephemerd should bake VS Build Tools into the
+        # Windows runner image; this step becomes a no-op fast-path.
+        run: |
+          $installPath = "C:\BuildTools"
+          $msbuild = "$installPath\MSBuild\Current\Bin\MSBuild.exe"
+          if (Test-Path $msbuild) {
+            Write-Host "VS Build Tools already present at $installPath"
+          } else {
+            Write-Host "Downloading VS Build Tools bootstrapper..."
+            Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile vs_buildtools.exe
+            $proc = Start-Process -FilePath .\vs_buildtools.exe `
+              -ArgumentList @(
+                '--quiet', '--wait', '--norestart', '--nocache',
+                '--installPath', $installPath,
+                '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--includeRecommended'
+              ) -Wait -PassThru -NoNewWindow
+            Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
+            Remove-Item vs_buildtools.exe
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while (-not (Test-Path $msbuild) -and $sw.Elapsed.TotalMinutes -lt 20) {
+              Start-Sleep -Seconds 30
+              Write-Host ("  ...waiting for VS install ({0:F0}s)" -f $sw.Elapsed.TotalSeconds)
+            }
+            if (-not (Test-Path $msbuild)) {
+              Write-Host "::error::VS install timed out - $msbuild never appeared"
+              exit 1
+            }
+            Write-Host ("MSBuild.exe found after {0:F0}s" -f $sw.Elapsed.TotalSeconds)
+          }
+
       - name: Enter MSVC developer environment
-        # Imports vcvars64.bat into the workflow environment so cl.exe,
-        # link.exe, and the Windows SDK includes/libs are on PATH for the
-        # cargo build below (and for cc-rs crates like ring that compile
-        # their own C). Assumes VS Build Tools are pre-installed on the
-        # runner (php-sdk's build.yml installs them on first use and the
-        # install persists across ephemerd-managed runner sessions).
+        # Imports vcvars64.bat into GITHUB_ENV so cl.exe, link.exe, and
+        # the Windows SDK includes/libs are on PATH for cargo build and
+        # cc-rs-driven crates like `ring`.
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
+          vsversion: "2022"
 
       - name: Build ephpm.exe
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,10 +155,44 @@ jobs:
           }
           rustup show
 
+      - name: Install Visual Studio Build Tools
+        shell: powershell
+        # Mirrors php-sdk's install block; runner image is bare so each
+        # job installs VS Build Tools fresh via the official bootstrapper.
+        run: |
+          $installPath = "C:\BuildTools"
+          $msbuild = "$installPath\MSBuild\Current\Bin\MSBuild.exe"
+          if (Test-Path $msbuild) {
+            Write-Host "VS Build Tools already present at $installPath"
+          } else {
+            Write-Host "Downloading VS Build Tools bootstrapper..."
+            Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile vs_buildtools.exe
+            $proc = Start-Process -FilePath .\vs_buildtools.exe `
+              -ArgumentList @(
+                '--quiet', '--wait', '--norestart', '--nocache',
+                '--installPath', $installPath,
+                '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--includeRecommended'
+              ) -Wait -PassThru -NoNewWindow
+            Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
+            Remove-Item vs_buildtools.exe
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while (-not (Test-Path $msbuild) -and $sw.Elapsed.TotalMinutes -lt 20) {
+              Start-Sleep -Seconds 30
+              Write-Host ("  ...waiting for VS install ({0:F0}s)" -f $sw.Elapsed.TotalSeconds)
+            }
+            if (-not (Test-Path $msbuild)) {
+              Write-Host "::error::VS install timed out - $msbuild never appeared"
+              exit 1
+            }
+            Write-Host ("MSBuild.exe found after {0:F0}s" -f $sw.Elapsed.TotalSeconds)
+          }
+
       - name: Enter MSVC developer environment
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
+          vsversion: "2022"
 
       - name: Build ephpm.exe
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,10 @@ jobs:
           name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-macos-aarch64
           path: ${{ steps.pkg.outputs.archive }}
 
-  # ── Windows binaries (cross-compiled from Linux via cargo-xwin) ────────────
+  # ── Windows binaries (native on self-hosted Windows runner) ──────────────
   build-windows:
     name: Build (PHP ${{ matrix.php_full }}, windows-x86_64)
-    runs-on: [self-hosted, linux, x64]
-    container: ephpm/ephpm-ci:latest
+    runs-on: [self-hosted, windows, x64]
     strategy:
       fail-fast: false
       matrix:
@@ -143,29 +142,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install cargo-xwin
-        run: cargo install cargo-xwin --locked || true
+      - name: Install Rust toolchain
+        shell: powershell
+        run: |
+          $rustcPath = (Get-Command rustc -ErrorAction SilentlyContinue).Source
+          if (-not $rustcPath) {
+            Write-Host "Installing rustup..."
+            Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+            .\rustup-init.exe -y --default-toolchain stable --profile minimal
+            Remove-Item rustup-init.exe
+            "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          }
+          rustup show
 
-      - name: Build Windows .exe
+      - name: Enter MSVC developer environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Build ephpm.exe
+        shell: powershell
         run: cargo xtask release ${{ matrix.php_minor }} --target windows --no-sqld
 
       - name: Package archive
         id: pkg
+        shell: powershell
         env:
           VERSION: ${{ github.ref_name }}
           PHP_FULL: ${{ matrix.php_full }}
         run: |
-          set -eu
-          name="ephpm-${VERSION}+php${PHP_FULL}-windows-x86_64"
-          mkdir -p "dist/${name}"
-          cp target/x86_64-pc-windows-msvc/release/ephpm.exe "dist/${name}/ephpm.exe"
-          cp LICENSE "dist/${name}/LICENSE"
-          cp .github/release-readme.txt "dist/${name}/README.txt"
-          # tar.gz on Windows too: built-in `tar` (bsdtar) on Win10/11 1809+
-          # unpacks .tar.gz natively, so we don't need a separate .zip path.
-          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
-          rm -rf "dist/${name}"
-          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+          $name = "ephpm-$env:VERSION+php$env:PHP_FULL-windows-x86_64"
+          $stage = "dist\$name"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item target\x86_64-pc-windows-msvc\release\ephpm.exe "$stage\ephpm.exe"
+          Copy-Item LICENSE "$stage\LICENSE"
+          Copy-Item .github\release-readme.txt "$stage\README.txt"
+          # tar.gz on Windows: built-in `tar` (bsdtar) on Win10/11 1809+
+          # produces a portable archive consumers can `tar xzf` cross-OS.
+          tar -C dist -czf "dist\$name.tar.gz" $name
+          Remove-Item -Recurse -Force $stage
+          "archive=dist/$name.tar.gz" | Out-File -Append -FilePath $env:GITHUB_OUTPUT -Encoding utf8
 
       - name: Upload archive
         uses: actions/upload-artifact@v4

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> ExitCode {
     let cmd = args.first().map(String::as_str);
 
     match cmd {
-        Some("release") => require_unix(|| release(&args[1..])),
+        Some("release") => release(&args[1..]),
         // php-sdk is a pure download — works on any platform with curl + tar.
         Some("php-sdk") => php_sdk(&args[1..]),
         Some("e2e") => e2e(&args[1..]),
@@ -64,8 +64,8 @@ The PHP SDK is downloaded from github.com/ephpm/php-sdk releases. Pass a minor
 shorthand (e.g. \"8.5\") to use the pinned patch release, or a full version
 (e.g. \"8.5.2\") for an explicit pin.
 
-Cross-compilation:
-  --target windows    Cross-compile a Windows .exe from WSL/Linux (requires cargo-xwin).
+Windows builds:
+  --target windows    Build a native Windows .exe (must run on Windows; MSVC build tools required).
                       Downloads the same prebuilt SDK as Linux/macOS, but for windows-x86_64.
 
 SQLite clustering:
@@ -128,9 +128,13 @@ fn parse_release_php_version(args: &[String]) -> &str {
 }
 
 /// Dispatch release builds based on `--target` flag.
+///
+/// `release_native` requires a Unix host (musl-gcc on Linux); the Windows
+/// path requires native Windows (no cargo-xwin cross-compile). Each path
+/// applies its own host guard.
 fn release(args: &[String]) -> ExitCode {
     match parse_target(args) {
-        None => release_native(args),
+        None => require_unix(|| release_native(args)),
         Some("windows") => release_windows(args),
         Some(other) => {
             eprintln!("error: unsupported target '{other}' (supported: windows)");
@@ -231,22 +235,44 @@ fn require_macos_arm64() -> Result<(), ExitCode> {
     Err(ExitCode::FAILURE)
 }
 
-/// Cross-compile a Windows .exe from WSL/Linux using cargo-xwin.
+/// Build a Windows `ephpm.exe` natively on a Windows host.
+///
+/// Requires native Windows with the MSVC build tools (`cl.exe`, `link.exe`)
+/// and the Windows SDK on PATH — same prerequisites as any other native
+/// `cargo build` for `x86_64-pc-windows-msvc`. CI populates these by entering
+/// a VS developer environment (`ilammy/msvc-dev-cmd` or equivalent vcvars
+/// import) before invoking xtask.
 ///
 /// The Windows SDK is the same `php-sdk` GitHub release used for Linux/macOS,
 /// just the `windows-x86_64` artifact: it contains `php8embed.dll`,
-/// `php8embed.lib`, and the headers under `include/php/`. cargo-xwin handles
-/// the MSVC link.
+/// `php8embed.lib`, and the headers under `include/php/`. The build links
+/// against `php8embed.lib` (import lib for the DLL).
 ///
 /// The resulting binary requires `php8embed.dll` at runtime, which is also
 /// embedded into the binary via `include_bytes!()` in `windows_dll.rs` and
 /// extracted at startup.
+///
+/// History: this used to cross-compile from Linux via `cargo-xwin`. That path
+/// was removed because every Windows SDK case-sensitivity / transitive-include
+/// gap (Ws2tcpip.h, intsafe.h, dllimport vs static linkage, etc.) ate hours of
+/// debugging that a native build doesn't have to deal with. Native Windows
+/// runners are already provisioned on the self-hosted fleet (php-sdk uses
+/// them); ephpm now does too.
 fn release_windows(args: &[String]) -> ExitCode {
+    if !cfg!(target_os = "windows") {
+        eprintln!("error: release_windows requires a native Windows host.");
+        eprintln!("       The cargo-xwin cross-compile path was removed.");
+        eprintln!(
+            "       Use the [self-hosted, windows, x64] runner pattern in CI, \
+             or run on a Windows workstation locally."
+        );
+        return ExitCode::FAILURE;
+    }
+
     // sqld has no Windows binary — error if user tries to embed it.
     if parse_sqld_binary(args).is_some() {
         eprintln!("error: sqld is not available for Windows.");
         eprintln!("       Clustered SQLite requires Linux or macOS.");
-        eprintln!("       Use WSL to build a Linux binary with sqld embedded.");
         return ExitCode::FAILURE;
     }
     if !args.iter().any(|a| a == "--no-sqld") {
@@ -258,13 +284,6 @@ fn release_windows(args: &[String]) -> ExitCode {
         return ExitCode::FAILURE;
     };
     let target = "x86_64-pc-windows-msvc";
-
-    eprintln!("==> Checking prerequisites...");
-    if !has_command("cargo-xwin") {
-        eprintln!("error: cargo-xwin not installed");
-        eprintln!("       cargo install cargo-xwin");
-        return ExitCode::FAILURE;
-    }
 
     if ensure_php_sdk_for(&php_version, "windows", "x86_64").is_err() {
         return ExitCode::FAILURE;
@@ -280,12 +299,12 @@ fn release_windows(args: &[String]) -> ExitCode {
 
     eprintln!("==> Building ephpm.exe (release, target: {target})...");
     let status = Command::new("cargo")
-        .args(["xwin", "build", "--release", "--package", "ephpm", "--target", target])
+        .args(["build", "--release", "--package", "ephpm", "--target", target])
         .env("PHP_SDK_PATH", &sdk_dir)
         .status();
 
     if !ran_ok(&status) {
-        eprintln!("error: cargo xwin build failed");
+        eprintln!("error: cargo build failed");
         return ExitCode::FAILURE;
     }
 


### PR DESCRIPTION
## Summary

Switch ephpm's Windows builds from `cargo-xwin` cross-compile (Linux container → Windows binary) to native Windows on the self-hosted Windows runner. Same fleet `php-sdk` already uses.

## Why now

Every Windows-specific issue we've debugged this session was a direct consequence of cross-compiling:

| Issue | Cross via xwin | Native Windows |
|---|---|---|
| `Ws2tcpip.h` not found | Case-sensitive FS vs lowercase xwin headers | Non-issue (case-insensitive NTFS) |
| `LongLongAdd` undeclared | xwin's header layout doesn't pull `intsafe.h` via the `windows.h` umbrella | Non-issue (native `windows.h` does) |
| `clang-cl` for `ring`/`cc-rs` | Whole PR (#44) to add `clang+lld` to CI image | Non-issue (native MSVC) |
| `PHP_EMBED_STATIC` validation | `dumpbin /dependents` not on Linux; have to fish for symbols | One command |
| `cargo install cargo-xwin` per CI run | ~30s every nightly | Not needed |

The self-hosted Windows runner already exists — `ephpm/php-sdk`'s `build-windows` job runs on `[self-hosted, windows, x64]` with VS Build Tools pre-installed by an earlier provisioning step. ephpm was the odd one out.

## Changes

### `xtask/src/main.rs::release_windows`
- Drop `cargo-xwin` requirement check and `cargo xwin build` invocation
- Use plain `cargo build --release --target x86_64-pc-windows-msvc`
- Guard with `cfg!(target_os = "windows")` — fail fast with a clear message if invoked from Linux/macOS
- `require_unix` host guard now wraps only the native (Linux/macOS) release path, not the Windows path

### `.github/workflows/nightly.yml` + `release.yml` `build-windows`
- `runs-on: [self-hosted, windows, x64]` (was `[self-hosted, linux, x64]` with `container: ephpm/ephpm-ci:latest`)
- Drop `Install cargo-xwin` step
- Add Rust install via `rustup-init.exe` if not present
- Add `ilammy/msvc-dev-cmd@v1` step to import `vcvars64` (cl.exe, link.exe, Windows SDK on PATH for `cc-rs` crates and the wrapper compile)
- PowerShell shell for steps; Windows-native path conventions
- Add `dumpbin /headers` + `dumpbin /dependents` to the Verify step — these become trivially available, and make `PHP_EMBED_STATIC` validation a one-liner once that patch lands

## Assumptions

VS Build Tools are pre-installed on the Windows runner. `php-sdk`'s `build-windows` job installs them on first use (long PowerShell block at lines ~227-300 of its `build.yml`), and the install persists across ephemerd-managed runner sessions. If that assumption is wrong for ephpm's runs, the `ilammy/msvc-dev-cmd@v1` step will fail with a clear error pointing at the missing VS install.

If we hit that, easiest fix is to add the same VS Build Tools install step as `php-sdk`'s `build.yml` has — but ideally the runner image gets it baked in once, since both projects need it.

## Side effect (separate cleanup later)

PR #44's `clang+lld` additions to `docker/Dockerfile.gha` were specifically for `cargo-xwin`'s `cc-rs`-driven Windows crates. Those are unused after this PR but cheap to keep; removable in a follow-up cleanup PR if/when the CI image is otherwise refreshed.

## Test plan

- [ ] Merge, then trigger nightly. `Build (PHP 8.4, windows-x86_64)` and `Build (PHP 8.5, windows-x86_64)` should both go green for the first time this cycle.
- [ ] Verify the artifact via `dumpbin /dependents` shows the expected runtime DLL dependencies (notably `php8embed.dll`, system DLLs like `kernel32.dll`, `ws2_32.dll`, etc.).
- [ ] Once `PHP_EMBED_STATIC` lands, re-verify that `dumpbin /dependents` no longer shows `php8embed.dll` in the static-link mode.
- [ ] Eventually, cut a `v0.0.0-rc1` tag and confirm the Release workflow produces `ephpm-v0.0.0-rc1+php8.5.6-windows-x86_64.tar.gz` containing a real `ephpm.exe`.