### PR TITLE
fix(ephpm-php): pass clang -resource-dir for bindgen on Windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -260,23 +260,13 @@ jobs:
           } else {
             Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
           }
-          # Pin clang's builtin-header resource dir for bindgen. Without it,
-          # libclang parses with only the MSVC/UCRT headers, which never
-          # define C11 max_align_t -- zend_portability.h:797 then fails with
-          # "unknown type name 'max_align_t'". Clang's own stddef.h defines
-          # max_align_t even on MSVC targets, but only when the resource dir
-          # resolves. Same class of fix as the macOS job's
-          # BINDGEN_EXTRA_CLANG_ARGS resource-dir pin.
-          $clangLibRoot = "C:\BuildTools\VC\Tools\Llvm\x64\lib\clang"
-          $resourceDir = Get-ChildItem -Directory $clangLibRoot -ErrorAction SilentlyContinue |
-            Sort-Object Name -Descending | Select-Object -First 1
-          if ($resourceDir) {
-            "BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=$($resourceDir.FullName)" |
-              Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-            Write-Host "BINDGEN_EXTRA_CLANG_ARGS resource-dir set to $($resourceDir.FullName)"
-          } else {
-            Write-Warning "clang resource dir not found under $clangLibRoot -- bindgen may miss builtin headers"
-          }
+          # NOTE: clang's builtin-header resource dir (needed for C11
+          # max_align_t in zend_portability.h) is handled in
+          # crates/ephpm-php/build.rs, NOT here. Passing -resource-dir via the
+          # BINDGEN_EXTRA_CLANG_ARGS env var does not work on Windows: bindgen
+          # shlex-parses that value and eats the backslashes in the path.
+          # build.rs derives the dir from `clang --print-resource-dir`,
+          # forward-slashes it, and passes it as a bindgen clang_arg.
 
       - name: Build ephpm.exe
         shell: powershell

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -358,6 +358,27 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
                 );
             }
         }
+
+        // clang's builtin headers (stddef.h, stdarg.h, ...) are NOT on the
+        // MSVC INCLUDE path. zend_portability.h's C11 branch does
+        // `typedef max_align_t zend_max_align_t`, and max_align_t lives only
+        // in clang's own stddef.h under its resource dir — MSVC's stddef.h
+        // doesn't define it. Without this, bindgen fails with
+        // "unknown type name 'max_align_t'".
+        //
+        // Pass `-resource-dir` (not `-isystem`): it makes libclang search its
+        // builtin headers with highest priority, so clang's stddef.h wins over
+        // the MSVC one regardless of -isystem ordering. Forward-slash the path
+        // — clang/bindgen mishandle backslashes in args, and passing this via
+        // the BINDGEN_EXTRA_CLANG_ARGS env var fails outright because bindgen
+        // shlex-parses that value and eats `\` as escape characters.
+        if let Some(clang_include) = find_clang_resource_include() {
+            if let Some(resource_dir) = clang_include.parent() {
+                let dir = resource_dir.display().to_string().replace('\\', "/");
+                println!("cargo::warning=bindgen: -resource-dir={dir}");
+                builder = builder.clang_arg(format!("-resource-dir={dir}"));
+            }
+        }
     } else {
         // ZTS builds: define ZTS for bindgen so PHP headers use thread-safe macros.
         builder = builder.clang_arg("-DZTS=1").clang_arg("-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");


### PR DESCRIPTION
## Summary

Follow-up to the Windows bindgen saga. Nightly run 27321511500 (with the prior resource-dir attempt) cleared the INCLUDE-path error but still failed at:

```
php\Zend\zend_portability.h:797:9: error: unknown type name 'max_align_t'
```

**Root cause (two layers):**
1. The Windows bindgen path in `build.rs` forwarded the MSVC INCLUDE dirs but never added clang's own builtin-header resource dir. `zend_portability.h`'s C11 branch does `typedef max_align_t zend_max_align_t`, and `max_align_t` is defined only in **clang's** `stddef.h` (under its resource dir) — MSVC's `stddef.h` doesn't define it.
2. The earlier fix set `BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=...` from the workflow. That silently did nothing: bindgen **shlex-parses** that env value and eats the backslashes in the Windows path (`C:\BuildTools\...\clang\19` → `C:BuildToolsclang19`). The diagnostic from that run is the tell — the workflow logged `resource-dir set to C:\BuildTools\VC\Tools\Llvm\x64\lib\clang\19` correctly, yet bindgen still failed, meaning the value was mangled in transit, not absent. This is the same backslash hazard `build.rs` already works around for INCLUDE forwarding.

**Fix:** handle it in `build.rs` instead. Reuse the existing `find_clang_resource_include()` (runs `clang --print-resource-dir`, verifies `stddef.h` exists), take its parent as the resource dir, forward-slash the path, and pass `-resource-dir` as a bindgen `clang_arg`. Using `-resource-dir` (not `-isystem`) makes clang search its builtin headers with highest priority, so its `stddef.h` wins over the MSVC one regardless of `-isystem` ordering. The broken workflow env-var block is removed; `LIBCLANG_PATH` stays.

## What the last nightly already proved green

This is the only remaining blocker from run 27321511500. That run confirmed the other fixes landed:
- ✅ **fuzz_resp_parser** — no crash on the seeded DoS input (#71)
- ✅ **Dependency Audit** — single cargo-deny gate (#72)
- ✅ all Linux/macOS builds + all 4 fuzz targets

(E2E/Smoke still need the buildx CI-image rebuild from #70 to propagate + the ephemerd endpoint work — tracked separately.)

## Test plan

- [x] `cargo check -p ephpm-php` compiles (stub mode locally; Windows path is runner-only)
- [ ] Next nightly: Windows Build gets past bindgen (green, or the next real link-stage error)