### PR TITLE
fix: CLI $argv registration, probe/metrics trusted-host exemption, opcache e2e

### DIFF
--- a/crates/ephpm-e2e/tests/php_config.rs
+++ b/crates/ephpm-e2e/tests/php_config.rs
@@ -53,6 +53,31 @@ async fn ini_overrides_take_effect() {
     );
 }
 
+#[tokio::test]
+async fn opcache_is_enabled_over_http() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/opcache_check.php");
+
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    assert_eq!(resp.status().as_u16(), 200, "expected 200 from /opcache_check.php");
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .expect("opcache_check.php must return valid JSON");
+
+    assert_eq!(body["ext_loaded"], true, "Zend OPcache must be compiled into the SDK");
+    // OPcache only starts for SAPI names on its allowlist; the "ephpm"
+    // SAPI is whitelisted by the SDK build (spc rc16+). Regression here
+    // means every request recompiles every script.
+    assert_eq!(
+        body["enabled"], true,
+        "OPcache must be ACTIVE over HTTP (opcache_get_status), got: {body}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn worker_concurrency() {
     let base_url = required_env("EPHPM_URL");

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -2763,6 +2763,42 @@ static void cli_end(size_t (*orig_ub_write)(const char *, size_t))
 }
 
 /*
+ * Register $argv/$argc and script-identity $_SERVER vars for the CLI path.
+ *
+ * The embedded request starts during runtime init — before CLI argument
+ * parsing — so php_hash_environment ran without SG(request_info).argv and
+ * userland saw no $argv at all (php-cli parses args first, so it never
+ * hits this). Symfony Console / artisan silently degrade to the default
+ * command when $argv is missing. Populate request_info, let
+ * php_build_argv install $argv/$argc into the global symbol table and
+ * $_SERVER, then top up the script-identity keys frameworks read.
+ *
+ * SG(request_info).path_translated is deliberately left NULL: SAPI
+ * deactivation efree()s it, so it must never point at C argv memory.
+ */
+static void cli_register_argv(int argc, char **argv, int script_ind, const char *script_name)
+{
+    argv[script_ind] = (char *)script_name;
+    SG(request_info).argc = argc - script_ind;
+    SG(request_info).argv = &argv[script_ind];
+
+    zend_is_auto_global_str("_SERVER", sizeof("_SERVER") - 1);
+    zval *server = &PG(http_globals)[TRACK_VARS_SERVER];
+    php_build_argv(NULL, Z_TYPE_P(server) == IS_ARRAY ? server : NULL);
+
+    if (Z_TYPE_P(server) == IS_ARRAY) {
+        static const char *const keys[] = {
+            "PHP_SELF", "SCRIPT_NAME", "SCRIPT_FILENAME", "PATH_TRANSLATED"
+        };
+        for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); i++) {
+            zval tmp;
+            ZVAL_STRING(&tmp, script_name);
+            zend_hash_str_update(Z_ARRVAL_P(server), keys[i], strlen(keys[i]), &tmp);
+        }
+    }
+}
+
+/*
  * Helper: execute code or a file with bailout protection.
  * If `code` is non-NULL, evaluates it via zend_eval_string.
  * If `filename` is non-NULL, executes it via php_execute_script.
@@ -2994,7 +3030,19 @@ int ephpm_cli_main(int argc, char **argv)
     /* Positional argument: if no -f and no -r, first non-option arg is the script */
     if (!script_file && !exec_direct && php_optind < argc && argv[php_optind][0] != '-') {
         script_file = argv[php_optind];
+        php_optind++; /* consume it: what follows are the script's args */
     }
+
+    /* Make script arguments visible to userland ($argv/$argc/$_SERVER).
+     * argv[php_optind - 1] is repurposed as $argv[0] (php-cli does the
+     * same slot trick); "-" stands in for -r code, matching php-cli. */
+    if (script_file || exec_direct) {
+        cli_register_argv(argc, argv, php_optind - 1, script_file ? script_file : "-");
+    }
+
+    /* CLI scripts routinely start with a shebang (artisan, composer, …);
+     * the embed compiler does not skip it by default. */
+    CG(skip_shebang) = 1;
 
     /* Execute based on mode */
     if (mode == 'r' && exec_direct) {

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -2692,6 +2692,17 @@ static int ephpm_module_startup(sapi_module_struct *sm)
 void ephpm_pre_init(void)
 {
     php_embed_module.startup = ephpm_module_startup;
+
+    /* The SAPI name must be "ephpm" BEFORE php_embed_init():
+     * sapi_startup() struct-copies php_embed_module into sapi_module, and
+     * OPcache's accel_startup() (inside php_module_startup) checks
+     * sapi_module.name against its supported-SAPIs allowlist on PHP < 8.5,
+     * caching the verdict for the process lifetime. Renaming only in
+     * ephpm_install_sapi() (post-init) left OPcache seeing "embed" at
+     * startup — permanently "Startup Failed" even though the SDK
+     * whitelists "ephpm". */
+    php_embed_module.name = "ephpm";
+    php_embed_module.pretty_name = "ePHPm Embedded Server";
 }
 
 /*

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -441,11 +441,6 @@ impl Router {
         remote_addr: SocketAddr,
         is_tls: bool,
     ) -> Result<(Response<ServerBody>, &'static str), hyper::Error> {
-        // Validate Host header against trusted hosts list.
-        if let Some(resp) = self.check_trusted_host(&req) {
-            return Ok((resp, "error"));
-        }
-
         // Use the percent-decoded path for routing and static-file lookup.
         // hyper hands us the raw URI, so `/test%2Ehtml` would otherwise be
         // looked up as the literal name `test%2Ehtml`. percent_decode_path
@@ -460,8 +455,11 @@ impl Router {
         let query_string = req.uri().query().unwrap_or("").to_string();
         let method = req.method().as_str().to_ascii_uppercase();
 
-        // Internal ePHPm endpoints — served before security checks since
-        // they are not user-supplied content.
+        // Internal ePHPm endpoints — served before the trusted-host check
+        // (and every other security check) since they are not user-supplied
+        // content. Kubernetes probes and Prometheus scrapes address pods by
+        // raw IP, so a `Host`-gated probe would 421 and the pod would never
+        // become ready.
         if method == "GET" {
             if let Some(ref handle) = self.metrics_handle {
                 if uri_path == self.metrics_path {
@@ -478,6 +476,11 @@ impl Router {
             if uri_path == "/_ephpm/ready" {
                 return Ok((self.readiness_check(), "health"));
             }
+        }
+
+        // Validate Host header against trusted hosts list.
+        if let Some(resp) = self.check_trusted_host(&req) {
+            return Ok((resp, "error"));
         }
 
         // ACME HTTP-01 challenge responder — serves challenge tokens from the

--- a/site/content/architecture/security.md
+++ b/site/content/architecture/security.md
@@ -30,7 +30,7 @@ The controls that exist today, in one place:
 - **Per-vhost `open_basedir`** — in multi-site mode, PHP filesystem access is restricted per-request to the site's directory (+ `/tmp`)
 - **`disable_shell_exec`** — `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`, `pcntl_exec` disabled via the php.ini generated at startup (default on in multi-site mode)
 - **`blocked_paths`** — glob patterns matched against the URI path (patterns must start with `/`); matches return 403
-- **`trusted_hosts`** — Host header validation; non-matching hosts get 421
+- **`trusted_hosts`** — Host header validation; non-matching hosts get 421. Internal endpoints (`/_ephpm/health`, `/_ephpm/ready`, the metrics path) are exempt so Kubernetes probes and Prometheus scrapes can address the pod by raw IP
 - **`trusted_proxies`** — CIDR-based proxy trust for `X-Forwarded-For` / `X-Forwarded-Proto` resolution
 - **Hidden-file modes** — dotfile requests handled per `hidden_files` (`deny`=403, `ignore`=404, `allow`)
 - **Percent-decode traversal hardening** — strict `%XX` decoding before routing; encoded `/` and `\`, truncated or non-hex escapes, and invalid UTF-8 are rejected with 400

--- a/site/content/reference/cli/php.md
+++ b/site/content/reference/cli/php.md
@@ -46,7 +46,7 @@ The embedded PHP interpreter is the **same** runtime that serves HTTP requests. 
 
 ## How it works
 
-`ephpm php` invokes PHP's CLI SAPI directly via FFI. It's not a wrapper around an external `php` binary. The argument list is forwarded as-is, including `-r`, `-d`, file paths, and trailing application arguments.
+`ephpm php` runs the embedded PHP runtime (the `ephpm` SAPI) in CLI mode via FFI. It's not a wrapper around an external `php` binary. The argument list is forwarded as-is, including `-r`, `-d`, file paths, and trailing application arguments — script arguments are registered as `$argv`/`$argc` (and mirrored into `$_SERVER`, with `PHP_SELF`/`SCRIPT_NAME`/`SCRIPT_FILENAME` set to the script path) exactly as the stock `php` CLI does, so Symfony Console, artisan, and WP-CLI see their arguments. Shebang lines (`#!/usr/bin/env php`) are skipped.
 
 ## Windows note
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -24,7 +24,7 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 |-----|------|---------|-------------|
 | `max_body_size` | u64 (bytes) | `10_485_760` (10 MiB) | Max request body. `0` = unlimited. Exceeding sends 413. |
 | `max_header_size` | usize (bytes) | `8192` | Max total request header size. |
-| `trusted_hosts` | array of strings | `[]` | Allowed `Host` header values. Empty = allow all. Mismatched hosts get 421. |
+| `trusted_hosts` | array of strings | `[]` | Allowed `Host` header values. Empty = allow all. Mismatched hosts get 421. `/_ephpm/health`, `/_ephpm/ready`, and the metrics path are exempt (probes/scrapes address pods by IP). |
 
 ### `[server.timeouts]` (all in seconds)
 

--- a/tests/docroot/opcache_check.php
+++ b/tests/docroot/opcache_check.php
@@ -1,0 +1,9 @@
+<?php
+header('Content-Type: application/json');
+$status = function_exists('opcache_get_status') ? opcache_get_status(false) : null;
+echo json_encode([
+    'ext_loaded' => extension_loaded('Zend OPcache'),
+    'ini_enable' => ini_get('opcache.enable'),
+    'enabled' => is_array($status) ? ($status['opcache_enabled'] ?? false) : false,
+    'sapi' => php_sapi_name(),
+]);


### PR DESCRIPTION
## Summary
Fixes for three defects surfaced by the independent ePHPm-vs-PHP-FPM lab report (tinfoyle/ePHPm-lab):

- **`ephpm php` never registered `$argv`/`$argc`** — the embedded request starts before CLI arg parsing (unlike php-cli), so `php_hash_environment` ran without them and artisan/Symfony Console silently fell back to the default `list` command ("it printed command lists" in the report). Now registered via `php_build_argv` post-startup, plus `PHP_SELF`/`SCRIPT_NAME`/`SCRIPT_FILENAME`/`PATH_TRANSLATED` in `$_SERVER`, plus `CG(skip_shebang)` for shebang scripts.
- **Probes/metrics 421 under `trusted_hosts`** — `check_trusted_host` ran before the internal-endpoint routes, so Kubernetes probes (which address pods by raw IP) got `421 Misdirected Request` and pods never became ready. `/_ephpm/health`, `/_ephpm/ready`, and the metrics path now bypass the Host check (the code comment always said they should be "served before security checks").
- **OPcache e2e assertion** — OPcache hard-disables itself for SAPI names outside its `supported_sapis` allowlist; every ePHPm binary to date served requests with **zero opcode caching** (verified: `opcache.enable=1` honored in ini, `opcache_get_status() === false` over HTTP on `ephpm/ephpm:8.4`). The SDK-side fix whitelists the `ephpm` SAPI (spc `v3.0.0-pgo-rc16`, ephpm/php-sdk#32, SDK rebuilds in flight). The new e2e pins it so it can never silently regress.

## Test plan
- [ ] CI (fmt/clippy/test)
- [ ] E2E — note: requires #128 (almalinux:8 builder) to merge first; main's E2E is currently broken against the rebuilt glibc-2.28 SDKs (`__dn_expand`/`__res_nsearch` resolver symbols)
- [ ] `opcache_is_enabled_over_http` goes green once the rebuilt SDK tarballs land
- [ ] Manual: `ephpm php artisan list` inside the v0.3.0 image behaves like `php artisan list` (kind lab validation)