### PR TITLE
fix(worker): skip shebang lines; default log_errors=On in worker mode

### DIFF
--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1770,6 +1770,13 @@ int ephpm_worker_run(const char *script)
 
     EG(bailout) = &__bailout;
     if (SETJMP(__bailout) == 0) {
+        /* Worker entrypoints are routinely composer bin proxies / CLI-style
+         * scripts with a "#!/usr/bin/env php" shebang. The CLI SAPI skips
+         * that line; without this flag the embed compiler treats it as output
+         * BEFORE the first statement — a fatal compile error for any script
+         * opening with a namespace/declare statement (composer proxies do). */
+        CG(skip_shebang) = 1;
+
         zend_file_handle file_handle;
         zend_stream_init_filename(&file_handle, script);
         php_execute_script(&file_handle);

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -516,13 +516,24 @@ fn run_with_config(config: ephpm_config::Config, verbose: u8) -> anyhow::Result<
     // along on the generated ini instead of the per-request ini hook.
     let vhost_disable_shell =
         config.server.sites_dir.is_some() && config.server.effective_disable_shell_exec();
-    let want_generated_ini = !config.php.ini_overrides.is_empty() || vhost_disable_shell;
+    // Always generate the ini in worker mode: log_errors must default On there
+    // (see below) or a worker script that dies during boot leaves no
+    // diagnostic anywhere — display_errors output is captured into a buffer
+    // that is discarded when no request is in flight.
+    let worker_mode = config.php.mode == "worker";
+    let want_generated_ini =
+        !config.php.ini_overrides.is_empty() || vhost_disable_shell || worker_mode;
 
     let (effective_ini_path, _generated_ini_guard): (Option<PathBuf>, Option<TempFileGuard>) =
         if want_generated_ini {
             use std::fmt::Write as _;
 
             let mut content = String::new();
+            // Server-sane default, before ini_file/ini_overrides so either can
+            // override it: fatals must reach the engine log ([PHP] lines).
+            if worker_mode {
+                content.push_str("log_errors=On\n");
+            }
             if let Some(base) = &config.php.ini_file {
                 let base_content = std::fs::read_to_string(base).with_context(|| {
                     format!("failed to read php.ini file at {}", base.display())

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -128,7 +128,7 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `max_execution_time` | u32 (sec) | `30` | PHP `max_execution_time` per request. |
 | `memory_limit` | string | `"128M"` | PHP `memory_limit`. |
 | `ini_file` | path | (none) | Custom `php.ini` loaded before `ini_overrides`. |
-| `ini_overrides` | array of `[string, string]` | `[]` | INI directives applied after `ini_file`. |
+| `ini_overrides` | array of `[string, string]` | `[]` | INI directives applied after `ini_file`. In worker mode, `log_errors=On` is seeded as a default before `ini_file`/`ini_overrides` (either can override it) so worker-script fatals reach the engine log — `display_errors` output is captured into a buffer that is discarded when no request is in flight. |
 | `workers` | usize | `0` (unlimited) | Max concurrent PHP executions (php-fpm `pm.max_children` semantics); excess requests queue. `0` = unlimited. **Ignored in worker mode** (startup logs a WARN if set). |
 | `mode` | string | `"fpm"` | Request-execution model. `"fpm"` = per-request startup/shutdown (default, unchanged). `"worker"` = persistent worker mode: boot the framework once per worker, loop over requests (Octane/RoadRunner model). |
 | `worker_script` | path | (none) | Worker-mode entrypoint, relative to `document_root`. **Required** when `mode = "worker"`; config load hard-errors if absent or not a file under `document_root`. |


### PR DESCRIPTION
## Summary

- `ephpm_worker_run` sets `CG(skip_shebang) = 1` (as the CLI SAPI does): composer bin proxies (`vendor/bin/*`) start with `#!/usr/bin/env php` followed by `namespace Composer;`, and without the flag the shebang counts as output before the first statement — an instant compile fatal. This broke every documented `worker_script = "vendor/bin/..."` setup.
- Worker mode seeds `log_errors=On` into the generated ini (before `ini_file`/`ini_overrides`, so both can override): a worker script that dies during boot previously left no diagnostic anywhere, because `display_errors` output lands in a captured buffer that is discarded when no request is in flight.

## Test plan

- [x] Live e2e: Laravel 11.54 under Octane boots via the real `vendor/bin/ephpm-octane-worker` proxy (previously: instant-exit boot loop); fatals now appear as `[PHP] PHP Fatal error: ...` in the engine log
- [x] Full probe matrix green: boot-once, POST form + arrays, multipart upload (sha1 round-trip), 4 distinct Set-Cookie wire headers, 3MB BinaryFileResponse streamed, throwable -> 500 with worker surviving, CSRF 419
- [x] `cargo clippy -p ephpm` clean