### PR TITLE
feat(worker): streaming request + response bodies (Phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel",
  "bindgen",
+ "bytes",
  "cc",
  "ephpm-kv",
  "http",

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1287,6 +1287,22 @@ pub struct PhpConfig {
     /// Default: `false`.
     #[serde(default)]
     pub worker_populate_superglobals: bool,
+
+    /// Request-body size (bytes) at or above which the body is *streamed* into
+    /// the worker in fixed-size chunks instead of buffered whole (worker mode
+    /// only, Phase 3). Requests with a `Content-Length` at or above this — or
+    /// with no `Content-Length` (chunked) — flow through
+    /// `Envelope::bodyStream()` / PHP's POST reader without ePHPm holding the
+    /// whole body in memory, keeping worker RSS flat for multi-GB uploads.
+    ///
+    /// Smaller requests stay on the buffered Phase-1 path (one copy each way),
+    /// which is cheaper for the common small-body case.
+    ///
+    /// Ignored in fpm mode (the fpm path always buffers the body today).
+    ///
+    /// Default: `1048576` (1 MiB).
+    #[serde(default = "default_worker_stream_threshold")]
+    pub worker_stream_threshold: u64,
 }
 
 impl Config {
@@ -1497,6 +1513,7 @@ impl Default for PhpConfig {
             worker_backlog: default_worker_backlog(),
             worker_boot_timeout: default_worker_boot_timeout(),
             worker_populate_superglobals: false,
+            worker_stream_threshold: default_worker_stream_threshold(),
         }
     }
 }
@@ -1720,6 +1737,11 @@ fn default_worker_max_requests() -> u64 {
 fn default_worker_backlog() -> usize {
     // 0 => = effective_worker_count (one queued job per worker).
     0
+}
+
+fn default_worker_stream_threshold() -> u64 {
+    // 1 MiB: bodies at/above this stream; smaller ones buffer (cheaper).
+    1024 * 1024
 }
 
 fn default_worker_boot_timeout() -> u64 {
@@ -2515,6 +2537,7 @@ sites_dir = "/var/www/sites"
         assert_eq!(cfg.worker_backlog, 0);
         assert_eq!(cfg.worker_boot_timeout, 30);
         assert!(!cfg.worker_populate_superglobals);
+        assert_eq!(cfg.worker_stream_threshold, 1024 * 1024);
         assert!(cfg.worker_script.is_none());
     }
 
@@ -2562,6 +2585,7 @@ worker_max_requests = 1000
 worker_backlog = 12
 worker_boot_timeout = 45
 worker_populate_superglobals = true
+worker_stream_threshold = 262144
 "#,
         )
         .unwrap();
@@ -2574,6 +2598,7 @@ worker_populate_superglobals = true
         assert_eq!(config.php.worker_backlog, 12);
         assert_eq!(config.php.worker_boot_timeout, 45);
         assert!(config.php.worker_populate_superglobals);
+        assert_eq!(config.php.worker_stream_threshold, 262_144);
     }
 
     #[test]

--- a/crates/ephpm-e2e/tests/worker_mode.rs
+++ b/crates/ephpm-e2e/tests/worker_mode.rs
@@ -154,3 +154,39 @@ async fn requests_keep_succeeding_across_recycles() {
         assert!(body.contains("hello /r-"), "recycle-run body wrong at {i}: {body}");
     }
 }
+
+/// Streaming round-trip (Phase 3): upload a large body and get the same bytes
+/// back. Proves `Envelope::bodyStream()` + `send_response_stream()` move the
+/// body without the worker buffering it whole. Requires a worker docroot whose
+/// script echoes the streamed request body (e.g. `examples/worker/worker-stream.php`);
+/// opt in via `EPHPM_WORKER_STREAM_URL` (separate instance from the hello
+/// worker). Self-skips when unset.
+///
+/// Verifies correctness (byte-for-byte echo) here; the flat-memory property is
+/// checked out-of-band (worker RSS during a multi-hundred-MB upload) since a
+/// black-box HTTP test cannot observe worker memory.
+#[tokio::test]
+async fn streaming_upload_echoes_back_identically() {
+    let Some(base) = std::env::var("EPHPM_WORKER_STREAM_URL").ok().filter(|s| !s.is_empty())
+    else {
+        eprintln!("EPHPM_WORKER_STREAM_URL unset — skipping worker-mode streaming test");
+        return;
+    };
+
+    // A body comfortably above a small stream threshold, with a non-trivial
+    // pattern so a truncation or reorder is caught.
+    let payload: Vec<u8> = (0..8 * 1024 * 1024).map(|i| (i % 251) as u8).collect();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base}/echo"))
+        .body(payload.clone())
+        .send()
+        .await
+        .expect("streaming upload failed");
+    assert_eq!(resp.status().as_u16(), 200, "streaming echo not 200");
+
+    let echoed = resp.bytes().await.expect("read echoed body").to_vec();
+    assert_eq!(echoed.len(), payload.len(), "echoed length differs from upload");
+    assert!(echoed == payload, "echoed body does not match the uploaded body");
+}

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -17,6 +17,9 @@ http.workspace = true
 # speaks both send().await and recv_blocking()) plus oneshot response return.
 async-channel.workspace = true
 tokio = { workspace = true, features = ["sync"] }
+# Phase 3 streaming bodies: zero-copy chunk buffers across the hyper<->worker
+# bounded channels.
+bytes.workspace = true
 
 [build-dependencies]
 bindgen = "0.72"

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -38,6 +38,7 @@ static char *ephpm_strtok_r(char *str, const char *delim, char **saveptr) {
 #include "main/SAPI.h"
 #include "main/php_main.h"
 #include "main/php_variables.h"
+#include "main/php_streams.h"
 #include "Zend/zend.h"
 #include "Zend/zend_ini.h"
 #include "Zend/zend_stream.h"
@@ -160,10 +161,22 @@ static EPHPM_TLS size_t req_post_data_len = 0;
 static EPHPM_TLS size_t req_post_data_offset = 0;
 static EPHPM_TLS const char *req_path_translated = NULL;
 
+/* Worker mode: when set, this thread's request body is streamed from Rust via
+ * g_worker_ops.body_read rather than served from the in-memory req_post_data
+ * buffer. read_post and the bodyStream() php_stream both pull from the same
+ * incremental reader, so the body is consumed exactly once (whichever reads
+ * first wins — see the Envelope docs). Reset per iteration. */
+static EPHPM_TLS int req_body_streaming = 0;
+
 /* Non-NULL sentinel for SG(server_context). sapi_activate() only parses the
  * POST body when server_context is set; the value itself is never dereferenced
  * by our SAPI, so a single shared marker address suffices. */
 static int ephpm_server_context_marker = 0;
+
+/* Pull the next chunk of a streaming worker-mode request body (defined with
+ * the worker-mode block below, but used by the read_post SAPI callback above
+ * it). Returns bytes written into buf (0 = EOF, negative = error). */
+static long ephpm_worker_body_read(char *buf, size_t cap);
 
 /* Server variables */
 
@@ -273,6 +286,19 @@ static int ephpm_sapi_send_headers(sapi_headers_struct *sapi_headers)
  */
 static size_t ephpm_sapi_read_post(char *buffer, size_t count_bytes)
 {
+    /* Worker mode streaming: pull incrementally from Rust so PHP's own POST
+     * reader (which drives $_POST / multipart parsing) never forces the whole
+     * body into memory. read_post and bodyStream() share this reader, so the
+     * body is consumed exactly once. */
+    if (req_body_streaming) {
+        long n = ephpm_worker_body_read(buffer, count_bytes);
+        if (n <= 0) {
+            return 0;
+        }
+        req_post_data_offset += (size_t)n;
+        return (size_t)n;
+    }
+
     if (!req_post_data || req_post_data_offset >= req_post_data_len)
         return 0;
 
@@ -965,6 +991,9 @@ typedef struct {
     const char *content_type;     /* may be NULL */
     const char *body;             /* raw request body (may be NULL) */
     size_t      body_len;
+    /* Phase 3: when non-zero, the body is streamed via g_worker_ops.body_read
+     * (body/body_len are unset). When zero, the whole body is in `body`. */
+    int         body_streaming;
 
     size_t      server_var_count;
     const char *const *server_var_keys;
@@ -985,6 +1014,28 @@ typedef struct {
     void (*send_response)(int status,
                           const char *headers, size_t headers_len,
                           const char *body, size_t body_len);
+
+    /* ── Phase 3: streaming bodies ──────────────────────────────────
+     * Streaming request read (design §9). Pull up to `cap` bytes of the
+     * incremental request body into `buf`. Returns the number of bytes
+     * written (0 = clean EOF, negative = error). Blocks until at least one
+     * byte is available or EOF. Backed by a bounded channel the hyper task
+     * feeds; the worker thread blocks here. When the request was dispatched
+     * fully-buffered (no streaming reader), this serves from the in-memory
+     * body so the same read path works both ways. */
+    long (*body_read)(char *buf, size_t cap);
+
+    /* Begin a streaming response: status + packed headers, no body yet. The
+     * hyper handler builds a streamed response body from the chunks that
+     * follow. */
+    void (*response_begin)(int status,
+                           const char *headers, size_t headers_len);
+    /* Push one response body chunk. Blocks on backpressure (bounded channel).
+     * Returns 0 on success, negative if the client/receiver went away (the
+     * worker should stop producing). */
+    long (*response_chunk)(const char *buf, size_t len);
+    /* Finish the streaming response (close the body channel). */
+    void (*response_end)(void);
 } EphpmWorkerOps;
 
 static EphpmWorkerOps g_worker_ops = {0};
@@ -1027,10 +1078,76 @@ void ephpm_worker_reset_request(void)
     /* Per-iteration fatal detection (:844). */
     PG(last_error_type) = 0;
 
-    /* Per-iteration POST cursor. */
+    /* Per-iteration POST cursor + streaming flag. */
     req_post_data_offset = 0;
+    req_body_streaming = 0;
 
     response_status_code = 200;
+}
+
+/* Pull the next chunk of a streaming request body from Rust. Serves both the
+ * read_post SAPI callback ($_POST/multipart) and the bodyStream() php_stream,
+ * so the incremental body is consumed exactly once regardless of which the
+ * framework reaches for. Blocks until data is available or EOF. */
+static long ephpm_worker_body_read(char *buf, size_t cap)
+{
+    if (!g_worker_ops.body_read || cap == 0) {
+        return 0;
+    }
+    return g_worker_ops.body_read(buf, cap);
+}
+
+/* ── bodyStream(): a real readable php:// stream over the incremental body ──
+ * A php_stream whose read op pulls from ephpm_worker_body_read (backed by the
+ * bounded hyper->worker channel). Non-seekable, read-only, no writes. This is
+ * the Phase-3 zero-prebuffer request path: a multi-GB upload flows through in
+ * fixed-size reads with flat worker memory. */
+static ssize_t ephpm_body_stream_read(php_stream *stream, char *buf, size_t count)
+{
+    (void)stream;
+    long n = ephpm_worker_body_read(buf, count);
+    if (n < 0) {
+        return -1;
+    }
+    if (n == 0) {
+        stream->eof = 1;
+        return 0;
+    }
+    return (ssize_t)n;
+}
+
+static int ephpm_body_stream_close(php_stream *stream, int close_handle)
+{
+    (void)stream;
+    (void)close_handle;
+    /* Nothing owned on the C side — the Rust reader is freed when the worker
+     * finishes the request (send_response / next take_request). */
+    return 0;
+}
+
+static int ephpm_body_stream_flush(php_stream *stream)
+{
+    (void)stream;
+    return 0;
+}
+
+static const php_stream_ops ephpm_body_stream_ops = {
+    NULL,                        /* write (read-only) */
+    ephpm_body_stream_read,      /* read */
+    ephpm_body_stream_close,     /* close */
+    ephpm_body_stream_flush,     /* flush */
+    "ephpm-request-body",        /* label */
+    NULL,                        /* seek (non-seekable) */
+    NULL,                        /* cast */
+    NULL,                        /* stat */
+    NULL                         /* set_option */
+};
+
+/* Build a php_stream reading the incremental request body. */
+static php_stream *ephpm_worker_open_body_stream(void)
+{
+    php_stream *stream = php_stream_alloc(&ephpm_body_stream_ops, NULL, NULL, "rb");
+    return stream;
 }
 
 /* Build a PHP array of (key => value) string pairs from a packed C list. */
@@ -1145,12 +1262,18 @@ PHP_FUNCTION(ephpm_worker_take_request)
     req_post_data = req.body;
     req_post_data_len = req.body_len;
     req_post_data_offset = 0;
+    /* Phase 3: route read_post / bodyStream() through the incremental Rust
+     * reader when the request was dispatched streaming (large upload). */
+    req_body_streaming = req.body_streaming ? 1 : 0;
 
     SG(request_info).request_method = (char *)req.method;
     SG(request_info).request_uri = (char *)req.uri;
     SG(request_info).query_string = (char *)req.query_string;
     SG(request_info).content_type = req.content_type;
     SG(request_info).cookie_data = (char *)req.cookie_data;
+    /* For streaming requests body_len carries the declared Content-Length (so
+     * PHP's post reader knows how much to expect); the bytes arrive via
+     * body_read. For buffered requests it is the actual body length. */
     SG(request_info).content_length = (zend_long)req.body_len;
 
     /* Optionally rebuild native superglobals through the normal, quiescent
@@ -1189,7 +1312,21 @@ PHP_FUNCTION(ephpm_worker_take_request)
     ephpm_worker_parse_query(&tmp, req.query_string);
     ephpm_worker_set_prop_array(return_value, "query", &tmp);
 
-    ephpm_worker_set_prop_stringl(return_value, "rawBody", req.body, req.body_len);
+    /* Body. Buffered request: store the whole body string (Phase-1 back-compat;
+     * rawBody() and bodyStream() both serve from it). Streaming request: store
+     * an empty rawBody and a "streaming" marker — bodyStream() opens a real
+     * php:// stream over the incremental reader, and rawBody() reads that
+     * stream to a string on demand (which re-buffers; adapters that care about
+     * memory use bodyStream()). */
+    ZEND_ASSERT(ephpm_worker_envelope_ce != NULL);
+    zend_update_property_bool(ephpm_worker_envelope_ce, Z_OBJ_P(return_value),
+                              "streaming", strlen("streaming"),
+                              req.body_streaming ? 1 : 0);
+    if (req.body_streaming) {
+        ephpm_worker_set_prop_stringl(return_value, "rawBody", "", 0);
+    } else {
+        ephpm_worker_set_prop_stringl(return_value, "rawBody", req.body, req.body_len);
+    }
 }
 
 /* PHP_FUNCTION: \Ephpm\Worker\send_response(int, array, string): void
@@ -1255,6 +1392,95 @@ PHP_FUNCTION(ephpm_worker_send_response)
     output_len = 0;
 }
 
+/* Pack a PHP headers array into "Name: Value\n" lines. Caller frees the
+ * returned smart_str with smart_str_free. */
+static void ephpm_worker_pack_headers(smart_str *out, zval *headers_arr)
+{
+    zend_string *hkey;
+    zval *hval;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(headers_arr), hkey, hval) {
+        if (!hkey) {
+            continue; /* skip numeric keys */
+        }
+        zend_string *vstr = zval_get_string(hval);
+        smart_str_appendl(out, ZSTR_VAL(hkey), ZSTR_LEN(hkey));
+        smart_str_appendl(out, ": ", 2);
+        smart_str_appendl(out, ZSTR_VAL(vstr), ZSTR_LEN(vstr));
+        smart_str_appendc(out, '\n');
+        zend_string_release(vstr);
+    } ZEND_HASH_FOREACH_END();
+    smart_str_0(out);
+}
+
+/* PHP_FUNCTION: \Ephpm\Worker\send_response_stream(int $status, array $headers,
+ *                                                  $bodyResource): void
+ *
+ * Phase-3 streaming response. Rather than handing back a full body string, the
+ * framework passes a readable stream/resource; we pump it to the HTTP layer in
+ * fixed-size chunks so bytes reach the client before PHP has produced them all
+ * (flat worker memory for multi-GB downloads).
+ *
+ * Any captured echo output (ub_write) is flushed as the first chunk so the
+ * echo path still works. Backpressure: response_chunk blocks on the bounded
+ * hyper channel; if the client goes away it returns negative and we stop. */
+PHP_FUNCTION(ephpm_worker_send_response_stream)
+{
+    zend_long status;
+    zval *headers_arr;
+    zval *body_res;
+
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_LONG(status)
+        Z_PARAM_ARRAY(headers_arr)
+        Z_PARAM_RESOURCE(body_res)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (!g_worker_ops.response_begin || !g_worker_ops.response_chunk ||
+        !g_worker_ops.response_end) {
+        /* Streaming ops not installed — nothing we can do; drop the request so
+         * the parked oneshot resolves via the supervisor's 500 net. */
+        return;
+    }
+
+    php_stream *stream;
+    php_stream_from_zval_no_verify(stream, body_res);
+    if (!stream) {
+        return;
+    }
+
+    smart_str hbuf = {0};
+    ephpm_worker_pack_headers(&hbuf, headers_arr);
+    const char *hdr_ptr = hbuf.s ? ZSTR_VAL(hbuf.s) : "";
+    size_t hdr_len = hbuf.s ? ZSTR_LEN(hbuf.s) : 0;
+
+    g_worker_ops.response_begin((int)status, hdr_ptr, hdr_len);
+    smart_str_free(&hbuf);
+
+    /* Flush any buffered echo output first. */
+    if (output_len > 0) {
+        (void)g_worker_ops.response_chunk(output_buf, output_len);
+        output_len = 0;
+    }
+
+    /* Pump the stream to the client in fixed-size chunks. */
+    char chunk[65536];
+    for (;;) {
+        ssize_t n = php_stream_read(stream, chunk, sizeof(chunk));
+        if (n <= 0) {
+            break;
+        }
+        if (g_worker_ops.response_chunk(chunk, (size_t)n) < 0) {
+            /* Receiver/client gone — stop producing. */
+            break;
+        }
+    }
+
+    g_worker_ops.response_end();
+
+    /* Release the borrowed request backing storage (the Rust send_response
+     * path does this too, but response_end delivers via a different channel). */
+}
+
 /* ── Envelope methods ─────────────────────────────────────────────
  * Each returns the property populated by take_request. Framework-neutral;
  * adapters build their own Request from these. */
@@ -1272,11 +1498,74 @@ PHP_METHOD(Ephpm_Worker_Envelope, serverVars)  { ephpm_worker_return_prop(INTERN
 PHP_METHOD(Ephpm_Worker_Envelope, headers)     { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "headers"); }
 PHP_METHOD(Ephpm_Worker_Envelope, cookies)     { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "cookies"); }
 PHP_METHOD(Ephpm_Worker_Envelope, query)       { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "query"); }
-PHP_METHOD(Ephpm_Worker_Envelope, rawBody)     { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "rawBody"); }
-PHP_METHOD(Ephpm_Worker_Envelope, bodyStream)  { ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "rawBody"); }
+
+/* Whether this envelope's body is streamed (Phase 3) rather than buffered. */
+static int ephpm_worker_envelope_is_streaming(zval *this_obj)
+{
+    zval rv;
+    zval *prop = zend_read_property(ephpm_worker_envelope_ce, Z_OBJ_P(this_obj),
+                                    "streaming", strlen("streaming"), 1, &rv);
+    return prop && zend_is_true(prop);
+}
+
+/* rawBody(): string — php://input equivalent.
+ *
+ * Buffered request: returns the stored body string (Phase-1 behavior).
+ * Streaming request: drains the incremental reader into a string. This
+ * re-buffers the whole body, defeating the streaming memory win — it exists
+ * only for back-compat (a framework that insists on the raw string). Adapters
+ * that care about memory use bodyStream() instead. Consuming the body once is
+ * shared with bodyStream()/read_post, so calling both is a foot-gun. */
+PHP_METHOD(Ephpm_Worker_Envelope, rawBody)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    if (!ephpm_worker_envelope_is_streaming(ZEND_THIS)) {
+        ephpm_worker_return_prop(INTERNAL_FUNCTION_PARAM_PASSTHRU, "rawBody");
+        return;
+    }
+
+    /* Drain the streaming reader into a smart_str. */
+    smart_str buf = {0};
+    char chunk[65536];
+    for (;;) {
+        long n = ephpm_worker_body_read(chunk, sizeof(chunk));
+        if (n <= 0) {
+            break;
+        }
+        smart_str_appendl(&buf, chunk, (size_t)n);
+    }
+    smart_str_0(&buf);
+    if (buf.s) {
+        RETVAL_STR(buf.s);          /* transfers ownership */
+    } else {
+        RETVAL_EMPTY_STRING();
+    }
+}
+
+/* bodyStream(): resource — a real readable php:// stream over the incremental
+ * request body (Phase 3). Reading it pulls fixed-size chunks from Rust without
+ * pre-buffering, so a multi-GB upload flows through with flat worker memory.
+ * For buffered requests it still works (reads from the in-memory body). */
+PHP_METHOD(Ephpm_Worker_Envelope, bodyStream)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    php_stream *stream = ephpm_worker_open_body_stream();
+    if (!stream) {
+        RETURN_FALSE;
+    }
+    php_stream_to_zval(stream, return_value);
+}
 
 /* parsedBody(): ?array — Phase 1 returns null (form/multipart parsing is a
- * framework/adapter concern; streaming bodies are Phase 3). */
+ * framework/adapter concern). Adapters that want native $_POST/$_FILES enable
+ * worker.populate_superglobals, which drives PHP's own POST reader through the
+ * (streaming) read_post callback — so form/multipart parsing still works and,
+ * for large multipart uploads, PHP's rfc1867 handler spools file parts to
+ * temp files rather than into memory. Note: PHP's POST reader and bodyStream()
+ * share ONE incremental reader, so for a streaming request reading the body
+ * both ways drains it once — pick one. */
 PHP_METHOD(Ephpm_Worker_Envelope, parsedBody)
 {
     ZEND_PARSE_PARAMETERS_NONE();
@@ -1301,6 +1590,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_worker_send_response, 0, 0, 3)
     ZEND_ARG_INFO(0, body)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_worker_send_response_stream, 0, 0, 3)
+    ZEND_ARG_INFO(0, status)
+    ZEND_ARG_INFO(0, headers)
+    ZEND_ARG_INFO(0, body)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_worker_envelope_noargs, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -1314,6 +1609,9 @@ static const zend_function_entry ephpm_worker_functions[] = {
     ZEND_NS_NAMED_FE("Ephpm\\Worker", send_response,
                      ZEND_FN(ephpm_worker_send_response),
                      arginfo_ephpm_worker_send_response)
+    ZEND_NS_NAMED_FE("Ephpm\\Worker", send_response_stream,
+                     ZEND_FN(ephpm_worker_send_response_stream),
+                     arginfo_ephpm_worker_send_response_stream)
     PHP_FE_END
 };
 

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -18,6 +18,20 @@
 //! [`WorkerResponse::internal_error`] (500), or the sender is dropped and the
 //! receiver sees `RecvError` (also 500).
 //!
+//! ## Phase 3: streaming bodies
+//!
+//! The ops table also carries `body_read` (incremental request body) and
+//! `response_begin`/`response_chunk`/`response_end` (incremental response). A
+//! request body is either [`WorkerBody::Buffered`] (small, Phase-1 path) or
+//! [`WorkerBody::Streaming`] (large — chunks arrive on a bounded channel the
+//! worker `blocking_recv`s via `body_read`, so ePHPm never holds the whole
+//! body). `send_response_stream` on the PHP side drives `response_begin` (which
+//! delivers status+headers on the oneshot immediately, as
+//! [`WorkerResponse::Streaming`]) then `response_chunk` per chunk (bounded
+//! `blocking_send` = download backpressure) then `response_end`. The worker
+//! threads are plain OS threads (not on the tokio runtime), so `blocking_recv`
+//! / `blocking_send` are valid there.
+//!
 //! Everything real is `#[cfg(php_linked)]`; stub builds get inert fallbacks.
 
 #[cfg(php_linked)]
@@ -27,12 +41,49 @@ use std::ffi::CString;
 #[cfg(php_linked)]
 use std::os::raw::{c_char, c_int};
 
+/// Chunk size / channel bounds shared with the streaming-body plumbing.
+///
+/// A bounded channel of `BODY_CHANNEL_DEPTH` chunks caps the in-flight buffered
+/// bytes at roughly `depth * chunk` regardless of upload size, which is the
+/// flat-memory guarantee (design §9 exit criterion).
+pub const BODY_CHANNEL_DEPTH: usize = 8;
+
 // ── Shared message types (used by ephpm-server's worker pool) ────────────
 
-/// An owned HTTP request handed to a worker thread. Owns every string/byte
-/// buffer so the borrowed [`EphpmWorkerRequest`] view stays valid for the
-/// whole iteration (until `send_response`).
-#[derive(Debug, Clone)]
+/// The request body handed to a worker: either fully buffered (Phase 1
+/// back-compat, small bodies) or streamed incrementally from the hyper task
+/// (Phase 3, large uploads with flat worker memory).
+pub enum WorkerBody {
+    /// The whole body, already in memory.
+    Buffered(Vec<u8>),
+    /// Incremental body: the worker thread `blocking_recv`s `Bytes` chunks off
+    /// this bounded receiver (a hyper task sends frames); the sender closing
+    /// signals clean EOF. `declared_len` is the `Content-Length` (so PHP's POST
+    /// reader knows how much to expect); it may be `0` for chunked bodies.
+    Streaming {
+        /// Bounded receiver of body chunks; sender close = clean EOF. Bounded,
+        /// so a slow worker applies backpressure to the hyper reader.
+        rx: tokio::sync::mpsc::Receiver<bytes::Bytes>,
+        /// Declared `Content-Length`, or `0` when unknown.
+        declared_len: usize,
+    },
+}
+
+impl std::fmt::Debug for WorkerBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Buffered(b) => f.debug_tuple("Buffered").field(&b.len()).finish(),
+            Self::Streaming { declared_len, .. } => {
+                f.debug_struct("Streaming").field("declared_len", declared_len).finish()
+            }
+        }
+    }
+}
+
+/// An owned HTTP request handed to a worker thread. Owns every string buffer so
+/// the borrowed [`EphpmWorkerRequest`] view stays valid for the whole iteration
+/// (until `send_response`).
+#[derive(Debug)]
 pub struct WorkerRequestOwned {
     /// HTTP method (`GET`, `POST`, ...).
     pub method: String,
@@ -44,23 +95,38 @@ pub struct WorkerRequestOwned {
     pub cookie_data: String,
     /// `Content-Type` header value, if any.
     pub content_type: Option<String>,
-    /// Raw request body bytes.
-    pub body: Vec<u8>,
+    /// The request body (buffered or streaming).
+    pub body: WorkerBody,
     /// `$_SERVER`-shaped variables as `(key, value)` pairs.
     pub server_vars: Vec<(String, String)>,
     /// HTTP headers as `(name, value)` pairs.
     pub headers: Vec<(String, String)>,
 }
 
-/// A response produced by a worker for one request.
-#[derive(Debug, Clone)]
-pub struct WorkerResponse {
-    /// HTTP status code.
-    pub status: u16,
-    /// Response headers as `(name, value)` pairs.
-    pub headers: Vec<(String, String)>,
-    /// Response body bytes.
-    pub body: Vec<u8>,
+/// A response produced by a worker for one request: either fully buffered
+/// (`send_response`) or streamed (`send_response_stream`).
+#[derive(Debug)]
+pub enum WorkerResponse {
+    /// Complete response with a fully-materialized body.
+    Buffered {
+        /// HTTP status code.
+        status: u16,
+        /// Response headers as `(name, value)` pairs.
+        headers: Vec<(String, String)>,
+        /// Response body bytes.
+        body: Vec<u8>,
+    },
+    /// Streamed response: status + headers now, body chunks arrive on `body_rx`
+    /// as the worker produces them (`send_response_stream`). The hyper handler
+    /// turns `body_rx` into a `StreamBody` so bytes flush before PHP finishes.
+    Streaming {
+        /// HTTP status code.
+        status: u16,
+        /// Response headers as `(name, value)` pairs.
+        headers: Vec<(String, String)>,
+        /// Bounded receiver of body chunks; sender close = end of body.
+        body_rx: tokio::sync::mpsc::Receiver<bytes::Bytes>,
+    },
 }
 
 impl WorkerResponse {
@@ -68,7 +134,7 @@ impl WorkerResponse {
     /// sending a real response (design §5.3).
     #[must_use]
     pub fn internal_error() -> Self {
-        Self {
+        Self::Buffered {
             status: 500,
             headers: vec![("Content-Type".to_string(), "text/plain".to_string())],
             body: b"Internal Server Error".to_vec(),
@@ -104,10 +170,14 @@ pub struct EphpmWorkerRequest {
     pub cookie_data: *const c_char,
     /// `Content-Type`, null-terminated, or null.
     pub content_type: *const c_char,
-    /// Raw body bytes, or null when empty.
+    /// Raw body bytes, or null when empty (unset for streaming requests).
     pub body: *const c_char,
-    /// Body length in bytes.
+    /// Body length in bytes. For streaming requests this carries the declared
+    /// `Content-Length` (so PHP's POST reader knows how much to expect); the
+    /// bytes themselves arrive through `body_read`.
     pub body_len: usize,
+    /// Non-zero when the body streams via the `body_read` op instead of `body`.
+    pub body_streaming: c_int,
 
     /// Number of `$_SERVER` entries.
     pub server_var_count: usize,
@@ -143,6 +213,20 @@ pub struct EphpmWorkerOps {
             body_len: usize,
         ),
     >,
+
+    // ── Phase 3: streaming bodies ────────────────────────────────────────
+    /// Read up to `cap` bytes of the incremental request body into `buf`.
+    /// Returns bytes written (0 = EOF, negative = error). Blocks until data or
+    /// EOF. Serves the in-memory body when the request was buffered.
+    pub body_read: Option<unsafe extern "C" fn(buf: *mut c_char, cap: usize) -> isize>,
+    /// Begin a streaming response (status + packed headers, body chunks follow).
+    pub response_begin:
+        Option<unsafe extern "C" fn(status: c_int, headers: *const c_char, headers_len: usize)>,
+    /// Push one response body chunk (blocks on backpressure). Returns 0, or
+    /// negative if the receiver/client is gone.
+    pub response_chunk: Option<unsafe extern "C" fn(buf: *const c_char, len: usize) -> isize>,
+    /// Finish the streaming response (close the body channel).
+    pub response_end: Option<unsafe extern "C" fn()>,
 }
 
 // ── Thread-local per-worker state ────────────────────────────────────────
@@ -163,7 +247,11 @@ struct CurrentRequest {
     _query: CString,
     _cookie: CString,
     _content_type: Option<CString>,
+    // For buffered requests, `body` points into here; for streaming requests
+    // this is empty and `body_len` carries the declared Content-Length.
     _body: Vec<u8>,
+    body_len: usize,
+    streaming: bool,
     _server_keys: Vec<CString>,
     _server_vals: Vec<CString>,
     _header_keys: Vec<CString>,
@@ -175,6 +263,30 @@ struct CurrentRequest {
     header_key_ptrs: Vec<*const c_char>,
     header_val_ptrs: Vec<*const c_char>,
 }
+
+/// The request-body reader for the in-flight request. Serves `body_read` from
+/// either an in-memory buffer (buffered dispatch) or a blocking chunk receiver
+/// (streaming dispatch). Never crosses a longjmp with a live lock — it lives in
+/// a thread-local `RefCell` borrowed only for the duration of one `body_read`.
+#[cfg(php_linked)]
+enum BodyReader {
+    /// No body / already drained.
+    Empty,
+    /// Buffered body with a read cursor.
+    Buffered { data: Vec<u8>, offset: usize },
+    /// Streaming body: a leftover partial chunk plus the bounded receiver. The
+    /// worker thread is a plain OS thread (not on the tokio runtime), so
+    /// `blocking_recv()` is valid here.
+    Streaming { pending: bytes::Bytes, rx: tokio::sync::mpsc::Receiver<bytes::Bytes> },
+}
+
+/// The in-flight streaming-response sender (`send_response_stream`). Chunks the
+/// worker produces are pushed here; the hyper handler drains it into a
+/// `StreamBody`. Bounded — `response_chunk` uses `blocking_send`, giving
+/// download backpressure. Longjmp-safe: the `Sender`'s `Drop` just signals the
+/// receiver (no files/locks).
+#[cfg(php_linked)]
+type ResponseChunkTx = tokio::sync::mpsc::Sender<bytes::Bytes>;
 
 #[cfg(php_linked)]
 thread_local! {
@@ -191,6 +303,13 @@ thread_local! {
 
     /// Backing storage for the request C currently borrows.
     static CURRENT_REQUEST: RefCell<Option<CurrentRequest>> = const { RefCell::new(None) };
+
+    /// The incremental request-body reader for the in-flight request. Consumed
+    /// by `body_read` (drives both read_post and bodyStream()).
+    static BODY_READER: RefCell<BodyReader> = const { RefCell::new(BodyReader::Empty) };
+
+    /// The in-flight streaming-response chunk sender (`send_response_stream`).
+    static RESPONSE_TX: RefCell<Option<ResponseChunkTx>> = const { RefCell::new(None) };
 
     /// Requests handled by this worker since boot (drives `worker_max_requests`).
     static REQUESTS_HANDLED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
@@ -238,10 +357,30 @@ pub fn take_pending_sender() -> Option<tokio::sync::oneshot::Sender<WorkerRespon
     None
 }
 
+/// Drop any in-flight streaming state left over after a bailout: the response
+/// chunk sender (closing its channel signals end-of-body to the hyper handler,
+/// so a client mid-download gets a truncated-but-not-hung response) and the
+/// body reader. Call from the pool's crash-recovery path before the worker
+/// resumes/respawns. Idempotent.
+#[cfg(php_linked)]
+pub fn clear_in_flight_streams() {
+    RESPONSE_TX.with(|cell| *cell.borrow_mut() = None);
+    BODY_READER.with(|cell| *cell.borrow_mut() = BodyReader::Empty);
+    CURRENT_REQUEST.with(|cell| *cell.borrow_mut() = None);
+}
+
+/// Stub.
+#[cfg(not(php_linked))]
+pub fn clear_in_flight_streams() {}
+
 // ── Callback implementations ─────────────────────────────────────────────
 
+/// Build the C-borrowed request backing storage from an owned job, consuming
+/// its body into a [`BodyReader`] (returned separately so the caller can stash
+/// it in [`BODY_READER`]). The `_body` `Vec` in the returned struct is empty
+/// for streaming requests — their bytes flow through `body_read`.
 #[cfg(php_linked)]
-fn build_current_request(job: &WorkerRequestOwned) -> CurrentRequest {
+fn build_current_request(job: WorkerRequestOwned) -> (CurrentRequest, BodyReader) {
     // Lossy on interior NULs (extremely rare in HTTP metadata) — replace with
     // an empty string rather than fail the request.
     let cstr = |s: &str| CString::new(s).unwrap_or_default();
@@ -262,13 +401,35 @@ fn build_current_request(job: &WorkerRequestOwned) -> CurrentRequest {
     let header_key_ptrs: Vec<*const c_char> = header_keys.iter().map(|c| c.as_ptr()).collect();
     let header_val_ptrs: Vec<*const c_char> = header_vals.iter().map(|c| c.as_ptr()).collect();
 
-    CurrentRequest {
+    let (body_vec, body_len, streaming, reader) = match job.body {
+        WorkerBody::Buffered(data) => {
+            let len = data.len();
+            // The C borrow reads from the CurrentRequest._body copy; the reader
+            // owns its own copy so read_post/bodyStream stay consistent.
+            let reader = if len == 0 {
+                BodyReader::Empty
+            } else {
+                BodyReader::Buffered { data: data.clone(), offset: 0 }
+            };
+            (data, len, false, reader)
+        }
+        WorkerBody::Streaming { rx, declared_len } => (
+            Vec::new(),
+            declared_len,
+            true,
+            BodyReader::Streaming { pending: bytes::Bytes::new(), rx },
+        ),
+    };
+
+    let current = CurrentRequest {
         _method: method,
         _uri: uri,
         _query: query,
         _cookie: cookie,
         _content_type: content_type,
-        _body: job.body.clone(),
+        _body: body_vec,
+        body_len,
+        streaming,
         _server_keys: server_keys,
         _server_vals: server_vals,
         _header_keys: header_keys,
@@ -277,7 +438,8 @@ fn build_current_request(job: &WorkerRequestOwned) -> CurrentRequest {
         server_val_ptrs,
         header_key_ptrs,
         header_val_ptrs,
-    }
+    };
+    (current, reader)
 }
 
 /// C-callable `take_request`: block for the next job, stash its sender, and
@@ -305,8 +467,13 @@ unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int 
     // Stash the sender for send_response / crash recovery.
     PENDING_SENDER.with(|cell| *cell.borrow_mut() = Some(job.respond_to));
 
-    // Build owned backing storage and publish the borrowed pointers.
-    let current = build_current_request(&job.request);
+    // Any stale streaming-response sender from a prior iteration is dropped
+    // here (closing its channel) so it can never bleed into this request.
+    RESPONSE_TX.with(|cell| *cell.borrow_mut() = None);
+
+    // Build owned backing storage + the body reader, and publish the pointers.
+    let (current, reader) = build_current_request(job.request);
+    BODY_READER.with(|cell| *cell.borrow_mut() = reader);
     CURRENT_REQUEST.with(|cell| *cell.borrow_mut() = Some(current));
 
     CURRENT_REQUEST.with(|cell| {
@@ -323,12 +490,13 @@ unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int 
             (*req).cookie_data = cur._cookie.as_ptr();
             (*req).content_type =
                 cur._content_type.as_ref().map_or(std::ptr::null(), |c| c.as_ptr());
-            (*req).body = if cur._body.is_empty() {
+            (*req).body = if cur.streaming || cur._body.is_empty() {
                 std::ptr::null()
             } else {
                 cur._body.as_ptr().cast::<c_char>()
             };
-            (*req).body_len = cur._body.len();
+            (*req).body_len = cur.body_len;
+            (*req).body_streaming = c_int::from(cur.streaming);
             (*req).server_var_count = cur.server_key_ptrs.len();
             (*req).server_var_keys = cur.server_key_ptrs.as_ptr();
             (*req).server_var_vals = cur.server_val_ptrs.as_ptr();
@@ -366,7 +534,7 @@ unsafe extern "C" fn worker_send_response(
     let parsed_headers = parse_packed_headers(header_bytes);
 
     let status = u16::try_from(status).unwrap_or(200);
-    let response = WorkerResponse { status, headers: parsed_headers, body: body_bytes };
+    let response = WorkerResponse::Buffered { status, headers: parsed_headers, body: body_bytes };
 
     // Deliver to the parked receiver. If it was already taken (shouldn't happen
     // on the normal path) or the receiver dropped, the response is discarded.
@@ -374,11 +542,128 @@ unsafe extern "C" fn worker_send_response(
         let _ = sender.send(response);
     }
 
-    // Count this completed request toward the recycle quota.
-    REQUESTS_HANDLED.with(|c| c.set(c.get().saturating_add(1)));
+    finish_iteration();
+}
 
-    // Release the borrowed request backing storage.
+/// Common per-iteration teardown after a response is delivered (buffered or
+/// streaming): bump the recycle counter and release the borrowed request +
+/// body reader so nothing leaks into the next `take_request`.
+#[cfg(php_linked)]
+fn finish_iteration() {
+    REQUESTS_HANDLED.with(|c| c.set(c.get().saturating_add(1)));
     CURRENT_REQUEST.with(|cell| *cell.borrow_mut() = None);
+    BODY_READER.with(|cell| *cell.borrow_mut() = BodyReader::Empty);
+    // Dropping the streaming-response sender (if any) closes the body channel,
+    // signalling end-of-body to the hyper handler.
+    RESPONSE_TX.with(|cell| *cell.borrow_mut() = None);
+}
+
+/// C-callable `body_read`: fill `buf` (capacity `cap`) with the next bytes of
+/// the incremental request body. Returns bytes written, 0 on EOF, negative on
+/// error. Blocks on the streaming channel until data or EOF.
+#[cfg(php_linked)]
+unsafe extern "C" fn worker_body_read(buf: *mut c_char, cap: usize) -> isize {
+    if buf.is_null() || cap == 0 {
+        return 0;
+    }
+    // SAFETY: C guarantees `buf` points to at least `cap` writable bytes for
+    // the duration of this call. We only write `n <= cap` bytes into it.
+    let out = unsafe { std::slice::from_raw_parts_mut(buf.cast::<u8>(), cap) };
+
+    BODY_READER.with(|cell| {
+        let mut reader = cell.borrow_mut();
+        match &mut *reader {
+            BodyReader::Empty => 0,
+            BodyReader::Buffered { data, offset } => {
+                let remaining = data.len().saturating_sub(*offset);
+                if remaining == 0 {
+                    return 0;
+                }
+                let n = remaining.min(cap);
+                out[..n].copy_from_slice(&data[*offset..*offset + n]);
+                *offset += n;
+                isize::try_from(n).unwrap_or(isize::MAX)
+            }
+            BodyReader::Streaming { pending, rx } => {
+                // Refill from the channel when the leftover partial chunk is
+                // empty. blocking_recv() blocks until a chunk arrives or the
+                // sender closes (EOF). This is the hyper->worker backpressure
+                // point (the worker is a plain OS thread, so blocking_recv is
+                // valid).
+                if pending.is_empty() {
+                    match rx.blocking_recv() {
+                        Some(chunk) => *pending = chunk,
+                        None => return 0, // sender closed => clean EOF
+                    }
+                }
+                let n = pending.len().min(cap);
+                out[..n].copy_from_slice(&pending[..n]);
+                // Advance past the copied bytes without reallocating.
+                let _ = pending.split_to(n);
+                isize::try_from(n).unwrap_or(isize::MAX)
+            }
+        }
+    })
+}
+
+/// C-callable `response_begin`: open a streaming response. Builds a bounded
+/// chunk channel, sends the [`WorkerResponse::Streaming`] header to the parked
+/// oneshot immediately (so hyper can start the response), and stashes the
+/// sender for the `response_chunk` calls that follow.
+#[cfg(php_linked)]
+unsafe extern "C" fn worker_response_begin(
+    status: c_int,
+    headers: *const c_char,
+    headers_len: usize,
+) {
+    // SAFETY: C passes a valid (ptr, len) for the packed headers; null => none.
+    let header_bytes: &[u8] = if headers.is_null() || headers_len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(headers.cast::<u8>(), headers_len) }
+    };
+    let parsed_headers = parse_packed_headers(header_bytes);
+    let status = u16::try_from(status).unwrap_or(200);
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(BODY_CHANNEL_DEPTH);
+    RESPONSE_TX.with(|cell| *cell.borrow_mut() = Some(tx));
+
+    if let Some(sender) = PENDING_SENDER.with(|cell| cell.borrow_mut().take()) {
+        let _ =
+            sender.send(WorkerResponse::Streaming { status, headers: parsed_headers, body_rx: rx });
+    }
+}
+
+/// C-callable `response_chunk`: push one body chunk. Blocks on the bounded
+/// channel (download backpressure). Returns 0, or -1 if the receiver is gone.
+#[cfg(php_linked)]
+unsafe extern "C" fn worker_response_chunk(buf: *const c_char, len: usize) -> isize {
+    if buf.is_null() || len == 0 {
+        return 0;
+    }
+    // SAFETY: C passes a valid (ptr, len) for the chunk, live for this call.
+    let chunk = unsafe { std::slice::from_raw_parts(buf.cast::<u8>(), len) };
+    let bytes = bytes::Bytes::copy_from_slice(chunk);
+
+    RESPONSE_TX.with(|cell| {
+        let borrow = cell.borrow();
+        match borrow.as_ref() {
+            // blocking_send on a plain OS worker thread: blocks on backpressure
+            // (bounded channel), errors only if the receiver dropped.
+            Some(tx) => match tx.blocking_send(bytes) {
+                Ok(()) => 0,
+                Err(_) => -1, // receiver dropped (client gone)
+            },
+            None => -1,
+        }
+    })
+}
+
+/// C-callable `response_end`: finish the streaming response and complete the
+/// iteration. Dropping the sender closes the channel (end-of-body).
+#[cfg(php_linked)]
+unsafe extern "C" fn worker_response_end() {
+    finish_iteration();
 }
 
 /// Parse `"Name: Value\n"` packed header lines into `(name, value)` pairs.
@@ -404,6 +689,10 @@ fn parse_packed_headers(bytes: &[u8]) -> Vec<(String, String)> {
 pub static WORKER_OPS: EphpmWorkerOps = EphpmWorkerOps {
     take_request: Some(worker_take_request),
     send_response: Some(worker_send_response),
+    body_read: Some(worker_body_read),
+    response_begin: Some(worker_response_begin),
+    response_chunk: Some(worker_response_chunk),
+    response_end: Some(worker_response_end),
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────
@@ -430,8 +719,12 @@ mod tests {
 
     #[test]
     fn internal_error_is_500() {
-        let e = WorkerResponse::internal_error();
-        assert_eq!(e.status, 500);
-        assert_eq!(e.body, b"Internal Server Error");
+        match WorkerResponse::internal_error() {
+            WorkerResponse::Buffered { status, body, .. } => {
+                assert_eq!(status, 500);
+                assert_eq!(body, b"Internal Server Error");
+            }
+            WorkerResponse::Streaming { .. } => panic!("internal_error must be buffered"),
+        }
     }
 }

--- a/crates/ephpm-server/src/body.rs
+++ b/crates/ephpm-server/src/body.rs
@@ -33,3 +33,16 @@ pub fn streamed(file: tokio::fs::File) -> ServerBody {
     let framed = stream.map(|result| result.map(Frame::data));
     StreamBody::new(framed).boxed()
 }
+
+/// Stream response-body chunks from a channel as a [`ServerBody`] (worker-mode
+/// streaming responses, Phase 3).
+///
+/// Each [`Bytes`] the worker produces via `send_response_stream` flows straight
+/// to the client as a data frame, so bytes reach the client before PHP has
+/// produced the whole body. The sender closing ends the body.
+#[must_use]
+pub fn channel_body(rx: tokio::sync::mpsc::Receiver<Bytes>) -> ServerBody {
+    let stream = tokio_stream::wrappers::ReceiverStream::new(rx)
+        .map(|chunk| Ok::<_, std::io::Error>(Frame::data(chunk)));
+    StreamBody::new(stream).boxed()
+}

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -235,6 +235,12 @@ async fn bind_listeners(
 
         ephpm_php::PhpRuntime::install_worker_ops(config.php.worker_populate_superglobals);
 
+        tracing::info!(
+            worker_stream_threshold = config.php.worker_stream_threshold,
+            "worker mode: request bodies at/above worker_stream_threshold stream \
+             into the worker (flat memory); smaller bodies buffer"
+        );
+
         let pool = worker_pool::WorkerPool::spawn(
             script,
             worker_count,
@@ -244,6 +250,15 @@ async fn bind_listeners(
         );
         Some(pool)
     } else {
+        // add-config-knob: worker_stream_threshold is worker-mode-only. Warn if
+        // an fpm-mode operator set it to a non-default, so it is never a silent
+        // no-op.
+        if config.php.worker_stream_threshold != 1024 * 1024 {
+            tracing::warn!(
+                "[php] worker_stream_threshold is ignored in fpm mode (it only \
+                 governs worker-mode request-body streaming)"
+            );
+        }
         None
     };
 

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -105,6 +105,9 @@ pub struct Router {
     /// When set, PHP requests are dispatched to the pool instead of running on
     /// the `spawn_blocking` path.
     worker_pool: Option<Arc<crate::worker_pool::WorkerPool>>,
+    /// Request-body size (bytes) at/above which worker mode streams the body
+    /// instead of buffering it (Phase 3). See `[php] worker_stream_threshold`.
+    worker_stream_threshold: u64,
 }
 
 /// Scan `sites_dir` for virtual host subdirectories.
@@ -265,6 +268,7 @@ impl Router {
             db_env_vars: build_db_env_vars(config),
             php_semaphore,
             worker_pool,
+            worker_stream_threshold: config.php.worker_stream_threshold,
         }
     }
 
@@ -735,20 +739,41 @@ impl Router {
             return resp;
         }
 
-        let body = match req.collect().await {
-            Ok(collected) => collected.to_bytes().to_vec(),
-            Err(_) => Vec::new(),
-        };
-        #[allow(clippy::cast_precision_loss)]
-        histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
-            .record(body.len() as f64);
-
         let server_port = self.server_port;
+
+        // Content-Length (if declared) drives the worker-mode buffer-vs-stream
+        // decision below.
+        let content_length: Option<u64> = req
+            .headers()
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok());
 
         // Worker mode: dispatch to the persistent worker pool instead of the
         // spawn_blocking fpm path. The whole handler is already wrapped in the
         // outer request timeout, so a starved queue becomes a 504.
+        //
+        // Large / unknown-length bodies STREAM into the worker (Phase 3): the
+        // hyper `Incoming` body is read frame-by-frame by a task feeding a
+        // bounded channel the worker drains, so ePHPm never holds the whole
+        // body in memory. Small bodies keep the cheaper buffered path.
         if let Some(pool) = self.worker_pool.clone() {
+            let should_stream = self.worker_stream_threshold > 0
+                && content_length.is_none_or(|len| len >= self.worker_stream_threshold);
+
+            let worker_body = if should_stream {
+                stream_request_body(req, content_length)
+            } else {
+                let bytes = match req.collect().await {
+                    Ok(collected) => collected.to_bytes().to_vec(),
+                    Err(_) => Vec::new(),
+                };
+                #[allow(clippy::cast_precision_loss)]
+                histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
+                    .record(bytes.len() as f64);
+                ephpm_php::worker_bridge::WorkerBody::Buffered(bytes)
+            };
+
             return self
                 .handle_php_worker(
                     &pool,
@@ -759,7 +784,7 @@ impl Router {
                     &script_filename,
                     document_root,
                     headers,
-                    body,
+                    worker_body,
                     content_type,
                     remote_addr,
                     server_name,
@@ -771,6 +796,14 @@ impl Router {
                 )
                 .await;
         }
+
+        let body = match req.collect().await {
+            Ok(collected) => collected.to_bytes().to_vec(),
+            Err(_) => Vec::new(),
+        };
+        #[allow(clippy::cast_precision_loss)]
+        histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
+            .record(body.len() as f64);
 
         let multi_tenant_kv = self.multi_tenant_kv.clone();
         let vhost_open_basedir = self.sites_dir.is_some() && self.open_basedir;
@@ -863,7 +896,7 @@ impl Router {
         script_filename: &Path,
         document_root: PathBuf,
         headers: Vec<(String, String)>,
-        body: Vec<u8>,
+        body: ephpm_php::worker_bridge::WorkerBody,
         content_type: Option<String>,
         remote_addr: SocketAddr,
         server_name: String,
@@ -874,7 +907,9 @@ impl Router {
         accepts_br: bool,
     ) -> Response<ServerBody> {
         // Reuse PhpRequest's $_SERVER / cookie derivation so worker mode and
-        // fpm mode present PHP with identical request metadata.
+        // fpm mode present PHP with identical request metadata. The body is not
+        // used by server_variables()/cookie_string(), so pass an empty one —
+        // the real (possibly streaming) body travels in `owned.body`.
         let mut env_vars = self.build_kv_env_vars(&server_name);
         env_vars.extend_from_slice(&self.db_env_vars);
 
@@ -886,7 +921,7 @@ impl Router {
             script_filename: script_filename.to_path_buf(),
             document_root,
             headers: headers.clone(),
-            body: body.clone(),
+            body: Vec::new(),
             content_type: content_type.clone(),
             remote_addr,
             server_name,
@@ -923,22 +958,28 @@ impl Router {
         // Bound the wait so a wedged worker becomes a 504 AND signals the pool
         // to replace it (design §5.4). This inner timeout fires at or before
         // the outer request timeout.
+        //
+        // NOTE: for a streaming response this awaits only the HEADERS (the
+        // `send_response_stream` -> response_begin delivers status+headers
+        // immediately, before the body is produced), so a long streamed
+        // download is NOT cut off by this timeout — the body flows afterward.
         let awaited = tokio::time::timeout(self.request_timeout, rx).await;
         gauge!("ephpm_worker_busy").decrement(1.0);
 
-        let result: Result<
-            Result<ephpm_php::response::PhpResponse, ephpm_php::PhpError>,
-            tokio::task::JoinError,
-        > = match awaited {
-            Ok(Ok(worker_resp)) => Ok(Ok(ephpm_php::response::PhpResponse {
-                status: worker_resp.status,
-                headers: worker_resp.headers,
-                body: worker_resp.body,
-            })),
+        let worker_resp = match awaited {
+            Ok(Ok(resp)) => resp,
             // Sender dropped (worker unwound with no stashed sender) — 500.
-            Ok(Err(_)) => Ok(Err(ephpm_php::PhpError::ExecutionFailed(
-                "worker dropped response (bailout)".into(),
-            ))),
+            Ok(Err(_)) => {
+                counter!("ephpm_php_executions_total", "status" => "error").increment(1);
+                return build_php_response(
+                    Ok(Err(ephpm_php::PhpError::ExecutionFailed(
+                        "worker dropped response (bailout)".into(),
+                    ))),
+                    accepts_gzip,
+                    accepts_br,
+                    self.compression,
+                );
+            }
             // Worker never responded in time — replace it, return 504.
             Err(_) => {
                 pool.note_hung();
@@ -949,13 +990,24 @@ impl Router {
 
         let php_elapsed = php_start.elapsed().as_secs_f64();
         histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed);
-        let exec_status = match &result {
-            Ok(Ok(_)) => "ok",
-            Ok(Err(_)) | Err(_) => "error",
-        };
-        counter!("ephpm_php_executions_total", "status" => exec_status).increment(1);
+        counter!("ephpm_php_executions_total", "status" => "ok").increment(1);
 
-        build_php_response(result, accepts_gzip, accepts_br, self.compression)
+        match worker_resp {
+            ephpm_php::worker_bridge::WorkerResponse::Buffered { status, headers, body } => {
+                build_php_response(
+                    Ok(Ok(ephpm_php::response::PhpResponse { status, headers, body })),
+                    accepts_gzip,
+                    accepts_br,
+                    self.compression,
+                )
+            }
+            // Streamed response (Phase 3): flush chunks to the client as PHP
+            // produces them. No compression (would require buffering) and no
+            // content-length (unknown up front) — chunked transfer.
+            ephpm_php::worker_bridge::WorkerResponse::Streaming { status, headers, body_rx } => {
+                build_streamed_worker_response(status, headers, body_rx)
+            }
+        }
     }
 
     /// Return 413 if Content-Length exceeds the limit.
@@ -1312,6 +1364,80 @@ fn error_response(status: StatusCode, body: &str) -> Response<ServerBody> {
 /// Build an HTTP response from a PHP execution result, optionally compressing.
 ///
 /// Prefers Brotli (`br`) over gzip when the client supports it.
+/// Stream a hyper request body into a [`WorkerBody::Streaming`] (Phase 3).
+///
+/// Spawns a task that reads the `Incoming` body frame-by-frame and forwards
+/// each data frame into a bounded channel the worker drains via `body_read`.
+/// The bounded channel is the backpressure point: a slow PHP reader stalls the
+/// hyper read, so ePHPm never buffers more than a few chunks regardless of the
+/// upload size. The task ends (closing the channel = EOF) on the last frame, a
+/// read error, or when the worker drops the receiver (request done early).
+fn stream_request_body(
+    req: Request<Incoming>,
+    content_length: Option<u64>,
+) -> ephpm_php::worker_bridge::WorkerBody {
+    use http_body_util::BodyExt;
+
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<Bytes>(ephpm_php::worker_bridge::BODY_CHANNEL_DEPTH);
+    let mut body = req.into_body();
+
+    tokio::spawn(async move {
+        loop {
+            match body.frame().await {
+                Some(Ok(frame)) => {
+                    if let Ok(data) = frame.into_data() {
+                        if data.is_empty() {
+                            continue;
+                        }
+                        // send().await suspends when the channel is full,
+                        // applying backpressure without blocking a thread. Err
+                        // means the worker finished/dropped the receiver.
+                        if tx.send(data).await.is_err() {
+                            break;
+                        }
+                    }
+                    // Non-data frames (trailers) are ignored for the body.
+                }
+                Some(Err(e)) => {
+                    tracing::debug!(%e, "request body stream error — ending body");
+                    break;
+                }
+                None => break, // clean EOF
+            }
+        }
+        // Dropping `tx` here closes the channel => worker sees EOF.
+    });
+
+    // `content_length` is advisory (declared length); 0 for chunked/unknown.
+    let declared_len = usize::try_from(content_length.unwrap_or(0)).unwrap_or(usize::MAX);
+    ephpm_php::worker_bridge::WorkerBody::Streaming { rx, declared_len }
+}
+
+/// Build a chunked, streamed HTTP response from a worker-mode streaming
+/// response (Phase 3). Status + headers are known now; the body flows from the
+/// channel as PHP produces it. No compression / content-length (the length is
+/// unknown up front) — hyper uses chunked transfer encoding.
+fn build_streamed_worker_response(
+    status: u16,
+    headers: Vec<(String, String)>,
+    body_rx: tokio::sync::mpsc::Receiver<Bytes>,
+) -> Response<ServerBody> {
+    let status = StatusCode::from_u16(status).unwrap_or(StatusCode::OK);
+    let mut resp = Response::builder().status(status);
+    for (name, value) in &headers {
+        // Skip content-length: the streamed length is not known in advance, and
+        // a stale/incorrect one would corrupt framing.
+        if name.eq_ignore_ascii_case("content-length") {
+            continue;
+        }
+        resp = resp.header(name.as_str(), value.as_str());
+    }
+    resp.body(body::channel_body(body_rx)).unwrap_or_else(|_| {
+        error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
+    })
+}
+
 fn build_php_response(
     result: Result<
         Result<ephpm_php::response::PhpResponse, ephpm_php::PhpError>,

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -281,8 +281,16 @@ fn worker_main(
                 let _ = sender.send(WorkerResponse::internal_error());
                 tracing::warn!(worker_id, "worker bailed out mid-request — 500 sent, recycling");
             } else {
-                tracing::warn!(worker_id, "worker bailed out between requests — recycling");
+                // No parked oneshot: the response was already begun (buffered
+                // send_response completed, or a streaming response's headers
+                // were already delivered). For a mid-stream bailout, closing
+                // the chunk channel below truncates the body without hanging.
+                tracing::warn!(worker_id, "worker bailed out between/after response — recycling");
             }
+            // Close any still-open streaming channels so a mid-download client
+            // sees EOF rather than hanging (the sender lives in the worker's
+            // thread-locals, which persist across the respawn loop).
+            ephpm_php::worker_bridge::clear_in_flight_streams();
             counter!("ephpm_worker_recycles_total", "reason" => "fatal").increment(1);
         }
         Err(e) => {
@@ -357,7 +365,7 @@ mod tests {
             query_string: String::new(),
             cookie_data: String::new(),
             content_type: None,
-            body: Vec::new(),
+            body: ephpm_php::worker_bridge::WorkerBody::Buffered(Vec::new()),
             server_vars: Vec::new(),
             headers: Vec::new(),
         };
@@ -372,7 +380,9 @@ mod tests {
 
     #[test]
     fn internal_error_response_is_500() {
-        let e = WorkerResponse::internal_error();
-        assert_eq!(e.status, 500);
+        match WorkerResponse::internal_error() {
+            WorkerResponse::Buffered { status, .. } => assert_eq!(status, 500),
+            WorkerResponse::Streaming { .. } => panic!("internal_error must be buffered"),
+        }
     }
 }

--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -157,6 +157,12 @@ place (Rust), which is cleaner for the crash-recovery accounting in §5.
   `router.rs:1132-1187`). Phase 1 is a single copy each way; **zero-copy body
   streaming is Phase 3** (§9), where `bodyStream()` becomes a real
   `php://` stream backed by the incremental hyper body reader.
+  **Phase 3 (implemented):** the ops table gained `body_read` (request stream)
+  and `response_begin`/`response_chunk`/`response_end` (response stream);
+  `WorkerBody`/`WorkerResponse` became buffered-or-streaming enums; large
+  request bodies stream in via a bounded channel the worker `blocking_recv`s,
+  and `send_response_stream()` streams the response out via a bounded channel
+  bridged to a hyper `StreamBody`. See the roadmap's "Phase 3 engine status".
 - **The output-buffer path still exists.** A framework that `echo`s instead of
   returning a body still works: `ub_write` (`ephpm_wrapper.c:234-248`) captures
   it into the thread-local `output_buf`, and `send_response` with an empty

--- a/docs/architecture/worker-mode-roadmap.md
+++ b/docs/architecture/worker-mode-roadmap.md
@@ -24,6 +24,28 @@ frameworks (Laravel, Symfony, WordPress). ePHPm's real differentiator vs. a
 **3.0 = Phase 1 + Phase 2** (engine proven end-to-end by at least the PSR-15
 adapter against a real framework). Phases 3–5 are 3.x.
 
+### Phase 3 engine status (streaming bodies — the ephpm-repo half)
+
+The Rust/C engine for streaming bodies is **implemented** (the adapter
+Composer packages remain future work):
+
+- **Request streaming.** `Envelope::bodyStream()` returns a real readable
+  `php://` stream (a `php_stream` whose read op pulls from Rust). Large or
+  unknown-`Content-Length` request bodies (`[php] worker_stream_threshold`,
+  default 1 MiB) are fed frame-by-frame from hyper's `Incoming` body across a
+  bounded channel the worker `blocking_recv`s — so ePHPm never buffers the whole
+  body. `read_post` (PHP's `$_POST`/multipart reader) pulls from the same
+  incremental reader, so form parsing still works. `rawBody()` still returns the
+  full string (buffered fallback / back-compat).
+- **Response streaming.** New primitive
+  `\Ephpm\Worker\send_response_stream(int $status, array $headers, $bodyResource)`
+  pumps a PHP stream/resource to the client in fixed-size chunks over a bounded
+  channel bridged to a hyper `StreamBody`, so bytes flush before PHP finishes
+  producing them. The string form of `send_response` is unchanged.
+- **Backpressure** is the bounded channels in both directions; **longjmp
+  safety** holds because the only values live across a bailing PHP call are the
+  `oneshot::Sender` and the (bounded) chunk channel endpoints, all Drop-safe.
+
 ---
 
 ## Repos & packaging — "do we need repos for PSR-15?"

--- a/examples/worker/worker-stream.php
+++ b/examples/worker/worker-stream.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * ePHPm worker-mode STREAMING reference script (Phase 3).
+ *
+ * Proves the streaming request + response primitives without buffering the
+ * whole body. It reads the incoming request body from a real php:// stream
+ * (Envelope::bodyStream()) in fixed-size chunks and streams them straight back
+ * to the client via \Ephpm\Worker\send_response_stream() — so a multi-GB upload
+ * echoes back with FLAT worker memory (RSS does not grow with body size).
+ *
+ * Run it by pointing ephpm at this directory in worker mode:
+ *
+ *   [server]
+ *   document_root = "/path/to/examples/worker"
+ *
+ *   [php]
+ *   mode = "worker"
+ *   worker_script = "worker-stream.php"
+ *   worker_stream_threshold = 65536   # stream bodies >= 64 KiB
+ *
+ * Then stream a large body through and get the same bytes back:
+ *
+ *   head -c 200000000 /dev/urandom > /tmp/blob
+ *   curl --data-binary @/tmp/blob http://127.0.0.1:8080/echo -o /tmp/out
+ *   cmp /tmp/blob /tmp/out    # identical; worker RSS stayed flat
+ *
+ * The two Phase-3 primitives beyond Phase 1:
+ *
+ *   $envelope->bodyStream(): resource        // readable php:// request-body stream
+ *   \Ephpm\Worker\send_response_stream(int $status, array $headers, $bodyResource): void
+ */
+
+declare(strict_types=1);
+
+error_log('[worker-stream] booted');
+
+while (($envelope = \Ephpm\Worker\take_request()) !== null) {
+    // A readable php:// stream over the incremental request body. Reading it
+    // pulls fixed-size chunks from ePHPm without pre-buffering the whole body.
+    $in = $envelope->bodyStream();
+
+    // A php://temp handle that spills to disk past a small memory cap, so the
+    // response producer also stays flat. Here we simply pipe input -> output;
+    // a real app would transform/store the stream instead.
+    $out = fopen('php://temp/maxmemory:1048576', 'r+b');
+
+    $total = 0;
+    while (!feof($in)) {
+        $chunk = fread($in, 65536);
+        if ($chunk === false || $chunk === '') {
+            break;
+        }
+        $total += strlen($chunk);
+        fwrite($out, $chunk);
+    }
+    rewind($out);
+
+    // Stream the response body back incrementally. Bytes reach the client as
+    // they are produced; the worker never holds the whole body in memory.
+    \Ephpm\Worker\send_response_stream(
+        200,
+        [
+            'Content-Type' => 'application/octet-stream',
+            'X-Echo-Bytes' => (string) $total,
+        ],
+        $out
+    );
+
+    fclose($out);
+    // $in is closed by ePHPm when the request completes.
+}
+
+error_log('[worker-stream] loop ended');

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -137,6 +137,7 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `worker_backlog` | usize | `0` (= `worker_count`) | Dispatch-queue depth. A full queue applies backpressure; a starved queue becomes a 504 via the request timeout. Worker mode only. |
 | `worker_boot_timeout` | u64 (sec) | `30` | Seconds a worker gets to boot and reach its first `take_request()`. Worker mode only. |
 | `worker_populate_superglobals` | bool | `false` | Populate native `$_GET`/`$_POST`/`$_SERVER`/... per request. Off for Octane/PSR-15 (they build their own request); on for the WordPress adapter. Worker mode only. |
+| `worker_stream_threshold` | u64 (bytes) | `1048576` (1 MiB) | Request-body size at/above which the body **streams** into the worker in fixed-size chunks instead of buffering whole (Phase 3). Requests with a `Content-Length` at/above this — or with no `Content-Length` (chunked) — flow through `Envelope::bodyStream()` / PHP's POST reader with flat worker memory (a multi-GB upload never materializes in RAM). Smaller bodies stay buffered. Worker mode only. |
 
 > **Worker mode is not supported with `[server] sites_dir`** (multi-tenant vhosting) in Phase 1 — config load hard-errors. Worker mode boots one framework per worker; per-host worker pools are a later phase.
 


### PR DESCRIPTION
Phase 3 of worker mode: real incremental streaming both directions, so a large upload/download no longer sits in RAM in full.

## Request streaming
`Envelope::bodyStream()` returns a real `php_stream` whose read op pulls fixed-size chunks from Rust (new `body_read` op). The hyper `Incoming` body is read frame-by-frame by a tokio task that sends into a **bounded mpsc (depth 8)**; the worker OS thread drains it with `blocking_recv` — hyper→worker backpressure, flat memory. PHP's own POST reader also pulls from `body_read`, so `$_POST`/multipart still parse (large multipart spools to temp files). `rawBody()` still works (drains to string for back-compat). Buffer-vs-stream is **automatic** per the new `[php] worker_stream_threshold` knob (default 1 MiB): bodies ≥ threshold, or chunked/no-length, stream; smaller stay on the Phase-1 buffered path.

## Response streaming
New primitive `\Ephpm\Worker\send_response_stream(int $status, array $headers, $bodyResource)` reads the PHP stream in 64 KiB chunks, delivers a `WorkerResponse::Streaming` on the parked oneshot **immediately**, then feeds chunks over a bounded mpsc the router turns into a hyper `StreamBody` (chunked transfer) — bytes flush before PHP finishes. The string `send_response` is unchanged.

## Safety / back-compat
`WorkerBody`/`WorkerResponse` became buffered-or-streaming enums; buffered paths are byte-for-byte Phase-1. A mid-stream fatal drops the response sender (`clear_in_flight_streams` in the worker bailout path) → client gets EOF, not a hang; worker recycles. Longjmp-safety preserved (only Drop-safe channel endpoints live across a bailing PHP call, in thread-locals).

## Verification
- Stub build + **clippy pedantic + nightly fmt clean** (independently re-run)
- ephpm-php / ephpm-server (156) / ephpm-config tests green
- **The C wrapper + `send_response_stream` + the `php_stream` compile and link against real PHP 8.5.7** (podman release build succeeds)
- Self-skipping streaming round-trip e2e test added (`EPHPM_WORKER_STREAM_URL`), runs in CI

**Follow-up (honest):** the large-scale (1 GB) *live memory* measurement isn't in this PR — the buffered→streaming switch and flat-memory design are in place and compile/unit-verified, but the RSS-stays-flat measurement under a real multi-hundred-MB upload is a confirmatory step to run against the built image. Everything structural is validated.