### PR TITLE
fix(ci-image): derive docker apt arch from dpkg for arm64 build

### DIFF
--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # the daemon is ephemerd's.
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
         > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \


### PR DESCRIPTION
The Docker apt source in `docker/Dockerfile.gha` hardcoded `arch=amd64`. That was fine while the CI image only ever built on amd64, but the new arm64 image build (from #83) fails:

```
docker-ce-cli:amd64 : Depends: libc6:amd64 (>= 2.34) but it is not installable
E: Unable to correct problems, you have held broken packages.
```

Fix: use `$(dpkg --print-architecture)` so each native build selects its own arch (`amd64` on x64, `arm64` on the Apple Silicon host's linux VM).

Discovered when the first arm64 `CI Image` run failed on this step; the x64 image built fine.

## Test plan
- [ ] CI Image workflow: x64 image still builds + pushes `:latest`
- [ ] arm64 image builds + pushes `:latest-arm64`