### PR TITLE
fix(ephpm-php): forward MSVC INCLUDE paths to bindgen on Windows

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -320,6 +320,18 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
             .clang_arg("-DPHP_WIN32")
             .clang_arg("-DZEND_DEBUG=0")
             .clang_arg("-DZTS=0");
+
+        // bindgen runs libclang directly and does NOT consume the
+        // MSVC INCLUDE env var (cl.exe does, libclang doesn't). Without
+        // this, system headers like intsafe.h and windows.h fail to
+        // resolve even though they're on disk. Read INCLUDE (set by
+        // vcvars64.bat in the workflow) and forward each path to clang
+        // as -isystem so the lookup succeeds.
+        if let Ok(include) = env::var("INCLUDE") {
+            for path in include.split(';').filter(|p| !p.is_empty()) {
+                builder = builder.clang_arg(format!("-isystem{path}"));
+            }
+        }
     } else {
         // ZTS builds: define ZTS for bindgen so PHP headers use thread-safe macros.
         builder = builder.clang_arg("-DZTS=1").clang_arg("-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");


### PR DESCRIPTION
## Summary

PR #62 added `#include <intsafe.h>` to `wrapper.h` to silence the `LongLongAdd`/`LongLongSub` undeclared-function errors. But the include itself wasn't actually resolving on the runner because **bindgen runs libclang directly, which does NOT consume the MSVC `INCLUDE` env var** that `cl.exe` relies on for system header lookup.

Result: PR #62 looked fine in CI (the `#ifdef _WIN32` branch ran, the `#include` line was emitted), but `intsafe.h` was never actually found, so the prototypes never landed, and bindgen still errored on the same call sites.

## Fix

Read `INCLUDE` (set by `vcvars64.bat` in the Enter MSVC developer environment step) and forward each `;`-separated path to clang as `-isystem`. After this, bindgen sees the same header world as `cl.exe`.

```rust
if let Ok(include) = env::var("INCLUDE") {
    for path in include.split(';').filter(|p| !p.is_empty()) {
        builder = builder.clang_arg(format!("-isystem{path}"));
    }
}
```

## Test plan
- [ ] Merge, trigger nightly. Windows bindgen should resolve `intsafe.h` cleanly; `LongLongAdd`/`LongLongSub` errors go away; build proceeds to link.