### PR TITLE
ci(nightly): fix auxiliary job environments on ephemerd runners

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -290,6 +290,9 @@ jobs:
   fuzz:
     name: Fuzz (${{ matrix.target }})
     runs-on: [self-hosted, linux, x64]
+    # Run inside the CI image: `cargo install cargo-fuzz` and the fuzz
+    # targets themselves need a C linker, and bare runners only ship rustup.
+    container: ephpm/ephpm-ci:latest
     # Auxiliary -- does not gate the release path.
     continue-on-error: true
     strategy:
@@ -363,6 +366,10 @@ jobs:
     name: Smoke Tests (PHP ${{ matrix.php }})
     needs: [build-linux]
     runs-on: [self-hosted, linux, x64]
+    # Run inside the CI image: the bare runner has no `file` utility and
+    # its docker CLI lacks the compose v2 plugin. The image ships both,
+    # and ephemerd's host docker socket is reachable from inside.
+    container: ephpm/ephpm-ci:latest
     # Auxiliary -- does not gate the release path.
     continue-on-error: true
     strategy:
@@ -456,17 +463,27 @@ jobs:
   audit:
     name: Dependency Audit
     runs-on: [self-hosted, linux, x64]
-    # Auxiliary -- does not gate the release path. Currently broken because
-    # cargo-deny-action uses buildx, which needs --privileged (disabled by
-    # the ephemerd runner).
+    # Run inside the CI image so cargo-audit/cargo-outdated can compile
+    # (they need a C linker; bare runners only ship rustup).
+    container: ephpm/ephpm-ci:latest
+    # Auxiliary -- does not gate the release path.
     continue-on-error: true
+    env:
+      # Prebuilt musl binary -- avoids both compiling cargo-deny from
+      # source and the Docker-based cargo-deny-action, whose buildx path
+      # needs --privileged (disabled by the ephemerd runner).
+      CARGO_DENY_VERSION: 0.19.8
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
 
       - name: cargo deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        run: |
+          curl -fsSL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | tar xz --strip-components=1 -C /usr/local/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
+          cargo-deny --version
+          cargo-deny check
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked || true

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -39,6 +39,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libclang-dev libssl-dev musl-tools musl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# ── Docker CLI + compose plugin (client only, no daemon) ─────────────────────
+#
+# The nightly E2E and smoke-test jobs run inside this image and talk to
+# ephemerd's host docker socket. The socket is mounted into the job
+# container, but the client binary has to live in the image: E2E needs
+# `docker` for kind cluster creation, smoke tests need `docker compose`
+# for the WordPress/Laravel/Symfony fixtures. Only the CLI and compose
+# plugin are installed — no containerd/dockerd, the daemon is ephemerd's.
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────
 #
 # The stable component set MUST be a superset of rust-toolchain.toml's


### PR DESCRIPTION
## Summary

Last night's nightly (run 27215354931) showed all four auxiliary jobs failing for runner-environment reasons, not real test failures:

- **Fuzz x4**: `linker 'cc' not found` -- the job ran on the bare ephemerd runner (rustup only). Now runs inside `ephpm/ephpm-ci:latest`.
- **E2E x2**: `docker: executable file not found in $PATH` -- the job already ran in the CI image, but the image never installed the docker CLI. The image now ships `docker-ce-cli` + `docker-compose-plugin` (client only; the daemon stays ephemerd's host socket).
- **Smoke x2**: bare runner is missing `file` (killed Prepare binary, exit 127) and its docker CLI has no compose v2 plugin (`unknown shorthand flag: 'f'`). Moved into the CI image, which has both after the Dockerfile change.
- **Dependency Audit**: `cargo-deny-action` is a Docker action whose buildx path needs `--privileged` (disabled on ephemerd). Replaced with the prebuilt cargo-deny musl binary (pinned 0.19.8) run directly. Job also moves into the CI image so `cargo install cargo-audit` / `cargo-outdated` get a C linker.

Merge sequencing is automatic: the CI Image workflow rebuilds and pushes `:latest` on merge (Dockerfile.gha path filter), so the next nightly picks up the docker CLI without manual steps.

The Windows Build failures from the same run are separate -- fixed in #67.

## Test plan

- [ ] CI Image workflow rebuilds green after merge
- [ ] Next nightly: Fuzz x4 reach the actual fuzz run (no linker error)
- [ ] Next nightly: E2E x2 create the kind cluster (docker CLI resolves)
- [ ] Next nightly: Smoke x2 get past Prepare binary and `docker compose up`
- [ ] Next nightly: Dependency Audit runs cargo-deny check directly