### PR TITLE
ci(windows+macos): fix PS 5.1 cmd subshell + add -lc++ on macOS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -214,21 +214,31 @@ jobs:
         shell: powershell
         # Source vcvars64.bat from our custom install path (C:\BuildTools)
         # and export the resulting env vars to GITHUB_ENV. ilammy/msvc-dev-cmd
-        # only probes standard VS install paths (Program Files\Microsoft
-        # Visual Studio\2022\{Enterprise,Professional,Community,BuildTools})
-        # and doesn't find our Server Core-friendly C:\BuildTools install.
+        # only probes standard VS install paths and doesn't find our
+        # Server Core-friendly C:\BuildTools install.
+        #
+        # Use a temp .bat (rather than `cmd /c "...vcvars... && set"`)
+        # because Windows PowerShell 5.1 — the only PowerShell on the
+        # Server Core runner image — parses `&&` as a statement separator
+        # even inside double-quoted strings, breaking the cmd subshell.
         run: |
           $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           if (-not (Test-Path $vcvars)) {
             Write-Error "vcvars64.bat not found at $vcvars — VS Build Tools install may have failed"
             exit 1
           }
-          # cmd /c sources vcvars, then `set` dumps the env; capture and
-          # forward to GITHUB_ENV so subsequent cargo steps see cl.exe,
-          # link.exe, INCLUDE, LIB, LIBPATH, etc.
           $envBefore = @{}
-          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) { $envBefore[$e.Key] = $e.Value }
-          $output = & "${env:COMSPEC}" /s /c "`"$vcvars`" >NUL && set"
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+            $envBefore[$e.Key] = $e.Value
+          }
+          $dumpBat = Join-Path $env:TEMP "vcvars-dump.bat"
+          @"
+          @echo off
+          call "$vcvars" >NUL
+          set
+          "@ | Out-File -Encoding ascii -FilePath $dumpBat
+          $output = & cmd /c $dumpBat
+          Remove-Item $dumpBat
           $count = 0
           foreach ($line in $output) {
             if ($line -match '^([^=]+)=(.*)$') {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,17 +190,21 @@ jobs:
 
       - name: Enter MSVC developer environment
         shell: powershell
-        # Source vcvars64.bat from our custom install path (C:\BuildTools);
-        # ilammy/msvc-dev-cmd only probes standard Program Files locations.
         run: |
           $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          if (-not (Test-Path $vcvars)) {
-            Write-Error "vcvars64.bat not found at $vcvars"
-            exit 1
-          }
+          if (-not (Test-Path $vcvars)) { Write-Error "vcvars64.bat not found"; exit 1 }
           $envBefore = @{}
-          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) { $envBefore[$e.Key] = $e.Value }
-          $output = & "${env:COMSPEC}" /s /c "`"$vcvars`" >NUL && set"
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+            $envBefore[$e.Key] = $e.Value
+          }
+          $dumpBat = Join-Path $env:TEMP "vcvars-dump.bat"
+          @"
+          @echo off
+          call "$vcvars" >NUL
+          set
+          "@ | Out-File -Encoding ascii -FilePath $dumpBat
+          $output = & cmd /c $dumpBat
+          Remove-Item $dumpBat
           foreach ($line in $output) {
             if ($line -match '^([^=]+)=(.*)$') {
               if ($envBefore[$matches[1]] -ne $matches[2]) {

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -57,6 +57,16 @@ fn main() {
                 println!("cargo::rustc-link-arg={}", archive.display());
             }
         }
+        // ICU on macOS is built against libc++ (Apple's C++ stdlib);
+        // libphp's intl extension drags in std::logic_error,
+        // std::length_error, ___gxx_personality_v0, etc. Rust doesn't
+        // auto-add -lc++ when we override the link line with explicit
+        // rustc-link-arg directives, so add it explicitly.
+        //
+        // Order matters: must come AFTER the static archives so ld64
+        // sees the unresolved references first, then resolves them
+        // from libc++.
+        println!("cargo::rustc-link-arg=-lc++");
         return;
     }
 


### PR DESCRIPTION
## Summary

Two more follow-ups from the fourth nightly. Both real failures from real logs, both clearly in our court.

### Windows: PowerShell 5.1 chokes on `&&` in cmd subshell string

```
At ...ps1:12 char:54
+ $output = & "${env:COMSPEC}" /s /c "`"$vcvars`" >/dev/null && set"
+                                                      ~~
The token '&&' is not a valid statement separator in this version.
```

The runner image (`mcr.microsoft.com/windows/servercore:ltsc2025`) only has **Windows PowerShell 5.1** — `pwsh` (PowerShell 7+) isn't installed. PS 5.1's parser treats `&&` as a statement separator and chokes on it even inside double-quoted argument strings to external commands.

**Fix:** ditch the inline `cmd /c "...vcvars... && set"` and use a temp `.bat` file with `call vcvars64.bat` then `set` on separate lines. Run `cmd /c <bat>` and capture stdout. No `&&` ever crosses PowerShell's parser.

### macOS: missing C++ runtime symbols after the GNU-flag fix

PR #55 removed the GNU ld flags so the link could actually run. Link now reaches symbol resolution but fails with:

```
Undefined symbols for architecture arm64:
  "std::logic_error::logic_error(char const*)", referenced from:
      std::length_error::length_error[abi:nqe220106](char const*) in libephpm_php.rlib[278](msgformat_helpers.o)
  "std::length_error::~length_error()", referenced from: ...
  "___gxx_personality_v0", referenced from:
      .../libephpm_php.rlib[3969](uloc.ao)
```

These are libc++ symbols. macOS PHP's intl extension is built against Apple's `libc++` (Apple's C++ stdlib), so ICU `.a` archives reference `std::*`, `__cxa_*`, `___gxx_personality_v0`. Rust auto-adds `-lc++` for crates targeting macOS *when it manages the link line*, but we override the link line with explicit `rustc-link-arg` directives, so the auto-add doesn't happen.

**Fix:** add `println!("cargo::rustc-link-arg=-lc++")` AFTER the static archives in the macOS branch of `crates/ephpm/build.rs`. Position matters — ld64 needs to see the unresolved references first, then resolve them from libc++.

## Test plan
- [ ] Merge, trigger nightly. Windows MSVC env step should pass; macOS Build ephpm step should link successfully and produce binaries.