### PR TITLE
chore: bump PHP SDK pins to 8.4.22 / 8.5.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.21"
+            php_full: "8.4.22"
           - php_minor: "8.5"
-            php_full: "8.5.6"
+            php_full: "8.5.7"
     steps:
       - uses: actions/checkout@v4
 
@@ -79,9 +79,9 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.21"
+            php_full: "8.4.22"
           - php_minor: "8.5"
-            php_full: "8.5.6"
+            php_full: "8.5.7"
     steps:
       - uses: actions/checkout@v4
 
@@ -135,9 +135,9 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.21"
+            php_full: "8.4.22"
           - php_minor: "8.5"
-            php_full: "8.5.6"
+            php_full: "8.5.7"
     steps:
       - uses: actions/checkout@v4
 
@@ -254,10 +254,10 @@ jobs:
       matrix:
         include:
           - php_minor: "8.4"
-            php_full: "8.4.21"
+            php_full: "8.4.22"
             default: false
           - php_minor: "8.5"
-            php_full: "8.5.6"
+            php_full: "8.5.7"
             default: true
     steps:
       - uses: actions/checkout@v4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,9 @@
 # version via xtask::PHP_SDK_VERSIONS and passes it as PHP_SDK_VERSION.
 
 # Pinned full version of the PHP SDK to download. Must match a release tag
-# at github.com/ephpm/php-sdk/releases (e.g., v8.5.6). The default mirrors
+# at github.com/ephpm/php-sdk/releases (e.g., v8.5.7). The default mirrors
 # xtask::PHP_SDK_VERSIONS — keep them in sync if you bump.
-ARG PHP_SDK_VERSION=8.5.6
+ARG PHP_SDK_VERSION=8.5.7
 
 # ── Stage 1: base — system deps + Rust toolchain ─────────────────────────────
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,7 +9,7 @@ use std::{env, fs};
 /// shorthand (e.g. "8.5") to the specific patch release we publish SDKs for.
 /// Users may also pass a full version explicitly (e.g. "8.5.6") and the
 /// resolver will accept it as-is.
-const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.21"), ("8.5", "8.5.6")];
+const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.22"), ("8.5", "8.5.7")];
 
 /// Default PHP minor when no version is specified on the command line.
 const DEFAULT_PHP_MINOR: &str = "8.5";


### PR DESCRIPTION
## Summary

- The v8.4.21 and v8.3.31 php-sdk releases shipped with **PHP 8.5.7 contents on every platform** (spc silently ignored `--with-php` and built latest stable). php-sdk moved forward instead of patching history: **v8.4.22** and **v8.5.7** are freshly built, v8.3.31 was rebuilt in place. All three verified by reading `php_version.h` out of the published linux-x86_64 tarballs.
- php-sdk now hard-fails at packaging time on any staged-version mismatch (ephpm/php-sdk#13), so this class of mispackaging cannot recur. The guard already proved itself: the first attempted 8.4.21 rebuild was correctly rejected.
- Updates all three sync points: `xtask::PHP_SDK_VERSIONS`, the Dockerfile `ARG` default, and the release.yml matrix (8 entries).

## Why E2E (PHP 8.4) has been red

`php_version_matches` was correctly failing: it built ephpm against the v8.4.21 SDK and got a PHP 8.5.7 binary. With this bump pointing at the clean v8.4.22, that check should go green — the first fully-green E2E pair since June 4.

## Test plan

- [ ] PR CI E2E (PHP 8.4) passes (asserts "PHP Version: 8.4" against the 8.4.22 binary)
- [ ] PR CI E2E (PHP 8.5) passes (8.5.7)
- [ ] Nightly Build matrix green across linux/macos with new pins (Windows pending #67)