### PR TITLE
fix(ephpm-php): define max_align_t for Windows bindgen; drop -resource-dir

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -260,13 +260,11 @@ jobs:
           } else {
             Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
           }
-          # NOTE: clang's builtin-header resource dir (needed for C11
-          # max_align_t in zend_portability.h) is handled in
-          # crates/ephpm-php/build.rs, NOT here. Passing -resource-dir via the
-          # BINDGEN_EXTRA_CLANG_ARGS env var does not work on Windows: bindgen
-          # shlex-parses that value and eats the backslashes in the path.
-          # build.rs derives the dir from `clang --print-resource-dir`,
-          # forward-slashes it, and passes it as a bindgen clang_arg.
+          # NOTE: the C11 max_align_t gap in MSVC's stddef.h (which broke
+          # bindgen at zend_portability.h) is handled in
+          # crates/ephpm-php/build.rs by defining max_align_t for the bindgen
+          # parse — NOT here, and NOT via clang's -resource-dir (which is
+          # detrimental once the MSVC headers are forwarded as -isystem).
 
       - name: Build ephpm.exe
         shell: powershell

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -319,7 +319,29 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
             .clang_arg("-DZEND_WIN32")
             .clang_arg("-DPHP_WIN32")
             .clang_arg("-DZEND_DEBUG=0")
-            .clang_arg("-DZTS=0");
+            .clang_arg("-DZTS=0")
+            // MSVC's <stddef.h> does not define C11 `max_align_t` — a real,
+            // long-standing gap in the Windows CRT (it's missing even under
+            // /std:c17 on current Windows SDKs). zend_portability.h's
+            // `#if __STDC_VERSION__ >= 201112L` branch then does
+            // `typedef max_align_t zend_max_align_t` and bindgen fails with
+            // "unknown type name 'max_align_t'".
+            //
+            // PHP's real Windows build compiles with cl.exe, whose C mode is
+            // pre-C11 by default, so it takes zend_portability.h's *fallback*
+            // union branch and never references max_align_t. We make bindgen's
+            // libclang parse succeed the same way by defining max_align_t to
+            // `double` — the exact type MSVC uses for max_align_t when it does
+            // define it, and 8-byte aligned on x64 (identical to both the
+            // fallback union and the real ABI). `zend_max_align_t` is not in
+            // ephpm's allowlisted binding surface, so this only needs to parse.
+            //
+            // We do NOT pass `-resource-dir` to point at clang's own stddef.h:
+            // with the MSVC headers forwarded as -isystem, -resource-dir takes
+            // priority over the /imsvc search and breaks system-header
+            // resolution rather than helping (it also did not resolve
+            // max_align_t in practice — see nightly 27326138898).
+            .clang_arg("-Dmax_align_t=double");
 
         // bindgen runs libclang directly and does NOT consume the MSVC
         // INCLUDE env var (cl.exe does, libclang doesn't). Without this,
@@ -356,27 +378,6 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
                     "cargo::warning=bindgen: INCLUDE env var not set; \
                      Windows SDK headers won't resolve"
                 );
-            }
-        }
-
-        // clang's builtin headers (stddef.h, stdarg.h, ...) are NOT on the
-        // MSVC INCLUDE path. zend_portability.h's C11 branch does
-        // `typedef max_align_t zend_max_align_t`, and max_align_t lives only
-        // in clang's own stddef.h under its resource dir — MSVC's stddef.h
-        // doesn't define it. Without this, bindgen fails with
-        // "unknown type name 'max_align_t'".
-        //
-        // Pass `-resource-dir` (not `-isystem`): it makes libclang search its
-        // builtin headers with highest priority, so clang's stddef.h wins over
-        // the MSVC one regardless of -isystem ordering. Forward-slash the path
-        // — clang/bindgen mishandle backslashes in args, and passing this via
-        // the BINDGEN_EXTRA_CLANG_ARGS env var fails outright because bindgen
-        // shlex-parses that value and eats `\` as escape characters.
-        if let Some(clang_include) = find_clang_resource_include() {
-            if let Some(resource_dir) = clang_include.parent() {
-                let dir = resource_dir.display().to_string().replace('\\', "/");
-                println!("cargo::warning=bindgen: -resource-dir={dir}");
-                builder = builder.clang_arg(format!("-resource-dir={dir}"));
             }
         }
     } else {


### PR DESCRIPTION
## Summary

The `-resource-dir` approach (#73) **did not** fix Windows bindgen — nightly 27326138898 proved it: the log shows the dir was found and passed correctly (`-resource-dir=C:/BuildTools/VC/Tools/Llvm/x64/lib/clang/19`, clean forward slashes), yet bindgen still failed with `unknown type name 'max_align_t'` at `zend_portability.h:797`.

**Real root cause** — a genuine Windows CRT gap, researched and confirmed:
- MSVC's `<stddef.h>` **does not define C11 `max_align_t`**, missing even under `/std:c17` on current Windows SDKs ([Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/1726147/why-max-align-t-not-defined-in-stddef-h-in-windows), [VS dev community](https://developercommunity.visualstudio.com/t/stdc11-should-add-max-align-t-to-stddefh/1386891)).
- We forward the MSVC INCLUDE dirs to libclang as `-isystem` (necessary in the CI container), so clang resolves `<stddef.h>` to MSVC's. `-resource-dir` pointing at clang's own stddef.h is **detrimental** here — it takes priority over the `/imsvc` search and breaks system-header resolution rather than helping.

**Fix:** PHP's real Windows build uses cl.exe, whose C mode is pre-C11 by default, so it takes `zend_portability.h`'s **fallback union** branch and never references `max_align_t`. Make bindgen's parse succeed the same way by defining `max_align_t` to `double` — the type MSVC uses for `max_align_t` when present, 8-byte aligned on x64 (identical to both the fallback union and the real ABI). `zend_max_align_t` is not in ephpm's allowlisted binding surface, so this only needs to parse.

Cross-checked against **ext-php-rs**, which bindgens these same PHP headers on MSVC: it never forwards MSVC system includes manually nor sets `-resource-dir` — it lets clang auto-detect and keeps clang's builtin stddef.h at highest priority. Our CI-container constraint forces the manual INCLUDE forwarding, so we define the one missing type instead.

Removes the now-unused `-resource-dir` block (`find_clang_resource_include()` is still used on the musl path).

## Test plan

- [x] `cargo check -p ephpm-php` compiles (stub mode; Windows path is runner-only)
- [ ] Next nightly: Windows Build gets past bindgen — either green, or a genuine downstream (link-stage) error that means the FFI layer finally parsed