### PR TITLE
fix(release): use correct DOCKER_USERNAME/DOCKER_PASSWORD secret names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,8 +288,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Compute image tags
         id: tags


### PR DESCRIPTION
All three Docker jobs failed on the first RC run with `Username and password required`.

release.yml referenced `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` but the repo secrets are `DOCKER_USERNAME` / `DOCKER_PASSWORD` (matching nightly.yml).

The 12 binary builds all passed green. Only Docker + the downstream `Create Release` job were blocked.

## Test plan
- [ ] Merge, re-run the failed Docker jobs on the RC run (or re-tag)