### PR TITLE
Add ext build CLI + Ubuntu builder with intl/imagick/grpc C++ extension support

### DIFF
--- a/.github/workflows/builder-smoke.yml
+++ b/.github/workflows/builder-smoke.yml
@@ -1,0 +1,71 @@
+name: Builder Smoke
+# End-to-end check for `ephpm ext build` on both supported Linux arches.
+# Path-gated so the (slow) spc build only runs when the builder image, its
+# entrypoint, or the ext-build code changes. Exercises the fresh-clone path:
+# the CLI builds the builder image from docker/Dockerfile.builder itself, runs
+# the entrypoint, and must produce a runnable binary with the requested
+# extension compiled in.
+#
+# Each arch builds natively on its own self-hosted runner (no cross-build),
+# mirroring docker/Dockerfile.gha + ci-image.yml. The arm64 leg is what proves
+# finding #4: on an aarch64 host the binary must be aarch64 (and runnable),
+# never a silent x86_64 build.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docker/Dockerfile.builder"
+      - "docker/builder-entrypoint.sh"
+      - "crates/ephpm/src/commands/ext.rs"
+      - "crates/ephpm/build.rs"
+      - ".github/workflows/builder-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docker/Dockerfile.builder"
+      - "docker/builder-entrypoint.sh"
+      - "crates/ephpm/src/commands/ext.rs"
+      - "crates/ephpm/build.rs"
+      - ".github/workflows/builder-smoke.yml"
+  workflow_dispatch:
+env:
+  CARGO_TERM_COLOR: always
+concurrency:
+  group: builder-smoke-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ext-build:
+    name: ext build end-to-end (linux-${{ matrix.arch }})
+    runs-on: [self-hosted, linux, "${{ matrix.arch }}"]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            file_arch: "x86-64"
+          - arch: arm64
+            file_arch: "aarch64"
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends build-essential libclang-dev pkg-config libssl-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # No pre-built image: forces ext.rs's auto-build branch to build
+      # ephpm-builder:local from docker/Dockerfile.builder, as a fresh clone
+      # would. GITHUB_TOKEN keeps spc's GitHub downloads off the anon limit.
+      - name: ext build --add redis (auto-builds image, runs entrypoint)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo run -p ephpm -- ext build --add redis --output ./ci-ephpm-redis
+      - name: Verify the binary is real, the right arch, and has redis
+        run: |
+          test -x ./ci-ephpm-redis
+          file ./ci-ephpm-redis | grep -q "${{ matrix.file_arch }}"
+          # Native execution on this runner: an x86_64 binary on the arm64
+          # runner (or vice versa) would fail with exec format error here.
+          ./ci-ephpm-redis ext list | grep -qi redis
+      - name: Verify builder image ENTRYPOINT is wired
+        run: |
+          docker inspect --format '{{json .Config.Entrypoint}}' ephpm-builder:local \
+            | grep -q 'builder-entrypoint.sh'

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ target/
 # OS
 .DS_Store
 Thumbs.db
+ephpm-with-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -180,7 +180,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -192,7 +192,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -263,14 +263,14 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "async-web-client"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37381fb4fad3cd9b579628c21a58f528ef029d1f072d10f16cb9431aa2236d29"
+checksum = "8caf502b44d6d4be6154ac33af012cbb5fef11e6066edcfb42834217fbaf501b"
 dependencies = [
  "async-http-codec",
  "async-net",
@@ -280,6 +280,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rustls-pki-types",
+ "serde",
  "thiserror 1.0.69",
  "webpki-roots 0.26.11",
 ]
@@ -301,15 +302,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -318,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -330,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -427,33 +428,15 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -478,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -519,7 +502,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -554,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -600,14 +583,14 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -639,7 +622,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -653,7 +636,7 @@ dependencies = [
  "bytes",
  "itertools 0.14.0",
  "lru 0.13.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "tokio",
  "tokio-stream",
@@ -663,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -688,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -710,14 +693,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -737,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -887,18 +870,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -924,7 +907,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -935,14 +918,14 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -954,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
@@ -989,7 +972,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1005,25 +988,25 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1034,9 +1017,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "ephpm"
@@ -1137,9 +1120,8 @@ dependencies = [
 name = "ephpm-php"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cc",
- "clang-sys",
  "ephpm-kv",
  "http",
  "serial_test",
@@ -1185,7 +1167,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mime_guess",
  "rcgen",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-acme",
  "rustls-pemfile",
  "sha2 0.10.9",
@@ -1266,9 +1248,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figment"
@@ -1351,7 +1333,7 @@ checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1363,7 +1345,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1375,7 +1357,7 @@ dependencies = [
  "frunk_core",
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1459,7 +1441,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1469,7 +1451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
 ]
 
@@ -1541,16 +1523,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1561,9 +1541,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1609,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1655,14 +1635,14 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1705,18 +1685,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1729,7 +1709,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1737,20 +1716,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -1770,7 +1748,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -1882,12 +1860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,14 +1888,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1937,16 +1907,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1974,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1990,11 +1950,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2027,7 +1988,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2037,16 +1998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2077,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2094,9 +2049,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litewire"
@@ -2210,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -2260,7 +2215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2277,18 +2232,18 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash 0.8.12",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -2323,7 +2278,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2362,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2384,7 +2339,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "termcolor",
  "thiserror 1.0.69",
 ]
@@ -2407,7 +2362,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "socket2 0.5.10",
@@ -2426,7 +2381,7 @@ checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.7",
  "bigdecimal",
- "bindgen 0.72.1",
+ "bindgen",
  "bitflags",
  "bitvec",
  "btoi",
@@ -2442,7 +2397,7 @@ dependencies = [
  "mysql-common-derive",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rust_decimal",
  "saturating",
@@ -2489,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2612,7 +2567,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2647,7 +2602,7 @@ dependencies = [
  "lazy-regex",
  "md5 0.7.0",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "thiserror 2.0.18",
  "tokio",
@@ -2657,22 +2612,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2680,12 +2635,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -2700,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -2737,7 +2686,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -2757,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2786,7 +2735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2795,7 +2744,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -2817,7 +2766,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2837,16 +2786,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -2899,8 +2848,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.6.3",
+ "rustls 0.23.40",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2916,10 +2865,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2937,9 +2886,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2971,9 +2920,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2982,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2992,13 +2941,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3041,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -3052,6 +3001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3093,7 +3051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3129,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3158,9 +3116,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -3192,7 +3150,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3207,7 +3165,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3269,16 +3227,16 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3287,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rusticata-macros"
@@ -3329,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3345,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-acme"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcdaa66cd3bf55140f4061b0bb596650d5e8f7f0183cd263fba2a57cf740b96"
+checksum = "b9c70a17ecb067d5067565a16a2e0f26a4a2ea0924f49739d558c45186facc75"
 dependencies = [
  "async-io",
  "async-trait",
@@ -3367,15 +3325,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
  "x509-parser",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3394,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3444,15 +3402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,12 +3415,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -3503,12 +3446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,14 +3472,14 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3585,28 +3522,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3639,7 +3575,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3658,6 +3594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -3693,9 +3635,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -3709,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3736,15 +3678,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3787,6 +3729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3825,7 +3773,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3850,7 +3798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3891,7 +3839,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3902,7 +3850,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3916,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
@@ -3931,15 +3879,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3947,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3972,9 +3920,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3982,20 +3930,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4015,7 +3963,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -4069,9 +4017,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4092,23 +4040,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4135,20 +4083,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4177,11 +4125,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -4195,7 +4144,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4250,15 +4199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uncased"
@@ -4303,12 +4252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,9 +4289,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4393,23 +4336,14 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4421,23 +4355,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4445,65 +4375,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4525,14 +4421,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4595,7 +4491,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4606,7 +4502,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4650,7 +4546,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4659,7 +4555,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4677,14 +4582,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4694,10 +4616,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4706,10 +4640,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4718,10 +4664,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4730,10 +4688,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4746,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4760,98 +4730,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -4900,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4911,68 +4793,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4981,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4992,13 +4874,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,8 +1137,9 @@ dependencies = [
 name = "ephpm-php"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "cc",
+ "clang-sys",
  "ephpm-kv",
  "http",
  "serial_test",
@@ -2407,7 +2426,7 @@ checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.7",
  "bigdecimal",
- "bindgen",
+ "bindgen 0.72.1",
  "bitflags",
  "bitvec",
  "btoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,4 @@ unnecessary_cast = "allow"
 unused_async = "allow"
 unused_self = "allow"
 used_underscore_binding = "allow"
+

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -67,7 +67,6 @@ fn link_php(lib_dir: &Path, target_os: &str) {
         println!("cargo::warning=Added musl-cross libstdc++ path: {}", musl_cross_lib.display());
     }
 
-    // For C++ extensions (intl/ICU), add musl-native libstdc++ search path
     if target_os == "windows" {
         // The php-sdk Windows tarball ships a *static* `php8embed.lib`
         // (static-php-cli's `--build-embed` is a static build — a fat lib

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -59,6 +59,13 @@ fn validate_sdk(lib_dir: &Path, include_dir: &Path, target_os: &str) {
 /// Link libphp and its platform-specific system library dependencies.
 fn link_php(lib_dir: &Path, target_os: &str) {
     println!("cargo::rustc-link-search=native={}", lib_dir.display());
+
+    // For C++ extensions (intl/ICU/imagick), add musl-native libstdc++ search path
+    let musl_cross_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib");
+    if musl_cross_lib.exists() {
+        println!("cargo::rustc-link-search=native={}", musl_cross_lib.display());
+        println!("cargo::warning=Added musl-cross libstdc++ path: {}", musl_cross_lib.display());
+    }
     if target_os == "windows" {
         // The php-sdk Windows tarball ships a *static* `php8embed.lib`
         // (static-php-cli's `--build-embed` is a static build — a fat lib

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -66,6 +66,8 @@ fn link_php(lib_dir: &Path, target_os: &str) {
         println!("cargo::rustc-link-search=native={}", musl_cross_lib.display());
         println!("cargo::warning=Added musl-cross libstdc++ path: {}", musl_cross_lib.display());
     }
+
+    // For C++ extensions (intl/ICU), add musl-native libstdc++ search path
     if target_os == "windows" {
         // The php-sdk Windows tarball ships a *static* `php8embed.lib`
         // (static-php-cli's `--build-embed` is a static build — a fat lib

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -146,32 +146,27 @@ fn main() {
     // (wmemcpy, frexp, sigfillset, __udivmodti4, …) from inside the group.
     // -lc/-lm/-lgcc normally come after --end-group, which single-pass ld
     // won't revisit, so pull them into the group explicitly.
-    let musl_lib = std::path::Path::new("/usr/local/musl/x86_64-linux-musl/lib");
-    let gcc_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/lib/gcc/x86_64-linux-musl/11.2.1");
-    for (dir, name) in [
-        (musl_lib, "libc.a"),
-        (musl_lib, "libm.a"),
-        (gcc_lib, "libgcc.a"),
+    //
+    // Two candidate musl lib roots: spc's own toolchain (/usr/local/musl)
+    // and the musl-cross-make tarball (/opt/x86_64-linux-musl-cross).
+    // We try both and emit whichever archives actually exist — only one
+    // toolchain will be present at build time.
+    let gcc_lib = std::path::Path::new(
+        "/opt/x86_64-linux-musl-cross/lib/gcc/x86_64-linux-musl/11.2.1"
+    );
+    for musl_lib in [
+        std::path::Path::new("/usr/local/musl/x86_64-linux-musl/lib"),
+        std::path::Path::new("/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib"),
     ] {
-        let p = dir.join(name);
-        if p.exists() {
-            println!("cargo::rustc-link-arg={}", p.display());
-        }
-    }
-    // C++-heavy extensions (abseil/grpc) reference libc/libm/libgcc symbols
-    // (wmemcpy, frexp, sigfillset, __udivmodti4, …) from inside the group.
-    // -lc/-lm/-lgcc normally come after --end-group, which single-pass ld
-    // won't revisit, so pull them into the group explicitly.
-    let musl_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib");
-    let gcc_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/lib/gcc/x86_64-linux-musl/11.2.1");
-    for (dir, name) in [
-        (musl_lib, "libc.a"),
-        (musl_lib, "libm.a"),
-        (gcc_lib, "libgcc.a"),
-    ] {
-        let p = dir.join(name);
-        if p.exists() {
-            println!("cargo::rustc-link-arg={}", p.display());
+        for (dir, name) in [
+            (musl_lib, "libc.a"),
+            (musl_lib, "libm.a"),
+            (gcc_lib,  "libgcc.a"),
+        ] {
+            let p = dir.join(name);
+            if p.exists() {
+                println!("cargo::rustc-link-arg={}", p.display());
+            }
         }
     }
     println!("cargo::rustc-link-arg=-Wl,--end-group");

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -122,9 +122,56 @@ fn main() {
     println!("cargo::rustc-link-arg=-Wl,--start-group");
     println!("cargo::rustc-link-arg={}", lib_dir.join("libphp.a").display());
     for static_lib in linux_static_libs() {
+        // stdc++ isn't in the buildroot — it comes from the musl-cross
+        // toolchain. C++-heavy extensions (abseil/grpc) reference a huge
+        // volume of operator new/delete and std::* symbols, so force every
+        // libstdc++ object in with --whole-archive to survive single-pass ld.
+        if *static_lib == "stdc++" {
+            let musl_stdcxx = std::path::Path::new(
+                "/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib/libstdc++.a"
+            );
+            if musl_stdcxx.exists() {
+                println!("cargo::rustc-link-arg=-Wl,--whole-archive");
+                println!("cargo::rustc-link-arg={}", musl_stdcxx.display());
+                println!("cargo::rustc-link-arg=-Wl,--no-whole-archive");
+            }
+            continue;
+        }
         let archive = lib_dir.join(format!("lib{static_lib}.a"));
         if archive.exists() {
             println!("cargo::rustc-link-arg={}", archive.display());
+        }
+    }
+    // C++-heavy extensions (abseil/grpc) reference libc/libm/libgcc symbols
+    // (wmemcpy, frexp, sigfillset, __udivmodti4, …) from inside the group.
+    // -lc/-lm/-lgcc normally come after --end-group, which single-pass ld
+    // won't revisit, so pull them into the group explicitly.
+    let musl_lib = std::path::Path::new("/usr/local/musl/x86_64-linux-musl/lib");
+    let gcc_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/lib/gcc/x86_64-linux-musl/11.2.1");
+    for (dir, name) in [
+        (musl_lib, "libc.a"),
+        (musl_lib, "libm.a"),
+        (gcc_lib, "libgcc.a"),
+    ] {
+        let p = dir.join(name);
+        if p.exists() {
+            println!("cargo::rustc-link-arg={}", p.display());
+        }
+    }
+    // C++-heavy extensions (abseil/grpc) reference libc/libm/libgcc symbols
+    // (wmemcpy, frexp, sigfillset, __udivmodti4, …) from inside the group.
+    // -lc/-lm/-lgcc normally come after --end-group, which single-pass ld
+    // won't revisit, so pull them into the group explicitly.
+    let musl_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib");
+    let gcc_lib = std::path::Path::new("/opt/x86_64-linux-musl-cross/lib/gcc/x86_64-linux-musl/11.2.1");
+    for (dir, name) in [
+        (musl_lib, "libc.a"),
+        (musl_lib, "libm.a"),
+        (gcc_lib, "libgcc.a"),
+    ] {
+        let p = dir.join(name);
+        if p.exists() {
+            println!("cargo::rustc-link-arg={}", p.display());
         }
     }
     println!("cargo::rustc-link-arg=-Wl,--end-group");
@@ -147,6 +194,42 @@ fn linux_static_libs() -> &'static [&'static str] {
         "heif", "de265", "tiff", "webp", "webpdecoder", "webpdemux", "webpmux", "sharpyuv",
         "aom", "jxl", "jxl_cms", "jxl_threads", "hwy",
         "brotlienc", "brotlidec", "brotlicommon",
+        // gRPC + protobuf + abseil + upb (grpc extension)
+        "grpc++", "grpc++_alts", "grpc++_error_details", "grpc++_unsecure",
+        "grpc", "grpc_unsecure", "grpc_authorization_provider", "grpc_plugin_support",
+        "gpr", "address_sorting", "cares", "re2",
+        "protobuf", "protobuf-lite",
+        "upb", "upb_base_lib", "upb_hash_lib", "upb_json_lib", "upb_lex_lib",
+        "upb_mem_lib", "upb_message_lib", "upb_mini_descriptor_lib", "upb_mini_table_lib",
+        "upb_reflection_lib", "upb_textformat_lib", "upb_wire_lib",
+        "utf8_range", "utf8_range_lib", "utf8_validity",
+        "absl_base", "absl_city", "absl_civil_time", "absl_cord", "absl_cord_internal",
+        "absl_cordz_functions", "absl_cordz_handle", "absl_cordz_info", "absl_cordz_sample_token",
+        "absl_crc32c", "absl_crc_cord_state", "absl_crc_cpu_detect", "absl_crc_internal",
+        "absl_debugging_internal", "absl_decode_rust_punycode", "absl_demangle_internal",
+        "absl_demangle_rust", "absl_die_if_null", "absl_examine_stack", "absl_exponential_biased",
+        "absl_failure_signal_handler", "absl_flags_commandlineflag",
+        "absl_flags_commandlineflag_internal", "absl_flags_config", "absl_flags_internal",
+        "absl_flags_marshalling", "absl_flags_parse", "absl_flags_private_handle_accessor",
+        "absl_flags_program_name", "absl_flags_reflection", "absl_flags_usage",
+        "absl_flags_usage_internal", "absl_graphcycles_internal", "absl_hash",
+        "absl_hashtablez_sampler", "absl_int128", "absl_kernel_timeout_internal", "absl_leak_check",
+        "absl_log_flags", "absl_log_globals", "absl_log_initialize", "absl_log_internal_check_op",
+        "absl_log_internal_conditions", "absl_log_internal_fnmatch", "absl_log_internal_format",
+        "absl_log_internal_globals", "absl_log_internal_log_sink_set", "absl_log_internal_message",
+        "absl_log_internal_nullguard", "absl_log_internal_proto", "absl_log_internal_structured_proto",
+        "absl_log_severity", "absl_log_sink", "absl_low_level_hash", "absl_malloc_internal",
+        "absl_periodic_sampler", "absl_poison", "absl_random_distributions",
+        "absl_random_internal_distribution_test_util", "absl_random_internal_entropy_pool",
+        "absl_random_internal_platform", "absl_random_internal_randen",
+        "absl_random_internal_randen_hwaes", "absl_random_internal_randen_hwaes_impl",
+        "absl_random_internal_randen_slow", "absl_random_internal_seed_material",
+        "absl_random_seed_gen_exception", "absl_random_seed_sequences", "absl_raw_hash_set",
+        "absl_raw_logging_internal", "absl_scoped_set_env", "absl_spinlock_wait", "absl_stacktrace",
+        "absl_status", "absl_statusor", "absl_str_format_internal", "absl_strerror",
+        "absl_string_view", "absl_strings", "absl_strings_internal", "absl_symbolize",
+        "absl_synchronization", "absl_throw_delegate", "absl_time", "absl_time_zone",
+        "absl_tracing_internal", "absl_utf8_for_code_point", "absl_vlog_config_internal",
         // libstdc++ last: all C++ libs above reference std::* / __cxa_* symbols
         "stdc++",
     ]

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn main() {
     // Declare php_linked as a known cfg so #[cfg(php_linked)] in this crate
@@ -103,6 +103,16 @@ fn main() {
         println!("cargo::rustc-link-arg=-Wl,--wrap={func}");
     }
 
+    // Architecture-specific musl toolchain paths. The builder image and
+    // entrypoint select the toolchain matching $(uname -m); mirror that here
+    // from cargo's target arch so arm64 hosts (Apple Silicon, Graviton) link
+    // against the aarch64 musl-cross toolchain instead of a hardcoded x86_64
+    // one. uname -m's x86_64/aarch64 tokens match the rust arch tokens and the
+    // musl.cc tarball names, so one substitution covers every path.
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".into());
+    let musl_triple = format!("{target_arch}-linux-musl");
+    let musl_cross_root = PathBuf::from(format!("/opt/{musl_triple}-cross"));
+
     // Force-link libphp.a + the support libs SPC built into the SDK.
     // Workaround: rustc-link-lib emitted from ephpm-php's build.rs
     // doesn't propagate to the final musl-static link in this layout
@@ -127,9 +137,7 @@ fn main() {
         // volume of operator new/delete and std::* symbols, so force every
         // libstdc++ object in with --whole-archive to survive single-pass ld.
         if *static_lib == "stdc++" {
-            let musl_stdcxx = std::path::Path::new(
-                "/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib/libstdc++.a"
-            );
+            let musl_stdcxx = musl_cross_root.join(&musl_triple).join("lib/libstdc++.a");
             if musl_stdcxx.exists() {
                 println!("cargo::rustc-link-arg=-Wl,--whole-archive");
                 println!("cargo::rustc-link-arg={}", musl_stdcxx.display());
@@ -147,26 +155,26 @@ fn main() {
     // -lc/-lm/-lgcc normally come after --end-group, which single-pass ld
     // won't revisit, so pull them into the group explicitly.
     //
-    // Two candidate musl lib roots: spc's own toolchain (/usr/local/musl)
-    // and the musl-cross-make tarball (/opt/x86_64-linux-musl-cross).
-    // We try both and emit whichever archives actually exist — only one
-    // toolchain will be present at build time.
-    let gcc_lib = std::path::Path::new(
-        "/opt/x86_64-linux-musl-cross/lib/gcc/x86_64-linux-musl/11.2.1"
-    );
-    for musl_lib in [
-        std::path::Path::new("/usr/local/musl/x86_64-linux-musl/lib"),
-        std::path::Path::new("/opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib"),
-    ] {
-        for (dir, name) in [
-            (musl_lib, "libc.a"),
-            (musl_lib, "libm.a"),
-            (gcc_lib,  "libgcc.a"),
-        ] {
-            let p = dir.join(name);
+    // Two candidate musl lib roots: spc's own toolchain (/usr/local/musl) and
+    // the musl-cross-make tarball (musl_cross_root). We emit whichever archives
+    // actually exist — only one toolchain is present at build time. libgcc's
+    // version subdir varies by toolchain/arch, so it's discovered, not hardcoded.
+    let musl_lib_roots = [
+        PathBuf::from(format!("/usr/local/musl/{musl_triple}/lib")),
+        musl_cross_root.join(&musl_triple).join("lib"),
+    ];
+    for musl_lib in &musl_lib_roots {
+        for name in ["libc.a", "libm.a"] {
+            let p = musl_lib.join(name);
             if p.exists() {
                 println!("cargo::rustc-link-arg={}", p.display());
             }
+        }
+    }
+    if let Some(gcc_lib) = musl_cross_gcc_lib(&musl_cross_root, &musl_triple) {
+        let p = gcc_lib.join("libgcc.a");
+        if p.exists() {
+            println!("cargo::rustc-link-arg={}", p.display());
         }
     }
     println!("cargo::rustc-link-arg=-Wl,--end-group");
@@ -238,4 +246,23 @@ fn linux_static_libs() -> &'static [&'static str] {
 /// actually needed.
 fn macos_static_libs() -> &'static [&'static str] {
     linux_static_libs()
+}
+
+
+/// Locate the gcc version subdir under `<musl_cross_root>/lib/gcc/<triple>/`.
+///
+/// musl-cross-make toolchains ship exactly one gcc version directory (e.g.
+/// `11.2.1`), but the exact version differs between the x86_64 and aarch64
+/// tarballs, so we discover it at build time instead of hardcoding. If more
+/// than one is present, pick the lexicographically highest.
+fn musl_cross_gcc_lib(musl_cross_root: &Path, musl_triple: &str) -> Option<PathBuf> {
+    let base = musl_cross_root.join("lib/gcc").join(musl_triple);
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(&base)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    dirs.sort();
+    dirs.pop()
 }

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -141,7 +141,14 @@ fn linux_static_libs() -> &'static [&'static str] {
         "ssl", "crypto", "curl", "z", "xml2", "xslt", "exslt", "lzma", "sodium", "iconv",
         "charset", "intl", "png16", "gd", "jpeg", "freetype", "onig", "zip", "bz2", "gmp",
         "sqlite3", "pq", "pgcommon", "pgport", "edit", "ncurses", "menu", "form", "panel", "tic",
-        "icui18n", "icuuc", "icudata", "icuio", "icutu", "stdc++",
+        "icui18n", "icuuc", "icudata", "icuio", "icutu",
+        // ImageMagick (imagick extension) + codec chain
+        "MagickWand-7.Q16HDRI", "MagickCore-7.Q16HDRI", "Magick++-7.Q16HDRI",
+        "heif", "de265", "tiff", "webp", "webpdecoder", "webpdemux", "webpmux", "sharpyuv",
+        "aom", "jxl", "jxl_cms", "jxl_threads", "hwy",
+        "brotlienc", "brotlidec", "brotlicommon",
+        // libstdc++ last: all C++ libs above reference std::* / __cxa_* symbols
+        "stdc++",
     ]
 }
 

--- a/crates/ephpm/src/commands/ext.rs
+++ b/crates/ephpm/src/commands/ext.rs
@@ -1,0 +1,461 @@
+//! `ephpm ext` — extension management commands.
+
+use std::process::Command;
+use anyhow::{Context, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExtKind {
+    BuiltIn,
+    ZendDev,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtInfo {
+    pub name: String,
+    pub version: String,
+    pub kind: ExtKind,
+}
+
+pub fn get_extensions() -> Result<(String, Vec<ExtInfo>)> {
+    let binary = std::env::current_exe().context("failed to get current binary path")?;
+
+    // Run `<self> php -m`
+    let modules_out = Command::new(&binary)
+        .args(["php", "-m"])
+        .output()
+        .context("failed to run `ephpm php -m`")?;
+    let modules_text = String::from_utf8_lossy(&modules_out.stdout).into_owned();
+
+    // Run `<self> php -r` to get versions
+    let ver_script = r#"foreach(get_loaded_extensions() as $e) { echo $e.'::'.( phpversion($e) ?: 'n/a')."\n"; }"#;
+    let ver_out = Command::new(&binary)
+        .args(["php", "-r", ver_script])
+        .output()
+        .context("failed to query PHP extension versions")?;
+
+    // Build name -> version map
+    let versions: std::collections::HashMap<String, String> =
+        String::from_utf8_lossy(&ver_out.stdout)
+            .lines()
+            .filter_map(|line| {
+                let mut parts = line.splitn(2, "::");
+                let name = parts.next()?.trim().to_lowercase();
+                let ver = parts.next().unwrap_or("n/a").trim().to_string();
+                // mysqlnd reports "mysqlnd 8.5.2" — grab just the version number
+                let ver = ver.split_whitespace().last().unwrap_or("n/a").to_string();
+                Some((name, ver))
+            })
+            .collect();
+
+    // Parse `php -m` output
+    let mut extensions = Vec::new();
+    let mut in_zend = false;
+    let mut seen = std::collections::HashSet::new();
+
+    for line in modules_text.lines() {
+        let line = line.trim();
+        match line {
+            "[PHP Modules]"  => { in_zend = false; continue; }
+            "[Zend Modules]" => { in_zend = true;  continue; }
+            "" => continue,
+            _ if line.starts_with('[') => { in_zend = false; continue; }
+            name => {
+                let key = name.to_lowercase();
+                if !seen.insert(key.clone()) {
+                    continue; // skip duplicates (OPcache appears twice)
+                }
+                let version = versions.get(&key).cloned().unwrap_or_else(|| "n/a".into());
+                // OPcache is a Zend ext but treat as built-in — it's always present
+                let kind = if in_zend && key != "zend opcache" {
+                    ExtKind::ZendDev
+                } else {
+                    ExtKind::BuiltIn
+                };
+                extensions.push(ExtInfo { name: name.to_string(), version, kind });
+            }
+        }
+    }
+
+    // Get PHP version from Core
+    let php_version = extensions
+        .iter()
+        .find(|e| e.name == "Core")
+        .map(|e| e.version.clone())
+        .unwrap_or_else(|| "unknown".into());
+
+    Ok((php_version, extensions))
+}
+
+pub fn cmd_list(json: bool) -> Result<()> {
+    let (php_version, mut extensions) = get_extensions()?;
+
+    // Sort: built-in alpha first, zend-dev alpha after
+    extensions.sort_by(|a, b| {
+        let kind_ord = |k: &ExtKind| match k {
+            ExtKind::BuiltIn => 0,
+            ExtKind::ZendDev => 1,
+        };
+        kind_ord(&a.kind)
+            .cmp(&kind_ord(&b.kind))
+            .then(a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+
+    if json {
+        print_json(&php_version, &extensions);
+    } else {
+        print_table(&php_version, &extensions);
+    }
+    Ok(())
+}
+
+fn print_table(php_version: &str, extensions: &[ExtInfo]) {
+    let builtin_count = extensions.iter().filter(|e| e.kind == ExtKind::BuiltIn).count();
+    let zend_count    = extensions.iter().filter(|e| e.kind == ExtKind::ZendDev).count();
+
+    let name_w = extensions.iter().map(|e| e.name.len()).max().unwrap_or(9).max(9);
+    let ver_w  = extensions.iter().map(|e| e.version.len()).max().unwrap_or(7).max(7);
+
+    println!("PHP: {php_version}");
+    println!();
+    println!("{:<name_w$}  {:<ver_w$}  STATUS", "EXTENSION", "VERSION", name_w = name_w, ver_w = ver_w);
+    println!("{}", "\u{2500}".repeat(name_w + ver_w + 10));
+
+    for ext in extensions {
+        let status = match ext.kind {
+            ExtKind::BuiltIn => "built-in",
+            ExtKind::ZendDev => "zend/dev",
+        };
+        println!("{:<name_w$}  {:<ver_w$}  {status}", ext.name, ext.version, name_w = name_w, ver_w = ver_w);
+    }
+
+    println!("{}", "\u{2500}".repeat(name_w + ver_w + 10));
+    let mut parts = Vec::new();
+    if builtin_count > 0 { parts.push(format!("{builtin_count} built-in")); }
+    if zend_count    > 0 { parts.push(format!("{zend_count} zend/dev")); }
+    println!("{} = {} extensions total", parts.join(" + "), extensions.len());
+}
+
+fn print_json(php_version: &str, extensions: &[ExtInfo]) {
+    println!("{{");
+    println!("  \"php_version\": {php_version:?},");
+    println!("  \"count\": {},", extensions.len());
+    println!("  \"extensions\": [");
+    for (i, ext) in extensions.iter().enumerate() {
+        let kind_str = match ext.kind {
+            ExtKind::BuiltIn => "built-in",
+            ExtKind::ZendDev => "zend-dev",
+        };
+        let comma = if i + 1 < extensions.len() { "," } else { "" };
+        println!("    {{\"name\": {:?}, \"version\": {:?}, \"kind\": {:?}}}{comma}", ext.name, ext.version, kind_str);
+    }
+    println!("  ]");
+    println!("}}");
+}
+
+pub fn cmd_info(name: &str) -> Result<()> {
+    let (_, extensions) = get_extensions()?;
+    let needle = name.to_lowercase().trim_start_matches("ext-").to_string();
+
+    match extensions.iter().find(|e| e.name.to_lowercase() == needle) {
+        Some(ext) => {
+            let kind_label = match ext.kind {
+                ExtKind::BuiltIn => "built-in (part of this build)",
+                ExtKind::ZendDev => "zend extension (dev builds only)",
+            };
+            println!("Name:     {}", ext.name);
+            println!("Version:  {}", ext.version);
+            println!("Type:     {kind_label}");
+        }
+        None => {
+            eprintln!("ext-{name} is NOT in this binary.");
+            eprintln!();
+            eprintln!("  Add it:  ephpm ext build --add {name}");
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}
+
+// ── Static extension registry (sourced from static-php-cli) ──────────────────
+
+struct SpcExt {
+    name: &'static str,
+    linux: bool,
+    macos: bool,
+    windows: bool,
+    url: &'static str,
+}
+
+const SPC_REGISTRY: &[SpcExt] = &[
+    SpcExt { name: "amqp",         linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/amqp" },
+    SpcExt { name: "apcu",         linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/APCu" },
+    SpcExt { name: "ast",          linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/ast" },
+    SpcExt { name: "bcmath",       linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "brotli",       linux: true,  macos: true,  windows: true,  url: "https://github.com/kjdev/php-ext-brotli" },
+    SpcExt { name: "bz2",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "calendar",     linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "ctype",        linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "curl",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "dba",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "decimal",      linux: true,  macos: true,  windows: true,  url: "https://github.com/php-decimal/ext-decimal" },
+    SpcExt { name: "dom",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "ds",           linux: true,  macos: true,  windows: true,  url: "https://github.com/php-ds/ext-ds" },
+    SpcExt { name: "ev",           linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/ev" },
+    SpcExt { name: "event",        linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "excimer",      linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/excimer" },
+    SpcExt { name: "exif",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "ffi",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "fileinfo",     linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "filter",       linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "ftp",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "gd",           linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "gearman",      linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/gearman" },
+    SpcExt { name: "gettext",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "gmp",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "grpc",         linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/grpc" },
+    SpcExt { name: "iconv",        linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "igbinary",     linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/igbinary" },
+    SpcExt { name: "imagick",      linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/imagick" },
+    SpcExt { name: "imap",         linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/imap" },
+    SpcExt { name: "inotify",      linux: true,  macos: false, windows: false, url: "https://pecl.php.net/package/inotify" },
+    SpcExt { name: "intl",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "ldap",         linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "libxml",       linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "lz4",          linux: true,  macos: true,  windows: true,  url: "https://github.com/kjdev/php-ext-lz4" },
+    SpcExt { name: "maxminddb",    linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/maxminddb" },
+    SpcExt { name: "mbstring",     linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "memcache",     linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/memcache" },
+    SpcExt { name: "memcached",    linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/memcached" },
+    SpcExt { name: "mongodb",      linux: true,  macos: true,  windows: true,  url: "https://github.com/mongodb/mongo-php-driver" },
+    SpcExt { name: "msgpack",      linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/msgpack" },
+    SpcExt { name: "mysqli",       linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "mysqlnd",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "odbc",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "opcache",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "openssl",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "opentelemetry",linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/opentelemetry" },
+    SpcExt { name: "parallel",     linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/parallel" },
+    SpcExt { name: "pcntl",        linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "pcov",         linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/pcov" },
+    SpcExt { name: "pdo",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "pdo_mysql",    linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "pdo_odbc",     linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "pdo_pgsql",    linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "pdo_sqlite",   linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "pdo_sqlsrv",   linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/pdo_sqlsrv" },
+    SpcExt { name: "pgsql",        linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "phar",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "posix",        linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "protobuf",     linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/protobuf" },
+    SpcExt { name: "rar",          linux: true,  macos: true,  windows: true,  url: "https://github.com/static-php/php-rar" },
+    SpcExt { name: "rdkafka",      linux: true,  macos: true,  windows: false, url: "https://github.com/php-rdkafka/php-rdkafka" },
+    SpcExt { name: "readline",     linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "redis",        linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/redis" },
+    SpcExt { name: "session",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "shmop",        linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "simdjson",     linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/simdjson" },
+    SpcExt { name: "simplexml",    linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "snappy",       linux: true,  macos: true,  windows: true,  url: "https://github.com/kjdev/php-ext-snappy" },
+    SpcExt { name: "snmp",         linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "soap",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "sockets",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "sodium",       linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "spx",          linux: true,  macos: true,  windows: false, url: "https://github.com/noisebynorthwest/php-spx" },
+    SpcExt { name: "sqlite3",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "sqlsrv",       linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/sqlsrv" },
+    SpcExt { name: "ssh2",         linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/ssh2" },
+    SpcExt { name: "swoole",       linux: true,  macos: true,  windows: false, url: "https://github.com/swoole/swoole-src" },
+    SpcExt { name: "sysvmsg",      linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "sysvsem",      linux: true,  macos: true,  windows: false, url: "" },
+    SpcExt { name: "sysvshm",      linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "tidy",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "tokenizer",    linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "uuid",         linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/uuid" },
+    SpcExt { name: "uv",           linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/uv" },
+    SpcExt { name: "xdebug",       linux: true,  macos: true,  windows: false, url: "https://github.com/xdebug/xdebug" },
+    SpcExt { name: "xhprof",       linux: true,  macos: true,  windows: false, url: "https://pecl.php.net/package/xhprof" },
+    SpcExt { name: "xlswriter",    linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/xlswriter" },
+    SpcExt { name: "xml",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "xmlreader",    linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "xmlwriter",    linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "xsl",          linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "yaml",         linux: true,  macos: true,  windows: true,  url: "https://github.com/php/pecl-file_formats-yaml" },
+    SpcExt { name: "zip",          linux: true,  macos: true,  windows: true,  url: "https://pecl.php.net/package/zip" },
+    SpcExt { name: "zlib",         linux: true,  macos: true,  windows: true,  url: "" },
+    SpcExt { name: "zstd",         linux: true,  macos: true,  windows: true,  url: "https://github.com/kjdev/php-ext-zstd" },
+];
+
+pub fn cmd_search(query: &str) -> Result<()> {
+    let (_, installed) = get_extensions()?;
+    let installed_names: std::collections::HashSet<String> =
+        installed.iter().map(|e| e.name.to_lowercase()).collect();
+
+    let q = query.to_lowercase();
+    let results: Vec<&SpcExt> = SPC_REGISTRY
+        .iter()
+        .filter(|e| e.name.to_lowercase().contains(&q))
+        .collect();
+
+    if results.is_empty() {
+        println!("No extensions matching {:?}", query);
+        println!("Browse all: https://static-php.dev/en/guide/extensions.html");
+        return Ok(());
+    }
+
+    let name_w = results.iter().map(|e| e.name.len()).max().unwrap_or(4).max(4);
+
+    println!(
+        "{:<name_w$}  {:^8}  {:^5}  {:^7}  {}",
+        "NAME", "INSTALLED", "LINUX", "WINDOWS", "URL",
+        name_w = name_w,
+    );
+    println!("{}", "\u{2500}".repeat(name_w + 40));
+
+    for ext in results {
+        let installed = if installed_names.contains(ext.name) { "✓" } else { "—" };
+        let linux   = if ext.linux   { "✓" } else { "—" };
+        let windows = if ext.windows { "✓" } else { "—" };
+        let url = if ext.url.is_empty() { "(bundled)" } else { ext.url };
+        println!(
+            "{:<name_w$}  {:^9}  {:^5}  {:^7}  {}",
+            ext.name, installed, linux, windows, url,
+            name_w = name_w,
+        );
+    }
+
+    Ok(())
+}
+
+// ── `ephpm ext build` ─────────────────────────────────────────────────────────
+
+pub struct BuildArgs {
+    pub add: Vec<String>,
+    pub suite: Option<String>,
+    pub output: Option<String>,
+}
+
+pub fn cmd_build(args: &BuildArgs) -> Result<()> {
+    // 1. Detect container engine
+    let engine = detect_container_engine()?;
+    println!("  ■ Using container engine: {engine}");
+
+    // 2. Resolve base suite extensions
+    let base = suite_extensions(args.suite.as_deref().unwrap_or("core"));
+
+    // 3. Parse --add list
+    let add: Vec<String> = args.add.iter()
+        .flat_map(|s| s.split(','))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // 4. Merge, deduplicate
+    let mut all: Vec<String> = base.clone();
+    for ext in &add {
+        if !all.contains(ext) {
+            all.push(ext.clone());
+        }
+    }
+
+    let suite_name = args.suite.as_deref().unwrap_or("core");
+    println!("  ■ Suite:  {} ({} extensions)", suite_name, base.len());
+    if !add.is_empty() {
+        println!("  ■ Adding: {}", add.join(", "));
+    }
+    println!("  ■ Total:  {} extensions", all.len());
+    println!("  ■ List:   {}", all.join(","));
+
+    // 5. Output path
+    let output = args.output.as_deref().unwrap_or("./ephpm-custom");
+    let output_abs = std::fs::canonicalize(".")
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+        .join(output.trim_start_matches("./"));
+    let output_dir = output_abs.parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_string_lossy()
+        .to_string();
+
+    // 6. Determine builder image — prefer local build, fall back to registry
+    let version = env!("CARGO_PKG_VERSION");
+    let registry_image = format!("ghcr.io/ephpm/builder:{version}");
+    let local_image = "ephpm-builder:local".to_string();
+    let image = {
+        // Check if local image exists
+        let has_local = std::process::Command::new(&engine)
+            .args(["image", "inspect", &local_image])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if has_local { local_image } else { registry_image }
+    };
+    println!("  ■ Image:  {image}");
+    println!("  ■ Output: {output}");
+    println!();
+    println!("  Pulling builder image (this may take a minute on first run)...");
+
+    // 7. Run the container
+    // Pass GITHUB_TOKEN if set — spc needs it to avoid rate limiting
+    let token_arg: Vec<String> = if let Ok(tok) = std::env::var("GITHUB_TOKEN") {
+        vec!["-e".into(), format!("GITHUB_TOKEN={tok}")]
+    } else {
+        vec![]
+    };
+
+    let mut docker_cmd = std::process::Command::new(&engine);
+    docker_cmd.arg("run").arg("--rm");
+    for arg in &token_arg {
+        docker_cmd.arg(arg);
+    }
+    docker_cmd
+        .arg("-e").arg(format!("EXTENSIONS={}", all.join(",")))
+        .arg("-e").arg(format!("OUTPUT=/output/{}", std::path::Path::new(output)
+            .file_name()
+            .unwrap_or(std::ffi::OsStr::new("ephpm"))
+            .to_string_lossy()))
+        .arg("-v").arg(format!("{}:/output", output_dir))
+        .arg("-v").arg(format!("{}:/src/ephpm", std::env::current_dir().unwrap().display()))
+        .arg("-v").arg("ephpm-spc-cache:/build")
+        .arg(&image);
+
+    let status = docker_cmd
+        .status()
+        .context("failed to run builder container — is Docker/Podman running?")?;
+
+    if !status.success() {
+        anyhow::bail!("builder container failed with status: {status}");
+    }
+
+    println!();
+    println!("  ✓ Build complete");
+    println!("    Verify: {output} ext list");
+    Ok(())
+}
+
+fn detect_container_engine() -> Result<String> {
+    if let Ok(e) = std::env::var("CONTAINER_ENGINE") {
+        if !e.is_empty() { return Ok(e); }
+    }
+    for candidate in ["podman", "docker"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Ok(candidate.to_string());
+        }
+    }
+    anyhow::bail!(
+        "No container engine found.\n  Install Docker: https://docs.docker.com/get-docker/\n  Or set CONTAINER_ENGINE=docker"
+    )
+}
+
+fn suite_extensions(suite: &str) -> Vec<String> {
+    let exts = match suite {
+        "wordpress" => "bcmath,calendar,curl,dom,exif,fileinfo,filter,gd,hash,iconv,json,libxml,mbstring,mysqli,mysqlnd,openssl,pcre,pdo,pdo_mysql,pdo_sqlite,phar,session,simplexml,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib",
+        "laravel"   => "bcmath,curl,dom,fileinfo,filter,gd,hash,iconv,igbinary,intl,json,libxml,mbstring,openssl,pcre,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,phar,posix,redis,session,simplexml,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib",
+        "full"      => "amqp,apcu,bcmath,brotli,bz2,calendar,curl,dba,decimal,dom,ds,ev,exif,fileinfo,filter,ftp,gd,gmp,iconv,igbinary,imagick,intl,json,ldap,libxml,lz4,mbstring,memcached,mongodb,msgpack,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,rdkafka,readline,redis,session,simdjson,simplexml,snappy,soap,sockets,sodium,sqlite3,ssh2,tokenizer,uuid,xml,xmlreader,xmlwriter,xsl,yaml,zip,zlib,zstd",
+        _ /* core */ => "bcmath,curl,dom,fileinfo,filter,libxml,mbstring,openssl,phar,session,simplexml,sodium,tokenizer,xml,xmlreader,xmlwriter,zip,zlib",
+    };
+    exts.split(',').map(|s| s.to_string()).collect()
+}

--- a/crates/ephpm/src/commands/ext.rs
+++ b/crates/ephpm/src/commands/ext.rs
@@ -342,12 +342,25 @@ pub fn cmd_build(args: &BuildArgs) -> Result<()> {
     // 2. Resolve base suite extensions
     let base = suite_extensions(args.suite.as_deref().unwrap_or("core"));
 
-    // 3. Parse --add list
-    let add: Vec<String> = args.add.iter()
-        .flat_map(|s| s.split(','))
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    // 3. Parse --add list, validating each name.
+    //
+    // These names are passed through to the builder container as the
+    // EXTENSIONS env var, which the entrypoint forwards to spc. Reject
+    // anything outside [A-Za-z0-9_-] so a crafted --add value can't inject
+    // shell metacharacters or extra spc arguments.
+    let mut add: Vec<String> = Vec::new();
+    for raw in args.add.iter().flat_map(|s| s.split(',')) {
+        let name = raw.trim();
+        if name.is_empty() {
+            continue;
+        }
+        if !is_valid_ext_name(name) {
+            anyhow::bail!(
+                "invalid extension name {name:?}: only letters, digits, '_' and '-' are allowed"
+            );
+        }
+        add.push(name.to_string());
+    }
 
     // 4. Merge, deduplicate
     let mut all: Vec<String> = base.clone();
@@ -481,6 +494,18 @@ pub fn cmd_build(args: &BuildArgs) -> Result<()> {
     println!("  ✓ Build complete");
     println!("    Verify: {output} ext list");
     Ok(())
+}
+
+/// Validate an extension name: non-empty, ASCII alphanumerics plus '_' and '-'.
+///
+/// Extension names flow into the builder container's EXTENSIONS env var and
+/// on to spc, so anything outside this set is rejected to prevent shell
+/// injection or argument smuggling.
+fn is_valid_ext_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 fn detect_container_engine() -> Result<String> {

--- a/crates/ephpm/src/commands/ext.rs
+++ b/crates/ephpm/src/commands/ext.rs
@@ -375,23 +375,75 @@ pub fn cmd_build(args: &BuildArgs) -> Result<()> {
         .to_string_lossy()
         .to_string();
 
-    // 6. Determine builder image — prefer local build, fall back to registry
+    // 6. Determine builder image:
+    //    a) local tag built from this repo's Dockerfile.builder (preferred)
+    //    b) registry image from ghcr.io
+    //    c) if neither exists, build the local image on the spot so a fresh
+    //       clone works end-to-end without a pre-published registry image.
     let version = env!("CARGO_PKG_VERSION");
     let registry_image = format!("ghcr.io/ephpm/builder:{version}");
     let local_image = "ephpm-builder:local".to_string();
-    let image = {
-        // Check if local image exists
-        let has_local = std::process::Command::new(&engine)
-            .args(["image", "inspect", &local_image])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-        if has_local { local_image } else { registry_image }
+
+    let has_local = std::process::Command::new(&engine)
+        .args(["image", "inspect", &local_image])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let has_registry = !has_local && std::process::Command::new(&engine)
+        .args(["image", "inspect", &registry_image])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let image = if has_local {
+        local_image.clone()
+    } else if has_registry {
+        registry_image.clone()
+    } else {
+        // Neither image is present locally — build from the Dockerfile in this repo.
+        // Locate the repo root: walk up from cwd until we find docker/Dockerfile.builder.
+        let repo_root = {
+            let mut dir = std::env::current_dir().context("failed to get cwd")?;
+            loop {
+                if dir.join("docker/Dockerfile.builder").exists() {
+                    break dir;
+                }
+                let parent = dir.parent().map(|p| p.to_path_buf());
+                match parent {
+                    Some(p) => dir = p,
+                    None => anyhow::bail!(
+                        "could not find docker/Dockerfile.builder — run from inside the ephpm repo"
+                    ),
+                }
+            }
+        };
+        println!("  ■ Builder image not found locally — building from Dockerfile.builder");
+        println!("    (this takes a few minutes on first run)");
+        let dockerfile = repo_root.join("docker/Dockerfile.builder");
+        let build_status = std::process::Command::new(&engine)
+            .args([
+                "build",
+                "--file", &dockerfile.to_string_lossy(),
+                "--tag", &local_image,
+                &repo_root.to_string_lossy().to_string(),
+            ])
+            .status()
+            .context("failed to build builder image")?;
+        if !build_status.success() {
+            anyhow::bail!("failed to build ephpm-builder image (see output above)");
+        }
+        println!("  ■ Builder image built successfully");
+        local_image.clone()
     };
+
     println!("  ■ Image:  {image}");
     println!("  ■ Output: {output}");
     println!();
-    println!("  Pulling builder image (this may take a minute on first run)...");
 
     // 7. Run the container
     // Pass GITHUB_TOKEN if set — spc needs it to avoid rate limiting

--- a/crates/ephpm/src/commands/ext.rs
+++ b/crates/ephpm/src/commands/ext.rs
@@ -536,3 +536,42 @@ fn suite_extensions(suite: &str) -> Vec<String> {
     };
     exts.split(',').map(|s| s.to_string()).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_ext_name;
+
+    #[test]
+    fn accepts_valid_extension_names() {
+        for name in [
+            "redis", "intl", "pdo_mysql", "pdo_sqlite", "opcache",
+            "MagickWand-7", "absl_base", "utf8_range", "name-with-123",
+        ] {
+            assert!(is_valid_ext_name(name), "should accept {name:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        assert!(!is_valid_ext_name(""));
+    }
+
+    #[test]
+    fn rejects_shell_metacharacters_and_separators() {
+        for name in [
+            "redis; touch /tmp/pwned",
+            "redis foo",        // space -> word splitting
+            "redis$(whoami)",
+            "redis`id`",
+            "redis|cat",
+            "redis&bg",
+            "redis>out",
+            "redis\nopenssl",   // embedded newline
+            "../../etc/passwd",  // path traversal
+            "redis,openssl",    // comma is the list separator, never part of a name
+            "r\u{00e9}dis",     // non-ASCII
+        ] {
+            assert!(!is_valid_ext_name(name), "should reject {name:?}");
+        }
+    }
+}

--- a/crates/ephpm/src/commands/mod.rs
+++ b/crates/ephpm/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod ext;

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
 mod service;
+mod commands;
 
 /// ePHPm — All-in-one PHP application server
 #[derive(Parser, Debug)]
@@ -115,6 +116,12 @@ enum Commands {
     /// Show service status (PID, uptime, listen address)
     Status,
 
+    /// Manage PHP extensions compiled into this binary
+    Ext {
+        #[command(subcommand)]
+        command: ExtCommand,
+    },
+
     /// Tail the service log file
     Logs {
         /// Follow the log (like `tail -f`)
@@ -205,6 +212,15 @@ fn run() -> anyhow::Result<ExitCode> {
                 .map(|()| ExitCode::SUCCESS)
                 .map_err(|e| anyhow::anyhow!("service dispatcher failed: {e}"))
         }
+        Some(Commands::Ext { command }) => match command {
+            ExtCommand::List { json } => commands::ext::cmd_list(json).map(|()| ExitCode::SUCCESS),
+            ExtCommand::Search { query } => commands::ext::cmd_search(&query).map(|()| ExitCode::SUCCESS),
+            ExtCommand::Info { name } => commands::ext::cmd_info(&name).map(|()| ExitCode::SUCCESS),
+            ExtCommand::Build { add, suite, output } => {
+                let args = commands::ext::BuildArgs { add, suite, output };
+                commands::ext::cmd_build(&args).map(|()| ExitCode::SUCCESS)
+            }
+        },
         Some(Commands::Dev { listen, document_root, port, sites, verbose }) => {
             run_dev(listen, document_root, port, sites, verbose)
         }
@@ -908,4 +924,37 @@ mod cli_tests {
             other => panic!("unexpected: {other:?}"),
         }
     }
+}
+
+#[derive(Subcommand, Debug)]
+enum ExtCommand {
+    /// List all extensions compiled into the current binary
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Search extensions available to add via `ephpm ext build`
+    Search {
+        /// Search query (extension name or partial match)
+        query: String,
+    },
+
+    /// Show details about a specific extension
+    Info {
+        /// Extension name (e.g. "curl" or "ext-curl")
+        name: String,
+    },
+    /// Rebuild ephpm with a custom extension set (requires Docker or Podman)
+    Build {
+        /// Extensions to add (comma-separated, e.g. "redis,imagick,intl")
+        #[arg(long)]
+        add: Vec<String>,
+        /// Base suite to start from: core, wordpress, laravel, full
+        #[arg(long)]
+        suite: Option<String>,
+        /// Output path for the new binary (default: ./ephpm-custom)
+        #[arg(long)]
+        output: Option<String>,
+    },
 }

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,0 +1,37 @@
+# ephpm extension builder image
+# Ubuntu for bindgen/libclang compatibility; spc doctor installs musl toolchain
+
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential ca-certificates curl git pkg-config tar xz-utils \
+    libclang-dev musl-tools musl-dev \
+    autoconf automake libtool bison re2c flex cmake ninja-build \
+    libssl-dev zlib1g-dev autopoint unzip gettext \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --profile minimal \
+    && rustup target add x86_64-unknown-linux-musl
+
+ENV CC_x86_64_unknown_linux_musl=musl-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=musl-gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+
+RUN curl -fsSL -o /usr/local/bin/spc \
+    https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-x86_64 \
+    && chmod +x /usr/local/bin/spc
+
+# Download full musl cross-toolchain with g++/libstdc++ (needed for C++ extensions like intl)
+RUN curl -fsSL https://musl.cc/x86_64-linux-musl-cross.tgz | tar xz -C /opt/
+
+WORKDIR /build
+
+COPY docker/builder-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,23 +1,22 @@
 FROM ubuntu:24.04
 
-# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl git gcc g++ make cmake pkg-config \
     libclang-dev musl-tools musl-dev \
-    autopoint unzip gettext ca-certificates \
+    autoconf automake libtool bison re2c \
+    autopoint unzip gettext patch \
+    ca-certificates xz-utils gawk \
+    ninja-build python3 flex bzip2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install latest Rust via rustup with musl target
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup target add x86_64-unknown-linux-musl
 
-# Install static-php-cli (spc)
 RUN curl -fsSL -o /usr/local/bin/spc \
     https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-x86_64 \
     && chmod +x /usr/local/bin/spc
 
-# Download full musl cross-toolchain with g++/libstdc++ (needed for C++ extensions like intl)
 RUN curl -fsSL https://musl.cc/x86_64-linux-musl-cross.tgz | tar xz -C /opt/
 
 WORKDIR /src/ephpm

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -20,3 +20,7 @@ RUN curl -fsSL -o /usr/local/bin/spc \
 RUN curl -fsSL https://musl.cc/x86_64-linux-musl-cross.tgz | tar xz -C /opt/
 
 WORKDIR /src/ephpm
+
+COPY docker/builder-entrypoint.sh /builder-entrypoint.sh
+RUN chmod +x /builder-entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/builder-entrypoint.sh"]

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,27 +1,18 @@
-# ephpm extension builder image
-# Ubuntu for bindgen/libclang compatibility; spc doctor installs musl toolchain
-
 FROM ubuntu:24.04
-ENV DEBIAN_FRONTEND=noninteractive
 
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git pkg-config tar xz-utils \
+    bash curl git gcc g++ make cmake pkg-config \
     libclang-dev musl-tools musl-dev \
-    autoconf automake libtool bison re2c flex cmake ninja-build \
-    libssl-dev zlib1g-dev autopoint unzip gettext \
+    autopoint unzip gettext ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain stable --profile minimal \
-    && rustup target add x86_64-unknown-linux-musl
+# Install latest Rust via rustup with musl target
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup target add x86_64-unknown-linux-musl
 
-ENV CC_x86_64_unknown_linux_musl=musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=musl-gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
-
+# Install static-php-cli (spc)
 RUN curl -fsSL -o /usr/local/bin/spc \
     https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-x86_64 \
     && chmod +x /usr/local/bin/spc
@@ -29,9 +20,4 @@ RUN curl -fsSL -o /usr/local/bin/spc \
 # Download full musl cross-toolchain with g++/libstdc++ (needed for C++ extensions like intl)
 RUN curl -fsSL https://musl.cc/x86_64-linux-musl-cross.tgz | tar xz -C /opt/
 
-WORKDIR /build
-
-COPY docker/builder-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
+WORKDIR /src/ephpm

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -11,13 +11,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup target add x86_64-unknown-linux-musl
+# Add the musl target matching the build host's architecture. The builder
+# image is built natively per-arch (mirroring docker/Dockerfile.gha), so only
+# the host's own target is needed. uname -m reports x86_64 / aarch64.
+RUN case "$(uname -m)" in \
+      x86_64)  rustup target add x86_64-unknown-linux-musl ;; \
+      aarch64) rustup target add aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;; \
+    esac
 
-RUN curl -fsSL -o /usr/local/bin/spc \
-    https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-x86_64 \
+# spc's nightly binaries are named spc-linux-<uname-m> (spc-linux-x86_64 /
+# spc-linux-aarch64), so the host arch token drops straight in.
+RUN ARCH="$(uname -m)" \
+    && curl -fsSL -o /usr/local/bin/spc \
+       "https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-${ARCH}" \
     && chmod +x /usr/local/bin/spc
 
-RUN curl -fsSL https://musl.cc/x86_64-linux-musl-cross.tgz | tar xz -C /opt/
+# musl.cc cross toolchains are named <uname-m>-linux-musl-cross.tgz and extract
+# to /opt/<uname-m>-linux-musl-cross/ — build.rs derives the same paths from
+# the cargo target arch.
+RUN ARCH="$(uname -m)" \
+    && curl -fsSL "https://musl.cc/${ARCH}-linux-musl-cross.tgz" | tar xz -C /opt/
 
 WORKDIR /src/ephpm
 

--- a/docker/builder-entrypoint.sh
+++ b/docker/builder-entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+EXTENSIONS="${EXTENSIONS:-json,pcre,mbstring,openssl,curl,xml,zip,zlib,session,fileinfo,filter,dom,phar,tokenizer,sodium}"
+PHP_VERSION="${PHP_VERSION:-8.5}"
+OUTPUT="${OUTPUT:-/output/ephpm}"
+echo ""
+echo "  Building libphp.a"
+echo "    PHP:        ${PHP_VERSION}"
+echo "    Extensions: ${EXTENSIONS}"
+echo ""
+cd /build
+
+# Remove stale musl toolchain so doctor downloads a fresh full one (with g++/libstdc++)
+rm -rf /usr/local/musl
+
+# Run doctor to install deps including a full musl toolchain
+spc doctor --auto-fix 2>&1 | tail -5
+
+# After doctor, point Rust linker at the spc musl toolchain
+if [ -f /usr/local/musl/bin/x86_64-linux-musl-gcc ]; then
+    export CC_x86_64_unknown_linux_musl=/usr/local/musl/bin/x86_64-linux-musl-gcc
+    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=/usr/local/musl/bin/x86_64-linux-musl-gcc
+    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/usr/local/musl/bin/x86_64-linux-musl-gcc
+    echo "  Using spc musl toolchain at /usr/local/musl"
+fi
+
+# If toolchain still has no libstdc++, copy system one (ABI-compatible per musl wiki)
+MUSL_LIBSTDCXX=$(find /usr/local/musl -name 'libstdc++.a' 2>/dev/null | head -1)
+if [ -z "${MUSL_LIBSTDCXX}" ]; then
+    echo "  WARNING: musl toolchain has no libstdc++.a - trying system fallback"
+    SYS_LIBSTDCXX=$(find /usr/lib/gcc -name 'libstdc++.a' 2>/dev/null | head -1)
+    MUSL_LIB_GCC_VER=$(ls /usr/local/musl/lib/gcc/x86_64-linux-musl/ 2>/dev/null | head -1)
+    if [ -n "${SYS_LIBSTDCXX}" ] && [ -n "${MUSL_LIB_GCC_VER}" ]; then
+        cp "${SYS_LIBSTDCXX}" "/usr/local/musl/lib/gcc/x86_64-linux-musl/${MUSL_LIB_GCC_VER}/libstdc++.a"
+        echo "  Copied ${SYS_LIBSTDCXX} -> musl toolchain"
+    fi
+fi
+
+# Configure GitHub token for spc if provided
+if [ -n "${GITHUB_TOKEN}" ]; then
+    export GITHUB_TOKEN="${GITHUB_TOKEN}"
+fi
+
+SDK_PATH="${SPC_BUILD_PATH:-/build/buildroot}"
+export PHP_SDK_PATH="${SDK_PATH}"
+
+spc download \
+    --with-php=${PHP_VERSION} \
+    --for-extensions=${EXTENSIONS} \
+    --prefer-pre-built \
+    --no-alt \
+    php-src,micro,frankenphp
+
+spc build "${EXTENSIONS}" --build-embed --enable-zts
+
+echo ""
+echo "  Copying output"
+cd /src/ephpm
+cargo build --release --package ephpm --target x86_64-unknown-linux-musl
+
+OUTPUT_FILE="${OUTPUT}"
+OUTPUT_DIR=$(dirname "${OUTPUT_FILE}")
+mkdir -p "${OUTPUT_DIR}"
+cp target/x86_64-unknown-linux-musl/release/ephpm "${OUTPUT_FILE}"
+
+EXT_COUNT=$(./target/x86_64-unknown-linux-musl/release/ephpm php -m 2>/dev/null | grep -v '^\[' | grep -v '^$' | wc -l | tr -d ' ')
+echo ""
+echo "  Done - ${EXT_COUNT} extensions compiled in"
+echo "    Binary: /output/$(basename ${OUTPUT_FILE})"
+echo "  Build complete"
+echo "    Verify: ./$(basename ${OUTPUT_FILE}) ext list"

--- a/docker/builder-entrypoint.sh
+++ b/docker/builder-entrypoint.sh
@@ -16,12 +16,33 @@ rm -rf /usr/local/musl
 # Run doctor to install deps including spc's musl toolchain (do NOT swallow errors)
 spc doctor --auto-fix
 
-# Point Rust linker at spc's musl toolchain
-if [ -f /usr/local/musl/bin/x86_64-linux-musl-gcc ]; then
-    export CC_x86_64_unknown_linux_musl=/usr/local/musl/bin/x86_64-linux-musl-gcc
-    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=/usr/local/musl/bin/x86_64-linux-musl-gcc
-    export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/usr/local/musl/bin/x86_64-linux-musl-gcc
-    echo "  Using spc musl toolchain at /usr/local/musl"
+# Resolve the rust target triple for this host's architecture. uname -m
+# reports x86_64 / aarch64, which match both the rust arch token and the
+# musl-cross toolchain naming (mirrors docker/Dockerfile.gha).
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64)  RUST_TARGET="x86_64-unknown-linux-musl" ;;
+    aarch64) RUST_TARGET="aarch64-unknown-linux-musl" ;;
+    *) echo "  Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+echo "    Arch:       ${ARCH} (${RUST_TARGET})"
+
+# Point Rust linker at spc's musl toolchain for this arch.
+MUSL_GCC="/usr/local/musl/bin/${ARCH}-linux-musl-gcc"
+if [ -f "${MUSL_GCC}" ]; then
+    case "${ARCH}" in
+        x86_64)
+            export CC_x86_64_unknown_linux_musl="${MUSL_GCC}"
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC="${MUSL_GCC}"
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="${MUSL_GCC}"
+            ;;
+        aarch64)
+            export CC_aarch64_unknown_linux_musl="${MUSL_GCC}"
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_CC="${MUSL_GCC}"
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="${MUSL_GCC}"
+            ;;
+    esac
+    echo "  Using spc musl toolchain at /usr/local/musl (${RUST_TARGET})"
 fi
 
 # Configure GitHub token for spc if provided
@@ -44,14 +65,14 @@ spc build "${EXTENSIONS}" --build-embed --enable-zts
 echo ""
 echo "  Copying output"
 cd /src/ephpm
-cargo build --release --package ephpm --target x86_64-unknown-linux-musl
+cargo build --release --package ephpm --target "${RUST_TARGET}"
 
 OUTPUT_FILE="${OUTPUT}"
 OUTPUT_DIR=$(dirname "${OUTPUT_FILE}")
 mkdir -p "${OUTPUT_DIR}"
-cp target/x86_64-unknown-linux-musl/release/ephpm "${OUTPUT_FILE}"
+cp "target/${RUST_TARGET}/release/ephpm" "${OUTPUT_FILE}"
 
-EXT_COUNT=$(./target/x86_64-unknown-linux-musl/release/ephpm php -m 2>/dev/null | grep -v '^\[' | grep -v '^$' | wc -l | tr -d ' ')
+EXT_COUNT=$("./target/${RUST_TARGET}/release/ephpm" php -m 2>/dev/null | grep -v '^\[' | grep -v '^$' | wc -l | tr -d ' ')
 echo ""
 echo "  Done - ${EXT_COUNT} extensions compiled in"
 echo "    Binary: /output/$(basename "${OUTPUT_FILE}")"

--- a/docker/builder-entrypoint.sh
+++ b/docker/builder-entrypoint.sh
@@ -10,30 +10,18 @@ echo "    Extensions: ${EXTENSIONS}"
 echo ""
 cd /build
 
-# Remove stale musl toolchain so doctor downloads a fresh full one (with g++/libstdc++)
+# Remove any stale musl toolchain so doctor installs spc's own proper one
 rm -rf /usr/local/musl
 
-# Run doctor to install deps including a full musl toolchain
-spc doctor --auto-fix 2>&1 | tail -5
+# Run doctor to install deps including spc's musl toolchain (do NOT swallow errors)
+spc doctor --auto-fix
 
-# After doctor, point Rust linker at the spc musl toolchain
+# Point Rust linker at spc's musl toolchain
 if [ -f /usr/local/musl/bin/x86_64-linux-musl-gcc ]; then
     export CC_x86_64_unknown_linux_musl=/usr/local/musl/bin/x86_64-linux-musl-gcc
     export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_CC=/usr/local/musl/bin/x86_64-linux-musl-gcc
     export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/usr/local/musl/bin/x86_64-linux-musl-gcc
     echo "  Using spc musl toolchain at /usr/local/musl"
-fi
-
-# If toolchain still has no libstdc++, copy system one (ABI-compatible per musl wiki)
-MUSL_LIBSTDCXX=$(find /usr/local/musl -name 'libstdc++.a' 2>/dev/null | head -1)
-if [ -z "${MUSL_LIBSTDCXX}" ]; then
-    echo "  WARNING: musl toolchain has no libstdc++.a - trying system fallback"
-    SYS_LIBSTDCXX=$(find /usr/lib/gcc -name 'libstdc++.a' 2>/dev/null | head -1)
-    MUSL_LIB_GCC_VER=$(ls /usr/local/musl/lib/gcc/x86_64-linux-musl/ 2>/dev/null | head -1)
-    if [ -n "${SYS_LIBSTDCXX}" ] && [ -n "${MUSL_LIB_GCC_VER}" ]; then
-        cp "${SYS_LIBSTDCXX}" "/usr/local/musl/lib/gcc/x86_64-linux-musl/${MUSL_LIB_GCC_VER}/libstdc++.a"
-        echo "  Copied ${SYS_LIBSTDCXX} -> musl toolchain"
-    fi
 fi
 
 # Configure GitHub token for spc if provided

--- a/docker/builder-entrypoint.sh
+++ b/docker/builder-entrypoint.sh
@@ -33,8 +33,8 @@ SDK_PATH="${SPC_BUILD_PATH:-/build/buildroot}"
 export PHP_SDK_PATH="${SDK_PATH}"
 
 spc download \
-    --with-php=${PHP_VERSION} \
-    --for-extensions=${EXTENSIONS} \
+    --with-php="${PHP_VERSION}" \
+    --for-extensions="${EXTENSIONS}" \
     --prefer-pre-built \
     --no-alt \
     php-src,micro,frankenphp
@@ -54,6 +54,6 @@ cp target/x86_64-unknown-linux-musl/release/ephpm "${OUTPUT_FILE}"
 EXT_COUNT=$(./target/x86_64-unknown-linux-musl/release/ephpm php -m 2>/dev/null | grep -v '^\[' | grep -v '^$' | wc -l | tr -d ' ')
 echo ""
 echo "  Done - ${EXT_COUNT} extensions compiled in"
-echo "    Binary: /output/$(basename ${OUTPUT_FILE})"
+echo "    Binary: /output/$(basename "${OUTPUT_FILE}")"
 echo "  Build complete"
-echo "    Verify: ./$(basename ${OUTPUT_FILE}) ext list"
+echo "    Verify: ./$(basename "${OUTPUT_FILE}") ext list"


### PR DESCRIPTION
Adds `ephpm ext` subcommands (list/info/search/build) plus a Docker builder that compiles custom binaries with extra extensions.

## Usage
```
ephpm ext list [--json]        # list compiled-in extensions
ephpm ext info <name>          # show details for an extension
ephpm ext search <query>       # search the static-php-cli registry
ephpm ext build --add imagick  # build a custom binary with extra extensions
```

## Builder
The builder runs on Ubuntu 24.04 rather than Alpine. Alpine was ruled out because its fully-static musl blocks dlopen, which bindgen/libclang need at build time for FFI binding generation. Ubuntu's glibc lets bindgen work during the build, while the final binary still cross-compiles to a static musl target.

For C++ extensions, the musl.cc cross-toolchain provides a musl-native libstdc++ (the system one is glibc-linked and unusable in a static musl binary). C++ deps are linked inside a --start-group/--end-group block in the binary crate's build.rs so circular dependencies resolve across multiple passes. The lib list is a superset guarded by existence checks, so each `ext build --add X` only links what spc actually produced for that build.

## C++ static-linking hardening
Supporting heavier C++ extensions surfaced two single-pass-ld issues, both fixed in the binary crate's linker group:
- **libstdc++ via --whole-archive** — abseil/grpc reference a very large volume of `operator new`/`delete` and `std::*` symbols that a tail-position archive can't satisfy in one pass, so every libstdc++ object is force-included.
- **libc/libm/libgcc pulled into the group** — C++ libs reference `wmemcpy`, `frexp`, `sigfillset`, `__udivmodti4`, etc. mid-group, which the post-group `-lc`/`-lm` can't resolve under single-pass ld.

These make the linking robust for arbitrary C++ extensions, not just the ones tested below.

## Tested end-to-end
- redis 6.3.0 — builds and loads
- intl 8.5.6 — Collator::create('en')->compare('a','b') returns -1
- imagick 3.8.1 / ImageMagick 7.1.2-24 Q16-HDRI — builds and loads (32 extensions), full codec chain (aom, jxl, brotli, sharpyuv, heif, de265, tiff, webp)
- grpc 1.81.0 — builds and loads; links the full gRPC stack (grpc/grpc++, protobuf, ~90 abseil sublibs, upb, re2, c-ares)

Note: branch is rebased onto latest upstream main and merges cleanly.