### PR TITLE
fix(release): bake tag into ephpm --version via build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Compute release version
+        # Strip the leading "v" from the git ref name so EPHPM_RELEASE_VERSION
+        # is a bare SemVer string ("v0.1.1" -> "0.1.1") matching clap's
+        # default `<bin> <version>` formatting. crates/ephpm/build.rs forwards
+        # this into the binary so `ephpm --version` reports the actual tag
+        # instead of the frozen workspace version in Cargo.toml.
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          echo "EPHPM_RELEASE_VERSION=${REF_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Build ephpm
         run: cargo xtask release ${{ matrix.php.minor }}
 
@@ -102,6 +114,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
+      - name: Compute release version
+        # See build-linux for rationale; strips leading "v" from the git ref.
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          echo "EPHPM_RELEASE_VERSION=${REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Pin libclang for bindgen
         # Pin libclang to brew llvm@17 to dodge the bindgen
@@ -232,6 +252,15 @@ jobs:
             Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
           }
 
+      - name: Compute release version
+        # See build-linux for rationale; strips leading "v" from the git ref.
+        shell: powershell
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          $version = $env:REF_NAME -replace '^v',''
+          "EPHPM_RELEASE_VERSION=$version" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
       - name: Build ephpm.exe
         shell: powershell
         run: cargo xtask release ${{ matrix.php_minor }} --target windows --no-sqld
@@ -300,6 +329,11 @@ jobs:
           IS_DEFAULT: ${{ matrix.default }}
         run: |
           set -eu
+          # Strip leading "v" so EPHPM_RELEASE_VERSION matches clap formatting
+          # ("v0.1.1" -> "0.1.1"). Forwarded to the Docker builder as a
+          # build-arg so the in-container `cargo xtask release` reports the
+          # tag via `ephpm --version`. See crates/ephpm/build.rs.
+          echo "release_version=${VERSION#v}" >> "$GITHUB_OUTPUT"
           # All tags substitute "+" -> "-" because OCI tag regex rejects "+".
           # The real SemVer string lives in the OCI label (see --label below).
           # Pre-release tags (e.g. v0.1.0-rc.1, detected by the "-") must not
@@ -338,6 +372,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             PHP_SDK_VERSION=${{ matrix.php_full }}
+            EPHPM_RELEASE_VERSION=${{ steps.tags.outputs.release_version }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           labels: |

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -8,6 +8,22 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(php_linked)");
     println!("cargo::rerun-if-env-changed=PHP_SDK_PATH");
 
+    // Forward the release tag (set by .github/workflows/release.yml before
+    // `cargo xtask release`) into the binary so `ephpm --version` reports
+    // the actual published tag instead of the frozen workspace
+    // `version = "..."` in Cargo.toml. Falls back to CARGO_PKG_VERSION for
+    // dev builds where the env var is unset, so `cargo build` still works.
+    //
+    // The workflow strips the leading "v" from the git ref name so this
+    // value is the SemVer string ("0.1.1"), matching clap's default
+    // `<bin> <version>` formatting.
+    println!("cargo::rerun-if-env-changed=EPHPM_RELEASE_VERSION");
+    let version = std::env::var("EPHPM_RELEASE_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").unwrap_or_default());
+    println!("cargo::rustc-env=EPHPM_VERSION={version}");
+
     // When PHP is linked (release builds), override PHP's zend_signal_*
     // functions with our no-op wrappers in ephpm_wrapper.c.
     //

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -15,7 +15,7 @@ mod service;
 
 /// ePHPm — All-in-one PHP application server
 #[derive(Parser, Debug)]
-#[command(name = "ephpm", version, about)]
+#[command(name = "ephpm", version = env!("EPHPM_VERSION"), about)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -309,7 +309,7 @@ fn run_dev(
 /// so it's stable across log-format changes and visible regardless of
 /// `RUST_LOG`.
 fn print_dev_banner(config: &ephpm_config::Config) {
-    let version = env!("CARGO_PKG_VERSION");
+    let version = env!("EPHPM_VERSION");
     let url = format!("http://{}", config.server.listen);
     let php = ephpm_php::PhpRuntime::php_version();
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,6 +91,13 @@ FROM base AS builder
 
 ARG PHP_SDK_VERSION
 
+# Release-time override forwarded by .github/workflows/release.yml so the
+# in-container `cargo xtask release` bakes the actual tag into the binary
+# (`ephpm --version`). Empty for local `docker build` and `cargo xtask e2e`,
+# in which case crates/ephpm/build.rs falls back to CARGO_PKG_VERSION.
+ARG EPHPM_RELEASE_VERSION=""
+ENV EPHPM_RELEASE_VERSION=${EPHPM_RELEASE_VERSION}
+
 WORKDIR /src
 
 # Pull the SDK in from the cached php-sdk stage. xtask::release_native


### PR DESCRIPTION
## Problem

We released `v0.1.1` but `ephpm --version` still prints `ephpm 0.1.0` because the workspace `version = "0.1.0"` in `Cargo.toml` was never bumped. There is no automation tying the published git tag to the binary's self-reported version, so every release ships with a stale `--version`. This caused real confusion in a recent debugging session when we could not tell from `--version` whether a container had the pre- or post-handshake-fix build.

## Approach

I considered three options:

- **A. Bump `Cargo.toml` at tag time.** Simplest, but still manual (or requires a release script). Easy to forget. PR churn per patch.
- **B. Inject the git tag at build time via `build.rs` + `env!`.** The release workflow sets `EPHPM_RELEASE_VERSION` before `cargo xtask release`; build.rs forwards it via `cargo::rustc-env=`; clap reads it via `env!`. Falls back to `CARGO_PKG_VERSION` for dev builds.
- **C. Use `vergen` for rich version info.** Pulls in another dep + macro layer for a problem we can solve in 15 lines.

**Picked B.** The crate already has a `build.rs` and the project uses the `cargo::rustc-env=` pattern (see `ephpm-sqld/build.rs` for `SQLD_BINARY_PATH`). Zero `Cargo.toml` churn per release, no extra deps, and the tag literally drives the binary -- the next time we cut a tag, the binary picks it up with no human in the loop.

## Implementation

- `crates/ephpm/build.rs` reads `EPHPM_RELEASE_VERSION` (with `rerun-if-env-changed`), falls back to `CARGO_PKG_VERSION` when unset/empty, and emits `cargo::rustc-env=EPHPM_VERSION=<value>`.
- `crates/ephpm/src/main.rs` switches clap's `#[command(version)]` to `version = env!("EPHPM_VERSION")` and the dev banner to `env!("EPHPM_VERSION")`.
- `.github/workflows/release.yml` adds a `Compute release version` step to each of `build-linux`, `build-macos`, `build-windows` that strips the leading `v` from `github.ref_name` and writes `EPHPM_RELEASE_VERSION=<x.y.z>` to `$GITHUB_ENV`. The `docker-image` job exposes the same stripped version as a step output and passes it through `docker/build-push-action` as a build-arg.
- `docker/Dockerfile` builder stage takes `ARG EPHPM_RELEASE_VERSION=""` and re-exports it as `ENV` so the in-container `cargo xtask release` picks it up. Empty default means local `docker build` and `cargo xtask e2e` fall back to `CARGO_PKG_VERSION`, same as plain `cargo build`.

## Before / after

```
# Before (any build, including current main):
$ ephpm --version
ephpm 0.1.0

# After, dev build (no env var set):
$ cargo build -p ephpm && ./target/debug/ephpm --version
ephpm 0.1.0   # falls back to CARGO_PKG_VERSION

# After, simulated tag build:
$ EPHPM_RELEASE_VERSION=0.1.1 cargo build -p ephpm && ./target/debug/ephpm --version
ephpm 0.1.1
```

## How the next release picks this up

When we push tag `v0.1.2`:
1. `release.yml` jobs see `github.ref_name = v0.1.2`.
2. The `Compute release version` step strips the `v` and exports `EPHPM_RELEASE_VERSION=0.1.2`.
3. `cargo xtask release` runs; `crates/ephpm/build.rs` forwards the env var into `rustc-env`.
4. `ephpm --version` reports `ephpm 0.1.2` on every published artifact (Linux/macOS/Windows tarballs and Docker images).

No `Cargo.toml` bump needed.

## Test plan

- [x] `cargo build -p ephpm` with no env var -> `ephpm 0.1.0` (fallback to `CARGO_PKG_VERSION`)
- [x] `EPHPM_RELEASE_VERSION=0.1.1 cargo build -p ephpm` -> `ephpm 0.1.1`
- [x] `cargo clippy -p ephpm --all-targets -- -D warnings` clean
- [x] `cargo test -p ephpm --bins cli_tests` passes (5/5)
- [ ] Verified end-to-end by the next real tag push (workflow change cannot run on a PR -- only `tags: ['v*']`)