### PR TITLE
ci: build linux-aarch64 (4th OS/arch target)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -12,8 +12,20 @@ env:
 
 jobs:
   build:
-    name: Build CI Image
-    runs-on: [self-hosted, linux, x64]
+    name: Build CI Image (${{ matrix.arch }})
+    # Build each arch's image natively on a runner of that arch (no buildx /
+    # cross-build, which would need --privileged). amd64 -> :latest,
+    # arm64 -> :latest-arm64. The arm64 runner is the Apple Silicon host's
+    # embedded linux VM (ephemerd dispatches `[self-hosted, linux, arm64]`).
+    runs-on: [self-hosted, linux, "${{ matrix.arch }}"]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            suffix: ""
+          - arch: arm64
+            suffix: "-arm64"
     steps:
       - uses: actions/checkout@v4
 
@@ -28,12 +40,14 @@ jobs:
       # Plain `docker build` (no buildx) — routes through the ephemerd
       # fake-daemon's /build endpoint and the embedded BuildKit solver.
       # Avoids the buildkit-in-a-container path that needs --privileged.
+      # The arch suffix keeps the two single-arch images separate (we don't
+      # publish a multi-arch manifest; consumers pick the tag for their arch).
       - name: Build and push
         env:
           DOCKER_BUILDKIT: "0"
         run: |
-          TAG_LATEST="${{ env.IMAGE_REPO }}:latest"
-          TAG_DATED="${{ env.IMAGE_REPO }}:${{ env.DATE_TAG }}"
+          TAG_LATEST="${{ env.IMAGE_REPO }}:latest${{ matrix.suffix }}"
+          TAG_DATED="${{ env.IMAGE_REPO }}:${{ env.DATE_TAG }}${{ matrix.suffix }}"
           docker build -t "$TAG_LATEST" -t "$TAG_DATED" -f docker/Dockerfile.gha .
           docker push "$TAG_LATEST"
           docker push "$TAG_DATED"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,13 +28,25 @@ jobs:
   # -- 1. Full release builds ------------------------------------------------
 
   build-linux:
-    name: Build (PHP ${{ matrix.php }}, linux-x86_64)
-    runs-on: [self-hosted, linux, x64]
-    container: ephpm/ephpm-ci:latest
+    name: Build (PHP ${{ matrix.php }}, ${{ matrix.arch.sdk }})
+    # Built natively per arch: x64 on the WSL2 linux runner, arm64 on the
+    # Apple Silicon host's embedded linux VM (ephemerd dispatches
+    # `[self-hosted, linux, arm64]`). Each uses the matching CI image.
+    runs-on: [self-hosted, linux, "${{ matrix.arch.runner }}"]
+    container: "ephpm/ephpm-ci:${{ matrix.arch.image }}"
     strategy:
       fail-fast: false
       matrix:
         php: ["8.3", "8.4", "8.5"]
+        arch:
+          - runner: x64
+            image: latest
+            triple: x86_64-unknown-linux-musl
+            sdk: linux-x86_64
+          - runner: arm64
+            image: latest-arm64
+            triple: aarch64-unknown-linux-musl
+            sdk: linux-aarch64
     steps:
       - uses: actions/checkout@v4
 
@@ -48,10 +60,10 @@ jobs:
         # task; meanwhile keep running it so we can observe the error change.
         continue-on-error: true
         run: |
-          PHP_SDK_PATH=$(find "$(pwd)/php-sdk" -mindepth 1 -maxdepth 1 -type d -name '*-linux-x86_64' | head -1)
+          PHP_SDK_PATH=$(find "$(pwd)/php-sdk" -mindepth 1 -maxdepth 1 -type d -name '*-${{ matrix.arch.sdk }}' | head -1)
           test -n "$PHP_SDK_PATH" || { echo "::error::PHP SDK not found"; exit 1; }
           PHP_SDK_PATH="$PHP_SDK_PATH" cargo nextest run \
-            --target x86_64-unknown-linux-musl \
+            --target ${{ matrix.arch.triple }} \
             --workspace --run-ignored ignored-only
 
       - name: Verify binary
@@ -59,7 +71,7 @@ jobs:
         # musl-linked), so the artifact lives under the musl triple, not
         # the host triple.
         run: |
-          FILE="target/x86_64-unknown-linux-musl/release/ephpm"
+          FILE="target/${{ matrix.arch.triple }}/release/ephpm"
           test -f "$FILE" || { echo "::error::Binary not found at $FILE"; exit 1; }
           file "$FILE"
           ls -lh "$FILE"
@@ -67,8 +79,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-php${{ matrix.php }}-linux-x86_64
-          path: target/x86_64-unknown-linux-musl/release/ephpm
+          name: ephpm-php${{ matrix.php }}-${{ matrix.arch.sdk }}
+          path: target/${{ matrix.arch.triple }}/release/ephpm
 
   build-macos:
     name: Build (PHP ${{ matrix.php }}, macos-aarch64)

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -69,16 +69,30 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
+# Add the musl target matching the image's own architecture. This Dockerfile
+# is built once per arch (amd64 -> ephpm/ephpm-ci:latest, arm64 ->
+# :latest-arm64), each natively on its own runner, so we only need the host's
+# musl target. `uname -m` reports x86_64 / aarch64; map to the rust triple.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --profile minimal \
         --component rustfmt,clippy,llvm-tools-preview \
     && rustup toolchain install nightly --component rustfmt \
-    && rustup target add x86_64-unknown-linux-musl \
+    && case "$(uname -m)" in \
+         x86_64)  rustup target add x86_64-unknown-linux-musl ;; \
+         aarch64) rustup target add aarch64-unknown-linux-musl ;; \
+         *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;; \
+       esac \
     && cargo install cargo-nextest --locked \
     && rm -rf /usr/local/cargo/registry
 
+# musl-gcc (from musl-tools) is the native musl compiler on whichever arch this
+# image was built for. Set the CC/linker vars for BOTH musl triples so the same
+# image works regardless — only the host-arch triple is ever actually built.
 ENV CC_x86_64_unknown_linux_musl=musl-gcc \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    CC_aarch64_unknown_linux_musl=musl-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_CC=musl-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

linux-aarch64 was the one gap in the matrix — and it turned out to be **infrastructure, not code**. The SDK already ships `linux-aarch64` tarballs for 8.3.31/8.4.22/8.5.7, the build is arch-agnostic on Linux, and ephemerd **can** serve `[self-hosted, linux, arm64]` jobs: the Apple Silicon host runs Linux jobs in an embedded **arm64** VM (`scheduler.canHandleJob` accepts `linux` on a darwin host + `arm64` when `GOARCH == arm64`). No workflow ever requested those labels, and the CI image was amd64-only.

- **docker/Dockerfile.gha** — add the host-arch musl target via `uname -m` (x86_64 → `x86_64-unknown-linux-musl`, aarch64 → `aarch64-unknown-linux-musl`) and set CC/linker env for both triples so one Dockerfile works on either arch.
- **ci-image.yml** — matrix the image build over arch, each built **natively** on its own runner (no buildx/privileged): amd64 → `:latest`, arm64 → `:latest-arm64`.
- **nightly.yml `build-linux`** — matrix `php × arch` (x64 + arm64); each entry selects its runner label, CI image tag, musl triple, and SDK/artifact suffix. arm64 runs on `[self-hosted, linux, arm64]` (the Mac's linux VM) — a **real arm64 run**, so the binary is genuinely built + verified, not cross-compiled.

Takes the nightly build matrix from **9 → 12** (adds linux-aarch64 × 3 PHP).

## Deliberately deferred (focused follow-ups)
- **Release-artifact arm64** — release.yml packages from a different output path; will parameterize separately.
- **E2E/smoke arm64** — needs kind-on-arm64 validation.

## Sequencing
The arm64 build jobs need the arm64 CI image to exist first. After merge, **dispatch the CI Image workflow** (builds `:latest-arm64` on the Mac's linux VM), then run a nightly.

## Test plan
- [x] YAML valid; matrices expand to x64+arm64
- [ ] CI Image workflow builds `:latest-arm64` on `[self-hosted, linux, arm64]`
- [ ] Nightly: Build (PHP 8.x, linux-aarch64) ×3 green → 12/12