### PR TITLE
chore(deps): bump postgres-protocol/postgres-types for RUSTSEC-2026-0179/0180

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,9 +2707,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "array-init",
  "bytes",


### PR DESCRIPTION
## Summary

Two advisories landed in the live RustSec DB and started tripping the `Cargo Deny` / Dependency Audit gate on every branch (independent of the diff):

- **RUSTSEC-2026-0179** — unbounded SCRAM iteration count → CPU-exhaustion DoS (`postgres-protocol` 0.6.11)
- **RUSTSEC-2026-0180** — panic decoding a malformed `hstore` value → DoS (`postgres-types` 0.2.13)

Both are transitive via litewire's PostgreSQL support. Patched releases exist; lockfile-only bump, no API changes:
- `postgres-protocol` 0.6.11 → **0.6.12**
- `postgres-types` 0.2.13 → **0.2.14**

## Test plan

- [x] `cargo check -p ephpm-server` clean with bumped lockfile
- [ ] Cargo Deny green (advisories cleared)