### PR TITLE
ci(windows+macos): fix install-step PATH and bindgen resource-dir

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,11 +97,22 @@ jobs:
         # /opt/homebrew/bin isn't on the runner's default PATH for
         # non-login shells, so prepend it before calling brew (same
         # pattern php-sdk's macOS job uses).
+        #
+        # BINDGEN_EXTRA_CLANG_ARGS pins clang's resource-dir to llvm@17's
+        # bundled headers. Without this, libclang@17 ends up parsing
+        # Apple-clang 21's NEON intrinsic headers (arm_neon.h /
+        # arm_vector_types.h), which use __mfp8 — a type added in
+        # clang 19+ that llvm@17 doesn't know. The build then fails
+        # with hundreds of "unknown type name '__mfp8'" /
+        # "incompatible constant for this __builtin_neon function".
         run: |
           export PATH="/opt/homebrew/bin:$PATH"
           brew install llvm@17 || brew upgrade llvm@17 || true
           LLVM_PREFIX=$(brew --prefix llvm@17)
+          # Find llvm@17's clang resource dir (varies by patch version)
+          LLVM_RESOURCE_DIR=$(ls -d "${LLVM_PREFIX}"/lib/clang/* | head -1)
           echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=${LLVM_RESOURCE_DIR}" >> "$GITHUB_ENV"
 
       - name: Build ephpm
         # Pulls libphp.a from github.com/ephpm/php-sdk; no system PHP/spc
@@ -148,15 +159,18 @@ jobs:
       - name: Install Rust toolchain
         shell: powershell
         run: |
-          $rustcPath = (Get-Command rustc -ErrorAction SilentlyContinue).Source
-          if (-not $rustcPath) {
+          $cargoBin = "$env:USERPROFILE\.cargo\bin"
+          if (-not (Test-Path "$cargoBin\rustup.exe")) {
             Write-Host "Installing rustup..."
             Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
             .\rustup-init.exe -y --default-toolchain stable --profile minimal
             Remove-Item rustup-init.exe
-            "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           }
-          rustup show
+          # GITHUB_PATH applies to subsequent steps only; also update the
+          # current step's PATH so the verification below can find rustup.
+          $env:PATH = "$cargoBin;$env:PATH"
+          $cargoBin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & "$cargoBin\rustup.exe" show
 
       - name: Install Visual Studio Build Tools
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,18 +89,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Pin libclang for bindgen
-        # The runner's system Apple-clang (Xcode 16+) emits CXCallingConv
-        # value 20 (CXCallingConv_PreserveNone, added in clang 18), which
-        # bindgen 0.72 doesn't know how to tokenize — it panics with
-        # "Cannot turn unknown calling convention to tokens: 20".
-        # Pointing bindgen at llvm@17's libclang avoids the new enum value
-        # entirely. Mirrors the same step in nightly.yml — remove from
-        # both once bindgen learns the new CCs or falls back gracefully.
+        # Pin libclang to brew llvm@17 to dodge the bindgen
+        # CXCallingConv-20 panic; also pin the clang resource-dir so
+        # bindgen uses llvm@17's NEON headers instead of Apple-clang
+        # 21's (which use the newer __mfp8 type). Mirrors nightly.yml.
         run: |
           export PATH="/opt/homebrew/bin:$PATH"
           brew install llvm@17 || brew upgrade llvm@17 || true
           LLVM_PREFIX=$(brew --prefix llvm@17)
+          LLVM_RESOURCE_DIR=$(ls -d "${LLVM_PREFIX}"/lib/clang/* | head -1)
           echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=${LLVM_RESOURCE_DIR}" >> "$GITHUB_ENV"
 
       - name: Build ephpm
         run: cargo xtask release ${{ matrix.php_minor }}
@@ -145,15 +144,16 @@ jobs:
       - name: Install Rust toolchain
         shell: powershell
         run: |
-          $rustcPath = (Get-Command rustc -ErrorAction SilentlyContinue).Source
-          if (-not $rustcPath) {
+          $cargoBin = "$env:USERPROFILE\.cargo\bin"
+          if (-not (Test-Path "$cargoBin\rustup.exe")) {
             Write-Host "Installing rustup..."
             Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
             .\rustup-init.exe -y --default-toolchain stable --profile minimal
             Remove-Item rustup-init.exe
-            "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           }
-          rustup show
+          $env:PATH = "$cargoBin;$env:PATH"
+          $cargoBin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & "$cargoBin\rustup.exe" show
 
       - name: Install Visual Studio Build Tools
         shell: powershell


### PR DESCRIPTION
## Summary

Two follow-up fixes to #53 surfaced by the first nightly that exercised native Windows + the libclang pin actually working on macOS.

### Windows — `rustup not recognized`

PR #53's Install Rust toolchain step succeeded in installing rustup, then immediately tried `rustup show` in the same step and got `'rustup' is not recognized`. Root cause: I appended to `$env:GITHUB_PATH`, which only applies to **subsequent** steps. Same-step PATH updates need `$env:PATH`.

Fix:
- Update `$env:PATH` in the current step (and `$env:GITHUB_PATH` for downstream)
- Invoke rustup via absolute path for the verify call: `& \"$cargoBin\rustup.exe\" show`
- Use `Test-Path \"$cargoBin\rustup.exe\"` for the install-skip gate instead of `Get-Command rustc`, which returns null on a fresh shell even for installed-but-not-yet-PATHed binaries

### macOS — bindgen hits `__mfp8` after libclang pin works

PR #52's libclang pin step finally succeeded for the first time (took ~6 min for `brew install llvm@17`). bindgen got past `CXCallingConv 20`, then hit a *different* mismatch: libclang@17 was parsing Apple-clang 21's NEON intrinsic headers (`arm_neon.h`, `arm_vector_types.h`), which use `__mfp8` — a type added in clang 19+. Hundreds of errors like:

```
arm_vector_types.h:20:9: error: unknown type name '__mfp8'
arm_neon.h:1938:42: error: incompatible constant for this __builtin_neon function
```

Root cause: `LIBCLANG_PATH` points bindgen's library at llvm@17, but clang's auto-resource-dir discovery on macOS picks up Apple's `/Library/Developer/CommandLineTools/usr/lib/clang/21/include/`. So libclang@17 was trying to parse clang-21 NEON headers.

Fix: also export `BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=$LLVM_RESOURCE_DIR` where `LLVM_RESOURCE_DIR=$(brew --prefix llvm@17)/lib/clang/*`. This pins both the libclang implementation **and** the headers it uses to the same version. bindgen reads `BINDGEN_EXTRA_CLANG_ARGS` and prepends those to its clang invocation.

## Test plan

- [ ] Merge, trigger nightly. Both Windows 8.4/8.5 should advance past Install Rust toolchain step; macOS 8.4/8.5 should advance past Build ephpm step.