### PR TITLE
fix(db-proxy): return from handle_backend_auth after SCRAM completes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "tracing",
 ]
 
@@ -1502,7 +1503,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2046,6 +2047,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,7 +2358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2493,6 +2503,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,6 +2662,25 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2863,7 +2910,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3661,6 +3708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,6 +4030,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.0",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -4369,6 +4448,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4384,6 +4472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -4516,6 +4613,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/ephpm-db/Cargo.toml
+++ b/crates/ephpm-db/Cargo.toml
@@ -25,6 +25,7 @@ base64ct = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 mysql_async = { version = "0.34", default-features = false, features = ["minimal-rust"] }
+tokio-postgres = { version = "0.7", default-features = false, features = ["runtime"] }
 
 [lints]
 workspace = true

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -298,12 +298,24 @@ impl PgProxy {
 /// Connect to the `PostgreSQL` backend and complete the startup/auth handshake.
 ///
 /// Returns the authenticated stream and server metadata.
+///
+/// # Note on handshake construction
+///
+/// The PG wire protocol has no capability bitfield, so the analogous MySQL
+/// "inherit-then-strip" bug fixed in PR #91 cannot occur here — the
+/// `StartupMessage` is built additively from an explicit set of parameters
+/// (`user`, `database`) plus the fixed `3.0` protocol version, none of which
+/// are derived from anything the server advertised. However, the *auth*
+/// flow has its own framing pitfall (consuming the right number of `R`
+/// messages on the right code path — see `handle_backend_auth`).
+/// Integration coverage in `tests/pg_proxy_integration.rs` pins this
+/// against real PG 13 (`md5`) and PG 17 (`scram-sha-256`).
 async fn pg_connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, PgServerMeta), DbError> {
     let mut stream = TcpStream::connect(url.addr()).await?;
 
     // Send StartupMessage: length (4) + protocol version (4) + key=value pairs + \0.
     let mut startup = Vec::with_capacity(128);
-    // Protocol version 3.0.
+    // Protocol version 3.0 — the stable PG protocol version since 7.4.
     startup.extend_from_slice(&0x0003_0000_i32.to_be_bytes());
     // user parameter.
     startup.extend_from_slice(b"user\0");
@@ -399,12 +411,18 @@ async fn handle_backend_auth(
                 send_password_message(stream, &response).await?;
             }
             AUTH_SASL => {
-                // SCRAM-SHA-256 negotiation.
+                // SCRAM-SHA-256 negotiation. `scram_sha256_exchange` consumes
+                // the full SASLContinue → SASLFinal → AuthenticationOk
+                // sequence itself, so we must return immediately on success
+                // rather than looping back to read another auth message —
+                // the next byte on the wire will be the post-auth
+                // `ParameterStatus` (`'S'`), not another `'R'`.
                 let mechanisms = parse_sasl_mechanisms(&payload[4..]);
                 if !mechanisms.iter().any(|m| m == "SCRAM-SHA-256") {
                     return Err(DbError::Auth("server requires unsupported SASL mechanism".into()));
                 }
                 scram_sha256_exchange(stream, username, password).await?;
+                return Ok(());
             }
             AUTH_SASL_CONTINUE | AUTH_SASL_FINAL => {
                 // These are handled within scram_sha256_exchange.
@@ -1193,6 +1211,87 @@ mod tests {
 
         let target = pg_select_pool(&primary, &replicas, &rr, &state, PgQueryKind::Read, &rw_split);
         assert!(std::ptr::eq(target, &raw const primary));
+    }
+
+    // ── handle_backend_auth SCRAM framing ────────────────────────────
+
+    /// Regression test for the SCRAM-SHA-256 "extra read after success" bug.
+    ///
+    /// After `scram_sha256_exchange` consumes the `AuthenticationOk`
+    /// (auth_type=0) itself, `handle_backend_auth` must return immediately —
+    /// not loop back and read another message. Otherwise it eats the
+    /// post-auth `ParameterStatus` (tag `'S'`) and dies with
+    /// "expected auth request, got 'S'".
+    ///
+    /// This test wires `handle_backend_auth` against a fake server that
+    /// drives the full SCRAM flow + a trailing `ParameterStatus`. A
+    /// successful return means the `ParameterStatus` was NOT consumed by
+    /// the auth handler — we can read it on the wire ourselves after.
+    #[tokio::test]
+    async fn handle_backend_auth_scram_stops_after_auth_ok() {
+        let (mut client_side, mut server_side) = make_tcp_pair().await;
+
+        // Fake server task: drive the SCRAM dance, then send a final
+        // ParameterStatus and remain open.
+        let server = tokio::spawn(async move {
+            // 1. AuthenticationSASL: i32 type=10 + "SCRAM-SHA-256\0\0"
+            let mut p = Vec::new();
+            p.extend_from_slice(&AUTH_SASL.to_be_bytes());
+            p.extend_from_slice(b"SCRAM-SHA-256\0\0");
+            write_pg_message(&mut server_side, MSG_AUTH, &p).await.unwrap();
+
+            // 2. Read client SASLInitialResponse: mechanism\0 + msg_len + msg
+            let (_tag, init) = read_pg_message(&mut server_side).await.unwrap();
+            // Find msg after "SCRAM-SHA-256\0" and 4-byte length.
+            let after_mech = &init[b"SCRAM-SHA-256\0".len() + 4..];
+            let client_first = std::str::from_utf8(after_mech).unwrap();
+            // Extract the client nonce: "n,,n=,r=<nonce>"
+            let client_nonce = client_first.split("r=").nth(1).unwrap();
+
+            // 3. AuthenticationSASLContinue: server-first-message.
+            // r=<client_nonce+server_extra>, s=<salt b64>, i=4096
+            let server_nonce = format!("{client_nonce}SERVEREXTRA");
+            let server_first = format!("r={server_nonce},s=c2FsdA==,i=4096");
+            let mut p = Vec::new();
+            p.extend_from_slice(&AUTH_SASL_CONTINUE.to_be_bytes());
+            p.extend_from_slice(server_first.as_bytes());
+            write_pg_message(&mut server_side, MSG_AUTH, &p).await.unwrap();
+
+            // 4. Read client SASLResponse (final). Discard contents — we don't
+            // verify the proof in this test; we just confirm framing.
+            let (_tag, _client_final) = read_pg_message(&mut server_side).await.unwrap();
+
+            // 5. AuthenticationSASLFinal: any v=<sig>.
+            let server_final = "v=AAAA";
+            let mut p = Vec::new();
+            p.extend_from_slice(&AUTH_SASL_FINAL.to_be_bytes());
+            p.extend_from_slice(server_final.as_bytes());
+            write_pg_message(&mut server_side, MSG_AUTH, &p).await.unwrap();
+
+            // 6. AuthenticationOk.
+            write_pg_message(&mut server_side, MSG_AUTH, &AUTH_OK.to_be_bytes()).await.unwrap();
+
+            // 7. Trailing ParameterStatus that must NOT be consumed by auth.
+            send_parameter_status(&mut server_side, "client_encoding", "UTF8").await.unwrap();
+
+            // Keep the socket open until the client closes it.
+            let mut buf = [0u8; 1];
+            let _ = server_side.read(&mut buf).await;
+        });
+
+        // Drive auth on the client side.
+        handle_backend_auth(&mut client_side, "u", "p").await.expect("SCRAM auth must succeed");
+
+        // The next byte on the wire must be 'S' (ParameterStatus). If
+        // handle_backend_auth incorrectly looped, it would have eaten this.
+        let (tag, payload) = read_pg_message(&mut client_side).await.unwrap();
+        assert_eq!(tag, MSG_PARAMETER_STATUS, "ParameterStatus must survive past auth");
+        let (k, v) = parse_parameter_status(&payload).unwrap();
+        assert_eq!(k, "client_encoding");
+        assert_eq!(v, "UTF8");
+
+        drop(client_side);
+        let _ = server.await;
     }
 
     // ── PG wire protocol helpers ────────────────────────────────────

--- a/crates/ephpm-db/tests/pg_proxy_integration.rs
+++ b/crates/ephpm-db/tests/pg_proxy_integration.rs
@@ -1,0 +1,313 @@
+//! Integration tests for the `PostgreSQL` proxy.
+//!
+//! These tests require a running `PostgreSQL` server. Set `PG_TEST_URL` to a
+//! connection string (e.g. `postgres://postgres:test@127.0.0.1:5433/test`) to
+//! enable them. All tests are `#[ignore]` so they only run in nightly CI via
+//! `cargo test -- --ignored`.
+//!
+//! These tests cover the analogous handshake-handling concerns that affected
+//! the MySQL proxy in PR #91. The PG wire protocol has no capability
+//! bitfield, so the exact MySQL "inherit-then-strip" bug class cannot
+//! recur. However, the auth flow has its own framing pitfalls — these tests
+//! were how we caught the SCRAM-SHA-256 off-by-one read in
+//! `handle_backend_auth` that this PR fixes. They pin that behavior against
+//! real servers across the two mainstream auth paths:
+//!
+//! - `postgres:17` — defaults to `scram-sha-256` (the modern path).
+//! - `postgres:13` — configured with `md5` (legacy path still in the wild).
+//!
+//! Spin them up with:
+//!
+//! ```text
+//! docker run -d --rm --name pgtest17 -e POSTGRES_PASSWORD=test \
+//!     -e POSTGRES_DB=test -p 5433:5432 postgres:17
+//! docker run -d --rm --name pgtest13 -e POSTGRES_PASSWORD=test \
+//!     -e POSTGRES_DB=test -e POSTGRES_HOST_AUTH_METHOD=md5 \
+//!     -p 5434:5432 postgres:13
+//! PG_TEST_URL=postgres://postgres:test@127.0.0.1:5433/test \
+//!     cargo test -p ephpm-db --test pg_proxy_integration -- --ignored
+//! ```
+
+use std::time::Duration;
+
+use ephpm_db::ResetStrategy;
+use ephpm_db::pool::PoolConfig;
+use ephpm_db::postgres::{PgProxy, PgRwSplitParams};
+use tokio_postgres::NoTls;
+
+/// Read `PG_TEST_URL` or return `None` (caller should skip).
+fn pg_url() -> Option<String> {
+    std::env::var("PG_TEST_URL").ok()
+}
+
+/// Build a default pool config suitable for tests.
+fn test_pool_config() -> PoolConfig {
+    PoolConfig {
+        min_connections: 1,
+        max_connections: 5,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        health_check_interval: Duration::from_secs(30),
+    }
+}
+
+/// Boot a [`PgProxy`] on a random OS-assigned port and return the listen
+/// address (e.g. `127.0.0.1:XXXXX`).
+async fn start_proxy(
+    backend_url: &str,
+    pool_config: PoolConfig,
+    reset_strategy: ResetStrategy,
+) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let listen_addr = addr.to_string();
+
+    let proxy = PgProxy::new(
+        backend_url,
+        &listen_addr,
+        pool_config,
+        reset_strategy,
+        vec![],
+        PgRwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+    )
+    .await
+    .expect("failed to create PgProxy — backend handshake failed");
+
+    drop(listener);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    tokio::spawn(async move {
+        if let Err(e) = proxy.run().await {
+            eprintln!("proxy stopped: {e}");
+        }
+    });
+
+    for _ in 0..50 {
+        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
+            return listen_addr;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("proxy did not become ready at {listen_addr}");
+}
+
+/// Build a `tokio_postgres` config that routes through the proxy.
+///
+/// User/password are intentionally bogus because the proxy issues
+/// `AuthenticationOk` without validating client creds (loopback only).
+fn proxy_config(proxy_addr: &str) -> tokio_postgres::Config {
+    let (host, port) = proxy_addr.split_once(':').unwrap();
+    let mut cfg = tokio_postgres::Config::new();
+    cfg.host(host).port(port.parse().unwrap()).user("ignored").password("ignored").dbname("test");
+    cfg
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// Smoke test: the backend handshake completes against a real PG server.
+/// If `pg_connect_and_handshake` ever desynchronizes the auth message
+/// stream — e.g. consuming an extra message after SCRAM as the previous
+/// implementation did — the proxy will fail to spawn and this test will
+/// panic before `start_proxy` returns.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn backend_handshake_completes() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let addr = start_proxy(&url, test_pool_config(), ResetStrategy::Always).await;
+    // If we got here, the backend handshake succeeded and the listener is up.
+    let _ = tokio::net::TcpStream::connect(&addr).await.unwrap();
+}
+
+/// Round-trip a simple query through the proxy.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn basic_query_roundtrip() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let addr = start_proxy(&url, test_pool_config(), ResetStrategy::Always).await;
+    let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    client
+        .batch_execute(
+            "CREATE TABLE IF NOT EXISTS _ephpm_pg_roundtrip (id INT PRIMARY KEY, val TEXT)",
+        )
+        .await
+        .unwrap();
+    client
+        .batch_execute("INSERT INTO _ephpm_pg_roundtrip (id, val) VALUES (1, 'hello')")
+        .await
+        .unwrap();
+
+    let rows =
+        client.query("SELECT id, val FROM _ephpm_pg_roundtrip WHERE id = 1", &[]).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, i32>(0), 1);
+    assert_eq!(rows[0].get::<_, &str>(1), "hello");
+
+    client.batch_execute("DROP TABLE IF EXISTS _ephpm_pg_roundtrip").await.unwrap();
+}
+
+/// Open and close multiple connections; verify the pool reuses backends.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn connection_pool_reuse() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let cfg = PoolConfig {
+        min_connections: 2,
+        max_connections: 5,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        health_check_interval: Duration::from_secs(30),
+    };
+    let addr = start_proxy(&url, cfg, ResetStrategy::Always).await;
+
+    for i in 0..10 {
+        let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+        let handle = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        let rows = client.query("SELECT 1::int", &[]).await.unwrap();
+        assert_eq!(rows[0].get::<_, i32>(0), 1, "iteration {i}");
+        drop(client);
+        let _ = handle.await;
+    }
+}
+
+/// Verify session state isolation across pooled connections. After
+/// `DISCARD ALL` (issued by the proxy on Always reset), session-local
+/// settings must not leak to the next client.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn session_isolation() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let addr = start_proxy(&url, test_pool_config(), ResetStrategy::Always).await;
+
+    // Client A: set a session-local GUC and a temp table.
+    {
+        let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+        let h = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client.batch_execute("SET LOCAL search_path TO 'pg_temp'").await.unwrap();
+        client.batch_execute("CREATE TEMP TABLE _ephpm_pg_session_leak (x INT)").await.unwrap();
+        drop(client);
+        let _ = h.await;
+    }
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Client B: temp table from the previous session must be gone.
+    {
+        let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+        let h = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        // to_regclass returns NULL when the relation doesn't exist.
+        let rows = client
+            .query("SELECT to_regclass('pg_temp._ephpm_pg_session_leak')::text", &[])
+            .await
+            .unwrap();
+        let val: Option<String> = rows[0].get(0);
+        assert!(val.is_none(), "temp table should not leak across sessions after DISCARD ALL");
+        drop(client);
+        let _ = h.await;
+    }
+}
+
+/// Verify BEGIN/INSERT/ROLLBACK semantics across the proxy.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn transaction_integrity() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let addr = start_proxy(&url, test_pool_config(), ResetStrategy::Always).await;
+    let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    client
+        .batch_execute("CREATE TABLE IF NOT EXISTS _ephpm_pg_txn (id INT PRIMARY KEY, val TEXT)")
+        .await
+        .unwrap();
+    client.batch_execute("DELETE FROM _ephpm_pg_txn").await.unwrap();
+
+    client.batch_execute("BEGIN").await.unwrap();
+    client.batch_execute("INSERT INTO _ephpm_pg_txn (id, val) VALUES (1, 'inside')").await.unwrap();
+
+    let rows = client.query("SELECT id, val FROM _ephpm_pg_txn WHERE id = 1", &[]).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, &str>(1), "inside");
+
+    client.batch_execute("ROLLBACK").await.unwrap();
+
+    let rows = client.query("SELECT id FROM _ephpm_pg_txn WHERE id = 1", &[]).await.unwrap();
+    assert!(rows.is_empty(), "row must vanish after ROLLBACK");
+
+    client.batch_execute("DROP TABLE IF EXISTS _ephpm_pg_txn").await.unwrap();
+}
+
+/// Prepared statement lifecycle through the proxy (extended query protocol:
+/// Parse/Bind/Execute/Sync). `tokio_postgres::query` always uses the extended
+/// protocol, so this exercises that path implicitly.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn prepared_statement_lifecycle() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let addr = start_proxy(&url, test_pool_config(), ResetStrategy::Always).await;
+    let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    client
+        .batch_execute("CREATE TABLE IF NOT EXISTS _ephpm_pg_ps (id INT PRIMARY KEY, name TEXT)")
+        .await
+        .unwrap();
+    client.batch_execute("DELETE FROM _ephpm_pg_ps").await.unwrap();
+    client
+        .batch_execute("INSERT INTO _ephpm_pg_ps (id, name) VALUES (1, 'alice'), (2, 'bob')")
+        .await
+        .unwrap();
+
+    let stmt = client.prepare("SELECT id, name FROM _ephpm_pg_ps WHERE id = $1").await.unwrap();
+
+    let rows = client.query(&stmt, &[&1_i32]).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, &str>(1), "alice");
+
+    let rows = client.query(&stmt, &[&2_i32]).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get::<_, &str>(1), "bob");
+
+    client.batch_execute("DROP TABLE IF EXISTS _ephpm_pg_ps").await.unwrap();
+}


### PR DESCRIPTION
## Summary

Audit follow-up to #91 (MySQL handshake capability mask fix) against the Postgres proxy. The MySQL "inherit-then-strip" bug class does not apply to PG (no capability bitfield) but the audit surfaced a different real bug on the SCRAM-SHA-256 auth path that prevented the proxy from connecting to **any** modern Postgres server (>=10, where `scram-sha-256` is default).

### Bug

`scram_sha256_exchange` already consumes the full `SASLContinue` -> `SASLFinal` -> `AuthenticationOk` sequence itself. But the outer `handle_backend_auth` loop then went back and tried to read another auth message. The next byte on the wire is the post-auth `ParameterStatus` (tag `S`), so the proxy died with:

```
Protocol("expected auth request, got 'S'")
```

…and no backend connection ever opened against a default-config PG 13+.

### Fix

One-liner: explicitly `return Ok(())` from the `AUTH_SASL` arm so the post-auth message stream is left intact for the existing `ParameterStatus` / `BackendKeyData` / `ReadyForQuery` loop in `pg_connect_and_handshake`. The MD5 and trust paths were correct already because they end with the server sending `AuthenticationOk` (auth_type=0), which `handle_backend_auth` then matches and returns on.

### Tests

- **Mock-server unit test** (`handle_backend_auth_scram_stops_after_auth_ok`): drives a fake SCRAM server through a `TcpStream` pair and asserts the post-auth `ParameterStatus` survives past the auth handler. This would have caught the regression without any external services.
- **Integration test suite** (`tests/pg_proxy_integration.rs`, gated on `PG_TEST_URL`, mirrors `proxy_integration.rs`): backend handshake, basic query round-trip, pool reuse, session isolation via `DISCARD ALL`, transaction integrity, prepared statement lifecycle.

### Compatibility matrix verified

| Server | Auth | Result |
|---|---|---|
| `postgres:17` | `scram-sha-256` (default) | 6/6 pass |
| `postgres:13` | `md5` (`POSTGRES_HOST_AUTH_METHOD=md5`) | 6/6 pass |

### Other notes

- Adds `tokio-postgres = "0.7"` as a `[dev-dependencies]` only (matches `mysql_async` pattern; not in release builds).
- Adds a doc comment on `pg_connect_and_handshake` explaining why the MySQL PR #91 bug class does not apply to PG (additive `StartupMessage` construction, no capability bitfield).

## Test plan

- [x] `cargo test -p ephpm-db` (unit tests, includes the new SCRAM framing regression)
- [x] `PG_TEST_URL=postgres://postgres:test@127.0.0.1:5433/test cargo test -p ephpm-db --test pg_proxy_integration -- --ignored` against `postgres:17`
- [x] `PG_TEST_URL=postgres://postgres:test@127.0.0.1:5434/test cargo test -p ephpm-db --test pg_proxy_integration -- --ignored` against `postgres:13` (md5)
- [x] `cargo clippy -p ephpm-db --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`