### PR TITLE
ci(windows): install VC.Llvm.Clang + set LIBCLANG_PATH for bindgen

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -194,6 +194,7 @@ jobs:
                 '--quiet', '--wait', '--norestart', '--nocache',
                 '--installPath', $installPath,
                 '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--add', 'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
                 '--includeRecommended'
               ) -Wait -PassThru -NoNewWindow
             Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
@@ -248,6 +249,17 @@ jobs:
             }
           }
           Write-Host "Forwarded $count env vars from vcvars64 to GITHUB_ENV"
+          # bindgen needs libclang.dll; the VC.Llvm.Clang component added
+          # to the VS Build Tools install puts it at this path. Set
+          # LIBCLANG_PATH so bindgen's runtime libloading search finds it
+          # without falling back to LLVM standard-locations probing.
+          $libclangDir = "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+          if (Test-Path "$libclangDir\libclang.dll") {
+            "LIBCLANG_PATH=$libclangDir" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+            Write-Host "LIBCLANG_PATH set to $libclangDir"
+          } else {
+            Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
+          }
 
       - name: Build ephpm.exe
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,7 @@ jobs:
                 '--quiet', '--wait', '--norestart', '--nocache',
                 '--installPath', $installPath,
                 '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--add', 'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
                 '--includeRecommended'
               ) -Wait -PassThru -NoNewWindow
             Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
@@ -205,6 +206,12 @@ jobs:
                 "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
               }
             }
+          }
+          $libclangDir = "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+          if (Test-Path "$libclangDir\libclang.dll") {
+            "LIBCLANG_PATH=$libclangDir" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          } else {
+            Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
           }
 
       - name: Build ephpm.exe


### PR DESCRIPTION
## Summary

Windows nightly now reaches `bindgen` and panics because `libclang.dll` isn't on the runner:

```
thread 'main' panicked at bindgen-0.72.1/lib.rs:616:27:
Unable to find libclang: "couldn't find any valid shared libraries
matching: ['clang.dll', 'libclang.dll'], set the `LIBCLANG_PATH`
environment variable to a path where one of these files can be found
(invalid: [])"
```

VS Build Tools ships a `Microsoft.VisualStudio.Component.VC.Llvm.Clang` component that includes `libclang.dll` alongside clang-cl. Two-line change:

1. Add `--add Microsoft.VisualStudio.Component.VC.Llvm.Clang` to the `vs_buildtools.exe` install args (nightly + release)
2. Export `LIBCLANG_PATH=C:\BuildTools\VC\Tools\Llvm\x64\bin` to `GITHUB_ENV` in the MSVC env step so bindgen's runtime libloading finds it without falling back to LLVM standard-locations probing

Both workflow files updated. Step warns if the DLL is not present instead of failing silently.

## Test plan
- [ ] Merge, trigger nightly. Windows MSVC env step exports `LIBCLANG_PATH`; bindgen runs cleanly; build proceeds to link.