### PR TITLE
fix(ephpm-php): #include intsafe.h for bindgen on Windows

### DIFF
--- a/crates/ephpm-php/wrapper.h
+++ b/crates/ephpm-php/wrapper.h
@@ -7,6 +7,17 @@
  *   $PHP_SDK_PATH/include/php/
  */
 
+#ifdef _WIN32
+/* PHP's Zend/zend_operators.h calls LongLongAdd / LongLongSub /
+ * ULongLongAdd / ULongLongSub directly without declaring them. MSVC
+ * cl.exe tolerates this as a warning because it auto-includes
+ * intsafe.h transitively via the Windows SDK umbrella; clang
+ * (libclang, used by bindgen) is strict and errors on the implicit
+ * declaration. Pull intsafe.h in here so bindgen sees the prototypes
+ * before parsing the Zend headers. */
+#include <intsafe.h>
+#endif
+
 #include "sapi/embed/php_embed.h"
 #include "main/php.h"
 #include "main/SAPI.h"


### PR DESCRIPTION
## Summary

bindgen on Windows now successfully takes the `PHP_WIN32` branches of the headers (PR #61) but still errors on undeclared `intsafe.h` intrinsics:

```
zend_operators.h:609:24: error: call to undeclared function 'LongLongAdd';
  ISO C99 and later do not support implicit function declarations
zend_operators.h:688:24: error: call to undeclared function 'LongLongSub'; ...
zend_operators.h:785:24: error: call to undeclared function 'LongLongAdd'; ...
zend_operators.h:889:24: error: call to undeclared function 'LongLongSub'; ...
```

**Root cause:** PHP's `Zend/zend_operators.h` calls `LongLongAdd` / `LongLongSub` / `ULongLongAdd` / `ULongLongSub` without declaring them. MSVC's `cl.exe` tolerates the implicit declarations as warnings -- `intsafe.h` is pulled in transitively through the Windows SDK umbrella. Clang (libclang, used by bindgen) is stricter and errors.

**Fix:** pre-include `intsafe.h` from `wrapper.h` under `#ifdef _WIN32` so bindgen sees the prototypes before parsing the Zend headers. No-op for Linux/macOS; no-op for `cl.exe` on Windows either since `intsafe.h` is idempotent.

## Test plan
- [ ] Merge, trigger nightly. Windows bindgen step should succeed; build proceeds to link.