### PR TITLE
ci(nightly): run E2E job inside the CI container

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -337,6 +337,11 @@ jobs:
     name: E2E (PHP ${{ matrix.php }})
     needs: [build-linux]
     runs-on: [self-hosted, linux, x64]
+    # Run inside the CI image so cargo has a C linker available
+    # (xtask needs `cc` to compile; bare runners only ship rustup).
+    # Same image as build-linux; ephemerd's host docker socket is
+    # reachable from inside so the kind cluster inside xtask works.
+    container: ephpm/ephpm-ci:latest
     # Auxiliary -- does not gate the release path.
     continue-on-error: true
     strategy:
@@ -345,8 +350,6 @@ jobs:
         php: ["8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - name: Install E2E tools (kind, tilt, kubectl)
         run: cargo xtask e2e-install


### PR DESCRIPTION
Switches the nightly E2E job from the bare self-hosted runner to the `ephpm/ephpm-ci:latest` container.

**Why:** the bare runner has rustup but no C linker, so `cargo xtask e2e-install` fails with `linker 'cc' not found` before it ever gets to creating the kind cluster. The failure was masked by the dind `--privileged` block previously; with that now resolved, the linker gap is the next layer.

**Approach:** add `container: ephpm/ephpm-ci:latest` (same image as `build-linux`) and drop `dtolnay/rust-toolchain@stable` (the image already ships stable + the rust-toolchain.toml component set).

ephemerd's host docker socket is reachable from inside this container (proven by `build-linux` doing `docker build` from inside it), so the kind cluster that `xtask e2e` drives can still be created.

## Test plan
- [ ] Merge, trigger nightly, watch the E2E job advance past `Install E2E tools` into actual cluster creation + test run.