### PR TITLE
ci(windows): use single ampersand for cmd separator (PS 5.1 compat)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -217,10 +217,13 @@ jobs:
         # only probes standard VS install paths and doesn't find our
         # Server Core-friendly C:\BuildTools install.
         #
-        # Use a temp .bat (rather than `cmd /c "...vcvars... && set"`)
-        # because Windows PowerShell 5.1 — the only PowerShell on the
-        # Server Core runner image — parses `&&` as a statement separator
-        # even inside double-quoted strings, breaking the cmd subshell.
+        # PS 5.1 parser notes:
+        #   - `&&` is rejected even inside quoted strings ("not a valid
+        #     statement separator in this version"). Use `&` (single
+        #     ampersand) — cmd treats it as unconditional separator, PS
+        #     parses it as literal inside a double-quoted string.
+        #   - here-strings (@"..."@) require the closing "@ at column 0
+        #     which fights YAML indentation; avoid them.
         run: |
           $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           if (-not (Test-Path $vcvars)) {
@@ -231,14 +234,8 @@ jobs:
           foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
             $envBefore[$e.Key] = $e.Value
           }
-          $dumpBat = Join-Path $env:TEMP "vcvars-dump.bat"
-          @"
-          @echo off
-          call "$vcvars" >NUL
-          set
-          "@ | Out-File -Encoding ascii -FilePath $dumpBat
-          $output = & cmd /c $dumpBat
-          Remove-Item $dumpBat
+          $cmdLine = 'call "' + $vcvars + '" >NUL & set'
+          $output = & cmd /c $cmdLine
           $count = 0
           foreach ($line in $output) {
             if ($line -match '^([^=]+)=(.*)$') {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,14 +197,8 @@ jobs:
           foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
             $envBefore[$e.Key] = $e.Value
           }
-          $dumpBat = Join-Path $env:TEMP "vcvars-dump.bat"
-          @"
-          @echo off
-          call "$vcvars" >NUL
-          set
-          "@ | Out-File -Encoding ascii -FilePath $dumpBat
-          $output = & cmd /c $dumpBat
-          Remove-Item $dumpBat
+          $cmdLine = 'call "' + $vcvars + '" >NUL & set'
+          $output = & cmd /c $cmdLine
           foreach ($line in $output) {
             if ($line -match '^([^=]+)=(.*)$') {
               if ($envBefore[$matches[1]] -ne $matches[2]) {


### PR DESCRIPTION
## Summary

Third iteration of the vcvars MSVC env step. Lessons from PRs #55 and #56:

| Iteration | Approach | Why it failed |
|---|---|---|
| #55 | \`cmd /c \"vcvars && set\"\` (inline \`&&\`) | PS 5.1 rejects \`&&\` even inside double-quoted argument strings to external commands |
| #56 | Temp .bat file via here-string \`@\"...\"@\` | PS 5.1 here-string requires closing \`\"@\` at column 0; fights YAML's indented run-block, parser treats body as PowerShell code (\`@echo off\` → splatting error) |
| **#57** | Build cmd arg as plain string, use single \`&\` for cmd separator | PS 5.1 parses single \`&\` inside a string as literal; cmd treats it as unconditional separator (looser than \`&&\` but no failure-stop needed here since vcvars64.bat doesn't fail) |

The simplest version, finally:

\`\`\`powershell
\$cmdLine = 'call \"' + \$vcvars + '\" >/dev/null & set'
\$output = & cmd /c \$cmdLine
\`\`\`

Single-quoted strings don't interpolate, so the only escaping needed is concatenating in \`\$vcvars\`. No \`&&\`, no temp files, no heredocs.

## Test plan
- [ ] Merge, trigger nightly. Windows MSVC env step should finally succeed; the build step is then the only thing left to validate on Windows.