### PR TITLE
fix(deps): bump anyhow to 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"


### PR DESCRIPTION
RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut()` after `.context()`) landed in the advisory database today and fails the Cargo Deny check on every branch (first seen on #106). `anyhow 1.0.103` carries the upstream fix — this is the one-line lockfile bump.

The e2e crate's separate lockfile has no anyhow dependency, so no change there.

Merging this first unblocks Cargo Deny for #106 and #107 (they'll pick it up via branch update).