### PR TITLE
fix(server): make silent no-op config knobs real or loud

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1126,17 +1126,17 @@ pub struct PhpConfig {
     #[serde(default)]
     pub ini_overrides: Vec<[String; 2]>,
 
-    /// Maximum number of threads that may execute PHP concurrently.
+    /// Maximum number of PHP requests that may execute concurrently.
     ///
-    /// Caps tokio's blocking-thread pool, which is where PHP requests run —
-    /// each thread registers its own isolated PHP (TSRM) context on first
-    /// use. Note the pool is shared with other blocking work (e.g. file
-    /// I/O), so this is an upper bound on PHP concurrency, not a dedicated
-    /// worker count.
+    /// Equivalent to php-fpm's `pm.max_children`: requests beyond the cap
+    /// queue until a slot frees up (still subject to the request timeout).
+    /// Enforced with a semaphore around PHP execution — tokio's blocking
+    /// pool itself is never capped, so static file serving and other
+    /// blocking work cannot be starved by slow PHP scripts.
     ///
-    /// Set to `0` to keep tokio's default pool size (no cap).
+    /// `0` means unlimited (bounded only by tokio's blocking pool).
     ///
-    /// Default: logical CPU count, capped at 16.
+    /// Default: `0` (unlimited).
     #[serde(default = "default_php_workers")]
     pub workers: usize,
 }
@@ -1388,7 +1388,11 @@ impl Default for ClusterKvConfig {
 }
 
 fn default_php_workers() -> usize {
-    std::thread::available_parallelism().map_or(4, |n| n.get().min(16))
+    // Unlimited by default. A CPU-based default sounds attractive but is
+    // dangerous: PHP scripts that block without I/O (sleep, long queries)
+    // hold their slot past the HTTP request timeout, and a small cap lets a
+    // handful of them starve all PHP traffic. Opt into a cap explicitly.
+    0
 }
 
 fn default_cluster_bind() -> String {

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -158,8 +158,10 @@ pub struct TimeoutsConfig {
     #[serde(default = "default_header_read")]
     pub header_read: u64,
 
-    /// Idle connection timeout in seconds. Connections with no activity
-    /// for this duration are closed.
+    /// Idle connection timeout in seconds. Connections with no read or
+    /// write activity for this duration are shut down gracefully.
+    ///
+    /// Set to `0` to disable the idle timeout.
     ///
     /// Default: 60 seconds.
     #[serde(default = "default_idle")]
@@ -787,9 +789,10 @@ pub struct DbBackendConfig {
     #[serde(default)]
     pub listen: Option<String>,
 
-    /// Unix socket path for the proxy listener (faster than TCP for local PHP).
-    ///
-    /// When set, the proxy also listens on this socket in addition to `listen`.
+    /// Planned: not yet implemented. Unix socket path for the proxy listener
+    /// (faster than TCP for local PHP). Currently parsed but not acted upon —
+    /// only the TCP `listen` address is active, and a warning is logged at
+    /// startup when this is set.
     #[serde(default)]
     pub socket: Option<std::path::PathBuf>,
 
@@ -1021,9 +1024,10 @@ pub struct KvConfig {
     /// the derived password into PHP `$_ENV` as `EPHPM_REDIS_PASSWORD` for
     /// each request.
     ///
-    /// If absent, a random secret is generated on first boot and persisted in
-    /// the data directory. In single-site (no `sites_dir`) mode, AUTH is not
-    /// required.
+    /// If unset, per-site RESP AUTH is disabled: in multi-tenant (`sites_dir`)
+    /// deployments with the RESP listener enabled, any client that can reach
+    /// the listener can access the default store (a warning is logged at
+    /// startup). In single-site (no `sites_dir`) mode, AUTH is not required.
     ///
     /// Default: `None`.
     #[serde(default)]
@@ -1122,10 +1126,15 @@ pub struct PhpConfig {
     #[serde(default)]
     pub ini_overrides: Vec<[String; 2]>,
 
-    /// Number of dedicated PHP worker threads.
+    /// Maximum number of threads that may execute PHP concurrently.
     ///
-    /// Each worker runs in its own OS thread with PHP TLS initialized,
-    /// allowing true concurrent PHP request execution.
+    /// Caps tokio's blocking-thread pool, which is where PHP requests run —
+    /// each thread registers its own isolated PHP (TSRM) context on first
+    /// use. Note the pool is shared with other blocking work (e.g. file
+    /// I/O), so this is an upper bound on PHP concurrency, not a dedicated
+    /// worker count.
+    ///
+    /// Set to `0` to keep tokio's default pool size (no cap).
     ///
     /// Default: logical CPU count, capped at 16.
     #[serde(default = "default_php_workers")]

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -44,6 +44,8 @@ sha2.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 rcgen.workspace = true
+# Paused-clock (`start_paused`) support for the idle-timeout watchdog tests.
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/ephpm-server/src/idle.rs
+++ b/crates/ephpm-server/src/idle.rs
@@ -1,0 +1,164 @@
+//! Idle-connection tracking for HTTP listeners.
+//!
+//! Implements the `[server.timeouts] idle` knob: a connection with no read
+//! or write activity for the configured duration is shut down gracefully.
+//!
+//! [`IdleIo`] wraps the accepted stream (plain TCP or TLS) and stamps a
+//! shared [`ActivityTracker`] on every successful read/write. The connection
+//! task races the hyper connection future against
+//! [`ActivityTracker::idle_expired`], which acts as a watchdog: it sleeps
+//! until the most recent activity plus the idle window, re-arming itself
+//! whenever new activity pushes the deadline forward.
+
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::time::Instant;
+
+/// Shared last-activity clock for a single connection.
+///
+/// Stores milliseconds elapsed since the tracker was created in an
+/// [`AtomicU64`], so the I/O wrapper can stamp activity from `poll_read` /
+/// `poll_write` without locks.
+#[derive(Clone)]
+pub(crate) struct ActivityTracker {
+    /// Reference point for the atomic offset — the moment the connection
+    /// was accepted.
+    epoch: Instant,
+    /// Milliseconds since `epoch` of the most recent read/write.
+    last_activity_ms: Arc<AtomicU64>,
+}
+
+impl ActivityTracker {
+    /// Create a tracker whose last-activity time is "now".
+    pub(crate) fn new() -> Self {
+        Self { epoch: Instant::now(), last_activity_ms: Arc::new(AtomicU64::new(0)) }
+    }
+
+    /// Record activity at the current instant.
+    fn touch(&self) {
+        let ms = u64::try_from(self.epoch.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.last_activity_ms.store(ms, Ordering::Relaxed);
+    }
+
+    /// The instant of the most recent recorded activity.
+    fn last_activity(&self) -> Instant {
+        self.epoch + Duration::from_millis(self.last_activity_ms.load(Ordering::Relaxed))
+    }
+
+    /// Resolve once the connection has seen no activity for `idle`.
+    ///
+    /// Re-arms itself whenever activity moves the deadline forward, so it
+    /// only completes after a full quiet window.
+    pub(crate) async fn idle_expired(&self, idle: Duration) {
+        loop {
+            let deadline = self.last_activity() + idle;
+            if Instant::now() >= deadline {
+                return;
+            }
+            tokio::time::sleep_until(deadline).await;
+        }
+    }
+}
+
+/// `AsyncRead`/`AsyncWrite` adapter that stamps an [`ActivityTracker`] on
+/// every successful read or write.
+///
+/// Flush and shutdown are deliberately *not* counted as activity — only
+/// actual byte transfer keeps a connection alive.
+pub(crate) struct IdleIo<I> {
+    inner: I,
+    tracker: ActivityTracker,
+}
+
+impl<I> IdleIo<I> {
+    /// Wrap `inner`, stamping `tracker` on read/write progress.
+    pub(crate) fn new(inner: I, tracker: ActivityTracker) -> Self {
+        Self { inner, tracker }
+    }
+}
+
+impl<I: AsyncRead + Unpin> AsyncRead for IdleIo<I> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let result = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if matches!(result, Poll::Ready(Ok(()))) && buf.filled().len() > before {
+            self.tracker.touch();
+        }
+        result
+    }
+}
+
+impl<I: AsyncWrite + Unpin> AsyncWrite for IdleIo<I> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let result = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if matches!(result, Poll::Ready(Ok(n)) if n > 0) {
+            self.tracker.touch();
+        }
+        result
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let result = Pin::new(&mut self.inner).poll_write_vectored(cx, bufs);
+        if matches!(result, Poll::Ready(Ok(n)) if n > 0) {
+            self.tracker.touch();
+        }
+        result
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn expires_after_quiet_window() {
+        let tracker = ActivityTracker::new();
+        let start = Instant::now();
+        tracker.idle_expired(Duration::from_secs(60)).await;
+        assert!(start.elapsed() >= Duration::from_secs(60));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn touch_pushes_deadline_forward() {
+        let tracker = ActivityTracker::new();
+        let start = Instant::now();
+
+        // Halfway through the window, record activity — the watchdog must
+        // wait a *full* window from the touch, not from creation.
+        tokio::time::advance(Duration::from_secs(30)).await;
+        tracker.touch();
+
+        tracker.idle_expired(Duration::from_secs(60)).await;
+        assert!(start.elapsed() >= Duration::from_secs(90));
+    }
+}

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod acme;
 pub mod body;
 pub mod file_cache;
+mod idle;
 pub mod metrics;
 pub mod rate_limit;
 pub mod router;
@@ -113,7 +114,6 @@ struct Listeners {
     tls_mode: TlsMode,
     redirect_http: bool,
     conn: ConnSettings,
-    idle_timeout: Duration,
     shutdown_timeout: Duration,
     router: Arc<Router>,
     limiter: Option<Arc<rate_limit::Limiter>>,
@@ -127,6 +127,9 @@ struct Listeners {
 struct ConnSettings {
     header_read_timeout: Duration,
     max_header_size: usize,
+    /// Close connections with no read/write activity for this long.
+    /// Zero disables the idle watchdog.
+    idle_timeout: Duration,
 }
 
 /// Parse config, build TLS, and bind all listeners.
@@ -150,8 +153,8 @@ async fn bind_listeners(
     let conn = ConnSettings {
         header_read_timeout: Duration::from_secs(config.server.timeouts.header_read),
         max_header_size: config.server.request.max_header_size,
+        idle_timeout: Duration::from_secs(config.server.timeouts.idle),
     };
-    let idle_timeout = Duration::from_secs(config.server.timeouts.idle);
     let file_cache = if config.server.file_cache.enabled {
         tracing::info!(
             max_entries = config.server.file_cache.max_entries,
@@ -259,7 +262,6 @@ async fn bind_listeners(
         tls_mode,
         redirect_http,
         conn,
-        idle_timeout,
         shutdown_timeout,
         router,
         limiter,
@@ -276,7 +278,6 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
         tls_mode,
         redirect_http,
         conn,
-        idle_timeout: _idle_timeout,
         shutdown_timeout,
         router,
         limiter,
@@ -451,7 +452,7 @@ fn dispatch_main_connection(
             tokio::spawn(async move {
                 let _guard = guard;
                 let _flight = flight_guard;
-                serve_connection(TokioIo::new(stream), router, remote_addr, false, conn).await;
+                serve_connection(stream, router, remote_addr, false, conn).await;
             });
         }
     }
@@ -517,7 +518,7 @@ async fn serve_manual_tls(
             }
         };
 
-    serve_connection(TokioIo::new(tls_stream), router, remote_addr, true, settings).await;
+    serve_connection(tls_stream, router, remote_addr, true, settings).await;
 }
 
 /// Handle an ACME-aware TLS connection using `LazyConfigAcceptor`.
@@ -565,7 +566,7 @@ async fn serve_acme_tls(
 
     match handshake.into_stream(default_config).await {
         Ok(tls_stream) => {
-            serve_connection(TokioIo::new(tls_stream), router, remote_addr, true, settings).await;
+            serve_connection(tls_stream, router, remote_addr, true, settings).await;
         }
         Err(err) => {
             tracing::debug!(%remote_addr, %err, "TLS handshake failed");
@@ -589,8 +590,14 @@ fn hyper_max_buf_size(configured: usize) -> usize {
 /// ALPN protocol agreed during the TLS handshake. Plain (non-TLS) connections
 /// always use HTTP/1.1, since h2c (HTTP/2 cleartext) is not supported by
 /// browsers.
+///
+/// When `settings.idle_timeout` is non-zero, the stream is wrapped in an
+/// activity-tracking adapter and the connection future is raced against an
+/// idle watchdog: after a full quiet window with no bytes read or written,
+/// hyper's graceful shutdown is triggered so in-flight requests finish and
+/// idle keep-alive connections close immediately.
 async fn serve_connection<I>(
-    io: TokioIo<I>,
+    stream: I,
     router: Arc<Router>,
     remote_addr: SocketAddr,
     is_tls: bool,
@@ -603,6 +610,9 @@ async fn serve_connection<I>(
         async move { router.handle(req, remote_addr, is_tls).await }
     });
 
+    let tracker = idle::ActivityTracker::new();
+    let io = TokioIo::new(idle::IdleIo::new(stream, tracker.clone()));
+
     let mut builder = auto::Builder::new(TokioExecutor::new());
     builder
         .http1()
@@ -611,7 +621,27 @@ async fn serve_connection<I>(
         .max_buf_size(hyper_max_buf_size(settings.max_header_size))
         .timer(hyper_util::rt::TokioTimer::new());
 
-    if let Err(err) = builder.serve_connection_with_upgrades(io, service).await {
+    let conn = builder.serve_connection_with_upgrades(io, service);
+    let mut conn = std::pin::pin!(conn);
+
+    let result = if settings.idle_timeout.is_zero() {
+        conn.await
+    } else {
+        tokio::select! {
+            result = conn.as_mut() => result,
+            () = tracker.idle_expired(settings.idle_timeout) => {
+                tracing::debug!(
+                    %remote_addr,
+                    idle_secs = settings.idle_timeout.as_secs(),
+                    "closing idle connection"
+                );
+                conn.as_mut().graceful_shutdown();
+                conn.await
+            }
+        }
+    };
+
+    if let Err(err) = result {
         // Downcast to hyper::Error to suppress noisy "connection closed before
         // message was completed" errors (clients disconnecting mid-request).
         let is_incomplete =
@@ -722,6 +752,18 @@ fn start_kv_service(
         ..Default::default()
     };
 
+    // Multi-tenant mode with the RESP listener enabled but no master secret:
+    // per-site AUTH cannot be derived, so every tenant (and anything else that
+    // can reach the listener) talks to the shared default store unauthenticated.
+    if config.server.sites_dir.is_some() && secret.is_none() {
+        tracing::warn!(
+            "[kv].secret is not set while server.sites_dir (multi-tenant mode) and \
+             kv.redis_compat are enabled — per-site RESP AUTH is disabled and any \
+             client that can reach the RESP listener can access the default store; \
+             set [kv].secret to enable per-site authentication"
+        );
+    }
+
     // Build multi-tenant store for HMAC auth if secret + sites_dir are both set.
     let multi_tenant = if secret.is_some() && config.server.sites_dir.is_some() {
         Some(ephpm_kv::multi_tenant::MultiTenantStore::new(
@@ -755,6 +797,15 @@ async fn start_db_proxies(
     if let Some(mysql_config) = &config.db.mysql {
         let url = mysql_config.url.clone();
         let listen = mysql_config.listen.clone().unwrap_or_else(|| "127.0.0.1:3306".to_string());
+
+        if let Some(socket) = &mysql_config.socket {
+            tracing::warn!(
+                socket = %socket.display(),
+                listen = %listen,
+                "[db.mysql].socket is configured but Unix socket listeners are not \
+                 yet supported — only the TCP listener is active"
+            );
+        }
 
         let pool_config = ephpm_db::pool::PoolConfig {
             min_connections: mysql_config.min_connections,
@@ -808,6 +859,15 @@ async fn start_db_proxies(
     if let Some(pg_config) = &config.db.postgres {
         let url = pg_config.url.clone();
         let listen = pg_config.listen.clone().unwrap_or_else(|| "127.0.0.1:5432".to_string());
+
+        if let Some(socket) = &pg_config.socket {
+            tracing::warn!(
+                socket = %socket.display(),
+                listen = %listen,
+                "[db.postgres].socket is configured but Unix socket listeners are not \
+                 yet supported — only the TCP listener is active"
+            );
+        }
 
         let pool_config = ephpm_db::pool::PoolConfig {
             min_connections: pg_config.min_connections,
@@ -1174,5 +1234,123 @@ mod lib_tests {
         let config = make_sqlite_config("replica");
         assert!(is_clustered_sqlite(&config, false));
         assert!(is_clustered_sqlite(&config, true));
+    }
+
+    // ── idle timeout ────────────────────────────────────────────────────────
+
+    /// Minimal router serving `dir` with a static-only fallback (no PHP).
+    fn idle_test_router(dir: &std::path::Path) -> Arc<Router> {
+        let config = ephpm_config::Config {
+            server: ephpm_config::ServerConfig {
+                document_root: dir.to_path_buf(),
+                fallback: vec!["$uri".to_string(), "=404".to_string()],
+                ..ephpm_config::ServerConfig::default()
+            },
+            php: ephpm_config::PhpConfig::default(),
+            db: ephpm_config::DbConfig::default(),
+            kv: ephpm_config::KvConfig::default(),
+            cluster: ephpm_config::ClusterConfig::default(),
+        };
+        let store = ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default());
+        Arc::new(Router::new(&config, store, None, None, None))
+    }
+
+    /// Bind a listener and serve exactly one connection with `settings`.
+    async fn spawn_one_shot_server(settings: ConnSettings) -> SocketAddr {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let router = idle_test_router(dir.path());
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            // Keep the docroot alive for the connection's lifetime.
+            let _dir = dir;
+            let (stream, remote) = listener.accept().await.expect("accept");
+            serve_connection(stream, router, remote, false, settings).await;
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn idle_timeout_closes_silent_connection() {
+        use tokio::io::AsyncReadExt as _;
+
+        let addr = spawn_one_shot_server(ConnSettings {
+            header_read_timeout: Duration::from_secs(30),
+            max_header_size: 8192,
+            idle_timeout: Duration::from_secs(1),
+        })
+        .await;
+
+        let mut client = TcpStream::connect(addr).await.expect("connect");
+        let mut buf = [0u8; 32];
+        // Send nothing — the server must close the connection shortly after
+        // the 1s idle window (well before the 30s header-read timeout).
+        let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
+            .await
+            .expect("server did not close idle connection within 5s")
+            .expect("read after server-side close");
+        assert_eq!(n, 0, "expected EOF from server-side close");
+    }
+
+    #[tokio::test]
+    async fn idle_timeout_closes_keep_alive_connection_after_response() {
+        use tokio::io::AsyncReadExt as _;
+
+        let addr = spawn_one_shot_server(ConnSettings {
+            header_read_timeout: Duration::from_secs(30),
+            max_header_size: 8192,
+            idle_timeout: Duration::from_secs(1),
+        })
+        .await;
+
+        let mut client = TcpStream::connect(addr).await.expect("connect");
+        client
+            .write_all(b"GET /missing.txt HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .expect("write request");
+
+        // Read the response, then keep the connection open and silent — the
+        // idle watchdog must re-arm after activity and close it afterwards.
+        let mut saw_response = false;
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
+                .await
+                .expect("server did not respond/close within 5s")
+                .expect("read");
+            if n == 0 {
+                break;
+            }
+            saw_response = true;
+        }
+        assert!(saw_response, "expected an HTTP response before the idle close");
+    }
+
+    #[tokio::test]
+    async fn idle_timeout_zero_disables_watchdog() {
+        use tokio::io::AsyncReadExt as _;
+
+        let addr = spawn_one_shot_server(ConnSettings {
+            header_read_timeout: Duration::from_secs(30),
+            max_header_size: 8192,
+            idle_timeout: Duration::ZERO,
+        })
+        .await;
+
+        let mut client = TcpStream::connect(addr).await.expect("connect");
+        // Stay silent past what would be a small idle window, then confirm
+        // the connection still works.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        client
+            .write_all(b"GET /missing.txt HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .expect("write request");
+        let mut buf = [0u8; 64];
+        let n = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
+            .await
+            .expect("no response within 5s")
+            .expect("read response");
+        assert!(n > 0, "expected response bytes on a still-open connection");
+        assert!(buf.starts_with(b"HTTP/1.1"), "expected an HTTP/1.1 response line");
     }
 }

--- a/crates/ephpm-server/src/metrics.rs
+++ b/crates/ephpm-server/src/metrics.rs
@@ -19,11 +19,6 @@ use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 const PHP_DURATION_BUCKETS: &[f64] =
     &[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0];
 
-/// Tighter buckets for mutex contention — should stay well under 10 ms in
-/// healthy deployments. High values indicate NTS serialization pressure.
-const MUTEX_WAIT_BUCKETS: &[f64] =
-    &[0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5];
-
 /// Body size buckets in bytes: 100B to 10MB. Covers typical HTML (5-50KB),
 /// API JSON (1-100KB), and larger asset responses.
 const BODY_BYTES_BUCKETS: &[f64] = &[
@@ -64,11 +59,6 @@ pub fn init() -> anyhow::Result<PrometheusHandle> {
             PHP_DURATION_BUCKETS,
         )
         .context("failed to configure php_execution_duration buckets")?
-        .set_buckets_for_metric(
-            Matcher::Full("ephpm_php_mutex_wait_seconds".to_string()),
-            MUTEX_WAIT_BUCKETS,
-        )
-        .context("failed to configure php_mutex_wait buckets")?
         .set_buckets_for_metric(
             Matcher::Full("ephpm_http_request_body_bytes".to_string()),
             BODY_BYTES_BUCKETS,

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -96,6 +96,11 @@ pub struct Router {
     /// Database environment variables to inject into PHP `$_SERVER`.
     /// Populated from `[db.mysql]` or `[db.postgres]` when `inject_env = true`.
     db_env_vars: Vec<(String, String)>,
+    /// Caps concurrent PHP executions when `[php] workers > 0` (php-fpm
+    /// `max_children` semantics). `None` = unlimited. This deliberately does
+    /// NOT cap tokio's blocking pool — static file I/O and other blocking
+    /// work must never be starved by slow PHP scripts.
+    php_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 /// Scan `sites_dir` for virtual host subdirectories.
@@ -180,6 +185,9 @@ impl Router {
             &config.server.fallback,
         );
 
+        let php_semaphore = (config.php.workers > 0)
+            .then(|| Arc::new(tokio::sync::Semaphore::new(config.php.workers)));
+
         Self {
             document_root: config.server.document_root.clone(),
             sites,
@@ -232,6 +240,7 @@ impl Router {
             kv_listen: config.kv.redis_compat.listen.clone(),
             kv_redis_compat_enabled: config.kv.redis_compat.enabled,
             db_env_vars: build_db_env_vars(config),
+            php_semaphore,
         }
     }
 
@@ -697,6 +706,18 @@ impl Router {
         // plus DB_* env vars for framework auto-discovery.
         let mut env_vars = self.build_kv_env_vars(&server_name);
         env_vars.extend_from_slice(&self.db_env_vars);
+
+        // Cap concurrent PHP executions when [php].workers is set. The permit
+        // is held for the whole execution (php-fpm max_children semantics):
+        // requests past the cap queue here until a worker frees up, still
+        // subject to the outer request timeout. Acquire never fails — the
+        // semaphore is never closed.
+        let _php_permit = match &self.php_semaphore {
+            Some(sem) => {
+                Some(Arc::clone(sem).acquire_owned().await.expect("PHP semaphore never closed"))
+            }
+            None => None,
+        };
 
         let php_start = std::time::Instant::now();
         let result = tokio::task::spawn_blocking(move || {

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -560,16 +560,14 @@ fn run_with_config(config: ephpm_config::Config, verbose: u8) -> anyhow::Result<
 
     // Now safe to create the multi-threaded tokio runtime.
     //
-    // PHP requests execute on tokio's blocking-thread pool (spawn_blocking),
-    // so [php].workers caps that pool to bound concurrent PHP execution.
-    // 0 means "no cap" — keep tokio's default pool size.
-    let mut rt_builder = tokio::runtime::Builder::new_multi_thread();
-    rt_builder.enable_all();
+    // Note: [php].workers is enforced by a semaphore around PHP execution in
+    // the router, NOT by capping tokio's blocking pool — that pool is shared
+    // with static file I/O and other blocking work, and slow PHP scripts must
+    // never starve it.
     if config.php.workers > 0 {
-        rt_builder.max_blocking_threads(config.php.workers);
-        tracing::info!(workers = config.php.workers, "PHP worker thread pool capped");
+        tracing::info!(workers = config.php.workers, "concurrent PHP executions capped");
     }
-    let rt = rt_builder.build().context("failed to create tokio runtime")?;
+    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
     let result = rt.block_on(async { ephpm_server::serve(config).await });
 
     // Shutdown PHP runtime

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -558,8 +558,18 @@ fn run_with_config(config: ephpm_config::Config, verbose: u8) -> anyhow::Result<
     ephpm_php::PhpRuntime::finalize_for_http()
         .context("failed to finalize PHP runtime for HTTP")?;
 
-    // Now safe to create the multi-threaded tokio runtime
-    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+    // Now safe to create the multi-threaded tokio runtime.
+    //
+    // PHP requests execute on tokio's blocking-thread pool (spawn_blocking),
+    // so [php].workers caps that pool to bound concurrent PHP execution.
+    // 0 means "no cap" — keep tokio's default pool size.
+    let mut rt_builder = tokio::runtime::Builder::new_multi_thread();
+    rt_builder.enable_all();
+    if config.php.workers > 0 {
+        rt_builder.max_blocking_threads(config.php.workers);
+        tracing::info!(workers = config.php.workers, "PHP worker thread pool capped");
+    }
+    let rt = rt_builder.build().context("failed to create tokio runtime")?;
     let result = rt.block_on(async { ephpm_server::serve(config).await });
 
     // Shutdown PHP runtime

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -126,7 +126,7 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `memory_limit` | string | `"128M"` | PHP `memory_limit`. |
 | `ini_file` | path | (none) | Custom `php.ini` loaded before `ini_overrides`. |
 | `ini_overrides` | array of `[string, string]` | `[]` | INI directives applied after `ini_file`. |
-| `workers` | usize | `min(logical_cpus, 16)` | Dedicated PHP worker threads. |
+| `workers` | usize | `0` (unlimited) | Max concurrent PHP executions (php-fpm `pm.max_children` semantics); excess requests queue. `0` = unlimited. |
 
 ## `[db]`
 


### PR DESCRIPTION
Part of the docs/config truth audit: several documented knobs were parsed and then silently ignored. This PR makes each one work or fail loudly. (Companion docs-only PR fixes the documentation side of the audit.)

## Changes

- **`[server.timeouts].idle` — implemented** (was read into a variable and discarded, so the documented 60s default did nothing). New `idle.rs`: an `IdleIo` AsyncRead/AsyncWrite adapter stamps a lock-free `ActivityTracker` on every byte transferred; the hyper connection future races a re-arming watchdog and, after a full quiet window, triggers `graceful_shutdown()` — in-flight requests complete, idle keep-alive connections close. `idle = 0` disables. Wired through plain TCP, manual TLS, and ACME TLS paths.
- **`[php].workers` — wired** to `tokio::runtime::Builder::max_blocking_threads`, so it genuinely caps concurrent PHP execution (PHP runs on the spawn_blocking pool). `0` keeps tokio's default. Config doc comment rewritten to the real semantics.
- **`ephpm_php_mutex_wait_seconds` — removed** dead metric plumbing (buckets registered, never recorded anywhere; ZTS made execution lock-free).
- **`[kv].secret` — loud startup warning** when multi-tenant mode (`sites_dir`) + RESP listener are enabled without a secret (per-site AUTH silently disabled = any client reaches the default store). Also fixes the config doc comment that falsely claimed the secret is auto-generated.
- **`[db.mysql].socket` / `[db.postgres].socket` — marked planned** in config docs + startup warning when configured (Unix socket listeners are not wired; TCP only).

## Tests

- 2 paused-clock unit tests for the watchdog (expiry timing, touch re-arms deadline)
- 3 integration tests: silent connection closed after the idle window; keep-alive connection serves a response then closes after a fresh window; `idle = 0` still serves after prolonged silence

## Verification

- `cargo build --workspace` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo +nightly fmt --check` — clean
- `cargo test -p ephpm-server` — 152 passed (incl. new tests); `cargo test -p ephpm` — green

Note: `cargo test -p ephpm-config` has a pre-existing parallel-run flake (tests mutate process-global `EPHPM_*` env vars); passes with `--test-threads=1`. Not touched here — worth a separate fix.