### PR TITLE
fix(kv): bound the RESP lane (connection cap, input-buffer cap, idle timeout)

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1184,11 +1184,54 @@ pub struct KvRedisCompatConfig {
     /// Default: `None` (no authentication required).
     #[serde(default)]
     pub password: Option<String>,
+
+    /// Maximum concurrent RESP connections. Excess clients are refused
+    /// with `ERR max number of clients reached` (like Redis `maxclients`).
+    /// `0` = unlimited.
+    ///
+    /// Default: `1000`.
+    #[serde(default = "default_kv_max_connections")]
+    pub max_connections: usize,
+
+    /// Maximum RESP input buffer per connection, in bytes (like Redis'
+    /// `client-query-buffer-limit`). This memory is per connection and is
+    /// NOT counted against `[kv] memory_limit`.
+    ///
+    /// Default: `1048576` (1 MiB).
+    #[serde(default = "default_kv_max_input_buffer")]
+    pub max_input_buffer: usize,
+
+    /// Idle timeout in seconds for RESP connections; silent connections
+    /// are closed and their buffers freed. `0` = no timeout.
+    ///
+    /// Default: `300`.
+    #[serde(default = "default_kv_idle_timeout_secs")]
+    pub idle_timeout_secs: u64,
+}
+
+fn default_kv_max_connections() -> usize {
+    1000
+}
+
+fn default_kv_max_input_buffer() -> usize {
+    1024 * 1024
+}
+
+fn default_kv_idle_timeout_secs() -> u64 {
+    300
 }
 
 impl Default for KvRedisCompatConfig {
     fn default() -> Self {
-        Self { enabled: false, listen: default_kv_listen(), socket: None, password: None }
+        Self {
+            enabled: false,
+            listen: default_kv_listen(),
+            socket: None,
+            password: None,
+            max_connections: default_kv_max_connections(),
+            max_input_buffer: default_kv_max_input_buffer(),
+            idle_timeout_secs: default_kv_idle_timeout_secs(),
+        }
     }
 }
 

--- a/crates/ephpm-kv/src/server.rs
+++ b/crates/ephpm-kv/src/server.rs
@@ -1,9 +1,15 @@
 //! TCP server accepting RESP protocol connections.
 //!
-//! Listens on a configurable address (and optionally a Unix socket) and
-//! spawns a task per connection. Each connection reads RESP frames,
-//! dispatches them to the [`Store`] via [`command::dispatch`], and writes
-//! the response back.
+//! Listens on a configurable TCP address and spawns a task per
+//! connection. Each connection reads RESP frames, dispatches them to the
+//! [`Store`] via [`command::dispatch`], and writes the response back.
+//!
+//! Connections are bounded three ways (all configurable): a global
+//! connection cap (excess clients get `ERR max number of clients
+//! reached`, like Redis), a per-connection input-buffer cap, and an idle
+//! read timeout. Without these the lane's memory is proportional to
+//! `in-flight frame bytes x connections`, entirely outside the store's
+//! `memory_limit` accounting.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,8 +32,15 @@ pub struct ServerConfig {
     /// TCP listen address, e.g. `"127.0.0.1:6379"`.
     pub listen: String,
     /// Maximum input buffer size per connection (bytes). Protects against
-    /// clients sending enormous payloads.
+    /// clients sending enormous payloads. Note this is per connection and
+    /// is NOT counted against the store's `memory_limit`.
     pub max_input_buffer: usize,
+    /// Maximum concurrent connections. Excess clients are refused with
+    /// `ERR max number of clients reached`. `0` = unlimited.
+    pub max_connections: usize,
+    /// Idle read timeout in seconds. Connections that send nothing for
+    /// this long are closed, freeing their buffers. `0` = no timeout.
+    pub idle_timeout_secs: u64,
     /// Optional password for RESP AUTH. When set, clients must authenticate
     /// before any commands are accepted.
     pub password: Option<String>,
@@ -42,7 +55,12 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             listen: "127.0.0.1:6379".into(),
-            max_input_buffer: 64 * 1024 * 1024, // 64 MiB
+            // 1 MiB, matching Redis' client-query-buffer-limit default.
+            // The previous 64 MiB default let a handful of connections
+            // with large in-flight frames OOM a memory-capped container.
+            max_input_buffer: 1024 * 1024,
+            max_connections: 1000,
+            idle_timeout_secs: 300,
             password: None,
             secret: None,
         }
@@ -73,10 +91,7 @@ pub async fn run(
 
     info!(listen = %config.listen, "KV store RESP server listening");
 
-    let max_buf = config.max_input_buffer;
-    let password = config.password.clone();
-    let secret = config.secret.clone();
-    let accept = serve_on(Arc::clone(&store), listener, max_buf, password, secret, multi_tenant);
+    let accept = serve_on(Arc::clone(&store), listener, config, multi_tenant);
 
     tokio::select! {
         result = accept => result,
@@ -107,14 +122,19 @@ pub async fn run(
 pub async fn serve_on(
     store: Arc<Store>,
     listener: TcpListener,
-    max_input_buffer: usize,
-    password: Option<String>,
-    secret: Option<String>,
+    config: ServerConfig,
     multi_tenant: Option<MultiTenantStore>,
 ) -> anyhow::Result<()> {
-    let password: Option<Arc<str>> = password.map(|p| Arc::from(p.as_str()));
-    let secret: Option<Arc<str>> = secret.map(|s| Arc::from(s.as_str()));
+    let max_input_buffer = config.max_input_buffer;
+    let idle_timeout_secs = config.idle_timeout_secs;
+    let password: Option<Arc<str>> = config.password.map(|p| Arc::from(p.as_str()));
+    let secret: Option<Arc<str>> = config.secret.map(|s| Arc::from(s.as_str()));
     let multi_tenant = multi_tenant.map(Arc::new);
+
+    // Connection cap: excess clients get a Redis-style refusal instead of
+    // an unbounded task + buffers each. `0` disables the cap.
+    let conn_permits = (config.max_connections > 0)
+        .then(|| Arc::new(tokio::sync::Semaphore::new(config.max_connections)));
 
     // Background expiry reaper — runs every second.
     let expiry_store = Arc::clone(&store);
@@ -128,17 +148,35 @@ pub async fn serve_on(
 
     loop {
         match listener.accept().await {
-            Ok((stream, addr)) => {
+            Ok((mut stream, addr)) => {
+                let permit = match &conn_permits {
+                    Some(sem) => match Arc::clone(sem).try_acquire_owned() {
+                        Ok(permit) => Some(permit),
+                        Err(_) => {
+                            debug!(peer = %addr, "refusing KV connection: max clients reached");
+                            tokio::spawn(async move {
+                                let _ = stream
+                                    .write_all(b"-ERR max number of clients reached\r\n")
+                                    .await;
+                            });
+                            continue;
+                        }
+                    },
+                    None => None,
+                };
                 debug!(peer = %addr, "new KV connection");
                 let conn_store = Arc::clone(&store);
                 let conn_password = password.clone();
                 let conn_secret = secret.clone();
                 let conn_mt = multi_tenant.clone();
                 tokio::spawn(async move {
+                    // Hold the connection permit for the task's lifetime.
+                    let _permit = permit;
                     if let Err(e) = handle_connection(
                         stream,
                         &conn_store,
                         max_input_buffer,
+                        idle_timeout_secs,
                         conn_password,
                         conn_secret,
                         conn_mt,
@@ -260,10 +298,12 @@ fn handle_auth(
 }
 
 /// Handle a single RESP connection.
+#[allow(clippy::too_many_lines)]
 async fn handle_connection(
     mut stream: tokio::net::TcpStream,
     store: &Arc<Store>,
     max_buf: usize,
+    idle_timeout_secs: u64,
     password: Option<Arc<str>>,
     secret: Option<Arc<str>>,
     multi_tenant: Option<Arc<MultiTenantStore>>,
@@ -353,7 +393,21 @@ async fn handle_connection(
             return Ok(());
         }
 
-        let n = stream.read_buf(&mut buf).await?;
+        // Idle timeout: a silent peer must not pin this task (and its
+        // buffers) forever — half-open sockets otherwise linger until TCP
+        // keepalive, hours later.
+        let read = stream.read_buf(&mut buf);
+        let n = if idle_timeout_secs > 0 {
+            match tokio::time::timeout(Duration::from_secs(idle_timeout_secs), read).await {
+                Ok(result) => result?,
+                Err(_elapsed) => {
+                    debug!("closing idle KV connection");
+                    return Ok(());
+                }
+            }
+        } else {
+            read.await?
+        };
         if n == 0 {
             // Connection closed by client.
             return Ok(());

--- a/crates/ephpm-kv/tests/resp_compat.rs
+++ b/crates/ephpm-kv/tests/resp_compat.rs
@@ -28,7 +28,14 @@ impl TestServer {
 
         let store = Store::new(StoreConfig::default());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, None, None).await.ok();
+            server::serve_on(
+                store,
+                listener,
+                server::ServerConfig { max_input_buffer: 64 * 1024 * 1024, ..Default::default() },
+                None,
+            )
+            .await
+            .ok();
         });
 
         // Give the accept loop a moment to become ready.
@@ -51,6 +58,56 @@ impl Drop for TestServer {
     fn drop(&mut self) {
         self.handle.abort();
     }
+}
+
+// ── Connection limits ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn connection_cap_refuses_excess_clients() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr").to_string();
+    let store = Store::new(StoreConfig::default());
+    let handle = tokio::spawn(async move {
+        server::serve_on(
+            store,
+            listener,
+            server::ServerConfig { max_connections: 1, ..Default::default() },
+            None,
+        )
+        .await
+        .ok();
+    });
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // First client occupies the only slot.
+    let mut first = tokio::net::TcpStream::connect(&addr).await.expect("first connect");
+    first.write_all(b"*1\r\n$4\r\nPING\r\n").await.expect("write ping");
+    let mut pong = [0u8; 7];
+    first.read_exact(&mut pong).await.expect("read pong");
+    assert_eq!(&pong, b"+PONG\r\n");
+
+    // Second client must be refused with a Redis-style error.
+    let mut second = tokio::net::TcpStream::connect(&addr).await.expect("second connect");
+    let mut refusal = Vec::new();
+    second.read_to_end(&mut refusal).await.expect("read refusal");
+    let text = String::from_utf8_lossy(&refusal);
+    assert!(
+        text.starts_with("-ERR max number of clients reached"),
+        "expected max-clients refusal, got: {text:?}"
+    );
+
+    // Slot frees on disconnect: a third client succeeds afterwards.
+    drop(first);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let mut third = tokio::net::TcpStream::connect(&addr).await.expect("third connect");
+    third.write_all(b"*1\r\n$4\r\nPING\r\n").await.expect("write ping");
+    let mut pong = [0u8; 7];
+    third.read_exact(&mut pong).await.expect("read pong after slot freed");
+    assert_eq!(&pong, b"+PONG\r\n");
+
+    handle.abort();
 }
 
 // ── Connection commands ───────────────────────────────────────────────────────
@@ -641,7 +698,18 @@ impl AuthTestServer {
         let store = Store::new(StoreConfig::default());
         let pw = Some(password.to_string());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, pw, None, None).await.ok();
+            server::serve_on(
+                store,
+                listener,
+                server::ServerConfig {
+                    max_input_buffer: 64 * 1024 * 1024,
+                    password: pw,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .ok();
         });
 
         tokio::time::sleep(Duration::from_millis(5)).await;
@@ -727,7 +795,18 @@ impl HmacTestServer {
         let mt = MultiTenantStore::new(std::sync::Arc::clone(&store), StoreConfig::default());
         let sec = Some(secret.to_string());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, sec, Some(mt)).await.ok();
+            server::serve_on(
+                store,
+                listener,
+                server::ServerConfig {
+                    max_input_buffer: 64 * 1024 * 1024,
+                    secret: sec,
+                    ..Default::default()
+                },
+                Some(mt),
+            )
+            .await
+            .ok();
         });
 
         tokio::time::sleep(Duration::from_millis(5)).await;

--- a/crates/ephpm-kv/tests/stress.rs
+++ b/crates/ephpm-kv/tests/stress.rs
@@ -47,7 +47,14 @@ impl TestServer {
 
         let store = Store::new(config);
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, None, None).await.ok();
+            server::serve_on(
+                store,
+                listener,
+                server::ServerConfig { max_input_buffer: 64 * 1024 * 1024, ..Default::default() },
+                None,
+            )
+            .await
+            .ok();
         });
 
         // Give the accept loop a moment to become ready.
@@ -88,7 +95,18 @@ impl HmacTestServer {
         let mt = MultiTenantStore::new(Arc::clone(&store), StoreConfig::default());
         let sec = Some(secret.to_string());
         let handle = tokio::spawn(async move {
-            server::serve_on(store, listener, 64 * 1024 * 1024, None, sec, Some(mt)).await.ok();
+            server::serve_on(
+                store,
+                listener,
+                server::ServerConfig {
+                    max_input_buffer: 64 * 1024 * 1024,
+                    secret: sec,
+                    ..Default::default()
+                },
+                Some(mt),
+            )
+            .await
+            .ok();
         });
 
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -847,6 +847,14 @@ fn start_kv_service(
     }
 
     // Start RESP server if enabled
+    if config.kv.redis_compat.socket.is_some() {
+        tracing::warn!(
+            "[kv.redis_compat].socket is set but Unix-socket listening is not yet \
+             implemented — the RESP listener is TCP-only (listening on {}); remove \
+             the socket key or point clients at the TCP address",
+            config.kv.redis_compat.listen
+        );
+    }
     let listen = config.kv.redis_compat.listen.clone();
     let password = config.kv.redis_compat.password.clone();
     let secret = config.kv.secret.clone();
@@ -854,7 +862,9 @@ fn start_kv_service(
         listen,
         password,
         secret: secret.clone(),
-        ..Default::default()
+        max_connections: config.kv.redis_compat.max_connections,
+        max_input_buffer: config.kv.redis_compat.max_input_buffer,
+        idle_timeout_secs: config.kv.redis_compat.idle_timeout_secs,
     };
 
     // Multi-tenant mode with the RESP listener enabled but no master secret:

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -215,7 +215,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `memory_limit` | string | `"256MB"` | Max memory for the KV store. |
+| `memory_limit` | string | `"256MB"` | Max memory for **stored key/value payloads**. Per-connection RESP protocol buffers are NOT counted here — bound those with `[kv.redis_compat]` `max_connections` / `max_input_buffer`. |
 | `eviction_policy` | string | `"allkeys-lru"` | `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`. |
 | `compression` | string | `"none"` | `none`, `gzip`, `brotli`, `zstd`. |
 | `compression_level` | u32 | `6` | 1=fastest, 9=best. |
@@ -227,9 +227,12 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | bool | `false` | Enable the RESP listener. Off by default; in multi-tenant mode keep it off. |
-| `listen` | string | `"127.0.0.1:6379"` | RESP listener address. |
-| `socket` | string | (none) | **Not yet implemented** — parsed but unused. |
+| `listen` | string | `"127.0.0.1:6379"` | RESP listener address (TCP only). |
+| `socket` | string | (none) | **Not yet implemented** — parsed but unused; startup logs a warning if set. |
 | `password` | string | (none) | RESP `AUTH` password. |
+| `max_connections` | usize | `1000` | Max concurrent RESP connections; excess clients get `ERR max number of clients reached` (like Redis `maxclients`). `0` = unlimited. |
+| `max_input_buffer` | usize (bytes) | `1048576` (1 MiB) | Per-connection input buffer cap (like Redis `client-query-buffer-limit`). Not counted against `[kv] memory_limit`. |
+| `idle_timeout_secs` | u64 | `300` | Close RESP connections idle this long, freeing their buffers. `0` = never. |
 
 ## `[cluster]`
 


### PR DESCRIPTION
## Summary
Root-caused from the ePHPm-vs-PHP-FPM lab report's OOMKill during the Predis/RESP test. Reproduction against the published 8.4 image (podman, --memory=512m): RSS scales with in-flight frame bytes x concurrent connections — 10 connections x ~40MB unterminated bulk frames took RSS 34MB -> 425MB in ~3s; 20 x 60MB OOMKilled the container. `[kv] memory_limit` had zero effect (it only counts stored payload bytes). Clean-close Predis traffic does NOT leak (5000-connection churn: RSS flat at ~27MB) — the lab's specific OOM was compound pod pressure, but the lane was trivially DoS-able by anything reaching :6379.

Changes:
- `[kv.redis_compat] max_connections` (default 1000) — excess clients refused with `ERR max number of clients reached` (Redis `maxclients` semantics), enforced via semaphore permit held for the connection's lifetime
- `[kv.redis_compat] max_input_buffer` default cut 64MiB -> **1MiB** (Redis `client-query-buffer-limit` default)
- `[kv.redis_compat] idle_timeout_secs` (default 300) — silent/half-open connections no longer pin buffers until TCP keepalive
- Startup `tracing::warn!` when the unimplemented `socket` knob is set (was a silent TCP fallback — the lab configured a unix socket and unknowingly benchmarked TCP)
- Docs: `memory_limit` clarified as stored-payload-only; new knobs documented; module doc no longer claims unix-socket support
- `serve_on` now takes `ServerConfig` (params list was growing unbounded)

## Test plan
- [x] New e2e-style test: `connection_cap_refuses_excess_clients` (cap=1: second client refused, slot frees on disconnect)
- [x] `cargo test -p ephpm-kv` — all pass
- [x] `cargo test -p ephpm-config --lib -- --test-threads=1` — all pass
- [x] clippy workspace clean, fmt clean