### PR TITLE
fix(windows): force-include intrin.h for PHP 8.3 bindgen

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -424,7 +424,20 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
             .clang_arg("-DPHP_HAVE_BUILTIN_SSUBL_OVERFLOW=1")
             .clang_arg("-DPHP_HAVE_BUILTIN_SSUBLL_OVERFLOW=1")
             .clang_arg("-DPHP_HAVE_BUILTIN_SMULL_OVERFLOW=1")
-            .clang_arg("-DPHP_HAVE_BUILTIN_SMULLL_OVERFLOW=1");
+            .clang_arg("-DPHP_HAVE_BUILTIN_SMULLL_OVERFLOW=1")
+            // Force-include <intrin.h> for the bindgen parse. PHP 8.3's
+            // zend_call_stack.h calls the MSVC intrinsic
+            // `_AddressOfReturnAddress()` without including <intrin.h>; cl.exe
+            // knows it implicitly, but bindgen's libclang needs the
+            // declaration and fails with "call to undeclared library function
+            // '_AddressOfReturnAddress'". PHP 8.4 fixed the header to include
+            // <intrin.h> itself (under `#ifdef _MSC_VER`); force-including it
+            // here makes 8.3 behave the same. Harmless and redundant on
+            // 8.4/8.5 (their header already includes it, and `<intrin.h>` is
+            // include-guarded) — and bindgen already parses intrin.h cleanly
+            // there, so this adds no new risk.
+            .clang_arg("-include")
+            .clang_arg("intrin.h");
 
         // bindgen runs libclang directly and does NOT consume the MSVC
         // INCLUDE env var (cl.exe does, libclang doesn't). Without this,


### PR DESCRIPTION
## Summary

The full 3×3 nightly built **8 of 9** targets — only **Build (PHP 8.3, windows-x86_64)** failed, at bindgen:

```
zend_call_stack.h:42: call to undeclared library function '_AddressOfReturnAddress'
```

PHP 8.3's `zend_call_stack.h` calls the MSVC intrinsic `_AddressOfReturnAddress()` **without** including `<intrin.h>`. `cl.exe` knows the intrinsic implicitly; bindgen's libclang needs the declaration. PHP **8.4 fixed the header** to `#include <intrin.h>` under `#ifdef _MSC_VER` — which is exactly why 8.4/8.5 Windows build cleanly and 8.3 doesn't.

**Fix:** force-include `intrin.h` (`-include intrin.h`) for the Windows bindgen parse so 8.3 behaves like 8.4. Harmless and redundant on 8.4/8.5 (their header already includes it; `<intrin.h>` is include-guarded), and bindgen *already* parses `intrin.h` cleanly there — so this adds no new risk. The `cl.exe` wrapper compile is unaffected.

## Matrix status

| | 8.3 | 8.4 | 8.5 |
|---|---|---|---|
| linux | ✅ | ✅ | ✅ |
| macos | ✅ | ✅ | ✅ |
| windows | ⏳ this PR | ✅ | ✅ |

8.3 already builds + passes E2E on linux/macos (the POST shim works). This is the last gap to complete the matrix.

## Test plan

- [x] `cargo check` clean (stub)
- [ ] Next nightly: Build (PHP 8.3, windows-x86_64) green → full 9/9