### PR TITLE
fix(windows): whole-archive both libintl/libiconv + /FORCE:MULTIPLE

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -214,15 +214,18 @@ fn link_windows_static_deps(lib_dir: &Path) {
 
     stems.sort();
 
-    // Only libintl_a needs whole-archive: gettext (libintl) and iconv have a
-    // circular dependency and libintl packs its symbols into objects link.exe
-    // won't pull under a single forward pass. We do NOT whole-archive
-    // libiconv_a — now that the import stub is skipped above, it resolves
-    // (including the `_libiconv_version` data symbol) via normal lazy linking,
-    // and whole-archiving BOTH forces in each lib's bundled copy of libcharset's
-    // `locale_charset`, which collides as LNK2005. Whole-archiving only libintl
-    // means `locale_charset` is defined exactly once.
-    let whole_archive: [&str; 1] = ["libintl_a"];
+    // libintl (gettext) and libiconv both pack their public symbols into
+    // objects that link.exe won't pull under a single lazy forward pass
+    // (gettext's circular libintl_* refs; libiconv's iconv functions +
+    // the `_libiconv_version` data symbol). Both therefore need
+    // whole-archive. The catch: each GNU lib bundles its OWN identical copy
+    // of libcharset's `locale_charset`, so whole-archiving both makes that
+    // one symbol multiply-defined (LNK2005). There is no per-object exclude
+    // for whole-archive, so the binary crate's build.rs passes
+    // `/FORCE:MULTIPLE` to keep the first definition — safe here because
+    // `locale_charset` is the ONLY duplicate in the entire link and both
+    // copies are byte-identical libcharset.
+    let whole_archive: [&str; 2] = ["libintl_a", "libiconv_a"];
 
     for stem in &stems {
         if whole_archive.contains(&stem.as_str()) {

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -30,6 +30,16 @@ fn main() {
         // support GNU ld's `--wrap`, so the zend_signal_* SIGPROF wrapping
         // applied on Linux is a no-op here (ephpm enforces max_execution_time
         // at the tokio layer, so PHP's SIGPROF handler should never fire).
+        //
+        // /FORCE:MULTIPLE: libintl_a and libiconv_a are both whole-archived
+        // (see ephpm-php/build.rs::link_windows_static_deps) and each bundles
+        // an identical copy of libcharset's `locale_charset`, so it ends up
+        // multiply-defined. There is no per-object exclude for whole-archive;
+        // this tells link.exe to keep the first definition and continue.
+        // `locale_charset` is the only duplicate in the whole link and both
+        // copies are byte-identical, so first-wins is correct. Emits LNK4006
+        // warnings (visible in the build log) which we accept.
+        println!("cargo::rustc-link-arg=/FORCE:MULTIPLE");
         return;
     }
 


### PR DESCRIPTION
## Summary

Nightly 27450349618 **cleared the `locale_charset` LNK2005** — confirming the libintl-only whole-archive (#77) fixed that collision. But it brought back **4 unresolved iconv externals** (`libiconv_open`, `libiconv`, `libiconv_close`, `_libiconv_version`). So `libiconv_a` genuinely needs whole-archive too; skipping the import stub alone isn't enough to make link.exe pull its function objects under a single lazy pass.

**The catch-22, now fully confirmed by evidence:** both GNU libs need whole-archive, but each bundles its own *identical* copy of libcharset's `locale_charset` — so whole-archiving both makes that symbol multiply-defined, and there's no per-object exclude for whole-archive.

**Fix** (standard MSVC approach): whole-archive both `libintl_a` and `libiconv_a` so every gettext/iconv symbol resolves, and pass `/FORCE:MULTIPLE` in the binary crate's build.rs so link.exe keeps the first `locale_charset` and continues. Safe here — `locale_charset` is the *only* duplicate in the entire link and both copies are byte-identical libcharset. Emits LNK4006 warnings (visible in the log) which we accept.

## Why this should be the last one

We've now empirically mapped both horns of the dilemma: whole-archive both → one duplicate; whole-archive one → the other's symbols unresolved. `/FORCE:MULTIPLE` resolves the single remaining duplicate. Every other symbol in the entire static PHP + deps link already resolves.

## Test plan

- [x] `cargo clippy` clean
- [ ] Next nightly: Windows Build produces `ephpm.exe` (LNK4006 warnings for locale_charset are expected/accepted), or names a precise remaining symbol