### PR TITLE
fix(worker): stream-stall timeout, chunked body cap, ob-flush on exit

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1358,6 +1358,15 @@ impl Config {
     ///
     /// Returns [`ConfigError::Validation`] if any invariant is violated.
     pub fn validate(&self) -> Result<(), ConfigError> {
+        // Reject unknown modes outright: a typo like "workr" would otherwise
+        // silently mean fpm (the no-silent-knob rule).
+        if self.php.mode != "fpm" && self.php.mode != "worker" {
+            return Err(ConfigError::Validation(format!(
+                "[php] mode must be \"fpm\" or \"worker\", got \"{}\"",
+                self.php.mode,
+            )));
+        }
+
         if self.php.is_worker_mode() {
             if self.server.sites_dir.is_some() {
                 return Err(ConfigError::Validation(
@@ -2681,5 +2690,18 @@ worker_stream_threshold = 262144
         let err = cfg.validate().unwrap_err();
         assert!(matches!(err, ConfigError::Validation(_)));
         assert!(format!("{err}").contains("sites_dir"));
+    }
+
+    #[test]
+    fn test_validate_rejects_unknown_php_mode() {
+        // A typo like "workr" must hard-error, not silently mean fpm.
+        let mut cfg = Config::default();
+        cfg.php.mode = "workr".to_string();
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::Validation(_)));
+        assert!(format!("{err}").contains("mode"));
+
+        cfg.php.mode = "fpm".to_string();
+        assert!(cfg.validate().is_ok());
     }
 }

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -39,6 +39,7 @@ static char *ephpm_strtok_r(char *str, const char *delim, char **saveptr) {
 #include "main/php_main.h"
 #include "main/php_variables.h"
 #include "main/php_streams.h"
+#include "main/php_output.h"
 #include "Zend/zend.h"
 #include "Zend/zend_ini.h"
 #include "Zend/zend_stream.h"
@@ -1796,6 +1797,20 @@ int ephpm_worker_run(const char *script)
          * is safe here: unwind-exit is clean stack unwinding, not a bailout,
          * so SAPI globals and the capture buffers are intact. */
         if (req_in_flight && g_worker_ops.send_response) {
+            /* Unwind-exit skips the script's own ob_end_* calls, and worker
+             * mode has no per-request RSHUTDOWN to flush buffers — content
+             * still sitting in userland output buffers (WordPress wraps whole
+             * pages in ob_start) would otherwise never reach the ub_write
+             * capture and the synthesized response would have an empty body.
+             * Flush-and-end every buffer under a bailout guard (ob handlers
+             * run userland code). */
+            zend_try {
+                php_output_end_all();
+            } zend_catch {
+                /* A throwing ob handler forfeits its buffer; deliver what the
+                 * capture has. */
+            } zend_end_try();
+
             smart_str hbuf = {0};
             zend_llist_position pos;
             sapi_header_struct *h =

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -323,6 +323,13 @@ thread_local! {
     /// worker's entire life, so it can't distinguish boot from serving).
     static BOOT_NOTIFIER: RefCell<Option<Box<dyn FnOnce() + Send>>> =
         const { RefCell::new(None) };
+
+    /// Ceiling on how long `response_chunk` waits for the client to drain the
+    /// streaming-response channel. Without it, a client that stops reading
+    /// mid-download pins this worker thread in `blocking_send` forever — N
+    /// such clients wedge the whole pool undetected.
+    static STREAM_SEND_TIMEOUT: std::cell::Cell<std::time::Duration> =
+        const { std::cell::Cell::new(std::time::Duration::from_secs(60)) };
 }
 
 /// Install the dispatch receiver for the current worker thread. Called by the
@@ -359,6 +366,19 @@ pub fn set_boot_notifier(f: Box<dyn FnOnce() + Send>) {
 /// Stub: never fires (stub `run_worker` errors before any `take_request`).
 #[cfg(not(php_linked))]
 pub fn set_boot_notifier(_f: Box<dyn FnOnce() + Send>) {}
+
+/// Set this worker thread's streaming-response send timeout: how long
+/// `response_chunk` waits for a slow/stalled client before aborting the
+/// stream (the worker sees "client gone" and stops producing). Install
+/// before `run_worker`.
+#[cfg(php_linked)]
+pub fn set_stream_send_timeout(timeout: std::time::Duration) {
+    STREAM_SEND_TIMEOUT.with(|c| c.set(timeout));
+}
+
+/// Stub.
+#[cfg(not(php_linked))]
+pub fn set_stream_send_timeout(_timeout: std::time::Duration) {}
 
 /// Take the parked `oneshot::Sender` for the in-flight request, if one is
 /// still stashed. Used by the pool's crash-recovery path: after
@@ -675,7 +695,14 @@ unsafe extern "C" fn worker_response_begin(
 }
 
 /// C-callable `response_chunk`: push one body chunk. Blocks on the bounded
-/// channel (download backpressure). Returns 0, or -1 if the receiver is gone.
+/// channel (download backpressure), but only up to the per-worker
+/// [`STREAM_SEND_TIMEOUT`]. Returns 0, or -1 if the receiver is gone or the
+/// client made no progress within the timeout.
+///
+/// The timeout matters: once a streaming response's headers are delivered,
+/// the router's hung-worker net (oneshot timeout -> `note_hung`) can never
+/// fire again for this request — an unbounded `blocking_send` here would let
+/// a client that stops reading pin this worker OS thread forever.
 #[cfg(php_linked)]
 unsafe extern "C" fn worker_response_chunk(buf: *const c_char, len: usize) -> isize {
     if buf.is_null() || len == 0 {
@@ -683,18 +710,39 @@ unsafe extern "C" fn worker_response_chunk(buf: *const c_char, len: usize) -> is
     }
     // SAFETY: C passes a valid (ptr, len) for the chunk, live for this call.
     let chunk = unsafe { std::slice::from_raw_parts(buf.cast::<u8>(), len) };
-    let bytes = bytes::Bytes::copy_from_slice(chunk);
+    let mut bytes = bytes::Bytes::copy_from_slice(chunk);
+
+    let timeout = STREAM_SEND_TIMEOUT.with(std::cell::Cell::get);
+    let deadline = std::time::Instant::now() + timeout;
 
     RESPONSE_TX.with(|cell| {
         let borrow = cell.borrow();
-        match borrow.as_ref() {
-            // blocking_send on a plain OS worker thread: blocks on backpressure
-            // (bounded channel), errors only if the receiver dropped.
-            Some(tx) => match tx.blocking_send(bytes) {
-                Ok(()) => 0,
-                Err(_) => -1, // receiver dropped (client gone)
-            },
-            None => -1,
+        let Some(tx) = borrow.as_ref() else {
+            return -1;
+        };
+        // try_send + bounded sleep instead of blocking_send: same backpressure
+        // (the channel depth still caps in-flight bytes), but with an escape
+        // hatch for a stalled client. The sleep only runs while the channel is
+        // full — the normal path is a single successful try_send.
+        loop {
+            match tx.try_send(bytes) {
+                Ok(()) => return 0,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    return -1; // receiver dropped (client gone)
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Full(b)) => {
+                    if std::time::Instant::now() >= deadline {
+                        tracing::warn!(
+                            timeout_secs = timeout.as_secs(),
+                            "streaming response stalled (client not reading) — aborting stream"
+                        );
+                        metrics::counter!("ephpm_worker_stream_stalls_total").increment(1);
+                        return -1;
+                    }
+                    bytes = b;
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+            }
         }
     })
 }

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -247,6 +247,10 @@ async fn bind_listeners(
             config.php.worker_max_requests,
             config.php.effective_worker_backlog(),
             Duration::from_secs(config.php.worker_boot_timeout),
+            // A client that stops reading a streamed download for longer than
+            // the idle timeout aborts the stream (frees the worker thread) —
+            // same idleness contract the connection layer applies.
+            Duration::from_secs(config.server.timeouts.idle),
         );
         Some(pool)
     } else {

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -761,20 +761,38 @@ impl Router {
             let should_stream = self.worker_stream_threshold > 0
                 && content_length.is_none_or(|len| len >= self.worker_stream_threshold);
 
-            let worker_body = if should_stream {
-                stream_request_body(req, content_length)
+            let (worker_body, body_overflow) = if should_stream {
+                let (body, overflow) = stream_request_body(req, content_length, self.max_body_size);
+                (body, Some(overflow))
             } else {
-                let bytes = match req.collect().await {
-                    Ok(collected) => collected.to_bytes().to_vec(),
-                    Err(_) => Vec::new(),
+                // The Content-Length pre-check already 413'd declared-large
+                // bodies; `Limited` catches chunked / lying clients on the
+                // buffered path (`Err` on exceeding the cap).
+                let bytes = if self.max_body_size > 0 {
+                    let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
+                    match http_body_util::Limited::new(req, cap).collect().await {
+                        Ok(collected) => collected.to_bytes().to_vec(),
+                        Err(_) => {
+                            counter!("ephpm_http_body_overflow_total").increment(1);
+                            return error_response(
+                                StatusCode::PAYLOAD_TOO_LARGE,
+                                "413 Payload Too Large",
+                            );
+                        }
+                    }
+                } else {
+                    match req.collect().await {
+                        Ok(collected) => collected.to_bytes().to_vec(),
+                        Err(_) => Vec::new(),
+                    }
                 };
                 #[allow(clippy::cast_precision_loss)]
                 histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
                     .record(bytes.len() as f64);
-                ephpm_php::worker_bridge::WorkerBody::Buffered(bytes)
+                (ephpm_php::worker_bridge::WorkerBody::Buffered(bytes), None)
             };
 
-            return self
+            let resp = self
                 .handle_php_worker(
                     &pool,
                     method,
@@ -795,11 +813,35 @@ impl Router {
                     accepts_br,
                 )
                 .await;
+
+            // The streaming cap tripped mid-body: whatever the worker made of
+            // the truncated body, the request as sent was over the limit — the
+            // client gets a 413, exactly as the Content-Length pre-check would
+            // have produced.
+            if let Some(flag) = body_overflow {
+                if flag.load(std::sync::atomic::Ordering::Acquire) {
+                    return error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large");
+                }
+            }
+            return resp;
         }
 
-        let body = match req.collect().await {
-            Ok(collected) => collected.to_bytes().to_vec(),
-            Err(_) => Vec::new(),
+        // fpm path buffers the whole body; cap chunked / lying clients the same
+        // way the Content-Length pre-check caps declared bodies.
+        let body = if self.max_body_size > 0 {
+            let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
+            match http_body_util::Limited::new(req, cap).collect().await {
+                Ok(collected) => collected.to_bytes().to_vec(),
+                Err(_) => {
+                    counter!("ephpm_http_body_overflow_total").increment(1);
+                    return error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large");
+                }
+            }
+        } else {
+            match req.collect().await {
+                Ok(collected) => collected.to_bytes().to_vec(),
+                Err(_) => Vec::new(),
+            }
         };
         #[allow(clippy::cast_precision_loss)]
         histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
@@ -1375,20 +1417,41 @@ fn error_response(status: StatusCode, body: &str) -> Response<ServerBody> {
 fn stream_request_body(
     req: Request<Incoming>,
     content_length: Option<u64>,
-) -> ephpm_php::worker_bridge::WorkerBody {
+    max_body_size: u64,
+) -> (ephpm_php::worker_bridge::WorkerBody, Arc<std::sync::atomic::AtomicBool>) {
     use http_body_util::BodyExt;
 
     let (tx, rx) =
         tokio::sync::mpsc::channel::<Bytes>(ephpm_php::worker_bridge::BODY_CHANNEL_DEPTH);
     let mut body = req.into_body();
 
+    // Set when the cumulative body size exceeds `max_body_size`. The
+    // Content-Length pre-check can't see chunked / lying clients, so the cap
+    // is enforced on the actual bytes; the router turns the flag into a 413
+    // regardless of what the worker produced from the truncated body.
+    let overflow = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let overflow_task = Arc::clone(&overflow);
+
     tokio::spawn(async move {
+        let mut total: u64 = 0;
         loop {
             match body.frame().await {
                 Some(Ok(frame)) => {
                     if let Ok(data) = frame.into_data() {
                         if data.is_empty() {
                             continue;
+                        }
+                        total = total.saturating_add(data.len() as u64);
+                        if max_body_size > 0 && total > max_body_size {
+                            overflow_task.store(true, std::sync::atomic::Ordering::Release);
+                            counter!("ephpm_http_body_overflow_total").increment(1);
+                            tracing::warn!(
+                                total,
+                                max_body_size,
+                                "request body exceeded max_body_size mid-stream — \
+                                 truncating body and answering 413"
+                            );
+                            break;
                         }
                         // send().await suspends when the channel is full,
                         // applying backpressure without blocking a thread. Err
@@ -1411,7 +1474,7 @@ fn stream_request_body(
 
     // `content_length` is advisory (declared length); 0 for chunked/unknown.
     let declared_len = usize::try_from(content_length.unwrap_or(0)).unwrap_or(usize::MAX);
-    ephpm_php::worker_bridge::WorkerBody::Streaming { rx, declared_len }
+    (ephpm_php::worker_bridge::WorkerBody::Streaming { rx, declared_len }, overflow)
 }
 
 /// Build a chunked, streamed HTTP response from a worker-mode streaming

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -57,6 +57,9 @@ pub struct WorkerPool {
     worker_count: usize,
     /// Time each worker gets to reach its first `take_request()`.
     boot_timeout: Duration,
+    /// How long `response_chunk` waits for a stalled client before aborting a
+    /// streaming response (see `worker_bridge::set_stream_send_timeout`).
+    stream_send_timeout: Duration,
 }
 
 /// Shared, atomically-updated pool state.
@@ -89,6 +92,7 @@ impl WorkerPool {
         max_requests: u64,
         backlog: usize,
         boot_timeout: Duration,
+        stream_send_timeout: Duration,
     ) -> Arc<Self> {
         let (dispatch_tx, dispatch_rx) = async_channel::bounded(backlog.max(1));
         let state = Arc::new(PoolState {
@@ -111,6 +115,7 @@ impl WorkerPool {
             max_requests,
             worker_count,
             boot_timeout,
+            stream_send_timeout,
         });
 
         for _ in 0..worker_count {
@@ -230,6 +235,7 @@ fn worker_main(
     // so the very first take_request() inside the framework loop can pull work.
     ephpm_php::worker_bridge::set_dispatch_receiver(rx.clone());
     ephpm_php::worker_bridge::set_max_requests(max_requests);
+    ephpm_php::worker_bridge::set_stream_send_timeout(pool.stream_send_timeout);
 
     // TSRM register + start the one long-lived request the whole loop runs in.
     if let Err(e) = PhpRuntime::worker_thread_init() {
@@ -421,6 +427,7 @@ mod tests {
             500,
             4,
             Duration::from_secs(30),
+            Duration::from_secs(60),
         );
 
         assert_eq!(pool.ready_count(), 0, "no worker booted, so not ready");


### PR DESCRIPTION
## Summary

- **Stalled-client protection for streamed responses**: `response_chunk` bounds its send with the idle timeout (try_send + sleep loop; new `ephpm_worker_stream_stalls_total` counter). A client that stops reading can no longer pin a worker OS thread forever — the one hole the hung-worker net couldn't cover once streaming headers were out.
- **`max_body_size` enforces actual bytes**: cumulative cap on the streaming request path (413 + `ephpm_http_body_overflow_total`), `http_body_util::Limited` on the buffered worker path and the fpm path. Chunked / lying-Content-Length uploads previously bypassed the limit entirely.
- **exit-synthesis delivers ob-trapped content**: `php_output_end_all` (bailout-guarded) before synthesizing, fixing the "200 with empty body" seen for WordPress-style pages that `exit()` inside an ob buffer (found by the WP login e2e in #120).
- **`[php] mode` validated**: unknown values hard-error at config load instead of silently meaning fpm.

## Test plan

- [x] Live container probes: 1MiB upload ok / 3MiB Content-Length 413 / 3MiB chunked 413 (new) / worker alive after; `--limit-rate 1` download aborted at the 5s idle timeout with warn + counter, worker alive after; `/exit-ob` returns full body across 3 worker generations (was `content-length: 0`); plain `/exit` unchanged; `mode = "workr"` fails startup with a clear error
- [x] ephpm-config 43/43 (single-threaded; parallel runs hit a pre-existing env-var race between tests), ephpm-server 20/20, ephpm-php 156/156
- [x] clippy `-D warnings` clean, fmt clean