### PR TITLE
docs: Composer VCS install is the permanent method (^0.1 tags)

### DIFF
--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -706,7 +706,8 @@ it around the worker handle time too, so fpm↔worker latency is comparable.
 ## 8. Packaging / repos
 
 The engine (this design) ships **in the ephpm repo**. Everything framework-facing
-is a separate Composer package on Packagist under the `ephpm/` vendor namespace.
+is a separate Composer package under the `ephpm/` vendor namespace, distributed
+via its GitHub repository as a Composer `vcs` repo (not Packagist).
 
 **Stays in `ephpm/ephpm` (this repo):**
 - The Rust/C engine: `worker_bridge.rs`, `worker_pool.rs`, the C
@@ -717,7 +718,7 @@ is a separate Composer package on Packagist under the `ephpm/` vendor namespace.
   `laravel-octane-driver.md:339-341`). Not a framework adapter — just
   `while ($e = take_request()) { send_response(200, [...], "hello"); }`.
 
-**New org repos / Packagist packages (each its own repo under `github.com/ephpm`):**
+**New org repos (each its own repo under `github.com/ephpm`, installed as a Composer `vcs` repo):**
 
 | Package | Repo | Phase | Purpose |
 |---|---|---|---|

--- a/docs/architecture/worker-mode-roadmap.md
+++ b/docs/architecture/worker-mode-roadmap.md
@@ -12,8 +12,10 @@ frameworks (Laravel, Symfony, WordPress). ePHPm's real differentiator vs. a
 **Status (2026-07): shipped and e2e-validated** — the Phase-1 engine, the
 Phase-3 streaming engine, `ephpm/worker` (base package), `ephpm/octane-driver`,
 and `ephpm/wordpress-worker`. Still open: `ephpm/psr15-worker`,
-`ephpm/symfony-runtime`, Phase 4 (cache bindings + ticks), Phase 5, and
-Packagist publication (all shipped packages install via VCS repos for now).
+`ephpm/symfony-runtime`, Phase 4 (cache bindings + ticks), and Phase 5.
+Distribution is via each package's GitHub repository (Composer `vcs` repos) —
+the intended, supported install method; there are no plans to publish to
+Packagist.
 One deviation from the plan below: `php artisan octane:start --server=ephpm`
 is **not** supported — ePHPm supervises the workers itself, so the Octane
 driver is started by running `ephpm` against
@@ -64,8 +66,8 @@ Composer packages remain future work):
 piece is a **separate Composer package** under the `ephpm/` vendor namespace,
 PHP namespace `Ephpm\<Area>\*` (`composer require ephpm/<name>`, installs to
 `vendor/ephpm/<name>/` — `ephpm/cache-wordpress` set the convention). The
-worker packages are **not yet on Packagist** — install via VCS repositories
-until published.
+worker packages are distributed via their GitHub repositories (Composer `vcs`
+repos), not Packagist — this is the intended, supported install method.
 
 Repos (each its own `github.com/ephpm/<repo>`):
 

--- a/site/content/guides/laravel-octane.md
+++ b/site/content/guides/laravel-octane.md
@@ -17,23 +17,37 @@ built on the shared base package **`ephpm/worker`**
 provides the `Ephpm\Worker\Envelope` type and IDE stubs for the engine
 primitives.
 
-> **Packagist status:** not yet published. Until then, install from the VCS
-> repository (below).
+ePHPm's PHP packages are distributed via their GitHub repositories (not
+Packagist). Install them by adding each repo in the dependency tree as a
+Composer `vcs` repository.
 
 ## 1. Install the driver
 
-In your Laravel project:
+In your Laravel project, add every ePHPm repo in the tree to `composer.json`.
+The driver depends on `ephpm/worker`, so **both** repos are listed — Composer
+does **not** resolve a VCS dependency's own VCS repositories transitively, so
+each ePHPm package needs its own `repositories` entry:
 
 ```json
 // composer.json
-"repositories": [
+{
+  "repositories": [
     { "type": "vcs", "url": "https://github.com/ephpm/octane-driver" },
     { "type": "vcs", "url": "https://github.com/ephpm/php-worker" }
-]
+  ],
+  "require": {
+    "ephpm/octane-driver": "^0.1"
+  }
+}
 ```
 
+Both `ephpm/octane-driver` and its `ephpm/worker` dependency are tagged
+`v0.1.0`, so `^0.1` resolves for each; each still needs its own `repositories`
+entry because Composer does not resolve VCS repos transitively. Then:
+
 ```bash
-composer require laravel/octane ephpm/octane-driver
+composer require laravel/octane
+composer update
 ```
 
 This installs the worker entrypoint at `vendor/bin/ephpm-octane-worker`.

--- a/site/content/guides/psr15-worker.md
+++ b/site/content/guides/psr15-worker.md
@@ -15,21 +15,36 @@ built on the shared base package **`ephpm/worker`**
 ([github.com/ephpm/php-worker](https://github.com/ephpm/php-worker)). PSR-7
 objects come from `nyholm/psr7` + `nyholm/psr7-server`.
 
-> **Packagist status:** not yet published. Until then, install from the VCS
-> repositories (below).
+ePHPm's PHP packages are distributed via their GitHub repositories (not
+Packagist). Install them by adding each repo in the dependency tree as a
+Composer `vcs` repository.
 
 ## 1. Install
 
+Add every ePHPm repo in the tree to your app's `composer.json`. The adapter
+depends on `ephpm/worker`, so **both** repos are listed — Composer does **not**
+resolve a VCS dependency's own VCS repositories transitively, so each ePHPm
+package needs its own `repositories` entry:
+
 ```json
 // composer.json
-"repositories": [
+{
+  "repositories": [
     { "type": "vcs", "url": "https://github.com/ephpm/psr15-worker" },
     { "type": "vcs", "url": "https://github.com/ephpm/php-worker" }
-]
+  ],
+  "require": {
+    "ephpm/psr15-worker": "^0.1"
+  }
+}
 ```
 
+Both `ephpm/psr15-worker` and its `ephpm/worker` dependency are tagged
+`v0.1.0`, so `^0.1` resolves for each; each still needs its own `repositories`
+entry because Composer does not resolve VCS repos transitively. Then:
+
 ```bash
-composer require ephpm/psr15-worker
+composer update
 ```
 
 This installs the worker entrypoint at `vendor/bin/ephpm-worker` (shebang'd

--- a/site/content/guides/wordpress-worker.md
+++ b/site/content/guides/wordpress-worker.md
@@ -17,23 +17,36 @@ URL/headers/body (`$wp_query`, `$wp`, `$post`, superglobals, current user) and
 leaves worker-lifetime state (hook registry, post types, rewrite rules, the
 object cache) alone.
 
-> **Packagist status:** not yet published. Until then, install from the VCS
-> repository (below).
+ePHPm's PHP packages are distributed via their GitHub repositories (not
+Packagist). Install them by adding each repo in the dependency tree as a
+Composer `vcs` repository.
 
 ## 1. Install the adapter
 
-In a Composer-managed WordPress root:
+In a Composer-managed WordPress root, add every ePHPm repo in the tree to
+`composer.json`. The adapter depends on `ephpm/worker`, so **both** repos are
+listed — Composer does **not** resolve a VCS dependency's own VCS repositories
+transitively, so each ePHPm package needs its own `repositories` entry:
 
 ```json
 // composer.json
-"repositories": [
+{
+  "repositories": [
     { "type": "vcs", "url": "https://github.com/ephpm/wordpress-worker" },
     { "type": "vcs", "url": "https://github.com/ephpm/php-worker" }
-]
+  ],
+  "require": {
+    "ephpm/wordpress-worker": "^0.1"
+  }
+}
 ```
 
+Both `ephpm/wordpress-worker` and its `ephpm/worker` dependency are tagged
+`v0.1.0`, so `^0.1` resolves for each; each still needs its own `repositories`
+entry because Composer does not resolve VCS repos transitively. Then:
+
 ```bash
-composer require ephpm/wordpress-worker
+composer update
 ```
 
 This installs the entrypoint at `vendor/bin/ephpm-wp-worker`. (The engine skips


### PR DESCRIPTION
## Summary
- Flip the worker-mode guide install snippets (Laravel Octane, WordPress, PSR-15) from `dev-main` to `^0.1` now that `ephpm/octane-driver`, `ephpm/wordpress-worker`, and `ephpm/psr15-worker` are each tagged `v0.1.0`.
- Reword the explanatory text in each guide: both the adapter and its `ephpm/worker` dependency are tagged, and each still needs its own `repositories` entry because Composer does not resolve VCS repos transitively.
- Update the worker-mode architecture docs (design + roadmap) to describe Composer VCS distribution as the intended, supported install method rather than an interim step pending Packagist.

## Test plan
- [ ] Docs-only change; verify the rendered guides read correctly and no `dev-main` references remain in worker-mode guides.