### PR TITLE
feat(cluster): replicate large KV values (replication_factor/mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ join = ["ephpm-headless.default.svc.cluster.local"]
 
 [cluster.kv]
 small_key_threshold = 1024        # bytes — under this, replicate via gossip
-replication_factor = 3            # large keys: 3 owners on the ring
+replication_factor = 3            # large keys: 3 copies (owner + 2 replicas)
 replication_mode = "async"        # async | sync
 hot_key_cache = true              # cache hot remote values locally
 hot_key_max_memory = "64MB"

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -29,10 +29,38 @@ use ephpm_config::ClusterKvConfig;
 use ephpm_kv::store::Store;
 
 use crate::ClusterHandle;
+use crate::node::NodeInfo;
 use crate::secure_transport::ClusterCipher;
 
 /// Key prefix for hot-key version metadata in chitchat state.
 const HOT_PREFIX: &str = "hot:";
+
+/// How large-value writes propagate to replica nodes.
+///
+/// # Consistency guarantee
+///
+/// Replication is **write-time only** — there is no active anti-entropy
+/// or rebalancing. See [`ClusteredStore::set`] for the exact per-mode
+/// guarantee and the membership-change caveat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReplicationMode {
+    /// Return as soon as the primary/local copy is written; other
+    /// replicas are updated in the background (fire-and-forget).
+    Async,
+    /// Wait for every reachable replica to acknowledge before
+    /// returning; an unreachable replica is logged, not fatal.
+    Sync,
+}
+
+impl ReplicationMode {
+    /// Parse the `[cluster.kv] replication_mode` string.
+    ///
+    /// Anything other than `"sync"` (case-insensitive) is treated as
+    /// [`ReplicationMode::Async`], matching the config default.
+    fn from_config(mode: &str) -> Self {
+        if mode.eq_ignore_ascii_case("sync") { Self::Sync } else { Self::Async }
+    }
+}
 
 /// A clustered KV store that routes between gossip and local tiers.
 pub struct ClusteredStore {
@@ -52,6 +80,12 @@ pub struct ClusteredStore {
     subscribed: AtomicBool,
     /// Approximate memory used by the hot cache.
     hot_cache_mem: AtomicU64,
+    /// Count of replica writes that failed to reach a peer (data plane
+    /// error or rejection). Observability only — a failed replica write
+    /// never fails the client set (see [`ClusteredStore::set`]). Wrapped
+    /// in an `Arc` so fire-and-forget async replica tasks can record
+    /// their failures too.
+    replica_write_failures: Arc<AtomicU64>,
 }
 
 /// Tracks remote fetch frequency for a single key.
@@ -97,6 +131,7 @@ impl ClusteredStore {
             hot_cache: DashMap::new(),
             subscribed: AtomicBool::new(false),
             hot_cache_mem: AtomicU64::new(0),
+            replica_write_failures: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -169,19 +204,30 @@ impl ClusteredStore {
             }
         }
 
-        // 4. TCP fetch from the owner node via the data plane.
-        if let Some(owner_addr) = self.resolve_owner_data_addr(key).await {
-            match crate::kv_data_plane::fetch_remote(owner_addr, key, self.cipher.as_deref()).await
-            {
+        // 4. TCP fetch from the replica set via the data plane. Try the
+        //    primary owner first, then fall back to the other replicas in
+        //    ring order — this is what lets a large value survive the
+        //    loss of its owner (up to `replication_factor - 1` failures).
+        let self_id = self.cluster.self_node().id;
+        for node in self.replica_nodes(key).await {
+            // Skip ourselves: if we had the value it would have been
+            // served by the local-store check above.
+            if node.id == self_id {
+                continue;
+            }
+            let Some(addr) = node_data_addr(&node, self.config.data_port) else {
+                continue;
+            };
+            match crate::kv_data_plane::fetch_remote(addr, key, self.cipher.as_deref()).await {
                 Ok(Some(value)) => {
                     self.track_remote_fetch(key, &value);
                     return Some(value);
                 }
                 Ok(None) => {
-                    tracing::debug!(key, %owner_addr, "key not found on owner node");
+                    tracing::debug!(key, replica = %node.id, %addr, "key not found on replica");
                 }
                 Err(e) => {
-                    tracing::debug!(key, %owner_addr, %e, "TCP data plane fetch failed");
+                    tracing::debug!(key, replica = %node.id, %addr, %e, "replica fetch failed");
                 }
             }
         }
@@ -191,8 +237,40 @@ impl ClusteredStore {
 
     /// Set a value, routing through the appropriate tier.
     ///
-    /// Returns `true` on success, `false` if the local store rejected the
-    /// write (e.g., memory limit with `NoEviction` policy).
+    /// Returns `true` on success, `false` if the primary write failed
+    /// (the local store rejected it, or the primary owner rejected /
+    /// was unreachable and no local fallback succeeded).
+    ///
+    /// # Large-value replication
+    ///
+    /// Large values are written to the **replica set**: the primary
+    /// owner (`hash(key) % alive_nodes`) plus the next
+    /// `replication_factor - 1` distinct nodes on the sorted alive-node
+    /// ring (wrapping around; clamped to the number of alive nodes). The
+    /// client-visible result reflects only the **primary** write; replica
+    /// propagation follows the configured [`ReplicationMode`]:
+    ///
+    /// - **async** (default): the primary write is awaited, then replica
+    ///   writes are spawned fire-and-forget. Failures are counted
+    ///   ([`ClusteredStore::replica_write_failures`]) and logged at
+    ///   `warn`, but never fail or delay the client set.
+    /// - **sync**: replica writes are awaited best-effort. The guarantee
+    ///   is *"every reachable replica has acknowledged when `set`
+    ///   returns"*. A replica that is down or rejects the write is
+    ///   logged and counted but does **not** fail the set — this is not
+    ///   a quorum/consensus protocol, and no rollback is performed. It
+    ///   trades the async latency win for read-your-writes durability
+    ///   against reachable peers.
+    ///
+    /// ## Membership-change caveat (v1)
+    ///
+    /// Replication happens only at write time. There is no active
+    /// anti-entropy or rebalancing: a node that was down (or not yet in
+    /// the replica set) when a key was written will **not** hold that
+    /// key until the key is rewritten or fetched-through from a node
+    /// that has it. Likewise, when membership changes the replica set
+    /// for existing keys is not recomputed retroactively. This is an
+    /// honest v1 — durable-through-rebalance replication is future work.
     pub async fn set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
         if value.len() <= self.config.small_key_threshold {
             // Gossip tier: replicate to all nodes.
@@ -204,40 +282,146 @@ impl ClusteredStore {
                 self.maybe_bump_hot_version(&key).await;
             }
 
-            true
-        } else {
-            // Large value — route to the owner node via TCP data plane.
-            let ok = if let Some(owner_addr) = self.resolve_owner_data_addr(&key).await {
-                match crate::kv_data_plane::store_remote(
-                    owner_addr,
-                    &key,
-                    &value,
-                    self.cipher.as_deref(),
-                )
-                .await
-                {
-                    Ok(accepted) => accepted,
-                    Err(e) => {
-                        tracing::warn!(
-                            key,
-                            %owner_addr,
-                            %e,
-                            "TCP data plane store failed, storing locally"
-                        );
-                        self.store.set(key.clone(), value, ttl)
+            return true;
+        }
+
+        // Large value — write to the replica set (primary + N-1 peers).
+        let ok = self.set_large(&key, &value, ttl).await;
+
+        // Bump hot key version for remote invalidation.
+        if ok && self.config.hot_key_cache {
+            self.maybe_bump_hot_version(&key).await;
+        }
+
+        ok
+    }
+
+    /// Write a large value to its replica set. Returns whether the
+    /// primary write succeeded (the client-visible result). See
+    /// [`ClusteredStore::set`] for the replication semantics.
+    async fn set_large(&self, key: &str, value: &[u8], ttl: Option<Duration>) -> bool {
+        let self_id = self.cluster.self_node().id;
+        let replicas = self.replica_nodes(key).await;
+
+        // No cluster peers (single node, or only self alive): store
+        // locally and we're done.
+        if replicas.is_empty() {
+            return self.store.set(key.to_string(), value.to_vec(), ttl);
+        }
+
+        // The primary is the first replica; the rest are secondaries.
+        // Write the primary copy first — its result is what the client
+        // sees. Secondaries follow per the replication mode.
+        let (primary, secondaries) = replicas.split_first().expect("replicas is non-empty");
+        let primary_ok = self.write_one_replica(primary, &self_id, key, value, ttl).await;
+        if !primary_ok {
+            // The primary write failed. Fall back to a local copy so the
+            // value is not lost outright, mirroring the pre-replication
+            // behaviour. Do not attempt secondaries in this case.
+            if primary.id != self_id {
+                return self.store.set(key.to_string(), value.to_vec(), ttl);
+            }
+            return false;
+        }
+
+        let mode = ReplicationMode::from_config(&self.config.replication_mode);
+        match mode {
+            ReplicationMode::Async => {
+                // Fire-and-forget: spawn each secondary write and return.
+                for node in secondaries {
+                    if node.id == self_id {
+                        // Local replica — write inline (cheap, no task).
+                        if !self.store.set(key.to_string(), value.to_vec(), ttl) {
+                            self.replica_write_failures.fetch_add(1, Ordering::Relaxed);
+                            tracing::warn!(key, "local replica write rejected (memory limit?)");
+                        }
+                        continue;
+                    }
+                    let Some(addr) = node_data_addr(node, self.config.data_port) else {
+                        continue;
+                    };
+                    let cipher = self.cipher.clone();
+                    let key = key.to_string();
+                    let value = value.to_vec();
+                    let node_id = node.id.clone();
+                    let failures = Arc::clone(&self.replica_write_failures);
+                    tokio::spawn(async move {
+                        match crate::kv_data_plane::store_remote(
+                            addr,
+                            &key,
+                            &value,
+                            cipher.as_deref(),
+                        )
+                        .await
+                        {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                failures.fetch_add(1, Ordering::Relaxed);
+                                tracing::warn!(
+                                    key,
+                                    replica = %node_id,
+                                    %addr,
+                                    "async replica rejected large-value write"
+                                );
+                            }
+                            Err(e) => {
+                                failures.fetch_add(1, Ordering::Relaxed);
+                                tracing::warn!(
+                                    key,
+                                    replica = %node_id,
+                                    %addr,
+                                    %e,
+                                    "async replica write failed"
+                                );
+                            }
+                        }
+                    });
+                }
+            }
+            ReplicationMode::Sync => {
+                // Best-effort: await every reachable secondary. Failures
+                // are logged/counted but do not fail the client write.
+                for node in secondaries {
+                    let ok = self.write_one_replica(node, &self_id, key, value, ttl).await;
+                    if !ok {
+                        self.replica_write_failures.fetch_add(1, Ordering::Relaxed);
                     }
                 }
-            } else {
-                // We are the owner — store locally.
-                self.store.set(key.clone(), value, ttl)
-            };
-
-            // Bump hot key version for remote invalidation.
-            if ok && self.config.hot_key_cache {
-                self.maybe_bump_hot_version(&key).await;
             }
+        }
 
-            ok
+        true
+    }
+
+    /// Write one copy of a large value to a single replica node.
+    ///
+    /// Writes locally when `node` is this node, otherwise via the TCP
+    /// data plane. Returns whether the write was accepted (a data plane
+    /// error is logged and reported as `false`). The caller decides
+    /// whether a `false` result bumps the replica-failure counter — the
+    /// primary's failure is handled by the [`set_large`](Self::set_large)
+    /// fallback, not counted as a replica failure.
+    async fn write_one_replica(
+        &self,
+        node: &NodeInfo,
+        self_id: &str,
+        key: &str,
+        value: &[u8],
+        ttl: Option<Duration>,
+    ) -> bool {
+        if node.id == self_id {
+            return self.store.set(key.to_string(), value.to_vec(), ttl);
+        }
+        let Some(addr) = node_data_addr(node, self.config.data_port) else {
+            tracing::warn!(key, replica = %node.id, "replica has no parseable data address");
+            return false;
+        };
+        match crate::kv_data_plane::store_remote(addr, key, value, self.cipher.as_deref()).await {
+            Ok(accepted) => accepted,
+            Err(e) => {
+                tracing::warn!(key, replica = %node.id, %addr, %e, "replica write failed");
+                false
+            }
         }
     }
 
@@ -294,36 +478,34 @@ impl ClusteredStore {
         &self.cluster
     }
 
-    /// Determine the TCP data plane address for the node that owns this key.
+    /// Compute the replica set for `key` from live cluster membership.
     ///
-    /// Uses a simple hash-based owner selection: hash the key, pick a
-    /// live node by index. Returns `None` if the owner is this node
-    /// (already checked local store) or no remote nodes are alive.
-    async fn resolve_owner_data_addr(&self, key: &str) -> Option<SocketAddr> {
+    /// The set is the primary owner (`hash(key) % alive_nodes`) followed
+    /// by the next `replication_factor - 1` distinct alive nodes on the
+    /// sorted ring, wrapping around. The returned vector is ordered
+    /// primary-first (the read/write fallback order). Returns an empty
+    /// vector when only this node is alive (no clustering to do).
+    async fn replica_nodes(&self, key: &str) -> Vec<NodeInfo> {
         let nodes = self.cluster.nodes().await;
-        let alive: Vec<_> = nodes.iter().filter(|n| n.state == crate::NodeState::Alive).collect();
+        let mut alive: Vec<NodeInfo> =
+            nodes.into_iter().filter(|n| n.state == crate::NodeState::Alive).collect();
+        // `ClusterHandle::nodes` already sorts by id, but sort defensively
+        // so replica selection is stable regardless of caller.
+        alive.sort_by(|a, b| a.id.cmp(&b.id));
 
         if alive.len() <= 1 {
-            return None; // Only this node is alive.
+            return Vec::new(); // Only this node is alive.
         }
 
-        let key_hash = hash_key(key);
-        #[allow(clippy::cast_possible_truncation)]
-        let idx = (key_hash as usize) % alive.len();
-        let owner = &alive[idx];
+        replica_nodes_for(&alive, hash_key(key), self.config.replication_factor)
+    }
 
-        // If we own it, no remote fetch needed.
-        if owner.id == self.cluster.self_node().id {
-            return None;
-        }
-
-        // Derive data plane address from the node's gossip address IP
-        // and the configured data port.
-        owner
-            .gossip_addr
-            .parse::<SocketAddr>()
-            .ok()
-            .map(|gossip| SocketAddr::new(gossip.ip(), self.config.data_port))
+    /// Number of replica writes that failed to reach or be accepted by a
+    /// peer since startup. A failed replica write never fails the client
+    /// `set` — this counter is for observability only.
+    #[must_use]
+    pub fn replica_write_failures(&self) -> u64 {
+        self.replica_write_failures.load(Ordering::Relaxed)
     }
 
     /// Record a remote fetch and potentially promote a key to the hot
@@ -492,6 +674,44 @@ fn hash_key(key: &str) -> u64 {
     hasher.finish()
 }
 
+/// Select the replica set for a key from a sorted alive-node list.
+///
+/// The primary owner is `alive[key_hash % alive.len()]`; the replica set
+/// is the primary plus the next `factor - 1` distinct nodes clockwise on
+/// the ring (wrapping around). `factor` is clamped to `alive.len()`, so a
+/// replication factor larger than the cluster keeps one copy per node
+/// (never an error). The result is primary-first and contains no
+/// duplicates.
+///
+/// This is a pure function of `(alive, key_hash, factor)` so it is
+/// directly unit-testable with a fixed node list. `alive` MUST be sorted
+/// by a stable key (node id) by the caller for selection to be
+/// membership-stable.
+fn replica_nodes_for(alive: &[NodeInfo], key_hash: u64, factor: usize) -> Vec<NodeInfo> {
+    if alive.is_empty() {
+        return Vec::new();
+    }
+    let n = alive.len();
+    // Clamp the factor to the cluster size and to at least one copy.
+    let want = factor.clamp(1, n);
+    #[allow(clippy::cast_possible_truncation)]
+    let start = (key_hash as usize) % n;
+    // Walk `want` distinct nodes clockwise from the primary. Because we
+    // step over distinct indices `[start, start+1, ...] mod n`, the nodes
+    // are inherently distinct — no dedup needed.
+    (0..want).map(|offset| alive[(start + offset) % n].clone()).collect()
+}
+
+/// Derive a node's TCP data plane address from its gossip address and the
+/// configured data port. Returns `None` if the gossip address does not
+/// parse as a socket address.
+fn node_data_addr(node: &NodeInfo, data_port: u16) -> Option<SocketAddr> {
+    node.gossip_addr
+        .parse::<SocketAddr>()
+        .ok()
+        .map(|gossip| SocketAddr::new(gossip.ip(), data_port))
+}
+
 /// Parse a memory size string like `"64MB"` to bytes.
 ///
 /// Supported units (case-insensitive): `B`, `KB`/`K`, `MB`/`M`, `GB`/`G`.
@@ -608,5 +828,144 @@ mod tests {
     #[test]
     fn parse_memory_size_whitespace() {
         assert_eq!(parse_memory_size("  64MB  ").unwrap(), 64 * 1024 * 1024);
+    }
+
+    // -----------------------------------------------------------------
+    // Replica set selection
+    // -----------------------------------------------------------------
+
+    /// Build a sorted 5-node fixture: `n0`..`n4`.
+    fn fixture_nodes() -> Vec<NodeInfo> {
+        (0..5)
+            .map(|i| NodeInfo {
+                id: format!("n{i}"),
+                gossip_addr: format!("127.0.0.1:{}", 7946 + i),
+                state: crate::NodeState::Alive,
+            })
+            .collect()
+    }
+
+    /// The primary is `alive[key_hash % len]`, regardless of factor.
+    #[allow(clippy::cast_possible_truncation)]
+    fn primary_index(key_hash: u64, len: usize) -> usize {
+        (key_hash as usize) % len
+    }
+
+    #[test]
+    fn replica_set_factor_two_picks_primary_plus_next() {
+        let nodes = fixture_nodes();
+        // key_hash 7 % 5 = 2 → primary n2, then n3.
+        let set = replica_nodes_for(&nodes, 7, 2);
+        let ids: Vec<_> = set.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(ids, vec!["n2", "n3"]);
+    }
+
+    #[test]
+    fn replica_set_wraps_around_ring() {
+        let nodes = fixture_nodes();
+        // key_hash 4 % 5 = 4 → primary n4, then wrap to n0, n1.
+        let set = replica_nodes_for(&nodes, 4, 3);
+        let ids: Vec<_> = set.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(ids, vec!["n4", "n0", "n1"]);
+    }
+
+    #[test]
+    fn replica_set_clamps_to_alive_count() {
+        let nodes = fixture_nodes();
+        // Factor 9 on a 5-node cluster keeps 5 distinct copies, not error.
+        let set = replica_nodes_for(&nodes, 0, 9);
+        assert_eq!(set.len(), 5, "factor is clamped to the number of alive nodes");
+        // All distinct.
+        let mut ids: Vec<_> = set.iter().map(|n| n.id.clone()).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 5, "replica set must contain no duplicates");
+    }
+
+    #[test]
+    fn replica_set_factor_one_is_owner_only() {
+        let nodes = fixture_nodes();
+        for key_hash in [0u64, 1, 2, 3, 4, 99, 12_345] {
+            let set = replica_nodes_for(&nodes, key_hash, 1);
+            assert_eq!(set.len(), 1);
+            assert_eq!(set[0].id, nodes[primary_index(key_hash, 5)].id);
+        }
+    }
+
+    #[test]
+    fn replica_set_zero_factor_is_treated_as_one() {
+        let nodes = fixture_nodes();
+        // A misconfigured factor of 0 must still keep the primary copy.
+        let set = replica_nodes_for(&nodes, 3, 0);
+        assert_eq!(set.len(), 1);
+        assert_eq!(set[0].id, "n3");
+    }
+
+    #[test]
+    fn replica_set_empty_node_list() {
+        assert!(replica_nodes_for(&[], 42, 2).is_empty());
+    }
+
+    #[test]
+    fn replica_set_all_entries_distinct() {
+        let nodes = fixture_nodes();
+        // Exercise every start index at the max factor; each result must
+        // be duplicate-free and full-length.
+        for key_hash in 0..5u64 {
+            let set = replica_nodes_for(&nodes, key_hash, 5);
+            let mut ids: Vec<_> = set.iter().map(|n| n.id.clone()).collect();
+            assert_eq!(ids.len(), 5);
+            ids.sort();
+            ids.dedup();
+            assert_eq!(ids.len(), 5, "start={key_hash}: replicas must be distinct");
+        }
+    }
+
+    #[test]
+    fn replica_set_stable_when_unrelated_node_leaves() {
+        // Selection must be stable: dropping a node that is NOT in a
+        // key's replica set must not change that set's members. key_hash
+        // 0 % 5 = 0 → {n0, n1} with factor 2. Removing n3 (not in the
+        // set) keeps the same primary and secondary.
+        let full = fixture_nodes();
+        let before = replica_nodes_for(&full, 0, 2);
+        let before_ids: Vec<_> = before.iter().map(|n| n.id.clone()).collect();
+        assert_eq!(before_ids, vec!["n0", "n1"]);
+
+        let reduced: Vec<NodeInfo> = full.into_iter().filter(|n| n.id != "n3").collect();
+        let after = replica_nodes_for(&reduced, 0, 2);
+        let after_ids: Vec<_> = after.iter().map(|n| n.id.clone()).collect();
+        assert_eq!(after_ids, before_ids, "removing an unrelated node must not shift the set");
+    }
+
+    #[test]
+    fn node_data_addr_uses_configured_port() {
+        let node = NodeInfo {
+            id: "n0".to_string(),
+            gossip_addr: "10.0.0.5:7946".to_string(),
+            state: crate::NodeState::Alive,
+        };
+        let addr = node_data_addr(&node, 7947).unwrap();
+        assert_eq!(addr.to_string(), "10.0.0.5:7947");
+    }
+
+    #[test]
+    fn node_data_addr_rejects_unparseable_gossip_addr() {
+        let node = NodeInfo {
+            id: "n0".to_string(),
+            gossip_addr: "not-an-addr".to_string(),
+            state: crate::NodeState::Alive,
+        };
+        assert!(node_data_addr(&node, 7947).is_none());
+    }
+
+    #[test]
+    fn replication_mode_parsing() {
+        assert_eq!(ReplicationMode::from_config("sync"), ReplicationMode::Sync);
+        assert_eq!(ReplicationMode::from_config("SYNC"), ReplicationMode::Sync);
+        assert_eq!(ReplicationMode::from_config("async"), ReplicationMode::Async);
+        // Unknown / default falls back to async.
+        assert_eq!(ReplicationMode::from_config("whatever"), ReplicationMode::Async);
+        assert_eq!(ReplicationMode::from_config(""), ReplicationMode::Async);
     }
 }

--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -71,7 +71,7 @@ const SET_OK: u8 = 0x00;
 /// SET response: rejected (e.g., memory limit with `NoEviction`).
 const SET_REJECTED: u8 = 0x01;
 
-/// Start the TCP KV data plane listener.
+/// Start the TCP KV data plane listener on all interfaces at `port`.
 ///
 /// Serves lookups against the local [`Store`] so remote cluster nodes
 /// can fetch large values that exceed the gossip tier threshold.
@@ -87,7 +87,23 @@ pub async fn serve(
     port: u16,
     cipher: Option<Arc<ClusterCipher>>,
 ) -> anyhow::Result<()> {
-    let addr: SocketAddr = ([0, 0, 0, 0], port).into();
+    serve_on(store, ([0, 0, 0, 0], port).into(), cipher).await
+}
+
+/// Start the TCP KV data plane listener bound to a specific address.
+///
+/// Like [`serve`] but binds `addr` exactly instead of `0.0.0.0:port`.
+/// Useful when several nodes share one host (e.g. in-process tests on
+/// distinct `127.0.0.x` loopback addresses).
+///
+/// # Errors
+///
+/// Returns an error if the TCP listener fails to bind.
+pub async fn serve_on(
+    store: Arc<Store>,
+    addr: SocketAddr,
+    cipher: Option<Arc<ClusterCipher>>,
+) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|e| anyhow::anyhow!("failed to bind KV data plane to {addr}: {e}"))?;

--- a/crates/ephpm-cluster/tests/kv_replication.rs
+++ b/crates/ephpm-cluster/tests/kv_replication.rs
@@ -1,0 +1,308 @@
+//! Integration tests for large-value KV replication.
+//!
+//! These spin up several in-process cluster nodes, each with its own
+//! local [`Store`], gossip [`ClusterHandle`], KV data plane listener, and
+//! [`ClusteredStore`]. A large value is written with
+//! `replication_factor = 2` and read back from a non-owner node; then the
+//! owner node is dropped and the value is read again via a replica.
+//!
+//! ## Loopback addressing
+//!
+//! The production replica addressing maps a peer's gossip IP to the
+//! *local* `data_port` (every real node shares one data port on a
+//! different host). To reproduce that in-process, each node binds its
+//! gossip UDP and TCP data plane on a distinct `127.0.0.x` address while
+//! sharing the same `data_port`. Linux routes all of `127.0.0.0/8`, so
+//! CI exercises the full path. Some platforms (Windows, stock macOS)
+//! only bind `127.0.0.1`; there, [`loopback_aliases_available`] returns
+//! `false` and the multi-node tests skip with a logged notice rather
+//! than failing on an environment limitation.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ephpm_cluster::ClusteredStore;
+use ephpm_cluster::node::{ClusterHandle, NodeState, start_gossip};
+use ephpm_cluster::secure_transport::ClusterCipher;
+use ephpm_config::{ClusterConfig, ClusterKvConfig};
+use ephpm_kv::store::{Store, StoreConfig};
+
+/// Pick a currently-free TCP port on loopback. Each test uses its own
+/// data port (shared by that test's nodes on distinct `127.0.0.x`) so
+/// concurrently-running tests never collide on a fixed port.
+fn free_data_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// A single in-process cluster node under test.
+struct TestNode {
+    handle: Arc<ClusterHandle>,
+    store: Arc<ClusteredStore>,
+    /// Aborts the data plane listener task on drop.
+    data_plane: tokio::task::JoinHandle<()>,
+}
+
+impl TestNode {
+    async fn shutdown(self) {
+        self.data_plane.abort();
+        drop(self.store);
+        Arc::try_unwrap(self.handle)
+            .expect("all other handle Arcs dropped before shutdown")
+            .shutdown()
+            .await;
+    }
+}
+
+/// Whether this platform can bind `127.0.0.2` (loopback aliases). Linux
+/// routes all of `127.0.0.0/8`; Windows/macOS usually do not.
+fn loopback_aliases_available() -> bool {
+    std::net::TcpListener::bind("127.0.0.2:0").is_ok()
+}
+
+/// Build the KV config used by every test node.
+fn kv_config(data_port: u16) -> ClusterKvConfig {
+    ClusterKvConfig {
+        // Force everything above a tiny threshold onto the large-value
+        // (data plane) tier so we actually exercise replication.
+        small_key_threshold: 8,
+        replication_factor: 2,
+        replication_mode: "async".to_string(),
+        // Disable the hot-key cache so reads always hit the data plane
+        // and we test the true replica fallback, not a local cache.
+        hot_key_cache: false,
+        data_port,
+        ..ClusterKvConfig::default()
+    }
+}
+
+/// Start one node on `ip` (a `127.0.0.x` loopback), seeded at `seeds`.
+async fn start_test_node(
+    ip: &str,
+    data_port: u16,
+    seeds: Vec<String>,
+    node_id: &str,
+    secret: &str,
+    replication_mode: &str,
+) -> TestNode {
+    // Bind gossip on a random UDP port on this IP.
+    let gossip_sock =
+        tokio::net::UdpSocket::bind(format!("{ip}:0")).await.expect("bind gossip udp");
+    let gossip_port = gossip_sock.local_addr().expect("gossip local_addr").port();
+    drop(gossip_sock); // Release so chitchat can bind it.
+
+    let mut config = kv_config(data_port);
+    config.replication_mode = replication_mode.to_string();
+
+    let cluster_config = ClusterConfig {
+        enabled: true,
+        bind: format!("{ip}:{gossip_port}"),
+        join: seeds,
+        secret: secret.to_string(),
+        node_id: node_id.to_string(),
+        cluster_id: "kv-repl-test".to_string(),
+        kv: config.clone(),
+    };
+    let handle = Arc::new(
+        start_gossip(&cluster_config)
+            .await
+            .unwrap_or_else(|e| panic!("gossip start failed for {node_id}: {e}")),
+    );
+
+    let store = Store::new(StoreConfig::default());
+    let cipher: Option<Arc<ClusterCipher>> = if secret.is_empty() {
+        None
+    } else {
+        Some(Arc::new(ClusterCipher::for_kv_data_plane(secret)))
+    };
+
+    // Data plane listens on this node's IP + this test's data port.
+    // `serve_on` binds this exact address (not 0.0.0.0), so several
+    // nodes can share one host on distinct 127.0.0.x IPs.
+    let data_addr: SocketAddr = format!("{ip}:{data_port}").parse().expect("data addr");
+    let data_store = Arc::clone(&store);
+    let data_cipher = cipher.clone();
+    let data_plane = tokio::spawn(async move {
+        if let Err(e) =
+            ephpm_cluster::data_plane::serve_on(data_store, data_addr, data_cipher).await
+        {
+            eprintln!("data plane serve_on failed on {data_addr}: {e}");
+        }
+    });
+
+    let clustered = ClusteredStore::new(store, Arc::clone(&handle), config, cipher);
+    TestNode { handle, store: clustered, data_plane }
+}
+
+/// Wait until every handle sees `expected` alive nodes.
+async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        let mut all_ok = true;
+        for h in handles {
+            let alive = h.nodes().await.iter().filter(|n| n.state == NodeState::Alive).count();
+            if alive != expected {
+                all_ok = false;
+                break;
+            }
+        }
+        if all_ok {
+            return;
+        }
+        assert!(start.elapsed() <= timeout, "convergence timeout after {timeout:?}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Read `key` from `store`, retrying briefly to absorb gossip/replica
+/// propagation. Returns the value or `None` if not readable in time.
+async fn read_with_retry(store: &ClusteredStore, key: &str, timeout: Duration) -> Option<Vec<u8>> {
+    let start = Instant::now();
+    loop {
+        if let Some(v) = store.get(key).await {
+            return Some(v);
+        }
+        if start.elapsed() > timeout {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Core scenario shared by the async and sync tests.
+async fn replication_survives_owner_loss(mode: &str, secret: &str) {
+    if !loopback_aliases_available() {
+        eprintln!(
+            "skipping replication_survives_owner_loss[{mode}]: platform lacks 127.0.0.x \
+             loopback aliases (Linux-only in-process multi-node harness)"
+        );
+        return;
+    }
+
+    // Three nodes on distinct loopback IPs, all sharing this test's own
+    // data port (a fresh ephemeral port so parallel tests don't collide).
+    let data_port = free_data_port();
+    let n1 = start_test_node("127.0.0.1", data_port, vec![], "repl-a", secret, mode).await;
+    let seed = n1.handle.self_node().gossip_addr.clone();
+    let n2 =
+        start_test_node("127.0.0.2", data_port, vec![seed.clone()], "repl-b", secret, mode).await;
+    let n3 = start_test_node("127.0.0.3", data_port, vec![seed], "repl-c", secret, mode).await;
+
+    wait_for_convergence(
+        &[n1.handle.as_ref(), n2.handle.as_ref(), n3.handle.as_ref()],
+        3,
+        Duration::from_secs(15),
+    )
+    .await;
+
+    // Write a large value from node 1. With replication_factor = 2 it
+    // lands on its primary owner plus one secondary.
+    let key = "big:payload";
+    let value = vec![0xABu8; 4096];
+    assert!(n1.store.set(key.to_string(), value.clone(), None).await, "primary set must succeed");
+
+    // Give async replication a moment to fan out.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Readable from every node (each either owns a copy or fetches it
+    // from a replica over the data plane).
+    for (name, node) in [("n1", &n1), ("n2", &n2), ("n3", &n3)] {
+        let got = read_with_retry(node.store.as_ref(), key, Duration::from_secs(10)).await;
+        assert_eq!(got.as_deref(), Some(value.as_slice()), "value must be readable from {name}");
+    }
+
+    // Determine the primary owner of the key and drop that node, then
+    // assert a surviving node can still read via the replica.
+    let owner_id = {
+        let mut alive = n1.handle.nodes().await;
+        alive.retain(|n| n.state == NodeState::Alive);
+        alive.sort_by(|a, b| a.id.cmp(&b.id));
+        // Mirror the production owner selection: hash(key) % alive.len().
+        // Reduce mod len in u64 first, so the cast to usize is lossless.
+        let len = alive.len() as u64;
+        let idx = usize::try_from(fnv_like(key) % len).expect("index fits usize");
+        alive[idx].id.clone()
+    };
+
+    // Pick a surviving reader that is NOT the owner.
+    let nodes = [n1, n2, n3];
+    let (owner_idx, _) = nodes
+        .iter()
+        .enumerate()
+        .find(|(_, n)| n.handle.self_node().id == owner_id)
+        .expect("owner must be one of the three nodes");
+
+    // Shut the owner down (simulates node loss).
+    let mut survivors = Vec::new();
+    for (i, node) in nodes.into_iter().enumerate() {
+        if i == owner_idx {
+            node.shutdown().await;
+        } else {
+            survivors.push(node);
+        }
+    }
+
+    // Give gossip a chance to mark the owner dead so replica_nodes()
+    // drops it. This is best-effort: even if the owner is still listed
+    // as alive, the read fallback tolerates it — the fetch to the dead
+    // owner's (aborted) data plane fails and the loop moves on to the
+    // live replica. So we wait but do not hard-fail on non-convergence.
+    let converge_deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < converge_deadline {
+        let mut all_two = true;
+        for n in &survivors {
+            let alive =
+                n.handle.nodes().await.iter().filter(|m| m.state == NodeState::Alive).count();
+            if alive != 2 {
+                all_two = false;
+                break;
+            }
+        }
+        if all_two {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // The value must still be readable from a surviving node via the
+    // replica copy — this is the whole point of replication.
+    let reader = &survivors[0];
+    let got = read_with_retry(reader.store.as_ref(), key, Duration::from_secs(15)).await;
+    assert_eq!(
+        got.as_deref(),
+        Some(value.as_slice()),
+        "value must survive owner loss via a replica ({mode} mode)"
+    );
+
+    for node in survivors {
+        node.shutdown().await;
+    }
+}
+
+/// Hash matching `clustered_store::hash_key` (Rust `DefaultHasher` over
+/// the key string) so the test computes the same primary owner.
+fn fnv_like(key: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[tokio::test]
+async fn async_replication_survives_owner_loss() {
+    replication_survives_owner_loss("async", "").await;
+}
+
+#[tokio::test]
+async fn sync_replication_survives_owner_loss() {
+    replication_survives_owner_loss("sync", "").await;
+}
+
+#[tokio::test]
+async fn encrypted_replication_survives_owner_loss() {
+    replication_survives_owner_loss("sync", "kv-repl-secret").await;
+}

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1380,11 +1380,34 @@ pub struct ClusterKvConfig {
     #[serde(default = "default_small_key_threshold")]
     pub small_key_threshold: usize,
 
-    /// Number of replica copies for large keys.
+    /// Number of copies kept for each large (data-plane) key.
+    ///
+    /// A large key lives on its primary owner (`hash(key) % alive_nodes`)
+    /// plus the next `replication_factor - 1` distinct nodes on the
+    /// sorted alive-node ring. The factor is clamped to the number of
+    /// alive nodes, so a value larger than the cluster size simply keeps
+    /// one copy per node (never an error). `1` disables replication
+    /// (single owner copy). Default `2`.
+    ///
+    /// Replication is write-time only: a node that was down during a
+    /// write does not receive the key until it is rewritten or
+    /// fetched-through. Small (gossip-tier) values ignore this setting —
+    /// they are always replicated to every node.
     #[serde(default = "default_replication_factor")]
     pub replication_factor: usize,
 
-    /// Replication mode for large keys (`"async"` or `"sync"`).
+    /// How large-key replica writes propagate (`"async"` or `"sync"`).
+    ///
+    /// - `"async"` (default): the client write returns as soon as the
+    ///   primary copy is written; the remaining replicas are updated in
+    ///   the background (fire-and-forget, failures logged).
+    /// - `"sync"`: the write also awaits every *reachable* replica
+    ///   before returning (best-effort, read-your-writes durability
+    ///   against live peers). A replica that is down is logged but does
+    ///   not fail the write — this is not a quorum/consensus protocol.
+    ///
+    /// Any value other than `"sync"` (case-insensitive) is treated as
+    /// `"async"`.
     #[serde(default = "default_replication_mode")]
     pub replication_mode: String,
 

--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -52,14 +52,15 @@ through the same `effective_store()` path the `ephpm_kv_*` functions use, so
 config.
 
 In **clustered mode** (`[cluster] enabled = true`) sessions use the same
-two-tier KV path as everything else — with the same caveats. Session blobs
-at or under `cluster.kv.small_key_threshold` (default 512 bytes) ride the
-gossip layer and replicate to **every** node, so a session created on node A
-is readable from nodes B, C, D within gossip convergence time. Larger session
-blobs are placed on a **single** consistent-hash owner node: other nodes can
-fetch them remotely (so requests can still route anywhere), but they are not
-replicated — if the owner node dies, those sessions die with it. See
-[Cluster](#cluster) below.
+two-tier KV path as everything else. Session blobs at or under
+`cluster.kv.small_key_threshold` (default 512 bytes) ride the gossip layer and
+replicate to **every** node, so a session created on node A is readable from
+nodes B, C, D within gossip convergence time. Larger session blobs live on the
+data-plane tier, where they are replicated to `cluster.kv.replication_factor`
+nodes (default 2) — the primary owner (`hash(key) % alive_nodes`) plus the next
+node on the ring. Reads try the owner first, then fall back to a replica, so a
+large session survives the loss of its owner node (up to
+`replication_factor - 1` failures). See [Cluster](#cluster) below.
 
 ## Locking
 
@@ -162,14 +163,20 @@ about what the two-tier KV path gives you:
   bytes) gossip to every node. These survive node loss — the surviving nodes
   already have the data, and the load balancer is free to route the next
   request anywhere.
-- **Larger session blobs** live only on their single consistent-hash owner
-  node. Any node can *read* them (remote fetch from the owner), so routing
-  is still unrestricted — but there is no replication. Losing the owner node
-  loses every large session it owned.
+- **Larger session blobs** live on the data-plane tier and are replicated to
+  `cluster.kv.replication_factor` nodes (default 2): the primary owner
+  (`hash(key) % alive_nodes`) plus the next node on the ring. Any node can
+  *read* them (owner first, then replica fallback), so routing is
+  unrestricted, and a large session survives up to `replication_factor - 1`
+  simultaneous node losses.
 
-If sessions must survive node failure, keep `$_SESSION` small — a user id
-and a handful of flags serialise comfortably under 512 bytes. Shopping-cart
-sized payloads belong in the database, with the session holding just the key.
+Replication is write-time only — there is no active rebalancing yet. A large
+session written while a replica was down, or one whose replica set shifts after
+a topology change, may end up with fewer than `replication_factor` copies until
+it is rewritten. If sessions must survive arbitrary node churn, keep
+`$_SESSION` small — a user id and a handful of flags serialise comfortably
+under 512 bytes, gossiping to every node. Shopping-cart sized payloads belong
+in the database, with the session holding just the key.
 
 Convergence for the gossip tier is best-effort (~10–30s for full-mesh
 convergence under default chitchat timings), so a session created on node A
@@ -190,9 +197,11 @@ is invisible.
   so eviction stays rare.
 - **No persistence across `ephpm` restarts** (yet). The KV store is in-memory
   only. In clustered deployments, sessions small enough for the gossip tier
-  are re-synced to a restarted node by its peers; large sessions owned by the
-  restarted node are gone. Restarting every node simultaneously wipes all
-  sessions. AOF/snapshot persistence is on the roadmap.
+  are re-synced to a restarted node by its peers; a large session survives a
+  single node restart as long as one of its replicas stays up (the restarted
+  node won't get its old copies back, though — there's no anti-entropy yet).
+  Restarting every node simultaneously wipes all sessions. AOF/snapshot
+  persistence is on the roadmap.
 - **No cross-cluster replication.** Sessions live in the same KV tier as
   the rest of your data; if you have geographically split clusters you'll
   need application-level session token forwarding, the same as any

--- a/site/content/architecture/_index.md
+++ b/site/content/architecture/_index.md
@@ -32,7 +32,7 @@ This document describes the full vision for ePHPm. The matrix below tracks what 
 | sqld embedding | **Implemented** | Binary embedded via `include_bytes!()`; spawned per-role; auto-restart on role change |
 | Primary election | **Implemented** | Gossip KV tier (`kv:sqlite:primary`), lowest ordinal wins, TTL heartbeat |
 | KV store (single-node) | **Implemented** | RESP2 server (~30 Redis commands), TTL/expiry, DashMap-backed, SAPI bridge for zero-overhead PHP access |
-| KV store (clustering) | **Implemented** | Gossip discovery, consistent hash ring, cross-node replication |
+| KV store (clustering) | **Implemented** | Gossip discovery, `hash % nodes` key ownership, large-value replication (owner + N-1 replicas, async/sync, write-time only) |
 | KV compression | **Implemented** | gzip / zstd / brotli for stored values |
 | Clustering / gossip | **Implemented** | SWIM via `chitchat` in `ephpm-cluster` |
 | Admin UI / API | Planned | Management interface — not started |
@@ -111,7 +111,7 @@ Every ePHPm node runs as a serving node. The Node API is always present — it's
 ├─────────────┼───────────────┼────────────────────────┤
 │  ACME TLS   │  Clustered KV │  Node API :9090        │
 │ (rustls-    │  (gossip +    │  ├─ /health            │
-│  acme)      │   hash ring)  │  ├─ /metrics (prom)    │
+│  acme)      │  hash%nodes)  │  ├─ /metrics (prom)    │
 │             │               │  ├─ /api/workers       │
 │             │               │  ├─ /api/db/digests    │
 │             │               │  ├─ /api/db/slow       │
@@ -310,7 +310,7 @@ password = "changeme"                 # admin UI auth (separate from node API au
 - INFO command with basic server and memory stats
 - Thread-local get buffer for safe C FFI result passing
 - Eviction policies — `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random` — enforced against `memory_limit` with approximate memory accounting
-- **Clustering** — gossip-based peer discovery (`chitchat`), consistent hash ring, cross-node replication, owner / replica routing for keys (in `ephpm-cluster`)
+- **Clustering** — gossip-based peer discovery (`chitchat`), `hash % nodes` key ownership, large-value replication to `replication_factor` nodes with async/sync write modes and owner-then-replica read fallback (in `ephpm-cluster`)
 
 **Planned / Not Yet Implemented:**
 - Additional data structures (lists, sets, sorted sets) — currently strings + hashes only
@@ -347,7 +347,7 @@ The same arguments apply to embedding Redis, KeyDB, or Garnet. They're all stand
 | Single-node KV | RoadRunner: in-memory/BoltDB/Redis drivers (single-node). Swoole: `Swoole\Table` (single-process shared memory). | In-process concurrent hashmap, zero-overhead access from PHP via SAPI. |
 | Data structures | Redis-style: strings, hashes, lists, sets, sorted sets | `GET`/`SET`/`DEL`, `HGET`/`HSET`, `EXPIRE`, lists. Sorted sets if needed. |
 | TTL / expiry | Standard | Background sweeper + lazy expiry on access. |
-| Clustering | **Nobody has this.** All competitors require external Redis/Memcached. | Gossip-based peer discovery, consistent hash ring, cross-node routing. |
+| Clustering | **Nobody has this.** All competitors require external Redis/Memcached. | Gossip-based peer discovery, `hash % nodes` key ownership, cross-node routing with replication. |
 | PHP access | RoadRunner: Goridge RPC. Swoole: shared memory API. | SAPI function calls — zero serialization, zero network hop for local keys. |
 | Persistence | Optional | Optional AOF/snapshot for crash recovery. This is a cache, not a database. |
 | Redis protocol | Not required | Optional RESP listener so existing Redis clients/tools work. Nice-to-have, not critical. |
@@ -506,24 +506,29 @@ impl ClusterRouter {
 Replication behaves differently for the two value tiers:
 
 - **Small values** (≤ `[cluster.kv] small_key_threshold`, default 512 bytes) are replicated to **every node** via the gossip protocol. Each node holds a local copy; convergence is eventually consistent, typically within hundreds of milliseconds.
-- **Large values** live on **exactly one node** — the owner selected by `hash(key) % nodes`. There are no replica copies today. If the owner dies, its large values are gone and must be regenerated — fine for cache data, not for anything you can't recompute.
+- **Large values** are replicated to `[cluster.kv] replication_factor` nodes (default 2): the primary owner (`hash(key) % alive_nodes`) plus the next `replication_factor - 1` distinct nodes on the sorted alive-node ring (wrapping around, clamped to the cluster size). Writes go to the whole set; reads try the owner first and fall back to the other replicas, so a large value survives the loss of its owner — up to `replication_factor - 1` node failures.
 
-The `[cluster.kv]` keys `replication_factor` and `replication_mode` are **parsed but not implemented** — setting them has no effect. Multi-copy replication of large values (with sync/async write modes) is a planned feature.
+Write mode is controlled by `replication_mode`:
+
+- `"async"` (default) — the client write returns after the primary/local copy is written; the remaining replicas are updated in the background (fire-and-forget, failures logged and counted).
+- `"sync"` — the write also awaits every *reachable* replica before returning (best-effort read-your-writes durability against live peers). A replica that is down is logged but does **not** fail the write; this is not a quorum or consensus protocol, and no rollback is performed.
+
+Replication is **write-time only** — there is no active anti-entropy or rebalancing. A node that was down during a write does not receive the key until it is rewritten or fetched-through, and existing keys are not re-replicated when membership changes.
 
 ```toml
 [cluster.kv]
-replication_factor = 2        # parsed but NOT implemented — no effect today
-replication_mode = "async"    # parsed but NOT implemented — no effect today
+replication_factor = 2        # copies of each large value (owner + N-1 peers)
+replication_mode = "async"    # async (default) or sync
 ```
 
 #### 4. Node join / leave / failure
 
 | Event | What happens |
 |---|---|
-| **Node joins** | Gossip announces the new member. Ownership is recomputed (hash modulo the new node list) — most large-tier keys remap to new owners; remapped keys behave as cache misses until rewritten. |
-| **Node leaves gracefully** | Departure propagates via gossip; ownership is recomputed the same way. Large values held only by the departed node are gone. |
-| **Node crashes** | Gossip failure detector triggers after missed heartbeats. Surviving nodes recompute ownership; the crashed node's large values are lost. Small gossip-tier values survive — every node has a copy. |
-| **Network partition** | Nodes on each side continue serving their local keys. On heal, conflict resolution via last-write-wins (LWW) timestamps. |
+| **Node joins** | Gossip announces the new member. Ownership is recomputed (hash modulo the new node list) — most large-tier keys remap to new owner/replica sets. Because replication is write-time only, a remapped key isn't present on its *new* replicas until it's rewritten or fetched-through; the old replicas may still serve it during read fallback. |
+| **Node leaves gracefully** | Departure propagates via gossip; ownership is recomputed the same way. Large values it held survive if another replica in their set is still up (`replication_factor ≥ 2`); with `replication_factor = 1` they are gone. |
+| **Node crashes** | Gossip failure detector triggers after missed heartbeats. Surviving nodes recompute ownership and read via replicas — a large value survives up to `replication_factor - 1` simultaneous crashes. With `replication_factor = 1` (or more crashes than replicas) the affected large values are lost. Small gossip-tier values always survive — every node has a copy. |
+| **Network partition** | Nodes on each side continue serving their local keys and any replicas they hold. On heal, conflict resolution via last-write-wins (LWW) timestamps. |
 
 ### PHP Access: Zero-Overhead via SAPI
 
@@ -1637,7 +1642,7 @@ ephpm/
 │   ├── ephpm-config/           # Configuration (figment) — TOML + EPHPM_* env var overrides
 │   ├── ephpm-kv/               # Embedded KV store — DashMap, RESP2, TTL/expiry, gzip/zstd/brotli compression
 │   ├── ephpm-db/               # DB proxy — MySQL wire, connection pooling, R/W splitting
-│   ├── ephpm-cluster/          # Clustering — SWIM gossip (chitchat), consistent hash ring, KV replication, SQLite primary election
+│   ├── ephpm-cluster/          # Clustering — SWIM gossip (chitchat), hash%nodes key ownership, KV replication, SQLite primary election
 │   ├── ephpm-sqld/             # sqld embedding — binary extracted via include_bytes!, child process lifecycle, health checks
 │   ├── ephpm-query-stats/      # Query observability — SQL normalizer, digest tracker, slow query log, Prometheus metrics
 │   └── ephpm-e2e/              # E2E test harness — EXCLUDED from the workspace; runs in Docker via `cargo xtask e2e`
@@ -1669,7 +1674,7 @@ The original MVP — single binary, hyper + PHP, TOML config, WordPress demo —
 - Single-node SQLite via [litewire](https://github.com/ephpm/litewire) + `rusqlite`, transparent to PHP via `pdo_mysql`
 - Clustered SQLite via litewire + embedded `sqld` sidecar (gRPC WAL frame replication)
 - KV store: DashMap-backed, RESP2 protocol, gzip/zstd/brotli compression, SAPI bridge for in-process PHP access
-- Clustering: SWIM gossip (`chitchat`), consistent hash ring, KV replication, SQLite primary election
+- Clustering: SWIM gossip (`chitchat`), `hash % nodes` key ownership, large-value KV replication (owner + N-1 replicas), SQLite primary election
 
 **Observability** — partial:
 

--- a/site/content/architecture/clustering.md
+++ b/site/content/architecture/clustering.md
@@ -1,6 +1,8 @@
 # Clustering & KV Store Architecture
 
-This document covers the in-memory KV store, gossip-based clustering, consistent hashing, replication, and all features that depend on the KV layer (ACME cert coordination, PHP response cache, session storage).
+This document covers the in-memory KV store, gossip-based clustering, `hash % nodes` key ownership, large-value replication, and all features that depend on the KV layer (ACME cert coordination, PHP response cache, session storage).
+
+> **Doc status:** this is a broad design document written ahead of implementation. Sections describing the KV store, gossip transport security, key ownership, and replication have been reconciled with the shipped code (`crates/ephpm-cluster/`). Some later sections (auto-instrumentation, admin UI wiring, and the illustrative session-handler C listing) still describe the intended design and may not match the code line-for-line — those spots are flagged inline.
 
 ---
 
@@ -25,7 +27,7 @@ We evaluated embedding existing databases (Redis, Dragonfly, KeyDB, Garnet) and 
 | Single-node KV | RoadRunner: in-memory/BoltDB/Redis drivers. Swoole: `Swoole\Table`. | In-process concurrent hashmap, zero-overhead access from PHP via SAPI. |
 | Data structures | Redis-style: strings, hashes, lists, sets, sorted sets | MVP: strings + hashes only (covers 95% of PHP usage). Lists, sets, sorted sets added later if needed. |
 | TTL / expiry | Standard | Background sweeper + lazy expiry on access. |
-| Clustering | **Nobody has this.** All competitors require external Redis/Memcached. | Gossip-based peer discovery, consistent hash ring, cross-node routing. |
+| Clustering | **Nobody has this.** All competitors require external Redis/Memcached. | Gossip-based peer discovery, `hash % nodes` key ownership, cross-node routing with replication. |
 | PHP access | RoadRunner: Goridge RPC. Swoole: shared memory API. | SAPI function calls — zero serialization, zero network hop for local keys. |
 | Persistence | Optional | **Planned — not yet implemented.** Optional AOF/snapshot for crash recovery. This is a cache, not a database. |
 | Redis protocol compat | Not required | Optional RESP listener so existing Redis clients/tools work. |
@@ -331,7 +333,7 @@ The session handler implements PHP's `SessionHandlerInterface` at the C level:
 | `destroy($id)` | `ephpm_kv_del("session:$id")` |
 | `gc($max_lifetime)` | No-op (TTL expiry handles this) |
 
-With clustering, sessions are accessible from any node — no sticky sessions required at the load balancer. Consistent hashing on session ID means reads-after-writes within the same session naturally hit the same node (strong consistency for free with async replication).
+With clustering, sessions are accessible from any node — no sticky sessions required at the load balancer. Ownership is a deterministic `hash(session_id) % alive_nodes`, so within a stable cluster reads-after-writes for a session hit the same owner (read-your-writes for free). Large session blobs are additionally replicated to `replication_factor` nodes, so a session survives owner loss.
 
 ### 3. Direct SAPI Functions — Maximum Performance
 
@@ -421,7 +423,7 @@ The RESP paths have overhead from IPC + RESP serialization, but are still **100-
 
 ### Overview
 
-Three components: gossip-based peer discovery, consistent hash ring for key routing, and replication for fault tolerance.
+Three components: gossip-based peer discovery, `hash % nodes` key ownership for routing, and replication for fault tolerance.
 
 ```
    ┌─────────────────┐   gossip    ┌─────────────────┐   gossip    ┌─────────────────┐
@@ -432,11 +434,11 @@ Three components: gossip-based peer discovery, consistent hash ring for key rout
             │                               │                               │
             └────────────── gossip ─────────┴───────────────────────────────┘
             │                               │                               │
-            │           all three register on the shared ring               │
+            │      all three share one sorted alive-node list (gossip)      │
             ▼                               ▼                               ▼
             ┌───────────────────────────────────────────────────────────────┐
-            │                  consistent hash ring                         │
-            │              (key → owner-node mapping)                       │
+            │            key ownership: hash(key) % alive_nodes             │
+            │              (key → owner + replica-set mapping)              │
             └───────────────────────────────────────────────────────────────┘
 ```
 
@@ -544,46 +546,28 @@ A `StatefulSet` is preferred over a `Deployment` for the KV store — pods get s
 
 ### 2. Inter-Node Security
 
-Cluster communication has two channels with different security requirements:
+Cluster communication has two channels, and **both** are secured by the same symmetric pre-shared key (`[cluster] secret`) — there is no TLS or mTLS anywhere in the cluster transport. From the shared secret, ePHPm derives two domain-separated ChaCha20-Poly1305 keys via HKDF-SHA256 (`crates/ephpm-cluster/src/secure_transport.rs`):
+
+- gossip UDP: HKDF info `"ephpm-gossip-v1"`
+- KV data plane TCP: HKDF info `"ephpm-kv-data-v1"`
+
+Because the two planes derive different keys, a ciphertext valid on one plane is meaningless on the other.
 
 #### Gossip Channel (UDP)
 
-The SWIM gossip protocol uses UDP for high-frequency heartbeats and metadata exchange. Encrypted with a symmetric pre-shared key (like Consul's `encrypt` key). This prevents unauthorized nodes from joining the cluster and protects metadata (node addresses, health, KV stats) in transit.
+The SWIM gossip protocol uses UDP for high-frequency heartbeats and metadata exchange. Every datagram is sealed with the gossip key (nonce + Poly1305 tag). Datagrams that fail authentication are silently dropped, so a node without the matching secret — or one sending plaintext — is invisible to the cluster rather than an error. This prevents unauthorized nodes from joining and protects metadata (node addresses, health, KV stats) in transit.
 
-The shared secret is the only required security config — one value to set across all nodes.
+#### Data Plane (TCP + symmetric PSK)
 
-#### Data Plane (TCP + mTLS)
+KV operations between nodes (remote get/set and large-value replication) use TCP. When `[cluster] secret` is set, each request and response is sealed as a single ChaCha20-Poly1305 frame with the data-plane key:
 
-KV operations between nodes (remote get/set, replication, key rebalancing) use TCP with mutual TLS. Both sides authenticate — a rogue node can't join the cluster and read session data or inject cache entries.
-
-mTLS uses rustls (already a dependency for HTTPS serving). Two modes:
-
-**Auto-generated certs (default, zero-config):**
-
-```
-1. Node starts, generates ephemeral self-signed EC cert (P-256)
-2. Publishes cert fingerprint (SHA-256) via gossip
-   (gossip is encrypted with cluster secret, so fingerprint is trusted)
-3. Other nodes learn the fingerprint, add it to their trust store
-4. Data plane connections use mTLS — each side verifies the peer's
-   cert fingerprint against what gossip advertised
-5. Cert regenerated on restart — fingerprint propagates automatically
+```text
+[frame_len: u32 BE][nonce: 12 bytes][ciphertext + 16-byte tag]
 ```
 
-This is fully zero-config beyond the cluster secret. No CA infrastructure, no cert distribution, no renewal management. The gossip channel bootstraps trust for the data plane.
+This is **symmetric pre-shared-key authentication, not mutual TLS**. There are no certificates, no CA, no fingerprint exchange, and no `tls_cert`/`tls_key`/`tls_ca` cluster options. Both sides prove possession of the same secret by being able to seal/open frames; a peer with the wrong secret cannot read values or inject writes (frames fail authentication and the connection is dropped). When the secret is unset, the data plane is plaintext and a warning is logged at startup — only acceptable on a trusted private network.
 
-**Manual certs (enterprise/compliance):**
-
-For environments that require certs from a specific CA (corporate PKI, compliance requirements):
-
-```toml
-[cluster]
-tls_cert = "/etc/ephpm/node.pem"
-tls_key = "/etc/ephpm/node-key.pem"
-tls_ca = "/etc/ephpm/ca.pem"        # CA that signed all node certs
-```
-
-When manual certs are provided, auto-generation is skipped and standard CA verification is used instead of fingerprint pinning.
+The shared secret is the only security config — one value to set across all nodes, covering both planes.
 
 #### Security Summary
 
@@ -592,7 +576,7 @@ When manual certs are provided, auto-generation is skipped and standard CA verif
                     │         Cluster Secret           │
                     │   (symmetric, pre-shared key)    │
                     └──────────┬──────────────────────┘
-                               │
+                               │  HKDF-SHA256 (domain-separated)
                ┌───────────────┼───────────────┐
                │               │               │
                ▼               ▼               ▼
@@ -600,67 +584,50 @@ When manual certs are provided, auto-generation is skipped and standard CA verif
           │ Node A  │    │ Node B  │    │ Node C  │
           └────┬────┘    └────┬────┘    └────┬────┘
                │              │              │
-  Gossip (UDP) │◄─encrypted──►│◄─encrypted──►│
-  symmetric key│              │              │
+  Gossip (UDP) │◄─sealed─────►│◄─sealed─────►│
+  ChaCha20     │  (gossip key)│              │
                │              │              │
-  Data (TCP)   │◄───mTLS─────►│◄───mTLS─────►│
-  cert pinning │              │              │
-  or CA verify │              │              │
-               │              │              │
+  Data (TCP)   │◄─sealed─────►│◄─sealed─────►│
+  ChaCha20     │  (data key)  │              │
+  (PSK, no TLS)│              │              │
 ```
 
 | Channel | Transport | Encryption | Authentication |
 |---------|-----------|------------|----------------|
-| Gossip | UDP | Symmetric (cluster secret) | Pre-shared key |
-| Data plane | TCP | TLS 1.3 (rustls) | mTLS — auto-generated certs with fingerprint pinning, or CA-signed certs |
+| Gossip | UDP | ChaCha20-Poly1305 (gossip key from cluster secret) | Symmetric PSK — undecryptable datagrams dropped |
+| Data plane | TCP | ChaCha20-Poly1305 (data-plane key from cluster secret) | Symmetric PSK — unauthenticated frames dropped, connection closed |
 
-### 3. Consistent Hash Ring
+### 3. Key Ownership (`hash % nodes`)
 
-Keys are distributed across nodes using a consistent hash ring. When a node joins or leaves, only ~1/N of keys need to be rebalanced (not all of them).
+Large-tier keys are distributed across nodes by a plain modulo of the **sorted alive-node list** — there is no consistent hash ring, no virtual nodes, and no `hashring` crate dependency (see `crates/ephpm-cluster/src/clustered_store.rs`):
 
 ```
-            ┌───────────────────────┐
-            │    Hash Ring          │
-            │                       │
-            │   0x0000 ──► Node A   │
-            │   0x5556 ──► Node B   │
-            │   0xAAAB ──► Node C   │
-            │                       │
-            │   Key "session:abc"   │
-            │   hash = 0x3A21       │
-            │   → owned by Node A   │
-            └───────────────────────┘
+owner = alive_nodes_sorted[ hash(key) % alive_nodes_sorted.len() ]
 ```
 
-Each node uses virtual nodes (vnodes) for even distribution — e.g., 150 vnodes per physical node. The `hashring` crate handles this.
+```
+            ┌───────────────────────────┐
+            │  sorted alive nodes:       │
+            │  [ Node A, Node B, Node C ]│
+            │                            │
+            │  Key "session:abc"         │
+            │  hash % 3 = 0 → Node A     │
+            └───────────────────────────┘
+```
+
+The trade-off vs a consistent hash ring: when membership changes (a node joins, leaves, or dies), ownership remaps **broadly** — most keys change owner, not the ~1/N a ring would give. For ePHPm's cache-oriented workload (values that can be refetched or recomputed) this is acceptable; a consistent-hashing scheme may replace it later if remapping cost becomes a problem.
 
 ```rust
-use hashring::HashRing;
-
 struct ClusterRouter {
-    ring: RwLock<HashRing<NodeId>>,
+    alive_nodes: RwLock<Vec<NodeId>>,   // sorted; from gossip membership
     local_node: NodeId,
-    peers: DashMap<NodeId, PeerConnection>,
 }
 
 impl ClusterRouter {
-    /// Route a key to the correct node.
+    /// Primary owner of a key.
     fn owner(&self, key: &[u8]) -> NodeId {
-        let ring = self.ring.read();
-        ring.get(key).cloned().unwrap()
-    }
-
-    /// Get a value — local fast path or network hop.
-    async fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let owner = self.owner(key);
-        if owner == self.local_node {
-            // Fast path: local lookup, no serialization, no network
-            self.local_store.get(key)
-        } else {
-            // Network hop: forward to owner node
-            let peer = self.peers.get(&owner)?;
-            peer.remote_get(key).await
-        }
+        let nodes = self.alive_nodes.read();
+        nodes[(hash(key) as usize) % nodes.len()].clone()
     }
 }
 ```
@@ -669,44 +636,52 @@ Crate dependencies:
 
 | Crate | Purpose |
 |-------|---------|
-| `chitchat` | Quickwit's SWIM gossip library (or custom implementation) |
-| `hashring` | Consistent hashing with virtual nodes |
+| `chitchat` | Quickwit's SWIM gossip library |
 
-### 3. Replication
+(Key ownership is a few lines of arithmetic over the gossip membership list — no external hashing crate.)
 
-Writes go to the owner node and N replicas (the next N nodes clockwise on the ring). This provides fault tolerance — if a node dies, its replicas can serve reads immediately.
+### 4. Replication
+
+Large-tier writes go to a **replica set**: the primary owner plus the next `replication_factor - 1` distinct nodes on the sorted alive-node ring (wrapping around, clamped to the cluster size). This provides fault tolerance — if the owner dies, a replica can serve reads. Small (gossip-tier) values are separately replicated to *every* node and ignore `replication_factor`.
 
 ```
-Write "session:abc" = "data"
+Write large "cart:abc" = <8 KiB>, replication_factor = 2
        │
        ▼
-   hash(key) → Node A (owner)
+   hash(key) % nodes → Node A (primary owner)
        │
-       ├──► write locally
-       ├──► replicate to Node B (replica 1)
-       └──► replicate to Node C (replica 2)
+       ├──► write to Node A (primary)
+       └──► replicate to Node B (next node on the ring)
+
+Read "cart:abc":  try Node A first → on miss/owner-down, fall back to Node B
 ```
 
-Replication modes:
-- **Asynchronous (default)** — write returns after local write, replicas updated in background (lower latency, eventual consistency)
-- **Synchronous** — write waits for N replicas to confirm (stronger consistency, higher latency)
+Replication modes (`[cluster.kv] replication_mode`):
+- **async (default)** — the client write returns after the primary/local copy is written; the remaining replicas are updated in the background (fire-and-forget, failures logged and counted). Lower latency, eventual replica convergence.
+- **sync** — the write also awaits every *reachable* replica before returning. This is best-effort read-your-writes durability against live peers: a replica that is down is logged but does **not** fail the write. It is **not** a quorum or consensus protocol (no Raft, no rollback).
 
-For sessions and cache data, async replication with read-your-writes consistency is the right default. PHP apps doing `$_SESSION['cart'] = ...` on one request and reading it on the next will hit the same node (session affinity via consistent hashing on session ID), so they get strong consistency for free.
+Read path: reads try the primary owner first, then fall back to the other replicas in ring order until one returns the value. A large value therefore survives up to `replication_factor - 1` node failures.
+
+> **Membership caveat (v1):** replication is write-time only. There is no active anti-entropy or rebalancing — a node that was down during a write does not receive the key until it is rewritten or fetched-through, and existing keys are not re-replicated when membership changes.
+
+For sessions and cache data, async replication is the right default. PHP apps doing `$_SESSION['cart'] = ...` on one request and reading it on the next hit the same owner (ownership is a deterministic function of the session id and the current membership), so within a stable cluster they get read-your-writes for free.
 
 ```toml
 [cluster.kv]
-replication_factor = 2        # copies on 2 additional nodes
-replication_mode = "async"    # or "sync"
+replication_factor = 2        # copies of each large value (owner + N-1 peers)
+replication_mode = "async"    # async (default) or sync
 ```
 
-### 4. Node Join / Leave / Failure
+### 5. Node Join / Leave / Failure
+
+Because ownership is `hash % alive_nodes` and replication is write-time only (no active rebalancing), membership changes remap ownership but do **not** move existing data:
 
 | Event | What happens |
 |-------|-------------|
-| **Node joins** | Gossip announces new member. Hash ring adds vnodes. Affected key ranges transfer from current owners to new node in background. |
-| **Node leaves gracefully** | Node announces departure via gossip. Key ranges transfer to next nodes on ring before shutdown. |
-| **Node crashes** | Gossip failure detector triggers after missed heartbeats. Replicas promote to owners for affected key ranges. New replicas created on surviving nodes. |
-| **Network partition** | Nodes on each side continue serving their local keys. On heal, conflict resolution via last-write-wins (LWW) timestamps. |
+| **Node joins** | Gossip announces the new member. Ownership is recomputed against the larger node list — most large-tier keys remap to new owner/replica sets. A remapped key is not present on its *new* replicas until it is rewritten or fetched-through; the old replicas may still serve it via read fallback. |
+| **Node leaves gracefully** | Departure propagates via gossip; ownership is recomputed. Large values it held survive if another replica in their set is still up (`replication_factor ≥ 2`); with `replication_factor = 1` they are gone. |
+| **Node crashes** | Gossip failure detector triggers after missed heartbeats. Surviving nodes recompute ownership and read via replicas — a large value survives up to `replication_factor - 1` simultaneous crashes. Small gossip-tier values always survive (every node has a copy). There is no background re-replication to restore the lost copy count yet. |
+| **Network partition** | Nodes on each side continue serving their local keys and any replicas they hold. On heal, conflict resolution via last-write-wins (LWW) timestamps. |
 
 ---
 
@@ -898,6 +873,8 @@ PHP: session_start()
 
 The session handler is registered during SAPI initialization via `php_session_register_module()`. All functions go through `ephpm_wrapper.c` with `zend_try`/`zend_catch` bailout protection.
 
+> **TODO verify / does not match the shipped code:** the C listing below is the *original design sketch*. The actual implementation in `crates/ephpm-php/ephpm_wrapper.c` does not use the `ephpm_kv_session_lock(const char *id, size_t id_len)` / `ephpm_kv_session_unlock(...)` FFI signatures shown here. Locking is done inside the wrapper via a KV op table (`g_kv_ops.set_nx` / `g_kv_ops.del`) and internal `static` helpers `ephpm_session_lock_acquire(sid, sid_len)` / `ephpm_session_lock_release(void)`, with the acquired sid tracked in thread-local state (`session_lock:<sid>`, 30s TTL, spin-with-backoff). See [the Sessions feature doc](/features/sessions/) for the authoritative behaviour.
+
 ```c
 // ephpm_wrapper.c
 
@@ -1082,7 +1059,7 @@ fn session_lock(session_id: &str, timeout: Duration) -> bool {
 }
 ```
 
-With clustering, the lock lives on whichever node owns the `session_lock:{id}` key via the hash ring. Since the session data key (`session:{id}`) hashes to the same node prefix, lock + data will typically be co-located — no extra network hop for the common case.
+With clustering, the lock key `session_lock:{id}` is small and rides the gossip tier (it is well under `small_key_threshold`), so it is replicated to every node — the `SETNX` and `DEL` operate on the local gossip-backed view. (In the shipped implementation the lock is node-local; see the [Sessions feature doc](/features/sessions/) for the exact cross-node semantics.)
 
 #### Serialization
 
@@ -1128,9 +1105,9 @@ Client → Load Balancer → Pod 0: session_start()
   │                          → session data available immediately
 ```
 
-No sticky sessions needed at the load balancer. Any node can read/write any session. Consistent hashing ensures the session key always routes to the same owner node, so there's no replication lag concern for read-your-writes within a single session.
+No sticky sessions needed at the load balancer. Any node can read/write any session. Ownership (`hash(session_id) % alive_nodes`) keeps a session on the same owner while membership is stable, so there's no replication-lag concern for read-your-writes within a single session.
 
-If the owner node (Pod 2) crashes, the replica promotes to owner automatically. The next session request routes to the new owner — no data loss, no user impact.
+If the owner node (Pod 2) crashes, a surviving node recomputes ownership and reads the session from a replica (large blobs are replicated to `replication_factor` nodes; small blobs live on every node via gossip). The session survives up to `replication_factor - 1` simultaneous owner-side failures. Note the write-time-only caveat: there is no background re-replication, so after a crash the surviving copies are not automatically topped back up to `replication_factor` until the session is rewritten.
 
 #### Performance vs Other Session Handlers
 
@@ -1197,9 +1174,9 @@ The KV store and clustering should be built incrementally:
 | **4. Session handler** | Custom PHP session save handler using KV (SAPI path) | Phase 3 |
 | **5. Composer package** | `ephpm/ephpm` — PSR-6/PSR-16 adapters, Laravel/Symfony drivers, Redis fallback | Phase 3 |
 | **6. Gossip** | `chitchat` integration, peer discovery, health, symmetric encryption | Nothing — can start in parallel with Phase 1 |
-| **6b. Inter-node mTLS** | Auto-generated certs, fingerprint exchange via gossip, data plane TLS | Phase 6 |
-| **7. Hash ring** | Consistent hashing, key routing, local vs remote (over mTLS) | Phase 1 + Phase 6b |
-| **8. Replication** | Async/sync replication, failure promotion | Phase 7 |
+| **6b. Data plane PSK encryption** | ChaCha20-Poly1305 sealing of the TCP data plane with a key derived from `[cluster] secret` (symmetric PSK, not mTLS) | Phase 6 |
+| **7. Key ownership** | `hash % nodes` owner selection, local vs remote routing over the (optionally sealed) data plane | Phase 1 + Phase 6b |
+| **8. Replication** | Async/sync large-value replication to `replication_factor` nodes, owner-then-replica read fallback (write-time only; no active rebalancing) | Phase 7 |
 | **9. ACME on KV** | Swap `DirCache` for `KvCache` in rustls-acme | Phase 8 |
 | **10. PHP response cache** | ETag interception, 304 short-circuit | Phase 7 |
 | **11. Distributed locks** | TTL-based locks, leader election | Phase 7 |
@@ -1207,7 +1184,7 @@ The KV store and clustering should be built incrementally:
 | **13. RESP lists** | `LPUSH`/`RPUSH`/`LPOP`/`RPOP`/`BRPOP` — only if Laravel queue demand warrants it | Phase 2 |
 | **14. RESP sets + sorted sets** | `SADD`/`ZADD` etc. — low priority, most apps needing these keep a dedicated Redis | Phase 2 |
 
-Phases 1-5 (single-node) and Phase 6 (gossip) can be developed in parallel. Everything after Phase 7 depends on the hash ring being operational. RESP data structure phases (13-14) can be added at any time after Phase 2.
+Phases 1-5 (single-node) and Phase 6 (gossip) can be developed in parallel. Everything after Phase 7 depends on key ownership being operational. RESP data structure phases (13-14) can be added at any time after Phase 2.
 
 ---
 
@@ -1230,16 +1207,12 @@ socket = "/run/ephpm/redis.sock"       # Unix socket (~2-5x faster than TCP)
 enabled = false
 bind = "0.0.0.0:7946"                 # gossip listen address
 join = ["10.0.1.2:7946"]              # seed nodes
-secret = ""                            # shared secret — encrypts gossip + KV data plane, authenticates nodes
-
-# mTLS for data plane (auto-generated certs by default)
-# When omitted, nodes generate ephemeral self-signed certs and
-# exchange fingerprints via the encrypted gossip channel (zero-config).
-# tls_cert = "/etc/ephpm/node.pem"    # manual: PEM cert for this node
-# tls_key = "/etc/ephpm/node-key.pem" # manual: PEM private key
-# tls_ca = "/etc/ephpm/ca.pem"        # manual: CA that signed all node certs
+secret = ""                            # shared secret — a ChaCha20-Poly1305 PSK that
+                                       # seals BOTH gossip UDP and the KV data plane TCP
+                                       # (no TLS/mTLS; there are no tls_cert/tls_key/tls_ca
+                                       # cluster options). Empty = plaintext + startup warning.
 
 [cluster.kv]
-replication_factor = 2                 # copies on N additional nodes
-replication_mode = "async"             # async or sync
+replication_factor = 2                 # copies of each large value (owner + N-1 peers); clamped to cluster size
+replication_mode = "async"             # async (default) or sync — see Replication above
 ```

--- a/site/content/architecture/kv-store.md
+++ b/site/content/architecture/kv-store.md
@@ -106,9 +106,14 @@ This is where `kv:sqlite:primary` and other cluster-wide control state lives. De
 
 ### Tier 2 — TCP data plane (large values)
 
-Values above the threshold live on a single "owner" node, selected as `hash(key)` modulo the sorted alive-node list (no consistent hash ring — see `crates/ephpm-cluster/src/clustered_store.rs`). Requests reach the owner over the TCP data plane (`data_port`, default 7947). Writes go to the owner; reads hit the owner unless the value is in the local hot-key cache.
+Values above the threshold live on a set of "owner" nodes. The primary owner is selected as `hash(key)` modulo the sorted alive-node list (no consistent hash ring — see `crates/ephpm-cluster/src/clustered_store.rs`). Requests reach the owners over the TCP data plane (`data_port`, default 7947).
 
-Large-tier values are **not replicated** — each exists only on its owner node, so an owner failure loses those values. The `replication_factor` and `replication_mode` config keys are parsed but not yet implemented; setting them has no effect today. Only small (gossip-tier) values are replicated — to every node.
+Large-tier values are **replicated** to `[cluster.kv] replication_factor` nodes (default 2): the primary owner plus the next `replication_factor - 1` distinct nodes on the sorted alive-node ring, wrapping around. The factor is clamped to the number of alive nodes.
+
+- **Writes** go to the whole replica set. `replication_mode = "async"` (default) returns after the primary copy is written and updates the other replicas in the background; `replication_mode = "sync"` also awaits every *reachable* replica before returning (best-effort — a down replica is logged, not fatal; this is not a quorum/consensus protocol).
+- **Reads** try the primary owner first, then fall back to the other replicas in ring order. This is what lets a large value survive the loss of its owner — up to `replication_factor - 1` node failures.
+
+Replication is **write-time only**: there is no active anti-entropy or rebalancing. A node that was down during a write does not hold that key until it is rewritten or fetched-through; when membership changes, existing keys are not retroactively re-replicated. Small (gossip-tier) values are still replicated to *every* node regardless of `replication_factor`.
 
 ### Hot-key promotion
 
@@ -140,5 +145,5 @@ If you outgrow it, the RESP listener means swapping back to standalone Redis is 
 
 - [KV from PHP](/guides/kv-from-php/) — the SAPI and RESP APIs
 - [`ephpm kv` CLI](/reference/cli/kv/) — debug the live store
-- [Architecture → Clustering](/architecture/clustering/) — gossip, hash ring, data plane
+- [Architecture → Clustering](/architecture/clustering/) — gossip, key ownership, data plane replication
 - [`crates/ephpm-kv/`](https://github.com/ephpm/ephpm/tree/main/crates/ephpm-kv) — implementation

--- a/site/content/guides/clustering-setup.md
+++ b/site/content/guides/clustering-setup.md
@@ -53,11 +53,13 @@ How it works:
 The KV store is two-tiered automatically when clustering is on:
 
 - **Small values** (≤ 512 bytes by default) ride the gossip protocol and end up on **every** node. Eventually consistent, fast convergence (~hundreds of ms).
-- **Large values** are routed via consistent hashing — each key lives on a single "owner" node, reached over the TCP data plane on port 7947. Get requests fetch from the owner; hot keys promote to a local cache. If the owner node dies, its large values are lost.
+- **Large values** are routed by `hash(key) % alive_nodes` (a plain modulo of the sorted alive-node list — no consistent hash ring or virtual nodes). Each key has a primary owner reached over the TCP data plane on port 7947, and is **replicated** to `replication_factor` nodes total (default 2). Reads try the owner first, then fall back to the other replicas, so a large value survives the loss of its owner. Hot keys additionally promote to a local read cache.
 
 ```toml
 [cluster.kv]
 small_key_threshold = 512           # bytes — boundary between tiers
+replication_factor  = 2             # copies of each large value (owner + N-1 peers)
+replication_mode    = "async"       # async (default) or sync
 hot_key_cache       = true
 hot_key_threshold   = 5             # remote fetches before local cache
 hot_key_local_ttl_secs = 30
@@ -65,7 +67,10 @@ hot_key_max_memory  = "64MB"
 data_port           = 7947
 ```
 
-> `replication_factor` and `replication_mode` appear in the config schema but are parsed and **not implemented** yet — large values are not replicated to peers. If a value must survive node loss, keep it under `small_key_threshold` (it will gossip everywhere) or store it in the clustered SQLite database instead.
+- `replication_factor = 2` keeps each large value on its owner plus the next node on the ring; it is clamped to the number of alive nodes, so a factor larger than the cluster just keeps one copy per node.
+- `replication_mode = "async"` (default) returns after the primary/local write and replicates in the background; `"sync"` also awaits every reachable replica (best-effort — a down replica is logged, not fatal).
+
+> **Membership caveat:** replication is write-time only — there's no active rebalancing yet. A node that was down during a write won't have that key until it's rewritten or fetched-through, and existing keys aren't re-replicated when membership changes. A value that must survive `replication_factor - 1` simultaneous node losses, or any topology churn, is safer under `small_key_threshold` (it gossips everywhere) or in the clustered SQLite database.
 
 ## Kubernetes
 


### PR DESCRIPTION
PR C — the final item on the "make the unflattering list work" series (after #110 cluster encryption and #111 security defaults + session locking, both merged). Builds on #110's encrypted data plane.

`cluster.kv.replication_factor` / `replication_mode` were parsed but unused — large KV values (and sessions >512B) lived on a single owner node and were **lost when it died**. This makes replication real.

## What it does

- **Replica set:** `replica_nodes_for(alive, key_hash, factor)` — primary = `hash % nodes`, then the next `factor-1` distinct nodes clockwise (wraparound), clamped to alive count. Pure + unit-tested.
- **Write:** primary first (client-visible), then secondaries. **async** (default) fire-and-forgets secondaries, returns on primary success, logs+counts failures; **sync** awaits every reachable secondary best-effort (down replicas logged, not fatal; no rollback — explicitly *not* quorum/consensus, documented).
- **Read:** primary, then fall back across replicas in ring order — this is what survives owner loss.
- Membership: write-time replication only (no anti-entropy/rebalancing) — documented as the honest v1 guarantee.

## Docs reconciled (same PR)

Config comments + replication sections across `architecture/{kv-store,clustering,_index}.md`, `guides/clustering-setup.md`, `sessions.md`, README now match the implementation. Also cleaned the **last false claims in clustering.md**: inter-node "mutual TLS" → symmetric ChaCha20-Poly1305 PSK (per #110); removed the fictional `tls_cert/tls_key/tls_ca` and the `hashring` crate/150-vnodes claim (`hash % nodes`); flagged the stale `ephpm_kv_session_lock` C signature. Sessions >`small_key_threshold` now survive up to `replication_factor-1` failures.

## Verification (run locally, all green)

- clippy pedantic + nightly fmt clean; `cargo build --workspace` clean
- 13 new unit tests (replica selection / mode parse); `tests/kv_replication.rs` — 3 in-process nodes, write large value @ RF=2, read from non-owner, **drop owner, read again via replica** (async / sync / encrypted variants)
- Fixed a real test-harness bug the author couldn't catch (their sandbox blocked cargo): the suite shared a fixed data port across tests → concurrent runs (incl. Linux CI) collided. Now each test uses an OS-assigned ephemeral port; ran the suite concurrently 3× with zero failures.
- Full `ephpm-cluster` suite green (63 lib + clustered_store + gossip + replication + secure_gossip); `ephpm-config` 31 (single-threaded); `ephpm-server` 154.