### PR TITLE
fix(release): retry artifact download up to 3x via gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,13 @@ jobs:
 
       - name: Build and push image
         uses: docker/build-push-action@v6
+        env:
+          # Don't upload the ".dockerbuild" build-record artifact. We never
+          # consume it, and it inflates the Create Release download to 15
+          # artifacts, adding parallel connections that the self-hosted
+          # runner's egress to Azure blob storage can't all sustain.
+          DOCKER_BUILD_RECORD_UPLOAD: false
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           file: docker/Dockerfile
@@ -349,14 +356,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download all artifacts (with retry)
+      - name: Download release archives (with retry)
         env:
           GH_TOKEN: ${{ github.token }}
+        # Only the binary tarballs are needed (pattern excludes any other
+        # artifact types). gh downloads sequentially, avoiding the parallel
+        # blob-storage connections that made actions/download-artifact@v4
+        # drop downloads on this self-hosted runner. Retry 3x for safety.
         run: |
           for attempt in 1 2 3; do
             echo "Download attempt $attempt/3..."
             rm -rf artifacts
-            if gh run download ${{ github.run_id }} --dir artifacts; then
+            if gh run download ${{ github.run_id }} --pattern 'ephpm-v*' --dir artifacts; then
               echo "Download succeeded on attempt $attempt."
               break
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,9 +349,24 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
+      - name: Download all artifacts (with retry)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in 1 2 3; do
+            echo "Download attempt $attempt/3..."
+            rm -rf artifacts
+            if gh run download ${{ github.run_id }} --dir artifacts; then
+              echo "Download succeeded on attempt $attempt."
+              break
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "::error::All 3 download attempts failed."
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
 
       - name: Collect archives and write SHA256SUMS
         id: collect


### PR DESCRIPTION
## Problem

`Create Release` has failed 3 times on rc.2 with the same transient error:

```
Error: Unable to download and extract artifact: Artifact download failed after 5 retries.
```

It consistently downloads 5–6 of the 12 artifacts then dies mid-batch. The linux-x86_64 artifacts (largest, ~55 MB each) are always in the remaining set. This is a GitHub Actions infrastructure flake on the self-hosted runner's outbound connection to blob storage.

## Fix

Replace `actions/download-artifact@v4` with a `gh run download` shell loop that retries up to 3 times with 30s backoff and a clean directory each attempt. `gh` is already on the runner; `GH_TOKEN` gives it the required permissions.

## After merging

Re-tag `v0.1.0-rc.3` (or re-run failed Create Release job once this lands on main and the next rc tag is cut) to get a clean release page.