### PR TITLE
docs(agents): truthfulness/hygiene directives + six project skills

### DIFF
--- a/.claude/skills/add-config-knob/SKILL.md
+++ b/.claude/skills/add-config-knob/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: add-config-knob
+description: Checklist for adding or changing an ephpm config field so it can never become a silent no-op. Use whenever a PR adds a key to ephpm-config, changes a default, or defers a knob's implementation.
+---
+
+# Add a config knob (no-silent-no-ops checklist)
+
+Every item, same PR. History: `[server.timeouts].idle` shipped parsed-but-discarded and `[php].workers` shipped never-read; both were documented as working (fixed in #106).
+
+1. **Field** in the right struct in `crates/ephpm-config/src/lib.rs` with `#[serde(default = "...")]` and a `default_*` fn.
+2. **Enforcement**: code actually reads the field and changes behavior. Grep for the field name outside ephpm-config - if the only hit is the struct, it's a no-op.
+   - If implementation is genuinely deferred: the doc comment MUST say `Planned: not yet implemented - parsed but not acted upon` (established phrasing, grep for it), AND startup must `tracing::warn!` when the knob is set to a non-default value.
+3. **Doc comment** (`///`): semantics, unit, default, and what `0`/absent means. Units in the name where ambiguous (`ttl_secs` not `ttl`).
+4. **Reference docs row** in `site/content/reference/config.md` - key, type, real default, one-line semantics. If it affects guides, update them too.
+5. **Default-choice review**: think about worst-case, not typical. A CPU-count default for a concurrency cap starved the whole server when PHP blocked (the `workers` lesson: blocking tasks can't be cancelled; permits/threads held past the request timeout). Prefer "0 = unlimited/disabled, opt into limits explicitly" unless there's a strong reason.
+6. **Resource-sharing check** for anything limiting concurrency/pools: never cap a shared resource (tokio blocking pool, connection pool) to enforce a per-subsystem limit - use a dedicated semaphore/limiter scoped to the subsystem.
+7. **Tests**: default value test in ephpm-config; behavior test where enforced (ephpm-config tests must pass with `--test-threads=1` - they mutate global env vars).
+8. **Env override sanity**: the key is reachable as `EPHPM_<SECTION>__<FIELD>` (double underscore). Mention it in docs only if users will need it.
+9. **Security defaults**: if the knob gates isolation/auth, remember serde section-level defaults - a `#[derive(Default)]` on the parent struct can silently zero your carefully chosen field default when the whole section is absent (the `[server.security]` lesson). Test both "section present" and "section absent".

--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: audit-docs
+description: Run a claims-vs-code truth audit of ephpm documentation (site/, docs/, examples/, README). Use before releases, after large refactors, or when the user asks whether the docs match reality. Finds documented features that don't exist, wrong defaults, and undersold shipped features.
+---
+
+# Docs truth audit
+
+Cross-check every user-facing claim against its source of truth. The first full audit (fixed in #106/#107) found ~25 fictional CLI commands, silently-ignored config knobs, and false security claims - assume drift accumulates and re-run periodically.
+
+## Source-of-truth map (verify claims ONLY against these)
+
+| Claim type | Authoritative source |
+|---|---|
+| CLI subcommands / flags | `crates/ephpm/src/main.rs` (clap derive) + `crates/ephpm/src/service/` |
+| Config keys, defaults, semantics | `crates/ephpm-config/src/lib.rs` structs + `default_*` fns; note fields whose own doc comment says "Planned: not yet implemented" |
+| PHP SAPI functions (names, arities, units) | `crates/ephpm-php/ephpm_wrapper.c` - check `ZEND_PARSE_PARAMETERS_START(min, max)` and unit conversions (e.g. `ttl * 1000LL` means the arg is SECONDS) |
+| RESP commands | `crates/ephpm-kv/src/command.rs` match arms |
+| Metric names / labels / buckets | `counter!`/`histogram!`/`gauge!` call sites (router.rs, lib.rs, query-stats) + `metrics.rs` bucket registration. A registered bucket with no recording call site = phantom metric |
+| HTTP behavior / lifecycle | `crates/ephpm-server/src/router.rs` + `lib.rs`; PHP lifecycle in `ephpm_wrapper.c` |
+| Cluster capabilities | `crates/ephpm-cluster/src/` - a config field existing does NOT mean the feature exists (grep for where it's read) |
+| Release assets / Docker tags | `.github/workflows/release.yml` |
+
+## Severity rubric
+
+- **BROKEN** - following the doc as written fails, or a promised security/durability property doesn't exist. Fix first.
+- **WRONG** - behavior/default/name/label differs from the doc.
+- **STALE** - doc lags code (includes underselling: "planned" for shipped features - check both directions!).
+
+## Procedure
+
+1. Fan out parallel research agents by doc surface (they don't fit one context): (a) `site/content/reference/`, (b) `site/content/guides/` + `migration/` + `getting-started/`, (c) `site/content/architecture/` + `developer/`, (d) README + `examples/` + `docs/`. Give each the source-of-truth map and rubric; require file:line for every finding.
+2. **Spot-verify the most damning findings yourself** before reporting (grep the cited code) - agents converging independently on a finding is good signal, but security claims deserve direct verification.
+3. Report grouped: security-critical false claims -> broken-if-followed -> silent no-ops -> wrong-mechanism -> underselling.
+4. Fixing: docs-only corrections in one PR; code changes (making a no-op knob real) in a separate PR. When both are in flight, coordinate which PR owns each truth (don't document a knob as dead while another PR implements it).
+
+## Recurring traps
+
+- Guides inventing config keys (`acme_domains` vs the real `domains`) - serde silently ignores unknown keys, so wrong keys "work" by doing nothing.
+- Unit errors in examples (ms vs seconds TTLs).
+- `blocked_paths` globs shown without the leading `/` (never match).
+- Reference pages that were actually design docs (aspirational CLI/API surfaces).
+- Compatibility floors ("needs v0.1.2+") are usually CORRECT - don't bump them to the current version.

--- a/.claude/skills/e2e-local/SKILL.md
+++ b/.claude/skills/e2e-local/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: e2e-local
+description: Reproduce ephpm E2E test failures locally against a containerized release build (podman), without the Kind/Tilt cluster. Use when CI E2E is red and you need fast iteration, or to verify a server-side fix before pushing.
+---
+
+# Run E2E tests against a local container
+
+The CI E2E harness is Kind + Tilt (`cargo xtask e2e`), but 90% of failures reproduce against a plain container plus the pre-built test binaries. Iteration: ~10 min image build, then seconds per test run.
+
+## 1. Build the release image
+
+```bash
+podman build -f docker/Dockerfile -t ephpm:<tag> .        # full PHP-linked release build
+podman tag docker.io/library/ephpm:<tag> localhost/ephpm:<tag>   # REQUIRED: podman run resolves localhost/, docker-style builds land in docker.io/library/
+```
+The image bakes `tests/docroot/` -> `/var/www/html` and `tests/ephpm-test.toml` -> `/etc/ephpm/ephpm.toml`.
+
+## 2. Run it
+
+```bash
+podman run -d --name ephpm-verify -p 18088:8080 \
+  -e EPHPM_SERVER__PHP_ETAG_CACHE__ENABLED=true \
+  localhost/ephpm:<tag>
+```
+Wait for ready: curl `http://127.0.0.1:18088/` until non-000. Config overrides use `EPHPM_` + double-underscore nesting.
+
+## 3. Point the test binaries at it
+
+The e2e crate is workspace-excluded; its tests are plain HTTP clients driven by env vars:
+```bash
+export EPHPM_URL="http://127.0.0.1:18088"
+export EXPECTED_PHP_VERSION=<php full version>    # phpinfo suite fails without it
+# pre-built binaries (from a previous cargo test --no-run) live at:
+crates/ephpm-e2e/target/debug/deps/<suite>-<hash>.exe --test-threads=4
+```
+Pick the newest binary per suite name. Server-side fixes do NOT require rebuilding the test binaries - only the image.
+
+## 4. Crash / regression verification loop
+
+After each suite, check the server survived:
+```bash
+podman inspect -f 'running={{.State.Running}} restarts={{.RestartCount}}' ephpm-verify
+```
+For crash bugs, run the full suite list 3 passes and require `running=true restarts=0` throughout AND rc=0 per binary. The `kv`/`concurrency` suites are the historical SIGSEGV triggers; `http` covers `$_POST`, `php` covers status-code leaks.
+
+## Known local-only artifacts (not real failures)
+
+- `etag_cache::php_etag_different_query_strings_independent` fails on pass 2+ against a long-lived container: the KV etag cache persists across passes; CI uses a fresh container. Restart the container for a clean pass.
+- `phpinfo::php_version_matches` needs `EXPECTED_PHP_VERSION` exported.
+- PHP etag 304 tests need `EPHPM_SERVER__PHP_ETAG_CACHE__ENABLED=true` (default off, and the baked toml doesn't set it).
+- sqlite suites have a pre-existing parallel-isolation issue (shared table) - compare against a v-tag image before blaming your change.
+- vhost/multi-tenant tests (security_p0, vhosts) need site dirs provisioned inside the container:
+  `podman exec ephpm-verify sh -c 'mkdir -p /var/www/sites/<host> && ...'` and requests sent with `-H "Host: <host>"` (the baked toml trusts `basedir-a.test`, `site-a.preview.ephpm.dev`, etc.).
+
+## Full-fidelity fallback
+
+If the failure needs the real cluster (readiness gates, sqld, gossip): `cargo xtask e2e` (Kind + Tilt, needs podman machine + privileged dind on ephemerd hosts). On failure it dumps pod logs, cluster diagnostics, container exit codes, and a FAILED-tests summary at the end of the output.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: release
+description: Cut and shepherd an ephpm release (tag, CI matrix, publish, verify). Use when the user wants to release a new version, an RC, or to rescue a stuck/partially-failed release run.
+---
+
+# Cut an ephpm release
+
+## 1. Pre-flight (do NOT tag until all pass)
+
+- `main` is green: latest CI **and E2E** runs on main succeeded (`gh run list --branch main --limit 4`).
+- Runner fleet can serve the whole matrix: Linux x64 + arm64, **macOS arm64** (native runners), **Windows x64** (ephemerd). A dead leg doesn't fail the release - it parks it forever, because the `Create Release` job `needs:` every build job. See the `triage-ci` skill for runner checks.
+- Docs version pins bumped on main first (grep `site/content/` + `docs/` + `examples/` for `ephpm/ephpm:vX` image pins and `ePHPm X.Y.Z` banners).
+- Confirm the version with the user (patch vs minor is their call).
+
+## 2. Tag
+
+```bash
+git tag -a vX.Y.Z <main-head-sha> -m "Release vX.Y.Z - <one-line summary>"
+git push origin vX.Y.Z
+```
+The `v*` push triggers `.github/workflows/release.yml`. `EPHPM_RELEASE_VERSION` is derived from the tag (leading `v` stripped) and baked into `ephpm --version`.
+
+## 3. What the matrix produces
+
+- Binaries: `ephpm-vX.Y.Z+php<FULL>-<os>-<arch>.tar.gz` for linux-x86_64, linux-aarch64, macos-aarch64, windows-x86_64 x PHP pins (see `matrix.php` in release.yml; keep in sync with `xtask::PHP_SDK_VERSIONS`). Plus `SHA256SUMS`.
+- Docker: `ephpm/ephpm:vX.Y.Z-php<FULL>`, `:vX.Y.Z-php<MINOR>`, `:<MINOR>`, `:vX.Y.Z`, `:latest` (rolling tags skip pre-releases; a `-` in the tag = prerelease, marked so on GitHub).
+- `Create Release` publishes ONLY after build-linux + build-macos + build-windows + docker-image all succeed.
+
+## 4. Monitor and rescue
+
+```bash
+gh run list --workflow=release.yml --limit 3
+gh run watch <RUN_ID> --exit-status --interval 45   # background it
+```
+If legs fail: **fix the cause, then `gh run cancel <RUN_ID>` (if still running) and `gh run rerun <RUN_ID> --failed`.** Green legs (e.g. Linux + Docker) are reused; only failed/cancelled legs re-run. **Never re-tag to retry** - rerun-failed on the same run publishes the same tag. GitHub refuses rerun while the run is in progress, hence cancel-first.
+
+Known leg-specific failures: see `triage-ci` (macOS llvm@17/libclang, Windows ephemerd runner version).
+
+## 5. Verify the release (always, before announcing)
+
+```bash
+gh release view vX.Y.Z --json isDraft,isPrerelease,assets   # expect 13 assets (12 tarballs + SHA256SUMS)
+gh release download vX.Y.Z --pattern "*php<DEFAULT_PHP>-linux-x86_64.tar.gz" --pattern "*windows-x86_64.tar.gz"
+```
+Smoke each downloaded binary: `ephpm --version` reports the tag; serve a one-line `<?php echo "PHPOK ".PHP_VERSION;` docroot and curl it (Linux binary is static musl - run it in `alpine:3.21` via podman; Windows runs natively). Expect HTTP 200 + `PHPOK <php-version>`.
+
+## 6. After
+
+- Update any remaining guide pins to the new version (straight to main per repo owner's preference, or PR).
+- If this was a stable release, confirm `:latest`/`:<minor>` Docker tags moved.

--- a/.claude/skills/review-ephpm/SKILL.md
+++ b/.claude/skills/review-ephpm/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: review-ephpm
+description: Repo-specific review lens for ephpm PRs - the FFI, threading, platform, and CI landmines a generic code review misses. Use when reviewing any PR touching ephpm-php, ephpm_wrapper.c, ephpm-server, config, workflows, or docs.
+---
+
+# ephpm PR review lens
+
+Apply ON TOP of a normal correctness review. Each item has bitten this repo at least once.
+
+## PHP embedding / wrapper (ephpm_wrapper.c, ephpm-php)
+
+- **Per-request lifecycle invariants** (violating any caused real SIGSEGVs or cross-request leaks):
+  - `SG(request_info)` fields set BEFORE `php_request_startup()`; startup owns superglobal construction. Never hand-rebuild `$_GET`/`$_POST`/`$_COOKIE` (`php_default_treat_data` on startup-built arrays = use-after-free).
+  - `SG(server_context)` must be non-NULL before startup or `$_POST` silently stays empty.
+  - Per-request resets after startup: `http_response_code = 200`, `headers_sent`, `no_headers`, `PG(last_error_type)` - or values leak across reused threads.
+  - Per-request INI (open_basedir) must be BUFFERED and replayed AFTER startup at `STAGE_ACTIVATE` (shutdown's `zend_ini_deactivate` wipes anything applied before; RUNTIME stage rejects non-tightening open_basedir). Buffered strings need `malloc` copies (Zend per-request allocator resets across the cycle).
+- All PHP calls go through the C wrapper's `zend_try`/SETJMP guards - never call PHP functions directly from Rust.
+- Stub mode (`cargo build` without `PHP_SDK_PATH`) must compile and pass tests - all FFI behind `#[cfg(php_linked)]`.
+- New SAPI userland functions must be registered via the MINIT shim (`ephpm_pre_init`) - post-init registration is invisible to new ZTS threads.
+- Thread-local (`EPHPM_TLS`) for all per-request C state; ZTS on Linux/macOS, **NTS on Windows** (single PHP context - watch for concurrency assumptions).
+
+## Concurrency / server
+
+- **Never cap or block the shared tokio blocking pool to limit a subsystem** - it also runs static-file I/O. Use a scoped semaphore (the `php.workers` lesson). Remember: blocking tasks cannot be cancelled; anything slot-based leaks slots past the request 504.
+- Config knobs: see the `add-config-knob` skill - reject parsed-but-unused fields.
+- Section-absent serde defaults: check behavior when the whole TOML section is missing, not just the field (the `[server.security]` default-off lesson).
+
+## Platform
+
+- `--wrap` linker no-ops (zend signals/timeout/stack) are **Linux-only**; macOS ld64 and MSVC have no equivalent. Don't rely on them cross-platform.
+- Windows: static-linked `php8embed.lib` (no DLL), `/FORCE:MULTIPLE` hack, sqld unsupported, clustered SQLite bails.
+- macOS release builds pin libclang to brew `llvm@17` - a step that does `brew ... || true` will mask a missing toolchain as green.
+- **ASCII-only in `.github/workflows/*`** touching PowerShell - em-dashes break the PS 5.1 tokenizer on Server Core. Grep `[^\x00-\x7F]` before approving.
+
+## Docs & truthfulness (see CLAUDE.md "Truthfulness" section)
+
+- Behavior/default/mechanism changes must update `site/content/`, `examples/`, `README.md` in the same PR - grep for the old claim.
+- No security/durability claims without implementation; no aspirational content in `reference/`/`guides/`.
+- `blocked_paths` examples need the leading `/`; KV TTL args are seconds (RESP `PEXPIRE` is the ms exception); `ephpm_kv_incr` is 1-arg (deltas = `incr_by`).
+
+## Process
+
+- Preserve outside contributors' authorship: prefer building on their branch/commits (merge-commit if squash would erase attribution - ask the owner).
+- `ephpm-e2e` is workspace-excluded - don't add it to workspace ops; its Cargo.lock drifts by design.
+- Gates: clippy pedantic `-D warnings`, `cargo +nightly fmt`, cargo-deny, MSRV 1.85.

--- a/.claude/skills/triage-ci/SKILL.md
+++ b/.claude/skills/triage-ci/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: triage-ci
+description: Diagnose a failing ephpm CI run (E2E, unit, deny, release). Use whenever a GitHub Actions check is red or queued-forever - it encodes the diagnostic ladder for crashes vs test failures vs runner/infra problems, and the self-hosted (ephemerd) runner fleet quirks.
+---
+
+# Triage a failing ephpm CI run
+
+Work the ladder top-down. Each step either identifies the failure class or rules it out.
+
+## 1. Read the failure summary FIRST (bottom of the E2E job log)
+
+`cargo xtask e2e` prints, as the LAST lines on failure (added in #105):
+- `==== FAILED E2E TESTS ====` - the extracted `... FAILED` / `panicked at` lines. Read these before scrolling anywhere else.
+- `--- ephpm pod: container exit code / signal ---` + a loud banner if the server crashed.
+
+Fetch logs:
+```bash
+gh run view --job <JOB_ID> --log-failed          # only after the whole run completes
+gh api repos/ephpm/ephpm/actions/jobs/<JOB_ID>/logs > tmp_job.log   # works while run is in progress
+```
+Never grep with `-E/-i/-v` flags through the PowerShell-backed shell (flags get eaten) - dump to a file and use the Grep tool.
+
+## 2. Classify by exit code / pod state
+
+| Signal | Meaning | It is a... |
+|---|---|---|
+| pod `RESTARTS>0`, exit `139` (=128+11 SIGSEGV) | server under test crashed | **server bug** (FFI/wrapper suspect first) |
+| exit `137` (SIGKILL) | OOM-killed | resource bug or VM pressure |
+| exit `134` (SIGABRT) | assertion/abort | server bug |
+| pod healthy (`RESTARTS 0`, `Ready True`) + assertion diffs (`left: X right: Y`) | test-level failure | logic/regression |
+| pod healthy + `error sending request` cascade + **readiness probe timing out mid-suite** | server alive but not answering | starvation (blocking pool / PHP worker cap / deadlock) |
+| `NodeNotReady` / `MemoryPressure=True` in the pre-tilt baseline | cluster contention | infra, retry after checking the box |
+
+Crash follow-up on musl static builds: `backtrace()` is a no-op stub - use the container exit code, kernel `dmesg` (`error 4` = userspace read of unmapped memory = use-after-free), and `addr2line` on the unstripped binary to map the fault offset.
+
+## 3. Job never starts (queued forever) = runner problem
+
+The Windows/Linux runners are **ephemerd** JIT runners on Luther's box; macOS runs on native self-hosted runners (up to 4).
+
+- Fleet state: `gh api 'repos/ephpm/ephpm/actions/runners?per_page=100&page=N'` - **paginate**; hundreds of `offline` ephemeral registrations are NORMAL. `offline` on an ephemeral runner means "not connected right now", not dead.
+- ephemerd service log: `C:\ProgramData\ephemerd\ephemerd.log`. Per-runner logs: `C:\ProgramData\ephemerd\logs\<runner-name>-runner.log`.
+- **Known signature - deprecated runner version**: ephemerd provisions a runner, it reaches "runner environment ready", then `runner exited exit_code=0` ~6s later without running the job; the per-runner log says `Runner version vX.Y.Z is deprecated and cannot receive messages`. The `ignoring duplicate queued event` spam in ephemerd.log is a *symptom* (dedup cache), not the cause. Fix: bump `RunnerVersion` in `~/ephemerd/mage/download/download.go`, delete the stale zip in `pkg/runner/embed/`, `mage build:windows`, stop service, swap `C:\Program Files\ephemerd\ephemerd.exe`, start service. A service restart alone does NOT help.
+- macOS runner history: needed `brew install llvm@17` (release builds pin `LIBCLANG_PATH` to it; the workflow step masks a missing install with `|| true`) and a sandbox fix to allow loopback `bind()` (EPERM on `TcpListener::bind("127.0.0.1:0")` = seatbelt/launchd context, not a code bug).
+
+## 4. Rerun rules
+
+- `gh run rerun <RUN_ID> --failed` is refused while any job in the run is still running/queued. **Cancel first, then rerun-failed** - completed-successful jobs (Linux legs, Docker) are preserved, only failed/cancelled legs re-execute. This also applies to release runs: never re-tag to retry.
+- E2E runs are serialized repo-wide via a concurrency group - "pending" E2E often just means another run holds the lock.
+
+## 5. Repo-wide sudden failures
+
+If Cargo Deny (or every PR) goes red simultaneously: new RUSTSEC advisory. `cargo update -p <crate>` on a tiny branch, merge first, then update other branches from main. Precedent: anyhow RUSTSEC-2026-0190 (#108); ignored-advisory precedent in `deny.toml` (proc-macro-error2).
+
+## Known flakes
+- `ephpm-config` tests mutate process-global `EPHPM_*` env vars - parallel runs flake; `cargo test -p ephpm-config -- --test-threads=1` is authoritative.
+- sqlite e2e suite has a pre-existing parallel-isolation issue (shared table).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,3 +137,21 @@ Without `SQLD_BINARY_PATH` (dev builds), `ephpm-sqld` compiles in stub mode — 
 ## CI Pipeline
 
 Runs on push/PR to main: fmt check → clippy → test → cargo-deny. Release builds triggered by `v*` tags across PHP 8.4/8.5 × Linux/macOS matrix.
+
+## Truthfulness: Docs Must Match Code
+
+A full audit (PRs #106/#107) once found ~25 documented commands that didn't exist, config knobs that were silently ignored, and docs claiming security properties the code doesn't have. These rules prevent recurrence:
+
+- **Never document something as working without verifying it in source.** Before writing user-facing docs, check the actual definition: CLI flags/subcommands in `crates/ephpm/src/main.rs` (clap), config keys and defaults in `crates/ephpm-config/src/lib.rs`, PHP SAPI functions and their arities/units in `crates/ephpm-php/ephpm_wrapper.c`, RESP commands in `crates/ephpm-kv/src/command.rs`, metric names/labels at their `counter!`/`histogram!` call sites.
+- **Future features are labeled, not implied.** Anything not implemented must say "Planned — not yet implemented." Design/aspirational docs belong in `site/content/roadmap/`, never in `reference/` or `guides/`.
+- **Never claim security or durability properties that aren't implemented** (auth, encryption, replication, isolation, credential validation). If in doubt, grep for the mechanism — a config field existing does not mean the feature exists.
+- **No silent no-op config knobs.** A new config field must be read and enforced by code in the same PR. If it genuinely can't be yet: the doc comment must say "Planned: not yet implemented — parsed but not acted upon" AND startup must `tracing::warn!` when the knob is set.
+- **No phantom metrics.** Don't register buckets for or document a metric unless something records it.
+- **Behavior changes update docs in the same PR.** When changing a default, mechanism, label, or lifecycle, grep `site/content/`, `docs/`, `examples/`, and `README.md` for the old claim and fix every hit.
+
+## Session Hygiene (branches, worktrees, scratch)
+
+- **Merge PRs with `--delete-branch`**, then delete the local branch too. After a worktree's PR merges: `git worktree remove <path>` and delete its `worktree-agent-*` branch. Never leave merged branches or worktrees behind.
+- **Review checkouts (`pr-NN-review`) are disposable** — delete them when the review ends; they're re-fetchable with `gh pr checkout NN`.
+- **Scratch output goes in gitignored paths** (`/tmp_*` at repo root is ignored) and gets deleted when the investigation ends. Never `git add -A`/`git add .` — stage files by name.
+- **Windows shells:** the null device is `$null` (PowerShell), not `NUL` — a stray redirect creates a literal `NUL` file at repo root.


### PR DESCRIPTION
Everything cleaned up in #106/#107 (and the CI/runner firefighting around v0.2.0) was agent-generated drift: fictional docs, silent no-op config knobs, phantom metrics, leaked branches/worktrees, and hard-won debugging knowledge that lived only in one session. This PR encodes the prevention rules and the procedures so every future agent session — any contributor's — gets them automatically.

## CLAUDE.md — two new directive sections

- **Truthfulness: Docs Must Match Code** — verify-before-documenting (with the source-of-truth file per claim type), planned features labeled not implied, no unimplemented security/durability claims, no silent no-op knobs (enforce in same PR or label + `warn!`), no phantom metrics, behavior changes grep-and-fix docs in the same PR.
- **Session Hygiene** — delete branches/worktrees when their PR merges, `pr-NN-review` checkouts are disposable, scratch stays in gitignored paths, stage by name (never `git add -A`), `$null` not `NUL` on Windows.

## `.claude/skills/` — six auto-discovered skills

| Skill | Encodes |
|---|---|
| `triage-ci` | CI diagnostic ladder: #105 failure-summary first, exit-code decoding (139/137/134), starvation signature, ephemerd fleet quirks incl. the deprecated-runner-version signature + full bump/rebuild/deploy fix, cancel-then-`rerun --failed`, known flakes |
| `release` | Tag/matrix/publish/rescue playbook: pre-flight gates, why a dead runner parks the publish, never-re-tag rescue, asset/tag shapes, mandatory binary smoke verification |
| `e2e-local` | Reproduce E2E failures against a local podman container: `localhost/` tag gotcha, env knobs, prebuilt test binaries, 3-pass crash loop, known local-only artifacts |
| `audit-docs` | Re-runnable claims-vs-code audit: source-of-truth map, BROKEN/WRONG/STALE rubric, fan-out procedure, recurring traps |
| `add-config-knob` | 9-point checklist so config fields can never ship as silent no-ops again (incl. the `workers` worst-case-default and shared-resource lessons, and the section-absent serde trap) |
| `review-ephpm` | Repo-specific review lens: wrapper per-request lifecycle invariants from #101/#104, blocking-pool rule, platform gaps (`--wrap` Linux-only, NTS Windows, llvm@17), ASCII-only workflows, authorship preservation |

Docs/markdown only — no code changes.