### PR TITLE
debug(ephpm-php): log INCLUDE forwarding for Windows bindgen

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -327,9 +327,23 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
         // resolve even though they're on disk. Read INCLUDE (set by
         // vcvars64.bat in the workflow) and forward each path to clang
         // as -isystem so the lookup succeeds.
-        if let Ok(include) = env::var("INCLUDE") {
-            for path in include.split(';').filter(|p| !p.is_empty()) {
-                builder = builder.clang_arg(format!("-isystem{path}"));
+        match env::var("INCLUDE") {
+            Ok(include) => {
+                let paths: Vec<&str> = include.split(';').filter(|p| !p.is_empty()).collect();
+                println!(
+                    "cargo::warning=bindgen: forwarding {} INCLUDE paths to clang",
+                    paths.len()
+                );
+                for path in paths {
+                    println!("cargo::warning=bindgen: -isystem{path}");
+                    builder = builder.clang_arg(format!("-isystem{path}"));
+                }
+            }
+            Err(_) => {
+                println!(
+                    "cargo::warning=bindgen: INCLUDE env var not set; \
+                     Windows SDK headers won't resolve"
+                );
             }
         }
     } else {


### PR DESCRIPTION
## Summary

PR #63 forwards `INCLUDE` env var entries to bindgen as `-isystem` paths. The next Windows nightly still failed with the same `LongLongAdd`/`LongLongSub` errors, meaning the forwarding didn't actually fix the lookup.

Three possibilities:
1. `INCLUDE` env var isn't set when `build.rs` runs (vcvars64 forwarded to `GITHUB_ENV` but maybe not propagated to the cargo invocation)
2. `INCLUDE` is set but doesn't include the Windows SDK `shared/` dir where `intsafe.h` lives
3. `-isystem<path>` with backslash paths isn't honored by libclang

Add `cargo::warning` diagnostics to disambiguate. The next nightly run's Windows job will show:
- Whether `INCLUDE` is set at all
- How many paths got forwarded
- Each path verbatim (so we can see if `shared/` is in there)

Pure diagnostic, no behavior change. Revert once Windows is green.

## Test plan
- [ ] Merge, trigger nightly, read the Windows job log for the `cargo::warning=bindgen:` lines, identify which of the three scenarios we're in.