### PR TITLE
fix(php): isolate per-request state with request shutdown/startup cycle

### DIFF
--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -683,9 +683,34 @@ void ephpm_request_set_ini(const char *key, const char *value)
  */
 int ephpm_execute_request(const char *filename)
 {
-    /* Reset output and response buffers */
+    /* ---- Per-request lifecycle (php-fpm-style isolation) ----
+     * Tear down the previous request and start a fresh one. Without this,
+     * a single request was reused for the whole life of the thread, so
+     * user functions/classes/constants and the global symbol table leaked
+     * across requests — vanilla WordPress rendered only the first request
+     * per worker thread ($wp_did_header / WP_USE_THEMES persisted).
+     *
+     * php_request_shutdown() runs zend_deactivate() -> shutdown_executor(),
+     * which destroys user symbols, constants, statics, and included_files;
+     * php_request_startup() then provides a clean executor. The signal /
+     * timeout / stack functions that made php_request_startup() crash on
+     * tokio spawn_blocking threads are already no-op'd via --wrap, so this
+     * is safe. OPcache's compiled bytecode lives in SHM and survives the
+     * cycle, so the opcode cache (and JIT buffer) are preserved — this is
+     * exactly the classic php-fpm + opcache model. */
+    if (request_active) {
+        php_request_shutdown(NULL);
+        request_active = 0;
+    }
+
+    /* Reset output and response buffers (thread-local C buffers) */
     output_len = 0;
     headers_buf_len = 0;
+
+    if (php_request_startup() != SUCCESS) {
+        return -1;
+    }
+    request_active = 1;
 
     /* Disable stack size checking */
     EG(max_allowed_stack_size) = 0;


### PR DESCRIPTION
## Problem

`ephpm_execute_request` reused a single long-lived PHP request for the entire
life of each worker thread and never tore it down. Only the superglobals were
rebuilt between requests, so **user functions, classes, constants, function
statics, static class properties, the global symbol table, and the
included-files list leaked across requests** on the same thread.

This breaks any app that defines constants/globals at the top level of the
entry script or bootstraps via `require_once` — including **vanilla
WordPress**, which only rendered the first request per worker thread.
`WP_USE_THEMES` (a constant) and `$wp_did_header` (a global) persisted, so
`wp-blog-header.php` skipped its entire bootstrap + render on every
subsequent request.

### Measured (PHP 8.5.7, embedded SQLite, before the fix)

| Test | Result |
|---|---|
| WordPress homepage, 8 sequential | req #1 = full 68 KB page; req #2–8 = 119-byte blank (`Warning: Constant WP_USE_THEMES already defined`) |
| WordPress homepage, 40 concurrent | 20 full / 20 blank (one good render per warmed thread) |
| `$GLOBALS` / statics / static props / constants | persisted and accumulated across requests |

## Fix

Run `php_request_shutdown(NULL)` + `php_request_startup()` per request in
`ephpm_execute_request`. `php_request_shutdown` → `zend_deactivate` →
`shutdown_executor` clears the leaked user state; `php_request_startup`
provides a clean executor.

This cycle was previously avoided because `php_request_startup()` crashed on
tokio `spawn_blocking` threads — but the offending `zend_signal_*` /
`zend_set_timeout` / `zend_call_stack_init` functions are **already
neutralised via `--wrap` no-ops** in this file, so the cycle is now safe.

OPcache's compiled bytecode and the JIT buffer live in SHM and **survive
request shutdown**, so the opcode/JIT cache is preserved. This is exactly the
classic **php-fpm + opcache** model.

## Validation (after the fix)

| Test | Result |
|---|---|
| WordPress, 8 sequential | **8/8 full 68 KB pages** |
| WordPress, 40 concurrent | **40 full / 0 blank** |
| `$GLOBALS` / statics / static props / constants | **reset to baseline every request** |
| `require_once` | re-includes per request (correct FPM semantics) |
| OPcache | still enabled & SHM-shared (4 misses for 4 scripts across 25 threads) |
| JIT | still on (tracing); one shared buffer across all threads |
| Perf (trivial no-op script, c=8) | ~5% (10358 → 9803 req/s); negligible on real workloads since bytecode stays cached |

## Notes / follow-ups

- Behavioural change to a shared hot path: this removes the (buggy)
  cross-request persistence. Nothing should depend on it.
- `docs/guides/wordpress.md` "live-tested" claim is now actually true under
  sustained load.
- The `roadmap/wordpress-worker-mode.md` boot-once design is now a pure
  *performance* optimization, orthogonal to this correctness fix.
- Not run by the author: full Kind/Tilt `cargo xtask e2e` and `cargo deny`
  (no dep changes); `cargo +nightly fmt` (no Rust changed). `cargo test -p
  ephpm-php` and `cargo clippy --workspace --all-targets -- -D warnings`
  pass.

Draft pending CI (fmt / clippy / test / e2e).
