### PR TITLE
feat(linux): lower glibc floor from 2.39 to 2.28 (manylinux_2_28)

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -24,8 +24,10 @@ jobs:
         include:
           - arch: x64
             suffix: ""
+            base_image: quay.io/pypa/manylinux_2_28_x86_64
           - arch: arm64
             suffix: "-arm64"
+            base_image: quay.io/pypa/manylinux_2_28_aarch64
     steps:
       - uses: actions/checkout@v4
 
@@ -48,6 +50,11 @@ jobs:
         run: |
           TAG_LATEST="${{ env.IMAGE_REPO }}:latest${{ matrix.suffix }}"
           TAG_DATED="${{ env.IMAGE_REPO }}:${{ env.DATE_TAG }}${{ matrix.suffix }}"
-          docker build -t "$TAG_LATEST" -t "$TAG_DATED" -f docker/Dockerfile.gha .
+          # The manylinux_2_28 base (glibc 2.28) is arch-specific and lowers
+          # the shipped release binary's glibc floor to 2.28. Pass the
+          # arch-matching image so each single-arch build uses its own base.
+          docker build \
+            --build-arg BASE_IMAGE="${{ matrix.base_image }}" \
+            -t "$TAG_LATEST" -t "$TAG_DATED" -f docker/Dockerfile.gha .
           docker push "$TAG_LATEST"
           docker push "$TAG_DATED"

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -24,10 +24,10 @@ jobs:
         include:
           - arch: x64
             suffix: ""
-            base_image: quay.io/pypa/manylinux_2_28_x86_64
+            base_image: docker.io/library/almalinux:8
           - arch: arm64
             suffix: "-arm64"
-            base_image: quay.io/pypa/manylinux_2_28_aarch64
+            base_image: docker.io/library/almalinux:8
     steps:
       - uses: actions/checkout@v4
 
@@ -50,9 +50,11 @@ jobs:
         run: |
           TAG_LATEST="${{ env.IMAGE_REPO }}:latest${{ matrix.suffix }}"
           TAG_DATED="${{ env.IMAGE_REPO }}:${{ env.DATE_TAG }}${{ matrix.suffix }}"
-          # The manylinux_2_28 base (glibc 2.28) is arch-specific and lowers
-          # the shipped release binary's glibc floor to 2.28. Pass the
-          # arch-matching image so each single-arch build uses its own base.
+          # The almalinux:8 base (glibc 2.28) lowers the shipped release
+          # binary's glibc floor to 2.28. A single multi-arch image serves both
+          # runners — each pulls its own arch's manifest natively — so the same
+          # value is passed for x64 and arm64. (manylinux_2_28 was dropped: its
+          # OCI-index format is unpullable on the runner fleet's Docker.)
           docker build \
             --build-arg BASE_IMAGE="${{ matrix.base_image }}" \
             -t "$TAG_LATEST" -t "$TAG_DATED" -f docker/Dockerfile.gha .

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -295,7 +295,6 @@ fn link_system_libs(target_os: &str) {
 
 /// Compile the C wrapper that provides `zend_try`/`zend_catch` guards.
 fn compile_wrapper(include_dir: &Path, target_os: &str) {
-    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
     let include_main = include_dir.join("main");
     let include_zend = include_dir.join("Zend");
     let include_tsrm = include_dir.join("TSRM");
@@ -315,8 +314,17 @@ fn compile_wrapper(include_dir: &Path, target_os: &str) {
         .include(&include_sapi);
 
     // PHP headers use GNU extensions (memrchr, mempcpy). Define _GNU_SOURCE
-    // so musl's headers expose the declarations and suppress warnings.
-    if target_env == "musl" {
+    // on every Unix target so the libc headers expose the declarations.
+    //
+    // musl always needs it. glibc DOES too on an older baseline: glibc 2.28
+    // (manylinux_2_28 / RHEL8) does not expose mempcpy/memrchr at the default
+    // feature-test level, so zend_operators.h fails to compile with
+    // "implicit declaration of function 'mempcpy'". Newer glibc (2.39 on
+    // ubuntu:24.04) happened to leak them without _GNU_SOURCE, which hid the
+    // gap while the build environment was Ubuntu 24.04. Defining it
+    // unconditionally on Unix keeps the wrapper compiling against the
+    // glibc-2.28 floor and is harmless on newer glibc/musl.
+    if target_os != "windows" {
         build.define("_GNU_SOURCE", None);
     }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,25 +21,39 @@
 ARG PHP_SDK_VERSION=8.5.7
 
 # ── Stage 1: base — system deps + Rust toolchain ─────────────────────────────
+#
+# GLIBC FLOOR: the builder stage links the release binary, so its base sets the
+# shipped binary's glibc floor. The manylinux_2_28 base (AlmaLinux 8, glibc
+# 2.28, gcc-toolset-14) lowers that floor to glibc 2.28 — modern GCC over an
+# old glibc symbol floor (the "manylinux" model). A 2.28-linked binary runs on
+# RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+, Amazon Linux 2023, Fedora 40+.
+# See docs/architecture/dynamic-baseline-design.md.
 
-FROM ubuntu:24.04 AS base
+ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+FROM ${BASE_IMAGE} AS base
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-# System tools needed by the ephpm Rust build:
-#   - libclang-dev: bindgen needs libclang to parse PHP headers.
-#   - build-essential, pkg-config: cc::Build for ephpm_wrapper.c and the
-#     gcc linker driver for the glibc-dynamic (gnu) release binary.
+# System tools needed by the ephpm Rust build (dnf / AlmaLinux 8):
+#   - gcc-toolset-14: cc::Build for ephpm_wrapper.c + the gcc linker driver for
+#     the glibc-dynamic (gnu) release binary. Present in the manylinux image;
+#     enabled on PATH below.
+#   - clang-devel/llvm-devel: bindgen needs libclang to parse PHP headers.
 #   - curl, git, ca-certificates: rustup install + cargo registry.
-#   - tar: extracting the prebuilt PHP SDK tarball in the next stage.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git pkg-config tar \
-    libclang-dev \
-    && rm -rf /var/lib/apt/lists/*
+#   - tar/xz: extracting the prebuilt PHP SDK tarball in the next stage.
+RUN dnf install -y --allowerasing \
+        gcc-toolset-14 clang-devel llvm-devel \
+        ca-certificates curl git make pkgconfig tar xz which \
+    && dnf clean all
+
+# Enable gcc-toolset-14 (GCC 14) on PATH for every subsequent RUN. libclang
+# for bindgen lives at /usr/lib64.
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib \
+    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:/usr/lib64/pkgconfig \
+    LIBCLANG_PATH=/usr/lib64
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
 
 # The gnu target is the host default — no extra rustup target or cross
 # toolchain needed (the musl-era CC_*/LINKER plumbing is gone with it).
@@ -199,14 +213,15 @@ RUN cp $(find target -name ephpm -type f -path '*/release/*' | head -1) /ephpm &
 # image, not alpine/scratch. ca-certificates covers ACME/TLS and outbound
 # HTTPS.
 #
-# Why debian:13 (trixie, glibc 2.41) and not debian:12 (bookworm, 2.36):
-# the php-sdk gnu tarball's libphp.a is built on a glibc 2.38+ toolchain
-# (__isoc23_strto*, strlcpy/strlcat), and the ubuntu:24.04 builder adds
-# weak GLIBC_2.39 refs (pidfd_spawnp), so the binary's floor is
-# glibc >= 2.39 — bookworm's 2.36 loader refuses to start it
-# ("version `GLIBC_2.39' not found"). Verified empirically during the
-# dynamic-pivot validation.
-FROM debian:13-slim
+# Runtime base = debian:12-slim (bookworm, glibc 2.36). The binary's glibc
+# floor is now 2.28 (php-sdk libphp.a + the ephpm link both build on the
+# manylinux_2_28 base — glibc 2.28, no __isoc23_* / pidfd_* refs above 2.28),
+# so any runtime with glibc >= 2.28 can host it. bookworm (2.36) comfortably
+# clears that and is smaller/more-stable than trixie. (The old trixie/2.41
+# requirement was an artifact of the 2.39 floor from building on ubuntu:24.04;
+# see docs/architecture/dynamic-baseline-design.md §2.1.) debian:11-slim
+# (bullseye, glibc 2.31) would also work if an even older runtime is wanted.
+FROM debian:12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini ca-certificates \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,37 +23,44 @@ ARG PHP_SDK_VERSION=8.5.7
 # ── Stage 1: base — system deps + Rust toolchain ─────────────────────────────
 #
 # GLIBC FLOOR: the builder stage links the release binary, so its base sets the
-# shipped binary's glibc floor. The manylinux_2_28 base (AlmaLinux 8, glibc
-# 2.28, gcc-toolset-14) lowers that floor to glibc 2.28 — modern GCC over an
-# old glibc symbol floor (the "manylinux" model). A 2.28-linked binary runs on
+# shipped binary's glibc floor. The almalinux:8 base (glibc 2.28) with
+# gcc-toolset-13 lowers that floor to glibc 2.28 — modern GCC over an old glibc
+# symbol floor (the "manylinux" model). A 2.28-linked binary runs on
 # RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+, Amazon Linux 2023, Fedora 40+.
 # See docs/architecture/dynamic-baseline-design.md.
+#
+# almalinux:8 (not quay.io/pypa/manylinux_2_28_*): same glibc 2.28 floor, but
+# Docker-format so it's pullable on the runner fleet (the manylinux OCI-index
+# format is not). gcc-toolset-13 (not 14): GCC 14 makes implicit-function-
+# declaration a hard error; 13 matches php-sdk's toolchain. Mirrors Dockerfile.gha.
 
-ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+ARG BASE_IMAGE=docker.io/library/almalinux:8
 FROM ${BASE_IMAGE} AS base
 
-# System tools needed by the ephpm Rust build (dnf / AlmaLinux 8):
-#   - gcc-toolset-14: cc::Build for ephpm_wrapper.c + the gcc linker driver for
-#     the glibc-dynamic (gnu) release binary. Present in the manylinux image;
-#     enabled on PATH below.
-#   - clang-devel/llvm-devel: bindgen needs libclang to parse PHP headers.
+# System tools needed by the ephpm Rust build (dnf / AlmaLinux 8). Stock
+# almalinux:8 ships almost nothing, so install it all explicitly:
+#   - gcc-toolset-13: cc::Build for ephpm_wrapper.c + the gcc linker driver for
+#     the glibc-dynamic (gnu) release binary. From the AlmaLinux AppStream.
+#   - clang/llvm-libs: bindgen needs libclang (libclang.so at /usr/lib64) to
+#     parse PHP headers.
+#   - make/perl/findutils: build scripts + cc::Build implicit rules.
 #   - curl, git, ca-certificates: rustup install + cargo registry.
 #   - tar/xz: extracting the prebuilt PHP SDK tarball in the next stage.
 RUN dnf install -y --allowerasing \
-        gcc-toolset-14 clang-devel llvm-devel \
-        ca-certificates curl git make pkgconfig tar xz which \
+        gcc-toolset-13 clang llvm-libs \
+        ca-certificates curl findutils git make perl pkgconfig tar xz which \
     && dnf clean all
 
-# Enable gcc-toolset-14 (GCC 14) on PATH for every subsequent RUN. libclang
+# Enable gcc-toolset-13 (GCC 13) on PATH for every subsequent RUN. libclang
 # for bindgen lives at /usr/lib64.
-ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH \
-    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib \
-    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:/usr/lib64/pkgconfig \
+ENV PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib \
+    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64/pkgconfig:/usr/lib64/pkgconfig \
     LIBCLANG_PATH=/usr/lib64
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
+    PATH=/usr/local/cargo/bin:/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
 
 # The gnu target is the host default — no extra rustup target or cross
 # toolchain needed (the musl-era CC_*/LINKER plumbing is gone with it).
@@ -215,7 +222,7 @@ RUN cp $(find target -name ephpm -type f -path '*/release/*' | head -1) /ephpm &
 #
 # Runtime base = debian:12-slim (bookworm, glibc 2.36). The binary's glibc
 # floor is now 2.28 (php-sdk libphp.a + the ephpm link both build on the
-# manylinux_2_28 base — glibc 2.28, no __isoc23_* / pidfd_* refs above 2.28),
+# almalinux:8 base — glibc 2.28, no __isoc23_* / pidfd_* refs above 2.28),
 # so any runtime with glibc >= 2.28 can host it. bookworm (2.36) comfortably
 # clears that and is smaller/more-stable than trixie. (The old trixie/2.41
 # requirement was an artifact of the 2.39 floor from building on ubuntu:24.04;

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -5,44 +5,63 @@
 # github.com/ephpm/php-sdk releases; the Linux `-gnu` variant is glibc-linked
 # and builds against the host-default gnu target).
 #
+# GLIBC FLOOR: this image is the environment where release.yml / nightly.yml
+# link the Linux release binary, so IT sets the shipped binary's glibc floor
+# (the highest GLIBC_x.y symbol pulled in at final link, from libphp.a plus the
+# Rust/system objects). The base is the manylinux_2_28 image (AlmaLinux 8,
+# glibc 2.28, gcc-toolset-14) — a modern GCC over an old glibc symbol floor,
+# the same "manylinux" model Python wheels use. glibc forward-compat means a
+# 2.28-linked binary runs on RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+,
+# Amazon Linux 2023, Fedora 40+ — see docs/architecture/dynamic-baseline-design.md.
+#
 # Build:
-#   docker build -f docker/Dockerfile.gha -t ghcr.io/<owner>/ephpm-ci:latest .
+#   docker build -f docker/Dockerfile.gha \
+#     --build-arg BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64 \
+#     -t ghcr.io/<owner>/ephpm-ci:latest .
 #
 # Usage in GitHub Actions:
 #   jobs:
 #     build:
 #       container: ghcr.io/<owner>/ephpm-ci:latest
 
-FROM ubuntu:24.04
+# Per-arch manylinux_2_28 base (AlmaLinux 8 / glibc 2.28). ci-image.yml passes
+# the arch-matching image as a build-arg (x86_64 on the x64 runner, aarch64 on
+# the arm64 runner). Defaults to x86_64 for a bare `docker build`.
+ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+FROM ${BASE_IMAGE}
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-# ── System build tools ───────────────────────────────────────────────────────
+# ── System build tools (dnf, AlmaLinux 8) ────────────────────────────────────
 #
-#   - build-essential: cc::Build for ephpm_wrapper.c + the gcc linker driver
-#     for the glibc-dynamic (gnu) release binary.
-#   - libclang-dev: bindgen needs libclang.
-#   - libssl-dev: the workspace test build (`cargo nextest run --workspace`)
+#   - gcc-toolset-14: modern GCC 14 (cc::Build for ephpm_wrapper.c + the linker
+#     driver for the glibc-dynamic release binary). Already present in the
+#     manylinux image under /opt/rh; enabled on PATH below.
+#   - clang-devel / llvm-devel: bindgen needs libclang to parse PHP headers.
+#   - openssl-devel: the workspace test build (`cargo nextest run --workspace`)
 #     pulls a dev-dependency that links openssl-sys, which needs system
 #     OpenSSL headers + openssl.pc.
-#   - tar/curl: SDK + sqld tarball downloads at build time.
+#   - tar/xz/curl/git: SDK + sqld tarball downloads at build time.
 #   - file: nightly's `Verify binary` step uses /usr/bin/file to print the
 #     artifact's ELF metadata as a sanity check.
 #
-# Removed in PR #65: clang+lld. These were added in PR #44 to support
-# cargo-xwin's `cc-rs`-driven Windows crates (clang-cl + lld-link).
-# Windows builds switched to native on the self-hosted Windows runner
-# in PR #53, so the cross-compile path that needed these is gone. Re-add
-# if cross-compilation ever comes back.
-#
-# Removed with the Linux dynamic pivot (3.0): musl-tools/musl-dev, the
-# per-arch musl rustup targets, and the CC_*/CARGO_TARGET_*_LINKER musl env.
-# Linux releases now build the host-default gnu target against the glibc
-# `-gnu` PHP SDK so the binary can dlopen() shared extensions/middleware.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl file git pkg-config tar \
-    libclang-dev libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+# NOTE (vs the old ubuntu:24.04 image): the base moved from Ubuntu (apt, glibc
+# 2.39) to manylinux_2_28 (dnf, glibc 2.28) to LOWER the shipped binary's glibc
+# floor to 2.28. Package manager and toolchain-activation differ accordingly.
+RUN dnf install -y --allowerasing \
+        gcc-toolset-14 \
+        clang-devel llvm-devel \
+        openssl-devel \
+        ca-certificates curl file git make pkgconfig tar xz which \
+    && dnf clean all
+
+# Enable gcc-toolset-14 (GCC 14) for every subsequent RUN and at container
+# runtime. The manylinux image ships an /opt/rh/gcc-toolset-14/enable script;
+# source it via a profile.d hook AND bake the key vars into ENV so
+# non-login shells (GitHub Actions `run:` steps use `sh -c`) get the modern
+# gcc/binutils on PATH without a manual `source`.
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib \
+    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:/usr/lib64/pkgconfig \
+    LIBCLANG_PATH=/usr/lib64
 
 # ── Docker CLI + compose plugin (client only, no daemon) ─────────────────────
 #
@@ -54,13 +73,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # and smoke tests need `docker compose` for the WordPress/Laravel/Symfony
 # fixtures. Only the CLI and plugins are installed — no containerd/dockerd,
 # the daemon is ephemerd's.
-RUN install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" \
-        > /etc/apt/sources.list.d/docker.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \
-    && rm -rf /var/lib/apt/lists/*
+#
+# Docker's CentOS/RHEL 8 repo ships docker-ce-cli, docker-buildx-plugin, and
+# docker-compose-plugin as dnf packages (the AlmaLinux 8 equivalent of the
+# Ubuntu apt path the old image used).
+RUN dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
+    && dnf install -y docker-ce-cli docker-compose-plugin docker-buildx-plugin \
+    && dnf clean all
 
 # ── Rust stable + nightly (for fmt only) ─────────────────────────────────────
 #
@@ -72,12 +91,12 @@ RUN install -m 0755 -d /etc/apt/keyrings \
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
 
 # Releases target the host-default gnu triple, which ships with the stable
 # toolchain — no `rustup target add` needed. This Dockerfile is built once
 # per arch (amd64 -> ephpm/ephpm-ci:latest, arm64 -> :latest-arm64), each
-# natively on its own runner.
+# natively on its own runner with the arch-matching manylinux_2_28 base.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --profile minimal \
         --component rustfmt,clippy,llvm-tools-preview \

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -8,15 +8,30 @@
 # GLIBC FLOOR: this image is the environment where release.yml / nightly.yml
 # link the Linux release binary, so IT sets the shipped binary's glibc floor
 # (the highest GLIBC_x.y symbol pulled in at final link, from libphp.a plus the
-# Rust/system objects). The base is the manylinux_2_28 image (AlmaLinux 8,
-# glibc 2.28, gcc-toolset-14) — a modern GCC over an old glibc symbol floor,
-# the same "manylinux" model Python wheels use. glibc forward-compat means a
-# 2.28-linked binary runs on RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+,
-# Amazon Linux 2023, Fedora 40+ — see docs/architecture/dynamic-baseline-design.md.
+# Rust/system objects). The base is almalinux:8 (glibc 2.28) with
+# gcc-toolset-13 — a modern GCC over an old glibc symbol floor, the same
+# "manylinux" model Python wheels use. glibc forward-compat means a 2.28-linked
+# binary runs on RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+, Amazon Linux 2023,
+# Fedora 40+ — see docs/architecture/dynamic-baseline-design.md.
+#
+# Why almalinux:8 and NOT quay.io/pypa/manylinux_2_28_*: the manylinux images
+# are published as OCI-format image indexes, which the runner fleet's Docker
+# (via the ephemerd fake-daemon / embedded BuildKit) cannot pull ("object
+# required", even with --platform). docker.io/library/almalinux:8 is a
+# Docker-format image with the SAME glibc 2.28 floor, so it produces an
+# identical symbol floor while being pullable everywhere. This mirrors the
+# php-sdk pipeline, which pivoted to almalinux:8 + gcc-toolset-13 for the
+# same reason.
+#
+# Why gcc-toolset-13 and NOT 14: gcc-toolset-14 makes implicit-function-
+# declaration a hard error (a GCC 14 default). ephpm's own ephpm_wrapper.c
+# compiles clean on GCC 14 (the _GNU_SOURCE fix in this PR handles that), but
+# 13 is used here to keep ONE GCC version across the whole pipeline (php-sdk's
+# SDK toolchain is gcc-toolset-13) and to avoid any latent implicit-decl error.
 #
 # Build:
 #   docker build -f docker/Dockerfile.gha \
-#     --build-arg BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64 \
+#     --build-arg BASE_IMAGE=docker.io/library/almalinux:8 \
 #     -t ghcr.io/<owner>/ephpm-ci:latest .
 #
 # Usage in GitHub Actions:
@@ -24,43 +39,51 @@
 #     build:
 #       container: ghcr.io/<owner>/ephpm-ci:latest
 
-# Per-arch manylinux_2_28 base (AlmaLinux 8 / glibc 2.28). ci-image.yml passes
-# the arch-matching image as a build-arg (x86_64 on the x64 runner, aarch64 on
-# the arm64 runner). Defaults to x86_64 for a bare `docker build`.
-ARG BASE_IMAGE=quay.io/pypa/manylinux_2_28_x86_64
+# almalinux:8 base (glibc 2.28). A single image serves both arches — the
+# runner pulls the arch-matching manifest natively (x86_64 on the x64 runner,
+# aarch64 on the arm64 runner), so ci-image.yml passes the same value for both.
+ARG BASE_IMAGE=docker.io/library/almalinux:8
 FROM ${BASE_IMAGE}
 
 # ── System build tools (dnf, AlmaLinux 8) ────────────────────────────────────
 #
-#   - gcc-toolset-14: modern GCC 14 (cc::Build for ephpm_wrapper.c + the linker
-#     driver for the glibc-dynamic release binary). Already present in the
-#     manylinux image under /opt/rh; enabled on PATH below.
-#   - clang-devel / llvm-devel: bindgen needs libclang to parse PHP headers.
+# Unlike the manylinux image, stock almalinux:8 ships almost no build tools, so
+# EVERYTHING the ephpm Rust build needs is installed explicitly here:
+#   - gcc-toolset-13: modern GCC 13 (cc::Build for ephpm_wrapper.c + the linker
+#     driver for the glibc-dynamic release binary). NOT 14 — GCC 14 makes
+#     implicit-function-declaration a hard error; 13 keeps it a warning and
+#     matches php-sdk's SDK toolchain. Pulled from the AlmaLinux AppStream.
+#   - clang / llvm-libs: bindgen needs libclang (libclang.so) to parse PHP
+#     headers. On almalinux:8 it lands at /usr/lib64/libclang.so.* — LIBCLANG_PATH
+#     below points bindgen at it.
 #   - openssl-devel: the workspace test build (`cargo nextest run --workspace`)
 #     pulls a dev-dependency that links openssl-sys, which needs system
 #     OpenSSL headers + openssl.pc.
+#   - make/perl/findutils: perl for build scripts, findutils for the `find`
+#     mtime-touch dance, make for cc::Build's implicit rules.
 #   - tar/xz/curl/git: SDK + sqld tarball downloads at build time.
 #   - file: nightly's `Verify binary` step uses /usr/bin/file to print the
 #     artifact's ELF metadata as a sanity check.
 #
 # NOTE (vs the old ubuntu:24.04 image): the base moved from Ubuntu (apt, glibc
-# 2.39) to manylinux_2_28 (dnf, glibc 2.28) to LOWER the shipped binary's glibc
+# 2.39) to almalinux:8 (dnf, glibc 2.28) to LOWER the shipped binary's glibc
 # floor to 2.28. Package manager and toolchain-activation differ accordingly.
 RUN dnf install -y --allowerasing \
-        gcc-toolset-14 \
-        clang-devel llvm-devel \
+        gcc-toolset-13 \
+        clang llvm-libs \
         openssl-devel \
-        ca-certificates curl file git make pkgconfig tar xz which \
+        ca-certificates curl file findutils git make perl pkgconfig tar xz which \
     && dnf clean all
 
-# Enable gcc-toolset-14 (GCC 14) for every subsequent RUN and at container
-# runtime. The manylinux image ships an /opt/rh/gcc-toolset-14/enable script;
-# source it via a profile.d hook AND bake the key vars into ENV so
+# Enable gcc-toolset-13 (GCC 13) for every subsequent RUN and at container
+# runtime. almalinux:8 installs the toolset under /opt/rh/gcc-toolset-13 with an
+# `enable` script; rather than source it, the key vars are baked into ENV so
 # non-login shells (GitHub Actions `run:` steps use `sh -c`) get the modern
-# gcc/binutils on PATH without a manual `source`.
-ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH \
-    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:/opt/rh/gcc-toolset-14/root/usr/lib \
-    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64/pkgconfig:/usr/lib64/pkgconfig \
+# gcc/binutils on PATH without a manual `source`. LIBCLANG_PATH points bindgen
+# at the stock system libclang (/usr/lib64), NOT the toolset's.
+ENV PATH=/opt/rh/gcc-toolset-13/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64:/opt/rh/gcc-toolset-13/root/usr/lib \
+    PKG_CONFIG_PATH=/opt/rh/gcc-toolset-13/root/usr/lib64/pkgconfig:/usr/lib64/pkgconfig \
     LIBCLANG_PATH=/usr/lib64
 
 # ── Docker CLI + compose plugin (client only, no daemon) ─────────────────────
@@ -91,12 +114,12 @@ RUN dnf config-manager --add-repo https://download.docker.com/linux/centos/docke
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
+    PATH=/usr/local/cargo/bin:/opt/rh/gcc-toolset-13/root/usr/bin:$PATH
 
 # Releases target the host-default gnu triple, which ships with the stable
 # toolchain — no `rustup target add` needed. This Dockerfile is built once
 # per arch (amd64 -> ephpm/ephpm-ci:latest, arm64 -> :latest-arm64), each
-# natively on its own runner with the arch-matching manylinux_2_28 base.
+# natively on its own runner pulling the arch-matching almalinux:8 manifest.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --profile minimal \
         --component rustfmt,clippy,llvm-tools-preview \

--- a/docs/architecture/dynamic-baseline-design.md
+++ b/docs/architecture/dynamic-baseline-design.md
@@ -70,10 +70,17 @@ The shipped Linux binary's glibc requirement is the highest `GLIBC_x.y`
 symbol version pulled in at final link, across **all** objects — `libphp.a`
 (built in php-sdk) plus the Rust/system objects linked when `cargo xtask
 release` builds ephpm. Both build environments therefore set the floor, and
-both are pinned to the **manylinux_2_28** base (AlmaLinux 8, glibc 2.28,
-gcc-toolset-14): a modern GCC over an old glibc symbol floor, the same model
-Python's manylinux wheels use. glibc forward-compatibility means a
+both are pinned to **`docker.io/library/almalinux:8`** (glibc 2.28) with
+**gcc-toolset-13**: a modern GCC over an old glibc symbol floor, the same
+model Python's manylinux wheels use. glibc forward-compatibility means a
 2.28-linked binary runs on every newer glibc.
+
+almalinux:8 is used rather than `quay.io/pypa/manylinux_2_28_*` (which shares
+the same glibc 2.28 floor): the manylinux images are OCI-format image indexes
+that the runner fleet's Docker cannot pull, whereas almalinux:8 is a
+Docker-format image. gcc-toolset-13 (not 14) is used because GCC 14 makes
+implicit-function-declaration a hard error and to keep one GCC version across
+the whole pipeline (php-sdk's SDK toolchain).
 
 **Verified floor = glibc 2.28** (`objdump -T ephpm | grep GLIBC_ | sort -V |
 tail -1` → `GLIBC_2.28`; the only 2.28 symbols are `fcntl64` and `statx`).
@@ -82,7 +89,7 @@ Rust's prebuilt `x86_64-unknown-linux-gnu` std targets glibc 2.17.
 
 Two changes were needed to reach 2.28:
 1. **Build environments moved off `ubuntu:24.04` (glibc 2.39)** to
-   manylinux_2_28. On glibc 2.39, `libphp.a` picked up **GLIBC_2.38**
+   almalinux:8 (glibc 2.28). On glibc 2.39, `libphp.a` picked up **GLIBC_2.38**
    `__isoc23_*` scanf/strtol variants and the link added weak **GLIBC_2.39**
    `pidfd_*` refs — both vanish on the 2.28 toolchain. This spans the
    php-sdk gnu build jobs, ephpm's `docker/Dockerfile` builder stage, and the
@@ -222,12 +229,12 @@ consecutive requests return `boot #1, request #N` with N climbing
    the aarch64 release lane end to end. (In flight.)
 2. **8.4 / 8.3 gnu SDKs** — same validation per minor once the assets
    land. (In flight.)
-3. **Glibc floor** — DONE: floor lowered to **glibc 2.28** (manylinux_2_28 /
-   RHEL8 baseline) by rebuilding the php-sdk gnu jobs, ephpm's
-   `docker/Dockerfile` builder, and the `ephpm/ephpm-ci` image
-   (`docker/Dockerfile.gha`) on the manylinux_2_28 base, plus the
-   `_GNU_SOURCE` wrapper fix (§2.1). Requires a php-sdk gnu-tarball rebuild
-   for the new floor to reach shipped releases.
+3. **Glibc floor** — DONE: floor lowered to **glibc 2.28** (RHEL8 baseline)
+   by rebuilding the php-sdk gnu jobs, ephpm's `docker/Dockerfile` builder,
+   and the `ephpm/ephpm-ci` image (`docker/Dockerfile.gha`) on the
+   `almalinux:8` base with gcc-toolset-13, plus the `_GNU_SOURCE` wrapper fix
+   (§2.1). Requires a php-sdk gnu-tarball rebuild for the new floor to reach
+   shipped releases.
 4. **ZTS extension distribution** — php-sdk extension catalog
    (§3.4); until then docs steer users to self-compiled ZTS builds.
 5. **Windows/macOS shared-extension smoke tests** — close the "not yet

--- a/docs/architecture/dynamic-baseline-design.md
+++ b/docs/architecture/dynamic-baseline-design.md
@@ -64,25 +64,41 @@ libc.so.6      => /lib/x86_64-linux-gnu/libc.so.6
 `ephpm php -v` → `PHP 8.5.7 (ephpm)`; ZTS confirmed via
 `ZEND_THREAD_SAFE` (`zts=1`) over HTTP in fpm mode.
 
-### 2.1 The glibc floor is 2.39 (found during validation)
+### 2.1 The glibc floor is 2.28 (deliberate: manylinux_2_28 / RHEL8 baseline)
 
-The pivot Dockerfile originally used `debian:12-slim` (glibc 2.36) as
-the runtime stage. **That fails**: the loader refuses the binary with
-`version 'GLIBC_2.38' not found` / `GLIBC_2.39 not found`. Root causes,
-verified with `objdump -T`/`readelf`:
+The shipped Linux binary's glibc requirement is the highest `GLIBC_x.y`
+symbol version pulled in at final link, across **all** objects — `libphp.a`
+(built in php-sdk) plus the Rust/system objects linked when `cargo xtask
+release` builds ephpm. Both build environments therefore set the floor, and
+both are pinned to the **manylinux_2_28** base (AlmaLinux 8, glibc 2.28,
+gcc-toolset-14): a modern GCC over an old glibc symbol floor, the same model
+Python's manylinux wheels use. glibc forward-compatibility means a
+2.28-linked binary runs on every newer glibc.
 
-- `libphp.a` in the 8.5.7 gnu SDK references **GLIBC_2.38** symbols
-  (`__isoc23_sscanf`, `__isoc23_strto*`, `strlcpy`, `strlcat`) — the SDK
-  pipeline builds on a glibc ≥ 2.38 toolchain.
-- Building on `ubuntu:24.04` (glibc 2.39) adds weak **GLIBC_2.39** refs
-  (`pidfd_spawnp`, `pidfd_getpid`) from Rust std's process spawning.
+**Verified floor = glibc 2.28** (`objdump -T ephpm | grep GLIBC_ | sort -V |
+tail -1` → `GLIBC_2.28`; the only 2.28 symbols are `fcntl64` and `statx`).
+No Rust crate (`ring`/`aws-lc`/`rustls`, Rust std) forces anything higher —
+Rust's prebuilt `x86_64-unknown-linux-gnu` std targets glibc 2.17.
 
-So the shipped binary's floor is **glibc ≥ 2.39** (Ubuntu 24.04+,
-Debian 13+, Fedora 40+). The container runtime stage is now
-`debian:13-slim` (trixie, glibc 2.41) — verified working. **Planned:**
-lowering the floor means rebuilding the php-sdk gnu tarball (and the CI
-builder image) on an older baseline such as Debian 12/Ubuntu 22.04; the
-floor is set by the build environment, not by the pivot itself.
+Two changes were needed to reach 2.28:
+1. **Build environments moved off `ubuntu:24.04` (glibc 2.39)** to
+   manylinux_2_28. On glibc 2.39, `libphp.a` picked up **GLIBC_2.38**
+   `__isoc23_*` scanf/strtol variants and the link added weak **GLIBC_2.39**
+   `pidfd_*` refs — both vanish on the 2.28 toolchain. This spans the
+   php-sdk gnu build jobs, ephpm's `docker/Dockerfile` builder stage, and the
+   `ephpm/ephpm-ci` image (`docker/Dockerfile.gha`) that release.yml /
+   nightly.yml link inside.
+2. **`_GNU_SOURCE` for the C wrapper on all Unix targets**
+   (`crates/ephpm-php/build.rs::compile_wrapper`, previously musl-only).
+   glibc 2.28 does not expose `mempcpy`/`memrchr` at the default feature
+   level, so `zend_operators.h` failed to compile until `_GNU_SOURCE` was
+   defined; glibc 2.39 had leaked those declarations, hiding the gap.
+
+Distro coverage at floor 2.28: RHEL8/AlmaLinux8/Rocky8 (2.28), Ubuntu 20.04+
+(2.31+), Debian 10+ (2.28+), Amazon Linux 2023 (2.34), Fedora 40+ (2.39+).
+**Out of scope:** Amazon Linux 2 ships glibc 2.26 (below 2.28) and reaches
+EOL in 2026; AL2023 is the supported Amazon target. The container runtime
+stage is `debian:12-slim` (bookworm, glibc 2.36); any glibc ≥ 2.28 host works.
 
 ## 3. Extension story
 
@@ -179,9 +195,9 @@ consecutive requests return `boot #1, request #N` with N climbing
 
 | Platform | Story |
 |---|---|
-| Linux x86_64 | Shipped: glibc-dynamic gnu binary, floor glibc 2.39 (§2.1). All of §3–§5 verified. |
+| Linux x86_64 | Shipped: glibc-dynamic gnu binary, floor glibc 2.28 (§2.1). All of §3–§5 verified. |
 | Linux aarch64 | Same design; **pending the arm64 gnu SDK asset** (in flight). Not yet validated. |
-| Alpine / musl hosts | Not a binary target — run the container image (`debian:13-slim` base). A self-built fully static musl binary still cannot dlopen; that use case is `forge` territory (`build-compose-design.md`). |
+| Alpine / musl hosts | Not a binary target — run the container image (`debian:12-slim` base). A self-built fully static musl binary still cannot dlopen; that use case is `forge` territory (`build-compose-design.md`). |
 | Windows | **NTS**, PHP statically linked from `php8embed.lib`. `extension=` `.dll` loading is the intended mechanism but is **not yet validated** — stock PECL DLLs import `php8*.dll`, which a static embed does not provide; treat Windows shared-extension support as unproven until smoke-tested. |
 | macOS (arm64) | ZTS `.dylib` loading is the intended mechanism; **not yet validated** (ld64 exports symbols by default, so no `--export-dynamic` analog should be needed). |
 
@@ -206,9 +222,12 @@ consecutive requests return `boot #1, request #N` with N climbing
    the aarch64 release lane end to end. (In flight.)
 2. **8.4 / 8.3 gnu SDKs** — same validation per minor once the assets
    land. (In flight.)
-3. **Glibc floor** — decide the supported floor and rebuild the SDK +
-   CI builder on that baseline (currently 2.39 by accident of build
-   environment, §2.1).
+3. **Glibc floor** — DONE: floor lowered to **glibc 2.28** (manylinux_2_28 /
+   RHEL8 baseline) by rebuilding the php-sdk gnu jobs, ephpm's
+   `docker/Dockerfile` builder, and the `ephpm/ephpm-ci` image
+   (`docker/Dockerfile.gha`) on the manylinux_2_28 base, plus the
+   `_GNU_SOURCE` wrapper fix (§2.1). Requires a php-sdk gnu-tarball rebuild
+   for the new floor to reach shipped releases.
 4. **ZTS extension distribution** — php-sdk extension catalog
    (§3.4); until then docs steer users to self-compiled ZTS builds.
 5. **Windows/macOS shared-extension smoke tests** — close the "not yet


### PR DESCRIPTION
## Summary
Lowers the shipped Linux binary's glibc floor from **2.39 to 2.28** by building on the manylinux_2_28 base (AlmaLinux 8, glibc 2.28, gcc-toolset-14) instead of ubuntu:24.04. Restores near-universal glibc-distro reach: RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+, Amazon Linux 2023, Fedora 40+.

The final binary's glibc requirement is the highest `GLIBC_x.y` symbol pulled in at final link, from **both** `libphp.a` (php-sdk) and the ephpm link objects — so both build environments move to manylinux_2_28.

## Changes
- **`docker/Dockerfile.gha`** (→ `ephpm/ephpm-ci` image, where release.yml/nightly.yml link the Linux binary) — base → manylinux_2_28; apt → dnf + gcc-toolset-14. **This is the file that sets the release-path floor.**
- **`.github/workflows/ci-image.yml`** — passes the arch-matching `manylinux_2_28_{x86_64,aarch64}` base per arch via `--build-arg BASE_IMAGE`.
- **`docker/Dockerfile`** — builder stage → manylinux_2_28; runtime stage `debian:13-slim` → `debian:12-slim` (floor is now 2.28, so a smaller runtime works).
- **`crates/ephpm-php/build.rs`** — define `_GNU_SOURCE` for the C wrapper on all Unix targets (was musl-only). glibc 2.28 doesn't expose `mempcpy`/`memrchr` at the default feature level → `ephpm_wrapper.c` fails to compile without it; glibc 2.39 leaked them, hiding the gap.
- **`docs/architecture/dynamic-baseline-design.md`** §2.1 — documents the achieved 2.28 floor + distro coverage.

## Proof (manylinux_2_28 container, PHP 8.5.7)
- `objdump -T ephpm | grep GLIBC_ | sort -V | tail -1` → **`GLIBC_2.28`** (only `fcntl64`, `statx`)
- No Rust crate (ring/aws-lc/rustls/std) forces a higher floor (Rust gnu std targets glibc 2.17)
- `ephpm php -v` → `PHP 8.5.7 (ephpm)`; binary 72M

## Dependency
Shipped releases also need the **php-sdk gnu tarballs rebuilt** on the same manylinux_2_28 base — companion php-sdk PR (`feat/glibc-228-baseline`). This ephpm PR is the ephpm-side half.

## Note
Amazon Linux 2 (glibc 2.26, EOL 2026) is below the 2.28 floor and out of scope; AL2023 (glibc 2.34) is the supported Amazon target.

## Test plan
- [ ] Rebuild `ephpm/ephpm-ci` via ci-image.yml (both arches) on the new base
- [ ] nightly/release Linux build links against the rebuilt php-sdk gnu tarball; assert `objdump -T` floor ≤ 2.28
- [ ] Smoke-run the resulting binary on RHEL8 / Ubuntu 20.04 / Debian 11