### PR TITLE
ci: pin Windows clang resource dir for bindgen; add buildx to CI image

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -260,6 +260,23 @@ jobs:
           } else {
             Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
           }
+          # Pin clang's builtin-header resource dir for bindgen. Without it,
+          # libclang parses with only the MSVC/UCRT headers, which never
+          # define C11 max_align_t -- zend_portability.h:797 then fails with
+          # "unknown type name 'max_align_t'". Clang's own stddef.h defines
+          # max_align_t even on MSVC targets, but only when the resource dir
+          # resolves. Same class of fix as the macOS job's
+          # BINDGEN_EXTRA_CLANG_ARGS resource-dir pin.
+          $clangLibRoot = "C:\BuildTools\VC\Tools\Llvm\x64\lib\clang"
+          $resourceDir = Get-ChildItem -Directory $clangLibRoot -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending | Select-Object -First 1
+          if ($resourceDir) {
+            "BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=$($resourceDir.FullName)" |
+              Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+            Write-Host "BINDGEN_EXTRA_CLANG_ARGS resource-dir set to $($resourceDir.FullName)"
+          } else {
+            Write-Warning "clang resource dir not found under $clangLibRoot -- bindgen may miss builtin headers"
+          }
 
       - name: Build ephpm.exe
         shell: powershell

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -44,15 +44,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # The nightly E2E and smoke-test jobs run inside this image and talk to
 # ephemerd's host docker socket. The socket is mounted into the job
 # container, but the client binary has to live in the image: E2E needs
-# `docker` for kind cluster creation, smoke tests need `docker compose`
-# for the WordPress/Laravel/Symfony fixtures. Only the CLI and compose
-# plugin are installed — no containerd/dockerd, the daemon is ephemerd's.
+# `docker` for kind cluster creation plus `docker buildx build --output`
+# (xtask builds the dev images as tarballs for `kind load image-archive`),
+# and smoke tests need `docker compose` for the WordPress/Laravel/Symfony
+# fixtures. Only the CLI and plugins are installed — no containerd/dockerd,
+# the daemon is ephemerd's.
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
     && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
         > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Two follow-ups from nightly run 27315322649 -- the first nightly on the corrected 8.4.22/8.5.7 SDKs:

- **Windows builds** cleared the old bindgen INCLUDE error (#67 confirmed working) and now fail one layer deeper: `zend_portability.h:797: unknown type name 'max_align_t'`. Root cause: VS Build Tools' libclang runs without its builtin-header resource dir, so clang's own `stddef.h` (which defines C11 `max_align_t` even on MSVC targets) never resolves and only the UCRT headers apply. Fix: pin `BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=<VS LLVM clang lib dir>` -- the mirror image of the macOS job's existing llvm@17 resource-dir pin.
- **E2E** now boots its kind cluster in 25s (docker CLI fix works) but dies on `docker buildx build --output`: the CI image got docker-ce-cli + compose in #68 but not buildx. Add `docker-buildx-plugin`.

## Test plan

- [ ] CI Image rebuilds green on merge
- [ ] Next nightly: Windows Build gets past bindgen (either green or the next real error)
- [ ] Next nightly: E2E gets past image build to `kind load` + test execution