### PR TITLE
fix: review follow-ups (ratelimit TTL, ext ini-injection, jwt float-exp, docs)

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1473,6 +1473,16 @@ impl Config {
                      name (e.g. \"redis\") or a path to a shared object",
                 )));
             }
+            // The generated php.ini writes `extension={ext}` verbatim, so a
+            // newline, carriage return, or NUL in an entry would inject a
+            // second arbitrary ini directive. Reject them outright.
+            if ext.contains(['\n', '\r', '\0']) {
+                return Err(ConfigError::Validation(format!(
+                    "[php] extensions entry {i} contains a newline, carriage \
+                     return, or NUL — such an entry could inject an arbitrary \
+                     ini directive into the generated php.ini",
+                )));
+            }
         }
 
         // Native middleware: an empty `library` can never resolve, and
@@ -2244,6 +2254,22 @@ extensions = ["redis", ""]
         let config = Config::load(&file).unwrap();
         let err = config.validate().expect_err("empty extension entry must be rejected");
         assert!(err.to_string().contains("extensions entry 1"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_php_extensions_ini_injection_rejected() {
+        // A newline/CR/NUL in an extension entry would inject a second ini
+        // directive into the generated php.ini. Build the config directly so
+        // the control characters survive verbatim.
+        for bad in ["redis\nmemory_limit=999G", "redis\rfoo=bar", "redis\0evil"] {
+            let mut config = Config::default();
+            config.php.extensions = vec![bad.to_string()];
+            let err = config
+                .validate()
+                .expect_err("extension entry with a control char must be rejected");
+            assert!(matches!(err, ConfigError::Validation(_)));
+            assert!(err.to_string().contains("extensions entry 0"), "unexpected error: {err}");
+        }
     }
 
     #[test]

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -429,6 +429,32 @@ impl Store {
     ///
     /// Returns `Err` if the stored value is not a valid integer string.
     pub fn incr_by(&self, key: &str, delta: i64) -> Result<i64, String> {
+        self.incr_by_with_ttl(key, delta, None)
+    }
+
+    /// Increment the value at `key` by `delta`, applying `ttl` only when the
+    /// key is created by this call. Treats the stored bytes as a decimal
+    /// integer string.
+    ///
+    /// Fixed-window semantics: when the key already exists the TTL is left
+    /// untouched (the window keeps counting down toward its original expiry);
+    /// when the key is absent it is created with value `delta` and the given
+    /// `ttl`. Passing `ttl = None` reproduces plain [`incr_by`] behaviour
+    /// (no expiry on create).
+    ///
+    /// This closes the fixed-window rate-limit race where a missing key
+    /// created by `incr` (no TTL) could become immortal if a separate
+    /// `set_nx` pre-seed lost the race or was skipped.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the stored value is not a valid integer string.
+    pub fn incr_by_with_ttl(
+        &self,
+        key: &str,
+        delta: i64,
+        ttl: Option<Duration>,
+    ) -> Result<i64, String> {
         // Fast path: key exists, try to update in place.
         if let Some(mut entry) = self.data.get_mut(key) {
             if entry.is_expired() {
@@ -482,9 +508,9 @@ impl Store {
             }
         }
 
-        // Key doesn't exist — create it.
+        // Key doesn't exist — create it with the caller's TTL (if any).
         let val_bytes = delta.to_string().into_bytes();
-        self.set(key.to_string(), val_bytes, None);
+        self.set(key.to_string(), val_bytes, ttl);
         Ok(delta)
     }
 
@@ -1064,6 +1090,45 @@ mod tests {
         assert!(s.set_nx("k".into(), b"v".to_vec(), Some(Duration::from_secs(60))));
         let entry = s.data.get("k").unwrap();
         assert!(entry.expires_at.is_some(), "expected TTL to be set");
+    }
+
+    #[test]
+    fn incr_by_with_ttl_sets_ttl_on_create_only() {
+        let s = test_store();
+        // First incr creates the key with the window TTL.
+        assert_eq!(s.incr_by_with_ttl("win", 1, Some(Duration::from_secs(60))), Ok(1));
+        let created_expiry = {
+            let entry = s.data.get("win").unwrap();
+            entry.expires_at.expect("expected TTL on create")
+        };
+
+        // A subsequent incr must NOT extend or reset the TTL (fixed window).
+        assert_eq!(s.incr_by_with_ttl("win", 1, Some(Duration::from_secs(600))), Ok(2));
+        let after_expiry = {
+            let entry = s.data.get("win").unwrap();
+            entry.expires_at.expect("TTL must survive subsequent incr")
+        };
+        assert_eq!(
+            created_expiry, after_expiry,
+            "TTL must be set on create and left untouched on later incrs"
+        );
+    }
+
+    #[test]
+    fn incr_by_with_ttl_recreates_after_expiry() {
+        let s = test_store();
+        // Plant an already-expired counter directly.
+        let expired =
+            Entry::with_expiry(b"5".to_vec(), 3, false, Instant::now() - Duration::from_secs(60));
+        let mem_size = expired.mem_size;
+        s.data.insert("win".into(), expired);
+        s.mem_add(mem_size);
+
+        // Incr treats the expired key as vacant: value resets to delta and a
+        // fresh TTL is applied.
+        assert_eq!(s.incr_by_with_ttl("win", 1, Some(Duration::from_secs(60))), Ok(1));
+        let entry = s.data.get("win").unwrap();
+        assert!(entry.expires_at.is_some(), "fresh window must have a TTL");
     }
 
     #[test]

--- a/crates/ephpm-middleware-builtins/src/jwt.rs
+++ b/crates/ephpm-middleware-builtins/src/jwt.rs
@@ -80,12 +80,15 @@ impl Jwt {
         let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
 
         // `exp` is required — a token that cannot expire is a config bug.
-        let exp = claims.get("exp").and_then(serde_json::Value::as_u64)?;
+        // RFC 7519 NumericDate allows non-integer values, so accept a JSON
+        // float (floored) as well as an integer rather than 401-ing a valid
+        // token.
+        let exp = claims.get("exp").and_then(numeric_date)?;
         if exp <= now {
             return None;
         }
         if let Some(nbf) = claims.get("nbf") {
-            if nbf.as_u64()? > now {
+            if numeric_date(nbf)? > now {
                 return None;
             }
         }
@@ -108,6 +111,30 @@ impl Jwt {
         }
 
         String::from_utf8(payload).ok()
+    }
+}
+
+/// Parse an RFC 7519 NumericDate claim (`exp`/`nbf`) as seconds since the
+/// epoch. Accepts a JSON integer or a JSON float (floored to whole seconds,
+/// negatives rejected); returns `None` for any other JSON type. This keeps
+/// enforcement identical while tolerating the non-integer NumericDates the
+/// spec permits.
+fn numeric_date(v: &serde_json::Value) -> Option<u64> {
+    if let Some(u) = v.as_u64() {
+        return Some(u);
+    }
+    let f = v.as_f64()?;
+    // floor() keeps the "not valid until this whole second" semantics; only
+    // finite, non-negative values within u64 range map to a NumericDate.
+    if f.is_finite() && (0.0..18_446_744_073_709_551_616.0).contains(&f) {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "bounds checked: finite, in [0, u64::MAX), floored"
+        )]
+        Some(f.floor() as u64)
+    } else {
+        None
     }
 }
 
@@ -220,6 +247,21 @@ mod tests {
         let t = token(SECRET, &format!(r#"{{"sub":"u1","exp":{}}}"#, future_exp()));
         let resp = invoke(&mw, &bearer(&t));
         assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn float_exp_and_nbf_are_accepted() {
+        // RFC 7519 NumericDate allows non-integer values. A JSON float exp
+        // (and nbf) in the future must not be spuriously rejected.
+        let mw = jwt(serde_json::json!({ "secret": SECRET }));
+        let exp = future_exp();
+        let claims = format!(r#"{{"sub":"u1","exp":{exp}.75,"nbf":{}.5}}"#, exp - 3700);
+        let resp = invoke(&mw, &bearer(&token(SECRET, &claims)));
+        assert_eq!(resp.__action(), ACTION_CONTINUE, "float exp/nbf must be honoured");
+
+        // An expired float exp is still rejected (floor keeps enforcement).
+        let expired = token(SECRET, r#"{"sub":"u1","exp":1000.9}"#);
+        assert_401(&invoke(&mw, &bearer(&expired)), "invalid token");
     }
 
     #[test]

--- a/crates/ephpm-middleware-builtins/src/ratelimit.rs
+++ b/crates/ephpm-middleware-builtins/src/ratelimit.rs
@@ -4,10 +4,12 @@
 //! Requests are counted in 10-second windows (less KV churn than 1-second
 //! windows): each window allows `per_ip_rps * 10 + burst` requests per
 //! client. The counter key is `mw:rl:{vhost}:{client}:{window_index}`,
-//! created with a TTL via `kv_set_nx` (since `kv_incr` cannot set TTLs) and
-//! bumped with a single atomic `kv_incr` — which is also what makes the
-//! limit cluster-wide when KV replication is on. Over the limit the client
-//! gets `429` with a `Retry-After` for the seconds left in the window.
+//! bumped with a single atomic `kv_incr_ttl` — one round trip that both
+//! increments the counter and (on the first request of a window) stamps the
+//! window TTL, so a counter can never be created without an expiry. That
+//! single call is also what makes the limit cluster-wide when KV replication
+//! is on. Over the limit the client gets `429` with a `Retry-After` for the
+//! seconds left in the window.
 //!
 //! **Fail-open by design:** when the KV store is unavailable (`kv_incr`
 //! errors), the request is allowed through with a warning log. For a rate
@@ -90,10 +92,12 @@ impl Middleware for RateLimit {
         let key = format!("mw:rl:{}:{}:{}", req.vhost_id(), client, window);
 
         let host = req.host();
-        // Create the counter with a TTL when absent (kv_incr cannot set
-        // one); when the key already exists this is a no-op.
-        let _ = host.kv_set_nx(&key, b"0", KEY_TTL_SECS);
-        let Some(count) = host.kv_incr(&key, 1) else {
+        // Atomically bump the counter, applying the window TTL only when this
+        // call creates the key. This makes it impossible for a counter to be
+        // created without an expiry (which would leak the key and could pin a
+        // client "limited" into the next window). Existing keys keep their
+        // original TTL — fixed-window semantics.
+        let Some(count) = host.kv_incr_ttl(&key, 1, KEY_TTL_SECS) else {
             // Fail-open: see the crate docs for the rationale.
             host.log(
                 LOG_WARN,

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -97,7 +97,7 @@ pub struct EphpmResponse {
 ///
 /// KV operations hit the embedded, gossip-replicated store — the same data
 /// PHP sees through `ephpm_kv_*` — which is what makes a cluster-wide rate
-/// limiter a single `kv_incr` call.
+/// limiter a single `kv_incr_ttl` call.
 #[repr(C)]
 pub struct EphpmHostV1 {
     /// Host ABI version (== [`ABI_V1`] for this table).
@@ -160,6 +160,23 @@ pub struct EphpmHostV1 {
     // ── Logging ──────────────────────────────────────────────────────────
     /// Log through the host's `tracing` subscriber (`LOG_*` levels).
     pub log: unsafe extern "C" fn(level: c_int, msg: *const u8, msg_len: usize),
+
+    // ── Additions (appended for ABI compatibility) ───────────────────────
+    /// Atomic increment that applies `ttl_secs` (`<= 0` = no expiry) ONLY
+    /// when the increment creates the key. Existing keys keep their current
+    /// TTL — fixed-window semantics. Returns 0 with the new value in `out`,
+    /// negative on error (e.g. non-numeric existing value).
+    ///
+    /// Appended after [`EphpmHostV1::log`]: older middleware built against a
+    /// table without this field never reads past the offsets it knows, so
+    /// growing the table at the end is ABI-compatible.
+    pub kv_incr_ttl: unsafe extern "C" fn(
+        key: *const u8,
+        key_len: usize,
+        by: i64,
+        ttl_secs: i64,
+        out: *mut i64,
+    ) -> c_int,
 }
 
 /// Symbol names the loader looks up.

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -224,6 +224,30 @@ unsafe extern "C" fn kv_incr(key: *const u8, key_len: usize, by: i64, out: *mut 
     }
 }
 
+unsafe extern "C" fn kv_incr_ttl(
+    key: *const u8,
+    key_len: usize,
+    by: i64,
+    ttl_secs: i64,
+    out: *mut i64,
+) -> c_int {
+    if out.is_null() {
+        return -1;
+    }
+    // SAFETY: ABI contract.
+    let (Some(store), Some(k)) = (kv(), unsafe { key_str(key, key_len) }) else {
+        return -1;
+    };
+    match store.incr_by_with_ttl(k, by, ttl_of(ttl_secs)) {
+        Ok(v) => {
+            // SAFETY: out checked non-null above.
+            unsafe { *out = v };
+            0
+        }
+        Err(_) => -2,
+    }
+}
+
 unsafe extern "C" fn host_log(level: c_int, msg: *const u8, msg_len: usize) {
     if msg.is_null() {
         return;
@@ -254,6 +278,7 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     kv_incr,
     kv_free,
     log: host_log,
+    kv_incr_ttl,
 };
 
 /// Wire the embedded KV store into the host table. Call once at startup,

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -319,6 +319,23 @@ impl<'a> Host<'a> {
         (rc == 0).then_some(out)
     }
 
+    /// Atomic increment that applies `ttl_secs` (`0` = no expiry) ONLY when
+    /// this call creates the key; existing keys keep their current TTL
+    /// (fixed-window semantics). `None` on error (e.g. non-numeric value).
+    ///
+    /// This is the correct primitive for fixed-window rate limiting: the
+    /// window key always gets its TTL atomically on creation, so a counter
+    /// can never be created without an expiry and leak.
+    #[must_use]
+    pub fn kv_incr_ttl(&self, key: &str, by: i64, ttl_secs: i64) -> Option<i64> {
+        let mut out: i64 = 0;
+        // SAFETY: valid key slice; out-param points at a local.
+        let rc = unsafe {
+            (self.table.kv_incr_ttl)(key.as_ptr(), key.len(), by, ttl_secs, &raw mut out)
+        };
+        (rc == 0).then_some(out)
+    }
+
     /// Log through the host's `tracing` subscriber.
     pub fn log(&self, level: i32, msg: &str) {
         // SAFETY: valid slice for the duration of the call.

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -16,6 +16,11 @@
 //!    stock release binaries on every platform (the Linux release is
 //!    glibc-dynamic).
 //!
+//! **Coverage (FPM mode):** the chain runs only for PHP-dispatched requests
+//! (inside `Router::handle_php`). Static-file responses and error responses
+//! (403/404 from the router) do NOT pass through middleware. Worker mode
+//! routes every request through PHP, so there the chain sees everything.
+//!
 //! v1 chain semantics: `RESPOND` short-circuits the chain immediately.
 //! `REWRITE` accumulates a path override (last writer wins) and header
 //! overrides (chain order); the router applies them AFTER the whole chain

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -389,9 +389,40 @@ fn find_free_port(host: &str, start_port: u16) -> anyhow::Result<u16> {
 
 /// Run the `ephpm php` subcommand — pass args through to the embedded PHP CLI.
 fn run_php(args: &[String]) -> anyhow::Result<ExitCode> {
+    warn_if_runtime_extension_flag(args);
     let exit_code = ephpm_php::PhpRuntime::cli_main(args).context("PHP CLI failed")?;
     let _ = ephpm_php::PhpRuntime::shutdown();
     Ok(exit_code_from(exit_code))
+}
+
+/// Warn when a runtime `-d extension=` is passed to `ephpm php`.
+///
+/// The embedded PHP runtime initialises before it parses `-d` directives, so
+/// `-d extension=…` is silently ignored (extensions must be registered at
+/// startup). Rather than let the knob be a silent no-op, warn once and point
+/// the user at the config equivalent.
+fn warn_if_runtime_extension_flag(args: &[String]) {
+    // Match `-d extension=…` (split), `-dextension=…`, and `-d=extension=…`.
+    let mut prev_was_d = false;
+    for arg in args {
+        let is_ext_directive = if prev_was_d {
+            arg.starts_with("extension=")
+        } else if let Some(rest) = arg.strip_prefix("-d") {
+            // `-dextension=…` or `-d=extension=…`
+            rest.strip_prefix('=').unwrap_or(rest).starts_with("extension=")
+        } else {
+            false
+        };
+        if is_ext_directive {
+            tracing::warn!(
+                "`-d extension=` is ignored by `ephpm php` — the embedded PHP \
+                 runtime loads extensions before parsing `-d`. Register shared \
+                 extensions via `[php] extensions` in ephpm.toml instead."
+            );
+            return;
+        }
+        prev_was_d = arg == "-d";
+    }
 }
 
 /// Convert a PHP exit code (i32) to a Rust `ExitCode`.

--- a/docs/architecture/dynamic-baseline-design.md
+++ b/docs/architecture/dynamic-baseline-design.md
@@ -115,11 +115,13 @@ With `[php] extensions = ["/mw/pivot_ping.so"]`:
 - CLI: `PHPRC=/mw/cli-php.ini ephpm php -r 'var_dump(pivot_ping());'` →
   same string.
 
-Caveat found: `ephpm php -d extension=...` is a **no-op** (silently —
-PHP is initialized before CLI args are parsed, and `extension=` only
-takes effect at MINIT). The CLI does not read `ephpm.toml` either; use
-`PHPRC` pointing at an ini with the `extension=` line. **Planned:** either
-honor `-d extension=` by deferring init, or warn when it is passed.
+Caveat found: `ephpm php -d extension=...` does **not** load the
+extension — PHP is initialized before CLI args are parsed, and
+`extension=` only takes effect at MINIT. `ephpm php` now **warns** when a
+runtime `-d extension=` is passed (rather than silently ignoring it) and
+points at `[php] extensions`. The CLI does not read `ephpm.toml` either;
+for a CLI-only load use `PHPRC` pointing at an ini with the `extension=`
+line.
 
 ### 3.3 ABI rules
 
@@ -180,7 +182,7 @@ consecutive requests return `boot #1, request #N` with N climbing
 | Platform | Story |
 |---|---|
 | Linux x86_64 | Shipped: glibc-dynamic gnu binary, floor glibc 2.39 (§2.1). All of §3–§5 verified. |
-| Linux aarch64 | Same design; **pending the arm64 gnu SDK asset** (in flight). Not yet validated. |
+| Linux aarch64 | Same design; the `linux-aarch64-gnu` SDK tarball is **published** (8.5.7 / 8.4.22 / 8.3.31). End-to-end release-lane validation on aarch64 is still to be confirmed. |
 | Alpine / musl hosts | Not a binary target — run the container image (`debian:13-slim` base). A self-built fully static musl binary still cannot dlopen; that use case is `forge` territory (`build-compose-design.md`). |
 | Windows | **NTS**, PHP statically linked from `php8embed.lib`. `extension=` `.dll` loading is the intended mechanism but is **not yet validated** — stock PECL DLLs import `php8*.dll`, which a static embed does not provide; treat Windows shared-extension support as unproven until smoke-tested. |
 | macOS (arm64) | ZTS `.dylib` loading is the intended mechanism; **not yet validated** (ld64 exports symbols by default, so no `--export-dynamic` analog should be needed). |
@@ -202,17 +204,18 @@ consecutive requests return `boot #1, request #N` with N climbing
 
 ## 8. Phasing / remaining work
 
-1. **arm64 gnu SDK** — publish `linux-aarch64-gnu` tarballs; validate
-   the aarch64 release lane end to end. (In flight.)
-2. **8.4 / 8.3 gnu SDKs** — same validation per minor once the assets
-   land. (In flight.)
-3. **Glibc floor** — decide the supported floor and rebuild the SDK +
+1. **gnu SDK tarballs — published.** All six `linux-{x86_64,aarch64}-gnu`
+   tarballs now exist for 8.5.7 / 8.4.22 / 8.3.31 (`gh release view
+   v8.5.7 --repo ephpm/php-sdk`). Remaining: confirm the aarch64 release
+   lane end to end (x86_64 is verified, §3–§5).
+2. **Glibc floor** — decide the supported floor and rebuild the SDK +
    CI builder on that baseline (currently 2.39 by accident of build
    environment, §2.1).
-4. **ZTS extension distribution** — php-sdk extension catalog
+3. **ZTS extension distribution** — php-sdk extension catalog
    (§3.4); until then docs steer users to self-compiled ZTS builds.
-5. **Windows/macOS shared-extension smoke tests** — close the "not yet
+4. **Windows/macOS shared-extension smoke tests** — close the "not yet
    validated" rows in §6.
-6. **macOS runner group** — bring macos-arm64 release validation onto
+5. **macOS runner group** — bring macos-arm64 release validation onto
    the native runner pool.
-7. **CLI ergonomics** — `ephpm php -d extension=` no-op (§3.2).
+6. **CLI ergonomics** — `ephpm php -d extension=` now warns rather than
+   silently ignoring the flag (§3.2).

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -176,8 +176,12 @@ v1 rules worth knowing:
   the body is read (rejecting before the transfer is the point);
   the ABI's body accessor currently always returns length 0.
 
-The chain runs on **PHP-bound requests only** — static file responses are
-not affected.
+**Coverage.** In **fpm mode** the chain runs on **PHP-dispatched requests
+only**: static-file responses and router error responses (403/404) do **not**
+pass through middleware. If you need a rule (rate limit, auth, security
+headers) to cover static assets or error pages under fpm mode, enforce it in
+front of ePHPm. In **worker mode** every request is routed through PHP, so the
+chain sees everything — static, dynamic, and error paths alike.
 
 ## The built-in modules
 


### PR DESCRIPTION
Batch of small reviewer-found fixes from the independent review of the merged middleware (#123) and dynamic-baseline (#124) PRs. Each item pairs the fix with the review finding it addresses.

## 1. Ratelimit fixed-window TTL race (real bug)
**Finding:** the limiter set the window TTL via `kv_set_nx(key,"0",ttl)` then `kv_incr(key,1)`, but `Store::incr_by` on a *missing* key created it with **no** TTL. If the `set_nx` pre-seed lost the race, the counter became immortal (leaked keys, could pin a client "limited" into the next window).
**Fix:** added an atomic `Store::incr_by_with_ttl(key, delta, ttl)` that applies the TTL **only on create** and never extends it on subsequent increments (fixed-window semantics). Threaded a new `kv_incr_ttl` host callback through the middleware ABI — **appended** to `EphpmHostV1` after `log` (ABI-compatible growth under the same major; no version bump), implemented in `host.rs`, exposed on the safe `Host` wrapper, and used from the `ratelimit` builtin. Dropped the now-redundant `set_nx` pre-seed.
**Tests:** `incr_by_with_ttl_sets_ttl_on_create_only` (TTL set on create, untouched on later incr), `incr_by_with_ttl_recreates_after_expiry`. Existing ratelimit tests stay green.

## 2. Extensions ini-injection (config validation)
**Finding:** `validate()` for `[php] extensions` only rejected empty entries; an entry containing `\n`/`\r` injects a second arbitrary directive into the generated php.ini (`extension={ext}` is written verbatim).
**Fix:** reject any entry containing newline, carriage return, or NUL. Test: `test_php_extensions_ini_injection_rejected`.

## 3. JWT float exp/nbf (interop nit)
**Finding:** `exp`/`nbf` were read with `as_u64()`, 401-ing valid tokens whose NumericDate is a JSON float (RFC 7519 permits non-integer).
**Fix:** `numeric_date()` helper accepts integer or float (floored, bounds-checked); enforcement semantics unchanged. Test: `float_exp_and_nbf_are_accepted`.

## 4. `ephpm php -d extension=` silent no-op -> warn
**Finding:** the CLI ignores `-d extension=` (PHP inits before args parse) with no signal — violates the no-silent-noop rule.
**Fix:** `warn_if_runtime_extension_flag()` detects `-d extension=` / `-dextension=` and warns once, pointing at `[php] extensions`. No behavior change beyond the warning.

## 5. Docs
- Middleware guide + `middleware.rs` module doc: state plainly that in **FPM mode** the chain runs only for PHP-dispatched requests — static files and 403/404 error responses do NOT pass through middleware; worker mode routes everything through PHP so it's unaffected. (Verified: chain only runs in `handle_php`.)
- `dynamic-baseline-design.md`: removed stale "arm64 / 8.4 / 8.3 gnu SDK in flight" language — all six `linux-{x86_64,aarch64}-gnu` tarballs are published (verified via `gh release view v8.5.7/v8.4.22/v8.3.31 --repo ephpm/php-sdk`). Also updated the 3.2 `-d extension=` caveat to reflect the new warning.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo +nightly fmt --all` applied.
- `cargo test -p ephpm-kv -p ephpm-config -p ephpm-middleware -p ephpm-middleware-builtins -p ephpm -- --test-threads=1`: all green (kv 169, config 50, middleware 5, builtins 30, ephpm 14 + integration suites).
- Stub build clean.