### PR TITLE
ci(e2e): serialize E2E runs repo-wide to fix apiserver-starvation flake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,18 @@ on:
   pull_request:
     branches: [main]
 
+# Serialize E2E across the whole repo. Each E2E job runs a full Kind cluster
+# plus a Rust release build inside ephemerd's shared 16 GB Linux VM; several
+# E2E runs overlapping (different PRs / push-to-main / re-pushes) saturate it
+# and the Kind apiserver gets starved mid-run ("connection reset by peer" ->
+# 30m Tilt timeout). `max-parallel: 1` already serializes the matrix legs
+# within a single run; this group serializes runs against each other so only
+# one E2E run is ever on the box at a time. cancel-in-progress: false because
+# we want queued runs to wait their turn, not be discarded.
+concurrency:
+  group: ephpm-e2e
+  cancel-in-progress: false
+
 jobs:
   e2e:
     name: E2E (PHP ${{ matrix.php }})


### PR DESCRIPTION
## What
Adds a workflow-level `concurrency` group to `e2e.yml` so only one E2E run executes on the self-hosted box at a time, repo-wide.

## Why (root-caused from the box)
The intermittent E2E failures on #93/#97 were **not** a kind-create problem — the job logs show `==> Kind cluster ready` every time. The failure happens *after* `Loading images into Kind cluster`: the kube apiserver at `127.0.0.1:40445` starts returning `connection reset by peer` / `EOF` / `TLS handshake timeout` and never recovers → `Timeout after 30m0s`.

Reading ephemerd's own logs on the host:
- All linux jobs share **one 16 GB Linux VM** (`[vm.linux] memory_mb = 16384`), with `[runner] max_concurrent = 4`.
- The semaphore was **continuously saturated** in the failure window (constant `job pending semaphore`), i.e. 4 concurrent jobs.
- Each E2E job runs a Kind control plane **+** a Rust release build **+** a 100 MB+ `kind load image-archive`. Several of those at once starve the control plane → apiserver dies mid-run.

It's load-dependent, hence "flaky": #98's E2E happened to run with low contention (sequentially) and passed.

## The fix
`max-parallel: 1` already serializes the 3 matrix legs (8.3/8.4/8.5) *within* a single run. This PR serializes separate E2E *runs* against each other so only one is ever on the box:

```yaml
concurrency:
  group: ephpm-e2e
  cancel-in-progress: false
```

- **Workflow-level, not job-level** — a job-level group on a 3-leg matrix would make GitHub cancel the 3rd leg (only 1 running + 1 pending kept per group). Workflow-level gates the whole run as a unit.
- **`cancel-in-progress: false`** — queued runs wait their turn rather than being discarded.

## Caveat
GitHub keeps only one *pending* run per group; if 3+ E2E runs stack up, the middle pending one is cancelled (shows as "cancelled", re-runnable). At this repo's traffic that's rare. This is the standard tradeoff for serialize-without-cancel.

## Scope
Targets only the heavy E2E jobs — clippy/fmt/unit tests keep parallelizing. No ephemerd change, no global throttle. Nightly's separate E2E (continue-on-error, 04:00 UTC) is left as-is; can join the group later if it ever overlaps.