### PR TITLE
ci: add PHP 8.3 to the build matrices

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        php: ["8.5", "8.4"]
+        php: ["8.3", "8.5", "8.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        php: ["8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        php: ["8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 
@@ -152,7 +152,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        php: ["8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 
@@ -355,7 +355,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        php: ["8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 
@@ -380,7 +380,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.4", "8.5"]
+        php: ["8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php_minor: "8.3"
+            php_full: "8.3.31"
           - php_minor: "8.4"
             php_full: "8.4.22"
           - php_minor: "8.5"
@@ -78,6 +80,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php_minor: "8.3"
+            php_full: "8.3.31"
           - php_minor: "8.4"
             php_full: "8.4.22"
           - php_minor: "8.5"
@@ -134,6 +138,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php_minor: "8.3"
+            php_full: "8.3.31"
           - php_minor: "8.4"
             php_full: "8.4.22"
           - php_minor: "8.5"
@@ -253,6 +259,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php_minor: "8.3"
+            php_full: "8.3.31"
           - php_minor: "8.4"
             php_full: "8.4.22"
             default: false

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -47,6 +47,70 @@ static char *ephpm_strtok_r(char *str, const char *delim, char **saveptr) {
 #include "main/php_version.h"
 #include "ext/session/php_session.h"
 
+#if PHP_VERSION_ID < 80400
+#include <ctype.h>
+/* PHP 8.4 added the public `sapi_read_post_data()` helper; 8.3 and earlier
+ * keep the identical logic inline inside `sapi_activate()`, with no callable
+ * entry point. Our request-reuse model needs to drive it explicitly (to set
+ * SG(request_info).post_entry for sapi_handle_post() and to read the raw body
+ * into request_body for php://input), so on pre-8.4 we replicate 8.4's
+ * sapi_read_post_data() verbatim. It uses only globals/APIs present since
+ * well before 8.3 (SG(known_post_content_types), post_entry, content_type_dup,
+ * sapi_module.default_post_reader), so it compiles and behaves identically. */
+static void ephpm_sapi_read_post_data_compat(void) {
+    sapi_post_entry *post_entry;
+    uint32_t content_type_length = (uint32_t)strlen(SG(request_info).content_type);
+    char *content_type = estrndup(SG(request_info).content_type, content_type_length);
+    char *p;
+    char oldchar = 0;
+    void (*post_reader_func)(void) = NULL;
+
+    /* Lowercase the content type and trim trailing descriptive data so only
+     * the bare "type/subtype" remains for the handler lookup. */
+    for (p = content_type; p < content_type + content_type_length; p++) {
+        switch (*p) {
+            case ';':
+            case ',':
+            case ' ':
+                content_type_length = p - content_type;
+                oldchar = *p;
+                *p = 0;
+                break;
+            default:
+                *p = tolower((unsigned char)*p);
+                break;
+        }
+    }
+
+    /* Find an appropriate POST content handler (e.g. rfc1867 for multipart). */
+    if ((post_entry = zend_hash_str_find_ptr(&SG(known_post_content_types), content_type,
+            content_type_length)) != NULL) {
+        SG(request_info).post_entry = post_entry;
+        post_reader_func = post_entry->post_reader;
+    } else {
+        SG(request_info).post_entry = NULL;
+        if (UNEXPECTED(!sapi_module.default_post_reader)) {
+            SG(request_info).content_type_dup = NULL;
+            sapi_module.sapi_error(E_WARNING, "Unsupported content type:  '%s'", content_type);
+            efree(content_type);
+            return;
+        }
+    }
+    if (oldchar) {
+        *(p - 1) = oldchar;
+    }
+
+    SG(request_info).content_type_dup = content_type;
+
+    if (post_reader_func) {
+        post_reader_func();
+    }
+    if (sapi_module.default_post_reader) {
+        sapi_module.default_post_reader();
+    }
+}
+#endif /* PHP_VERSION_ID < 80400 */
+
 /* ===== Per-thread state =====
  *
  * With ZTS, multiple threads execute PHP concurrently. All per-request
@@ -694,7 +758,11 @@ int ephpm_execute_request(const char *filename)
      * sapi_read_post_data() calls our read_post callback and creates
      * the request_body stream. Must happen before sapi_handle_post(). */
     if (req_post_data && req_post_data_len > 0) {
+#if PHP_VERSION_ID >= 80400
         sapi_read_post_data();
+#else
+        ephpm_sapi_read_post_data_compat();
+#endif
     }
 
     /* $_POST + $_FILES — use PHP's built-in POST handler.


### PR DESCRIPTION
## Summary

8.3 was pinned in xtask's `PHP_SDK_VERSIONS` (8.3.31) but **never built or tested** by any CI matrix — and its Windows SDK tarball predated the dep-lib packaging fix (#16). Now that the Windows static-link path is solid and the **8.3.31 Windows SDK has been rebuilt** with the full dependency libs (verified: 1 → **36** `.lib` files), make 8.3 a real, validated target:

- **nightly.yml**: add 8.3 to all five `php` matrices (build-linux/macos/windows, e2e, smoke-tests)
- **e2e.yml**: add 8.3
- **release.yml**: add an `8.3.31` entry to all four build jobs (linux/macos/windows/docker)

The Windows code-side fixes are all version-independent (the lone version-specific bit — the PHP 8.5 overflow-builtin defines — is emitted unconditionally and is harmless on 8.3), so 8.3 should build on every platform now that it consumes the rebuilt SDK.

## Context

Lands right after the first fully-green nightly (8.4/8.5 × linux/macos/windows all producing binaries). This extends that matrix to 8.3.

## Test plan

- [x] YAML valid; 8.3 present in all matrix sites
- [x] 8.3.31 Windows SDK tarball rebuilt with 36 dep libs
- [ ] Next nightly: Build (PHP 8.3, {linux,macos,windows}) all green