### PR TITLE
chore(ci): prerelease flag, mac concurrency cap, tmp_ gitignore

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,6 +88,14 @@ jobs:
     runs-on: [self-hosted, macos, arm64]
     strategy:
       fail-fast: false
+      # Cap at 2 to leave headroom on the Apple Silicon host. The same Mac
+      # also dispatches linux-aarch64 builds (via the embedded Linux VM),
+      # and ephemerd's per-host max_concurrent=4 was getting saturated when
+      # all 3 macos + 3 linux-aarch64 jobs hit at once -- the runner agent
+      # was reaped mid-build (observed: PHP 8.4 macos-aarch64 dying with no
+      # log activity after `actions/checkout`). 2 macos + ~2 linux-aarch64
+      # fits comfortably under the cap.
+      max-parallel: 2
       matrix:
         php: ["8.3", "8.4", "8.5"]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,3 +429,7 @@ jobs:
         with:
           files: release/*
           generate_release_notes: true
+          # SemVer pre-release tags carry a "-" (e.g. v0.1.0-rc.1, v0.2.0-beta.2).
+          # Mark them prerelease so GitHub does not promote them to "Latest"
+          # and demote the actual stable release in the Releases UI.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ target/
 # OS
 .DS_Store
 Thumbs.db
+
+# Session-local debugging scratch (logs, run-id files, crash dumps).
+# Repo-root only -- crates with their own tmp_/ stay tracked.
+/tmp_*
+
+# Downloaded release artifact directories (gh run download / extracted tarballs).
+/ephpm-v*-*/


### PR DESCRIPTION
Three small hygiene items from the post-v0.1.0 backlog. Independent fixes; happy to split if you'd prefer one PR each.

## 1. `release.yml` — mark `-rc`/`-beta` tags as prereleases
softprops/action-gh-release does not auto-detect SemVer pre-releases. `v0.1.0-rc.1` through `rc.4` all published as full releases this week and stole the "Latest" badge from v0.1.0 itself. Add `prerelease: ${{ contains(github.ref_name, "-") }}` so any tag containing `-` (SemVer's pre-release separator) is correctly flagged.

## 2. `nightly.yml` — cap `build-macos` `max-parallel: 2`
The Apple Silicon host runs both native macos jobs AND linux-aarch64 jobs (via the embedded Linux VM). ephemerd's per-host `max_concurrent=4` was getting saturated when all 3 macos + 3 linux-aarch64 jobs fired together — the runner agent for PHP 8.4 macos-aarch64 was reaped mid-build (the only failure in the v0.1.0 release-test nightly; cleared on re-run). 2 macos + ~2 linux-aarch64 fits under the cap.

## 3. `.gitignore` — `/tmp_*` and `/ephpm-v*-*/`
After a long debugging session, `git status` was showing 60+ untracked entries (per-job log files, run-id `.txt` files, `tmp_crash/`, and the extracted release-artifact directories). Both patterns anchored at repo root so crates with their own `tmp_/` stay tracked.

## Test plan
- [ ] CI passes
- Cut a `v0.1.1-test` tag manually after merge to confirm the prerelease flag works → then delete the tag.