### PR TITLE
ci(windows+macos): source vcvars64 directly + macOS-specific link flags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -211,13 +211,36 @@ jobs:
           }
 
       - name: Enter MSVC developer environment
-        # Imports vcvars64.bat into GITHUB_ENV so cl.exe, link.exe, and
-        # the Windows SDK includes/libs are on PATH for cargo build and
-        # cc-rs-driven crates like `ring`.
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-          vsversion: "2022"
+        shell: powershell
+        # Source vcvars64.bat from our custom install path (C:\BuildTools)
+        # and export the resulting env vars to GITHUB_ENV. ilammy/msvc-dev-cmd
+        # only probes standard VS install paths (Program Files\Microsoft
+        # Visual Studio\2022\{Enterprise,Professional,Community,BuildTools})
+        # and doesn't find our Server Core-friendly C:\BuildTools install.
+        run: |
+          $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) {
+            Write-Error "vcvars64.bat not found at $vcvars — VS Build Tools install may have failed"
+            exit 1
+          }
+          # cmd /c sources vcvars, then `set` dumps the env; capture and
+          # forward to GITHUB_ENV so subsequent cargo steps see cl.exe,
+          # link.exe, INCLUDE, LIB, LIBPATH, etc.
+          $envBefore = @{}
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) { $envBefore[$e.Key] = $e.Value }
+          $output = & "${env:COMSPEC}" /s /c "`"$vcvars`" >NUL && set"
+          $count = 0
+          foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              $name = $matches[1]
+              $value = $matches[2]
+              if ($envBefore[$name] -ne $value) {
+                "$name=$value" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+                $count++
+              }
+            }
+          }
+          Write-Host "Forwarded $count env vars from vcvars64 to GITHUB_ENV"
 
       - name: Build ephpm.exe
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,10 +189,25 @@ jobs:
           }
 
       - name: Enter MSVC developer environment
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-          vsversion: "2022"
+        shell: powershell
+        # Source vcvars64.bat from our custom install path (C:\BuildTools);
+        # ilammy/msvc-dev-cmd only probes standard Program Files locations.
+        run: |
+          $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) {
+            Write-Error "vcvars64.bat not found at $vcvars"
+            exit 1
+          }
+          $envBefore = @{}
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) { $envBefore[$e.Key] = $e.Value }
+          $output = & "${env:COMSPEC}" /s /c "`"$vcvars`" >NUL && set"
+          foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              if ($envBefore[$matches[1]] -ne $matches[2]) {
+                "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+              }
+            }
+          }
 
       - name: Build ephpm.exe
         shell: powershell

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -32,6 +32,37 @@ fn main() {
         return;
     }
 
+    let lib_dir = sdk_path.join("lib");
+
+    if target_os == "macos" {
+        // Apple's ld64 doesn't understand GNU ld's --wrap, --start-group/
+        // --end-group, or -Bstatic/-Bdynamic. ld64 does multi-pass
+        // symbol resolution by default, so the group flags aren't needed
+        // — just list the archives directly and let it sort circular
+        // deps out.
+        //
+        // The zend_signal_* SIGPROF wrapping that --wrap provides on
+        // Linux is currently NOT applied on macOS. This is a known gap
+        // (TODO: implement via -Wl,-alias_list or by overriding the
+        // symbols via a sibling .a built specifically to win symbol
+        // resolution order). It only matters if SIGPROF on tokio
+        // worker threads ever fires — PHP installs the handler in
+        // zend_signal_startup but typically only delivers it under
+        // max_execution_time, which ephpm enforces at the tokio layer
+        // instead and shouldn't trigger.
+        println!("cargo::rustc-link-arg={}", lib_dir.join("libphp.a").display());
+        for static_lib in macos_static_libs() {
+            let archive = lib_dir.join(format!("lib{static_lib}.a"));
+            if archive.exists() {
+                println!("cargo::rustc-link-arg={}", archive.display());
+            }
+        }
+        return;
+    }
+
+    // Linux path: GNU ld supports --wrap, --start-group/--end-group, and
+    // -Bstatic/-Bdynamic. We rely on all three.
+
     for func in &[
         "zend_signal_startup",
         "zend_signal_init",
@@ -66,14 +97,10 @@ fn main() {
     // Wrapping in --start-group/--end-group forces multi-pass symbol
     // resolution: PHP's static archives have circular dependencies
     // (libphp.a → libz.a → ...; libcurl → libssl; libxml2 → libz; etc.).
-    let lib_dir = sdk_path.join("lib");
     println!("cargo::rustc-link-arg=-Wl,-Bstatic");
     println!("cargo::rustc-link-arg=-Wl,--start-group");
     println!("cargo::rustc-link-arg={}", lib_dir.join("libphp.a").display());
-    for static_lib in &[
-        "ssl", "crypto", "curl", "z", "xml2", "sodium", "iconv", "charset", "png16", "gd", "jpeg",
-        "freetype", "onig", "zip", "bz2", "xslt", "exslt",
-    ] {
+    for static_lib in linux_static_libs() {
         let archive = lib_dir.join(format!("lib{static_lib}.a"));
         if archive.exists() {
             println!("cargo::rustc-link-arg={}", archive.display());
@@ -81,4 +108,28 @@ fn main() {
     }
     println!("cargo::rustc-link-arg=-Wl,--end-group");
     println!("cargo::rustc-link-arg=-Wl,-Bdynamic");
+}
+
+/// Static lib set the Linux SDK ships (musl-built).
+///
+/// Kept in sync with `crates/ephpm-php/build.rs`'s probe list — both
+/// paths need to know about the same SDK contents. If you add a lib
+/// here, mirror it there (and vice versa).
+fn linux_static_libs() -> &'static [&'static str] {
+    &[
+        "ssl", "crypto", "curl", "z", "xml2", "xslt", "exslt", "lzma", "sodium", "iconv",
+        "charset", "intl", "png16", "gd", "jpeg", "freetype", "onig", "zip", "bz2", "gmp",
+        "sqlite3", "pq", "pgcommon", "pgport", "edit", "ncurses", "menu", "form", "panel", "tic",
+        "icui18n", "icuuc", "icudata", "icuio", "icutu", "stdc++",
+    ]
+}
+
+/// Static lib set the macOS SDK ships.
+///
+/// macOS's libphp.a bundles some deps differently than Linux's (system
+/// libiconv lives in libSystem, libz/libxml2 are system frameworks, etc.).
+/// Start with the same list as Linux and tighten as we discover what's
+/// actually needed.
+fn macos_static_libs() -> &'static [&'static str] {
+    linux_static_libs()
 }


### PR DESCRIPTION
## Summary

Two follow-ups to PR #54 from the third nightly with native Windows + functional macOS libclang pin. Both new failures, both clearly in our court.

### Windows: ilammy can't find VS at C:\BuildTools

```
##[error]Could not setup Developer Command Prompt: Microsoft Visual Studio not found
```

`ilammy/msvc-dev-cmd@v1` only probes standard install paths (`C:\Program Files\Microsoft Visual Studio\2022\{Enterprise,Professional,Community,BuildTools}\`). Our VS Build Tools install lands at `C:\BuildTools` (Server-Core-friendly per php-sdk's pattern; Microsoft warns nested Program Files paths are flaky on Server Core).

**Fix:** drop `ilammy/msvc-dev-cmd`, source `vcvars64.bat` directly from `C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat`. Capture the env diff after sourcing and forward to `GITHUB_ENV` so subsequent cargo steps see `cl.exe`, `link.exe`, `INCLUDE`, `LIB`, `LIBPATH`.

### macOS: ld64 doesn't understand GNU ld flags

```
ld: unknown options: --wrap=zend_signal_startup --start-group --end-group -Bstatic -Bdynamic
```

`crates/ephpm/build.rs` was unconditionally emitting `-Wl,--wrap=...`, `-Wl,--start-group`, `-Wl,-Bstatic` for non-Windows builds. Apple's `ld64` doesn't speak any of these. Long-standing latent bug — never surfaced because macOS always failed at bindgen first (fixed by PR #54's resource-dir pin).

**Fix:** split the linker arg block by target_os:
- **Windows**: existing `/DELAYLOAD` path (unchanged)
- **macOS**: list static archives directly. `ld64` does multi-pass resolution by default, so `--start-group`/`--end-group` aren't needed. SIGPROF wrapping via `--wrap` is **not applied** — documented TODO. Only matters if `max_execution_time` fires; ephpm enforces the timeout at the tokio layer so this is fine in practice.
- **Linux**: existing GNU-ld path, refactored to use a shared `linux_static_libs()` helper

Also updated the static lib list to mirror `ephpm-php/build.rs`'s post-SDK-bump probe set (intl, gmp, sqlite3, pq*, edit, ncurses*, lzma, icu*, stdc++). macOS shares the list; missing libs get silently skipped via `if archive.exists()`.

## Test plan
- [ ] Merge, trigger nightly. Windows 8.4/8.5 should advance past the MSVC env step into the actual cargo build. macOS 8.4/8.5 should link successfully and produce binaries.