### PR TITLE
feat(security): multi-tenant defaults + KV session locking

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -97,8 +97,14 @@ pub struct ServerConfig {
     pub php_etag_cache: PhpETagCacheConfig,
 
     /// Security settings.
+    ///
+    /// `None` when the `[server.security]` section is absent from the TOML
+    /// (and no `EPHPM_SERVER__SECURITY__*` env var is set). Presence of the
+    /// section feeds into the resolved defaults for `open_basedir` and
+    /// `disable_shell_exec` — see [`ServerConfig::effective_open_basedir`]
+    /// and [`ServerConfig::effective_disable_shell_exec`].
     #[serde(default)]
-    pub security: SecurityConfig,
+    pub security: Option<SecurityConfig>,
 
     /// Logging settings.
     #[serde(default)]
@@ -340,10 +346,12 @@ pub struct SecurityConfig {
     /// set per-request to the site's directory + `/tmp`. PHP cannot read
     /// or write files outside that directory.
     ///
-    /// Default: `true` when `sites_dir` is set, `false` otherwise.
-    /// Override per-site via `site.toml`.
-    #[serde(default = "default_open_basedir")]
-    pub open_basedir: bool,
+    /// An explicitly set value always wins. When unset, resolves to `true`
+    /// if the `[server.security]` section is present OR `server.sites_dir`
+    /// is set (multi-tenant mode); otherwise `false`. Use
+    /// [`ServerConfig::effective_open_basedir`] to read the resolved value.
+    #[serde(default)]
+    pub open_basedir: Option<bool>,
 
     /// Disable dangerous PHP functions in multi-tenant mode.
     ///
@@ -351,18 +359,48 @@ pub struct SecurityConfig {
     /// `proc_open`, `popen`, and `pcntl_exec` are disabled via
     /// `disable_functions`. Prevents shell escape from `open_basedir`.
     ///
-    /// Default: `true` when `sites_dir` is set, `false` otherwise.
-    /// Override per-site via `site.toml`.
-    #[serde(default = "default_disable_shell_exec")]
-    pub disable_shell_exec: bool,
+    /// An explicitly set value always wins. When unset, resolves to `true`
+    /// if the `[server.security]` section is present OR `server.sites_dir`
+    /// is set (multi-tenant mode); otherwise `false`. Use
+    /// [`ServerConfig::effective_disable_shell_exec`] to read the resolved
+    /// value.
+    #[serde(default)]
+    pub disable_shell_exec: Option<bool>,
 }
 
-fn default_open_basedir() -> bool {
-    true
-}
+impl ServerConfig {
+    /// Resolved value of `security.open_basedir`.
+    ///
+    /// An explicitly set value always wins. When unset, resolves to `true`
+    /// if the `[server.security]` section is present (preserves the
+    /// historical present-section default) OR `sites_dir` is set (so a
+    /// multi-tenant deployment never silently runs without filesystem
+    /// isolation); otherwise `false`.
+    #[must_use]
+    pub fn effective_open_basedir(&self) -> bool {
+        self.resolve_security_flag(|s| s.open_basedir)
+    }
 
-fn default_disable_shell_exec() -> bool {
-    true
+    /// Resolved value of `security.disable_shell_exec`.
+    ///
+    /// Same resolution rules as [`Self::effective_open_basedir`]: explicit
+    /// value wins; unset resolves to `true` when the `[server.security]`
+    /// section is present or `sites_dir` is set, `false` otherwise.
+    #[must_use]
+    pub fn effective_disable_shell_exec(&self) -> bool {
+        self.resolve_security_flag(|s| s.disable_shell_exec)
+    }
+
+    /// Shared resolution for the two isolation flags.
+    fn resolve_security_flag(&self, field: impl Fn(&SecurityConfig) -> Option<bool>) -> bool {
+        match &self.security {
+            // Section present: unset fields default to true (compat with
+            // the previous `#[serde(default = "true")]` behavior).
+            Some(security) => field(security).unwrap_or(true),
+            // Section absent: default on only in multi-tenant mode.
+            None => self.sites_dir.is_some(),
+        }
+    }
 }
 
 /// Logging configuration (`[server.logging]`).
@@ -1188,7 +1226,7 @@ impl Default for ServerConfig {
             response: ResponseConfig::default(),
             static_files: StaticConfig::default(),
             php_etag_cache: PhpETagCacheConfig::default(),
-            security: SecurityConfig::default(),
+            security: None,
             logging: LoggingConfig::default(),
             metrics: MetricsConfig::default(),
             limits: LimitsConfig::default(),
@@ -2051,6 +2089,124 @@ path = "test.db"
             let config = Config::load(&file).unwrap();
             let sqlite = config.db.sqlite.expect("sqlite should be present");
             assert_eq!(sqlite.replication.role, "primary");
+        });
+    }
+
+    // ── Security isolation default resolution ──────────────────────────
+    //
+    // `open_basedir` / `disable_shell_exec` resolve to `true` when the
+    // `[server.security]` section is present OR `sites_dir` is set;
+    // an explicitly set value always wins.
+
+    #[test]
+    fn test_security_section_absent_no_sites_dir_defaults_off() {
+        let config = Config::default_config().unwrap();
+        assert!(config.server.security.is_none());
+        assert!(!config.server.effective_open_basedir());
+        assert!(!config.server.effective_disable_shell_exec());
+    }
+
+    #[test]
+    fn test_security_section_absent_sites_dir_defaults_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server]
+sites_dir = "/var/www/sites"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.security.is_none(), "no [server.security] section in this config");
+        assert!(config.server.effective_open_basedir());
+        assert!(config.server.effective_disable_shell_exec());
+    }
+
+    #[test]
+    fn test_security_explicit_false_wins_over_sites_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server]
+sites_dir = "/var/www/sites"
+
+[server.security]
+open_basedir = false
+disable_shell_exec = false
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(!config.server.effective_open_basedir());
+        assert!(!config.server.effective_disable_shell_exec());
+    }
+
+    #[test]
+    fn test_security_section_present_field_unset_no_sites_dir_defaults_on() {
+        // Compat: existing configs that declare [server.security] (for e.g.
+        // trusted_proxies) keep the historical "present section ⇒ true"
+        // defaults even without sites_dir.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server.security]
+trusted_proxies = ["10.0.0.0/8"]
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.security.is_some());
+        assert!(config.server.effective_open_basedir());
+        assert!(config.server.effective_disable_shell_exec());
+    }
+
+    #[test]
+    fn test_security_explicit_true_without_sites_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[server.security]
+open_basedir = true
+",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.effective_open_basedir());
+        // Unset sibling also resolves true because the section is present.
+        assert!(config.server.effective_disable_shell_exec());
+    }
+
+    #[test]
+    fn test_security_env_var_override_counts_as_explicit() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server]
+sites_dir = "/var/www/sites"
+"#,
+        )
+        .unwrap();
+
+        temp_env::with_var("EPHPM_SERVER__SECURITY__OPEN_BASEDIR", Some("false"), || {
+            let config = Config::load(&file).unwrap();
+            assert!(!config.server.effective_open_basedir());
+            // The env var materializes the section, so the unset sibling
+            // still resolves true (and sites_dir is set anyway).
+            assert!(config.server.effective_disable_shell_exec());
         });
     }
 }

--- a/crates/ephpm-e2e/tests/session_locking.rs
+++ b/crates/ephpm-e2e/tests/session_locking.rs
@@ -1,0 +1,115 @@
+//! Session locking regression tests.
+//!
+//! The ephpm session save handler takes a pessimistic per-session lock
+//! (`session_lock:<sid>`, SETNX + TTL) in PS_READ and releases it in
+//! PS_CLOSE, serializing concurrent requests that share a session id.
+//! Without the lock, concurrent read-modify-write cycles on `$_SESSION`
+//! lose updates.
+//!
+//! The fixture (`tests/docroot/session_counter.php`) reads a counter from
+//! `$_SESSION`, sleeps 50ms to widen the race window, increments, writes,
+//! and closes. With locking, N concurrent requests must land the counter
+//! at exactly N.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
+
+use ephpm_e2e::required_env;
+
+/// Extract the `PHPSESSID=<sid>` pair from a response's `Set-Cookie` headers.
+fn session_cookie(resp: &reqwest::Response) -> String {
+    resp.headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .find(|v| v.starts_with("PHPSESSID="))
+        .map(|v| v.split(';').next().unwrap_or(v).trim().to_owned())
+        .expect("init response must set a PHPSESSID cookie")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_session_increments_do_not_lose_updates() {
+    let base_url = required_env("EPHPM_URL");
+    let client = reqwest::Client::new();
+
+    // Prime: create the session, zero the counter, capture the cookie so
+    // every concurrent request rides the same session id.
+    let init = client
+        .get(format!("{base_url}/session_counter.php?mode=init"))
+        .send()
+        .await
+        .expect("init request failed");
+    assert_eq!(init.status().as_u16(), 200, "init must return 200");
+    let cookie = session_cookie(&init);
+    let init_body = init.text().await.expect("failed to read init body");
+    assert_eq!(init_body.trim(), "0", "init must reset the counter to 0");
+
+    const N: usize = 10;
+
+    // Fan out N concurrent increments sharing the session cookie. Each one
+    // holds the session (and its lock) across a 50ms sleep, so with locking
+    // they serialize; without it they'd stomp each other's writes.
+    let handles: Vec<_> = (0..N)
+        .map(|i| {
+            let client = client.clone();
+            let url = format!("{base_url}/session_counter.php?mode=incr");
+            let cookie = cookie.clone();
+            tokio::spawn(async move {
+                let resp = client
+                    .get(&url)
+                    .header(reqwest::header::COOKIE, cookie)
+                    .send()
+                    .await
+                    .unwrap_or_else(|e| panic!("incr request {i} failed: {e}"));
+                assert_eq!(
+                    resp.status().as_u16(),
+                    200,
+                    "incr request {i} expected 200, got {}",
+                    resp.status()
+                );
+                let body = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|e| panic!("incr request {i} body read failed: {e}"));
+                body.trim()
+                    .parse::<usize>()
+                    .unwrap_or_else(|_| panic!("incr request {i}: expected integer, got: {body}"))
+            })
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(N);
+    for (i, handle) in handles.into_iter().enumerate() {
+        results.push(handle.await.unwrap_or_else(|e| panic!("task {i} panicked: {e}")));
+    }
+
+    // Final read must observe every increment — a value below N means a
+    // concurrent request read a stale counter (lost update).
+    let final_resp = client
+        .get(format!("{base_url}/session_counter.php?mode=read"))
+        .header(reqwest::header::COOKIE, cookie)
+        .send()
+        .await
+        .expect("final read request failed");
+    let final_val: usize = final_resp
+        .text()
+        .await
+        .expect("failed to read final body")
+        .trim()
+        .parse()
+        .expect("final counter must be a valid integer");
+
+    assert_eq!(
+        final_val, N,
+        "session counter after {N} concurrent increments must be {N}, got {final_val} — \
+         indicates lost updates (session locking not serializing requests)"
+    );
+
+    // With serialized increments every response value is unique: 1..=N.
+    results.sort_unstable();
+    assert_eq!(
+        results,
+        (1..=N).collect::<Vec<_>>(),
+        "each increment must return a unique value 1..={N}, got: {results:?}"
+    );
+}

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1224,22 +1224,28 @@ static const zend_function_entry ephpm_kv_functions[] = {
  * Keys are namespaced as "session:<sid>". TTL comes from
  * session.gc_maxlifetime; we refresh it on every write and on every
  * timestamp update (so an active session does not expire mid-page).
+ *
+ * Concurrent requests on the same session id are serialized with a
+ * pessimistic per-session lock at "session_lock:<sid>" — see the
+ * "Session locking" section below.
  * =================================================================== */
 
 #define EPHPM_SESSION_KEY_PREFIX "session:"
 #define EPHPM_SESSION_KEY_PREFIX_LEN (sizeof(EPHPM_SESSION_KEY_PREFIX) - 1)
 
 /*
- * Build the KV key for a session id on the caller's stack when possible,
- * falling back to emalloc for unusually long sids. Returns a pointer that
- * the caller must release with `ephpm_session_key_free(buf, on_stack)`
- * when finished. `stack_buf` must be at least 64 bytes.
+ * Build a prefixed KV key for a session id on the caller's stack when
+ * possible, falling back to emalloc for unusually long sids. Returns a
+ * pointer that the caller must release with
+ * `ephpm_session_key_free(buf, used_heap)` when finished. `stack_buf`
+ * must be at least 64 bytes.
  */
-static char *ephpm_session_make_key(const char *sid, size_t sid_len,
-                                    char *stack_buf, size_t stack_buf_len,
-                                    int *used_heap)
+static char *ephpm_session_make_prefixed_key(const char *prefix, size_t prefix_len,
+                                             const char *sid, size_t sid_len,
+                                             char *stack_buf, size_t stack_buf_len,
+                                             int *used_heap)
 {
-    size_t need = EPHPM_SESSION_KEY_PREFIX_LEN + sid_len + 1;
+    size_t need = prefix_len + sid_len + 1;
     char *buf;
     if (need <= stack_buf_len) {
         buf = stack_buf;
@@ -1248,10 +1254,21 @@ static char *ephpm_session_make_key(const char *sid, size_t sid_len,
         buf = (char *)emalloc(need);
         *used_heap = 1;
     }
-    memcpy(buf, EPHPM_SESSION_KEY_PREFIX, EPHPM_SESSION_KEY_PREFIX_LEN);
-    memcpy(buf + EPHPM_SESSION_KEY_PREFIX_LEN, sid, sid_len);
-    buf[EPHPM_SESSION_KEY_PREFIX_LEN + sid_len] = '\0';
+    memcpy(buf, prefix, prefix_len);
+    memcpy(buf + prefix_len, sid, sid_len);
+    buf[prefix_len + sid_len] = '\0';
     return buf;
+}
+
+/* Convenience wrapper for the data key ("session:<sid>"). */
+static char *ephpm_session_make_key(const char *sid, size_t sid_len,
+                                    char *stack_buf, size_t stack_buf_len,
+                                    int *used_heap)
+{
+    return ephpm_session_make_prefixed_key(EPHPM_SESSION_KEY_PREFIX,
+                                           EPHPM_SESSION_KEY_PREFIX_LEN,
+                                           sid, sid_len,
+                                           stack_buf, stack_buf_len, used_heap);
 }
 
 static void ephpm_session_key_free(char *buf, int used_heap)
@@ -1272,23 +1289,214 @@ static long long ephpm_session_ttl_ms(void)
     return lifetime * 1000LL;
 }
 
+/* ── Session locking ────────────────────────────────────────────────
+ *
+ * Pessimistic per-session lock, php-fpm files-handler style: without it,
+ * two concurrent requests carrying the same session cookie both READ the
+ * blob, both mutate their in-memory copy, and the second WRITE silently
+ * clobbers the first (lost update).
+ *
+ * PS_READ acquires "session_lock:<sid>" via SETNX with a TTL before
+ * fetching the blob; PS_CLOSE (which PHP guarantees after WRITE, including
+ * during request shutdown after a bailout) releases it with DEL. On
+ * contention we spin with exponential backoff (start 10ms, cap 100ms) up
+ * to a total wait of 30s; if the lock is still held we log an E_WARNING
+ * and proceed WITHOUT the lock — a degraded read-modify-write race is
+ * strictly better than deadlocking the worker thread.
+ *
+ * The 30s TTL guards against crashed/stuck holders: a thread that dies
+ * while holding the lock stops blocking the session forever.
+ *
+ * KNOWN LIMITATION (accepted for v1): if a holder outlives the 30s TTL,
+ * the lock expires and another request may acquire it. Our release path
+ * is an unconditional DEL — the KV ops table has no compare-and-delete —
+ * so the original holder would then release the *new* holder's lock,
+ * letting a third request in early. The window requires a request that
+ * both holds a session open for >30s and overlaps two competitors, and
+ * the failure mode is the same lost-update race that exists without
+ * locking at all.
+ *
+ * On NTS builds (Windows) PHP execution is serialized in-process, so the
+ * lock is simply uncontended — the SETNX/DEL pair still balances.
+ */
+
+#define EPHPM_SESSION_LOCK_PREFIX "session_lock:"
+#define EPHPM_SESSION_LOCK_PREFIX_LEN (sizeof(EPHPM_SESSION_LOCK_PREFIX) - 1)
+
+/* Lock TTL — also the bound on how long a crashed holder can block others. */
+#define EPHPM_SESSION_LOCK_TTL_MS 30000LL
+/* Total time a contender waits before giving up and proceeding lockless. */
+#define EPHPM_SESSION_LOCK_MAX_WAIT_MS 30000u
+/* Spin backoff: start at 10ms, double each miss, cap at 100ms. */
+#define EPHPM_SESSION_LOCK_BACKOFF_START_MS 10u
+#define EPHPM_SESSION_LOCK_BACKOFF_MAX_MS 100u
+
+/* Lock ownership for the request running on this thread: the sid we hold
+ * the lock for (plain malloc — must survive Zend's per-request allocator),
+ * or NULL when no lock is held. NULL also covers the "gave up and
+ * proceeded lockless" case, so the release path never deletes a lock this
+ * thread did not acquire (except the TTL-expiry window described above). */
+static EPHPM_TLS char *session_lock_sid = NULL;
+static EPHPM_TLS size_t session_lock_sid_len = 0;
+
+/* Millisecond sleep for the lock spin loop (portable). */
+#if defined(PHP_WIN32) || defined(_WIN32)
+#include <windows.h>
+static void ephpm_sleep_ms(unsigned int ms)
+{
+    Sleep(ms);
+}
+#else
+#include <time.h>
+static void ephpm_sleep_ms(unsigned int ms)
+{
+    struct timespec ts;
+    ts.tv_sec = ms / 1000u;
+    ts.tv_nsec = (long)(ms % 1000u) * 1000000L;
+    nanosleep(&ts, NULL);
+}
+#endif
+
+/* Release the lock this thread holds, if any. Safe to call when no lock
+ * is held (no-op). */
+static void ephpm_session_lock_release(void)
+{
+    if (!session_lock_sid) {
+        return;
+    }
+    if (g_kv_ops.del) {
+        char stack[128];
+        int used_heap = 0;
+        char *lock_key = ephpm_session_make_prefixed_key(
+            EPHPM_SESSION_LOCK_PREFIX, EPHPM_SESSION_LOCK_PREFIX_LEN,
+            session_lock_sid, session_lock_sid_len,
+            stack, sizeof(stack), &used_heap);
+        (void)g_kv_ops.del(lock_key);
+        ephpm_session_key_free(lock_key, used_heap);
+    }
+    free(session_lock_sid);
+    session_lock_sid = NULL;
+    session_lock_sid_len = 0;
+}
+
+/* Acquire the per-session lock for `sid`, spinning with backoff on
+ * contention. On success, records ownership in the thread-local state so
+ * PS_CLOSE / PS_DESTROY can release it. On sustained contention (30s),
+ * warns and returns without the lock. */
+static void ephpm_session_lock_acquire(const char *sid, size_t sid_len)
+{
+    if (!g_kv_ops.set_nx || !g_kv_ops.del) {
+        /* No store (or no lock primitives) wired — nothing to lock with.
+         * The read path already degrades to an empty session in this
+         * configuration, so silently running lockless is consistent. */
+        return;
+    }
+
+    if (session_lock_sid) {
+        if (session_lock_sid_len == sid_len &&
+            memcmp(session_lock_sid, sid, sid_len) == 0) {
+            /* Already holding this session's lock (e.g. a second
+             * session_start() after session_abort() in the same request). */
+            return;
+        }
+        /* Stale lock from a different sid on this thread — a previous
+         * request that never reached PS_CLOSE (bailout edge). Release it
+         * so it cannot leak past its TTL. */
+        ephpm_session_lock_release();
+    }
+
+    char stack[128];
+    int used_heap = 0;
+    char *lock_key = ephpm_session_make_prefixed_key(
+        EPHPM_SESSION_LOCK_PREFIX, EPHPM_SESSION_LOCK_PREFIX_LEN,
+        sid, sid_len, stack, sizeof(stack), &used_heap);
+
+    unsigned int waited_ms = 0;
+    unsigned int backoff_ms = EPHPM_SESSION_LOCK_BACKOFF_START_MS;
+    int acquired = 0;
+
+    for (;;) {
+        if (g_kv_ops.set_nx(lock_key, "1", 1, EPHPM_SESSION_LOCK_TTL_MS)) {
+            acquired = 1;
+            break;
+        }
+        if (waited_ms >= EPHPM_SESSION_LOCK_MAX_WAIT_MS) {
+            break;
+        }
+        unsigned int sleep_ms = backoff_ms;
+        if (sleep_ms > EPHPM_SESSION_LOCK_MAX_WAIT_MS - waited_ms) {
+            sleep_ms = EPHPM_SESSION_LOCK_MAX_WAIT_MS - waited_ms;
+        }
+        ephpm_sleep_ms(sleep_ms);
+        waited_ms += sleep_ms;
+        backoff_ms *= 2u;
+        if (backoff_ms > EPHPM_SESSION_LOCK_BACKOFF_MAX_MS) {
+            backoff_ms = EPHPM_SESSION_LOCK_BACKOFF_MAX_MS;
+        }
+    }
+
+    if (acquired) {
+        char *owned = (char *)malloc(sid_len + 1);
+        if (owned) {
+            memcpy(owned, sid, sid_len);
+            owned[sid_len] = '\0';
+            session_lock_sid = owned;
+            session_lock_sid_len = sid_len;
+        } else {
+            /* OOM copying the sid: we cannot track ownership, so we must
+             * not keep the lock — a lock we can't release would block the
+             * session until the TTL fires. Undo and run lockless. */
+            (void)g_kv_ops.del(lock_key);
+            php_error_docref(NULL, E_WARNING,
+                "ephpm session handler: out of memory tracking session lock; "
+                "proceeding without lock");
+        }
+    } else {
+        php_error_docref(NULL, E_WARNING,
+            "ephpm session handler: could not acquire session lock after "
+            "%u ms; proceeding without lock (concurrent request may still "
+            "hold it)", waited_ms);
+    }
+
+    ephpm_session_key_free(lock_key, used_heap);
+}
+
 /* ── PS_OPEN / PS_CLOSE ─────────────────────────────────────────── */
+
+/* Non-NULL sentinel for PS(mod_data). ext/session gates the write/close
+ * handler calls on `PS(mod_data) || PS(mod_user_implemented)` (see
+ * php_session_save_current_state / php_rshutdown_session_globals in
+ * ext/session/session.c) — a native handler that leaves *mod_data NULL in
+ * open() never gets its write or close callbacks invoked, every
+ * session_write_close() warns "Failed to write session data", and nothing
+ * is persisted. We keep no real per-handler state (the KV store is global
+ * and the lock state is thread-local), so a shared marker address is all
+ * that's needed. The value is never dereferenced. */
+static int ephpm_session_mod_data_marker = 0;
 
 PS_OPEN_FUNC(ephpm)
 {
     /* save_path is irrelevant — we store in the in-process KV. session_name
-     * is the cookie name and is already tracked by ext/session. Nothing to
-     * do here, but we must not fail because php_session_initialize() bails
-     * on any non-SUCCESS return. */
+     * is the cookie name and is already tracked by ext/session. We must not
+     * fail because php_session_initialize() bails on any non-SUCCESS
+     * return, and we MUST set *mod_data non-NULL or PHP will silently skip
+     * our write/close handlers (see ephpm_session_mod_data_marker). */
     (void)save_path;
     (void)session_name;
-    (void)mod_data;
+    *mod_data = (void *)&ephpm_session_mod_data_marker;
     return SUCCESS;
 }
 
 PS_CLOSE_FUNC(ephpm)
 {
-    (void)mod_data;
+    /* PHP calls close after write (session_write_close, request shutdown,
+     * even after a bailout via RSHUTDOWN), making it the reliable place to
+     * release the per-session lock taken in PS_READ. No-op when this
+     * thread never acquired one (lockless fallback / no store). */
+    ephpm_session_lock_release();
+    /* Clear the sentinel like mod_files does — ext/session treats a
+     * non-NULL mod_data as "handler still open". */
+    *mod_data = NULL;
     return SUCCESS;
 }
 
@@ -1299,14 +1507,21 @@ PS_READ_FUNC(ephpm)
     (void)mod_data;
     (void)maxlifetime;
 
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+
+    /* Serialize concurrent requests on the same session id: take the
+     * per-session lock BEFORE reading the blob so the read-modify-write
+     * spanning PS_READ..PS_WRITE is atomic across requests. Released in
+     * PS_CLOSE / PS_DESTROY. */
+    ephpm_session_lock_acquire(sid_str, sid_len);
+
     if (!g_kv_ops.get || !g_kv_ops.get_result) {
         /* No store wired — behave like an empty session rather than failing. */
         *val = ZSTR_EMPTY_ALLOC();
         return SUCCESS;
     }
 
-    const char *sid_str = ZSTR_VAL(key);
-    size_t sid_len = ZSTR_LEN(key);
     char stack[128];
     int used_heap = 0;
     char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);
@@ -1357,12 +1572,22 @@ PS_DESTROY_FUNC(ephpm)
 {
     (void)mod_data;
 
+    const char *sid_str = ZSTR_VAL(key);
+    size_t sid_len = ZSTR_LEN(key);
+
+    /* session_destroy() / session_regenerate_id(true) — the destroyed sid
+     * will never be written again by this request, so release its lock now
+     * (only if this thread actually holds it; a lock for a different sid
+     * must stay put). */
+    if (session_lock_sid && session_lock_sid_len == sid_len &&
+        memcmp(session_lock_sid, sid_str, sid_len) == 0) {
+        ephpm_session_lock_release();
+    }
+
     if (!g_kv_ops.del) {
         return SUCCESS;
     }
 
-    const char *sid_str = ZSTR_VAL(key);
-    size_t sid_len = ZSTR_LEN(key);
     char stack[128];
     int used_heap = 0;
     char *kv_key = ephpm_session_make_key(sid_str, sid_len, stack, sizeof(stack), &used_heap);

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -166,10 +166,11 @@ impl Router {
         let port =
             config.server.listen.rsplit_once(':').and_then(|(_, p)| p.parse().ok()).unwrap_or(8080);
 
-        let trusted_proxies: Vec<IpNet> = config
-            .server
-            .security
-            .trusted_proxies
+        let security = config.server.security.as_ref();
+
+        let trusted_proxies: Vec<IpNet> = security
+            .map(|s| s.trusted_proxies.as_slice())
+            .unwrap_or_default()
             .iter()
             .filter_map(|cidr| {
                 cidr.parse::<IpNet>()
@@ -177,6 +178,23 @@ impl Router {
                     .ok()
             })
             .collect();
+
+        let open_basedir = config.server.effective_open_basedir();
+        if config.server.sites_dir.is_some() {
+            // Multi-tenant deployments get isolation by default; surface the
+            // resolved values so an explicit opt-out is never silent.
+            tracing::info!(
+                open_basedir,
+                disable_shell_exec = config.server.effective_disable_shell_exec(),
+                "multi-tenant security defaults resolved"
+            );
+            if !open_basedir {
+                tracing::warn!(
+                    "open_basedir explicitly disabled in multi-tenant mode — \
+                     sites can read each other's files"
+                );
+            }
+        }
 
         // Scan sites_dir for virtual host directories.
         let sites = scan_sites_dir(
@@ -211,8 +229,8 @@ impl Router {
             etag: config.server.static_files.etag,
             request_timeout: Duration::from_secs(config.server.timeouts.request),
             trusted_proxies,
-            blocked_paths: config.server.security.blocked_paths.clone(),
-            allowed_php_paths: config.server.security.allowed_php_paths.clone(),
+            blocked_paths: security.map(|s| s.blocked_paths.clone()).unwrap_or_default(),
+            allowed_php_paths: security.map(|s| s.allowed_php_paths.clone()).unwrap_or_default(),
             trusted_hosts: config.server.request.trusted_hosts.clone(),
             response_headers: config
                 .server
@@ -221,7 +239,7 @@ impl Router {
                 .iter()
                 .map(|[k, v]| (k.clone(), v.clone()))
                 .collect(),
-            open_basedir: config.server.security.open_basedir,
+            open_basedir,
             multi_tenant_kv: if config.server.sites_dir.is_some() {
                 Some(ephpm_kv::multi_tenant::MultiTenantStore::new(
                     Arc::clone(&store),
@@ -1549,7 +1567,8 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        config.server.security.trusted_proxies = vec!["10.0.0.0/8".to_string()];
+        config.server.security.get_or_insert_default().trusted_proxies =
+            vec!["10.0.0.0/8".to_string()];
         let router = Router::new(&config, test_store(), None, None, None);
 
         // 203.0.113.50 is the real client, 10.0.0.1 is the proxy
@@ -1571,7 +1590,8 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        config.server.security.trusted_proxies = vec!["10.0.0.0/8".to_string()];
+        config.server.security.get_or_insert_default().trusted_proxies =
+            vec!["10.0.0.0/8".to_string()];
         let router = Router::new(&config, test_store(), None, None, None);
 
         let xff = "10.0.0.2, 10.0.0.1";
@@ -1615,6 +1635,43 @@ mod tests {
         };
         let router = Router::new(&config, test_store(), None, None, None);
         assert_eq!(router.server_port, 8080);
+    }
+
+    // ── security default resolution ──────────────────────────────────
+
+    #[test]
+    fn test_open_basedir_defaults_on_when_sites_dir_set_without_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config {
+            server: ServerConfig {
+                document_root: dir.path().to_path_buf(),
+                sites_dir: Some(dir.path().to_path_buf()),
+                ..ServerConfig::default()
+            },
+            php: PhpConfig::default(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+        };
+        let router = Router::new(&config, test_store(), None, None, None);
+        assert!(router.open_basedir, "multi-tenant mode must default open_basedir on");
+    }
+
+    #[test]
+    fn test_open_basedir_defaults_off_without_section_or_sites_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config {
+            server: ServerConfig {
+                document_root: dir.path().to_path_buf(),
+                ..ServerConfig::default()
+            },
+            php: PhpConfig::default(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+        };
+        let router = Router::new(&config, test_store(), None, None, None);
+        assert!(!router.open_basedir);
     }
 
     // ── blocked paths ─────────────────────────────────────────────────
@@ -1673,7 +1730,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        config.server.security.allowed_php_paths =
+        config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-login.php".to_string()];
         let router = Router::new(&config, test_store(), None, None, None);
         assert!(router.is_php_allowed("/index.php"));
@@ -1694,7 +1751,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        config.server.security.allowed_php_paths =
+        config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-admin/*.php".to_string()];
         let router = Router::new(&config, test_store(), None, None, None);
         assert!(router.is_php_allowed("/index.php"));

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -515,7 +515,7 @@ fn run_with_config(config: ephpm_config::Config, verbose: u8) -> anyhow::Result<
     // functions callable, so vhost-mode disable_shell_exec needs to ride
     // along on the generated ini instead of the per-request ini hook.
     let vhost_disable_shell =
-        config.server.sites_dir.is_some() && config.server.security.disable_shell_exec;
+        config.server.sites_dir.is_some() && config.server.effective_disable_shell_exec();
     let want_generated_ini = !config.php.ini_overrides.is_empty() || vhost_disable_shell;
 
     let (effective_ini_path, _generated_ini_guard): (Option<PathBuf>, Option<TempFileGuard>) =

--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -61,6 +61,55 @@ fetch them remotely (so requests can still route anywhere), but they are not
 replicated — if the owner node dies, those sessions die with it. See
 [Cluster](#cluster) below.
 
+## Locking
+
+The handler takes a pessimistic per-session lock, the same discipline as
+PHP's built-in files handler: `session_start()` blocks while another request
+holds the same session open, so concurrent read-modify-write cycles on
+`$_SESSION` cannot lose updates. Locking is always on — there is no config
+knob.
+
+Mechanics:
+
+- On `read` (inside `session_start()`), the handler acquires
+  `session_lock:<sid>` via an atomic `SETNX` with a **30s TTL**. The TTL is
+  a dead-man's switch: a crashed or wedged holder stops blocking the session
+  after at most 30 seconds.
+- On contention it spins with exponential backoff — starting at 10ms,
+  doubling up to a 100ms cap — for a total wait of up to **30s**. If the lock
+  is still held after that, the handler logs an `E_WARNING` and proceeds
+  **without** the lock rather than deadlocking the worker: a degraded
+  lost-update window beats a hung request.
+- The lock is released (`DEL`) in `close` — which PHP fires on
+  `session_write_close()`, at request shutdown, and after fatal
+  errors/bailouts — and on `destroy` (`session_destroy()`,
+  `session_regenerate_id(true)`). Only the thread that actually acquired the
+  lock releases it; a request that proceeded lockless never deletes someone
+  else's lock.
+- Hold the session only as long as you need it: call `session_write_close()`
+  as soon as you're done mutating `$_SESSION`, exactly as you would under
+  php-fpm with the files handler, or concurrent AJAX requests from the same
+  browser will serialize on the lock.
+
+Known limitation (v1): if a request holds its session open past the 30s lock
+TTL, the lock expires and a competing request may acquire it; when the
+original holder finally closes, its unconditional `DEL` releases the *new*
+holder's lock early (the KV layer has no compare-and-delete yet). The
+exposure window requires a >30s session hold plus overlapping competitors,
+and the worst case is the same lost-update race that existed before locking.
+
+In multi-tenant mode the lock key lives in the same per-site store as the
+session data, so tenants cannot contend with each other. On Windows (NTS,
+serialized PHP execution) the lock is uncontended in-process but keeps the
+same acquire/release semantics.
+
+The lock is **node-local**: the `SETNX` runs against the in-process store,
+not the cluster tier. In clustered deployments, concurrent requests for the
+same session that land on *different* nodes are not serialized — use
+session-affinity routing (sticky sessions) if cross-node request storms on a
+single session are a real pattern for your app. On any single node the
+guarantee holds regardless of cluster mode.
+
 ## TTL behaviour
 
 The session TTL comes from `session.gc_maxlifetime` (seconds). On every

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -67,10 +67,10 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 | `trusted_proxies` | array of strings | `[]` | CIDR ranges trusted for `X-Forwarded-For`/`X-Forwarded-Proto`. |
 | `blocked_paths` | array of strings | `[]` | Glob patterns blocked with 403. |
 | `allowed_php_paths` | array of strings | `[]` | When non-empty, only matching PHP paths execute. Others get 403. |
-| `open_basedir` | bool | `true` if a `[server.security]` section is present, else `false` | Restrict PHP filesystem access to the site's document root. |
-| `disable_shell_exec` | bool | `true` if a `[server.security]` section is present, else `false` | Disable `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`, `pcntl_exec`. |
+| `open_basedir` | bool | `true` if a `[server.security]` section is present **or** `server.sites_dir` is set, else `false` | Restrict PHP filesystem access to the site's document root. |
+| `disable_shell_exec` | bool | `true` if a `[server.security]` section is present **or** `server.sites_dir` is set, else `false` | Disable `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`, `pcntl_exec`. |
 
-**Warning:** these two defaults depend on the presence of the `[server.security]` section itself — they never depend on `sites_dir`. If the section is absent entirely, both default to `false`. Multi-tenant deployments (`sites_dir` set) should always declare a `[server.security]` section explicitly.
+**Note:** an explicitly set value always wins. When unset, these two resolve to `true` if either the `[server.security]` section is present (matching earlier releases) or `server.sites_dir` is set — so multi-tenant deployments get filesystem isolation and shell-exec hardening by default, even without a `[server.security]` section. To opt out in multi-tenant mode you must set them to `false` explicitly (ephpm logs a warning at startup when you do).
 
 ### `[server.logging]`
 

--- a/site/content/testing/e2e.md
+++ b/site/content/testing/e2e.md
@@ -24,6 +24,7 @@ The `ephpm-e2e` crate lives in `crates/ephpm-e2e/` and runs inside a Kind cluste
 | `security_p0.rs` | 6 | Additional security tests (host validation, allowed PHP paths, etc.) |
 | `hidden_files.rs` | 2 | Hidden file blocking modes |
 | `concurrency.rs` | — | Parallel PHP requests, atomic KV increments under load (uses non-tokio test harness) |
+| `session_locking.rs` | 1 | Concurrent `$_SESSION` increments on one session id — per-session lock prevents lost updates |
 | `metrics.rs` | 9 | Prometheus format, build info, HTTP counters, handler labels, PHP execution metrics, in-flight gauge, body size histograms, metrics self-counting, status codes |
 | `etag_cache.rs` | 6 | PHP ETag 200+header, matching ETag 304, mismatched ETag 200, POST bypass, no If-None-Match 200, independent query strings |
 | `timeouts.rs` | 2 | PHP sleep exceeding timeout returns 504, server recovers after timeout |
@@ -70,6 +71,7 @@ The `ephpm-e2e` crate lives in `crates/ephpm-e2e/` and runs inside a Kind cluste
 | `json_response.php` | JSON `Content-Type` + `json_encode()` output |
 | `multi_cookie.php` | Sets 3 `Set-Cookie` headers via `setcookie()` |
 | `sleep.php` | `sleep(N)` via `?seconds=N` — timeout testing |
+| `session_counter.php` | Racy `$_SESSION` counter increment (50ms window) — session locking regression |
 | `large_output.php` | ~1 MiB repeating output — body size / compression |
 | `image.png` | 1x1 PNG (69 bytes) — binary content-type |
 | `test.html` | Static HTML |

--- a/tests/docroot/session_counter.php
+++ b/tests/docroot/session_counter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Session locking regression fixture.
+ *
+ * Performs a deliberately racy read-modify-write on a $_SESSION counter:
+ * read the value, sleep 50ms (wide race window), increment, write, close.
+ * Without pessimistic session locking, N concurrent requests sharing one
+ * session cookie lose updates and the final counter lands below N. With
+ * the ephpm handler's per-session lock (acquired in PS_READ, released in
+ * PS_CLOSE), the requests serialize and the counter reaches exactly N.
+ *
+ * Modes (?mode=...):
+ *   init — reset the counter to 0 and emit the session cookie
+ *   incr — read counter, usleep(50ms), write counter+1, echo new value
+ *   read — echo the current counter
+ *
+ * Consumed by crates/ephpm-e2e/tests/session_locking.rs.
+ */
+
+ini_set('session.save_handler', 'ephpm');
+header('Content-Type: text/plain');
+
+$mode = $_GET['mode'] ?? 'incr';
+
+session_start();
+
+if ($mode === 'init') {
+    $_SESSION['counter'] = 0;
+    session_write_close();
+    echo "0\n";
+    return;
+}
+
+if ($mode === 'read') {
+    $value = $_SESSION['counter'] ?? -1;
+    session_write_close();
+    echo $value . "\n";
+    return;
+}
+
+// incr: read-modify-write with a wide race window.
+$current = $_SESSION['counter'] ?? 0;
+usleep(50000); // 50ms — plenty of time for a concurrent request to interleave
+$_SESSION['counter'] = $current + 1;
+session_write_close();
+echo ($current + 1) . "\n";


### PR DESCRIPTION
PR A of the make-the-unflattering-list-work series (PR B: #110 cluster transport security; PR C: KV replication, follows).

## Multi-tenant security defaults

`open_basedir`/`disable_shell_exec` previously defaulted to `false` whenever the `[server.security]` section was absent — a multi-tenant deployment (`sites_dir` set) without that section silently ran with **no isolation**. New resolution: explicit value wins; unset resolves to `true` when the section is present (existing configs keep their behavior) **or** `sites_dir` is set (footgun closed); otherwise `false`. Router logs the resolved values in multi-tenant mode and warns on explicit opt-out. 6 config + 2 router tests cover the matrix.

## KV-backed session locking

Concurrent requests on one session ID no longer race (lost updates). PS_READ acquires `session_lock:<sid>` via SETNX + 30s TTL before reading the blob; PS_CLOSE/PS_DESTROY release. Contention spins 10ms→100ms backoff up to 30s, then warns and proceeds lockless (never deadlocks a worker). Ownership tracked per-thread; the TTL-expiry/unconditional-DEL limitation is documented in the code (no compare-and-delete in the KV ops table). NTS/Windows is uncontended in-process.

## Pre-existing bug found & fixed

`PS_OPEN` left `*mod_data` NULL and ext/session gates write/close on `PS(mod_data)` — **session writes were silently skipped and never persisted** ("Failed to write session data (ephpm)"); reads worked because `read` isn't gated. Fixed with the mod_files non-NULL-sentinel pattern. Verified live in a container before/after — without this, sessions never actually worked end-to-end.

## Verification

- clippy pedantic + nightly fmt clean; ephpm-config 31 (single-threaded), ephpm-server 154, ephpm all green
- C changes compile-checked via a full podman release build (PHP 8.5.7, musl)
- **Behavioral proof**: new e2e `session_locking.rs` (+ `tests/docroot/session_counter.php` fixture) run against a container build — 10 concurrent increments on one session ID yield exactly 1..=10, no lost updates
- `docs/features/sessions.md` gained a Locking section describing exactly what was built

Not verified: Windows/NTS compilation of the C changes (follows the file's existing MSVC patterns; CI's release job will confirm).