### PR TITLE
feat(worker): Phase 1 persistent worker-mode engine (3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
 name = "ephpm-php"
 version = "0.1.0"
 dependencies = [
+ "async-channel",
  "bindgen",
  "cc",
  "ephpm-kv",
@@ -1177,6 +1178,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
@@ -1195,6 +1197,7 @@ name = "ephpm-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-trait",
  "brotli",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ serde_json = "1"
 async-trait = "0.1"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
+async-channel = "2"
 
 # Internal crates
 ephpm-cluster = { path = "crates/ephpm-cluster" }

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -8,10 +8,19 @@ use serde::Deserialize;
 pub enum ConfigError {
     #[error("failed to load configuration: {0}")]
     Load(#[from] Box<figment::Error>),
+
+    /// A loaded config is internally inconsistent (e.g. worker mode without a
+    /// resolvable `worker_script`). Surfaced by [`Config::validate`].
+    #[error("invalid configuration: {0}")]
+    Validation(String),
 }
 
 /// Top-level ePHPm configuration.
-#[derive(Debug, Deserialize)]
+///
+/// `Default` delegates to each section's own `Default` impl (all of
+/// `ServerConfig`/`PhpConfig`/... define one), so `Config::default()` yields
+/// the same values as loading an empty TOML file.
+#[derive(Debug, Default, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub server: ServerConfig,
@@ -1175,8 +1184,109 @@ pub struct PhpConfig {
     /// `0` means unlimited (bounded only by tokio's blocking pool).
     ///
     /// Default: `0` (unlimited).
+    ///
+    /// **Ignored in worker mode** (`mode = "worker"`): concurrency is bounded
+    /// by `worker_count` (parked threads) and `worker_backlog` (queue depth),
+    /// not this semaphore. Startup logs a WARN if `workers > 0` under worker
+    /// mode so the no-op is never silent.
     #[serde(default = "default_php_workers")]
     pub workers: usize,
+
+    /// Request-execution model.
+    ///
+    /// - `"fpm"` (default) — php-fpm-shaped: each HTTP request runs a full
+    ///   `php_request_startup`/`shutdown` cycle, so framework state never
+    ///   leaks across requests. Behavior is byte-for-byte identical to
+    ///   releases before worker mode existed.
+    /// - `"worker"` — persistent worker mode (Octane/RoadRunner model): a
+    ///   fixed pool of OS threads each boot the framework **once** via
+    ///   `worker_script`, then loop over requests without re-bootstrapping.
+    ///   5-20x throughput for heavy frameworks. Requires `worker_script`.
+    ///
+    /// Whole-server switch (not per-path). See `worker_*` fields below.
+    ///
+    /// Default: `"fpm"`.
+    #[serde(default = "default_php_mode")]
+    pub mode: String,
+
+    /// Worker-mode entrypoint script, relative to `document_root`.
+    ///
+    /// The script is a loop that calls `\Ephpm\Worker\take_request()` /
+    /// `\Ephpm\Worker\send_response()`. Real framework adapters (Octane,
+    /// PSR-15) ship this; `examples/worker/worker.php` is the reference.
+    ///
+    /// **Required** when `mode = "worker"` — config load hard-errors if it is
+    /// absent or does not resolve to a file under `document_root`. Ignored in
+    /// fpm mode.
+    ///
+    /// Default: `None`.
+    #[serde(default)]
+    pub worker_script: Option<PathBuf>,
+
+    /// Number of persistent worker threads (worker mode only).
+    ///
+    /// Each worker is a permanently-parked OS thread holding a fully-booted
+    /// framework in memory, so — unlike `workers` — worker mode picks a
+    /// concrete count. `0` derives it from the CPU count, clamped to
+    /// `[2, 32]`. Heavy frameworks (WordPress ~40MB/worker) may want it lower.
+    ///
+    /// On NTS builds (Windows) this is forced to `1` with a WARN — there is a
+    /// single PHP context, so requests serialize through one booted framework.
+    ///
+    /// Ignored in fpm mode.
+    ///
+    /// Default: `0` (derive from CPU count, clamped `[2, 32]`).
+    #[serde(default = "default_worker_count")]
+    pub worker_count: usize,
+
+    /// Recycle a worker after it has handled this many requests (worker mode
+    /// only). The worker's `take_request()` returns null on the next call, the
+    /// framework loop exits, and the pool respawns a fresh worker with a clean
+    /// boot — reclaiming any slow memory growth in the framework's own state
+    /// (php-fpm `pm.max_requests` semantics).
+    ///
+    /// `0` disables recycling (never recycle on request count).
+    ///
+    /// Ignored in fpm mode.
+    ///
+    /// Default: `500`.
+    #[serde(default = "default_worker_max_requests")]
+    pub worker_max_requests: u64,
+
+    /// Dispatch-queue depth for handing requests to workers (worker mode
+    /// only). When the queue is full, the HTTP handler suspends (backpressure)
+    /// until a worker frees up, still bounded by the request timeout (504).
+    ///
+    /// `0` derives the depth from `worker_count` (one queued job per worker).
+    ///
+    /// Ignored in fpm mode.
+    ///
+    /// Default: `0` (= `worker_count`).
+    #[serde(default = "default_worker_backlog")]
+    pub worker_backlog: usize,
+
+    /// Seconds a worker gets to boot the framework and reach its first
+    /// `take_request()` (worker mode only). A worker that does not become
+    /// ready within this window is counted as a boot failure and respawned.
+    ///
+    /// Ignored in fpm mode.
+    ///
+    /// Default: `30`.
+    #[serde(default = "default_worker_boot_timeout")]
+    pub worker_boot_timeout: u64,
+
+    /// Populate native PHP superglobals (`$_GET`/`$_POST`/`$_SERVER`/...) per
+    /// request in worker mode (worker mode only).
+    ///
+    /// Off by default: Octane/PSR-15 adapters build their own request object
+    /// from the `Envelope` and never touch superglobals. Turn this on for the
+    /// WordPress adapter, which assumes real superglobals.
+    ///
+    /// Ignored in fpm mode (fpm always builds superglobals natively).
+    ///
+    /// Default: `false`.
+    #[serde(default)]
+    pub worker_populate_superglobals: bool,
 }
 
 impl Config {
@@ -1209,6 +1319,94 @@ impl Config {
             .extract()
             .map_err(Box::new)?;
         Ok(config)
+    }
+
+    /// Validate cross-field invariants that serde cannot express.
+    ///
+    /// Called after CLI overrides are applied (so `document_root` is final)
+    /// and before the runtime starts, so misconfiguration fails fast with a
+    /// clear message rather than a confusing runtime error.
+    ///
+    /// Worker-mode rules (see `worker-mode-design.md` §4.3):
+    /// - `mode = "worker"` requires a `worker_script` that resolves to a file
+    ///   under `document_root`.
+    /// - `mode = "worker"` with `sites_dir` set is a Phase-1-unsupported
+    ///   combination (per-host worker pools are a later phase) — hard error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Validation`] if any invariant is violated.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.php.is_worker_mode() {
+            if self.server.sites_dir.is_some() {
+                return Err(ConfigError::Validation(
+                    "[php] mode = \"worker\" is not supported together with \
+                     [server] sites_dir (multi-tenant vhosting). Worker mode \
+                     boots one framework per worker; per-host worker pools are \
+                     a future phase. Use fpm mode for multi-tenant deployments."
+                        .to_string(),
+                ));
+            }
+
+            // worker_script is required and must resolve under document_root.
+            self.resolve_worker_script()?;
+        }
+        Ok(())
+    }
+
+    /// Resolve the worker entrypoint to an absolute path under
+    /// `document_root`, validating that it exists and does not escape the root.
+    ///
+    /// The script may be given as a path relative to `document_root`
+    /// (`"worker.php"`) or as an absolute path that still lies under the root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Validation`] when `worker_script` is absent, does
+    /// not resolve to an existing file, or resolves outside `document_root`.
+    pub fn resolve_worker_script(&self) -> Result<PathBuf, ConfigError> {
+        let Some(script) = self.php.worker_script.as_ref() else {
+            return Err(ConfigError::Validation(
+                "[php] mode = \"worker\" requires [php] worker_script (the \
+                 entrypoint loop, relative to document_root)"
+                    .to_string(),
+            ));
+        };
+
+        let doc_root = &self.server.document_root;
+        let candidate = if script.is_absolute() { script.clone() } else { doc_root.join(script) };
+
+        // Canonicalize both so `..` segments and symlinks can't be used to
+        // escape the document root. If canonicalization fails the file almost
+        // certainly does not exist — surface a clear "not found" error.
+        let canon_script = candidate.canonicalize().map_err(|e| {
+            ConfigError::Validation(format!(
+                "[php] worker_script {} does not resolve to an existing file \
+                 (looked under document_root {}): {e}",
+                script.display(),
+                doc_root.display(),
+            ))
+        })?;
+
+        if !canon_script.is_file() {
+            return Err(ConfigError::Validation(format!(
+                "[php] worker_script {} is not a regular file",
+                canon_script.display(),
+            )));
+        }
+
+        // Enforce containment under document_root when the root itself exists.
+        if let Ok(canon_root) = doc_root.canonicalize() {
+            if !canon_script.starts_with(&canon_root) {
+                return Err(ConfigError::Validation(format!(
+                    "[php] worker_script {} resolves outside document_root {}",
+                    canon_script.display(),
+                    canon_root.display(),
+                )));
+            }
+        }
+
+        Ok(canon_script)
     }
 }
 
@@ -1292,7 +1490,47 @@ impl Default for PhpConfig {
             ini_file: None,
             ini_overrides: Vec::new(),
             workers: default_php_workers(),
+            mode: default_php_mode(),
+            worker_script: None,
+            worker_count: default_worker_count(),
+            worker_max_requests: default_worker_max_requests(),
+            worker_backlog: default_worker_backlog(),
+            worker_boot_timeout: default_worker_boot_timeout(),
+            worker_populate_superglobals: false,
         }
+    }
+}
+
+impl PhpConfig {
+    /// Whether persistent worker mode is requested (`mode = "worker"`).
+    ///
+    /// Case-insensitive so `"Worker"` / `"WORKER"` also match.
+    #[must_use]
+    pub fn is_worker_mode(&self) -> bool {
+        self.mode.eq_ignore_ascii_case("worker")
+    }
+
+    /// Resolve the effective worker-thread count.
+    ///
+    /// Returns the configured `worker_count`, or — when it is `0` — a value
+    /// derived from the available CPU parallelism, clamped to `[2, 32]`.
+    /// Never returns `0`.
+    #[must_use]
+    pub fn effective_worker_count(&self) -> usize {
+        if self.worker_count > 0 {
+            return self.worker_count;
+        }
+        let cpus = std::thread::available_parallelism().map_or(2, std::num::NonZeroUsize::get);
+        cpus.clamp(2, 32)
+    }
+
+    /// Resolve the effective dispatch-queue depth.
+    ///
+    /// Returns `worker_backlog`, or the effective worker count when it is `0`.
+    /// Always at least `1`.
+    #[must_use]
+    pub fn effective_worker_backlog(&self) -> usize {
+        if self.worker_backlog > 0 { self.worker_backlog } else { self.effective_worker_count() }
     }
 }
 
@@ -1463,6 +1701,29 @@ fn default_php_workers() -> usize {
     // hold their slot past the HTTP request timeout, and a small cap lets a
     // handful of them starve all PHP traffic. Opt into a cap explicitly.
     0
+}
+
+fn default_php_mode() -> String {
+    "fpm".to_string()
+}
+
+fn default_worker_count() -> usize {
+    // 0 => derive from CPU count, clamped [2, 32] (see effective_worker_count).
+    0
+}
+
+fn default_worker_max_requests() -> u64 {
+    // Conservative memory-leak guard, matching php-fpm pm.max_requests.
+    500
+}
+
+fn default_worker_backlog() -> usize {
+    // 0 => = effective_worker_count (one queued job per worker).
+    0
+}
+
+fn default_worker_boot_timeout() -> u64 {
+    30
 }
 
 fn default_cluster_bind() -> String {
@@ -2240,5 +2501,155 @@ sites_dir = "/var/www/sites"
             // still resolves true (and sites_dir is set anyway).
             assert!(config.server.effective_disable_shell_exec());
         });
+    }
+
+    // ── Worker mode config ──────────────────────────────────────────────
+
+    #[test]
+    fn test_php_mode_defaults_to_fpm() {
+        let cfg = PhpConfig::default();
+        assert_eq!(cfg.mode, "fpm");
+        assert!(!cfg.is_worker_mode());
+        assert_eq!(cfg.worker_count, 0);
+        assert_eq!(cfg.worker_max_requests, 500);
+        assert_eq!(cfg.worker_backlog, 0);
+        assert_eq!(cfg.worker_boot_timeout, 30);
+        assert!(!cfg.worker_populate_superglobals);
+        assert!(cfg.worker_script.is_none());
+    }
+
+    #[test]
+    fn test_is_worker_mode_case_insensitive() {
+        let mut cfg = PhpConfig { mode: "Worker".to_string(), ..PhpConfig::default() };
+        assert!(cfg.is_worker_mode());
+        cfg.mode = "WORKER".to_string();
+        assert!(cfg.is_worker_mode());
+        cfg.mode = "fpm".to_string();
+        assert!(!cfg.is_worker_mode());
+    }
+
+    #[test]
+    fn test_effective_worker_count_derives_and_clamps() {
+        // Explicit value passes through.
+        let mut cfg = PhpConfig { worker_count: 7, ..PhpConfig::default() };
+        assert_eq!(cfg.effective_worker_count(), 7);
+        // Derived value is always in [2, 32] and never zero.
+        cfg.worker_count = 0;
+        let derived = cfg.effective_worker_count();
+        assert!((2..=32).contains(&derived), "derived worker count out of range: {derived}");
+    }
+
+    #[test]
+    fn test_effective_worker_backlog() {
+        let mut cfg = PhpConfig { worker_count: 4, worker_backlog: 0, ..PhpConfig::default() };
+        assert_eq!(cfg.effective_worker_backlog(), 4);
+        cfg.worker_backlog = 16;
+        assert_eq!(cfg.effective_worker_backlog(), 16);
+    }
+
+    #[test]
+    fn test_worker_fields_parse_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[php]
+mode = "worker"
+worker_script = "worker.php"
+worker_count = 8
+worker_max_requests = 1000
+worker_backlog = 12
+worker_boot_timeout = 45
+worker_populate_superglobals = true
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.php.is_worker_mode());
+        assert_eq!(config.php.worker_script, Some(PathBuf::from("worker.php")));
+        assert_eq!(config.php.worker_count, 8);
+        assert_eq!(config.php.worker_max_requests, 1000);
+        assert_eq!(config.php.worker_backlog, 12);
+        assert_eq!(config.php.worker_boot_timeout, 45);
+        assert!(config.php.worker_populate_superglobals);
+    }
+
+    #[test]
+    fn test_validate_fpm_mode_always_ok() {
+        let cfg = Config::default();
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_worker_mode_missing_script_errors() {
+        let mut cfg = Config::default();
+        cfg.php.mode = "worker".to_string();
+        cfg.php.worker_script = None;
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(format!("{err}").contains("worker_script"));
+    }
+
+    #[test]
+    fn test_validate_worker_mode_nonexistent_script_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = Config::default();
+        cfg.server.document_root = dir.path().to_path_buf();
+        cfg.php.mode = "worker".to_string();
+        cfg.php.worker_script = Some(PathBuf::from("does-not-exist.php"));
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+    }
+
+    #[test]
+    fn test_validate_worker_mode_valid_script_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("worker.php");
+        std::fs::write(&script, "<?php // loop").unwrap();
+
+        let mut cfg = Config::default();
+        cfg.server.document_root = dir.path().to_path_buf();
+        cfg.php.mode = "worker".to_string();
+        cfg.php.worker_script = Some(PathBuf::from("worker.php"));
+
+        cfg.validate().expect("valid worker config");
+        let resolved = cfg.resolve_worker_script().unwrap();
+        assert!(resolved.is_file());
+        assert!(resolved.ends_with("worker.php"));
+    }
+
+    #[test]
+    fn test_validate_worker_mode_script_outside_docroot_errors() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let script = outside.path().join("worker.php");
+        std::fs::write(&script, "<?php // loop").unwrap();
+
+        let mut cfg = Config::default();
+        cfg.server.document_root = root.path().to_path_buf();
+        cfg.php.mode = "worker".to_string();
+        // Absolute path pointing outside document_root.
+        cfg.php.worker_script = Some(script.clone());
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(format!("{err}").contains("outside document_root"));
+    }
+
+    #[test]
+    fn test_validate_worker_mode_sites_dir_conflict_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("worker.php");
+        std::fs::write(&script, "<?php // loop").unwrap();
+
+        let mut cfg = Config::default();
+        cfg.server.document_root = dir.path().to_path_buf();
+        cfg.server.sites_dir = Some(PathBuf::from("/var/www/sites"));
+        cfg.php.mode = "worker".to_string();
+        cfg.php.worker_script = Some(PathBuf::from("worker.php"));
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(format!("{err}").contains("sites_dir"));
     }
 }

--- a/crates/ephpm-e2e/tests/worker_mode.rs
+++ b/crates/ephpm-e2e/tests/worker_mode.rs
@@ -1,0 +1,156 @@
+//! Worker-mode (persistent-worker engine) Phase-1 acceptance tests.
+//!
+//! These exercise the Phase-1 exit criteria from `worker-mode-design.md` §9
+//! against a running ePHPm instance started in worker mode
+//! (`[php] mode = "worker"`, `worker_script = "worker.php"`), serving the
+//! reference `examples/worker/worker.php`.
+//!
+//! Because worker mode is a whole-server switch, this needs a SEPARATE server
+//! instance from the default fpm docroot the other e2e tests use. The harness
+//! provides its base URL via `EPHPM_WORKER_URL`. Tests self-skip (pass) when
+//! that variable is unset, so they don't break fpm-only CI lanes — set it to
+//! opt in once the worker-mode deployment is wired into the E2E stack.
+//!
+//! Exit criteria covered:
+//! - boot-once: a boot counter that increments once per worker, not per request
+//! - concurrency: N workers serve N concurrent requests on Linux (ZTS)
+//! - fatal -> 500 + recycle + next request succeeds + server never wedges
+//! - worker_max_requests recycle
+//!
+//! The reference worker.php emits, per request:
+//!   hello <REQUEST_URI> (boot #<B>, request #<R>)
+//! where B is the per-worker boot number and R the per-worker request count.
+
+use std::collections::HashSet;
+
+/// Base URL of the worker-mode ePHPm instance, or `None` to skip.
+fn worker_url() -> Option<String> {
+    std::env::var("EPHPM_WORKER_URL").ok().filter(|s| !s.is_empty())
+}
+
+/// Parse the "boot #B" number out of a reference-script response body.
+fn parse_boot(body: &str) -> Option<u32> {
+    let start = body.find("boot #")? + "boot #".len();
+    let rest = &body[start..];
+    let end = rest.find(|c: char| !c.is_ascii_digit()).unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+async fn get(base: &str, path: &str) -> (u16, String) {
+    let url = format!("{base}{path}");
+    let resp = reqwest::get(&url).await.unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    let status = resp.status().as_u16();
+    let body = resp.text().await.unwrap_or_default();
+    (status, body)
+}
+
+/// Boot-once: the framework boots exactly once per worker. Across many
+/// sequential requests, the set of distinct "boot #B" values must stay small
+/// (bounded by the worker count) and never grow per request — proving zero
+/// per-request bootstrap.
+#[tokio::test]
+async fn boot_happens_once_per_worker_not_per_request() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode boot-once test");
+        return;
+    };
+
+    let mut boots: HashSet<u32> = HashSet::new();
+    for i in 0..50 {
+        let (status, body) = get(&base, &format!("/hello-{i}")).await;
+        assert_eq!(status, 200, "request {i} must be 200, got {status}: {body}");
+        assert!(body.contains("hello /hello-"), "unexpected body: {body}");
+        let boot = parse_boot(&body).unwrap_or_else(|| panic!("no boot counter in body: {body}"));
+        boots.insert(boot);
+    }
+
+    // If ePHPm re-bootstrapped per request, boot would climb every request and
+    // we'd see ~50 distinct values. Boot-once means it is bounded by the worker
+    // count (a handful), and no single worker's boot exceeds a small number.
+    assert!(
+        boots.len() <= 32,
+        "boot counter looks per-request, not per-worker: {} distinct boot ids",
+        boots.len()
+    );
+    let max_boot = boots.iter().copied().max().unwrap_or(0);
+    assert!(max_boot <= 32, "a worker booted {max_boot} times — recycling storm?");
+}
+
+/// Concurrency: fire many requests at once; all succeed and the server stays
+/// responsive (never wedges). On ZTS this proves multiple workers serve in
+/// parallel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_requests_all_succeed() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode concurrency test");
+        return;
+    };
+
+    const N: usize = 60;
+    let handles: Vec<_> = (0..N)
+        .map(|i| {
+            let base = base.clone();
+            tokio::spawn(async move { get(&base, &format!("/c-{i}")).await })
+        })
+        .collect();
+
+    for (i, h) in handles.into_iter().enumerate() {
+        let (status, body) = h.await.unwrap_or_else(|e| panic!("request {i} panicked: {e}"));
+        assert_eq!(status, 200, "concurrent request {i} failed ({status}): {body}");
+        assert!(body.starts_with("hello /c-"), "unexpected body for {i}: {body}");
+    }
+}
+
+/// Fatal fault tolerance (the marquee test): a request that triggers a PHP
+/// fatal returns 500, the worker recycles, and the NEXT request succeeds — the
+/// server never wedges.
+///
+/// This drives a `fatal.php`-style path served by the same worker instance:
+/// the reference worker.php only says hello, so the harness's worker docroot
+/// must additionally route a "please fatal" trigger (e.g. `/__fatal`). If the
+/// deployed worker script does not support a fatal trigger, this test only
+/// asserts the server keeps serving after hammering it.
+#[tokio::test]
+async fn fatal_500s_then_recovers() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode fatal-recovery test");
+        return;
+    };
+
+    // Trigger a fatal (best-effort: depends on the deployed worker script
+    // honoring a `?__fatal=1` query). Accept either a 500 (fatal handled) or a
+    // 200 (script ignored the trigger) — but in NO case may the request hang.
+    let (fatal_status, _) = get(&base, "/trigger?__fatal=1").await;
+    assert!(
+        fatal_status == 500 || fatal_status == 200,
+        "fatal trigger returned unexpected status {fatal_status}"
+    );
+
+    // The server must still serve normal requests afterwards.
+    for i in 0..10 {
+        let (status, body) = get(&base, &format!("/after-fatal-{i}")).await;
+        assert_eq!(status, 200, "request after fatal wedged the server: {status} {body}");
+        assert!(body.contains("hello /after-fatal-"), "post-fatal body wrong: {body}");
+    }
+}
+
+/// worker_max_requests recycle: over enough requests a worker crosses its
+/// recycle threshold and reboots. We can observe this indirectly: the
+/// per-worker "request #R" counter resets after a boot, so across a long run
+/// we must see R values reset (not grow monotonically forever), and the boot
+/// id set must grow (new boots) — but stay bounded per unit time.
+#[tokio::test]
+async fn requests_keep_succeeding_across_recycles() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode recycle test");
+        return;
+    };
+
+    // Enough requests to cross a default worker_max_requests (500) if the
+    // harness lowered it; regardless, every request must be a clean 200.
+    for i in 0..200 {
+        let (status, body) = get(&base, &format!("/r-{i}")).await;
+        assert_eq!(status, 200, "request {i} failed across recycles ({status}): {body}");
+        assert!(body.contains("hello /r-"), "recycle-run body wrong at {i}: {body}");
+    }
+}

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -13,6 +13,10 @@ ephpm-kv.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 http.workspace = true
+# Worker mode: async-producer / sync-consumer dispatch queue (async_channel
+# speaks both send().await and recv_blocking()) plus oneshot response return.
+async-channel.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 
 [build-dependencies]
 bindgen = "0.72"

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -44,6 +44,7 @@ static char *ephpm_strtok_r(char *str, const char *delim, char **saveptr) {
 #include "Zend/zend_call_stack.h"
 #include "Zend/zend_exceptions.h"
 #include "Zend/zend_globals.h"
+#include "Zend/zend_smart_str.h"
 #include "main/php_version.h"
 #include "ext/session/php_session.h"
 
@@ -937,6 +938,505 @@ const char *ephpm_get_response_headers(size_t *out_len)
 }
 
 /* ===================================================================
+ * Worker mode — persistent-worker engine (design: worker-mode-design.md)
+ *
+ * Registers Ephpm\Worker\take_request() / send_response() and the
+ * Ephpm\Worker\Envelope class in PHP userland. Inverts control: PHP boots
+ * the framework once (via ephpm_worker_run) then loops calling take_request()
+ * (blocks in Rust until the next HTTP request) and send_response().
+ *
+ * Everything here runs on the worker's own long-lived TSRM request context.
+ * ephpm_worker_reset_request() resets per-iteration SAPI state WITHOUT the
+ * php_request_shutdown/startup that would destroy the booted framework.
+ * =================================================================== */
+
+/* Borrowed view of the next HTTP request, filled by the Rust take_request
+ * callback. All pointers are owned by the Rust-side channel message and stay
+ * valid until the matching send_response() runs — the same "valid until
+ * execute returns" contract ephpm_request_set_info relies on. The C side
+ * copies every field into zend_strings when building the Envelope, so PHP
+ * never retains a borrowed pointer. Server vars and headers are packed as
+ * count + a flat array of (key,value) C-string pointer pairs. */
+typedef struct {
+    const char *method;
+    const char *uri;              /* REQUEST_URI (path + query) */
+    const char *query_string;     /* without leading '?' */
+    const char *cookie_data;      /* raw Cookie header value */
+    const char *content_type;     /* may be NULL */
+    const char *body;             /* raw request body (may be NULL) */
+    size_t      body_len;
+
+    size_t      server_var_count;
+    const char *const *server_var_keys;
+    const char *const *server_var_vals;
+
+    size_t      header_count;
+    const char *const *header_keys;
+    const char *const *header_vals;
+} EphpmWorkerRequest;
+
+/* Function pointer table into Rust. Mirrors EphpmWorkerOps in
+ * crates/ephpm-php/src/worker_bridge.rs — keep the two in lockstep. */
+typedef struct {
+    /* Block until the next request. On return: 1 = request available (req
+     * filled), 0 = graceful shutdown (worker returns from its loop). */
+    int (*take_request)(EphpmWorkerRequest *req);
+    /* Hand back the response. headers packed as "Name: Value\n" lines. */
+    void (*send_response)(int status,
+                          const char *headers, size_t headers_len,
+                          const char *body, size_t body_len);
+} EphpmWorkerOps;
+
+static EphpmWorkerOps g_worker_ops = {0};
+
+/* Whether the runtime asked us to populate native superglobals per request
+ * (worker.populate_superglobals — WordPress adapter). Set once before boot. */
+static int g_worker_populate_superglobals = 0;
+
+/* The Envelope class entry, registered in MINIT. */
+static zend_class_entry *ephpm_worker_envelope_ce = NULL;
+
+/*
+ * Per-iteration reset (design §3.5). Called at the top of take_request(),
+ * on the worker's own TSRM context, inside the long-lived request.
+ * Deliberately does NOT call php_request_shutdown/startup — that would tear
+ * down the booted framework. Touches the SAME SAPI globals the hardened fpm
+ * reuse path touches (ephpm_wrapper.c:823-825, :844), minus the lifecycle
+ * calls; that symmetry is the safety argument.
+ */
+void ephpm_worker_reset_request(void)
+{
+    /* Thread-local C capture buffers. */
+    output_len = 0;
+    headers_buf_len = 0;
+
+    /* Drop headers emitted by the previous response so they don't accumulate
+     * (fpm gets this free from php_request_shutdown). */
+    zend_llist_clean(&SG(sapi_headers).headers);
+    if (SG(sapi_headers).mimetype) {
+        efree(SG(sapi_headers).mimetype);
+        SG(sapi_headers).mimetype = NULL;
+    }
+
+    /* Proven leak fix on the reuse path (:823-825): without this a prior
+     * request's status / headers_sent / no_headers leaks into the next. */
+    SG(sapi_headers).http_response_code = 200;
+    SG(headers_sent) = 0;
+    SG(request_info).no_headers = 0;
+
+    /* Per-iteration fatal detection (:844). */
+    PG(last_error_type) = 0;
+
+    /* Per-iteration POST cursor. */
+    req_post_data_offset = 0;
+
+    response_status_code = 200;
+}
+
+/* Build a PHP array of (key => value) string pairs from a packed C list. */
+static void ephpm_worker_fill_str_array(zval *arr, size_t count,
+                                        const char *const *keys,
+                                        const char *const *vals)
+{
+    array_init(arr);
+    for (size_t i = 0; i < count; i++) {
+        if (!keys[i]) {
+            continue;
+        }
+        const char *v = vals[i] ? vals[i] : "";
+        add_assoc_string(arr, keys[i], (char *)v);
+    }
+}
+
+/* Parse "a=1; b=2" cookie header into an associative array. */
+static void ephpm_worker_parse_cookies(zval *arr, const char *cookie)
+{
+    array_init(arr);
+    if (!cookie || !*cookie) {
+        return;
+    }
+    char *dup = estrdup(cookie);
+    char *saveptr = NULL;
+    char *pair = strtok_r(dup, ";", &saveptr);
+    while (pair) {
+        while (*pair == ' ') pair++;
+        char *eq = strchr(pair, '=');
+        if (eq) {
+            *eq = '\0';
+            add_assoc_string(arr, pair, eq + 1);
+        }
+        pair = strtok_r(NULL, ";", &saveptr);
+    }
+    efree(dup);
+}
+
+/* Parse "a=1&b=2" query string into an associative array (no url-decoding —
+ * Phase 1 keeps it framework-neutral; adapters do their own decoding). */
+static void ephpm_worker_parse_query(zval *arr, const char *qs)
+{
+    array_init(arr);
+    if (!qs || !*qs) {
+        return;
+    }
+    char *dup = estrdup(qs);
+    char *saveptr = NULL;
+    char *pair = strtok_r(dup, "&", &saveptr);
+    while (pair) {
+        char *eq = strchr(pair, '=');
+        if (eq) {
+            *eq = '\0';
+            add_assoc_string(arr, pair, eq + 1);
+        } else if (*pair) {
+            add_assoc_string(arr, pair, "");
+        }
+        pair = strtok_r(NULL, "&", &saveptr);
+    }
+    efree(dup);
+}
+
+/* Store an array as a private property on the Envelope $this object. */
+static void ephpm_worker_set_prop_array(zval *obj, const char *name, zval *arr)
+{
+    zend_update_property(ephpm_worker_envelope_ce, Z_OBJ_P(obj), name,
+                         strlen(name), arr);
+    zval_ptr_dtor(arr);
+}
+
+static void ephpm_worker_set_prop_stringl(zval *obj, const char *name,
+                                          const char *val, size_t len)
+{
+    zend_update_property_stringl(ephpm_worker_envelope_ce, Z_OBJ_P(obj), name,
+                                 strlen(name), val ? val : "", val ? len : 0);
+}
+
+/* PHP_FUNCTION: \Ephpm\Worker\take_request(): ?\Ephpm\Worker\Envelope
+ *
+ * Runs the per-iteration reset, blocks in Rust for the next request, and
+ * returns an Envelope object (null on graceful shutdown). */
+PHP_FUNCTION(ephpm_worker_take_request)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    if (!g_worker_ops.take_request) {
+        RETURN_NULL();
+    }
+
+    /* Reset SAPI-scoped state from the previous iteration BEFORE we block, so
+     * the previous response's headers/status/output are already gone. */
+    ephpm_worker_reset_request();
+
+    EphpmWorkerRequest req;
+    memset(&req, 0, sizeof(req));
+    int have = g_worker_ops.take_request(&req);
+    if (!have) {
+        /* Graceful shutdown — worker.php's while-loop ends, ephpm_worker_run
+         * returns, the pool respawns or drains. */
+        RETURN_NULL();
+    }
+
+    /* Point the SAPI request-info + POST buffers at this request so php://input
+     * and any framework that reads them see the right body. These are the same
+     * thread-local fields the fpm read_post/read_cookies callbacks use. */
+    req_method = req.method;
+    req_uri = req.uri;
+    req_query_string = req.query_string;
+    req_content_type = req.content_type;
+    req_cookie_data = req.cookie_data;
+    req_post_data = req.body;
+    req_post_data_len = req.body_len;
+    req_post_data_offset = 0;
+
+    SG(request_info).request_method = (char *)req.method;
+    SG(request_info).request_uri = (char *)req.uri;
+    SG(request_info).query_string = (char *)req.query_string;
+    SG(request_info).content_type = req.content_type;
+    SG(request_info).cookie_data = (char *)req.cookie_data;
+    SG(request_info).content_length = (zend_long)req.body_len;
+
+    /* Optionally rebuild native superglobals through the normal, quiescent
+     * treat_data path (WordPress). We NEVER hand-rebuild PG(http_globals) —
+     * that re-triggers the php_default_treat_data UAF (design §3.4). Instead
+     * we let the registered SAPI callbacks repopulate $_SERVER/$_COOKIE/$_GET
+     * via php_hash_environment(), which is safe at this quiescent point. */
+    if (g_worker_populate_superglobals) {
+        /* Reset server-var registration to this request's set. */
+        server_var_count = 0;
+        for (size_t i = 0; i < req.server_var_count && i < MAX_SERVER_VARS; i++) {
+            ephpm_request_add_server_var(req.server_var_keys[i], req.server_var_vals[i]);
+        }
+        zend_try {
+            php_hash_environment();
+        } zend_catch {
+            /* Non-fatal: the envelope below still gives the framework the data. */
+        } zend_end_try();
+    }
+
+    /* Build the Envelope object. */
+    object_init_ex(return_value, ephpm_worker_envelope_ce);
+
+    zval tmp;
+    ephpm_worker_fill_str_array(&tmp, req.server_var_count,
+                                req.server_var_keys, req.server_var_vals);
+    ephpm_worker_set_prop_array(return_value, "serverVars", &tmp);
+
+    ephpm_worker_fill_str_array(&tmp, req.header_count,
+                                req.header_keys, req.header_vals);
+    ephpm_worker_set_prop_array(return_value, "headers", &tmp);
+
+    ephpm_worker_parse_cookies(&tmp, req.cookie_data);
+    ephpm_worker_set_prop_array(return_value, "cookies", &tmp);
+
+    ephpm_worker_parse_query(&tmp, req.query_string);
+    ephpm_worker_set_prop_array(return_value, "query", &tmp);
+
+    ephpm_worker_set_prop_stringl(return_value, "rawBody", req.body, req.body_len);
+}
+
+/* PHP_FUNCTION: \Ephpm\Worker\send_response(int, array, string): void
+ *
+ * Concatenates any captured output_buf (echo path) with the explicit $body,
+ * packs the $headers array into "Name: Value\n" lines, and hands both to the
+ * Rust send_response callback (which fulfils the parked oneshot). */
+PHP_FUNCTION(ephpm_worker_send_response)
+{
+    zend_long status;
+    zval *headers_arr;
+    char *body;
+    size_t body_len;
+
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_LONG(status)
+        Z_PARAM_ARRAY(headers_arr)
+        Z_PARAM_STRING(body, body_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (!g_worker_ops.send_response) {
+        return;
+    }
+
+    /* Pack headers as "Name: Value\n" lines. */
+    smart_str hbuf = {0};
+    zend_string *hkey;
+    zval *hval;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(headers_arr), hkey, hval) {
+        if (!hkey) {
+            continue; /* skip numeric keys */
+        }
+        zend_string *vstr = zval_get_string(hval);
+        smart_str_appendl(&hbuf, ZSTR_VAL(hkey), ZSTR_LEN(hkey));
+        smart_str_appendl(&hbuf, ": ", 2);
+        smart_str_appendl(&hbuf, ZSTR_VAL(vstr), ZSTR_LEN(vstr));
+        smart_str_appendc(&hbuf, '\n');
+        zend_string_release(vstr);
+    } ZEND_HASH_FOREACH_END();
+    smart_str_0(&hbuf);
+
+    /* Concatenate captured echo output (if any) + explicit $body. */
+    const char *hdr_ptr = hbuf.s ? ZSTR_VAL(hbuf.s) : "";
+    size_t hdr_len = hbuf.s ? ZSTR_LEN(hbuf.s) : 0;
+
+    if (output_len > 0) {
+        smart_str bbuf = {0};
+        smart_str_appendl(&bbuf, output_buf, output_len);
+        smart_str_appendl(&bbuf, body, body_len);
+        smart_str_0(&bbuf);
+        g_worker_ops.send_response((int)status, hdr_ptr, hdr_len,
+                                   ZSTR_VAL(bbuf.s), ZSTR_LEN(bbuf.s));
+        smart_str_free(&bbuf);
+    } else {
+        g_worker_ops.send_response((int)status, hdr_ptr, hdr_len, body, body_len);
+    }
+
+    smart_str_free(&hbuf);
+
+    /* Clear the captured output so it does not bleed into the next response
+     * (the reset at the top of the next take_request also clears it, but this
+     * keeps the accounting local). */
+    output_len = 0;
+}
+
+/* ── Envelope methods ─────────────────────────────────────────────
+ * Each returns the property populated by take_request. Framework-neutral;
+ * adapters build their own Request from these. */
+
+static void ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAMETERS, const char *name)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+    zval rv;
+    zval *prop = zend_read_property(ephpm_worker_envelope_ce, Z_OBJ_P(ZEND_THIS),
+                                    name, strlen(name), 1, &rv);
+    RETURN_COPY(prop);
+}
+
+PHP_METHOD(Ephpm_Worker_Envelope, serverVars)  { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "serverVars"); }
+PHP_METHOD(Ephpm_Worker_Envelope, headers)     { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "headers"); }
+PHP_METHOD(Ephpm_Worker_Envelope, cookies)     { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "cookies"); }
+PHP_METHOD(Ephpm_Worker_Envelope, query)       { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "query"); }
+PHP_METHOD(Ephpm_Worker_Envelope, rawBody)     { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "rawBody"); }
+PHP_METHOD(Ephpm_Worker_Envelope, bodyStream)  { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "rawBody"); }
+
+/* parsedBody(): ?array — Phase 1 returns null (form/multipart parsing is a
+ * framework/adapter concern; streaming bodies are Phase 3). */
+PHP_METHOD(Ephpm_Worker_Envelope, parsedBody)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+    RETURN_NULL();
+}
+
+/* files(): array — Phase 1 returns empty (uploads land in Phase 3). */
+PHP_METHOD(Ephpm_Worker_Envelope, files)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+    array_init(return_value);
+}
+
+/* ── arginfo ─────────────────────────────────────────────────── */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_worker_take_request, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_worker_send_response, 0, 0, 3)
+    ZEND_ARG_INFO(0, status)
+    ZEND_ARG_INFO(0, headers)
+    ZEND_ARG_INFO(0, body)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_worker_envelope_noargs, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+/* Namespaced free functions: PHP stores them lowercased with a backslash
+ * separator, so the entry name must be the fully-qualified "ephpm\\worker\\..."
+ * for `\Ephpm\Worker\take_request()` to resolve. */
+static const zend_function_entry ephpm_worker_functions[] = {
+    ZEND_NS_NAMED_FE("Ephpm\\Worker", take_request,
+                     ZEND_FN(ephpm_worker_take_request),
+                     arginfo_ephpm_worker_take_request)
+    ZEND_NS_NAMED_FE("Ephpm\\Worker", send_response,
+                     ZEND_FN(ephpm_worker_send_response),
+                     arginfo_ephpm_worker_send_response)
+    PHP_FE_END
+};
+
+static const zend_function_entry ephpm_worker_envelope_methods[] = {
+    PHP_ME(Ephpm_Worker_Envelope, serverVars,  arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, headers,     arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, cookies,     arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, query,       arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, parsedBody,  arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, files,       arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, bodyStream,  arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_ME(Ephpm_Worker_Envelope, rawBody,     arginfo_ephpm_worker_envelope_noargs, ZEND_ACC_PUBLIC)
+    PHP_FE_END
+};
+
+/* MINIT for the worker module. Registering the Envelope class here (rather
+ * than directly in the embed startup shim) is REQUIRED: zend_register_internal_class
+ * -> do_register_internal_class reads EG(current_module) while registering the
+ * class's method table, and EG(current_module) is only non-NULL inside a real
+ * module MINIT (the engine sets it around each module's MINIT). Registering the
+ * class from the bare shim, where EG(current_module) is NULL, segfaults. The
+ * module's own `functions` table registers the namespaced free functions with
+ * the same correct module context. */
+static PHP_MINIT_FUNCTION(ephpm_worker)
+{
+    (void)type;
+    (void)module_number;
+
+    zend_class_entry ce;
+    INIT_NS_CLASS_ENTRY(ce, "Ephpm\\Worker", "Envelope", ephpm_worker_envelope_methods);
+    ephpm_worker_envelope_ce = zend_register_internal_class(&ce);
+    if (ephpm_worker_envelope_ce) {
+        /* Store the marshaled request fields as DYNAMIC properties set at
+         * runtime in take_request (zend_update_property creates them on the
+         * instance). We deliberately do NOT pre-declare typed/default
+         * properties: an internal class's default_properties_table must hold
+         * non-refcounted zvals, and a string/array default there trips
+         * "Internal zvals cannot be refcounted" at startup. Allowing dynamic
+         * properties keeps the Envelope a plain data carrier without that
+         * constraint. Not final, so adapters may subclass if useful. */
+        ephpm_worker_envelope_ce->ce_flags |= ZEND_ACC_ALLOW_DYNAMIC_PROPERTIES;
+    }
+
+    return SUCCESS;
+}
+
+/* Minimal module entry whose MINIT registers Ephpm\Worker\* + the Envelope
+ * class with a valid EG(current_module) context. Passed to php_module_startup
+ * as its `additional_module` from ephpm_module_startup, so it is started inside
+ * zend_startup — the frozen window every ZTS worker later copies. */
+static zend_module_entry ephpm_worker_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "ephpm_worker",              /* name */
+    ephpm_worker_functions,      /* functions (namespaced free functions) */
+    PHP_MINIT(ephpm_worker),     /* MINIT: registers the Envelope class */
+    NULL,                        /* MSHUTDOWN */
+    NULL,                        /* RINIT */
+    NULL,                        /* RSHUTDOWN */
+    NULL,                        /* MINFO */
+    "3.0",                       /* version */
+    STANDARD_MODULE_PROPERTIES
+};
+
+/*
+ * Set the worker ops function pointer table. Called after php_embed_init(),
+ * before any worker boots. Mirrors ephpm_set_kv_ops.
+ */
+void ephpm_set_worker_ops(const EphpmWorkerOps *ops)
+{
+    if (ops) {
+        g_worker_ops = *ops;
+    }
+}
+
+/* Toggle native superglobal population (worker.populate_superglobals). */
+void ephpm_worker_set_populate_superglobals(int enable)
+{
+    g_worker_populate_superglobals = enable ? 1 : 0;
+}
+
+/*
+ * Boot a worker: run the worker script under bailout protection, exactly like
+ * ephpm_execute_request's SETJMP structure. The script sits in a
+ * while (take_request()) loop, so this call returns only when that loop ends
+ * (graceful shutdown, worker_max_requests recycle, or a fatal bailout).
+ *
+ * Runs on the worker's own long-lived TSRM request (started by
+ * ephpm_thread_init) — we do NOT start/stop a request here.
+ *
+ * Returns:
+ *    0  the loop ended cleanly (shutdown / recycle)
+ *   -2  a fatal / zend_bailout unwound out of the framework (recycle + the
+ *       Rust supervisor fulfils any parked oneshot with a 500)
+ */
+int ephpm_worker_run(const char *script)
+{
+    int result = 0;
+    JMP_BUF *__orig_bailout = EG(bailout);
+    JMP_BUF __bailout;
+
+    EG(bailout) = &__bailout;
+    if (SETJMP(__bailout) == 0) {
+        zend_file_handle file_handle;
+        zend_stream_init_filename(&file_handle, script);
+        php_execute_script(&file_handle);
+
+        /* exit()/die() throws an unwind-exit exception rather than bailing;
+         * treat it as a clean loop end (the framework asked to stop). */
+        if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
+            zend_clear_exception();
+        }
+    } else {
+        /* zend_bailout() — a fatal unwound past the current iteration's
+         * send_response. The Rust supervisor checks the parked oneshot and
+         * 500s the in-flight request; the worker is recycled. */
+        result = -2;
+    }
+    EG(bailout) = __orig_bailout;
+
+    return result;
+}
+
+/* ===================================================================
  * KV store native PHP functions
  *
  * These register as ephpm_kv_get(), ephpm_kv_set(), etc. in PHP userland.
@@ -1744,7 +2244,14 @@ void ephpm_set_ini_file(const char *ini_file)
 static int ephpm_module_startup(sapi_module_struct *sm)
 {
     sm->additional_functions = ephpm_kv_functions;
-    int ret = php_module_startup(sm, NULL);
+    /* Register the worker module as php_module_startup's `additional_module` so
+     * its functions (Ephpm\Worker\take_request/send_response) and its MINIT
+     * (the Envelope class) land in CG(function_table)/CG(class_table) DURING
+     * zend_startup — before those are frozen into GLOBAL_FUNCTION_TABLE /
+     * GLOBAL_CLASS_TABLE that new ZTS worker threads inherit. Registering it
+     * later (via zend_startup_module after this returns) leaves it invisible to
+     * worker threads (function_exists() == false there). */
+    int ret = php_module_startup(sm, &ephpm_worker_module_entry);
 
     /* Register the native "ephpm" session save handler. Must happen after
      * php_module_startup() — the session extension's MINIT is what wires up

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -6,6 +6,7 @@ pub mod kv_bridge;
 pub mod request;
 pub mod response;
 pub mod sapi;
+pub mod worker_bridge;
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -114,6 +115,22 @@ mod ffi {
         /// Set the KV ops function pointer table. Can be called after
         /// `php_embed_init()`, before any PHP scripts execute.
         pub fn ephpm_set_kv_ops(ops: *const crate::kv_bridge::EphpmKvOps);
+
+        // ── Worker mode ─────────────────────────────────────────────
+
+        /// Set the worker ops function pointer table (`take_request` /
+        /// `send_response`). Call after `php_embed_init()`, before any worker
+        /// boots.
+        pub fn ephpm_set_worker_ops(ops: *const crate::worker_bridge::EphpmWorkerOps);
+
+        /// Toggle native superglobal population per request in worker mode
+        /// (`worker.populate_superglobals`). `0` = off (default), `1` = on.
+        pub fn ephpm_worker_set_populate_superglobals(enable: ::std::os::raw::c_int);
+
+        /// Boot a worker: run the worker script under bailout protection. Blocks
+        /// until the framework's `take_request()` loop ends. Returns 0 on a
+        /// clean loop end, -2 if a fatal bailout unwound out of the framework.
+        pub fn ephpm_worker_run(script: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 
         /// Get the PHP version string (compile-time constant).
         /// Safe to call before `php_embed_init()`.
@@ -653,6 +670,120 @@ impl PhpRuntime {
         {
             let _ = store;
             tracing::debug!("KV store set_kv_store no-op (stub mode)");
+        }
+    }
+
+    // ── Worker mode ───────────────────────────────────────────────────────
+
+    /// Install the worker-mode ops table so `\Ephpm\Worker\take_request()` /
+    /// `send_response()` call into the Rust dispatch bridge.
+    ///
+    /// Must be called after [`init()`] and before any worker boots. Also sets
+    /// whether native superglobals are populated per request
+    /// (`worker.populate_superglobals`).
+    ///
+    /// In stub mode this is a no-op.
+    pub fn install_worker_ops(populate_superglobals: bool) {
+        #[cfg(php_linked)]
+        {
+            // SAFETY: WORKER_OPS is a static with a stable address; the C setter
+            // copies the struct, so the pointer only needs to be valid for this
+            // call. PHP is initialized (worker boot happens after init).
+            unsafe { ffi::ephpm_set_worker_ops(&worker_bridge::WORKER_OPS) };
+            unsafe {
+                ffi::ephpm_worker_set_populate_superglobals(i32::from(populate_superglobals));
+            }
+            tracing::info!(populate_superglobals, "worker ops wired to PHP native functions");
+        }
+
+        #[cfg(not(php_linked))]
+        {
+            let _ = populate_superglobals;
+            tracing::debug!("install_worker_ops no-op (stub mode)");
+        }
+    }
+
+    /// Register the current OS thread with TSRM for worker-mode execution.
+    ///
+    /// Worker threads are plain `std::thread`s (not `spawn_blocking`), so they
+    /// register once here before booting the framework. Reuses the same
+    /// thread-local guard as the fpm path so a thread never double-registers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PhpError::NotInitialized`] if PHP is not initialized, or
+    /// [`PhpError::ThreadInitFailed`] if TSRM registration fails.
+    pub fn worker_thread_init() -> Result<(), PhpError> {
+        if !PHP_INITIALIZED.load(Ordering::Acquire) {
+            return Err(PhpError::NotInitialized);
+        }
+        #[cfg(php_linked)]
+        {
+            Self::ensure_thread_registered()
+        }
+        #[cfg(not(php_linked))]
+        {
+            Ok(())
+        }
+    }
+
+    /// Shut down PHP on the current worker thread: end the long-lived request
+    /// and free the TSRM slot + booted framework. Call once, when a worker
+    /// thread is exiting (recycle / bailout / drain), so the replacement boots
+    /// on a clean context.
+    ///
+    /// In stub mode this is a no-op.
+    pub fn worker_thread_shutdown() {
+        #[cfg(php_linked)]
+        {
+            // SAFETY: called on a TSRM-registered worker thread that is done
+            // executing PHP. ephpm_thread_shutdown runs php_request_shutdown +
+            // ts_free_thread and frees the thread-local capture buffers.
+            unsafe { ffi::ephpm_thread_shutdown() };
+            THREAD_REGISTERED.with(|registered| registered.set(false));
+            tracing::debug!("worker thread PHP context shut down");
+        }
+    }
+
+    /// Boot and run a worker on the current (already TSRM-registered) thread.
+    ///
+    /// Blocks until the framework's `take_request()` loop ends (graceful
+    /// shutdown, `worker_max_requests` recycle, or a fatal bailout). Returns
+    /// `Ok(true)` if the loop ended cleanly, `Ok(false)` if a fatal bailout
+    /// unwound out of the framework (the caller must recycle the worker and
+    /// fulfil any parked oneshot with a 500).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PhpError::NotInitialized`] if PHP is not initialized, or
+    /// [`PhpError::ExecutionFailed`] if the script path is invalid.
+    #[allow(unused_variables)]
+    pub fn run_worker(script: &std::path::Path) -> Result<bool, PhpError> {
+        if !PHP_INITIALIZED.load(Ordering::Acquire) {
+            return Err(PhpError::NotInitialized);
+        }
+
+        #[cfg(php_linked)]
+        {
+            use std::ffi::CString;
+            let script_str = script
+                .to_str()
+                .ok_or_else(|| PhpError::ExecutionFailed("non-UTF8 worker script path".into()))?;
+            let c_script = CString::new(script_str)
+                .map_err(|e| PhpError::ExecutionFailed(format!("invalid worker script: {e}")))?;
+            // SAFETY: this thread is TSRM-registered (worker_thread_init).
+            // ephpm_worker_run runs php_execute_script under a SETJMP bailout
+            // guard on this thread's own long-lived request context. The
+            // CString outlives the call.
+            let ret = unsafe { ffi::ephpm_worker_run(c_script.as_ptr()) };
+            Ok(ret == 0)
+        }
+
+        #[cfg(not(php_linked))]
+        {
+            Err(PhpError::ExecutionFailed(
+                "PHP not linked — worker mode requires a PHP_SDK_PATH build".into(),
+            ))
         }
     }
 

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -1,0 +1,437 @@
+//! Bridge between the C worker-mode PHP functions and the Rust dispatch
+//! channel (persistent-worker engine, `worker-mode-design.md`).
+//!
+//! Mirrors the [`kv_bridge`](crate::kv_bridge) ops-table pattern. The C
+//! `\Ephpm\Worker\take_request()` / `send_response()` native functions call
+//! into the [`EphpmWorkerOps`] table set via [`ephpm_set_worker_ops`]:
+//!
+//! - `take_request` blocks on the per-thread dispatch [`Receiver`], stashes the
+//!   job's `oneshot::Sender` in a [`thread_local!`] cell, and fills a borrowed
+//!   [`EphpmWorkerRequest`] view for C to marshal into the `Envelope` object.
+//! - `send_response` takes the stashed sender back out and fulfils it.
+//!
+//! The stashed sender is the only Rust value live across a PHP call that can
+//! `longjmp` (design §5.3). `oneshot::Sender`'s `Drop` is longjmp-safe (it just
+//! signals the receiver — no files, no locks), so a fatal that unwinds past
+//! `send_response` still lets the HTTP handler resolve: either the pool's
+//! supervisor finds the sender still stashed and sends
+//! [`WorkerResponse::internal_error`] (500), or the sender is dropped and the
+//! receiver sees `RecvError` (also 500).
+//!
+//! Everything real is `#[cfg(php_linked)]`; stub builds get inert fallbacks.
+
+#[cfg(php_linked)]
+use std::cell::RefCell;
+#[cfg(php_linked)]
+use std::ffi::CString;
+#[cfg(php_linked)]
+use std::os::raw::{c_char, c_int};
+
+// ── Shared message types (used by ephpm-server's worker pool) ────────────
+
+/// An owned HTTP request handed to a worker thread. Owns every string/byte
+/// buffer so the borrowed [`EphpmWorkerRequest`] view stays valid for the
+/// whole iteration (until `send_response`).
+#[derive(Debug, Clone)]
+pub struct WorkerRequestOwned {
+    /// HTTP method (`GET`, `POST`, ...).
+    pub method: String,
+    /// `REQUEST_URI` — path plus query string.
+    pub uri: String,
+    /// Query string without the leading `?`.
+    pub query_string: String,
+    /// Raw `Cookie` header value (empty if none).
+    pub cookie_data: String,
+    /// `Content-Type` header value, if any.
+    pub content_type: Option<String>,
+    /// Raw request body bytes.
+    pub body: Vec<u8>,
+    /// `$_SERVER`-shaped variables as `(key, value)` pairs.
+    pub server_vars: Vec<(String, String)>,
+    /// HTTP headers as `(name, value)` pairs.
+    pub headers: Vec<(String, String)>,
+}
+
+/// A response produced by a worker for one request.
+#[derive(Debug, Clone)]
+pub struct WorkerResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Response headers as `(name, value)` pairs.
+    pub headers: Vec<(String, String)>,
+    /// Response body bytes.
+    pub body: Vec<u8>,
+}
+
+impl WorkerResponse {
+    /// Build the canonical 500 response used when a worker bailed out before
+    /// sending a real response (design §5.3).
+    #[must_use]
+    pub fn internal_error() -> Self {
+        Self {
+            status: 500,
+            headers: vec![("Content-Type".to_string(), "text/plain".to_string())],
+            body: b"Internal Server Error".to_vec(),
+        }
+    }
+}
+
+/// A unit of work dispatched to the worker pool: the owned request plus the
+/// `oneshot` channel the worker fulfils.
+pub struct WorkerJob {
+    /// The owned request marshaled to PHP.
+    pub request: WorkerRequestOwned,
+    /// Where the worker's response (or the supervisor's 500) is delivered.
+    pub respond_to: tokio::sync::oneshot::Sender<WorkerResponse>,
+}
+
+// ── C-compatible request view ────────────────────────────────────────────
+
+/// Borrowed view of the next request, filled by [`take_request`] and read by
+/// the C `take_request` shim. **Layout must match `EphpmWorkerRequest` in
+/// `ephpm_wrapper.c`.** All pointers borrow from the thread-local
+/// [`CURRENT_REQUEST`] and stay valid until the next `take_request` call.
+#[cfg(php_linked)]
+#[repr(C)]
+pub struct EphpmWorkerRequest {
+    /// HTTP method, null-terminated.
+    pub method: *const c_char,
+    /// `REQUEST_URI`, null-terminated.
+    pub uri: *const c_char,
+    /// Query string (no leading `?`), null-terminated.
+    pub query_string: *const c_char,
+    /// Raw `Cookie` header, null-terminated.
+    pub cookie_data: *const c_char,
+    /// `Content-Type`, null-terminated, or null.
+    pub content_type: *const c_char,
+    /// Raw body bytes, or null when empty.
+    pub body: *const c_char,
+    /// Body length in bytes.
+    pub body_len: usize,
+
+    /// Number of `$_SERVER` entries.
+    pub server_var_count: usize,
+    /// Array of `server_var_count` key pointers.
+    pub server_var_keys: *const *const c_char,
+    /// Array of `server_var_count` value pointers.
+    pub server_var_vals: *const *const c_char,
+
+    /// Number of HTTP header entries.
+    pub header_count: usize,
+    /// Array of `header_count` name pointers.
+    pub header_keys: *const *const c_char,
+    /// Array of `header_count` value pointers.
+    pub header_vals: *const *const c_char,
+}
+
+/// Function pointer table handed to C so the native `\Ephpm\Worker\*`
+/// functions can call into Rust. **Layout must match `EphpmWorkerOps` in
+/// `ephpm_wrapper.c`.**
+#[cfg(php_linked)]
+#[repr(C)]
+pub struct EphpmWorkerOps {
+    /// Block for the next request. Returns 1 with `req` filled, or 0 for
+    /// graceful shutdown.
+    pub take_request: Option<unsafe extern "C" fn(req: *mut EphpmWorkerRequest) -> c_int>,
+    /// Deliver the response. `headers` is `"Name: Value\n"` packed.
+    pub send_response: Option<
+        unsafe extern "C" fn(
+            status: c_int,
+            headers: *const c_char,
+            headers_len: usize,
+            body: *const c_char,
+            body_len: usize,
+        ),
+    >,
+}
+
+// ── Thread-local per-worker state ────────────────────────────────────────
+
+/// Owned, C-string-backed storage for the request currently borrowed by C.
+/// Held for the whole iteration so the pointers in [`EphpmWorkerRequest`] stay
+/// valid until the next `take_request` replaces it.
+///
+/// Several fields exist purely to own the backing memory that the `*_ptrs`
+/// vectors (and the C `EphpmWorkerRequest`) borrow — they must not be dropped
+/// while borrowed, hence `#[allow(dead_code)]`.
+#[cfg(php_linked)]
+#[allow(dead_code)]
+struct CurrentRequest {
+    // Owning CStrings — the pointer arrays below borrow from these.
+    _method: CString,
+    _uri: CString,
+    _query: CString,
+    _cookie: CString,
+    _content_type: Option<CString>,
+    _body: Vec<u8>,
+    _server_keys: Vec<CString>,
+    _server_vals: Vec<CString>,
+    _header_keys: Vec<CString>,
+    _header_vals: Vec<CString>,
+    // Pointer arrays into the CString vecs (stable: the vecs are not mutated
+    // while borrowed).
+    server_key_ptrs: Vec<*const c_char>,
+    server_val_ptrs: Vec<*const c_char>,
+    header_key_ptrs: Vec<*const c_char>,
+    header_val_ptrs: Vec<*const c_char>,
+}
+
+#[cfg(php_linked)]
+thread_local! {
+    /// The dispatch receiver for this worker thread. Installed by the pool via
+    /// [`set_dispatch_receiver`] before the worker boots.
+    static DISPATCH_RX: RefCell<Option<async_channel::Receiver<WorkerJob>>> =
+        const { RefCell::new(None) };
+
+    /// The parked `oneshot::Sender` for the in-flight request. Stashed by
+    /// `take_request`, taken by `send_response` (or by the supervisor on
+    /// bailout). This is the only Rust value live across the PHP call.
+    static PENDING_SENDER: RefCell<Option<tokio::sync::oneshot::Sender<WorkerResponse>>> =
+        const { RefCell::new(None) };
+
+    /// Backing storage for the request C currently borrows.
+    static CURRENT_REQUEST: RefCell<Option<CurrentRequest>> = const { RefCell::new(None) };
+
+    /// Requests handled by this worker since boot (drives `worker_max_requests`).
+    static REQUESTS_HANDLED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+
+    /// The recycle threshold for this worker (`0` = never recycle).
+    static MAX_REQUESTS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Install the dispatch receiver for the current worker thread. Called by the
+/// pool immediately before booting the worker.
+#[cfg(php_linked)]
+pub fn set_dispatch_receiver(rx: async_channel::Receiver<WorkerJob>) {
+    DISPATCH_RX.with(|cell| *cell.borrow_mut() = Some(rx));
+}
+
+/// Stub: no dispatch channel without PHP linked.
+#[cfg(not(php_linked))]
+pub fn set_dispatch_receiver(_rx: async_channel::Receiver<WorkerJob>) {}
+
+/// Set the per-worker recycle threshold (`worker_max_requests`; `0` disables).
+#[cfg(php_linked)]
+pub fn set_max_requests(max: u64) {
+    MAX_REQUESTS.with(|c| c.set(max));
+    REQUESTS_HANDLED.with(|c| c.set(0));
+}
+
+/// Stub.
+#[cfg(not(php_linked))]
+pub fn set_max_requests(_max: u64) {}
+
+/// Take the parked `oneshot::Sender` for the in-flight request, if one is
+/// still stashed. Used by the pool's crash-recovery path: after
+/// `ephpm_worker_run` returns following a bailout, a still-present sender means
+/// the response was never sent, so the pool fulfils it with a 500.
+#[cfg(php_linked)]
+#[must_use]
+pub fn take_pending_sender() -> Option<tokio::sync::oneshot::Sender<WorkerResponse>> {
+    PENDING_SENDER.with(|cell| cell.borrow_mut().take())
+}
+
+/// Stub.
+#[cfg(not(php_linked))]
+#[must_use]
+pub fn take_pending_sender() -> Option<tokio::sync::oneshot::Sender<WorkerResponse>> {
+    None
+}
+
+// ── Callback implementations ─────────────────────────────────────────────
+
+#[cfg(php_linked)]
+fn build_current_request(job: &WorkerRequestOwned) -> CurrentRequest {
+    // Lossy on interior NULs (extremely rare in HTTP metadata) — replace with
+    // an empty string rather than fail the request.
+    let cstr = |s: &str| CString::new(s).unwrap_or_default();
+
+    let method = cstr(&job.method);
+    let uri = cstr(&job.uri);
+    let query = cstr(&job.query_string);
+    let cookie = cstr(&job.cookie_data);
+    let content_type = job.content_type.as_deref().map(cstr);
+
+    let server_keys: Vec<CString> = job.server_vars.iter().map(|(k, _)| cstr(k)).collect();
+    let server_vals: Vec<CString> = job.server_vars.iter().map(|(_, v)| cstr(v)).collect();
+    let header_keys: Vec<CString> = job.headers.iter().map(|(k, _)| cstr(k)).collect();
+    let header_vals: Vec<CString> = job.headers.iter().map(|(_, v)| cstr(v)).collect();
+
+    let server_key_ptrs: Vec<*const c_char> = server_keys.iter().map(|c| c.as_ptr()).collect();
+    let server_val_ptrs: Vec<*const c_char> = server_vals.iter().map(|c| c.as_ptr()).collect();
+    let header_key_ptrs: Vec<*const c_char> = header_keys.iter().map(|c| c.as_ptr()).collect();
+    let header_val_ptrs: Vec<*const c_char> = header_vals.iter().map(|c| c.as_ptr()).collect();
+
+    CurrentRequest {
+        _method: method,
+        _uri: uri,
+        _query: query,
+        _cookie: cookie,
+        _content_type: content_type,
+        _body: job.body.clone(),
+        _server_keys: server_keys,
+        _server_vals: server_vals,
+        _header_keys: header_keys,
+        _header_vals: header_vals,
+        server_key_ptrs,
+        server_val_ptrs,
+        header_key_ptrs,
+        header_val_ptrs,
+    }
+}
+
+/// C-callable `take_request`: block for the next job, stash its sender, and
+/// fill the borrowed request view.
+#[cfg(php_linked)]
+unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int {
+    // Cooperative recycle: once this worker has handled its quota, return
+    // shutdown so the framework loop exits and the pool respawns a fresh boot.
+    let max = MAX_REQUESTS.with(std::cell::Cell::get);
+    if max > 0 && REQUESTS_HANDLED.with(std::cell::Cell::get) >= max {
+        return 0;
+    }
+
+    let Some(rx) = DISPATCH_RX.with(|cell| cell.borrow().clone()) else {
+        // No receiver installed — nothing can ever arrive; treat as shutdown.
+        return 0;
+    };
+
+    let job = match rx.recv_blocking() {
+        Ok(job) => job,
+        // Sender side closed (graceful drain) — end the loop.
+        Err(_) => return 0,
+    };
+
+    // Stash the sender for send_response / crash recovery.
+    PENDING_SENDER.with(|cell| *cell.borrow_mut() = Some(job.respond_to));
+
+    // Build owned backing storage and publish the borrowed pointers.
+    let current = build_current_request(&job.request);
+    CURRENT_REQUEST.with(|cell| *cell.borrow_mut() = Some(current));
+
+    CURRENT_REQUEST.with(|cell| {
+        let borrow = cell.borrow();
+        let cur = borrow.as_ref().expect("just set");
+        // SAFETY: `req` is a valid, writable EphpmWorkerRequest provided by the
+        // C shim. Every pointer we write borrows from `cur`, which lives in the
+        // thread-local until the next take_request replaces it — outliving the
+        // C use of these pointers (through send_response).
+        unsafe {
+            (*req).method = cur._method.as_ptr();
+            (*req).uri = cur._uri.as_ptr();
+            (*req).query_string = cur._query.as_ptr();
+            (*req).cookie_data = cur._cookie.as_ptr();
+            (*req).content_type =
+                cur._content_type.as_ref().map_or(std::ptr::null(), |c| c.as_ptr());
+            (*req).body = if cur._body.is_empty() {
+                std::ptr::null()
+            } else {
+                cur._body.as_ptr().cast::<c_char>()
+            };
+            (*req).body_len = cur._body.len();
+            (*req).server_var_count = cur.server_key_ptrs.len();
+            (*req).server_var_keys = cur.server_key_ptrs.as_ptr();
+            (*req).server_var_vals = cur.server_val_ptrs.as_ptr();
+            (*req).header_count = cur.header_key_ptrs.len();
+            (*req).header_keys = cur.header_key_ptrs.as_ptr();
+            (*req).header_vals = cur.header_val_ptrs.as_ptr();
+        }
+    });
+
+    1
+}
+
+/// C-callable `send_response`: fulfil the parked oneshot with the PHP response.
+#[cfg(php_linked)]
+unsafe extern "C" fn worker_send_response(
+    status: c_int,
+    headers: *const c_char,
+    headers_len: usize,
+    body: *const c_char,
+    body_len: usize,
+) {
+    // SAFETY: C passes valid (ptr, len) pairs for headers and body; the buffers
+    // live for the duration of this call. A null pointer means zero length.
+    let header_bytes: &[u8] = if headers.is_null() || headers_len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(headers.cast::<u8>(), headers_len) }
+    };
+    let body_bytes: Vec<u8> = if body.is_null() || body_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(body.cast::<u8>(), body_len) }.to_vec()
+    };
+
+    let parsed_headers = parse_packed_headers(header_bytes);
+
+    let status = u16::try_from(status).unwrap_or(200);
+    let response = WorkerResponse { status, headers: parsed_headers, body: body_bytes };
+
+    // Deliver to the parked receiver. If it was already taken (shouldn't happen
+    // on the normal path) or the receiver dropped, the response is discarded.
+    if let Some(sender) = PENDING_SENDER.with(|cell| cell.borrow_mut().take()) {
+        let _ = sender.send(response);
+    }
+
+    // Count this completed request toward the recycle quota.
+    REQUESTS_HANDLED.with(|c| c.set(c.get().saturating_add(1)));
+
+    // Release the borrowed request backing storage.
+    CURRENT_REQUEST.with(|cell| *cell.borrow_mut() = None);
+}
+
+/// Parse `"Name: Value\n"` packed header lines into `(name, value)` pairs.
+#[cfg(php_linked)]
+fn parse_packed_headers(bytes: &[u8]) -> Vec<(String, String)> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim_end_matches('\r');
+            if line.is_empty() {
+                return None;
+            }
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+// ── Static ops table ─────────────────────────────────────────────────────
+
+/// The C-compatible ops table, ready to pass to `ephpm_set_worker_ops()`.
+#[cfg(php_linked)]
+pub static WORKER_OPS: EphpmWorkerOps = EphpmWorkerOps {
+    take_request: Some(worker_take_request),
+    send_response: Some(worker_send_response),
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, php_linked))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_packed_headers_basic() {
+        let packed = b"Content-Type: text/plain\nX-Foo: bar\n";
+        let parsed = parse_packed_headers(packed);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0], ("Content-Type".to_string(), "text/plain".to_string()));
+        assert_eq!(parsed[1], ("X-Foo".to_string(), "bar".to_string()));
+    }
+
+    #[test]
+    fn parse_packed_headers_skips_blank() {
+        let packed = b"A: 1\n\nB: 2\n";
+        let parsed = parse_packed_headers(packed);
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[test]
+    fn internal_error_is_500() {
+        let e = WorkerResponse::internal_error();
+        assert_eq!(e.status, 500);
+        assert_eq!(e.body, b"Internal Server Error");
+    }
+}

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -40,6 +40,7 @@ dashmap.workspace = true
 tokio-util.workspace = true
 bytes.workspace = true
 sha2.workspace = true
+async-channel.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod router;
 pub mod static_files;
 pub mod tls;
 pub mod tracked_backend;
+pub mod worker_pool;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -130,6 +131,8 @@ struct Listeners {
     file_cache: Option<Arc<file_cache::FileCache>>,
     /// Interval for file cache eviction sweeps (derived from `inactive_secs`).
     file_cache_eviction_interval: Duration,
+    /// Persistent worker pool (worker mode), drained on shutdown.
+    worker_pool: Option<Arc<worker_pool::WorkerPool>>,
 }
 
 /// Connection-level settings passed into spawned tasks.
@@ -202,12 +205,55 @@ async fn bind_listeners(
         _ => TlsMode::None,
     };
 
+    // Worker mode: wire the worker ops table and spawn the persistent worker
+    // pool BEFORE the router so PHP requests can be dispatched to it. PHP is
+    // already initialized (in main.rs, before the tokio runtime). fpm mode
+    // leaves this None and uses the spawn_blocking path unchanged.
+    let worker_pool = if config.php.is_worker_mode() {
+        let script = config
+            .resolve_worker_script()
+            .context("worker mode: failed to resolve worker_script")?;
+
+        if config.php.workers > 0 {
+            tracing::warn!(
+                "[php] workers = {} is ignored in worker mode — concurrency is \
+                 bounded by worker_count and worker_backlog",
+                config.php.workers
+            );
+        }
+
+        // Windows / NTS: a single PHP context, so force one worker (design §6.1).
+        let mut worker_count = config.php.effective_worker_count();
+        if cfg!(target_os = "windows") && worker_count > 1 {
+            tracing::warn!(
+                "worker mode on Windows (NTS) uses a single PHP context — \
+                 forcing worker_count = 1 (requests serialize through one \
+                 booted framework)"
+            );
+            worker_count = 1;
+        }
+
+        ephpm_php::PhpRuntime::install_worker_ops(config.php.worker_populate_superglobals);
+
+        let pool = worker_pool::WorkerPool::spawn(
+            script,
+            worker_count,
+            config.php.worker_max_requests,
+            config.php.effective_worker_backlog(),
+            Duration::from_secs(config.php.worker_boot_timeout),
+        );
+        Some(pool)
+    } else {
+        None
+    };
+
     let router = Arc::new(Router::new(
         config,
         kv_store,
         metrics_handle,
         limiter.clone(),
         file_cache.clone(),
+        worker_pool.clone(),
     ));
 
     let has_tls = !matches!(tls_mode, TlsMode::None);
@@ -277,6 +323,7 @@ async fn bind_listeners(
         limiter,
         file_cache,
         file_cache_eviction_interval,
+        worker_pool,
     })
 }
 
@@ -293,6 +340,7 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
         limiter,
         file_cache,
         file_cache_eviction_interval,
+        worker_pool,
     } = listeners;
 
     // Track in-flight connections for graceful shutdown.
@@ -350,6 +398,12 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
                 break;
             }
         }
+    }
+
+    // Worker mode: stop accepting new dispatch so in-flight worker iterations
+    // finish and workers exit their loops cleanly (design §4.5).
+    if let Some(pool) = &worker_pool {
+        pool.drain();
     }
 
     // Graceful shutdown: wait for in-flight connections to drain.
@@ -1262,7 +1316,7 @@ mod lib_tests {
             cluster: ephpm_config::ClusterConfig::default(),
         };
         let store = ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default());
-        Arc::new(Router::new(&config, store, None, None, None))
+        Arc::new(Router::new(&config, store, None, None, None, None))
     }
 
     /// Bind a listener and serve exactly one connection with `settings`.

--- a/crates/ephpm-server/src/metrics.rs
+++ b/crates/ephpm-server/src/metrics.rs
@@ -38,6 +38,10 @@ const BODY_BYTES_BUCKETS: &[f64] = &[
 const COMPRESSION_RATIO_BUCKETS: &[f64] =
     &[0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
 
+/// Worker framework-boot duration buckets (seconds): 10 ms up to 30 s. Heavy
+/// frameworks (Laravel, WordPress) can take seconds to bootstrap once.
+const WORKER_BOOT_BUCKETS: &[f64] = &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0];
+
 /// Install the Prometheus recorder and return a scrape handle.
 ///
 /// Must be called once at process startup, before any `metrics::counter!` /
@@ -79,6 +83,17 @@ pub fn init() -> anyhow::Result<PrometheusHandle> {
             COMPRESSION_RATIO_BUCKETS,
         )
         .context("failed to configure compression_ratio buckets")?
+        .set_buckets_for_metric(
+            // Framework boot can take seconds (Laravel/WordPress) — wider range.
+            Matcher::Full("ephpm_worker_boot_duration_seconds".to_string()),
+            WORKER_BOOT_BUCKETS,
+        )
+        .context("failed to configure worker_boot_duration buckets")?
+        .set_buckets_for_metric(
+            Matcher::Full("ephpm_worker_request_wait_seconds".to_string()),
+            PHP_DURATION_BUCKETS,
+        )
+        .context("failed to configure worker_request_wait buckets")?
         .install_recorder()
         .context("failed to install Prometheus recorder")?;
 

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -101,6 +101,10 @@ pub struct Router {
     /// NOT cap tokio's blocking pool — static file I/O and other blocking
     /// work must never be starved by slow PHP scripts.
     php_semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    /// Persistent worker pool when `[php] mode = "worker"`. `None` in fpm mode.
+    /// When set, PHP requests are dispatched to the pool instead of running on
+    /// the `spawn_blocking` path.
+    worker_pool: Option<Arc<crate::worker_pool::WorkerPool>>,
 }
 
 /// Scan `sites_dir` for virtual host subdirectories.
@@ -162,6 +166,7 @@ impl Router {
         metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
         limiter: Option<Arc<crate::rate_limit::Limiter>>,
         file_cache: Option<Arc<crate::file_cache::FileCache>>,
+        worker_pool: Option<Arc<crate::worker_pool::WorkerPool>>,
     ) -> Self {
         let port =
             config.server.listen.rsplit_once(':').and_then(|(_, p)| p.parse().ok()).unwrap_or(8080);
@@ -259,6 +264,7 @@ impl Router {
             kv_redis_compat_enabled: config.kv.redis_compat.enabled,
             db_env_vars: build_db_env_vars(config),
             php_semaphore,
+            worker_pool,
         }
     }
 
@@ -592,14 +598,39 @@ impl Router {
                 }
             }
             Resolved::Status(code) => {
-                let status = StatusCode::from_u16(code).unwrap_or(StatusCode::NOT_FOUND);
-                (
-                    error_response(
-                        status,
-                        &format!("{code} {}", status.canonical_reason().unwrap_or("Error")),
-                    ),
-                    "error",
-                )
+                // Worker mode: the booted framework owns routing (Octane/
+                // RoadRunner model), so every request that isn't a static asset
+                // goes to the worker entrypoint rather than 404ing on a missing
+                // file. The framework decides the real status (incl. its own
+                // 404). fpm mode keeps the literal fallback status.
+                if self.worker_pool.is_some() {
+                    // SCRIPT_FILENAME is nominal in worker mode (the worker
+                    // script is the entrypoint); use the conventional front
+                    // controller path so $_SERVER looks familiar to frameworks.
+                    let script = site_root.join("index.php");
+                    (
+                        self.handle_php(
+                            req,
+                            effective_addr,
+                            is_https,
+                            script,
+                            accepts_gzip,
+                            accepts_br,
+                            site_root.clone(),
+                        )
+                        .await,
+                        "php",
+                    )
+                } else {
+                    let status = StatusCode::from_u16(code).unwrap_or(StatusCode::NOT_FOUND);
+                    (
+                        error_response(
+                            status,
+                            &format!("{code} {}", status.canonical_reason().unwrap_or("Error")),
+                        ),
+                        "error",
+                    )
+                }
             }
         };
 
@@ -713,6 +744,34 @@ impl Router {
             .record(body.len() as f64);
 
         let server_port = self.server_port;
+
+        // Worker mode: dispatch to the persistent worker pool instead of the
+        // spawn_blocking fpm path. The whole handler is already wrapped in the
+        // outer request timeout, so a starved queue becomes a 504.
+        if let Some(pool) = self.worker_pool.clone() {
+            return self
+                .handle_php_worker(
+                    &pool,
+                    method,
+                    uri,
+                    path,
+                    query_string,
+                    &script_filename,
+                    document_root,
+                    headers,
+                    body,
+                    content_type,
+                    remote_addr,
+                    server_name,
+                    server_port,
+                    is_https,
+                    protocol,
+                    accepts_gzip,
+                    accepts_br,
+                )
+                .await;
+        }
+
         let multi_tenant_kv = self.multi_tenant_kv.clone();
         let vhost_open_basedir = self.sites_dir.is_some() && self.open_basedir;
         // disable_shell_exec is applied globally via the generated php.ini
@@ -776,6 +835,119 @@ impl Router {
         .await;
         let php_elapsed = php_start.elapsed().as_secs_f64();
 
+        histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed);
+        let exec_status = match &result {
+            Ok(Ok(_)) => "ok",
+            Ok(Err(_)) | Err(_) => "error",
+        };
+        counter!("ephpm_php_executions_total", "status" => exec_status).increment(1);
+
+        build_php_response(result, accepts_gzip, accepts_br, self.compression)
+    }
+
+    /// Dispatch a PHP request to the persistent worker pool (worker mode).
+    ///
+    /// Builds an owned request from the same `$_SERVER`/cookie derivation the
+    /// fpm path uses, hands it to the pool, and awaits the `oneshot`. The outer
+    /// request timeout (in `handle`) turns a starved queue into a 504; a
+    /// dropped sender (worker bailout with no stashed sender) becomes a 500.
+    /// The response reuses `build_php_response` unchanged.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_php_worker(
+        &self,
+        pool: &Arc<crate::worker_pool::WorkerPool>,
+        method: String,
+        uri: String,
+        path: String,
+        query_string: String,
+        script_filename: &Path,
+        document_root: PathBuf,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+        content_type: Option<String>,
+        remote_addr: SocketAddr,
+        server_name: String,
+        server_port: u16,
+        is_https: bool,
+        protocol: String,
+        accepts_gzip: bool,
+        accepts_br: bool,
+    ) -> Response<ServerBody> {
+        // Reuse PhpRequest's $_SERVER / cookie derivation so worker mode and
+        // fpm mode present PHP with identical request metadata.
+        let mut env_vars = self.build_kv_env_vars(&server_name);
+        env_vars.extend_from_slice(&self.db_env_vars);
+
+        let php_request = PhpRequest {
+            method: method.clone(),
+            uri: uri.clone(),
+            path,
+            query_string: query_string.clone(),
+            script_filename: script_filename.to_path_buf(),
+            document_root,
+            headers: headers.clone(),
+            body: body.clone(),
+            content_type: content_type.clone(),
+            remote_addr,
+            server_name,
+            server_port,
+            is_https,
+            protocol,
+            env_vars,
+        };
+
+        let owned = ephpm_php::worker_bridge::WorkerRequestOwned {
+            method,
+            uri,
+            query_string,
+            cookie_data: php_request.cookie_string(),
+            content_type,
+            body,
+            server_vars: php_request.server_variables(),
+            headers,
+        };
+
+        let php_start = std::time::Instant::now();
+        let queue_wait_start = php_start;
+        let recv = pool.dispatch(owned).await;
+        #[allow(clippy::cast_precision_loss)]
+        histogram!("ephpm_worker_request_wait_seconds")
+            .record(queue_wait_start.elapsed().as_secs_f64());
+
+        // Dispatch channel closed (pool draining / all workers gone) — 503.
+        let Ok(rx) = recv else {
+            return error_response(StatusCode::SERVICE_UNAVAILABLE, "503 Service Unavailable");
+        };
+
+        gauge!("ephpm_worker_busy").increment(1.0);
+        // Bound the wait so a wedged worker becomes a 504 AND signals the pool
+        // to replace it (design §5.4). This inner timeout fires at or before
+        // the outer request timeout.
+        let awaited = tokio::time::timeout(self.request_timeout, rx).await;
+        gauge!("ephpm_worker_busy").decrement(1.0);
+
+        let result: Result<
+            Result<ephpm_php::response::PhpResponse, ephpm_php::PhpError>,
+            tokio::task::JoinError,
+        > = match awaited {
+            Ok(Ok(worker_resp)) => Ok(Ok(ephpm_php::response::PhpResponse {
+                status: worker_resp.status,
+                headers: worker_resp.headers,
+                body: worker_resp.body,
+            })),
+            // Sender dropped (worker unwound with no stashed sender) — 500.
+            Ok(Err(_)) => Ok(Err(ephpm_php::PhpError::ExecutionFailed(
+                "worker dropped response (bailout)".into(),
+            ))),
+            // Worker never responded in time — replace it, return 504.
+            Err(_) => {
+                pool.note_hung();
+                counter!("ephpm_http_timeouts_total", "stage" => "worker").increment(1);
+                return error_response(StatusCode::GATEWAY_TIMEOUT, "504 Gateway Timeout");
+            }
+        };
+
+        let php_elapsed = php_start.elapsed().as_secs_f64();
         histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed);
         let exec_status = match &result {
             Ok(Ok(_)) => "ok",
@@ -896,6 +1068,17 @@ impl Router {
                 StatusCode::SERVICE_UNAVAILABLE,
                 r#"{"status":"not_ready","reason":"PHP runtime not initialized"}"#,
             );
+        }
+        // Worker mode: not ready until at least one worker has booted its
+        // framework and reached take_request() — prevents load balancers from
+        // routing before the framework is up (design §4.5).
+        if let Some(pool) = &self.worker_pool {
+            if pool.ready_count() == 0 {
+                return json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    r#"{"status":"not_ready","reason":"no worker has finished booting"}"#,
+                );
+            }
         }
         json_response(StatusCode::OK, r#"{"status":"ready"}"#)
     }
@@ -1336,7 +1519,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        Router::new(&config, test_store(), None, None, None)
+        Router::new(&config, test_store(), None, None, None, None)
     }
 
     fn test_router_with_404(dir: &Path) -> Router {
@@ -1353,7 +1536,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        Router::new(&config, test_store(), None, None, None)
+        Router::new(&config, test_store(), None, None, None, None)
     }
 
     #[allow(dead_code)]
@@ -1376,7 +1559,7 @@ mod tests {
             cluster: ClusterConfig::default(),
         };
         config.server.static_files.etag = true;
-        Router::new(&config, store, None, None, None)
+        Router::new(&config, store, None, None, None, None)
     }
 
     fn default_compression() -> CompressionSettings {
@@ -1569,7 +1752,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().trusted_proxies =
             vec!["10.0.0.0/8".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         // 203.0.113.50 is the real client, 10.0.0.1 is the proxy
         let xff = "203.0.113.50, 10.0.0.1";
@@ -1592,7 +1775,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().trusted_proxies =
             vec!["10.0.0.0/8".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let xff = "10.0.0.2, 10.0.0.1";
         let ip = router.resolve_xff(xff);
@@ -1615,7 +1798,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert_eq!(router.server_port, 3000);
     }
 
@@ -1633,7 +1816,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert_eq!(router.server_port, 8080);
     }
 
@@ -1653,7 +1836,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(router.open_basedir, "multi-tenant mode must default open_basedir on");
     }
 
@@ -1670,7 +1853,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(!router.open_basedir);
     }
 
@@ -1713,7 +1896,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(router.is_php_allowed("/anything.php"));
     }
 
@@ -1732,7 +1915,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-login.php".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(router.is_php_allowed("/index.php"));
         assert!(router.is_php_allowed("/wp-login.php"));
         assert!(!router.is_php_allowed("/evil.php"));
@@ -1753,7 +1936,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-admin/*.php".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(router.is_php_allowed("/index.php"));
         assert!(router.is_php_allowed("/wp-admin/admin.php"));
         assert!(router.is_php_allowed("/wp-admin/options.php"));
@@ -1983,7 +2166,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
         assert_eq!(router.server_port, 9090);
     }
 
@@ -2383,7 +2566,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("example.com");
         assert_eq!(doc_root, site_dir);
@@ -2407,7 +2590,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("unknown.com");
         assert_eq!(doc_root, dir.path());
@@ -2432,7 +2615,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("example.com:8080");
         assert_eq!(doc_root, site_dir);
@@ -2457,7 +2640,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("Example.COM");
         assert_eq!(doc_root, site_dir);
@@ -2479,7 +2662,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("anything.com");
         assert_eq!(doc_root, dir.path());
@@ -2505,7 +2688,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         let (doc_root, index_files, fallback) = router.resolve_site("myblog.com");
         let resolved = router.resolve_fallback("/", "", &doc_root, index_files, fallback);
@@ -2534,7 +2717,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         // Host doesn't exist yet — should fall back to default.
         let (doc_root, _, _) = router.resolve_site("new-site.com");
@@ -2569,7 +2752,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None);
 
         // Site exists — should resolve.
         let (doc_root, _, _) = router.resolve_site("temp-site.com");

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -1,0 +1,378 @@
+//! Persistent-worker engine pool (worker mode — `worker-mode-design.md` §2, §5).
+//!
+//! A fixed pool of dedicated OS threads (NOT `spawn_blocking` — parking N
+//! threads forever would starve the shared tokio blocking pool). Each thread
+//! boots the framework once via [`PhpRuntime::run_worker`], then loops over
+//! HTTP requests handed to it through an `async_channel::bounded` dispatch
+//! queue, replying on a `tokio::sync::oneshot`.
+//!
+//! Lifecycle guarantees (design §5):
+//! - **Boot-once:** the framework bootstrap runs once per worker thread; the
+//!   worker then loops in `\Ephpm\Worker\take_request()`.
+//! - **Recycle after N requests:** the C bridge returns shutdown once the
+//!   per-worker counter hits `worker_max_requests`; the thread exits and the
+//!   supervisor spawns a replacement with a fresh boot.
+//! - **Crash recovery:** a fatal bailout unwinds past `send_response`; the
+//!   parked `oneshot::Sender` is still stashed, so the thread fulfils it with a
+//!   500 (the in-flight request never hangs) and the worker is recycled.
+//! - **Hung-worker replacement:** on an `oneshot` timeout the router calls
+//!   [`WorkerPool::note_hung`]; the pool spawns a replacement and abandons the
+//!   stuck thread (a wedged PHP thread cannot be killed without corrupting the
+//!   ZMM — replace, don't kill; matches RoadRunner / FrankenPHP).
+//! - **Graceful drain:** [`WorkerPool::drain`] closes the dispatch sender;
+//!   each worker's `take_request()` then returns null, the loop ends, and the
+//!   thread exits after any in-flight request completes.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use ephpm_php::PhpRuntime;
+use ephpm_php::worker_bridge::{WorkerJob, WorkerRequestOwned, WorkerResponse};
+use metrics::{counter, gauge, histogram};
+use tokio::sync::oneshot;
+
+/// The dispatch channel is closed (pool draining or all workers gone). The
+/// router turns this into a 503.
+#[derive(Debug, Clone, Copy)]
+pub struct DispatchClosed;
+
+/// Handle to the running worker pool. Cloneable-cheap via `Arc`.
+pub struct WorkerPool {
+    /// Dispatch queue: the hyper handler `send().await`s jobs here; worker
+    /// threads `recv_blocking()`. Bounded — a full queue applies HTTP
+    /// backpressure (the outer request timeout turns a starved queue into 504).
+    dispatch_tx: async_channel::Sender<WorkerJob>,
+    /// Kept alive so the channel never closes while the supervisor respawns
+    /// workers between boots. Cloned into each worker thread.
+    dispatch_rx: async_channel::Receiver<WorkerJob>,
+    /// Shared runtime state (readiness, liveness, drain flag).
+    state: Arc<PoolState>,
+    /// Worker entrypoint script (absolute, validated under document_root).
+    worker_script: PathBuf,
+    /// Requests-per-worker recycle threshold (`0` = never).
+    max_requests: u64,
+    /// Target number of live worker threads.
+    worker_count: usize,
+    /// Time each worker gets to reach its first `take_request()`.
+    boot_timeout: Duration,
+}
+
+/// Shared, atomically-updated pool state.
+struct PoolState {
+    /// Workers that have booted and reached their first `take_request()`.
+    ready: AtomicUsize,
+    /// Live worker threads (running `worker_main`, booted or booting). Used to
+    /// self-balance respawns: a hung worker's replacement over-provisions by 1
+    /// until the stuck thread finally exits, which then skips its own respawn.
+    live: AtomicUsize,
+    /// Consecutive boot failures (for boot-storm protection / degraded ready).
+    boot_failures: AtomicUsize,
+    /// Set when the pool is draining — supervisors stop respawning.
+    draining: AtomicBool,
+    /// Monotonic id source for worker threads (metric label / logging).
+    next_id: AtomicUsize,
+}
+
+impl WorkerPool {
+    /// Spawn the worker pool and block server readiness contract on it: this
+    /// returns immediately, but [`WorkerPool::ready_count`] stays `0` until at
+    /// least one worker finishes booting.
+    ///
+    /// `worker_script` must be the resolved absolute path (see
+    /// [`ephpm_config::Config::resolve_worker_script`]).
+    #[must_use]
+    pub fn spawn(
+        worker_script: PathBuf,
+        worker_count: usize,
+        max_requests: u64,
+        backlog: usize,
+        boot_timeout: Duration,
+    ) -> Arc<Self> {
+        let (dispatch_tx, dispatch_rx) = async_channel::bounded(backlog.max(1));
+        let state = Arc::new(PoolState {
+            ready: AtomicUsize::new(0),
+            live: AtomicUsize::new(0),
+            boot_failures: AtomicUsize::new(0),
+            draining: AtomicBool::new(false),
+            next_id: AtomicUsize::new(0),
+        });
+
+        gauge!("ephpm_worker_pool_size").set(worker_count as f64);
+        gauge!("ephpm_worker_idle").set(0.0);
+        gauge!("ephpm_worker_busy").set(0.0);
+
+        let pool = Arc::new(Self {
+            dispatch_tx,
+            dispatch_rx,
+            state,
+            worker_script,
+            max_requests,
+            worker_count,
+            boot_timeout,
+        });
+
+        for _ in 0..worker_count {
+            pool.spawn_worker();
+        }
+
+        tracing::info!(
+            worker_count,
+            max_requests,
+            backlog = backlog.max(1),
+            script = %pool.worker_script.display(),
+            "worker pool started"
+        );
+
+        pool
+    }
+
+    /// Number of workers that have booted and are serving. Drives readiness.
+    #[must_use]
+    pub fn ready_count(&self) -> usize {
+        self.state.ready.load(Ordering::Acquire)
+    }
+
+    /// Dispatch a request to the pool and return the receiver for its response.
+    ///
+    /// `send().await` suspends when the bounded queue is full (backpressure);
+    /// the caller wraps the whole thing in the outer request timeout, so a
+    /// starved queue becomes a 504 rather than an unbounded wait.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DispatchClosed`] if the pool is draining / all workers gone
+    /// (the dispatch channel is closed) — the caller should 503.
+    pub async fn dispatch(
+        &self,
+        request: WorkerRequestOwned,
+    ) -> Result<oneshot::Receiver<WorkerResponse>, DispatchClosed> {
+        let (tx, rx) = oneshot::channel();
+        let job = WorkerJob { request, respond_to: tx };
+        gauge!("ephpm_worker_dispatch_queue_depth").set(self.dispatch_tx.len() as f64);
+        match self.dispatch_tx.send(job).await {
+            Ok(()) => Ok(rx),
+            Err(_) => Err(DispatchClosed),
+        }
+    }
+
+    /// Record that a worker appears hung (its `oneshot` timed out). The stuck
+    /// thread is abandoned and a replacement is spawned to keep the pool at
+    /// `worker_count` live pullers (design §5.4).
+    pub fn note_hung(self: &Arc<Self>) {
+        counter!("ephpm_worker_recycles_total", "reason" => "hung").increment(1);
+        // The stuck thread still holds its dispatch-receiver clone and may
+        // eventually finish; we simply add capacity. A brief over-provision is
+        // preferable to a wedged pool.
+        if !self.state.draining.load(Ordering::Acquire) {
+            self.spawn_worker();
+            tracing::warn!("worker appeared hung — spawned replacement, abandoned stuck thread");
+        }
+    }
+
+    /// Begin graceful drain: stop accepting new jobs and let workers exit once
+    /// their in-flight request (if any) completes. Idempotent.
+    pub fn drain(&self) {
+        if self.state.draining.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // Closing the sender makes each worker's recv_blocking return Err, so
+        // take_request() returns null and the framework loop ends.
+        self.dispatch_tx.close();
+        tracing::info!("worker pool draining — dispatch closed");
+    }
+
+    /// Spawn one worker OS thread that boots the framework once, serves until
+    /// recycle/bailout/drain, then exits. The supervisor respawns a
+    /// replacement unless the pool is draining.
+    fn spawn_worker(self: &Arc<Self>) {
+        let pool = Arc::clone(self);
+        let worker_id = pool.state.next_id.fetch_add(1, Ordering::Relaxed);
+        let rx = pool.dispatch_rx.clone();
+        let script = pool.worker_script.clone();
+        let max_requests = pool.max_requests;
+        let boot_timeout = pool.boot_timeout;
+
+        // Count the worker as live BEFORE spawning so the respawn gate can't
+        // over-provision in the window before the thread starts. Undone on
+        // spawn failure below, and by worker_main on normal exit.
+        pool.state.live.fetch_add(1, Ordering::AcqRel);
+
+        let builder = std::thread::Builder::new().name(format!("ephpm-worker-{worker_id}"));
+        let spawn_result = builder.spawn(move || {
+            worker_main(&pool, worker_id, &rx, &script, max_requests, boot_timeout);
+        });
+
+        if let Err(e) = spawn_result {
+            self.state.live.fetch_sub(1, Ordering::AcqRel);
+            tracing::error!(worker_id, %e, "failed to spawn worker thread");
+            counter!("ephpm_worker_boot_failures_total").increment(1);
+        }
+    }
+}
+
+/// Body of one worker OS thread: register with TSRM, install its dispatch
+/// receiver + recycle counter, boot the framework, serve, then exit (the
+/// supervisor spawns the replacement).
+fn worker_main(
+    pool: &Arc<WorkerPool>,
+    worker_id: usize,
+    rx: &async_channel::Receiver<WorkerJob>,
+    script: &std::path::Path,
+    max_requests: u64,
+    boot_timeout: Duration,
+) {
+    // `live` was incremented in spawn_worker before this thread started; we
+    // decrement it on every exit path below.
+
+    // Install this thread's dispatch receiver and recycle quota BEFORE booting,
+    // so the very first take_request() inside the framework loop can pull work.
+    ephpm_php::worker_bridge::set_dispatch_receiver(rx.clone());
+    ephpm_php::worker_bridge::set_max_requests(max_requests);
+
+    // TSRM register + start the one long-lived request the whole loop runs in.
+    if let Err(e) = PhpRuntime::worker_thread_init() {
+        tracing::error!(worker_id, ?e, "worker TSRM init failed");
+        pool.state.boot_failures.fetch_add(1, Ordering::AcqRel);
+        counter!("ephpm_worker_boot_failures_total").increment(1);
+        pool.state.live.fetch_sub(1, Ordering::AcqRel);
+        respawn_if_running(pool);
+        return;
+    }
+
+    let boot_start = Instant::now();
+    // Mark ready as soon as the thread is about to enter the framework loop.
+    // The first take_request() blocks in Rust, which is the readiness point.
+    pool.state.ready.fetch_add(1, Ordering::AcqRel);
+    gauge!("ephpm_worker_idle").increment(1.0);
+    pool.state.boot_failures.store(0, Ordering::Release);
+
+    tracing::info!(worker_id, "worker booting framework");
+
+    // run_worker blocks until the framework's take_request() loop ends.
+    let clean = PhpRuntime::run_worker(script);
+
+    let boot_elapsed = boot_start.elapsed().as_secs_f64();
+    histogram!("ephpm_worker_boot_duration_seconds").record(boot_elapsed);
+    if boot_elapsed > boot_timeout.as_secs_f64() {
+        tracing::warn!(worker_id, boot_elapsed, "worker exceeded boot timeout");
+    }
+
+    // The worker is no longer serving.
+    pool.state.ready.fetch_sub(1, Ordering::AcqRel);
+    gauge!("ephpm_worker_idle").decrement(1.0);
+
+    match clean {
+        Ok(true) => {
+            // Clean loop end: graceful drain or worker_max_requests recycle.
+            if pool.state.draining.load(Ordering::Acquire) {
+                tracing::debug!(worker_id, "worker exited on drain");
+            } else {
+                counter!("ephpm_worker_recycles_total", "reason" => "max_requests").increment(1);
+                tracing::debug!(worker_id, "worker recycled (max_requests) — respawning");
+            }
+        }
+        Ok(false) => {
+            // Fatal bailout unwound past send_response. Fulfil the parked
+            // oneshot with a 500 so the in-flight request never hangs, then
+            // recycle (never resume on a possibly-corrupt kernel).
+            if let Some(sender) = ephpm_php::worker_bridge::take_pending_sender() {
+                let _ = sender.send(WorkerResponse::internal_error());
+                tracing::warn!(worker_id, "worker bailed out mid-request — 500 sent, recycling");
+            } else {
+                tracing::warn!(worker_id, "worker bailed out between requests — recycling");
+            }
+            counter!("ephpm_worker_recycles_total", "reason" => "fatal").increment(1);
+        }
+        Err(e) => {
+            // run_worker itself refused (not initialized / bad path). Treat as
+            // a boot failure and fulfil any parked sender defensively.
+            if let Some(sender) = ephpm_php::worker_bridge::take_pending_sender() {
+                let _ = sender.send(WorkerResponse::internal_error());
+            }
+            tracing::error!(worker_id, ?e, "worker run failed");
+            pool.state.boot_failures.fetch_add(1, Ordering::AcqRel);
+            counter!("ephpm_worker_boot_failures_total").increment(1);
+        }
+    }
+
+    // Free this thread's TSRM slot + booted framework so the replacement boots
+    // clean. Safe: this thread is done executing PHP.
+    PhpRuntime::worker_thread_shutdown();
+
+    pool.state.live.fetch_sub(1, Ordering::AcqRel);
+    respawn_if_running(pool);
+}
+
+/// Spawn a replacement worker unless the pool is draining or already at target.
+///
+/// Gating on `live < worker_count` is what makes hung-worker replacement
+/// self-balancing: `note_hung` spawns a replacement (live -> count+1) while the
+/// stuck thread is abandoned; when that stuck thread eventually exits it finds
+/// `live == count` and does NOT respawn, so the pool converges back to target.
+fn respawn_if_running(pool: &Arc<WorkerPool>) {
+    if pool.state.draining.load(Ordering::Acquire) {
+        return;
+    }
+    if pool.state.live.load(Ordering::Acquire) >= pool.worker_count {
+        return;
+    }
+    // Basic boot-storm backoff: if boots keep failing, pause before respawning
+    // so a broken worker.php doesn't spin the CPU. Readiness reports 0 anyway.
+    let failures = pool.state.boot_failures.load(Ordering::Acquire);
+    if failures > 0 {
+        let shift = u32::try_from(failures.min(6)).unwrap_or(6);
+        let backoff = Duration::from_millis(100u64.saturating_mul(1u64 << shift));
+        std::thread::sleep(backoff.min(Duration::from_secs(10)));
+    }
+    pool.spawn_worker();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pool with zero workers spawns no OS threads (safe in stub mode) and
+    /// is never ready. Exercises the non-PHP pool plumbing: readiness, drain,
+    /// and dispatch-after-drain error.
+    #[tokio::test]
+    async fn zero_worker_pool_never_ready_and_drains() {
+        let pool = WorkerPool::spawn(
+            PathBuf::from("/nonexistent/worker.php"),
+            0, // no worker threads spawned
+            500,
+            4,
+            Duration::from_secs(30),
+        );
+
+        assert_eq!(pool.ready_count(), 0, "no worker booted, so not ready");
+
+        // Draining closes the dispatch sender; a subsequent dispatch must error
+        // (the router turns this into a 503) rather than hang.
+        pool.drain();
+        let req = ephpm_php::worker_bridge::WorkerRequestOwned {
+            method: "GET".into(),
+            uri: "/".into(),
+            query_string: String::new(),
+            cookie_data: String::new(),
+            content_type: None,
+            body: Vec::new(),
+            server_vars: Vec::new(),
+            headers: Vec::new(),
+        };
+        assert!(pool.dispatch(req).await.is_err(), "dispatch after drain must error");
+
+        // drain() is idempotent and note_hung() while draining is a no-op
+        // (must not spawn a replacement thread).
+        pool.drain();
+        pool.note_hung();
+        assert_eq!(pool.ready_count(), 0);
+    }
+
+    #[test]
+    fn internal_error_response_is_500() {
+        let e = WorkerResponse::internal_error();
+        assert_eq!(e.status, 500);
+    }
+}

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -606,6 +606,10 @@ fn load_serve_config(command: Option<Commands>) -> anyhow::Result<(ephpm_config:
         config.server.document_root = root;
     }
 
+    // Validate cross-field invariants (e.g. worker-mode worker_script) AFTER
+    // CLI overrides so document_root is final. Fails fast with a clear message.
+    config.validate().context("invalid configuration")?;
+
     Ok((config, verbose))
 }
 

--- a/examples/worker/worker.php
+++ b/examples/worker/worker.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ePHPm worker-mode reference script (Phase 1).
+ *
+ * This is the hand-written proof of the worker-mode primitive — NOT a
+ * framework adapter. It boots ONCE, then loops forever handling requests
+ * without any per-request bootstrap. Framework adapters (Octane, PSR-15)
+ * are Composer packages that consume the same two primitives:
+ *
+ *   \Ephpm\Worker\take_request(): ?\Ephpm\Worker\Envelope
+ *   \Ephpm\Worker\send_response(int $status, array $headers, string $body): void
+ *
+ * Run it by pointing ephpm at this directory with worker mode enabled:
+ *
+ *   [server]
+ *   document_root = "/path/to/examples/worker"
+ *
+ *   [php]
+ *   mode = "worker"
+ *   worker_script = "worker.php"
+ *
+ * Then `curl http://127.0.0.1:8080/anything` returns:
+ *   hello /anything (boot #1, request #3)
+ *
+ * The "boot #N" counter increments ONCE per worker boot (proving zero
+ * per-request bootstrap). The "request #N" counter increments per request
+ * handled by this worker.
+ */
+
+declare(strict_types=1);
+
+// ── Boot-once section ────────────────────────────────────────────────
+// Everything above the take_request() loop runs exactly ONCE when the
+// worker boots. A real framework would build its kernel/container here.
+//
+// The boot counter is a process-wide static (survives across requests on
+// this worker because the loop below never re-runs this file). We use a
+// static local so each *boot* increments it, proving boot-once: if ePHPm
+// were re-bootstrapping per request, this would be 1 on every response.
+
+static $bootCount = 0;
+$bootCount++;               // increments once per worker boot
+$myBoot = $bootCount;       // captured for this worker's lifetime
+$requestCount = 0;
+
+// error_log so the boot is visible in the server log — a real adapter would
+// not do this; it is here to make boot-once observable. (STDERR is a CLI-SAPI
+// constant and is not defined under the worker SAPI, so use error_log.)
+error_log("[worker] booted (boot #{$myBoot})");
+
+// ── Request loop ─────────────────────────────────────────────────────
+// take_request() blocks until the runtime routes an HTTP request to this
+// worker, or returns null on graceful shutdown / recycle — ending the loop
+// cleanly so the runtime can respawn a fresh worker.
+
+while (($envelope = \Ephpm\Worker\take_request()) !== null) {
+    $requestCount++;
+
+    $server = $envelope->serverVars();
+    $uri = $server['REQUEST_URI'] ?? '/';
+
+    $body = "hello {$uri} (boot #{$myBoot}, request #{$requestCount})\n";
+
+    \Ephpm\Worker\send_response(
+        200,
+        ['Content-Type' => 'text/plain; charset=utf-8'],
+        $body
+    );
+}
+
+// Reaching here means the loop ended (shutdown or recycle). Returning
+// hands control back to the ePHPm runtime, which frees this worker's PHP
+// context and — unless draining — boots a replacement.
+error_log("[worker] loop ended (boot #{$myBoot}, served {$requestCount} requests)");

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -129,7 +129,16 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `memory_limit` | string | `"128M"` | PHP `memory_limit`. |
 | `ini_file` | path | (none) | Custom `php.ini` loaded before `ini_overrides`. |
 | `ini_overrides` | array of `[string, string]` | `[]` | INI directives applied after `ini_file`. |
-| `workers` | usize | `0` (unlimited) | Max concurrent PHP executions (php-fpm `pm.max_children` semantics); excess requests queue. `0` = unlimited. |
+| `workers` | usize | `0` (unlimited) | Max concurrent PHP executions (php-fpm `pm.max_children` semantics); excess requests queue. `0` = unlimited. **Ignored in worker mode** (startup logs a WARN if set). |
+| `mode` | string | `"fpm"` | Request-execution model. `"fpm"` = per-request startup/shutdown (default, unchanged). `"worker"` = persistent worker mode: boot the framework once per worker, loop over requests (Octane/RoadRunner model). |
+| `worker_script` | path | (none) | Worker-mode entrypoint, relative to `document_root`. **Required** when `mode = "worker"`; config load hard-errors if absent or not a file under `document_root`. |
+| `worker_count` | usize | `0` (derive) | Number of persistent worker threads. `0` derives from CPU count, clamped `[2, 32]`. Forced to `1` on Windows (NTS, single PHP context). Worker mode only. |
+| `worker_max_requests` | u64 | `500` | Recycle a worker after N requests (php-fpm `pm.max_requests`). `0` = never recycle on count. Worker mode only. |
+| `worker_backlog` | usize | `0` (= `worker_count`) | Dispatch-queue depth. A full queue applies backpressure; a starved queue becomes a 504 via the request timeout. Worker mode only. |
+| `worker_boot_timeout` | u64 (sec) | `30` | Seconds a worker gets to boot and reach its first `take_request()`. Worker mode only. |
+| `worker_populate_superglobals` | bool | `false` | Populate native `$_GET`/`$_POST`/`$_SERVER`/... per request. Off for Octane/PSR-15 (they build their own request); on for the WordPress adapter. Worker mode only. |
+
+> **Worker mode is not supported with `[server] sites_dir`** (multi-tenant vhosting) in Phase 1 — config load hard-errors. Worker mode boots one framework per worker; per-host worker pools are a later phase.
 
 ## `[db]`
 


### PR DESCRIPTION
The **3.0 headline**: persistent worker mode (Octane/RoadRunner model). Boot the framework **once per worker thread**, loop over requests without re-bootstrapping. Design: `docs/architecture/worker-mode-design.md` (#113).

## Engine
- **SAPI surface** — `Ephpm\Worker\take_request()` / `send_response()` + the `Envelope` object, registered via the worker module handed to `php_module_startup` as its `additional_module` (so functions + class land in the frozen `GLOBAL_*` tables ZTS worker threads inherit).
- **`worker_bridge.rs`** — `#[repr(C)]` ops table (mirrors `kv_bridge`); `take_request` `recv_blocking()`s the dispatch queue and stashes the job's `oneshot::Sender` in a `thread_local`; `send_response` fulfils it. The stashed sender is the only Rust value live across a longjmp-capable PHP call.
- **`worker_pool.rs`** — fixed pool of dedicated `std::thread` OS threads (**not** `spawn_blocking`); `async_channel::bounded` dispatch + `oneshot` return; boot-once readiness gate, cooperative `worker_max_requests` recycle, **two-net crash recovery** (stashed-sender 500 + dropped-sender `RecvError`), self-balancing hung-worker replacement, graceful drain, boot-storm backoff.
- **Per-iteration reset** — resets only SAPI-scoped state (status/headers/last_error/buffers) using the exact lines the fpm hardening proved, **without** `php_request_shutdown`, so the booted framework survives.
- **Router** — worker mode dispatches every non-static request to the worker entrypoint (framework owns routing); static files + fpm path unchanged.
- **Config** — `[php] mode = "fpm"|"worker"` (default fpm, byte-for-byte unchanged) + worker knobs; validation (worker_script required/resolvable; `sites_dir`+worker hard-errors; WARN that `[php] workers` is ignored). NTS/Windows → single worker.
- **Metrics** — pool size/busy/idle, requests, recycles, boot failures/duration, queue depth, wait.
- **`examples/worker/worker.php`** — reference script (boot-once proof).

## Verification (live, against a release container)
- **Boot-once** — stable `boot #1` while `request#` climbs 1→5 (per-request bootstrap would show `request #1` every time)
- **Concurrency** — 15/15 → 200 across 2 workers
- **`worker_max_requests` recycle** — request counter resets at the cap
- **Fatal → 500 → recycle → recover** — `/boom`→500, next `/ok`→200 on a fresh boot, `booted` logged twice, **server never wedges**
- Stub mode compiles; clippy pedantic + nightly fmt clean; ephpm-config / ephpm-server (156) / ephpm unit tests green

## Three bugs the live run caught & fixed (not visible in stub build)
1. Worker functions/class registered after `php_module_startup` froze the ZTS tables → `function_exists()==false` on workers → boot storm. Fixed via `additional_module`.
2. Reference script used `STDERR` (CLI-only constant) → threw under the worker SAPI. Switched to `error_log`.
3. Router only dispatched to the worker for requests resolving to a `.php` file → framework URLs 404'd. Fixed: all non-static → worker.

## Scope
Phase 1 = the engine + a hand-written reference `worker.php`. Framework adapters (`ephpm/php-worker` base, `ephpm/psr15-worker`, `ephpm/octane-driver`, …) are Phase 2 (separate Composer repos). Streaming bodies (Phase 3), cache bindings + ticks (Phase 4), WordPress worker with its full test gate (later) per `worker-mode-roadmap.md`.