### PR TITLE
feat(kv): add ephpm_kv_flush_all() SAPI function

### DIFF
--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -749,7 +749,20 @@ impl Store {
     }
 
     fn mem_sub(&self, n: usize) {
-        self.mem_used.fetch_sub(n, Ordering::Relaxed);
+        // Saturating subtraction: `mem_used` is an *approximate*, unsigned
+        // counter, so it must never underflow. `flush()` resets it to 0 with a
+        // plain `store`, which races with concurrent `remove`/`set` on other
+        // worker threads (the store is `Arc`-shared across the spawn_blocking
+        // pool): a thread can pull an entry out of the map — capturing its
+        // `mem_size` — just before `flush` zeroes the counter, then run its
+        // `mem_sub` afterwards. A plain `fetch_sub` would wrap to ~`usize::MAX`,
+        // making `ensure_memory` believe the store is permanently full
+        // (rejecting every write under NoEviction, eviction-spinning under LRU)
+        // until restart. Flooring at 0 turns that catastrophe into a harmless,
+        // self-correcting slight undercount.
+        let _ = self
+            .mem_used
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| Some(cur.saturating_sub(n)));
     }
 
     /// Ensure there is room for `needed` bytes. Runs eviction if necessary.
@@ -1712,5 +1725,44 @@ mod tests {
         // Confirm the store is still usable after flush.
         assert!(s.set("after_flush".into(), b"ok".to_vec(), None));
         assert_eq!(s.get("after_flush"), Some(b"ok".to_vec()));
+    }
+
+    #[test]
+    fn mem_sub_saturates_and_does_not_underflow_after_flush() {
+        // Regression for the flush/remove race: `flush()` resets `mem_used`
+        // to 0 while another thread may still owe a `mem_sub` for an entry it
+        // pulled from the map just before the flush. With a plain `fetch_sub`
+        // that stale subtraction wraps the unsigned counter to ~usize::MAX,
+        // which permanently wedges `ensure_memory`. Here we reproduce the
+        // outcome deterministically: zero the counter, then apply a stale sub.
+        let s = Store::new(StoreConfig {
+            memory_limit: 0,
+            eviction_policy: EvictionPolicy::NoEviction,
+            compression: CompressionConfig::default(),
+        });
+        s.set("k".into(), vec![0u8; 1024], None);
+        s.flush(); // mem_used == 0, but the entry's mem_size is still "owed"
+        assert_eq!(s.mem_used(), 0);
+
+        // Simulate the late `mem_sub` from a remove that captured the entry
+        // before flush ran. Must floor at 0, never wrap.
+        s.mem_sub(4096);
+        assert_eq!(s.mem_used(), 0, "mem_sub underflowed instead of saturating");
+
+        // And the store must still accept writes (a wrapped counter would make
+        // ensure_memory reject everything under a non-zero limit).
+        let s2 = Store::new(StoreConfig {
+            memory_limit: 1024 * 1024,
+            eviction_policy: EvictionPolicy::NoEviction,
+            compression: CompressionConfig::default(),
+        });
+        s2.set("a".into(), vec![1u8; 512], None);
+        s2.flush();
+        s2.mem_sub(99_999); // stale over-subtraction
+        assert_eq!(s2.mem_used(), 0);
+        assert!(
+            s2.set("b".into(), vec![2u8; 512], None),
+            "write rejected — counter likely underflowed and wedged ensure_memory"
+        );
     }
 }

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -1680,4 +1680,37 @@ mod tests {
         assert_eq!(s.hlen("h"), 0);
         assert!(!s.exists("h"));
     }
+
+    #[test]
+    fn flush_clears_mixed_ttl_keys_and_resets_memory() {
+        // FLUSHDB/FLUSHALL backing: confirm a single flush nukes both
+        // persistent and TTL'd string keys plus hash keys, and zeros the
+        // memory accountant so subsequent writes start from a clean slate.
+        let s = Store::new(StoreConfig {
+            memory_limit: 0,
+            eviction_policy: EvictionPolicy::NoEviction,
+            compression: CompressionConfig::default(),
+        });
+        s.set("persistent".into(), b"v1".to_vec(), None);
+        s.set("ttl".into(), b"v2".to_vec(), Some(Duration::from_secs(60)));
+        s.set("ttl_short".into(), b"v3".to_vec(), Some(Duration::from_millis(1)));
+        s.hset("h", "f1", b"hv1".to_vec());
+        s.hset("h", "f2", b"hv2".to_vec());
+        assert!(s.mem_used() > 0);
+        assert_eq!(s.len(), 4); // 3 strings + 1 hash
+
+        s.flush();
+
+        assert_eq!(s.len(), 0);
+        assert_eq!(s.mem_used(), 0);
+        assert!(!s.exists("persistent"));
+        assert!(!s.exists("ttl"));
+        assert!(!s.exists("ttl_short"));
+        assert!(!s.exists("h"));
+        assert_eq!(s.pttl("ttl"), None);
+
+        // Confirm the store is still usable after flush.
+        assert!(s.set("after_flush".into(), b"ok".to_vec(), None));
+        assert_eq!(s.get("after_flush"), Some(b"ok".to_vec()));
+    }
 }

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -952,6 +952,7 @@ typedef struct {
     int  (*incr_by)(const char *key, long long delta, long long *result);
     int  (*expire)(const char *key, long long ttl_ms);
     long long (*pttl)(const char *key);
+    int  (*flush_all)(void);
 } EphpmKvOps;
 
 static EphpmKvOps g_kv_ops = {0};
@@ -1117,6 +1118,19 @@ PHP_FUNCTION(ephpm_kv_pttl)
     RETURN_LONG((zend_long)g_kv_ops.pttl(key));
 }
 
+/* Redis-style FLUSHDB / FLUSHALL: removes every key from the effective
+ * store (per-site store if one was bound for this request, otherwise the
+ * global store). The Predis shim that backs the `redis-cache` WordPress
+ * plugin calls this from its flushdb()/flushall() handlers. Returns true
+ * on success, false if no KV store is registered. */
+PHP_FUNCTION(ephpm_kv_flush_all)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    if (!g_kv_ops.flush_all) { RETURN_FALSE; }
+    RETURN_BOOL(g_kv_ops.flush_all());
+}
+
 /* ── Argument info for reflection (arginfo) ──────────────────── */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_get, 0, 0, 1)
@@ -1169,20 +1183,24 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_pttl, 0, 0, 1)
     ZEND_ARG_INFO(0, key)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_flush_all, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 /* ── Function entry table (null-terminated) ──────────────────── */
 
 static const zend_function_entry ephpm_kv_functions[] = {
-    PHP_FE(ephpm_kv_get,      arginfo_ephpm_kv_get)
-    PHP_FE(ephpm_kv_set,      arginfo_ephpm_kv_set)
-    PHP_FE(ephpm_kv_setnx,    arginfo_ephpm_kv_setnx)
-    PHP_FE(ephpm_kv_del,      arginfo_ephpm_kv_del)
-    PHP_FE(ephpm_kv_exists,   arginfo_ephpm_kv_exists)
-    PHP_FE(ephpm_kv_incr,     arginfo_ephpm_kv_incr)
-    PHP_FE(ephpm_kv_decr,     arginfo_ephpm_kv_decr)
-    PHP_FE(ephpm_kv_incr_by,  arginfo_ephpm_kv_incr_by)
-    PHP_FE(ephpm_kv_expire,   arginfo_ephpm_kv_expire)
-    PHP_FE(ephpm_kv_ttl,      arginfo_ephpm_kv_ttl)
-    PHP_FE(ephpm_kv_pttl,     arginfo_ephpm_kv_pttl)
+    PHP_FE(ephpm_kv_get,       arginfo_ephpm_kv_get)
+    PHP_FE(ephpm_kv_set,       arginfo_ephpm_kv_set)
+    PHP_FE(ephpm_kv_setnx,     arginfo_ephpm_kv_setnx)
+    PHP_FE(ephpm_kv_del,       arginfo_ephpm_kv_del)
+    PHP_FE(ephpm_kv_exists,    arginfo_ephpm_kv_exists)
+    PHP_FE(ephpm_kv_incr,      arginfo_ephpm_kv_incr)
+    PHP_FE(ephpm_kv_decr,      arginfo_ephpm_kv_decr)
+    PHP_FE(ephpm_kv_incr_by,   arginfo_ephpm_kv_incr_by)
+    PHP_FE(ephpm_kv_expire,    arginfo_ephpm_kv_expire)
+    PHP_FE(ephpm_kv_ttl,       arginfo_ephpm_kv_ttl)
+    PHP_FE(ephpm_kv_pttl,      arginfo_ephpm_kv_pttl)
+    PHP_FE(ephpm_kv_flush_all, arginfo_ephpm_kv_flush_all)
     PHP_FE_END
 };
 

--- a/crates/ephpm-php/src/kv_bridge.rs
+++ b/crates/ephpm-php/src/kv_bridge.rs
@@ -132,6 +132,11 @@ pub struct EphpmKvOps {
     /// -2 for missing key.
     pub pttl:
         Option<unsafe extern "C" fn(key: *const std::os::raw::c_char) -> std::os::raw::c_longlong>,
+
+    /// Remove all keys from the effective store (per-site if set, else
+    /// global). Backs Redis-style `FLUSHDB` / `FLUSHALL` from PHP userland.
+    /// Returns 1 on success, 0 if no store is registered.
+    pub flush_all: Option<unsafe extern "C" fn() -> std::os::raw::c_int>,
 }
 
 // ── Callback implementations ────────────────────────────────────────────
@@ -328,6 +333,15 @@ unsafe extern "C" fn kv_pttl(key: *const std::os::raw::c_char) -> std::os::raw::
     }
 }
 
+#[cfg(php_linked)]
+unsafe extern "C" fn kv_flush_all() -> std::os::raw::c_int {
+    let Some(store) = effective_store() else {
+        return 0;
+    };
+    store.flush();
+    1
+}
+
 // ── Static ops table ────────────────────────────────────────────────────
 
 /// The C-compatible function pointer table, ready to pass to
@@ -343,6 +357,7 @@ pub static KV_OPS: EphpmKvOps = EphpmKvOps {
     incr_by: Some(kv_incr_by),
     expire: Some(kv_expire),
     pttl: Some(kv_pttl),
+    flush_all: Some(kv_flush_all),
 };
 
 // ── Public API ──────────────────────────────────────────────────────────
@@ -663,6 +678,55 @@ mod tests {
         // Safety: key is a valid C string.
         let ms = unsafe { kv_pttl(key.as_ptr()) };
         assert!(ms > 0 && ms <= 60_000, "expected PTTL in (0, 60000], got {ms}");
+    }
+
+    // ── kv_flush_all ────────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn flush_all_removes_all_keys_from_global_store() {
+        let store = init_store();
+        store.set("bridge_flush_a".into(), b"v1".to_vec(), None);
+        store.set("bridge_flush_b".into(), b"v2".to_vec(), Some(Duration::from_secs(60)));
+        store.hset("bridge_flush_h", "f", b"v".to_vec());
+
+        // Safety: no arguments; effective_store() falls back to global.
+        let ok = unsafe { kv_flush_all() };
+        assert_eq!(ok, 1);
+
+        assert_eq!(store.len(), 0);
+        assert_eq!(store.mem_used(), 0);
+        assert!(!store.exists("bridge_flush_a"));
+        assert!(!store.exists("bridge_flush_b"));
+        assert!(!store.exists("bridge_flush_h"));
+    }
+
+    #[test]
+    #[serial]
+    fn flush_all_only_affects_site_store_when_set() {
+        // Make sure the global store has data, then point this thread at a
+        // separate site store and flush; the global store must be untouched.
+        let global = init_store();
+        global.set("bridge_flush_global".into(), b"keep_me".to_vec(), None);
+
+        let site = Store::new(StoreConfig::default());
+        site.set("bridge_flush_site".into(), b"goodbye".to_vec(), None);
+        set_site_store(Some(Arc::clone(&site)));
+
+        // Safety: no arguments.
+        let ok = unsafe { kv_flush_all() };
+        assert_eq!(ok, 1);
+
+        assert_eq!(site.len(), 0, "site store should be empty");
+        assert_eq!(site.mem_used(), 0, "site mem counter should be reset");
+        assert_eq!(
+            global.get("bridge_flush_global"),
+            Some(b"keep_me".to_vec()),
+            "global store must be untouched when a site store is active"
+        );
+
+        // Reset thread-local state so it doesn't leak into other serial tests.
+        set_site_store(None);
     }
 
     // ── Thread safety of the get buffer ─────────────────────────────────


### PR DESCRIPTION
## Motivation

A follow-up Predis shim (separate workstream) routes WordPress `redis-cache` traffic in-process to ephpm's embedded KV store. Its `flushdb()` / `flushall()` implementations need a real backing primitive; today they `error_log()` and no-op. The C SAPI exports `ephpm_kv_get`, `set`, `setnx`, `del`, `exists`, `incr`/`decr`/`incr_by`, `expire`, `ttl`, `pttl` — but nothing that wipes the store.

## What this adds

A single new PHP userland function:

```php
bool ephpm_kv_flush_all();
```

- Removes **every** key from the **effective** store for the current request:
  - per-site store if one was bound via `set_site_store()` (multi-tenant mode), otherwise
  - the global store.
- Reuses the existing `Store::flush()`, which clears both string and hash DashMap shards and zeros the `mem_used` atomic.
- Returns `true` on success, `false` only if no KV store is registered (defensive guard, same pattern as the other op stubs).
- Zero arguments; `ZEND_PARSE_PARAMETERS_NONE()`.

## What this does **not** add

Intentionally narrow scope:

- No `SCAN`, no `KEYS`.
- No multi-DB (`SELECT n`).
- No `RENAME`, `DBSIZE`, `RANDOMKEY`, etc.

Those are separate workstreams if/when consumers need them.

## Changes

- `crates/ephpm-kv/src/store/mod.rs` — new unit test `flush_clears_mixed_ttl_keys_and_resets_memory` covering persistent + TTL'd strings + hashes plus `mem_used == 0` post-flush. `Store::flush()` already existed, so no new public API on `Store`.
- `crates/ephpm-php/src/kv_bridge.rs` — new `flush_all` field on `EphpmKvOps`, new `kv_flush_all` callback, wired into `KV_OPS`. Two new `(php_linked)` tests: one for the global-store path, one verifying a bound site store gets flushed while the global store is untouched.
- `crates/ephpm-php/ephpm_wrapper.c` — mirrored field on the C `EphpmKvOps` typedef, `PHP_FUNCTION(ephpm_kv_flush_all)`, `arginfo_ephpm_kv_flush_all` (0 required args), function entry in `ephpm_kv_functions[]`.

## Test plan

- [x] `cargo test -p ephpm-kv flush` — all 6 flush tests pass (new + existing).
- [x] `cargo test -p ephpm-php` — stub-mode tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [ ] CI (with `PHP_SDK_PATH` set) will exercise the `php_linked` bridge tests and link the new C function into libphp.
- [ ] Manual `php -r "var_dump(ephpm_kv_flush_all());"` once the Predis-shim PR lands its example.

## Caveats

- `Store::flush()` calls `mem_used.store(0, Relaxed)` after clearing both DashMaps. There's a tiny race window in which a concurrent in-flight writer that observed memory headroom *before* the flush could insert *after* the clear, leaving `mem_used` understated by that entry's size. The existing `flush()` already had this behaviour and Redis's own `FLUSHDB` makes the same trade-off; flagging it for awareness, not as a blocker.
- The function deliberately ignores the Redis `ASYNC` modifier — there is no background reclaim thread to defer to, it's all synchronous DashMap drops.