### PR TITLE
fix(php): per-request state isolation (supersedes #101)

### DIFF
--- a/crates/ephpm-e2e/Cargo.lock
+++ b/crates/ephpm-e2e/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +34,27 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -53,7 +89,10 @@ dependencies = [
 name = "ephpm-e2e"
 version = "0.1.0"
 dependencies = [
+ "brotli",
  "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
  "urlencoding",
 ]

--- a/crates/ephpm-e2e/tests/per_request_isolation.rs
+++ b/crates/ephpm-e2e/tests/per_request_isolation.rs
@@ -1,0 +1,113 @@
+//! Per-request PHP state isolation.
+//!
+//! Regression test for ephpm/ephpm#101. Before that fix, `ephpm_execute_request`
+//! reused a single PHP request for the lifetime of each worker thread and
+//! never tore it down — user-defined functions, classes, constants, function
+//! statics, static class properties, $GLOBALS, and the included-files list
+//! all leaked from one HTTP request into the next on the same thread. Vanilla
+//! WordPress rendered only the first request per worker (constants like
+//! `WP_USE_THEMES` persisted and short-circuited `wp-blog-header.php`).
+//!
+//! The fixture (`tests/docroot/per_request_state.php`) emits four canaries —
+//! a constant, a function-local static, a $GLOBALS counter, and a function-
+//! existence check. On a correct SAPI every response is byte-identical;
+//! under the leak, request #2+ on a warmed thread shows accumulated state.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use std::collections::HashSet;
+
+use ephpm_e2e::required_env;
+
+/// What a request to `per_request_state.php` MUST emit on a SAPI that
+/// resets per-request state correctly. Any deviation means the leak is
+/// back — most likely because `ephpm_execute_request` skipped the
+/// `php_request_shutdown` + `php_request_startup` cycle.
+const EXPECTED_CLEAN_RESPONSE: &str = "was_defined=false\n\
+                                       static_counter=1\n\
+                                       global_counter=1\n\
+                                       func_existed=false\n";
+
+async fn fetch_probe(base_url: &str) -> String {
+    let url = format!("{base_url}/per_request_state.php");
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "probe must return 200 (got {})",
+        resp.status()
+    );
+    resp.text()
+        .await
+        .expect("failed to read probe response body")
+}
+
+/// Sequential single-flight requests almost always reuse the freshest idle
+/// worker thread (LIFO scheduling). Without the fix, request #2 onward
+/// reports a leaked constant, an accumulating static, a growing $GLOBALS
+/// counter, and `func_existed=true` — the test diff is unambiguous.
+#[tokio::test]
+async fn sequential_requests_see_fresh_per_request_state() {
+    let base_url = required_env("EPHPM_URL");
+
+    // 8 sequential requests: matches the manual reproduction in the
+    // PR #101 body (req #1 worked, req #2-8 leaked).
+    for i in 1..=8 {
+        let body = fetch_probe(&base_url).await;
+        assert_eq!(
+            body, EXPECTED_CLEAN_RESPONSE,
+            "request #{i} returned leaked state — every request must start \
+             from a fresh per-request executor.\nGot:\n{body}\nExpected:\n{EXPECTED_CLEAN_RESPONSE}"
+        );
+    }
+}
+
+/// Even under concurrent load, every response must look like the first
+/// request on a fresh thread. Without the fix, a pool of W warm worker
+/// threads produces W "clean" responses (one per fresh thread) and N-W
+/// leaked responses — collecting the response set surfaces this as a
+/// non-singleton.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_requests_all_see_fresh_per_request_state() {
+    let base_url = required_env("EPHPM_URL");
+
+    const N: usize = 40;
+    let handles: Vec<_> = (0..N)
+        .map(|_| {
+            let base_url = base_url.clone();
+            tokio::spawn(async move { fetch_probe(&base_url).await })
+        })
+        .collect();
+
+    let mut responses: Vec<String> = Vec::with_capacity(N);
+    for (i, h) in handles.into_iter().enumerate() {
+        responses.push(
+            h.await
+                .unwrap_or_else(|e| panic!("request {i} panicked: {e}")),
+        );
+    }
+
+    let unique: HashSet<&String> = responses.iter().collect();
+    assert_eq!(
+        unique.len(),
+        1,
+        "expected every response identical, got {} distinct bodies across {N} requests:\n{}",
+        unique.len(),
+        unique
+            .iter()
+            .enumerate()
+            .map(|(i, b)| format!("--- variant {i} ---\n{b}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    let only = responses.first().expect("must have at least one response");
+    assert_eq!(
+        only, EXPECTED_CLEAN_RESPONSE,
+        "all responses agreed but disagreed with the clean baseline — \
+         per-request reset may be partial.\nGot:\n{only}\nExpected:\n{EXPECTED_CLEAN_RESPONSE}"
+    );
+}

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -683,9 +683,34 @@ void ephpm_request_set_ini(const char *key, const char *value)
  */
 int ephpm_execute_request(const char *filename)
 {
-    /* Reset output and response buffers */
+    /* ---- Per-request lifecycle (php-fpm-style isolation) ----
+     * Tear down the previous request and start a fresh one. Without this,
+     * a single request was reused for the whole life of the thread, so
+     * user functions/classes/constants and the global symbol table leaked
+     * across requests — vanilla WordPress rendered only the first request
+     * per worker thread ($wp_did_header / WP_USE_THEMES persisted).
+     *
+     * php_request_shutdown() runs zend_deactivate() -> shutdown_executor(),
+     * which destroys user symbols, constants, statics, and included_files;
+     * php_request_startup() then provides a clean executor. The signal /
+     * timeout / stack functions that made php_request_startup() crash on
+     * tokio spawn_blocking threads are already no-op'd via --wrap, so this
+     * is safe. OPcache's compiled bytecode lives in SHM and survives the
+     * cycle, so the opcode cache (and JIT buffer) are preserved — this is
+     * exactly the classic php-fpm + opcache model. */
+    if (request_active) {
+        php_request_shutdown(NULL);
+        request_active = 0;
+    }
+
+    /* Reset output and response buffers (thread-local C buffers) */
     output_len = 0;
     headers_buf_len = 0;
+
+    if (php_request_startup() != SUCCESS) {
+        return -1;
+    }
+    request_active = 1;
 
     /* Disable stack size checking */
     EG(max_allowed_stack_size) = 0;

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -175,8 +175,50 @@ static EPHPM_TLS struct {
 
 static EPHPM_TLS int server_var_count = 0;
 
+/* Per-request INI overrides (e.g. open_basedir for vhost isolation).
+ *
+ * These must be (re)applied AFTER php_request_startup() on every request:
+ * php_request_shutdown() runs zend_ini_deactivate(), which restores every
+ * entry modified during the request to its original value, so an override
+ * applied before the per-request shutdown/startup cycle is wiped before the
+ * script runs. We buffer the key/value pairs here (owning copies, since the
+ * caller frees its strings once ephpm_request_set_ini returns) and replay
+ * them inside ephpm_execute_request once the fresh request is live. */
+#define MAX_REQUEST_INI 16
+
+static EPHPM_TLS char *request_ini_keys[MAX_REQUEST_INI];
+static EPHPM_TLS char *request_ini_vals[MAX_REQUEST_INI];
+static EPHPM_TLS size_t request_ini_count = 0;
+
 /* Track whether a PHP request is currently active on this thread */
 static EPHPM_TLS int request_active = 0;
+
+/* Duplicate a C string with plain malloc (must outlive the Zend per-request
+ * allocator, so estrdup is unsuitable). Returns NULL on OOM or NULL input. */
+static char *ephpm_strdup_malloc(const char *s)
+{
+    if (!s) {
+        return NULL;
+    }
+    size_t n = strlen(s) + 1;
+    char *p = (char *)malloc(n);
+    if (p) {
+        memcpy(p, s, n);
+    }
+    return p;
+}
+
+/* Release all buffered per-request INI overrides. */
+static void ephpm_request_ini_reset(void)
+{
+    for (size_t i = 0; i < request_ini_count; i++) {
+        free(request_ini_keys[i]);
+        free(request_ini_vals[i]);
+        request_ini_keys[i] = NULL;
+        request_ini_vals[i] = NULL;
+    }
+    request_ini_count = 0;
+}
 
 /* ===================================================================
  * SAPI Callbacks
@@ -655,15 +697,28 @@ void ephpm_request_add_server_var(const char *key, const char *value)
  * STAGE_ACTIVATE — the bucket PHP itself uses during request_startup —
  * skips the tightening check, which is the behavior we want here.
  *
+ * Buffer the override rather than applying it now: ephpm_execute_request()
+ * tears down the active request (php_request_shutdown -> zend_ini_deactivate)
+ * before starting a fresh one, which would immediately undo an entry applied
+ * here. The buffered entries are replayed once the new request is live.
+ *
  * Call before ephpm_execute_request().
  */
 void ephpm_request_set_ini(const char *key, const char *value)
 {
-    zend_string *zkey = zend_string_init(key, strlen(key), 0);
-    zend_string *zval = zend_string_init(value, strlen(value), 0);
-    zend_alter_ini_entry(zkey, zval, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
-    zend_string_release(zval);
-    zend_string_release(zkey);
+    if (request_ini_count >= MAX_REQUEST_INI) {
+        return;
+    }
+    char *kd = ephpm_strdup_malloc(key);
+    char *vd = ephpm_strdup_malloc(value);
+    if (!kd || !vd) {
+        free(kd);
+        free(vd);
+        return;
+    }
+    request_ini_keys[request_ini_count] = kd;
+    request_ini_vals[request_ini_count] = vd;
+    request_ini_count++;
 }
 
 /*
@@ -769,6 +824,21 @@ int ephpm_execute_request(const char *filename)
     SG(headers_sent) = 0;
     SG(request_info).no_headers = 0;
 
+    /* Replay per-request INI overrides now that the fresh request is live.
+     * Applied at STAGE_ACTIVATE (the bucket request_startup itself uses), so
+     * open_basedir for vhost isolation takes effect for this request without
+     * tripping the runtime "can only tighten" check, and is restored by the
+     * next request's php_request_shutdown(). */
+    for (size_t i = 0; i < request_ini_count; i++) {
+        zend_string *zkey = zend_string_init(request_ini_keys[i],
+                                             strlen(request_ini_keys[i]), 0);
+        zend_string *zval = zend_string_init(request_ini_vals[i],
+                                             strlen(request_ini_vals[i]), 0);
+        zend_alter_ini_entry(zkey, zval, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+        zend_string_release(zval);
+        zend_string_release(zkey);
+    }
+
     /* Reset PHP's last-error tracking so we can tell whether THIS script
      * raised a fatal (vs. a value carried over from a prior request). */
     PG(last_error_type) = 0;
@@ -827,9 +897,12 @@ int ephpm_execute_request(const char *filename)
         response_status_code = 500;
     }
 
-    /* Note: we do NOT call php_request_shutdown here.
-     * We reuse the single embed request for all HTTP requests.
-     * php_embed_shutdown() handles final cleanup at process exit. */
+    /* Release this request's buffered INI overrides; they have already been
+     * applied to the live request above and must not leak into the next one
+     * (which buffers its own set before calling back in). The request itself
+     * is torn down lazily at the top of the next ephpm_execute_request(), or
+     * by php_embed_shutdown() at process exit. */
+    ephpm_request_ini_reset();
 
     return result;
 }

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -159,6 +159,11 @@ static EPHPM_TLS size_t req_post_data_len = 0;
 static EPHPM_TLS size_t req_post_data_offset = 0;
 static EPHPM_TLS const char *req_path_translated = NULL;
 
+/* Non-NULL sentinel for SG(server_context). sapi_activate() only parses the
+ * POST body when server_context is set; the value itself is never dereferenced
+ * by our SAPI, so a single shared marker address suffices. */
+static int ephpm_server_context_marker = 0;
+
 /* Server variables */
 
 #define MAX_SERVER_VARS 128
@@ -703,19 +708,30 @@ int ephpm_execute_request(const char *filename)
         request_active = 0;
     }
 
-    /* Reset output and response buffers (thread-local C buffers) */
+    /* Reset output and response buffers (thread-local C buffers). The
+     * C-side POST read cursor resets too, so our read_post callback serves
+     * the request body from the start. */
     output_len = 0;
     headers_buf_len = 0;
+    req_post_data_offset = 0;
 
-    if (php_request_startup() != SUCCESS) {
-        return -1;
-    }
-    request_active = 1;
-
-    /* Disable stack size checking */
-    EG(max_allowed_stack_size) = 0;
-
-    /* Update SAPI request info for this HTTP request */
+    /* Populate SG(request_info) BEFORE php_request_startup().
+     *
+     * PHP builds the superglobals ($_GET/$_POST/$_SERVER/$_COOKIE/$_FILES/
+     * $_REQUEST) during request startup and auto-globals creation, using our
+     * installed SAPI callbacks (treat_data, read_post, read_cookies,
+     * register_server_variables). Those callbacks read these request_info
+     * fields, so the fields must be set first.
+     *
+     * The old single-request reuse model could NOT call php_request_startup()
+     * per request, so it set request_info afterwards and hand-rebuilt the
+     * superglobals. Now that the per-request lifecycle calls
+     * php_request_startup() every request (above), that manual rebuild became
+     * actively harmful: it destroyed the PG(http_globals) arrays startup had
+     * just created and re-ran sapi_module.treat_data over them, which faulted
+     * inside php_default_treat_data (use-after-free → SIGSEGV) on tokio
+     * spawn_blocking threads under load. Letting php_request_startup() own
+     * superglobal construction is the correct, crash-free php-fpm model. */
     SG(request_info).request_method = (char *)req_method;
     SG(request_info).request_uri = (char *)req_uri;
     SG(request_info).query_string = (char *)req_query_string;
@@ -725,148 +741,36 @@ int ephpm_execute_request(const char *filename)
     SG(request_info).path_translated = (char *)req_path_translated;
     SG(request_info).proto_num = 1001; /* HTTP/1.1 */
 
-    /* Reset per-request SAPI state */
-    SG(headers_sent) = 0;
-    SG(request_info).no_headers = 0;
-    SG(sapi_headers).http_response_code = 200;
-    req_post_data_offset = 0;
+    /* sapi_activate() (run inside php_request_startup) only reads and parses
+     * the POST body into $_POST when SG(server_context) is non-NULL — that is
+     * the gate cli_server/cgi use to distinguish a real request from CLI. Our
+     * SAPI callbacks key off the thread-local request buffers rather than this
+     * pointer, so a stable non-NULL sentinel is all that's needed to enable
+     * native POST parsing. Without it $_POST stays empty (php://input still
+     * works because read_post is driven separately). */
+    SG(server_context) = &ephpm_server_context_marker;
 
-    /* Reset POST reading state so PHP re-reads body data.
-     * -1 means "not yet read"; PHP will call our read_post callback.
-     * Also close the request_body stream so php://input reads fresh. */
-    SG(read_post_bytes) = -1;
-    if (SG(request_info).request_body) {
-        php_stream_close(SG(request_info).request_body);
-        SG(request_info).request_body = NULL;
+    if (php_request_startup() != SUCCESS) {
+        return -1;
     }
+    request_active = 1;
 
-    /* Destroy old superglobal arrays so they don't carry stale data.
-     * PG(http_globals) holds zvals for $_GET, $_POST, $_SERVER, etc. */
-    for (int i = 0; i < NUM_TRACK_VARS; i++) {
-        if (Z_TYPE(PG(http_globals)[i]) != IS_UNDEF) {
-            zval_ptr_dtor(&PG(http_globals)[i]);
-            ZVAL_UNDEF(&PG(http_globals)[i]);
-        }
-    }
-
-    /* Clear the response header list from the previous request */
-    zend_llist_clean(&SG(sapi_headers).headers);
-
-    /* Rebuild superglobals by manually creating fresh arrays and
-     * populating them. We can't call php_hash_environment() because
-     * it depends on internal state set up by php_request_startup().
-     *
-     * $_SERVER — populated via our register_server_variables callback */
-    zval server_vars_zv;
-    array_init(&server_vars_zv);
-    ephpm_sapi_register_server_variables(&server_vars_zv);
-    zend_hash_update(&EG(symbol_table),
-        zend_string_init("_SERVER", sizeof("_SERVER") - 1, 0),
-        &server_vars_zv);
-    ZVAL_COPY(&PG(http_globals)[TRACK_VARS_SERVER], &server_vars_zv);
-
-    /* $_GET — parse from query string */
-    zval get_vars;
-    array_init(&get_vars);
-    if (req_query_string && *req_query_string) {
-        /* Use PHP's query string parser */
-        char *qs_copy = estrdup(req_query_string);
-        sapi_module.treat_data(PARSE_STRING, qs_copy, &get_vars);
-        /* treat_data frees qs_copy */
-    }
-    zend_hash_update(&EG(symbol_table),
-        zend_string_init("_GET", sizeof("_GET") - 1, 0),
-        &get_vars);
-    ZVAL_COPY(&PG(http_globals)[TRACK_VARS_GET], &get_vars);
-
-    /* Pre-read POST data so php://input and multipart parsing work.
-     * sapi_read_post_data() calls our read_post callback and creates
-     * the request_body stream. Must happen before sapi_handle_post(). */
-    if (req_post_data && req_post_data_len > 0) {
-#if PHP_VERSION_ID >= 80400
-        sapi_read_post_data();
-#else
-        ephpm_sapi_read_post_data_compat();
-#endif
-    }
-
-    /* $_POST + $_FILES — use PHP's built-in POST handler.
-     * For multipart/form-data, this invokes rfc1867 parsing which
-     * populates both $_POST and $_FILES. For url-encoded, it populates
-     * $_POST. For other content types, both stay empty. */
-    zval post_vars;
-    array_init(&post_vars);
-    zval files_vars;
-    array_init(&files_vars);
-    ZVAL_COPY(&PG(http_globals)[TRACK_VARS_POST], &post_vars);
-    ZVAL_COPY(&PG(http_globals)[TRACK_VARS_FILES], &files_vars);
-    if (req_post_data && req_post_data_len > 0 && req_content_type) {
-        sapi_handle_post(&PG(http_globals)[TRACK_VARS_POST]);
-        /* sapi_handle_post may have populated FILES directly */
-        zval_ptr_dtor(&files_vars);
-        ZVAL_COPY(&files_vars, &PG(http_globals)[TRACK_VARS_FILES]);
-        /* Re-read POST from http_globals in case handler replaced it */
-        zval_ptr_dtor(&post_vars);
-        ZVAL_COPY(&post_vars, &PG(http_globals)[TRACK_VARS_POST]);
-    }
-    zend_hash_update(&EG(symbol_table),
-        zend_string_init("_POST", sizeof("_POST") - 1, 0),
-        &post_vars);
-    ZVAL_COPY_VALUE(&PG(http_globals)[TRACK_VARS_POST], &post_vars);
-
-    /* $_COOKIE — parse from cookie header.
-     * Cookies are "key=value" pairs separated by "; ".
-     * We parse manually since treat_data(PARSE_COOKIE) requires
-     * internal SAPI state that isn't set up in our reuse model. */
-    zval cookie_vars;
-    array_init(&cookie_vars);
-    if (req_cookie_data && *req_cookie_data) {
-        char *cookie_copy = estrdup(req_cookie_data);
-        char *saveptr = NULL;
-        char *pair = strtok_r(cookie_copy, ";", &saveptr);
-        while (pair) {
-            /* Skip leading whitespace */
-            while (*pair == ' ') pair++;
-            char *eq = strchr(pair, '=');
-            if (eq) {
-                *eq = '\0';
-                char *val = eq + 1;
-                /* Trim trailing whitespace from value */
-                size_t vlen = strlen(val);
-                while (vlen > 0 && val[vlen - 1] == ' ') vlen--;
-                php_register_variable_safe(pair, val, vlen, &cookie_vars);
-            }
-            pair = strtok_r(NULL, ";", &saveptr);
-        }
-        efree(cookie_copy);
-    }
-    zend_hash_update(&EG(symbol_table),
-        zend_string_init("_COOKIE", sizeof("_COOKIE") - 1, 0),
-        &cookie_vars);
-    ZVAL_COPY(&PG(http_globals)[TRACK_VARS_COOKIE], &cookie_vars);
-
-    /* $_FILES — populated by sapi_handle_post() for multipart requests */
-    zend_hash_update(&EG(symbol_table),
-        zend_string_init("_FILES", sizeof("_FILES") - 1, 0),
-        &files_vars);
-    ZVAL_COPY_VALUE(&PG(http_globals)[TRACK_VARS_FILES], &files_vars);
-
-    /* $_REQUEST — merge of $_GET + $_POST + $_COOKIE per request_order */
-    zval request_vars;
-    array_init(&request_vars);
-    zend_hash_copy(Z_ARRVAL(request_vars), Z_ARRVAL(get_vars), zval_add_ref);
-    zend_hash_copy(Z_ARRVAL(request_vars), Z_ARRVAL(post_vars), zval_add_ref);
-    zend_hash_copy(Z_ARRVAL(request_vars), Z_ARRVAL(cookie_vars), zval_add_ref);
-    zend_hash_update(&EG(symbol_table),
-        zend_string_init("_REQUEST", sizeof("_REQUEST") - 1, 0),
-        &request_vars);
-
-    /* Re-disable stack checking (request startup may reset it) */
+    /* tokio spawn_blocking threads have small stacks; request startup may
+     * reset this guard, so clear it afterwards. */
     EG(max_allowed_stack_size) = 0;
 
+    /* Reset per-request response status. php_request_startup()/sapi_activate()
+     * does NOT reset SG(sapi_headers).http_response_code on this embed reuse
+     * path, so without this an explicit status from a prior request on the
+     * same worker thread (e.g. http_response_code(201), or a 500 from a fatal)
+     * leaks into the next request and a 200-expecting handler returns the
+     * stale code. headers_sent / no_headers are reset for the same reason. */
+    SG(sapi_headers).http_response_code = 200;
+    SG(headers_sent) = 0;
+    SG(request_info).no_headers = 0;
+
     /* Reset PHP's last-error tracking so we can tell whether THIS script
-     * raised a fatal (vs. a stale value carried over from a prior reuse
-     * of the embed request). */
+     * raised a fatal (vs. a value carried over from a prior request). */
     PG(last_error_type) = 0;
 
     /* Execute the script with bailout protection.

--- a/tests/docroot/per_request_state.php
+++ b/tests/docroot/per_request_state.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Per-request PHP state isolation probe.
+ *
+ * On a correct per-request SAPI (php-fpm, php-cgi, php cli-server, embed
+ * with proper php_request_startup/shutdown), every response is
+ * byte-identical regardless of how many times the same worker thread has
+ * already served this script:
+ *
+ *   was_defined=false
+ *   static_counter=1
+ *   global_counter=1
+ *   func_existed=false
+ *
+ * On a leaky embed SAPI that reuses a single PHP request across HTTP
+ * requests, request #2+ on the same worker thread sees state that should
+ * have been destroyed in request shutdown — constants, function-local
+ * statics, $GLOBALS entries, and user-declared functions all persist.
+ *
+ * Regression for ephpm/ephpm#101 ("isolate per-request state with
+ * request shutdown/startup cycle"). The test that consumes this fixture
+ * is `per_request_isolation.rs`.
+ */
+
+header('Content-Type: text/plain');
+
+// `function tick() { ... }` declared at top level would fatal on the
+// second request to the same worker thread under the leak — guard it
+// so the fixture survives long enough to report the other canaries.
+$func_existed = function_exists('tick');
+if (!$func_existed) {
+    function tick() {
+        static $n = 0;
+        $n++;
+        return $n;
+    }
+}
+
+$was_defined = defined('EPHPM_LEAK_PROBE');
+if (!$was_defined) {
+    define('EPHPM_LEAK_PROBE', 1);
+}
+
+if (!isset($GLOBALS['leak_global_counter'])) {
+    $GLOBALS['leak_global_counter'] = 0;
+}
+$GLOBALS['leak_global_counter']++;
+
+echo "was_defined=" . ($was_defined ? "true" : "false") . "\n";
+echo "static_counter=" . tick() . "\n";
+echo "global_counter=" . $GLOBALS['leak_global_counter'] . "\n";
+echo "func_existed=" . ($func_existed ? "true" : "false") . "\n";


### PR DESCRIPTION
Supersedes #101. Preserves Bryan's per-request isolation commit (`9715d61`, authored by @bryanspears) and adds the crash/POST/status fix plus an e2e regression test on top.

## Background

#101 made PHP run a real per-request `php_request_shutdown()` / `php_request_startup()` cycle on each request so user functions/classes/constants and the global symbol table no longer leak across requests on a reused worker thread (vanilla WordPress previously rendered only the first request per thread). That change is correct and necessary — but it exposed two problems in the surrounding wrapper code.

## Problem 1 — SIGSEGV under load

Once `php_request_startup()` runs every request, the old hand-rolled superglobal rebuild became actively harmful: it destroyed the `PG(http_globals)` arrays startup had just created and re-ran `php_default_treat_data` over them, faulting (use-after-free -> SIGSEGV) on tokio `spawn_blocking` threads under load. This is why the e2e job intermittently came back with the ephpm pod restarting (`RESTARTS=1`, `LASTREASON=Error`); the cluster itself was healthy.

## Problem 2 — `$_POST` empty / status leak (found while fixing #1)

Deleting the manual rebuild means PHP must populate the superglobals natively. Two gaps:

- `sapi_activate()` (run inside `php_request_startup()`) only reads and parses the POST body into `$_POST` when `SG(server_context)` is non-NULL -- the gate `cli_server`/`cgi` use. Our embed SAPI never set it, so `$_POST` stayed empty (`php://input` still worked because `read_post` is driven separately).
- `http_response_code` / `headers_sent` / `no_headers` were not reset per request, so a prior request's status (e.g. `201`, or `500` from a fatal) leaked into the next `200` response on a reused thread.

## Fix

In `ephpm_wrapper.c`:
- Set `SG(request_info)` **before** `php_request_startup()` and delete the manual GPC/POST/cookie/`$_REQUEST` rebuild -- let startup own superglobal construction (the php-fpm model).
- Set a non-NULL `SG(server_context)` sentinel before startup so native POST parsing runs. The value is never dereferenced by our SAPI.
- Reset per-request response status (`http_response_code` / `headers_sent` / `no_headers`).

## Tests

- `crates/ephpm-e2e/tests/per_request_isolation.rs` -- sequential + 40-way concurrent probes that each request returns fresh per-request state (constant/static/global/function canaries via `tests/docroot/per_request_state.php`). Red on #101's wrapper, green here.

## Verification

Release container, repeated request waves across the full e2e binary set:
- SIGSEGV gone -- `restarts=0` throughout, including the `kv` path that previously triggered the crash.
- `$_POST` / `$_GET` / `$_COOKIE` populate natively (`http::post_body_reaches_php` green).
- Per-request status no longer leaks (`php` status tests green).

Final gate is this PR's CI across PHP 8.3 / 8.4 / 8.5.