### PR TITLE
feat(cluster): encrypt gossip and KV data plane with cluster.secret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +625,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -622,6 +643,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -655,6 +689,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -864,6 +909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1050,13 +1096,17 @@ name = "ephpm-cluster"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64ct",
+ "chacha20poly1305",
  "chitchat",
  "dashmap",
  "ephpm-config",
  "ephpm-kv",
+ "hkdf",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1623,6 +1673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1972,15 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "ipnet"
@@ -2551,6 +2619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "opensrv-mysql"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2818,17 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3024,7 +3109,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -4367,6 +4452,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ bytes = "1"
 sha1 = "0.10"
 sha2 = "0.10"
 hmac = "0.12"
+hkdf = "0.12"
+chacha20poly1305 = "0.10"
 md5 = "0.8"
 base64ct = { version = "1", features = ["alloc"] }
 redis = { version = "0.27", default-features = false, features = ["tokio-comp"] }

--- a/crates/ephpm-cluster/Cargo.toml
+++ b/crates/ephpm-cluster/Cargo.toml
@@ -15,9 +15,13 @@ tokio.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
+async-trait.workspace = true
 base64ct.workspace = true
+chacha20poly1305.workspace = true
+hkdf.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -29,6 +29,7 @@ use ephpm_config::ClusterKvConfig;
 use ephpm_kv::store::Store;
 
 use crate::ClusterHandle;
+use crate::secure_transport::ClusterCipher;
 
 /// Key prefix for hot-key version metadata in chitchat state.
 const HOT_PREFIX: &str = "hot:";
@@ -41,6 +42,8 @@ pub struct ClusteredStore {
     cluster: Arc<ClusterHandle>,
     /// Configuration for tier routing and hot key behavior.
     config: ClusterKvConfig,
+    /// Cipher for TCP data plane traffic (`None` = plaintext).
+    cipher: Option<Arc<ClusterCipher>>,
     /// Per-key hit counters for hot key detection.
     hit_counters: DashMap<u64, HitCounter>,
     /// Locally cached hot key values.
@@ -73,16 +76,23 @@ struct CachedValue {
 
 impl ClusteredStore {
     /// Create a new clustered store.
+    ///
+    /// When `cipher` is `Some` (derive it with
+    /// [`ClusterCipher::for_kv_data_plane`] from `[cluster] secret`),
+    /// all TCP data plane traffic to remote nodes is sealed; the remote
+    /// listeners must be started with the same cipher.
     #[must_use]
     pub fn new(
         store: Arc<Store>,
         cluster: Arc<ClusterHandle>,
         config: ClusterKvConfig,
+        cipher: Option<Arc<ClusterCipher>>,
     ) -> Arc<Self> {
         Arc::new(Self {
             store,
             cluster,
             config,
+            cipher,
             hit_counters: DashMap::new(),
             hot_cache: DashMap::new(),
             subscribed: AtomicBool::new(false),
@@ -161,7 +171,8 @@ impl ClusteredStore {
 
         // 4. TCP fetch from the owner node via the data plane.
         if let Some(owner_addr) = self.resolve_owner_data_addr(key).await {
-            match crate::kv_data_plane::fetch_remote(owner_addr, key).await {
+            match crate::kv_data_plane::fetch_remote(owner_addr, key, self.cipher.as_deref()).await
+            {
                 Ok(Some(value)) => {
                     self.track_remote_fetch(key, &value);
                     return Some(value);
@@ -197,7 +208,14 @@ impl ClusteredStore {
         } else {
             // Large value — route to the owner node via TCP data plane.
             let ok = if let Some(owner_addr) = self.resolve_owner_data_addr(&key).await {
-                match crate::kv_data_plane::store_remote(owner_addr, &key, &value).await {
+                match crate::kv_data_plane::store_remote(
+                    owner_addr,
+                    &key,
+                    &value,
+                    self.cipher.as_deref(),
+                )
+                .await
+                {
                     Ok(accepted) => accepted,
                     Err(e) => {
                         tracing::warn!(

--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -4,7 +4,7 @@
 //! locally on the owner node. Other nodes fetch or store it on demand
 //! via a simple TCP protocol:
 //!
-//! ## Wire protocol
+//! ## Wire protocol (plaintext)
 //!
 //! **Request:** `[op: u8][key_len: u32 BE][key: bytes]`
 //!
@@ -20,6 +20,22 @@
 //! The sentinel `u32::MAX` indicates the key was not found. This is
 //! unambiguous because real values are bounded by memory limits well
 //! below 4 GiB.
+//!
+//! ## Wire protocol (encrypted)
+//!
+//! When `[cluster] secret` is set, both sides derive a
+//! ChaCha20-Poly1305 key via [`ClusterCipher::for_kv_data_plane`] and
+//! each logical message above (the whole request, the whole response)
+//! becomes one sealed frame:
+//!
+//! ```text
+//! [frame_len: u32 BE][nonce: 12 bytes][ciphertext + 16-byte tag]
+//! ```
+//!
+//! The plaintext inside a frame is byte-identical to the plaintext
+//! protocol message. A peer without the matching secret cannot read
+//! values or inject writes: frames that fail authentication cause the
+//! connection to be dropped without a response.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -27,6 +43,8 @@ use std::sync::Arc;
 use ephpm_kv::store::Store;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+
+use crate::secure_transport::{ClusterCipher, SEAL_OVERHEAD};
 
 /// Sentinel value indicating "key not found" in the wire protocol.
 const NOT_FOUND_SENTINEL: u32 = u32::MAX;
@@ -36,6 +54,10 @@ const MAX_KEY_LEN: u32 = 64 * 1024;
 
 /// Maximum value length accepted by the server (64 MiB).
 const MAX_VALUE_LEN: u32 = 64 * 1024 * 1024;
+
+/// Maximum sealed frame length accepted in encrypted mode: the largest
+/// legal plaintext message (SET request) plus sealing overhead.
+const MAX_FRAME_LEN: u32 = 1 + 4 + MAX_KEY_LEN + 4 + MAX_VALUE_LEN + SEAL_OVERHEAD as u32;
 
 /// Op code for GET requests.
 const OP_GET: u8 = 0x00;
@@ -54,15 +76,22 @@ const SET_REJECTED: u8 = 0x01;
 /// Serves lookups against the local [`Store`] so remote cluster nodes
 /// can fetch large values that exceed the gossip tier threshold.
 ///
+/// When `cipher` is `Some`, every request and response is exchanged as
+/// a sealed frame; connections that fail authentication are dropped.
+///
 /// # Errors
 ///
 /// Returns an error if the TCP listener fails to bind.
-pub async fn serve(store: Arc<Store>, port: u16) -> anyhow::Result<()> {
+pub async fn serve(
+    store: Arc<Store>,
+    port: u16,
+    cipher: Option<Arc<ClusterCipher>>,
+) -> anyhow::Result<()> {
     let addr: SocketAddr = ([0, 0, 0, 0], port).into();
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|e| anyhow::anyhow!("failed to bind KV data plane to {addr}: {e}"))?;
-    tracing::info!(%addr, "KV data plane listening");
+    tracing::info!(%addr, encrypted = cipher.is_some(), "KV data plane listening");
 
     loop {
         let (stream, peer) = match listener.accept().await {
@@ -73,87 +102,196 @@ pub async fn serve(store: Arc<Store>, port: u16) -> anyhow::Result<()> {
             }
         };
         let store = Arc::clone(&store);
+        let cipher = cipher.clone();
         tokio::spawn(async move {
-            if let Err(e) = handle_connection(stream, &store).await {
+            if let Err(e) = handle_connection(stream, &store, cipher.as_deref()).await {
                 tracing::debug!(%peer, %e, "KV data plane connection error");
             }
         });
     }
 }
 
-/// Handle a single TCP connection: read op + key, dispatch GET or SET.
-async fn handle_connection(mut stream: TcpStream, store: &Store) -> anyhow::Result<()> {
-    // Read op code.
-    let op = stream.read_u8().await?;
+/// A parsed data plane request.
+struct Request {
+    /// Op code ([`OP_GET`] or [`OP_SET`]).
+    op: u8,
+    /// The key being fetched or stored.
+    key: String,
+    /// The value for SET requests.
+    value: Option<Vec<u8>>,
+}
 
-    // Read key length.
-    let key_len = stream.read_u32().await?;
-    if key_len > MAX_KEY_LEN {
-        anyhow::bail!("key length {key_len} exceeds maximum {MAX_KEY_LEN}");
-    }
+/// Handle a single TCP connection: read one request, write one response.
+async fn handle_connection(
+    mut stream: TcpStream,
+    store: &Store,
+    cipher: Option<&ClusterCipher>,
+) -> anyhow::Result<()> {
+    let request = read_request(&mut stream, cipher).await?;
 
-    // Read key bytes.
-    let mut key_buf = vec![0u8; key_len as usize];
-    stream.read_exact(&mut key_buf).await?;
-    let key = String::from_utf8(key_buf).map_err(|_| anyhow::anyhow!("invalid UTF-8 key"))?;
-
-    match op {
+    let response = match request.op {
         OP_GET => {
-            // Look up in local store and write response.
-            if let Some(value) = store.get(&key) {
+            // Look up in local store and build the response.
+            if let Some(value) = store.get(&request.key) {
                 let len = u32::try_from(value.len()).unwrap_or(NOT_FOUND_SENTINEL - 1);
-                stream.write_u32(len).await?;
-                stream.write_all(&value).await?;
+                let mut response = Vec::with_capacity(4 + value.len());
+                response.extend_from_slice(&len.to_be_bytes());
+                response.extend_from_slice(&value);
+                response
             } else {
-                stream.write_u32(NOT_FOUND_SENTINEL).await?;
+                NOT_FOUND_SENTINEL.to_be_bytes().to_vec()
             }
         }
         OP_SET => {
-            // Read value length + value bytes.
-            let value_len = stream.read_u32().await?;
-            if value_len > MAX_VALUE_LEN {
-                anyhow::bail!("value length {value_len} exceeds maximum {MAX_VALUE_LEN}");
-            }
-            let mut value_buf = vec![0u8; value_len as usize];
-            stream.read_exact(&mut value_buf).await?;
-
-            let ok = store.set(key, value_buf, None);
-            stream.write_u8(if ok { SET_OK } else { SET_REJECTED }).await?;
+            let value = request.value.expect("SET request always carries a value");
+            let ok = store.set(request.key, value, None);
+            vec![if ok { SET_OK } else { SET_REJECTED }]
         }
         other => {
             anyhow::bail!("unknown op code: {other:#04x}");
         }
+    };
+
+    write_message(&mut stream, &response, cipher).await
+}
+
+/// Read and validate one request from the stream.
+///
+/// In plaintext mode the fields are read incrementally off the wire; in
+/// encrypted mode one sealed frame is read and parsed in memory.
+async fn read_request(
+    stream: &mut TcpStream,
+    cipher: Option<&ClusterCipher>,
+) -> anyhow::Result<Request> {
+    if let Some(cipher) = cipher {
+        let frame = read_frame(stream, cipher).await?;
+        return parse_request(&frame);
     }
 
+    // Plaintext: incremental reads, byte-compatible with older nodes.
+    let op = stream.read_u8().await?;
+
+    let key_len = stream.read_u32().await?;
+    if key_len > MAX_KEY_LEN {
+        anyhow::bail!("key length {key_len} exceeds maximum {MAX_KEY_LEN}");
+    }
+    let mut key_buf = vec![0u8; key_len as usize];
+    stream.read_exact(&mut key_buf).await?;
+    let key = String::from_utf8(key_buf).map_err(|_| anyhow::anyhow!("invalid UTF-8 key"))?;
+
+    let value = if op == OP_SET {
+        let value_len = stream.read_u32().await?;
+        if value_len > MAX_VALUE_LEN {
+            anyhow::bail!("value length {value_len} exceeds maximum {MAX_VALUE_LEN}");
+        }
+        let mut value_buf = vec![0u8; value_len as usize];
+        stream.read_exact(&mut value_buf).await?;
+        Some(value_buf)
+    } else {
+        None
+    };
+
+    Ok(Request { op, key, value })
+}
+
+/// Parse a plaintext request message from a decrypted frame.
+fn parse_request(mut buf: &[u8]) -> anyhow::Result<Request> {
+    let op = take_u8(&mut buf)?;
+
+    let key_len = take_u32(&mut buf)?;
+    if key_len > MAX_KEY_LEN {
+        anyhow::bail!("key length {key_len} exceeds maximum {MAX_KEY_LEN}");
+    }
+    let key = String::from_utf8(take_bytes(&mut buf, key_len as usize)?.to_vec())
+        .map_err(|_| anyhow::anyhow!("invalid UTF-8 key"))?;
+
+    let value = if op == OP_SET {
+        let value_len = take_u32(&mut buf)?;
+        if value_len > MAX_VALUE_LEN {
+            anyhow::bail!("value length {value_len} exceeds maximum {MAX_VALUE_LEN}");
+        }
+        Some(take_bytes(&mut buf, value_len as usize)?.to_vec())
+    } else {
+        None
+    };
+
+    Ok(Request { op, key, value })
+}
+
+/// Write one protocol message, sealing it into a frame when encrypted.
+async fn write_message(
+    stream: &mut TcpStream,
+    message: &[u8],
+    cipher: Option<&ClusterCipher>,
+) -> anyhow::Result<()> {
+    match cipher {
+        Some(cipher) => {
+            let sealed = cipher.seal(message)?;
+            let len = u32::try_from(sealed.len())
+                .map_err(|_| anyhow::anyhow!("sealed frame too large"))?;
+            stream.write_u32(len).await?;
+            stream.write_all(&sealed).await?;
+        }
+        None => {
+            stream.write_all(message).await?;
+        }
+    }
     stream.flush().await?;
     Ok(())
+}
+
+/// Read one sealed frame and decrypt it.
+async fn read_frame(stream: &mut TcpStream, cipher: &ClusterCipher) -> anyhow::Result<Vec<u8>> {
+    let frame_len = stream.read_u32().await?;
+    if frame_len > MAX_FRAME_LEN {
+        anyhow::bail!(
+            "frame length {frame_len} exceeds maximum {MAX_FRAME_LEN} \
+             (peer sending plaintext to an encrypted data plane?)"
+        );
+    }
+    let mut frame = vec![0u8; frame_len as usize];
+    stream.read_exact(&mut frame).await?;
+    cipher.open(&frame).ok_or_else(|| {
+        anyhow::anyhow!("failed to authenticate KV data plane frame (wrong cluster secret?)")
+    })
 }
 
 /// Fetch a value from a remote node's KV data plane.
 ///
 /// Opens a TCP connection to `addr`, sends a GET request, and reads the
 /// response. Returns `None` if the remote node does not have the key.
+/// `cipher` must match the remote node's setting (both `Some` with the
+/// same secret, or both `None`).
 ///
 /// # Errors
 ///
-/// Returns an error on connection or I/O failure.
-pub async fn fetch_remote(addr: SocketAddr, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+/// Returns an error on connection or I/O failure, or when the peer's
+/// encryption setting or secret does not match.
+pub async fn fetch_remote(
+    addr: SocketAddr,
+    key: &str,
+    cipher: Option<&ClusterCipher>,
+) -> anyhow::Result<Option<Vec<u8>>> {
     let mut stream = TcpStream::connect(addr).await?;
 
     // Send GET op + key.
-    stream.write_u8(OP_GET).await?;
-    let key_bytes = key.as_bytes();
-    let key_len = u32::try_from(key_bytes.len()).map_err(|_| anyhow::anyhow!("key too long"))?;
-    stream.write_u32(key_len).await?;
-    stream.write_all(key_bytes).await?;
-    stream.flush().await?;
+    write_message(&mut stream, &encode_get_request(key)?, cipher).await?;
 
     // Read response.
+    if let Some(cipher) = cipher {
+        let frame = read_frame(&mut stream, cipher).await?;
+        let mut buf = frame.as_slice();
+        let value_len = take_u32(&mut buf)?;
+        if value_len == NOT_FOUND_SENTINEL {
+            return Ok(None);
+        }
+        return Ok(Some(take_bytes(&mut buf, value_len as usize)?.to_vec()));
+    }
+
     let value_len = stream.read_u32().await?;
     if value_len == NOT_FOUND_SENTINEL {
         return Ok(None);
     }
-
     let mut buf = vec![0u8; value_len as usize];
     stream.read_exact(&mut buf).await?;
     Ok(Some(buf))
@@ -162,30 +300,83 @@ pub async fn fetch_remote(addr: SocketAddr, key: &str) -> anyhow::Result<Option<
 /// Store a value on a remote node's KV data plane.
 ///
 /// Opens a TCP connection to `addr`, sends a SET request with the key
-/// and value, and reads the status response.
+/// and value, and reads the status response. `cipher` must match the
+/// remote node's setting (both `Some` with the same secret, or both
+/// `None`).
 ///
 /// # Errors
 ///
-/// Returns an error on connection or I/O failure, or if the remote
-/// store rejected the write (e.g., memory limit with `NoEviction`).
-pub async fn store_remote(addr: SocketAddr, key: &str, value: &[u8]) -> anyhow::Result<bool> {
+/// Returns an error on connection or I/O failure, or when the peer's
+/// encryption setting or secret does not match.
+pub async fn store_remote(
+    addr: SocketAddr,
+    key: &str,
+    value: &[u8],
+    cipher: Option<&ClusterCipher>,
+) -> anyhow::Result<bool> {
     let mut stream = TcpStream::connect(addr).await?;
 
     // Send SET op + key + value.
-    stream.write_u8(OP_SET).await?;
-    let key_bytes = key.as_bytes();
-    let key_len = u32::try_from(key_bytes.len()).map_err(|_| anyhow::anyhow!("key too long"))?;
-    stream.write_u32(key_len).await?;
-    stream.write_all(key_bytes).await?;
-    let value_len = u32::try_from(value.len())
-        .map_err(|_| anyhow::anyhow!("value too large for TCP data plane"))?;
-    stream.write_u32(value_len).await?;
-    stream.write_all(value).await?;
-    stream.flush().await?;
+    write_message(&mut stream, &encode_set_request(key, value)?, cipher).await?;
 
     // Read status response.
-    let status = stream.read_u8().await?;
+    let status = if let Some(cipher) = cipher {
+        let frame = read_frame(&mut stream, cipher).await?;
+        take_u8(&mut frame.as_slice())?
+    } else {
+        stream.read_u8().await?
+    };
     Ok(status == SET_OK)
+}
+
+/// Encode a plaintext GET request message.
+fn encode_get_request(key: &str) -> anyhow::Result<Vec<u8>> {
+    let key_bytes = key.as_bytes();
+    let key_len = u32::try_from(key_bytes.len()).map_err(|_| anyhow::anyhow!("key too long"))?;
+    let mut message = Vec::with_capacity(1 + 4 + key_bytes.len());
+    message.push(OP_GET);
+    message.extend_from_slice(&key_len.to_be_bytes());
+    message.extend_from_slice(key_bytes);
+    Ok(message)
+}
+
+/// Encode a plaintext SET request message.
+fn encode_set_request(key: &str, value: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let key_bytes = key.as_bytes();
+    let key_len = u32::try_from(key_bytes.len()).map_err(|_| anyhow::anyhow!("key too long"))?;
+    let value_len = u32::try_from(value.len())
+        .map_err(|_| anyhow::anyhow!("value too large for TCP data plane"))?;
+    let mut message = Vec::with_capacity(1 + 4 + key_bytes.len() + 4 + value.len());
+    message.push(OP_SET);
+    message.extend_from_slice(&key_len.to_be_bytes());
+    message.extend_from_slice(key_bytes);
+    message.extend_from_slice(&value_len.to_be_bytes());
+    message.extend_from_slice(value);
+    Ok(message)
+}
+
+/// Take one byte from the front of `buf`.
+fn take_u8(buf: &mut &[u8]) -> anyhow::Result<u8> {
+    let (byte, rest) = buf.split_first().ok_or_else(|| anyhow::anyhow!("truncated message"))?;
+    *buf = rest;
+    Ok(*byte)
+}
+
+/// Take a big-endian u32 from the front of `buf`.
+fn take_u32(buf: &mut &[u8]) -> anyhow::Result<u32> {
+    let bytes: [u8; 4] =
+        take_bytes(buf, 4)?.try_into().expect("take_bytes(4) returns exactly 4 bytes");
+    Ok(u32::from_be_bytes(bytes))
+}
+
+/// Take `len` bytes from the front of `buf`.
+fn take_bytes<'a>(buf: &mut &'a [u8], len: usize) -> anyhow::Result<&'a [u8]> {
+    if buf.len() < len {
+        anyhow::bail!("truncated message: expected {len} bytes, got {}", buf.len());
+    }
+    let (bytes, rest) = buf.split_at(len);
+    *buf = rest;
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -193,18 +384,24 @@ mod tests {
     use super::*;
 
     /// Spawn a data plane listener that handles a single connection.
-    async fn spawn_single_handler(store: Arc<Store>) -> SocketAddr {
+    async fn spawn_single_handler(
+        store: Arc<Store>,
+        cipher: Option<Arc<ClusterCipher>>,
+    ) -> SocketAddr {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             let (stream, _) = listener.accept().await.unwrap();
-            handle_connection(stream, &store).await.unwrap();
+            handle_connection(stream, &store, cipher.as_deref()).await.unwrap();
         });
         addr
     }
 
     /// Spawn a data plane listener that handles multiple connections.
-    async fn spawn_multi_handler(store: Arc<Store>) -> SocketAddr {
+    async fn spawn_multi_handler(
+        store: Arc<Store>,
+        cipher: Option<Arc<ClusterCipher>>,
+    ) -> SocketAddr {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
@@ -213,12 +410,17 @@ mod tests {
                     break;
                 };
                 let store = Arc::clone(&store);
+                let cipher = cipher.clone();
                 tokio::spawn(async move {
-                    let _ = handle_connection(stream, &store).await;
+                    let _ = handle_connection(stream, &store, cipher.as_deref()).await;
                 });
             }
         });
         addr
+    }
+
+    fn test_cipher(secret: &str) -> Arc<ClusterCipher> {
+        Arc::new(ClusterCipher::for_kv_data_plane(secret))
     }
 
     #[tokio::test]
@@ -226,8 +428,8 @@ mod tests {
         let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
         store.set("hello".to_string(), b"world".to_vec(), None);
 
-        let addr = spawn_single_handler(Arc::clone(&store)).await;
-        let result = fetch_remote(addr, "hello").await.unwrap();
+        let addr = spawn_single_handler(Arc::clone(&store), None).await;
+        let result = fetch_remote(addr, "hello", None).await.unwrap();
         assert_eq!(result, Some(b"world".to_vec()));
     }
 
@@ -235,8 +437,8 @@ mod tests {
     async fn get_roundtrip_not_found() {
         let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
 
-        let addr = spawn_single_handler(Arc::clone(&store)).await;
-        let result = fetch_remote(addr, "missing").await.unwrap();
+        let addr = spawn_single_handler(Arc::clone(&store), None).await;
+        let result = fetch_remote(addr, "missing", None).await.unwrap();
         assert_eq!(result, None);
     }
 
@@ -244,10 +446,10 @@ mod tests {
     async fn set_roundtrip() {
         let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
 
-        let addr = spawn_multi_handler(Arc::clone(&store)).await;
+        let addr = spawn_multi_handler(Arc::clone(&store), None).await;
 
         // Store a value remotely.
-        let ok = store_remote(addr, "remote_key", b"remote_val").await.unwrap();
+        let ok = store_remote(addr, "remote_key", b"remote_val", None).await.unwrap();
         assert!(ok);
 
         // Verify it landed in the local store.
@@ -259,13 +461,13 @@ mod tests {
     async fn set_then_get_roundtrip() {
         let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
 
-        let addr = spawn_multi_handler(Arc::clone(&store)).await;
+        let addr = spawn_multi_handler(Arc::clone(&store), None).await;
 
         // Store remotely via TCP, then fetch remotely via TCP.
-        let ok = store_remote(addr, "k", b"v").await.unwrap();
+        let ok = store_remote(addr, "k", b"v", None).await.unwrap();
         assert!(ok);
 
-        let result = fetch_remote(addr, "k").await.unwrap();
+        let result = fetch_remote(addr, "k", None).await.unwrap();
         assert_eq!(result, Some(b"v".to_vec()));
     }
 
@@ -276,13 +478,13 @@ mod tests {
             store.set(format!("k{i}"), format!("v{i}").into_bytes(), None);
         }
 
-        let addr = spawn_multi_handler(Arc::clone(&store)).await;
+        let addr = spawn_multi_handler(Arc::clone(&store), None).await;
 
         // Launch 10 concurrent fetches.
         let mut handles = Vec::new();
         for i in 0..10 {
             let key = format!("k{i}");
-            handles.push(tokio::spawn(async move { fetch_remote(addr, &key).await }));
+            handles.push(tokio::spawn(async move { fetch_remote(addr, &key, None).await }));
         }
 
         for (i, handle) in handles.into_iter().enumerate() {
@@ -295,7 +497,7 @@ mod tests {
     async fn connection_refused_returns_error() {
         // Connect to a port that is not listening.
         let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
-        let result = fetch_remote(addr, "key").await;
+        let result = fetch_remote(addr, "key", None).await;
         assert!(result.is_err());
     }
 
@@ -303,15 +505,121 @@ mod tests {
     async fn set_large_value() {
         let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
 
-        let addr = spawn_multi_handler(Arc::clone(&store)).await;
+        let addr = spawn_multi_handler(Arc::clone(&store), None).await;
 
         // Store a 100 KiB value.
         let big_value = vec![42u8; 100 * 1024];
-        let ok = store_remote(addr, "big", &big_value).await.unwrap();
+        let ok = store_remote(addr, "big", &big_value, None).await.unwrap();
         assert!(ok);
 
-        let result = fetch_remote(addr, "big").await.unwrap();
+        let result = fetch_remote(addr, "big", None).await.unwrap();
         assert_eq!(result.as_ref().map(Vec::len), Some(big_value.len()));
         assert_eq!(result, Some(big_value));
+    }
+
+    #[tokio::test]
+    async fn encrypted_get_set_roundtrip() {
+        let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
+        let cipher = test_cipher("data-plane-secret");
+
+        let addr = spawn_multi_handler(Arc::clone(&store), Some(Arc::clone(&cipher))).await;
+
+        let ok = store_remote(addr, "enc_key", b"enc_val", Some(&cipher)).await.unwrap();
+        assert!(ok);
+        assert_eq!(store.get("enc_key"), Some(b"enc_val".to_vec()));
+
+        let result = fetch_remote(addr, "enc_key", Some(&cipher)).await.unwrap();
+        assert_eq!(result, Some(b"enc_val".to_vec()));
+
+        let missing = fetch_remote(addr, "nope", Some(&cipher)).await.unwrap();
+        assert_eq!(missing, None);
+    }
+
+    #[tokio::test]
+    async fn encrypted_large_value_roundtrip() {
+        let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
+        let cipher = test_cipher("data-plane-secret");
+
+        let addr = spawn_multi_handler(Arc::clone(&store), Some(Arc::clone(&cipher))).await;
+
+        let big_value = vec![7u8; 100 * 1024];
+        let ok = store_remote(addr, "big", &big_value, Some(&cipher)).await.unwrap();
+        assert!(ok);
+
+        let result = fetch_remote(addr, "big", Some(&cipher)).await.unwrap();
+        assert_eq!(result, Some(big_value));
+    }
+
+    #[tokio::test]
+    async fn wrong_secret_is_rejected() {
+        let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
+        let server_cipher = test_cipher("right-secret");
+        let client_cipher = test_cipher("wrong-secret");
+
+        let addr = spawn_multi_handler(Arc::clone(&store), Some(server_cipher)).await;
+
+        // Neither reads nor writes must succeed with the wrong secret.
+        let fetch = fetch_remote(addr, "key", Some(&client_cipher)).await;
+        assert!(fetch.is_err(), "wrong-secret fetch must fail");
+
+        let set = store_remote(addr, "key", b"injected", Some(&client_cipher)).await;
+        assert!(set.is_err(), "wrong-secret store must fail");
+        assert_eq!(store.get("key"), None, "wrong-secret write must not land in the store");
+    }
+
+    #[tokio::test]
+    async fn plaintext_client_rejected_by_encrypted_server() {
+        let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
+        store.set("key".to_string(), b"secret-value".to_vec(), None);
+        let server_cipher = test_cipher("server-secret");
+
+        let addr = spawn_multi_handler(Arc::clone(&store), Some(server_cipher)).await;
+
+        let result = fetch_remote(addr, "key", None).await;
+        assert!(result.is_err(), "plaintext client must not read from an encrypted server");
+    }
+
+    #[tokio::test]
+    async fn encrypted_client_rejected_by_plaintext_server() {
+        let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
+        let client_cipher = test_cipher("client-secret");
+
+        let addr = spawn_multi_handler(Arc::clone(&store), None).await;
+
+        // The plaintext server misparses the frame header and errors,
+        // returns garbage that fails frame authentication client-side,
+        // or (rarely) stalls waiting for bytes that never come — the
+        // timeout covers that case. All outcomes are a rejection.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            fetch_remote(addr, "key", Some(&client_cipher)),
+        )
+        .await;
+        assert!(
+            !matches!(result, Ok(Ok(_))),
+            "encrypted client must not accept a plaintext server"
+        );
+    }
+
+    #[test]
+    fn parse_request_rejects_truncated_input() {
+        assert!(parse_request(&[]).is_err());
+        assert!(parse_request(&[OP_GET]).is_err());
+        assert!(parse_request(&[OP_GET, 0, 0, 0, 5, b'a']).is_err());
+    }
+
+    #[test]
+    fn parse_request_roundtrips_encoders() {
+        let get = encode_get_request("mykey").unwrap();
+        let parsed = parse_request(&get).unwrap();
+        assert_eq!(parsed.op, OP_GET);
+        assert_eq!(parsed.key, "mykey");
+        assert!(parsed.value.is_none());
+
+        let set = encode_set_request("mykey", b"myvalue").unwrap();
+        let parsed = parse_request(&set).unwrap();
+        assert_eq!(parsed.op, OP_SET);
+        assert_eq!(parsed.key, "mykey");
+        assert_eq!(parsed.value.as_deref(), Some(b"myvalue".as_slice()));
     }
 }

--- a/crates/ephpm-cluster/src/lib.rs
+++ b/crates/ephpm-cluster/src/lib.rs
@@ -17,9 +17,11 @@ pub mod clustered_store;
 pub mod gossip_kv;
 pub mod kv_data_plane;
 pub mod node;
+pub mod secure_transport;
 pub mod sqlite_election;
 
 pub use clustered_store::ClusteredStore;
 pub use kv_data_plane as data_plane;
 pub use node::{ClusterHandle, NodeInfo, NodeState, start_gossip};
+pub use secure_transport::{ClusterCipher, EncryptedUdpTransport};
 pub use sqlite_election::{ElectedRole, SqliteElection};

--- a/crates/ephpm-cluster/src/node.rs
+++ b/crates/ephpm-cluster/src/node.rs
@@ -12,6 +12,8 @@ use chitchat::transport::UdpTransport;
 use chitchat::{ChitchatConfig, ChitchatHandle, ChitchatId, FailureDetectorConfig, spawn_chitchat};
 use ephpm_config::ClusterConfig;
 
+use crate::secure_transport::EncryptedUdpTransport;
+
 /// Information about a single cluster node.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct NodeInfo {
@@ -130,6 +132,12 @@ impl ClusterHandle {
 /// Binds a UDP listener on `config.bind`, joins seed nodes from
 /// `config.join`, and spawns the gossip background task.
 ///
+/// When `config.secret` is non-empty, gossip runs over the
+/// [`EncryptedUdpTransport`] — every datagram is sealed with
+/// ChaCha20-Poly1305 and peers without the matching secret are
+/// invisible. When empty, gossip is plaintext UDP and a warning is
+/// logged recommending a secret on untrusted networks.
+///
 /// # Errors
 ///
 /// Returns an error if the bind address is invalid or the UDP socket
@@ -166,15 +174,28 @@ pub async fn start_gossip(config: &ClusterConfig) -> anyhow::Result<ClusterHandl
         extra_liveness_predicate: None,
     };
 
-    let handle = spawn_chitchat(chitchat_config, vec![], &UdpTransport)
-        .await
-        .context("failed to spawn chitchat gossip")?;
+    // With a secret, every gossip datagram is sealed with a key derived
+    // from it — nodes without the matching secret cannot join, read, or
+    // inject. Without one, gossip is plaintext UDP.
+    let encrypted = !config.secret.is_empty();
+    let handle = if encrypted {
+        let transport = EncryptedUdpTransport::new(&config.secret);
+        spawn_chitchat(chitchat_config, vec![], &transport).await
+    } else {
+        tracing::warn!(
+            "cluster.secret is not set — gossip and KV data plane traffic is unauthenticated \
+             plaintext; set [cluster] secret when running on untrusted networks"
+        );
+        spawn_chitchat(chitchat_config, vec![], &UdpTransport).await
+    }
+    .context("failed to spawn chitchat gossip")?;
 
     tracing::info!(
         %node_id,
         %listen_addr,
         seeds = ?config.join,
         cluster_id = %config.cluster_id,
+        encrypted,
         "gossip started"
     );
 

--- a/crates/ephpm-cluster/src/secure_transport.rs
+++ b/crates/ephpm-cluster/src/secure_transport.rs
@@ -1,0 +1,383 @@
+//! Symmetric encryption for cluster transport.
+//!
+//! When `[cluster] secret` is set, all inter-node traffic — gossip UDP
+//! datagrams and KV data plane TCP frames — is authenticated and
+//! encrypted with ChaCha20-Poly1305. The 32-byte keys are derived from
+//! the shared secret via HKDF-SHA256 with domain-separated info strings
+//! so the gossip plane and the KV data plane never share a key:
+//!
+//! - gossip UDP: `"ephpm-gossip-v1"`
+//! - KV data plane TCP: `"ephpm-kv-data-v1"`
+//!
+//! ## Sealed message layout
+//!
+//! ```text
+//! [nonce: 12 bytes (random)][ciphertext + 16-byte Poly1305 tag]
+//! ```
+//!
+//! Nodes without the right secret cannot join the gossip mesh, read KV
+//! traffic, or inject messages: undecryptable datagrams are silently
+//! dropped (rate-limited warning), so a wrong-secret or plaintext peer
+//! is invisible rather than an error loop.
+//!
+//! The gossip side plugs into chitchat as an [`EncryptedUdpTransport`].
+//! chitchat's [`Socket`] trait sends and receives typed
+//! [`ChitchatMessage`]s (serialization happens inside the socket), so
+//! the encrypted transport owns its own UDP socket and mirrors
+//! chitchat's `UdpTransport`, sealing after serialization and opening
+//! before deserialization. A generic wrapper over an arbitrary inner
+//! `Transport` is not possible with this API — there is no byte-level
+//! hook to intercept.
+
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use chitchat::transport::{Socket, Transport};
+use chitchat::{ChitchatMessage, Deserializable, Serializable};
+use hkdf::Hkdf;
+use sha2::Sha256;
+
+/// HKDF domain-separation info string for the gossip UDP key.
+const GOSSIP_INFO: &[u8] = b"ephpm-gossip-v1";
+
+/// HKDF domain-separation info string for the KV data plane key.
+const KV_DATA_INFO: &[u8] = b"ephpm-kv-data-v1";
+
+/// ChaCha20-Poly1305 nonce length in bytes.
+const NONCE_LEN: usize = 12;
+
+/// Poly1305 authentication tag length in bytes.
+const TAG_LEN: usize = 16;
+
+/// Total sealing overhead per message: nonce + tag.
+pub const SEAL_OVERHEAD: usize = NONCE_LEN + TAG_LEN;
+
+/// Maximum UDP datagram payload size (mirrors chitchat's internal
+/// `MAX_UDP_DATAGRAM_PAYLOAD_SIZE`, which is not public).
+const MAX_UDP_PAYLOAD: usize = 65_507;
+
+/// Minimum interval between `warn!`-level logs for dropped datagrams.
+///
+/// A peer with the wrong secret retries every gossip interval, so
+/// without rate limiting the log would fill with one warning per
+/// second per bad peer. Drops within the window are logged at debug.
+const DROP_WARN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A symmetric cipher for sealing and opening cluster messages.
+///
+/// Construct with [`ClusterCipher::for_gossip`] or
+/// [`ClusterCipher::for_kv_data_plane`] — the two derive different keys
+/// from the same secret so ciphertexts are never valid across planes.
+#[derive(Clone)]
+pub struct ClusterCipher {
+    cipher: ChaCha20Poly1305,
+}
+
+impl std::fmt::Debug for ClusterCipher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print key material.
+        f.debug_struct("ClusterCipher").finish_non_exhaustive()
+    }
+}
+
+impl ClusterCipher {
+    /// Derive a cipher from the shared secret with the given HKDF info.
+    fn derive(secret: &str, info: &[u8]) -> Self {
+        let hkdf = Hkdf::<Sha256>::new(None, secret.as_bytes());
+        let mut key = [0u8; 32];
+        hkdf.expand(info, &mut key).expect("32 bytes is a valid HKDF-SHA256 output length");
+        Self { cipher: ChaCha20Poly1305::new(Key::from_slice(&key)) }
+    }
+
+    /// Create the cipher used for gossip UDP datagrams.
+    #[must_use]
+    pub fn for_gossip(secret: &str) -> Self {
+        Self::derive(secret, GOSSIP_INFO)
+    }
+
+    /// Create the cipher used for KV data plane TCP frames.
+    #[must_use]
+    pub fn for_kv_data_plane(secret: &str) -> Self {
+        Self::derive(secret, KV_DATA_INFO)
+    }
+
+    /// Seal a plaintext message: `nonce || ciphertext+tag`.
+    ///
+    /// A fresh random 12-byte nonce is generated per message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encryption fails (only possible for inputs
+    /// near the ChaCha20 length limit of 256 GiB).
+    pub fn seal(&self, plaintext: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let ciphertext = self
+            .cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|_| anyhow::anyhow!("ChaCha20-Poly1305 encryption failed"))?;
+        let mut sealed = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        sealed.extend_from_slice(&nonce);
+        sealed.extend_from_slice(&ciphertext);
+        Ok(sealed)
+    }
+
+    /// Open a sealed message, returning the plaintext.
+    ///
+    /// Returns `None` if the message is too short, was sealed with a
+    /// different key, or failed authentication (tampered). Callers must
+    /// treat `None` as "drop and ignore" — never as a protocol error to
+    /// report back to the peer.
+    #[must_use]
+    pub fn open(&self, sealed: &[u8]) -> Option<Vec<u8>> {
+        if sealed.len() < SEAL_OVERHEAD {
+            return None;
+        }
+        let (nonce, ciphertext) = sealed.split_at(NONCE_LEN);
+        self.cipher.decrypt(Nonce::from_slice(nonce), ciphertext).ok()
+    }
+}
+
+/// A chitchat [`Transport`] that seals every gossip datagram with
+/// ChaCha20-Poly1305 (key derived from `[cluster] secret`).
+///
+/// Peers without the matching secret cannot join, read, or inject:
+/// their datagrams fail authentication and are dropped, and this node's
+/// datagrams are undecryptable garbage to them.
+pub struct EncryptedUdpTransport {
+    cipher: ClusterCipher,
+}
+
+impl EncryptedUdpTransport {
+    /// Create a transport whose gossip key is derived from `secret`.
+    #[must_use]
+    pub fn new(secret: &str) -> Self {
+        Self { cipher: ClusterCipher::for_gossip(secret) }
+    }
+}
+
+#[async_trait]
+impl Transport for EncryptedUdpTransport {
+    async fn open(&self, listen_addr: SocketAddr) -> anyhow::Result<Box<dyn Socket>> {
+        let socket = tokio::net::UdpSocket::bind(listen_addr)
+            .await
+            .with_context(|| format!("failed to bind {listen_addr}/UDP for encrypted gossip"))?;
+        Ok(Box::new(EncryptedUdpSocket {
+            cipher: self.cipher.clone(),
+            socket,
+            buf_send: Vec::with_capacity(MAX_UDP_PAYLOAD),
+            buf_recv: vec![0u8; MAX_UDP_PAYLOAD].into_boxed_slice(),
+            last_drop_warn: None,
+            drops_since_warn: 0,
+        }))
+    }
+}
+
+/// UDP socket that seals on send and opens on receive.
+struct EncryptedUdpSocket {
+    cipher: ClusterCipher,
+    socket: tokio::net::UdpSocket,
+    buf_send: Vec<u8>,
+    buf_recv: Box<[u8]>,
+    /// When the last `warn!` for a dropped datagram was emitted.
+    last_drop_warn: Option<Instant>,
+    /// Datagrams dropped since the last `warn!` (logged at debug).
+    drops_since_warn: u64,
+}
+
+#[async_trait]
+impl Socket for EncryptedUdpSocket {
+    async fn send(&mut self, to: SocketAddr, message: ChitchatMessage) -> anyhow::Result<()> {
+        self.buf_send.clear();
+        message.serialize(&mut self.buf_send);
+        let sealed = self.cipher.seal(&self.buf_send)?;
+        if sealed.len() > MAX_UDP_PAYLOAD {
+            // chitchat packs messages up to the UDP payload limit; the
+            // 28-byte sealing overhead can push a maximally-packed
+            // datagram over it. Drop rather than fail the gossip loop —
+            // the next round retransmits smaller deltas.
+            tracing::warn!(
+                %to,
+                sealed_len = sealed.len(),
+                "sealed gossip datagram exceeds UDP payload limit, dropping"
+            );
+            return Ok(());
+        }
+        self.socket
+            .send_to(&sealed, to)
+            .await
+            .with_context(|| format!("failed to send encrypted gossip datagram to {to}"))?;
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> anyhow::Result<(SocketAddr, ChitchatMessage)> {
+        loop {
+            let (len, from) = self
+                .socket
+                .recv_from(&mut self.buf_recv)
+                .await
+                .context("error receiving encrypted gossip datagram")?;
+
+            // A wrong-secret or plaintext peer must be invisible: drop
+            // undecryptable datagrams and keep listening.
+            let Some(plaintext) = self.cipher.open(&self.buf_recv[..len]) else {
+                self.log_drop(from, len);
+                continue;
+            };
+
+            let mut cursor = plaintext.as_slice();
+            match ChitchatMessage::deserialize(&mut cursor) {
+                Ok(message) => return Ok((from, message)),
+                Err(e) => {
+                    // Authenticated but malformed — a same-secret peer
+                    // speaking an incompatible chitchat version.
+                    tracing::warn!(%from, error = %e, "dropping undeserializable gossip message");
+                }
+            }
+        }
+    }
+}
+
+impl EncryptedUdpSocket {
+    /// Log a dropped (undecryptable) datagram, rate-limiting `warn!` to
+    /// once per [`DROP_WARN_INTERVAL`]; the rest go to debug.
+    fn log_drop(&mut self, from: SocketAddr, len: usize) {
+        self.drops_since_warn += 1;
+        let warn_due = self.last_drop_warn.is_none_or(|t| t.elapsed() >= DROP_WARN_INTERVAL);
+        if warn_due {
+            tracing::warn!(
+                %from,
+                payload_len = len,
+                dropped = self.drops_since_warn,
+                "dropping undecryptable gossip datagram(s) — peer has the wrong cluster \
+                 secret or is sending plaintext"
+            );
+            self.last_drop_warn = Some(Instant::now());
+            self.drops_since_warn = 0;
+        } else {
+            tracing::debug!(%from, payload_len = len, "dropping undecryptable gossip datagram");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seal_open_roundtrip() {
+        let cipher = ClusterCipher::for_gossip("test-secret");
+        let sealed = cipher.seal(b"hello cluster").unwrap();
+        assert_eq!(cipher.open(&sealed).unwrap(), b"hello cluster");
+    }
+
+    #[test]
+    fn seal_is_randomized() {
+        let cipher = ClusterCipher::for_gossip("test-secret");
+        let a = cipher.seal(b"same plaintext").unwrap();
+        let b = cipher.seal(b"same plaintext").unwrap();
+        assert_ne!(a, b, "each seal must use a fresh nonce");
+    }
+
+    #[test]
+    fn wrong_secret_fails_to_open() {
+        let sealed = ClusterCipher::for_gossip("secret-a").seal(b"data").unwrap();
+        assert!(ClusterCipher::for_gossip("secret-b").open(&sealed).is_none());
+    }
+
+    #[test]
+    fn domain_separation_between_planes() {
+        // Same secret, different info string → different key.
+        let sealed = ClusterCipher::for_gossip("shared").seal(b"data").unwrap();
+        assert!(ClusterCipher::for_kv_data_plane("shared").open(&sealed).is_none());
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails_to_open() {
+        let cipher = ClusterCipher::for_gossip("test-secret");
+        let mut sealed = cipher.seal(b"data").unwrap();
+        let last = sealed.len() - 1;
+        sealed[last] ^= 0x01;
+        assert!(cipher.open(&sealed).is_none());
+    }
+
+    #[test]
+    fn short_and_empty_inputs_are_rejected() {
+        let cipher = ClusterCipher::for_gossip("test-secret");
+        assert!(cipher.open(b"").is_none());
+        assert!(cipher.open(b"short").is_none());
+        assert!(cipher.open(&[0u8; SEAL_OVERHEAD - 1]).is_none());
+    }
+
+    #[test]
+    fn empty_plaintext_roundtrip() {
+        let cipher = ClusterCipher::for_kv_data_plane("test-secret");
+        let sealed = cipher.seal(b"").unwrap();
+        assert_eq!(sealed.len(), SEAL_OVERHEAD);
+        assert_eq!(cipher.open(&sealed).unwrap(), b"");
+    }
+
+    #[test]
+    fn debug_does_not_leak_key() {
+        let cipher = ClusterCipher::for_gossip("super-secret-value");
+        let debug = format!("{cipher:?}");
+        assert!(!debug.contains("super-secret-value"));
+    }
+
+    #[tokio::test]
+    async fn encrypted_udp_roundtrip() {
+        let transport = EncryptedUdpTransport::new("udp-test-secret");
+        let addr_a: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+        // Bind two sockets on ephemeral ports.
+        let sock_a = tokio::net::UdpSocket::bind(addr_a).await.unwrap();
+        let recv_addr = sock_a.local_addr().unwrap();
+        drop(sock_a); // Release so the transport can bind it.
+        let mut receiver = transport.open(recv_addr).await.unwrap();
+
+        let sock_b = tokio::net::UdpSocket::bind(addr_a).await.unwrap();
+        let send_addr = sock_b.local_addr().unwrap();
+        drop(sock_b);
+        let mut sender = transport.open(send_addr).await.unwrap();
+
+        sender.send(recv_addr, ChitchatMessage::BadCluster).await.unwrap();
+        let (from, message) = receiver.recv().await.unwrap();
+        assert_eq!(from, send_addr);
+        assert_eq!(message, ChitchatMessage::BadCluster);
+    }
+
+    #[tokio::test]
+    async fn plaintext_and_wrong_secret_datagrams_are_dropped() {
+        let transport = EncryptedUdpTransport::new("right-secret");
+        let tmp = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let recv_addr = tmp.local_addr().unwrap();
+        drop(tmp);
+        let mut receiver = transport.open(recv_addr).await.unwrap();
+
+        let raw = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        // 1. Plaintext junk — must be dropped.
+        raw.send_to(b"plaintext junk", recv_addr).await.unwrap();
+
+        // 2. A valid chitchat message sealed with the WRONG secret.
+        let wrong = ClusterCipher::for_gossip("wrong-secret");
+        let msg_bytes = ChitchatMessage::BadCluster.serialize_to_vec();
+        let sealed_wrong = wrong.seal(&msg_bytes).unwrap();
+        raw.send_to(&sealed_wrong, recv_addr).await.unwrap();
+
+        // 3. Finally a correctly sealed message — the only one received.
+        let right = ClusterCipher::for_gossip("right-secret");
+        let sealed_right = right.seal(&msg_bytes).unwrap();
+        raw.send_to(&sealed_right, recv_addr).await.unwrap();
+
+        let (from, message) = tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("receiver should get the valid datagram")
+            .unwrap();
+        assert_eq!(from, raw.local_addr().unwrap());
+        assert_eq!(message, ChitchatMessage::BadCluster);
+    }
+}

--- a/crates/ephpm-cluster/tests/clustered_store.rs
+++ b/crates/ephpm-cluster/tests/clustered_store.rs
@@ -72,7 +72,7 @@ async fn small_value_routes_via_gossip() {
     let store = local_store();
     let config = ClusterKvConfig { small_key_threshold: 64, ..ClusterKvConfig::default() };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     // A small value should go to gossip, not local store.
     cs.set("tiny".to_string(), b"abc".to_vec(), None).await;
@@ -99,7 +99,7 @@ async fn large_value_routes_to_local_store() {
     let store = local_store();
     let config = ClusterKvConfig { small_key_threshold: 8, ..ClusterKvConfig::default() };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     // A large value should go to local store.
     let big = vec![0u8; 100];
@@ -129,8 +129,8 @@ async fn small_value_replicates_via_clustered_store() {
 
     wait_for_convergence(&[&h1, &h2], 2, Duration::from_secs(10)).await;
 
-    let cs1 = ClusteredStore::new(local_store(), Arc::clone(&h1), ClusterKvConfig::default());
-    let cs2 = ClusteredStore::new(local_store(), Arc::clone(&h2), ClusterKvConfig::default());
+    let cs1 = ClusteredStore::new(local_store(), Arc::clone(&h1), ClusterKvConfig::default(), None);
+    let cs2 = ClusteredStore::new(local_store(), Arc::clone(&h2), ClusterKvConfig::default(), None);
 
     // Set on node1's clustered store.
     cs1.set("replicated".to_string(), b"data".to_vec(), None).await;
@@ -159,7 +159,7 @@ async fn exists_checks_both_tiers() {
     let store = local_store();
     let config = ClusterKvConfig { small_key_threshold: 16, ..ClusterKvConfig::default() };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     // Small key → gossip.
     cs.set("s".to_string(), b"x".to_vec(), None).await;
@@ -181,7 +181,7 @@ async fn remove_from_both_tiers() {
     let store = local_store();
     let config = ClusterKvConfig { small_key_threshold: 16, ..ClusterKvConfig::default() };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     cs.set("gs".to_string(), b"tiny".to_vec(), None).await;
     cs.set("ls".to_string(), vec![0u8; 32], None).await;
@@ -214,7 +214,7 @@ async fn hot_key_promotion_after_threshold() {
         ..ClusterKvConfig::default()
     };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     let value = b"large-value-data-here";
 
@@ -250,7 +250,7 @@ async fn hot_key_cache_respects_memory_limit() {
         ..ClusterKvConfig::default()
     };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     // First key: should fit.
     let small = vec![0u8; 50];
@@ -282,7 +282,7 @@ async fn hot_key_cache_ttl_expiry() {
         ..ClusterKvConfig::default()
     };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     cs.track_remote_fetch("expires", b"data");
     assert_eq!(cs.hot_cache_len(), 1);
@@ -312,7 +312,7 @@ async fn hot_cache_cleanup_evicts_stale() {
         ..ClusterKvConfig::default()
     };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     cs.track_remote_fetch("stale", b"data");
     assert_eq!(cs.hot_cache_len(), 1);
@@ -338,7 +338,7 @@ async fn hot_key_disabled_skips_tracking() {
         ..ClusterKvConfig::default()
     };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     cs.track_remote_fetch("ignored", b"data");
     assert_eq!(cs.hot_cache_len(), 0, "should not track when disabled");
@@ -358,7 +358,7 @@ async fn pttl_gossip_tier_key() {
     let store = local_store();
     let config = ClusterKvConfig { small_key_threshold: 64, ..ClusterKvConfig::default() };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     // Small key with TTL → gossip tier
     cs.set("tiny-ttl".to_string(), b"val".to_vec(), Some(Duration::from_secs(60))).await;
@@ -379,7 +379,7 @@ async fn pttl_local_store_key() {
     let store = local_store();
     let config = ClusterKvConfig { small_key_threshold: 8, ..ClusterKvConfig::default() };
 
-    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config);
+    let cs = ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), config, None);
 
     // Large key with TTL → local store
     let big = vec![0u8; 100];
@@ -400,8 +400,12 @@ async fn pttl_missing_key_returns_none() {
     let handle = Arc::new(start_node(port, vec![], "pttl-miss").await);
     let store = local_store();
 
-    let cs =
-        ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
+    let cs = ClusteredStore::new(
+        Arc::clone(&store),
+        Arc::clone(&handle),
+        ClusterKvConfig::default(),
+        None,
+    );
 
     // pttl for non-existent key should return None (or -2 via local store).
     // The ClusteredStore checks gossip first (returns None), then local store.
@@ -426,8 +430,12 @@ async fn local_store_accessor_returns_correct_store() {
     let handle = Arc::new(start_node(port, vec![], "accessor").await);
     let store = local_store();
 
-    let cs =
-        ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
+    let cs = ClusteredStore::new(
+        Arc::clone(&store),
+        Arc::clone(&handle),
+        ClusterKvConfig::default(),
+        None,
+    );
 
     // Write directly to local store, verify via accessor.
     store.set("direct".to_string(), b"value".to_vec(), None);
@@ -443,8 +451,12 @@ async fn set_returns_true_on_success() {
     let handle = Arc::new(start_node(port, vec![], "set-ok").await);
     let store = local_store();
 
-    let cs =
-        ClusteredStore::new(Arc::clone(&store), Arc::clone(&handle), ClusterKvConfig::default());
+    let cs = ClusteredStore::new(
+        Arc::clone(&store),
+        Arc::clone(&handle),
+        ClusterKvConfig::default(),
+        None,
+    );
 
     // Both small and large values should succeed.
     let small_ok = cs.set("s".to_string(), b"x".to_vec(), None).await;

--- a/crates/ephpm-cluster/tests/secure_gossip.rs
+++ b/crates/ephpm-cluster/tests/secure_gossip.rs
@@ -1,0 +1,133 @@
+//! Integration tests for encrypted gossip (`[cluster] secret`).
+//!
+//! Verifies that nodes sharing a secret form a cluster over the
+//! encrypted UDP transport, and that a node with the wrong secret (or
+//! no secret at all) is invisible to the cluster — it can neither join
+//! nor be joined.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use ephpm_cluster::{ClusterHandle, NodeState, start_gossip};
+use ephpm_config::ClusterConfig;
+
+/// Find a free UDP port by binding to port 0 and returning the address.
+fn free_udp_addr() -> SocketAddr {
+    let sock = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind to port 0");
+    sock.local_addr().expect("local addr")
+}
+
+/// Start a gossip node on a fresh random port, retrying on bind
+/// collisions (the port from [`free_udp_addr`] is released before use,
+/// so parallel tests can race for it).
+async fn start_node(
+    node_id: &str,
+    cluster_id: &str,
+    seeds: Vec<String>,
+    secret: &str,
+) -> ClusterHandle {
+    let mut last_err = None;
+    for _ in 0..10 {
+        let config = ClusterConfig {
+            enabled: true,
+            bind: free_udp_addr().to_string(),
+            join: seeds.clone(),
+            secret: secret.to_string(),
+            node_id: node_id.to_string(),
+            cluster_id: cluster_id.to_string(),
+            ..ClusterConfig::default()
+        };
+        match start_gossip(&config).await {
+            Ok(handle) => return handle,
+            Err(e) => last_err = Some(e),
+        }
+    }
+    panic!("{node_id} failed to start after 10 attempts: {last_err:?}");
+}
+
+#[tokio::test]
+async fn nodes_with_matching_secret_converge() {
+    let handle1 = start_node("enc-a", "test-encrypted", vec![], "shared-secret").await;
+    let seed = handle1.self_node().gossip_addr;
+
+    let handle2 = start_node("enc-b", "test-encrypted", vec![seed], "shared-secret").await;
+
+    // Wait for gossip convergence over the encrypted transport.
+    let mut discovered = false;
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        if handle1.live_node_count().await >= 2 {
+            discovered = true;
+            break;
+        }
+    }
+    assert!(discovered, "nodes with matching secrets should discover each other");
+
+    // KV must propagate through the encrypted channel too.
+    handle1.gossip_set("enc-key", b"enc-value", None).await;
+    let mut found = false;
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        if let Some(value) = handle2.gossip_get("enc-key").await {
+            assert_eq!(value, b"enc-value");
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "KV should propagate over encrypted gossip");
+
+    handle1.shutdown().await;
+    handle2.shutdown().await;
+}
+
+#[tokio::test]
+async fn wrong_secret_node_cannot_join() {
+    let handle1 = start_node("sec-good", "test-wrong-secret", vec![], "right-secret").await;
+    let seed = handle1.self_node().gossip_addr;
+
+    // Same cluster_id, wrong secret, seeds at the good node.
+    let handle2 = start_node("sec-bad", "test-wrong-secret", vec![seed], "wrong-secret").await;
+
+    // Give gossip plenty of rounds to (incorrectly) converge.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // The good node must not have learned about the intruder…
+    let good_view = handle1.nodes().await;
+    assert!(
+        !good_view.iter().any(|n| n.id == "sec-bad"),
+        "node with the wrong secret must be invisible, got {good_view:?}"
+    );
+
+    // …and the intruder must not have learned about the cluster.
+    let bad_view = handle2.nodes().await;
+    let alive: Vec<_> = bad_view.iter().filter(|n| n.state == NodeState::Alive).collect();
+    assert_eq!(alive.len(), 1, "wrong-secret node should only see itself, got {bad_view:?}");
+    assert_eq!(alive[0].id, "sec-bad");
+
+    handle1.shutdown().await;
+    handle2.shutdown().await;
+}
+
+#[tokio::test]
+async fn plaintext_node_cannot_join_encrypted_cluster() {
+    let handle1 = start_node("pt-good", "test-plaintext-mix", vec![], "cluster-secret").await;
+    let seed = handle1.self_node().gossip_addr;
+
+    // No secret at all → plaintext UDP transport.
+    let handle2 = start_node("pt-bare", "test-plaintext-mix", vec![seed], "").await;
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let good_view = handle1.nodes().await;
+    assert!(
+        !good_view.iter().any(|n| n.id == "pt-bare"),
+        "plaintext node must be invisible to an encrypted cluster, got {good_view:?}"
+    );
+
+    let bare_view = handle2.nodes().await;
+    let alive: Vec<_> = bare_view.iter().filter(|n| n.state == NodeState::Alive).collect();
+    assert_eq!(alive.len(), 1, "plaintext node should only see itself, got {bare_view:?}");
+
+    handle1.shutdown().await;
+    handle2.shutdown().await;
+}

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1295,7 +1295,16 @@ pub struct ClusterConfig {
     #[serde(default)]
     pub join: Vec<String>,
 
-    /// Base64-encoded 32-byte symmetric key for gossip encryption.
+    /// Shared secret for cluster transport security.
+    ///
+    /// When set, all inter-node traffic (gossip UDP and the KV TCP data
+    /// plane) is authenticated and encrypted with ChaCha20-Poly1305
+    /// keys derived from this secret via HKDF-SHA256. Nodes without the
+    /// matching secret cannot join, read, or inject traffic.
+    ///
+    /// Any high-entropy string works (e.g. `openssl rand -base64 32`).
+    /// When empty, inter-node traffic is unauthenticated plaintext and
+    /// a warning is logged at cluster startup.
     #[serde(default)]
     pub secret: String,
 

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -70,10 +70,20 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         );
 
         // Start the KV TCP data plane for large-value cross-node fetches.
+        // When [cluster] secret is set, frames are sealed with a key
+        // derived from it (nodes without the secret cannot read/inject).
         let data_port = config.cluster.kv.data_port;
         let data_plane_store = Arc::clone(&kv_store);
+        let data_plane_cipher = if config.cluster.secret.is_empty() {
+            None
+        } else {
+            Some(Arc::new(ephpm_cluster::ClusterCipher::for_kv_data_plane(&config.cluster.secret)))
+        };
         tokio::spawn(async move {
-            if let Err(e) = ephpm_cluster::data_plane::serve(data_plane_store, data_port).await {
+            if let Err(e) =
+                ephpm_cluster::data_plane::serve(data_plane_store, data_port, data_plane_cipher)
+                    .await
+            {
                 tracing::error!(%e, "KV data plane error");
             }
         });

--- a/ephpm.toml
+++ b/ephpm.toml
@@ -182,7 +182,8 @@ ini_overrides = [
 # enabled = false
 # bind = "0.0.0.0:7946"               # gossip listen address
 # join = ["10.0.1.2:7946"]            # seed nodes (or k8s headless service DNS)
-# secret = ""                          # base64-encoded 32-byte key (encrypts gossip)
+# secret = ""                          # shared secret — encrypts gossip + KV data plane
+#                                      # (any high-entropy string; empty = plaintext)
 #
 # [cluster.kv]
 # replication_factor = 2               # copies on N additional nodes

--- a/site/content/architecture/clustering.md
+++ b/site/content/architecture/clustering.md
@@ -1230,7 +1230,7 @@ socket = "/run/ephpm/redis.sock"       # Unix socket (~2-5x faster than TCP)
 enabled = false
 bind = "0.0.0.0:7946"                 # gossip listen address
 join = ["10.0.1.2:7946"]              # seed nodes
-secret = ""                            # base64-encoded 32-byte key — encrypts gossip, authenticates nodes
+secret = ""                            # shared secret — encrypts gossip + KV data plane, authenticates nodes
 
 # mTLS for data plane (auto-generated certs by default)
 # When omitted, nodes generate ephemeral self-signed certs and

--- a/site/content/guides/clustering-setup.md
+++ b/site/content/guides/clustering-setup.md
@@ -18,7 +18,7 @@ join    = ["10.0.1.10:7946", "10.0.1.11:7946", "10.0.1.12:7946"]
 cluster_id = "ephpm-prod"          # only nodes with the same id will pair
 ```
 
-> **Security note:** `cluster.secret` exists in the config schema but is currently parsed and **not used** — gossip traffic is unauthenticated and unencrypted today. Run the cluster on a trusted private network (VPC, WireGuard, Tailscale) and firewall ports 7946/7947 from the public internet. Different `cluster_id`s let you run multiple independent clusters on the same network.
+> **Security note:** set `cluster.secret` (any high-entropy string, e.g. `openssl rand -base64 32`) on every node. When set, all inter-node traffic — gossip UDP **and** the TCP KV data plane — is authenticated and encrypted with ChaCha20-Poly1305 keys derived from the secret via HKDF-SHA256. Nodes without the matching secret cannot join, read, or inject; their packets are silently dropped. When unset, inter-node traffic is unauthenticated plaintext (a warning is logged at startup) — only do that on a trusted private network (VPC, WireGuard, Tailscale) with ports 7946/7947 firewalled from the public internet. Different `cluster_id`s let you run multiple independent clusters on the same network.
 
 `join` only needs to list a few seeds — once a node joins, it discovers the rest.
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -227,7 +227,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `enabled` | bool | `false` | Enable gossip clustering. |
 | `bind` | string | `"0.0.0.0:7946"` | Gossip UDP listener. |
 | `join` | array of strings | `[]` | Seed addresses for initial cluster join. |
-| `secret` | base64 string | `""` | 32-byte symmetric key for gossip encryption. |
+| `secret` | string | `""` | Shared secret for cluster transport security. When set, gossip UDP and the KV TCP data plane are encrypted and authenticated (ChaCha20-Poly1305, keys derived via HKDF-SHA256); nodes without it cannot join, read, or inject. Empty = plaintext (warning logged at startup). |
 | `node_id` | string | (auto) | Unique node identifier. Auto-generated if empty. |
 | `cluster_id` | string | `"ephpm"` | Nodes with different `cluster_id`s ignore each other. |
 


### PR DESCRIPTION
PR B of the make-the-unflattering-list-work series (PR A: security defaults + session locking; PR C: KV replication, follows this one).

`[cluster] secret` was parsed but never used — gossip was unauthenticated UDP and the KV data plane plaintext TCP. This makes the secret real: when set, **all inter-node traffic is authenticated and encrypted**; nodes without the matching secret cannot join, read, or inject.

## Design

- **`ClusterCipher`** — HKDF-SHA256 over the secret with domain-separated info strings (`ephpm-gossip-v1` / `ephpm-kv-data-v1`) → 32-byte ChaCha20-Poly1305 keys; ciphertexts are never valid across planes. Sealed layout: `nonce(12, random) || ciphertext+tag`. `Debug` never prints key material.
- **Gossip** — `EncryptedUdpTransport` implements chitchat's `Transport`. chitchat 0.10's `Socket` serializes internally (no byte-level hook), so the transport owns its own UDP socket mirroring `UdpTransport`: serialize → seal → send / recv → open → deserialize. Undecryptable/short/plaintext/wrong-secret datagrams are **dropped** with a rate-limited warning (bad peers are invisible, not an error loop).
- **KV data plane** — with a cipher, each logical request/response is one sealed frame `[len u32][nonce||ct]`; the plaintext inside is byte-identical to the legacy protocol. Auth failure drops the connection with no response.
- **No secret** → unchanged plaintext behavior + a startup warning recommending one on untrusted networks. Not mTLS — symmetric PSK; docs updated to say exactly that.

## Deps

`chacha20poly1305 0.10`, `hkdf 0.12` (RustCrypto, MIT/Apache-2.0 — within deny.toml's allow list; no new RNG dep, uses aead's OsRng).

## Tests

Seal/open roundtrip, nonce freshness, wrong-key + cross-plane rejection, tampering, plaintext↔encrypted mismatch in both directions, encrypted GET/SET incl. 100 KiB values, and a `secure_gossip` integration suite: matching-secret nodes converge; wrong-secret and plaintext nodes are invisible in both directions.

## Verification

clippy pedantic clean, nightly fmt clean, `cargo test -p ephpm-cluster` all suites green (independently re-run 3× on the gossip suite), `ephpm-server` 152 green. Docs (config reference, clustering guide + architecture page, ephpm.toml example) updated to the implemented truth in the same PR.