### PR TITLE
feat: OPcache cluster-wide invalidation (Phase 1) + wire KV replication into the server

### DIFF
--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -306,7 +306,7 @@ impl ClusteredStore {
         // No cluster peers (single node, or only self alive): store
         // locally and we're done.
         if replicas.is_empty() {
-            return self.store.set(key.to_string(), value.to_vec(), ttl);
+            return self.store.set_local(key.to_string(), value.to_vec(), ttl);
         }
 
         // The primary is the first replica; the rest are secondaries.
@@ -319,7 +319,7 @@ impl ClusteredStore {
             // value is not lost outright, mirroring the pre-replication
             // behaviour. Do not attempt secondaries in this case.
             if primary.id != self_id {
-                return self.store.set(key.to_string(), value.to_vec(), ttl);
+                return self.store.set_local(key.to_string(), value.to_vec(), ttl);
             }
             return false;
         }
@@ -331,7 +331,7 @@ impl ClusteredStore {
                 for node in secondaries {
                     if node.id == self_id {
                         // Local replica — write inline (cheap, no task).
-                        if !self.store.set(key.to_string(), value.to_vec(), ttl) {
+                        if !self.store.set_local(key.to_string(), value.to_vec(), ttl) {
                             self.replica_write_failures.fetch_add(1, Ordering::Relaxed);
                             tracing::warn!(key, "local replica write rejected (memory limit?)");
                         }
@@ -410,7 +410,7 @@ impl ClusteredStore {
         ttl: Option<Duration>,
     ) -> bool {
         if node.id == self_id {
-            return self.store.set(key.to_string(), value.to_vec(), ttl);
+            return self.store.set_local(key.to_string(), value.to_vec(), ttl);
         }
         let Some(addr) = node_data_addr(node, self.config.data_port) else {
             tracing::warn!(key, replica = %node.id, "replica has no parseable data address");
@@ -430,8 +430,10 @@ impl ClusteredStore {
         // Try gossip tier first.
         let gossip_deleted = self.cluster.gossip_del(key).await;
 
-        // Also remove from local store.
-        let local_deleted = self.store.remove(key);
+        // Also remove from local store. `remove_local` skips the Replicator
+        // hook so we don't re-enter ourselves when this ClusteredStore is
+        // installed as its own local Store's replicator.
+        let local_deleted = self.store.remove_local(key);
 
         // Evict from hot cache.
         if self.config.hot_key_cache {
@@ -664,6 +666,105 @@ impl ClusterHandle {
                 callback(event.key, event.value);
             })
             .forever();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Sync bridge to `ephpm_kv::store::Replicator`
+// ─────────────────────────────────────────────────────────────────────
+
+/// Adapter that implements the synchronous
+/// [`ephpm_kv::store::Replicator`] trait on top of the async
+/// [`ClusteredStore`] API.
+///
+/// The RESP command dispatcher and the PHP `kv_bridge` FFI callbacks call
+/// `Store::set` / `remove` / `expire` from **non-async** contexts, but
+/// `ClusteredStore`'s routing is async (chitchat writes, data-plane RPCs).
+/// This adapter bridges the two by pinning a tokio [`Handle`] at
+/// construction time and calling
+/// [`Handle::spawn`] for the async work.
+///
+/// ## Semantics
+///
+/// - **Small keys (≤ `small_key_threshold`)** — gossip fan-out is spawned
+///   fire-and-forget. The hook returns `true` immediately (the gossip tier
+///   never rejects a write locally). Peers converge in gossip-time.
+/// - **Large keys** — a bounded-inline primary write happens synchronously
+///   via `Handle::block_on` **only** when we are NOT already inside a
+///   tokio runtime. Inside a runtime we cannot `block_on` (that panics),
+///   so we spawn and return `true`. This matches the semantics operators
+///   already accept from the `replication_mode = "async"` path: replicas
+///   are best-effort, the client sees success as long as the local write
+///   would have succeeded.
+/// - **Remove / expire** — always spawned fire-and-forget. The return
+///   value reflects only the local action.
+///
+/// This is a v1 sync-bridge. A future revision may collapse the runtime
+/// gap by making the RESP dispatcher itself async and threading a routing
+/// trait through it; that is a larger refactor and out of scope here.
+pub struct KvReplicator {
+    inner: Arc<ClusteredStore>,
+    /// The tokio runtime that owns the cluster gossip + data plane tasks.
+    /// Captured at construction so sync callers on any thread can spawn
+    /// async replication work.
+    handle: tokio::runtime::Handle,
+}
+
+impl std::fmt::Debug for KvReplicator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KvReplicator").field("clustered_store", &"<ClusteredStore>").finish()
+    }
+}
+
+impl KvReplicator {
+    /// Wrap a [`ClusteredStore`] as a sync [`ephpm_kv::store::Replicator`]
+    /// bound to the given tokio runtime `handle`. Typically
+    /// [`tokio::runtime::Handle::current`] captured from the server's
+    /// tokio context at startup.
+    #[must_use]
+    pub fn new(inner: Arc<ClusteredStore>, handle: tokio::runtime::Handle) -> Arc<Self> {
+        Arc::new(Self { inner, handle })
+    }
+}
+
+impl ephpm_kv::store::Replicator for KvReplicator {
+    fn replicate_set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        // Fire-and-forget: hand the routed write off to the runtime and
+        // return success. The clustered set() itself decides gossip vs
+        // local + replica fan-out and does all local writes via
+        // Store::set_local, so no recursion is possible.
+        let inner = Arc::clone(&self.inner);
+        self.handle.spawn(async move {
+            let ok = inner.set(key.clone(), value, ttl).await;
+            if !ok {
+                tracing::warn!(key, "clustered set returned false (primary rejected)");
+            }
+        });
+        true
+    }
+
+    fn replicate_remove(&self, key: &str) -> bool {
+        let inner = Arc::clone(&self.inner);
+        let key = key.to_string();
+        self.handle.spawn(async move {
+            let _ = inner.remove(&key).await;
+        });
+        // We cannot know synchronously whether the key existed on any
+        // tier; return `true` optimistically (RESP DEL semantics: the
+        // caller uses this as an "attempted" signal, not a guarantee).
+        true
+    }
+
+    fn replicate_expire(&self, key: &str, ttl: Duration) -> bool {
+        // ClusteredStore does not yet expose a cluster-wide `expire` — the
+        // gossip TTL is set at write time. Update the local copy so the
+        // node the caller is talking to honours the new expiry; remote
+        // copies keep their originally-set TTL. Document this v1 gap.
+        let ok = self.inner.local_store().expire_local(key, ttl);
+        if !ok {
+            tracing::debug!(key, "expire: no local copy (may exist only on remote replicas)");
+        }
+        ok
     }
 }
 

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -729,6 +729,15 @@ impl KvReplicator {
 
 impl ephpm_kv::store::Replicator for KvReplicator {
     fn replicate_set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        // Small values: materialize the LOCAL copy synchronously first.
+        // The gossip tier lives in chitchat state, invisible to raw-store
+        // readers (RESP GET, PHP native functions, the OPcache watcher) —
+        // without this, the origin node itself could not read back its own
+        // write. Peers materialize via the gossip applier
+        // (start_gossip_applier).
+        if value.len() <= self.inner.config.small_key_threshold {
+            self.inner.store.set_local(key.clone(), value.clone(), ttl);
+        }
         // Fire-and-forget: hand the routed write off to the runtime and
         // return success. The clustered set() itself decides gossip vs
         // local + replica fan-out and does all local writes via
@@ -744,6 +753,9 @@ impl ephpm_kv::store::Replicator for KvReplicator {
     }
 
     fn replicate_remove(&self, key: &str) -> bool {
+        // Drop the local materialized copy synchronously (mirror of the
+        // set path above), then propagate the removal.
+        self.inner.store.remove_local(key);
         let inner = Arc::clone(&self.inner);
         let key = key.to_string();
         self.handle.spawn(async move {
@@ -766,6 +778,32 @@ impl ephpm_kv::store::Replicator for KvReplicator {
         }
         ok
     }
+}
+
+/// Materialize gossip-tier small values into the local raw [`Store`].
+///
+/// The gossip tier lives in chitchat node state — invisible to the raw
+/// `Store` that the RESP dispatcher, PHP native functions, and the OPcache
+/// watcher read. This applier subscribes to gossip KV changes and writes
+/// every REMOTE small-value update into the local store via `set_local`,
+/// making gossip a replication transport with per-node materialization.
+/// Origin nodes materialize synchronously in
+/// [`KvReplicator::replicate_set`]; their own events are skipped here.
+///
+/// Known v1 gap: `gossip_del` tombstones do not decode as values, so
+/// remote deletions do not remove the local copy until TTL expiry or a
+/// subsequent overwrite.
+pub async fn start_gossip_applier(cluster: &ClusterHandle, store: Arc<Store>) {
+    let self_id = cluster.self_node().id.clone();
+    cluster
+        .subscribe_kv_changes(move |key, value, ttl, node| {
+            if node.node_id == self_id {
+                return;
+            }
+            store.set_local(key.to_string(), value.to_vec(), ttl);
+            tracing::trace!(key, from = %node.node_id, "gossip KV change materialized locally");
+        })
+        .await;
 }
 
 /// FNV-1a-style hash for key → u64 mapping.

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -708,6 +708,10 @@ pub struct KvReplicator {
     /// Captured at construction so sync callers on any thread can spawn
     /// async replication work.
     handle: tokio::runtime::Handle,
+    /// Shared with [`start_gossip_applier`]. When we materialize a local
+    /// copy synchronously we also record the origin `write_ms` here so a
+    /// slower echo of that same write cannot clobber a newer overwrite.
+    applied: AppliedWriteMap,
 }
 
 impl std::fmt::Debug for KvReplicator {
@@ -721,9 +725,18 @@ impl KvReplicator {
     /// bound to the given tokio runtime `handle`. Typically
     /// [`tokio::runtime::Handle::current`] captured from the server's
     /// tokio context at startup.
+    ///
+    /// `applied` MUST be the same handle passed to
+    /// [`start_gossip_applier`] on this node — sharing it is what makes
+    /// local writes and remote applies participate in the same
+    /// last-arrival-wins ordering.
     #[must_use]
-    pub fn new(inner: Arc<ClusteredStore>, handle: tokio::runtime::Handle) -> Arc<Self> {
-        Arc::new(Self { inner, handle })
+    pub fn new(
+        inner: Arc<ClusteredStore>,
+        handle: tokio::runtime::Handle,
+        applied: AppliedWriteMap,
+    ) -> Arc<Self> {
+        Arc::new(Self { inner, handle, applied })
     }
 }
 
@@ -737,6 +750,20 @@ impl ephpm_kv::store::Replicator for KvReplicator {
         // (start_gossip_applier).
         if value.len() <= self.inner.config.small_key_threshold {
             self.inner.store.set_local(key.clone(), value.clone(), ttl);
+            // Record OUR own write in the applied map so a slower echo of
+            // this write from gossip does not clobber a newer local
+            // overwrite that lands between the local materialization and
+            // the echo. Use the same wall-clock now-ms that encode_value
+            // stamps into the gossip payload so the ordering is
+            // consistent across the two paths.
+            let write_ms = u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0),
+            )
+            .unwrap_or(u64::MAX);
+            self.applied.insert(key.clone(), write_ms);
         }
         // Fire-and-forget: hand the routed write off to the runtime and
         // return success. The clustered set() itself decides gossip vs
@@ -780,6 +807,26 @@ impl ephpm_kv::store::Replicator for KvReplicator {
     }
 }
 
+/// Per-key last-applied `write_ms` shared between the gossip applier and
+/// the origin-side [`KvReplicator::replicate_set`]. Keeps the local
+/// materialized copy last-arrival-wins: a slow gossip echo of an older
+/// write can no longer clobber a newer write we already applied
+/// locally.
+///
+/// v1 legacy entries decode as `write_ms = 0` and always apply on first
+/// arrival (0 <= any current-format write_ms is not true for the strict
+/// `<=` check → applied on first sight; a second stale echo with
+/// write_ms=0 is skipped, which is the correct behavior).
+pub type AppliedWriteMap = Arc<DashMap<String, u64>>;
+
+/// Construct a fresh [`AppliedWriteMap`] for use by both the applier and
+/// [`KvReplicator`]. Callers wire the SAME handle through both so origin
+/// writes and remote applies participate in the same ordering.
+#[must_use]
+pub fn new_applied_write_map() -> AppliedWriteMap {
+    Arc::new(DashMap::new())
+}
+
 /// Materialize gossip-tier small values into the local raw [`Store`].
 ///
 /// The gossip tier lives in chitchat node state — invisible to the raw
@@ -790,20 +837,64 @@ impl ephpm_kv::store::Replicator for KvReplicator {
 /// Origin nodes materialize synchronously in
 /// [`KvReplicator::replicate_set`]; their own events are skipped here.
 ///
+/// **Last-arrival-wins ordering.** The applier keeps a per-key
+/// `last-applied write_ms` in `applied` and skips any incoming write
+/// whose `write_ms <= last_seen`. The origin also records its own
+/// `write_ms` in the same map, so a delayed echo of the origin's own
+/// write cannot clobber a newer local overwrite. Pre-`write_ms` peers
+/// send `write_ms = 0`, which always applies on first sight.
+///
 /// Known v1 gap: `gossip_del` tombstones do not decode as values, so
 /// remote deletions do not remove the local copy until TTL expiry or a
 /// subsequent overwrite.
-pub async fn start_gossip_applier(cluster: &ClusterHandle, store: Arc<Store>) {
+pub async fn start_gossip_applier(
+    cluster: &ClusterHandle,
+    store: Arc<Store>,
+    applied: AppliedWriteMap,
+) {
     let self_id = cluster.self_node().id.clone();
     cluster
-        .subscribe_kv_changes(move |key, value, ttl, node| {
+        .subscribe_kv_changes(move |key, value, ttl, write_ms, node| {
             if node.node_id == self_id {
                 return;
             }
+            if !should_apply(&applied, key, write_ms) {
+                tracing::trace!(
+                    key,
+                    from = %node.node_id,
+                    write_ms,
+                    "gossip KV change skipped as stale"
+                );
+                return;
+            }
             store.set_local(key.to_string(), value.to_vec(), ttl);
-            tracing::trace!(key, from = %node.node_id, "gossip KV change materialized locally");
+            tracing::trace!(
+                key,
+                from = %node.node_id,
+                write_ms,
+                "gossip KV change materialized locally"
+            );
         })
         .await;
+}
+
+/// Pure last-arrival-wins gate for the gossip applier.
+///
+/// Returns `true` (and records `write_ms`) when this incoming write is
+/// strictly newer than the last one we materialized for `key`; returns
+/// `false` when it is stale (write_ms <= last-applied) so a slow echo
+/// cannot clobber a newer write we already accepted. Legacy v1 payloads
+/// (`write_ms = 0`) apply on first sight — the map has no entry yet —
+/// and subsequent v1 echoes for the same key are skipped, which is the
+/// desired behavior.
+fn should_apply(applied: &AppliedWriteMap, key: &str, write_ms: u64) -> bool {
+    if let Some(prev) = applied.get(key) {
+        if write_ms <= *prev {
+            return false;
+        }
+    }
+    applied.insert(key.to_string(), write_ms);
+    true
 }
 
 /// FNV-1a-style hash for key → u64 mapping.
@@ -1106,5 +1197,59 @@ mod tests {
         // Unknown / default falls back to async.
         assert_eq!(ReplicationMode::from_config("whatever"), ReplicationMode::Async);
         assert_eq!(ReplicationMode::from_config(""), ReplicationMode::Async);
+    }
+
+    // -----------------------------------------------------------------
+    // Last-arrival-wins ordering (issue #150.1)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn should_apply_first_write_lands() {
+        let applied = new_applied_write_map();
+        assert!(should_apply(&applied, "k", 1000));
+        assert_eq!(*applied.get("k").unwrap(), 1000);
+    }
+
+    #[test]
+    fn should_apply_newer_write_lands() {
+        let applied = new_applied_write_map();
+        assert!(should_apply(&applied, "k", 1000));
+        assert!(should_apply(&applied, "k", 2000));
+        assert_eq!(*applied.get("k").unwrap(), 2000);
+    }
+
+    #[test]
+    fn should_apply_stale_write_is_skipped() {
+        let applied = new_applied_write_map();
+        assert!(should_apply(&applied, "k", 2000));
+        // Delayed echo of an older write must NOT clobber the newer one.
+        assert!(!should_apply(&applied, "k", 1000));
+        // Equal write_ms is treated as stale (write_ms <= last_applied).
+        assert!(!should_apply(&applied, "k", 2000));
+        assert_eq!(*applied.get("k").unwrap(), 2000);
+    }
+
+    #[test]
+    fn should_apply_legacy_zero_write_ms_lands_once() {
+        // Pre-write_ms peers emit write_ms = 0. The first echo applies
+        // (map has no entry), the second is treated as stale — matches
+        // the desired "apply on first sight, deduplicate re-sends"
+        // behavior during rolling upgrades.
+        let applied = new_applied_write_map();
+        assert!(should_apply(&applied, "legacy-key", 0));
+        assert!(!should_apply(&applied, "legacy-key", 0));
+    }
+
+    #[test]
+    fn should_apply_origin_recorded_write_blocks_stale_echo() {
+        // Simulates KvReplicator::replicate_set recording its own write
+        // in the applied map, then a slow echo of the SAME write coming
+        // back through gossip. The echo must be skipped.
+        let applied = new_applied_write_map();
+        let origin_write_ms = 5000;
+        applied.insert("origin-key".into(), origin_write_ms);
+        assert!(!should_apply(&applied, "origin-key", origin_write_ms));
+        // A newer overwrite (say a follow-up SET) should still apply.
+        assert!(should_apply(&applied, "origin-key", origin_write_ms + 1));
     }
 }

--- a/crates/ephpm-cluster/src/gossip_kv.rs
+++ b/crates/ephpm-cluster/src/gossip_kv.rs
@@ -177,18 +177,22 @@ impl ClusterHandle {
     /// Subscribe to gossip KV changes across all nodes.
     ///
     /// The callback receives the key (without the `kv:` prefix), the
-    /// decoded value, and the node that changed it. Used for hot-key
-    /// invalidation notifications.
+    /// decoded value, the remaining TTL (when the entry carries one),
+    /// and the node that changed it. Used by the gossip→local-store
+    /// applier and hot-key invalidation notifications.
     pub async fn subscribe_kv_changes<F>(&self, callback: F)
     where
-        F: Fn(&str, &[u8], &ChitchatId) + Send + Sync + 'static,
+        F: Fn(&str, &[u8], Option<Duration>, &ChitchatId) + Send + Sync + 'static,
     {
         let chitchat = self.handle.chitchat();
         let guard = chitchat.lock().await;
         guard
             .subscribe_event(KV_PREFIX, move |event| {
                 if let Some(value) = decode_value(event.value) {
-                    callback(event.key, &value, event.node);
+                    let ttl = remaining_ttl_ms(event.value)
+                        .filter(|ms| *ms > 0)
+                        .map(Duration::from_millis);
+                    callback(event.key, &value, ttl, event.node);
                 }
             })
             .forever();

--- a/crates/ephpm-cluster/src/gossip_kv.rs
+++ b/crates/ephpm-cluster/src/gossip_kv.rs
@@ -5,10 +5,23 @@
 //! other node automatically via the SWIM gossip protocol.
 //!
 //! Values are base64-encoded (chitchat stores `String → String`) with
-//! an optional TTL encoded as an epoch-millisecond prefix.
+//! an optional TTL and the origin's wall-clock write time encoded as a
+//! millisecond prefix pair.
 //!
-//! Wire format: `"{expiry_ms}:{base64_value}"` where `expiry_ms` is
-//! `0` for no-TTL entries.
+//! Wire format: `"{expiry_ms}:{write_ms}:{base64_value}"`.
+//!   - `expiry_ms` is the epoch-millisecond expiry (0 = no TTL).
+//!   - `write_ms` is the epoch-millisecond the origin node produced the
+//!     value. Used by the gossip applier for last-arrival-wins ordering
+//!     so a slow echo of an older write cannot clobber a newer one.
+//!
+//! **Legacy format compatibility.** The v1 format was
+//! `"{expiry_ms}:{base64_value}"` (no `write_ms`). `decode_value`,
+//! `remaining_ttl_ms`, and the subscription decoder still accept it so a
+//! rolling upgrade from a pre-`write_ms` peer does not drop data on the
+//! floor. Legacy entries are treated as `write_ms = 0`, which means the
+//! applier will always apply them (they are strictly older than any
+//! current-format entry). Only encode is one-way: new writes always
+//! emit the three-field form.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -30,21 +43,49 @@ fn now_epoch_ms() -> u64 {
 }
 
 /// Encode a binary value + optional TTL into the chitchat string format.
+///
+/// Emits the current three-field form `"{expiry_ms}:{write_ms}:{b64}"`.
+/// `write_ms` is stamped at encode time so the applier on remote nodes
+/// can order overlapping writes deterministically (last arrival wins).
 fn encode_value(value: &[u8], ttl: Option<Duration>) -> String {
+    let now_ms = now_epoch_ms();
     let expiry_ms = ttl.map_or(0u64, |d| {
         let ttl_ms = u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
-        now_epoch_ms().saturating_add(ttl_ms)
+        now_ms.saturating_add(ttl_ms)
     });
     let b64 = Base64::encode_string(value);
-    format!("{expiry_ms}:{b64}")
+    format!("{expiry_ms}:{now_ms}:{b64}")
+}
+
+/// Split an encoded value into (expiry_ms, write_ms, base64) while
+/// accepting both the v1 two-field format and the v2 three-field format.
+///
+/// v1 entries are reported with `write_ms = 0` — the smallest possible
+/// value, which lets the applier treat them as strictly older than any
+/// current-format entry and always apply them once.
+fn split_encoded(encoded: &str) -> Option<(u64, u64, &str)> {
+    let (first, rest) = encoded.split_once(':')?;
+    let expiry_ms: u64 = first.parse().ok()?;
+    if let Some((second, tail)) = rest.split_once(':') {
+        // Three-field form. `second` MUST parse as u64 for this to be a
+        // v2 payload; if it doesn't, fall back to treating `rest` as
+        // legacy base64 (unlikely — base64 alphabet has no ':' — but
+        // symmetric with the accept-both contract).
+        if let Ok(write_ms) = second.parse::<u64>() {
+            return Some((expiry_ms, write_ms, tail));
+        }
+    }
+    // v1 two-field form: no write_ms, `rest` is the base64 payload.
+    Some((expiry_ms, 0, rest))
 }
 
 /// Decode a chitchat value string back to binary, checking TTL.
 ///
-/// Returns `None` if the entry has expired.
+/// Accepts BOTH the v2 three-field format and the v1 two-field format —
+/// necessary during a rolling upgrade where some peers still run the
+/// pre-`write_ms` code path. Returns `None` if the entry has expired.
 fn decode_value(encoded: &str) -> Option<Vec<u8>> {
-    let (expiry_str, b64) = encoded.split_once(':')?;
-    let expiry_ms: u64 = expiry_str.parse().ok()?;
+    let (expiry_ms, _write_ms, b64) = split_encoded(encoded)?;
 
     if expiry_ms > 0 && now_epoch_ms() >= expiry_ms {
         return None; // expired
@@ -53,13 +94,27 @@ fn decode_value(encoded: &str) -> Option<Vec<u8>> {
     Base64::decode_vec(b64).ok()
 }
 
-/// Remaining TTL from an encoded value, in milliseconds.
+/// Decode and also return the origin write time. Used by the gossip
+/// applier for stale-write detection.
+///
+/// v1 legacy entries return `write_ms = 0`, which sorts before any
+/// v2 timestamp — so a legacy entry always applies on first arrival.
+fn decode_value_with_write_ms(encoded: &str) -> Option<(Vec<u8>, u64)> {
+    let (expiry_ms, write_ms, b64) = split_encoded(encoded)?;
+    if expiry_ms > 0 && now_epoch_ms() >= expiry_ms {
+        return None;
+    }
+    let bytes = Base64::decode_vec(b64).ok()?;
+    Some((bytes, write_ms))
+}
+
+/// Remaining TTL from an encoded value, in milliseconds. Accepts both
+/// v1 and v2 wire formats (rolling-upgrade compatible).
 ///
 /// Returns `None` if no TTL is set or the value format is invalid.
 /// Returns `Some(0)` if already expired.
 fn remaining_ttl_ms(encoded: &str) -> Option<u64> {
-    let (expiry_str, _) = encoded.split_once(':')?;
-    let expiry_ms: u64 = expiry_str.parse().ok()?;
+    let (expiry_ms, _write_ms, _b64) = split_encoded(encoded)?;
     if expiry_ms == 0 {
         return None; // no TTL
     }
@@ -178,21 +233,22 @@ impl ClusterHandle {
     ///
     /// The callback receives the key (without the `kv:` prefix), the
     /// decoded value, the remaining TTL (when the entry carries one),
-    /// and the node that changed it. Used by the gossip→local-store
-    /// applier and hot-key invalidation notifications.
+    /// the origin `write_ms` stamped by the writer (0 for pre-`write_ms`
+    /// legacy entries), and the node that changed it. Used by the
+    /// gossip→local-store applier and hot-key invalidation notifications.
     pub async fn subscribe_kv_changes<F>(&self, callback: F)
     where
-        F: Fn(&str, &[u8], Option<Duration>, &ChitchatId) + Send + Sync + 'static,
+        F: Fn(&str, &[u8], Option<Duration>, u64, &ChitchatId) + Send + Sync + 'static,
     {
         let chitchat = self.handle.chitchat();
         let guard = chitchat.lock().await;
         guard
             .subscribe_event(KV_PREFIX, move |event| {
-                if let Some(value) = decode_value(event.value) {
+                if let Some((value, write_ms)) = decode_value_with_write_ms(event.value) {
                     let ttl = remaining_ttl_ms(event.value)
                         .filter(|ms| *ms > 0)
                         .map(Duration::from_millis);
-                    callback(event.key, &value, ttl, event.node);
+                    callback(event.key, &value, ttl, write_ms, event.node);
                 }
             })
             .forever();
@@ -223,7 +279,10 @@ mod tests {
     fn encode_decode_no_ttl() {
         let value = b"hello world";
         let encoded = encode_value(value, None);
+        // v2 wire form: "{expiry}:{write_ms}:{b64}", so the leading "0:"
+        // (no TTL) is followed by another numeric colon-terminated field.
         assert!(encoded.starts_with("0:"));
+        assert!(encoded.matches(':').count() >= 2);
         let decoded = decode_value(&encoded).expect("should decode");
         assert_eq!(decoded, value);
     }
@@ -232,10 +291,10 @@ mod tests {
     fn encode_decode_with_ttl() {
         let value = b"test data";
         let encoded = encode_value(value, Some(Duration::from_secs(3600)));
-        // Expiry should be non-zero.
-        let (expiry_str, _) = encoded.split_once(':').unwrap();
-        let expiry: u64 = expiry_str.parse().unwrap();
+        // Expiry should be non-zero, and write_ms should also be non-zero.
+        let (expiry, write_ms, _b64) = split_encoded(&encoded).unwrap();
         assert!(expiry > 0);
+        assert!(write_ms > 0);
         // Should decode fine (not expired).
         let decoded = decode_value(&encoded).expect("should decode");
         assert_eq!(decoded, value);
@@ -245,8 +304,35 @@ mod tests {
     fn decode_expired_returns_none() {
         // Manually craft an expired entry (expiry in the past).
         let b64 = Base64::encode_string(b"old data");
-        let encoded = format!("1:{b64}"); // epoch ms = 1 → long expired
+        let encoded = format!("1:1:{b64}"); // epoch ms = 1 → long expired
         assert!(decode_value(&encoded).is_none());
+    }
+
+    #[test]
+    fn decode_accepts_legacy_two_field_format() {
+        // A pre-write_ms peer emits "{expiry}:{b64}" with no write_ms
+        // slot. The applier still needs to accept those during a rolling
+        // upgrade or data goes on the floor.
+        let value = b"legacy peer wrote this";
+        let b64 = Base64::encode_string(value);
+        let legacy = format!("0:{b64}"); // no TTL, no write_ms
+        let decoded = decode_value(&legacy).expect("legacy form should decode");
+        assert_eq!(decoded, value);
+        let (bytes, write_ms) =
+            decode_value_with_write_ms(&legacy).expect("legacy form should split");
+        assert_eq!(bytes, value);
+        assert_eq!(write_ms, 0, "legacy entries report write_ms = 0");
+        assert!(remaining_ttl_ms(&legacy).is_none());
+    }
+
+    #[test]
+    fn decode_accepts_current_three_field_format() {
+        // Round-trip through encode_value → decode_value_with_write_ms.
+        let value = b"v2 write";
+        let encoded = encode_value(value, None);
+        let (bytes, write_ms) = decode_value_with_write_ms(&encoded).expect("v2 should decode");
+        assert_eq!(bytes, value);
+        assert!(write_ms > 0, "v2 entries carry a real write_ms");
     }
 
     #[test]
@@ -267,8 +353,19 @@ mod tests {
     #[test]
     fn remaining_ttl_expired() {
         let b64 = Base64::encode_string(b"x");
-        let encoded = format!("1:{b64}");
+        let encoded = format!("1:1:{b64}");
         let ttl = remaining_ttl_ms(&encoded).expect("should have TTL");
+        assert_eq!(ttl, 0);
+    }
+
+    #[test]
+    fn remaining_ttl_expired_legacy_two_field() {
+        // Legacy peer emits "{expiry}:{b64}" — remaining_ttl_ms MUST still
+        // report a value or a rolling upgrade would silently break TTL
+        // observability on freshly-written keys from the older peer.
+        let b64 = Base64::encode_string(b"x");
+        let encoded = format!("1:{b64}");
+        let ttl = remaining_ttl_ms(&encoded).expect("legacy TTL should decode");
         assert_eq!(ttl, 0);
     }
 

--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -160,7 +160,11 @@ async fn handle_connection(
         }
         OP_SET => {
             let value = request.value.expect("SET request always carries a value");
-            let ok = store.set(request.key, value, None);
+            // Replica-side write: we are the receiver of a fanned-out replica
+            // copy, not the origin. Use `set_local` so we don't re-enter any
+            // installed Replicator hook and re-fanout the same key back to
+            // our peers (infinite loop).
+            let ok = store.set_local(request.key, value, None);
             vec![if ok { SET_OK } else { SET_REJECTED }]
         }
         other => {

--- a/crates/ephpm-cluster/src/lib.rs
+++ b/crates/ephpm-cluster/src/lib.rs
@@ -20,7 +20,7 @@ pub mod node;
 pub mod secure_transport;
 pub mod sqlite_election;
 
-pub use clustered_store::ClusteredStore;
+pub use clustered_store::{ClusteredStore, KvReplicator};
 pub use kv_data_plane as data_plane;
 pub use node::{ClusterHandle, NodeInfo, NodeState, start_gossip};
 pub use secure_transport::{ClusterCipher, EncryptedUdpTransport};

--- a/crates/ephpm-cluster/tests/kv_replicator_seam.rs
+++ b/crates/ephpm-cluster/tests/kv_replicator_seam.rs
@@ -1,0 +1,226 @@
+//! Integration tests for the sync `KvReplicator` -> `ClusteredStore` seam.
+//!
+//! `Store::set` / `remove` / `expire` are called from **sync** contexts
+//! (RESP command dispatcher, PHP FFI callbacks). `KvReplicator` bridges
+//! those sync callers to the async `ClusteredStore` by pinning a tokio
+//! [`Handle`] and spawning the routed write. These tests verify:
+//!
+//! 1. A sync `Store::set` on a hooked local store causes the cluster
+//!    tier to observe the write (issue #143 root cause: without a
+//!    replicator installed, SETs never left the local map).
+//! 2. Small values (≤ `small_key_threshold`) land in the gossip tier.
+//! 3. Large values land in the local store via the `ClusteredStore`
+//!    routing (proving `set_local` is what runs, not a re-entrant
+//!    `set`).
+//! 4. Two-node smoke: a hooked SET on node A becomes visible via
+//!    `ClusteredStore::get` on node B for a small (gossip-replicated)
+//!    value.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ephpm_cluster::node::{ClusterHandle, NodeState, start_gossip};
+use ephpm_cluster::{ClusteredStore, KvReplicator};
+use ephpm_config::{ClusterConfig, ClusterKvConfig};
+use ephpm_kv::store::{Replicator, Store, StoreConfig};
+
+async fn random_udp_port() -> u16 {
+    let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.expect("bind failed");
+    sock.local_addr().expect("local_addr failed").port()
+}
+
+async fn start_node(port: u16, seeds: Vec<String>, node_id: &str) -> ClusterHandle {
+    let config = ClusterConfig {
+        enabled: true,
+        bind: format!("127.0.0.1:{port}"),
+        join: seeds,
+        secret: String::new(),
+        node_id: node_id.to_string(),
+        cluster_id: "seam-test".to_string(),
+        kv: ClusterKvConfig::default(),
+    };
+    start_gossip(&config).await.unwrap_or_else(|e| panic!("gossip start failed for {node_id}: {e}"))
+}
+
+async fn shutdown(handle: Arc<ClusterHandle>) {
+    Arc::try_unwrap(handle)
+        .expect("other Arc references must be dropped before shutdown")
+        .shutdown()
+        .await;
+}
+
+async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        let mut all_ok = true;
+        for h in handles {
+            let alive = h.nodes().await.iter().filter(|n| n.state == NodeState::Alive).count();
+            if alive != expected {
+                all_ok = false;
+                break;
+            }
+        }
+        if all_ok {
+            return;
+        }
+        assert!(start.elapsed() <= timeout, "convergence timeout after {timeout:?}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// The core seam guarantee for issue #143: `Store::set` from a **sync
+/// context** on a hooked store DOES cause the clustered write to happen —
+/// specifically, the value ends up routed through `ClusteredStore` and
+/// visible on the gossip tier (for a small value).
+#[tokio::test]
+async fn sync_store_set_routes_through_clustered_store_gossip_tier() {
+    let port = random_udp_port().await;
+    let handle = Arc::new(start_node(port, vec![], "seam-a").await);
+
+    let local = Store::new(StoreConfig::default());
+    let clustered = ClusteredStore::new(
+        Arc::clone(&local),
+        Arc::clone(&handle),
+        // Force everything into the gossip tier so we can inspect it
+        // deterministically.
+        ClusterKvConfig { small_key_threshold: 4096, ..ClusterKvConfig::default() },
+        None,
+    );
+
+    // Install the sync bridge on the local store — this is what
+    // `serve()` does at startup.
+    let replicator = KvReplicator::new(Arc::clone(&clustered), tokio::runtime::Handle::current());
+    local.set_replicator(Some(replicator as Arc<dyn Replicator>));
+
+    // Sync API — mirrors what the RESP dispatcher and PHP kv_bridge do.
+    // Without the fix these would only touch `local` and gossip would
+    // never see the write.
+    assert!(local.set("issue-143".into(), b"v".to_vec(), None));
+
+    // The bridge spawns the routed write on the runtime; wait briefly
+    // for the async gossip-set to land.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(v) = handle.gossip_get("issue-143").await {
+            assert_eq!(v, b"v".to_vec(), "gossip must hold the value written via sync Store::set");
+            break;
+        }
+        assert!(Instant::now() < deadline, "sync SET never reached gossip within 5s");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Small keys are gossip-only — the local map must NOT hold a copy,
+    // proving Store::set delegated to the replicator and did not also
+    // do a direct-write.
+    assert!(local.get("issue-143").is_none(), "local map must not double-store small values");
+
+    // Clear the replicator so its Arc<ClusteredStore> is released; then
+    // drop the clustered handle and the local store — leaving `handle`
+    // as the sole owner for shutdown.
+    local.set_replicator(None);
+    drop(clustered);
+    drop(local);
+    shutdown(handle).await;
+}
+
+/// Large values (above `small_key_threshold`) route to the local store
+/// tier via `ClusteredStore` — that path uses `set_local` internally so
+/// this must NOT recurse into the replicator.
+#[tokio::test]
+async fn sync_store_set_routes_large_value_to_local_via_set_local() {
+    let port = random_udp_port().await;
+    let handle = Arc::new(start_node(port, vec![], "seam-large").await);
+
+    let local = Store::new(StoreConfig::default());
+    let clustered = ClusteredStore::new(
+        Arc::clone(&local),
+        Arc::clone(&handle),
+        ClusterKvConfig { small_key_threshold: 8, ..ClusterKvConfig::default() },
+        None,
+    );
+    let replicator = KvReplicator::new(Arc::clone(&clustered), tokio::runtime::Handle::current());
+    local.set_replicator(Some(replicator as Arc<dyn Replicator>));
+
+    // Large value — goes to the local store tier via ClusteredStore.
+    assert!(local.set("large".into(), vec![0xAB; 64], None));
+
+    // Wait for the spawned routed write to land locally.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if local.get("large").is_some() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "large-value routed write never landed locally");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(local.get("large"), Some(vec![0xAB; 64]));
+    // Gossip must not hold the large value.
+    assert!(handle.gossip_get("large").await.is_none());
+
+    // Clear the replicator so its Arc<ClusteredStore> is released; then
+    // drop the clustered handle and the local store — leaving `handle`
+    // as the sole owner for shutdown.
+    local.set_replicator(None);
+    drop(clustered);
+    drop(local);
+    shutdown(handle).await;
+}
+
+/// Two-node smoke: a hooked sync SET on node A becomes visible via the
+/// ClusteredStore reader on node B (gossip-replicated tier). This is the
+/// end-to-end shape of what the OPcache invalidation feature needs from
+/// the KV layer.
+#[tokio::test]
+async fn hooked_sync_set_replicates_to_peer_via_gossip() {
+    let port1 = random_udp_port().await;
+    let port2 = random_udp_port().await;
+    let seed = format!("127.0.0.1:{port1}");
+
+    let h1 = Arc::new(start_node(port1, vec![], "peer-a").await);
+    let h2 = Arc::new(start_node(port2, vec![seed], "peer-b").await);
+
+    wait_for_convergence(&[&h1, &h2], 2, Duration::from_secs(10)).await;
+
+    let local1 = Store::new(StoreConfig::default());
+    let cs1 = ClusteredStore::new(
+        Arc::clone(&local1),
+        Arc::clone(&h1),
+        // Force gossip tier so the write is small enough to fan out via
+        // chitchat.
+        ClusterKvConfig { small_key_threshold: 4096, ..ClusterKvConfig::default() },
+        None,
+    );
+    let rep1 = KvReplicator::new(Arc::clone(&cs1), tokio::runtime::Handle::current());
+    local1.set_replicator(Some(rep1 as Arc<dyn Replicator>));
+
+    let local2 = Store::new(StoreConfig::default());
+    let cs2 = ClusteredStore::new(
+        Arc::clone(&local2),
+        Arc::clone(&h2),
+        ClusterKvConfig { small_key_threshold: 4096, ..ClusterKvConfig::default() },
+        None,
+    );
+
+    // The bug reproduction: sync SET on node A. Before the fix this
+    // never left A. After the fix, gossip propagates it and B's
+    // ClusteredStore::get returns the value.
+    assert!(local1.set("opcache:version:demo".into(), b"1".to_vec(), None));
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(v) = cs2.get("opcache:version:demo").await {
+            assert_eq!(v, b"1", "peer B must see the value written via sync SET on peer A");
+            break;
+        }
+        assert!(Instant::now() < deadline, "cross-node gossip propagation timeout");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    local1.set_replicator(None);
+    drop(cs1);
+    drop(cs2);
+    drop(local1);
+    drop(local2);
+    shutdown(h1).await;
+    shutdown(h2).await;
+}

--- a/crates/ephpm-cluster/tests/kv_replicator_seam.rs
+++ b/crates/ephpm-cluster/tests/kv_replicator_seam.rs
@@ -109,10 +109,17 @@ async fn sync_store_set_routes_through_clustered_store_gossip_tier() {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
-    // Small keys are gossip-only — the local map must NOT hold a copy,
-    // proving Store::set delegated to the replicator and did not also
-    // do a direct-write.
-    assert!(local.get("issue-143").is_none(), "local map must not double-store small values");
+    // The ORIGIN node must hold a materialized local copy: raw-store
+    // readers (RESP GET, PHP native functions, the OPcache watcher) never
+    // consult the gossip tier, so without local materialization the
+    // origin could not read back its own write (found live on the
+    // two-node kind demo). Gossip is the transport; each node's Store is
+    // the materialized view.
+    assert_eq!(
+        local.get("issue-143").as_deref(),
+        Some(b"v".as_slice()),
+        "origin node must materialize its own small-value write locally"
+    );
 
     // Clear the replicator so its Arc<ClusteredStore> is released; then
     // drop the clustered handle and the local store — leaving `handle`

--- a/crates/ephpm-cluster/tests/kv_replicator_seam.rs
+++ b/crates/ephpm-cluster/tests/kv_replicator_seam.rs
@@ -89,7 +89,11 @@ async fn sync_store_set_routes_through_clustered_store_gossip_tier() {
 
     // Install the sync bridge on the local store — this is what
     // `serve()` does at startup.
-    let replicator = KvReplicator::new(Arc::clone(&clustered), tokio::runtime::Handle::current());
+    let replicator = KvReplicator::new(
+        Arc::clone(&clustered),
+        tokio::runtime::Handle::current(),
+        ephpm_cluster::clustered_store::new_applied_write_map(),
+    );
     local.set_replicator(Some(replicator as Arc<dyn Replicator>));
 
     // Sync API — mirrors what the RESP dispatcher and PHP kv_bridge do.
@@ -145,7 +149,11 @@ async fn sync_store_set_routes_large_value_to_local_via_set_local() {
         ClusterKvConfig { small_key_threshold: 8, ..ClusterKvConfig::default() },
         None,
     );
-    let replicator = KvReplicator::new(Arc::clone(&clustered), tokio::runtime::Handle::current());
+    let replicator = KvReplicator::new(
+        Arc::clone(&clustered),
+        tokio::runtime::Handle::current(),
+        ephpm_cluster::clustered_store::new_applied_write_map(),
+    );
     local.set_replicator(Some(replicator as Arc<dyn Replicator>));
 
     // Large value — goes to the local store tier via ClusteredStore.
@@ -197,7 +205,11 @@ async fn hooked_sync_set_replicates_to_peer_via_gossip() {
         ClusterKvConfig { small_key_threshold: 4096, ..ClusterKvConfig::default() },
         None,
     );
-    let rep1 = KvReplicator::new(Arc::clone(&cs1), tokio::runtime::Handle::current());
+    let rep1 = KvReplicator::new(
+        Arc::clone(&cs1),
+        tokio::runtime::Handle::current(),
+        ephpm_cluster::clustered_store::new_applied_write_map(),
+    );
     local1.set_replicator(Some(rep1 as Arc<dyn Replicator>));
 
     let local2 = Store::new(StoreConfig::default());

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -41,6 +41,12 @@ pub struct Config {
     /// Default: empty (no middleware loaded).
     #[serde(default)]
     pub middleware: Vec<MiddlewareMount>,
+
+    /// OPcache clustering settings (`[opcache]`).
+    ///
+    /// Governs cluster-wide OPcache invalidation. See [`OpcacheConfig`].
+    #[serde(default)]
+    pub opcache: OpcacheConfig,
 }
 
 /// One native middleware mount (`[[middleware]]`).
@@ -1838,6 +1844,55 @@ impl Default for ClusterKvConfig {
             hot_key_max_memory: default_hot_key_max_memory(),
             data_port: default_kv_data_port(),
         }
+    }
+}
+
+/// OPcache clustering configuration (`[opcache]`).
+///
+/// Governs the cluster-wide invalidation watcher that fires when the KV key
+/// `opcache:version:<vhost>` changes. See
+/// `site/content/roadmap/opcache-clustering.md` for the design.
+#[derive(Debug, Deserialize, Clone)]
+pub struct OpcacheConfig {
+    /// Watch the KV store for cluster-wide invalidation events.
+    ///
+    /// When enabled, every PHP request checks `opcache:version:<vhost>` before
+    /// executing. If the version has advanced since the last invalidation on
+    /// this node, `opcache_invalidate()` is called for every cached script
+    /// under the vhost's document root before the request runs.
+    ///
+    /// The KV lookup is an in-process `DashMap::get` — sub-microsecond — so the
+    /// per-request overhead is negligible.
+    ///
+    /// Default resolution (see [`OpcacheConfig::effective_cluster_invalidation`]):
+    /// - `Some(true)` / `Some(false)` — explicit value from TOML
+    /// - `None` — defaults to `true` when `[cluster] enabled = true`,
+    ///   `false` otherwise (single-node: `ephpm cache reset` is the right
+    ///   interface).
+    ///
+    /// **Applies to fpm mode only.** In worker mode
+    /// (`[php] mode = "worker"`), the watcher is not currently invoked — the
+    /// framework holds compiled bytecode in the booted process and cluster
+    /// invalidation of a worker's OPcache is a future phase. Startup emits a
+    /// WARN when `cluster_invalidation` resolves to true under worker mode so
+    /// the no-op is never silent.
+    #[serde(default)]
+    pub cluster_invalidation: Option<bool>,
+}
+
+impl Default for OpcacheConfig {
+    fn default() -> Self {
+        Self { cluster_invalidation: None }
+    }
+}
+
+impl OpcacheConfig {
+    /// Resolve the effective `cluster_invalidation` setting.
+    ///
+    /// `None` means "auto": on when clustering is enabled, off otherwise.
+    #[must_use]
+    pub fn effective_cluster_invalidation(&self, cluster_enabled: bool) -> bool {
+        self.cluster_invalidation.unwrap_or(cluster_enabled)
     }
 }
 

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1852,7 +1852,7 @@ impl Default for ClusterKvConfig {
 /// Governs the cluster-wide invalidation watcher that fires when the KV key
 /// `opcache:version:<vhost>` changes. See
 /// `site/content/roadmap/opcache-clustering.md` for the design.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct OpcacheConfig {
     /// Watch the KV store for cluster-wide invalidation events.
     ///
@@ -1878,12 +1878,6 @@ pub struct OpcacheConfig {
     /// the no-op is never silent.
     #[serde(default)]
     pub cluster_invalidation: Option<bool>,
-}
-
-impl Default for OpcacheConfig {
-    fn default() -> Self {
-        Self { cluster_invalidation: None }
-    }
 }
 
 impl OpcacheConfig {

--- a/crates/ephpm-e2e/Cargo.toml
+++ b/crates/ephpm-e2e/Cargo.toml
@@ -14,8 +14,13 @@ publish = false
 
 [dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time", "sync", "net", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 urlencoding = "2"
 brotli = "7"
+# Used by the opcache_invalidation test to write invalidation-version keys
+# via the RESP listener (same wire the ephpm CLI uses).
+ephpm-kv = { path = "../ephpm-kv" }
+bytes = "1"
+anyhow = "1"

--- a/crates/ephpm-e2e/tests/opcache_invalidation.rs
+++ b/crates/ephpm-e2e/tests/opcache_invalidation.rs
@@ -1,16 +1,16 @@
 //! OPcache clustered invalidation e2e tests (Phase 1).
 //!
 //! Validates the watcher end-to-end:
-//!   1. PRE — warm the OPcache by hitting `opcache_status.php` and confirming
-//!      the target file is cached (`target_cached: true`).
+//!   1. PRE — warm the OPcache by hitting `opcache_status.php` (warming
+//!      probe) and confirming the target file is cached.
 //!   2. Trigger — write `opcache:version:_default` (single-node) or
 //!      `opcache:version:_all` (cluster) via the RESP listener so the watcher
 //!      fires on the next request.
-//!   3. POST — hit `opcache_status.php` again. The first post-trigger request
-//!      pays the invalidation, so `target_cached` may still be true (the
-//!      probe includes the target, which recompiles). What we assert is that
-//!      the version key has taken effect: a follow-up trigger with a NEWER
-//!      version advances the state, which the metrics/log path confirms.
+//!   3. POST — hit `opcache_status.php?warm=0` (cold probe). The request
+//!      trips the watcher BEFORE the probe script runs, so the probe must
+//!      see the target genuinely dropped (`opcache_is_script_cached` =
+//!      false). A follow-up warming probe then re-caches it. This is the
+//!      strong assertion pair — it fails if the invalidator silently no-ops.
 //!
 //! Both `EPHPM_URL` (single-node) and `EPHPM_CLUSTER_URL_*` (cluster) paths
 //! are covered. Tests skip gracefully when the required env vars are unset,
@@ -62,8 +62,20 @@ fn cluster_urls() -> Vec<String> {
 
 /// Fetch and decode the probe JSON at `<base>/opcache_status.php`.
 async fn probe_status(base_url: &str) -> serde_json::Value {
+    probe_status_with(base_url, true).await
+}
+
+/// Probe without warming (`warm=0`) — required to observe that an
+/// invalidation dropped the target, since a warming probe re-caches it
+/// within the same request.
+async fn probe_status_cold(base_url: &str) -> serde_json::Value {
+    probe_status_with(base_url, false).await
+}
+
+async fn probe_status_with(base_url: &str, warm: bool) -> serde_json::Value {
     let client = reqwest::Client::new();
-    let url = format!("{base_url}/opcache_status.php");
+    let warm_q = if warm { "1" } else { "0" };
+    let url = format!("{base_url}/opcache_status.php?warm={warm_q}");
     let resp = client
         .get(&url)
         .send()
@@ -173,17 +185,26 @@ async fn single_node_deploy_triggers_invalidation() {
         .await
         .expect("SET version key");
 
-    // POST: probe again. The endpoint returns 200 with valid JSON.
-    // opcache_enabled must still be true — the watcher must not have
-    // disabled OPcache, only invalidated the cached scripts under docroot.
-    let post = probe_status(base_url.as_str()).await;
+    // POST (cold probe): this request trips the watcher, which invalidates
+    // everything under docroot BEFORE the probe script runs — so the probe
+    // must see the target genuinely dropped (opcache_is_script_cached =
+    // false). This is the strong assertion: it fails if the invalidator
+    // silently no-ops.
+    let post = probe_status_cold(base_url.as_str()).await;
     assert!(
         post["opcache_enabled"].as_bool().unwrap_or(false),
         "OPcache should still be enabled after invalidation: {post}"
     );
     assert!(
-        post["target_cached"].as_bool().unwrap_or(false),
-        "target should be recompiled + re-cached by this request: {post}"
+        !post["target_cached"].as_bool().unwrap_or(true),
+        "target should be DROPPED by the invalidation: {post}"
+    );
+
+    // RE-WARM: the next warming probe recompiles and re-caches it.
+    let rewarm = probe_status(base_url.as_str()).await;
+    assert!(
+        rewarm["target_cached"].as_bool().unwrap_or(false),
+        "target should be recompiled + re-cached after re-warm: {rewarm}"
     );
 }
 
@@ -273,22 +294,30 @@ async fn cluster_broadcast_fans_out_to_all_nodes() {
         .await
         .expect("SET broadcast key on node 0");
 
-    // POST: probe every node. Gossip needs a moment to reach peers; retry
-    // for up to ~15 s. The probe just needs to return valid JSON with
-    // OPcache enabled after invalidation.
+    // POST: cold-probe every node until the target shows as DROPPED —
+    // the strong signal that the broadcast reached that node and its
+    // watcher ran the invalidation. Gossip needs a moment to reach peers;
+    // retry for up to ~15 s per node.
     for (i, url) in urls.iter().enumerate() {
-        let mut ok = false;
+        let mut dropped = false;
         for _ in 0..30 {
-            let post = probe_status(url.as_str()).await;
+            let post = probe_status_cold(url.as_str()).await;
             if post["opcache_enabled"].as_bool().unwrap_or(false)
-                && post["target_cached"].as_bool().unwrap_or(false)
+                && !post["target_cached"].as_bool().unwrap_or(true)
             {
-                ok = true;
+                dropped = true;
                 break;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
-        assert!(ok, "node {i} ({url}) never re-cached target after broadcast");
+        assert!(dropped, "node {i} ({url}) never dropped the target after broadcast");
+
+        // And a warming probe recompiles it — the node stays serviceable.
+        let rewarm = probe_status(url.as_str()).await;
+        assert!(
+            rewarm["target_cached"].as_bool().unwrap_or(false),
+            "node {i} ({url}) failed to re-cache after invalidation: {rewarm}"
+        );
     }
 }
 

--- a/crates/ephpm-e2e/tests/opcache_invalidation.rs
+++ b/crates/ephpm-e2e/tests/opcache_invalidation.rs
@@ -1,0 +1,334 @@
+//! OPcache clustered invalidation e2e tests (Phase 1).
+//!
+//! Validates the watcher end-to-end:
+//!   1. PRE — warm the OPcache by hitting `opcache_status.php` and confirming
+//!      the target file is cached (`target_cached: true`).
+//!   2. Trigger — write `opcache:version:_default` (single-node) or
+//!      `opcache:version:_all` (cluster) via the RESP listener so the watcher
+//!      fires on the next request.
+//!   3. POST — hit `opcache_status.php` again. The first post-trigger request
+//!      pays the invalidation, so `target_cached` may still be true (the
+//!      probe includes the target, which recompiles). What we assert is that
+//!      the version key has taken effect: a follow-up trigger with a NEWER
+//!      version advances the state, which the metrics/log path confirms.
+//!
+//! Both `EPHPM_URL` (single-node) and `EPHPM_CLUSTER_URL_*` (cluster) paths
+//! are covered. Tests skip gracefully when the required env vars are unset,
+//! so they don't break the single-node runner.
+//!
+//! # Fixtures
+//!
+//! - `tests/docroot/opcache_status.php` — probe endpoint returning JSON
+//! - `tests/docroot/opcache_target.php`  — file whose OPcache entry is tracked
+//!
+//! # Environment
+//!
+//! - `EPHPM_URL` — single-node base URL (skips cluster tests)
+//! - `EPHPM_CLUSTER_URL_0`, `EPHPM_CLUSTER_URL_1`, `EPHPM_CLUSTER_URL_2` —
+//!   cluster node base URLs (skips cluster tests when unset)
+//! - `EPHPM_KV_HOST` / `EPHPM_KV_PORT` — RESP listener the CLI would target;
+//!   defaults to `127.0.0.1:6379`. Only used by the single-node test since
+//!   cluster tests hit each node's RESP listener via its base host.
+
+use std::time::Duration;
+
+use bytes::BytesMut;
+use ephpm_e2e::required_env;
+use ephpm_kv::resp::{Frame, parse_frame};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// KV key prefix — must match `ephpm-server::opcache::KV_VERSION_PREFIX`.
+const OPCACHE_VERSION_PREFIX: &str = "opcache:version:";
+/// Broadcast vhost — must match `ephpm-server::opcache::BROADCAST_VHOST`.
+const OPCACHE_BROADCAST_VHOST: &str = "_all";
+/// Default vhost — must match `ephpm-server::opcache::DEFAULT_VHOST`.
+const OPCACHE_DEFAULT_VHOST: &str = "_default";
+
+fn cluster_env(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
+fn cluster_urls() -> Vec<String> {
+    let mut urls = Vec::new();
+    for name in ["EPHPM_CLUSTER_URL_0", "EPHPM_CLUSTER_URL_1", "EPHPM_CLUSTER_URL_2"] {
+        match cluster_env(name) {
+            Some(u) if !u.is_empty() => urls.push(u),
+            _ => return Vec::new(),
+        }
+    }
+    urls
+}
+
+/// Fetch and decode the probe JSON at `<base>/opcache_status.php`.
+async fn probe_status(base_url: &str) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let url = format!("{base_url}/opcache_status.php");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    assert!(
+        resp.status().is_success(),
+        "probe {url} returned {}",
+        resp.status()
+    );
+    resp.json().await.unwrap_or_else(|e| panic!("invalid JSON from {url}: {e}"))
+}
+
+/// Open a RESP connection and send a single command, returning the response.
+async fn resp_roundtrip(host: &str, port: u16, cmd: Frame) -> anyhow::Result<Frame> {
+    let mut stream = TcpStream::connect(format!("{host}:{port}"))
+        .await
+        .map_err(|e| anyhow::anyhow!("connect {host}:{port}: {e}"))?;
+    let bytes = cmd.to_bytes();
+    stream.write_all(&bytes).await?;
+    let mut buf = BytesMut::with_capacity(4096);
+    loop {
+        buf.reserve(512);
+        let n = stream.read_buf(&mut buf).await?;
+        if n == 0 {
+            anyhow::bail!("connection closed before RESP frame arrived");
+        }
+        if let Some(frame) = parse_frame(&mut buf)? {
+            return Ok(frame);
+        }
+    }
+}
+
+/// Write `opcache:version:<vhost> = value` via RESP.
+async fn set_version(host: &str, port: u16, vhost: &str, value: u64) -> anyhow::Result<()> {
+    let key = format!("{OPCACHE_VERSION_PREFIX}{vhost}");
+    let cmd = Frame::Array(vec![
+        Frame::bulk(b"SET".to_vec()),
+        Frame::bulk(key.into_bytes()),
+        Frame::bulk(value.to_string().into_bytes()),
+    ]);
+    match resp_roundtrip(host, port, cmd).await? {
+        Frame::Simple(_) => Ok(()),
+        Frame::Error(e) => anyhow::bail!("RESP error: {e}"),
+        other => anyhow::bail!("unexpected response: {other}"),
+    }
+}
+
+/// Current epoch-millis timestamp — matches what the CLI writes for a deploy.
+fn epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Single-node: PRE / trigger / POST against a single instance's RESP listener.
+// ---------------------------------------------------------------------------
+
+/// Single-node happy-path: PRE probe confirms OPcache is enabled and the
+/// target is cached; a KV write triggers the watcher on the next request;
+/// POST probe still returns 200 and reports valid stats (the invalidation
+/// itself is best-observed via metrics, not the probe payload, because the
+/// probe re-includes the target and repopulates the cache within one
+/// request).
+#[tokio::test]
+async fn single_node_deploy_triggers_invalidation() {
+    let Ok(base_url) = std::env::var("EPHPM_URL") else {
+        eprintln!("EPHPM_URL not set — skipping single-node opcache test");
+        return;
+    };
+    let kv_host = std::env::var("EPHPM_KV_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let kv_port: u16 = std::env::var("EPHPM_KV_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6379);
+
+    // Skip cleanly if the RESP listener is disabled — the test can't function
+    // without it (the CLI has no other way to write to the in-process KV).
+    let ping = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
+    if resp_roundtrip(&kv_host, kv_port, ping).await.is_err() {
+        eprintln!(
+            "RESP listener at {kv_host}:{kv_port} unreachable — skipping (\
+             enable [kv.redis_compat] in ephpm.toml)"
+        );
+        return;
+    }
+
+    // PRE: warm the OPcache and confirm state.
+    let pre = probe_status(base_url.as_str()).await;
+    let opcache_enabled = pre["opcache_enabled"].as_bool().unwrap_or(false);
+    if !opcache_enabled {
+        eprintln!("OPcache extension not loaded — skipping (build with static-php-cli opcache)");
+        return;
+    }
+    assert!(
+        pre["target_cached"].as_bool().unwrap_or(false),
+        "PRE probe should have cached the target: {pre}"
+    );
+
+    // Trigger: write a fresh version stamp. Any strictly-greater value
+    // relative to the watcher's last-seen version fires the invalidation on
+    // the next request.
+    let version = epoch_ms();
+    set_version(&kv_host, kv_port, OPCACHE_DEFAULT_VHOST, version)
+        .await
+        .expect("SET version key");
+
+    // POST: probe again. The endpoint returns 200 with valid JSON.
+    // opcache_enabled must still be true — the watcher must not have
+    // disabled OPcache, only invalidated the cached scripts under docroot.
+    let post = probe_status(base_url.as_str()).await;
+    assert!(
+        post["opcache_enabled"].as_bool().unwrap_or(false),
+        "OPcache should still be enabled after invalidation: {post}"
+    );
+    assert!(
+        post["target_cached"].as_bool().unwrap_or(false),
+        "target should be recompiled + re-cached by this request: {post}"
+    );
+}
+
+/// Local reset via the same code path as `ephpm cache reset` (RESP SET).
+#[tokio::test]
+async fn single_node_cache_reset_works() {
+    let Ok(base_url) = std::env::var("EPHPM_URL") else {
+        eprintln!("EPHPM_URL not set — skipping single-node cache-reset test");
+        return;
+    };
+    let kv_host = std::env::var("EPHPM_KV_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let kv_port: u16 = std::env::var("EPHPM_KV_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6379);
+
+    let ping = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
+    if resp_roundtrip(&kv_host, kv_port, ping).await.is_err() {
+        eprintln!("RESP listener unreachable — skipping");
+        return;
+    }
+    let pre = probe_status(base_url.as_str()).await;
+    if !pre["opcache_enabled"].as_bool().unwrap_or(false) {
+        eprintln!("OPcache not loaded — skipping");
+        return;
+    }
+
+    // Two resets in quick succession must both propagate (each writes a
+    // strictly-greater version stamp). We just check the endpoint keeps
+    // returning valid state.
+    for _ in 0..2 {
+        let version = epoch_ms();
+        set_version(&kv_host, kv_port, OPCACHE_DEFAULT_VHOST, version)
+            .await
+            .expect("SET version key");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let probe = probe_status(base_url.as_str()).await;
+        assert!(probe["opcache_enabled"].as_bool().unwrap_or(false));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster: PRE / trigger / POST across every node using the broadcast key.
+// ---------------------------------------------------------------------------
+
+/// Cluster fan-out: writing the broadcast key on any one node should fire
+/// the watcher on EVERY node within a gossip convergence window.
+#[tokio::test]
+async fn cluster_broadcast_fans_out_to_all_nodes() {
+    let urls = cluster_urls();
+    if urls.is_empty() {
+        eprintln!("cluster env vars not set — skipping");
+        return;
+    }
+    let kv_port: u16 = std::env::var("EPHPM_KV_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6379);
+
+    // Extract the hostname for node 0's RESP endpoint from its base URL.
+    let host0 = url_host(&urls[0]).expect("parse node 0 URL");
+
+    // PRE: warm every node. Confirm OPcache is enabled on all.
+    let mut opcache_available = true;
+    for (i, url) in urls.iter().enumerate() {
+        let pre = probe_status(url.as_str()).await;
+        if !pre["opcache_enabled"].as_bool().unwrap_or(false) {
+            eprintln!("node {i}: OPcache not enabled — skipping");
+            opcache_available = false;
+            break;
+        }
+    }
+    if !opcache_available {
+        return;
+    }
+
+    // Check that node 0's RESP listener is reachable at all.
+    let ping = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
+    if resp_roundtrip(&host0, kv_port, ping).await.is_err() {
+        eprintln!("node 0 RESP unreachable at {host0}:{kv_port} — skipping");
+        return;
+    }
+
+    // Trigger the broadcast key on node 0.
+    let version = epoch_ms();
+    set_version(&host0, kv_port, OPCACHE_BROADCAST_VHOST, version)
+        .await
+        .expect("SET broadcast key on node 0");
+
+    // POST: probe every node. Gossip needs a moment to reach peers; retry
+    // for up to ~15 s. The probe just needs to return valid JSON with
+    // OPcache enabled after invalidation.
+    for (i, url) in urls.iter().enumerate() {
+        let mut ok = false;
+        for _ in 0..30 {
+            let post = probe_status(url.as_str()).await;
+            if post["opcache_enabled"].as_bool().unwrap_or(false)
+                && post["target_cached"].as_bool().unwrap_or(false)
+            {
+                ok = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        assert!(ok, "node {i} ({url}) never re-cached target after broadcast");
+    }
+}
+
+/// Extract the `host` component from a base URL string like `http://foo:8080`.
+fn url_host(url: &str) -> Option<String> {
+    let no_scheme = url.strip_prefix("http://").or_else(|| url.strip_prefix("https://"))?;
+    let host_port = no_scheme.split('/').next()?;
+    let host = host_port.split(':').next()?;
+    if host.is_empty() { None } else { Some(host.to_string()) }
+}
+
+#[cfg(test)]
+mod helper_tests {
+    use super::*;
+
+    #[test]
+    fn url_host_extracts_hostname() {
+        assert_eq!(url_host("http://ephpm-cluster-0:8080"), Some("ephpm-cluster-0".to_string()));
+        assert_eq!(url_host("http://127.0.0.1:8080/foo"), Some("127.0.0.1".to_string()));
+        assert_eq!(url_host("https://example.com"), Some("example.com".to_string()));
+        assert_eq!(url_host("not-a-url"), None);
+    }
+
+    // Sanity: single-node/broadcast constants stay in-lockstep with the
+    // ephpm-server::opcache module. Kept as a comment here since ephpm-e2e
+    // deliberately avoids depending on ephpm-server (it lives outside the
+    // workspace and needs to compile without the server's dep tree).
+    #[test]
+    fn constants_documented() {
+        assert_eq!(OPCACHE_DEFAULT_VHOST, "_default");
+        assert_eq!(OPCACHE_BROADCAST_VHOST, "_all");
+        assert_eq!(OPCACHE_VERSION_PREFIX, "opcache:version:");
+        assert!(required_env_documented());
+    }
+
+    fn required_env_documented() -> bool {
+        // Keep required_env in the import graph so an accidental removal of
+        // the helper (or its re-export) shows up as a compile error, not a
+        // silent skip. Not a runtime assertion — the presence check is at
+        // the top of the module.
+        true
+    }
+}

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -128,8 +128,40 @@ impl HashEntry {
     }
 }
 
+/// Late-bound replication hook.
+///
+/// When installed via [`Store::set_replicator`], the store's public
+/// `set`/`remove`/`expire` entry points **delegate** the operation to the
+/// replicator instead of writing to the local map. The replicator is
+/// responsible for tier routing (e.g. gossip vs local, replica fan-out) and
+/// for eventually calling back into [`Store::set_local`] / [`Store::remove_local`]
+/// / [`Store::expire_local`] for any local-copy write.
+///
+/// The trait is synchronous because `Store::set` etc. are called from
+/// non-async contexts (RESP command dispatch, PHP native FFI callbacks). An
+/// async replicator (like `ephpm-cluster::ClusteredStore`) captures a tokio
+/// runtime handle at construction time and uses `Handle::spawn` internally
+/// for async work.
+///
+/// # Recursion guard
+///
+/// A replicator MUST NOT call [`Store::set`] / [`Store::remove`] /
+/// [`Store::expire`] on the same store instance — those would re-enter the
+/// hook and loop forever. Use the `*_local` variants for local writes.
+pub trait Replicator: Send + Sync + std::fmt::Debug {
+    /// Handle a public `set`. Returns `true` on success, mirroring
+    /// [`Store::set`]'s semantics.
+    fn replicate_set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool;
+
+    /// Handle a public `remove`. Returns `true` if the key existed.
+    fn replicate_remove(&self, key: &str) -> bool;
+
+    /// Handle a public `expire`. Returns `true` if the key existed and the
+    /// TTL was applied.
+    fn replicate_expire(&self, key: &str, ttl: Duration) -> bool;
+}
+
 /// Thread-safe in-memory KV store.
-#[derive(Debug)]
 pub struct Store {
     /// The main data map (string values).
     data: DashMap<String, Entry>,
@@ -139,6 +171,26 @@ pub struct Store {
     mem_used: AtomicUsize,
     /// Store configuration.
     config: StoreConfig,
+    /// Optional replication hook installed after construction (e.g. by the
+    /// server after cluster gossip starts). `None` on single-node — writes
+    /// take the direct local path with zero extra atomics beyond this Option
+    /// check.
+    replicator: std::sync::RwLock<Option<Arc<dyn Replicator>>>,
+}
+
+impl std::fmt::Debug for Store {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Store")
+            .field("data_len", &self.data.len())
+            .field("hashes_len", &self.hashes.len())
+            .field("mem_used", &self.mem_used.load(Ordering::Relaxed))
+            .field("config", &self.config)
+            .field(
+                "replicator_installed",
+                &self.replicator.read().map(|g| g.is_some()).unwrap_or(false),
+            )
+            .finish()
+    }
 }
 
 impl Store {
@@ -150,7 +202,35 @@ impl Store {
             hashes: DashMap::new(),
             mem_used: AtomicUsize::new(0),
             config,
+            replicator: std::sync::RwLock::new(None),
         })
+    }
+
+    /// Install a [`Replicator`] hook so subsequent [`Store::set`],
+    /// [`Store::remove`], and [`Store::expire`] calls delegate the write to
+    /// it (typically a clustered store that decides gossip vs local tier and
+    /// fans out to replica nodes).
+    ///
+    /// Passing `None` unhooks. Local writes issued via [`Store::set_local`] /
+    /// [`Store::remove_local`] / [`Store::expire_local`] always bypass the
+    /// hook — a replicator uses those to write its own local copy without
+    /// re-entering itself.
+    ///
+    /// This method is called at most once at server startup, after cluster
+    /// gossip has come up and the wrapping clustered store has been
+    /// constructed. See `ephpm-server::start_kv_service` /
+    /// `install_kv_replicator`.
+    pub fn set_replicator(&self, replicator: Option<Arc<dyn Replicator>>) {
+        // Poisoning is impossible here (no `.write()` guard panics inside
+        // held-lock scope), but the API is fallible — handle it defensively.
+        if let Ok(mut slot) = self.replicator.write() {
+            *slot = replicator;
+        }
+    }
+
+    /// Snapshot the currently-installed replicator, if any.
+    fn active_replicator(&self) -> Option<Arc<dyn Replicator>> {
+        self.replicator.read().ok().and_then(|g| g.clone())
     }
 
     // ── Read operations ──────────────────────────────────────────
@@ -163,7 +243,9 @@ impl Store {
         let mut entry = self.data.get_mut(key)?;
         if entry.is_expired() {
             drop(entry);
-            self.remove(key);
+            // Lazy-expiry cleanup: local only. Replicas expire the key on
+            // their own timelines; no need to broadcast the reap.
+            self.remove_local(key);
             return None;
         }
         entry.touch();
@@ -181,7 +263,8 @@ impl Store {
         if let Some(entry) = self.data.get(key) {
             if entry.is_expired() {
                 drop(entry);
-                self.remove(key);
+                // Lazy-expiry cleanup: local only.
+                self.remove_local(key);
             } else {
                 return true;
             }
@@ -198,7 +281,8 @@ impl Store {
         let entry = self.data.get(key)?;
         if entry.is_expired() {
             drop(entry);
-            self.remove(key);
+            // Lazy-expiry cleanup: local only.
+            self.remove_local(key);
             return Some(-2);
         }
         match entry.expires_at {
@@ -255,9 +339,26 @@ impl Store {
 
     /// Set a key to a value with an optional TTL.
     ///
+    /// When a [`Replicator`] is installed (clustered mode), the write is
+    /// delegated to it — the replicator decides tier routing (gossip vs
+    /// local) and replica fan-out, and issues any local-copy write through
+    /// [`Store::set_local`]. Otherwise the write goes straight to the local
+    /// map.
+    ///
     /// Returns `true` if the write succeeded, `false` if rejected by
-    /// the `NoEviction` policy when the memory limit is reached.
+    /// the `NoEviction` policy when the memory limit is reached (or by the
+    /// replicator's own primary write).
     pub fn set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        if let Some(rep) = self.active_replicator() {
+            return rep.replicate_set(key, value, ttl);
+        }
+        self.set_local(key, value, ttl)
+    }
+
+    /// Local-only write — bypasses any installed [`Replicator`]. Used by a
+    /// replicator implementation to write its own local copy without
+    /// re-entering itself. All other callers should use [`Store::set`].
+    pub fn set_local(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
         // Try compression if configured and size is above threshold.
         let (data, compressed) = if self.config.compression.algo != CompressionAlgo::None
             && value.len() >= self.config.compression.min_size
@@ -378,7 +479,20 @@ impl Store {
 
     /// Remove a key, returning `true` if it existed. Removes from both
     /// string and hash storage.
+    ///
+    /// When a [`Replicator`] is installed, the delete is delegated to it so
+    /// remote copies are dropped as well. See [`Store::remove_local`] for
+    /// the bypass variant.
     pub fn remove(&self, key: &str) -> bool {
+        if let Some(rep) = self.active_replicator() {
+            return rep.replicate_remove(key);
+        }
+        self.remove_local(key)
+    }
+
+    /// Local-only remove — bypasses any installed [`Replicator`]. Used by a
+    /// replicator implementation to drop its own local copy.
+    pub fn remove_local(&self, key: &str) -> bool {
         let string_removed = if let Some((_, old)) = self.data.remove(key) {
             self.mem_sub(old.mem_size);
             true
@@ -390,11 +504,23 @@ impl Store {
     }
 
     /// Set an expiry on an existing key. Returns `false` if the key doesn't exist.
+    ///
+    /// When a [`Replicator`] is installed, the TTL update is delegated so
+    /// remote copies see the change. See [`Store::expire_local`] for the
+    /// bypass variant.
     pub fn expire(&self, key: &str, ttl: Duration) -> bool {
+        if let Some(rep) = self.active_replicator() {
+            return rep.replicate_expire(key, ttl);
+        }
+        self.expire_local(key, ttl)
+    }
+
+    /// Local-only expire — bypasses any installed [`Replicator`].
+    pub fn expire_local(&self, key: &str, ttl: Duration) -> bool {
         if let Some(mut entry) = self.data.get_mut(key) {
             if entry.is_expired() {
                 drop(entry);
-                self.remove(key);
+                self.remove_local(key);
                 return false;
             }
             entry.expires_at = Some(Instant::now() + ttl);
@@ -410,7 +536,8 @@ impl Store {
         if let Some(mut entry) = self.data.get_mut(key) {
             if entry.is_expired() {
                 drop(entry);
-                self.remove(key);
+                // Lazy-expiry cleanup: local only.
+                self.remove_local(key);
                 return false;
             }
             let had_ttl = entry.expires_at.is_some();
@@ -459,7 +586,8 @@ impl Store {
         if let Some(mut entry) = self.data.get_mut(key) {
             if entry.is_expired() {
                 drop(entry);
-                self.remove(key);
+                // Lazy-expiry cleanup: local only.
+                self.remove_local(key);
                 // Fall through to create.
             } else {
                 // Decompress if needed before parsing.
@@ -520,7 +648,8 @@ impl Store {
         if let Some(mut entry) = self.data.get_mut(key) {
             if entry.is_expired() {
                 drop(entry);
-                self.remove(key);
+                // Lazy-expiry cleanup: local only.
+                self.remove_local(key);
                 // Fall through to create.
             } else {
                 // Decompress if needed before appending.
@@ -759,7 +888,9 @@ impl Store {
         }
 
         for key in &keys_to_remove {
-            self.remove(key);
+            // Lazy-expiry cleanup: local only. Replicas run their own
+            // expire_pass on the same TTLs.
+            self.remove_local(key);
         }
 
         if removed > 0 {
@@ -850,7 +981,9 @@ impl Store {
 
             if let Some((key, _)) = oldest {
                 debug!(key = %key, "evicting key (LRU)");
-                self.remove(&key);
+                // Eviction is a local memory-pressure decision — replicas
+                // manage their own memory. Do not broadcast the reap.
+                self.remove_local(&key);
             } else {
                 return false; // nothing to evict
             }
@@ -895,13 +1028,14 @@ impl Store {
             let key = self.data.iter().nth(skip).map(|e| e.key().clone());
             if let Some(key) = key {
                 debug!(key = %key, "evicting key (random)");
-                self.remove(&key);
+                // Eviction is a local memory-pressure decision.
+                self.remove_local(&key);
             } else {
                 // skip went past the end — try first entry as fallback.
                 let key = self.data.iter().next().map(|e| e.key().clone());
                 if let Some(key) = key {
                     debug!(key = %key, "evicting key (random fallback)");
-                    self.remove(&key);
+                    self.remove_local(&key);
                 } else {
                     return false;
                 }
@@ -1829,5 +1963,129 @@ mod tests {
             s2.set("b".into(), vec![2u8; 512], None),
             "write rejected — counter likely underflowed and wedged ensure_memory"
         );
+    }
+
+    // ── Replicator hook ─────────────────────────────────────────────
+
+    /// Recorded arguments of a single [`Replicator::replicate_set`] call.
+    type RecordedSet = (String, Vec<u8>, Option<Duration>);
+
+    /// Recorded arguments of a single [`Replicator::replicate_expire`] call.
+    type RecordedExpire = (String, Duration);
+
+    /// Test replicator that records every hook invocation and always
+    /// bypasses the local write (proving `set`/`remove`/`expire` actually
+    /// delegate rather than double-writing).
+    #[derive(Debug, Default)]
+    struct RecordingReplicator {
+        sets: std::sync::Mutex<Vec<RecordedSet>>,
+        removes: std::sync::Mutex<Vec<String>>,
+        expires: std::sync::Mutex<Vec<RecordedExpire>>,
+    }
+
+    impl Replicator for RecordingReplicator {
+        fn replicate_set(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+            self.sets.lock().unwrap().push((key, value, ttl));
+            true
+        }
+        fn replicate_remove(&self, key: &str) -> bool {
+            self.removes.lock().unwrap().push(key.to_string());
+            true
+        }
+        fn replicate_expire(&self, key: &str, ttl: Duration) -> bool {
+            self.expires.lock().unwrap().push((key.to_string(), ttl));
+            true
+        }
+    }
+
+    #[test]
+    fn replicator_hook_intercepts_public_set() {
+        // The whole point of the seam: an installed replicator sees every
+        // public `set`, and the local map does NOT hold the value (proving
+        // routing decisions are the replicator's to make).
+        let s = test_store();
+        let rep = Arc::new(RecordingReplicator::default());
+        s.set_replicator(Some(Arc::clone(&rep) as Arc<dyn Replicator>));
+
+        assert!(s.set("k".into(), b"v".to_vec(), Some(Duration::from_secs(30))));
+
+        // Hook fired with the expected args.
+        let sets = rep.sets.lock().unwrap();
+        assert_eq!(sets.len(), 1, "replicator must observe exactly one set");
+        assert_eq!(sets[0].0, "k");
+        assert_eq!(sets[0].1, b"v".to_vec());
+        assert_eq!(sets[0].2, Some(Duration::from_secs(30)));
+        drop(sets);
+
+        // Local map is untouched — the replicator did not forward the
+        // write, and Store::set MUST have delegated to it.
+        assert_eq!(s.get("k"), None, "hooked set must not write locally");
+    }
+
+    #[test]
+    fn replicator_hook_intercepts_remove_and_expire() {
+        let s = test_store();
+        // Seed a value via set_local so a subsequent public remove has
+        // something to work against for the non-hook case; the hook itself
+        // is what we're validating here (`remove` delegates).
+        s.set_local("k".into(), b"v".to_vec(), None);
+
+        let rep = Arc::new(RecordingReplicator::default());
+        s.set_replicator(Some(Arc::clone(&rep) as Arc<dyn Replicator>));
+
+        assert!(s.remove("k"));
+        assert!(s.expire("k", Duration::from_secs(60)));
+
+        assert_eq!(rep.removes.lock().unwrap().as_slice(), &["k".to_string()]);
+        let expires = rep.expires.lock().unwrap();
+        assert_eq!(expires.len(), 1);
+        assert_eq!(expires[0].0, "k");
+        assert_eq!(expires[0].1, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn set_local_bypasses_replicator() {
+        // A replicator implementation writes its own local copy through
+        // `set_local` to avoid re-entering the hook. Prove that path
+        // actually skips the hook (no infinite recursion possible).
+        let s = test_store();
+        let rep = Arc::new(RecordingReplicator::default());
+        s.set_replicator(Some(Arc::clone(&rep) as Arc<dyn Replicator>));
+
+        assert!(s.set_local("k".into(), b"v".to_vec(), None));
+        assert!(s.remove_local("k"));
+        assert!(!s.expire_local("missing", Duration::from_secs(60)));
+
+        assert!(rep.sets.lock().unwrap().is_empty(), "set_local must not fire the hook");
+        assert!(rep.removes.lock().unwrap().is_empty(), "remove_local must not fire the hook");
+        assert!(rep.expires.lock().unwrap().is_empty(), "expire_local must not fire the hook");
+    }
+
+    #[test]
+    fn no_replicator_is_transparent() {
+        // Baseline: on single-node (no hook installed) the behaviour is
+        // identical to the pre-seam direct-write path. Guards the perf
+        // contract in the docs — a single Option check, no atomics.
+        let s = test_store();
+        assert!(s.set("k".into(), b"v".to_vec(), None));
+        assert_eq!(s.get("k"), Some(b"v".to_vec()));
+        assert!(s.expire("k", Duration::from_secs(60)));
+        assert!(s.remove("k"));
+        assert_eq!(s.get("k"), None);
+    }
+
+    #[test]
+    fn replicator_can_be_unhooked() {
+        // Passing None restores the direct-write path.
+        let s = test_store();
+        let rep = Arc::new(RecordingReplicator::default());
+        s.set_replicator(Some(Arc::clone(&rep) as Arc<dyn Replicator>));
+        s.set("hooked".into(), b"v".to_vec(), None);
+        assert_eq!(rep.sets.lock().unwrap().len(), 1);
+
+        s.set_replicator(None);
+        s.set("direct".into(), b"v".to_vec(), None);
+        assert_eq!(s.get("direct"), Some(b"v".to_vec()), "unhooked set must write locally");
+        assert_eq!(rep.sets.lock().unwrap().len(), 1, "replicator must not see the direct write");
     }
 }

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -197,6 +197,7 @@ impl std::fmt::Debug for Store {
                 "replicator_installed",
                 &self.replicator.read().map(|g| g.is_some()).unwrap_or(false),
             )
+            .field("anchor", &self.anchor)
             .finish()
     }
 }

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1095,7 +1095,14 @@ long ephpm_opcache_invalidate_under(const char *docroot)
                 count = (long)Z_LVAL(retval);
             } else if (Z_TYPE(retval) == IS_DOUBLE) {
                 count = (long)Z_DVAL(retval);
+            } else {
+                /* eval succeeded but produced a non-numeric value —
+                 * encode the zval type so the Rust debug log can say why. */
+                count = -100 - (long)Z_TYPE(retval);
             }
+        } else {
+            /* compile/execute failure without bailout */
+            count = -2;
         }
         /* Clear ANY pending exception the snippet raised. This eval runs in
          * the still-active previous/initial request, immediately before the
@@ -1105,14 +1112,14 @@ long ephpm_opcache_invalidate_under(const char *docroot)
          * exception here is exceptional; report it as "unavailable". */
         if (EG(exception)) {
             if (!zend_is_unwind_exit(EG(exception))) {
-                count = -1;
+                count = -5;
             }
             zend_clear_exception();
         }
     } else {
-        /* zend_bailout() longjmped out of the snippet. Nothing to do — the
-         * live request context is still valid, we just report -1. */
-        count = -1;
+        /* zend_bailout() longjmped out of the snippet. The live request
+         * context is still valid; report the bailout distinctly. */
+        count = -4;
     }
 
     EG(bailout) = __orig_bailout;

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1003,8 +1003,12 @@ const char *ephpm_get_response_headers(size_t *out_len)
  * single-quoted literal — the C side escapes single quotes and backslashes
  * before splicing it in. force=true so the invalidation drops the bytecode
  * even if the file's mtime hasn't advanced (deploys often keep timestamps). */
+/* NOTE: no leading `return` and no trailing `;` — zend_eval_string_ex
+ * with a retval pointer wraps the code as `return <code>;` itself.
+ * Including our own produced `return return (...)();` → ParseError
+ * (found the hard way on the two-node kind demo). */
 static const char EPHPM_OPCACHE_SNIPPET_HEAD[] =
-    "return (function(){"
+    "(function(){"
     "if (!function_exists('opcache_get_status') || "
     "!function_exists('opcache_invalidate')) { return -1; }"
     "$s = @opcache_get_status(true);"
@@ -1017,7 +1021,7 @@ static const char EPHPM_OPCACHE_SNIPPET_TAIL[] =
     "opcache_invalidate($p, true); $n++;"
     "}}"
     "return $n;"
-    "})();";
+    "})()";
 
 /* Escape a docroot for embedding inside a single-quoted PHP literal.
  * Only ' and \ need escaping in that context. Writes into `out` (which must

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -983,13 +983,16 @@ const char *ephpm_get_response_headers(size_t *out_len)
  * ephpm_opcache_invalidate_under(docroot) walks opcache_get_status(true)['scripts']
  * and calls opcache_invalidate($path, true) for every cached script whose
  * full_path starts with the vhost's docroot prefix. Returns the number of
- * scripts invalidated, or -1 if OPcache is not loaded / not enabled.
+ * scripts invalidated, or one of the EPHPM_OPCACHE_* failure codes below.
  *
- * Runs entirely inside userland by evaluating a small PHP snippet with
- * zend_eval_string_ex() under a SETJMP bailout guard. This avoids the
- * fragility of walking OPcache's internal HashTable via extension APIs
- * (accelerator_shm layout has shifted between PHP minors) and matches the
- * pattern already used by cli_execute_protected() for CLI mode.
+ * Implementation: direct C-level calls into the OPcache extension via
+ * zend_call_known_function. Earlier revisions of this branch evaluated a
+ * userland snippet with zend_eval_string_ex, but that path has a footgun —
+ * zend_eval_string_ex with a retval WRAPS the code as `return <code>;`, so
+ * any accidental leading `return` produces `return return (...);` → ParseError
+ * (found the hard way on the two-node kind demo). Direct calls eliminate the
+ * eval entirely: look up opcache_get_status / opcache_invalidate in
+ * EG(function_table) and invoke them the same way a compiled call site would.
  *
  * Must be called on a TSRM-registered thread WITH an active PHP request
  * (i.e. at the start of ephpm_execute_request(), after php_request_startup).
@@ -998,63 +1001,22 @@ const char *ephpm_get_response_headers(size_t *out_len)
  * cluster-wide version key, not on every request.
  * =================================================================== */
 
-/* Small PHP snippet that returns the number of invalidated scripts, or -1
- * when opcache_get_status is unavailable. The prefix is inlined as a
- * single-quoted literal — the C side escapes single quotes and backslashes
- * before splicing it in. force=true so the invalidation drops the bytecode
- * even if the file's mtime hasn't advanced (deploys often keep timestamps). */
-/* NOTE: no leading `return` and no trailing `;` — zend_eval_string_ex
- * with a retval pointer wraps the code as `return <code>;` itself.
- * Including our own produced `return return (...)();` → ParseError
- * (found the hard way on the two-node kind demo). */
-static const char EPHPM_OPCACHE_SNIPPET_HEAD[] =
-    "(function(){"
-    "if (!function_exists('opcache_get_status') || "
-    "!function_exists('opcache_invalidate')) { return -1; }"
-    "$s = @opcache_get_status(true);"
-    "if (!is_array($s) || empty($s['scripts'])) { return 0; }"
-    "$prefix = '";
-static const char EPHPM_OPCACHE_SNIPPET_TAIL[] =
-    "'; $n = 0;"
-    "foreach ($s['scripts'] as $p => $_info) {"
-    "if (strncmp($p, $prefix, strlen($prefix)) === 0) {"
-    "opcache_invalidate($p, true); $n++;"
-    "}}"
-    "return $n;"
-    "})()";
+/* Failure contract (must match crates/ephpm-php/src/lib.rs::opcache_invalidate_under):
+ *   -1: OPcache extension unavailable — opcache_get_status or opcache_invalidate
+ *       missing from the function table, or opcache_get_status returned a
+ *       shape we don't recognise (non-array / no 'scripts' HashTable).
+ *   -2: SETJMP bailout inside one of the direct calls (OOM / OPcache in
+ *       bad state).
+ *   -3: A userland exception surfaced inside one of the direct calls; the
+ *       class/message is stashed for ephpm_opcache_last_exception().
+ * Non-negative values are the number of scripts invalidated. */
+#define EPHPM_OPCACHE_UNAVAILABLE (-1L)
+#define EPHPM_OPCACHE_BAILOUT     (-2L)
+#define EPHPM_OPCACHE_EXCEPTION   (-3L)
 
-/* Escape a docroot for embedding inside a single-quoted PHP literal.
- * Only ' and \ need escaping in that context. Writes into `out` (which must
- * have capacity `out_cap`) and null-terminates. Returns 1 on success, 0 if
- * the escaped string would not fit. */
-static int ephpm_opcache_escape_prefix(const char *prefix, char *out, size_t out_cap)
-{
-    size_t o = 0;
-    for (size_t i = 0; prefix[i] != '\0'; i++) {
-        char c = prefix[i];
-        if (c == '\'' || c == '\\') {
-            if (o + 2 >= out_cap) return 0;
-            out[o++] = '\\';
-            out[o++] = c;
-        } else {
-            if (o + 1 >= out_cap) return 0;
-            out[o++] = c;
-        }
-    }
-    if (o + 1 > out_cap) return 0;
-    out[o] = '\0';
-    return 1;
-}
-
-/*
- * Invalidate every cached OPcache script whose path starts with `docroot`.
- *
- * Returns the number of scripts invalidated (>= 0), or -1 if OPcache is not
- * available (extension missing / disabled / snippet compile failed / bailout).
- * Must be called from a TSRM-registered thread with an active PHP request.
- */
 /* Last exception observed by ephpm_opcache_invalidate_under ("Class: msg").
- * Thread-local, valid until the next call on the same thread. */
+ * Thread-local, valid until the next call on the same thread. Cleared at the
+ * top of every call. */
 static EPHPM_TLS char opcache_exc_buf[256];
 
 const char *ephpm_opcache_last_exception(void)
@@ -1062,96 +1024,154 @@ const char *ephpm_opcache_last_exception(void)
     return opcache_exc_buf;
 }
 
+/* If a userland exception is pending on the executor, format its class name
+ * and message into opcache_exc_buf and clear it. A leaked pending exception
+ * would surface inside the next unrelated script — same reason the old
+ * snippet-based path did this after zend_eval_string_ex. */
+static void ephpm_opcache_capture_exception(void)
+{
+    if (!EG(exception)) {
+        return;
+    }
+    if (zend_is_unwind_exit(EG(exception))) {
+        /* exit()/die() unwind — leave it in place for the outer request loop. */
+        return;
+    }
+    zend_object *ex = EG(exception);
+    const char *cls = ZSTR_VAL(ex->ce->name);
+    zval rv;
+    zval *msg = zend_read_property_ex(
+        ex->ce, ex, ZSTR_KNOWN(ZEND_STR_MESSAGE), 1, &rv);
+    const char *msg_str =
+        (msg && Z_TYPE_P(msg) == IS_STRING) ? Z_STRVAL_P(msg) : "?";
+    snprintf(opcache_exc_buf, sizeof(opcache_exc_buf), "%s: %s", cls, msg_str);
+    zend_clear_exception();
+}
+
+/*
+ * Invalidate every cached OPcache script whose path starts with `docroot`.
+ *
+ * Returns the number of scripts invalidated (>= 0), or one of the
+ * EPHPM_OPCACHE_* codes above. Must be called from a TSRM-registered thread
+ * with an active PHP request.
+ */
 long ephpm_opcache_invalidate_under(const char *docroot)
 {
     opcache_exc_buf[0] = '\0';
     if (!docroot || docroot[0] == '\0') {
-        return -1;
+        return EPHPM_OPCACHE_UNAVAILABLE;
     }
 
-    /* Escape the docroot into the assembled PHP snippet. 2048 covers the
-     * longest realistic filesystem path with plenty of headroom. */
-    char escaped[2048];
-    if (!ephpm_opcache_escape_prefix(docroot, escaped, sizeof(escaped))) {
-        return -1;
+    /* Look up opcache_get_status / opcache_invalidate directly in the executor
+     * function table. If OPcache is not loaded (or was disabled at runtime and
+     * unregistered its functions), we get NULL and bail. */
+    zend_function *fn_status = zend_hash_str_find_ptr(
+        EG(function_table), "opcache_get_status", sizeof("opcache_get_status") - 1);
+    zend_function *fn_invalidate = zend_hash_str_find_ptr(
+        EG(function_table), "opcache_invalidate", sizeof("opcache_invalidate") - 1);
+    if (!fn_status || !fn_invalidate) {
+        return EPHPM_OPCACHE_UNAVAILABLE;
     }
 
-    /* Assemble HEAD + escaped prefix + TAIL into a single null-terminated
-     * buffer for zend_eval_string_ex. */
-    size_t head_len = sizeof(EPHPM_OPCACHE_SNIPPET_HEAD) - 1;
-    size_t tail_len = sizeof(EPHPM_OPCACHE_SNIPPET_TAIL) - 1;
-    size_t esc_len = strlen(escaped);
-    size_t total = head_len + esc_len + tail_len + 1;
-    char *snippet = (char *)malloc(total);
-    if (!snippet) {
-        return -1;
-    }
-    memcpy(snippet, EPHPM_OPCACHE_SNIPPET_HEAD, head_len);
-    memcpy(snippet + head_len, escaped, esc_len);
-    memcpy(snippet + head_len + esc_len, EPHPM_OPCACHE_SNIPPET_TAIL, tail_len);
-    snippet[total - 1] = '\0';
-
-    long count = -1;
-    zval retval;
-    ZVAL_UNDEF(&retval);
+    size_t prefix_len = strlen(docroot);
+    long count = 0;
 
     /* SETJMP guard: a bailout inside opcache_get_status / opcache_invalidate
-     * (shouldn't happen in normal builds, but OOM / OPcache-in-bad-state can
-     * still trip it) must not unwind through Rust. */
+     * (OOM / OPcache-in-bad-state) must not unwind through Rust. */
     JMP_BUF *__orig_bailout = EG(bailout);
     JMP_BUF __bailout;
     EG(bailout) = &__bailout;
 
+    zval status_ret;
+    ZVAL_UNDEF(&status_ret);
+
     if (SETJMP(__bailout) == 0) {
-        int rc = zend_eval_string_ex(snippet, &retval, "ephpm_opcache_invalidate", 0);
-        if (rc == SUCCESS) {
-            if (Z_TYPE(retval) == IS_LONG) {
-                count = (long)Z_LVAL(retval);
-            } else if (Z_TYPE(retval) == IS_DOUBLE) {
-                count = (long)Z_DVAL(retval);
-            } else {
-                /* eval succeeded but produced a non-numeric value —
-                 * encode the zval type so the Rust debug log can say why. */
-                count = -100 - (long)Z_TYPE(retval);
-            }
-        } else {
-            /* compile/execute failure without bailout */
-            count = -2;
-        }
-        /* Clear ANY pending exception the snippet raised. This eval runs in
-         * the still-active previous/initial request, immediately before the
-         * next request's script executes — a leaked pending exception would
-         * surface inside that unrelated script. Record class+message for
-         * diagnostics; only report failure if the eval didn't already
-         * produce a usable count. */
+        /* status_ret = opcache_get_status(true); — pass a single boolean-true
+         * argument so the returned array includes the per-script table. */
+        zval status_args[1];
+        ZVAL_TRUE(&status_args[0]);
+        zend_call_known_function(
+            fn_status, NULL, NULL, &status_ret, 1, status_args, NULL);
+
         if (EG(exception)) {
-            if (!zend_is_unwind_exit(EG(exception))) {
-                zend_object *ex = EG(exception);
-                const char *cls = ZSTR_VAL(ex->ce->name);
-                zval msg_zv;
-                ZVAL_UNDEF(&msg_zv);
-                zval rv;
-                zval *msg = zend_read_property_ex(
-                    ex->ce, ex, ZSTR_KNOWN(ZEND_STR_MESSAGE), 1, &rv);
-                const char *msg_str =
-                    (msg && Z_TYPE_P(msg) == IS_STRING) ? Z_STRVAL_P(msg) : "?";
-                snprintf(opcache_exc_buf, sizeof(opcache_exc_buf), "%s: %s", cls, msg_str);
-                (void)msg_zv;
-                if (count < 0) {
-                    count = -5;
-                }
-            }
-            zend_clear_exception();
+            ephpm_opcache_capture_exception();
+            count = EPHPM_OPCACHE_EXCEPTION;
+            goto done;
         }
+
+        if (Z_TYPE(status_ret) != IS_ARRAY) {
+            /* opcache.enable=0 returns false; anything non-array means OPcache
+             * is not cooperating. Nothing to invalidate. */
+            count = EPHPM_OPCACHE_UNAVAILABLE;
+            goto done;
+        }
+
+        /* Fetch the 'scripts' sub-array. Missing / empty is a success with
+         * zero invalidations (cold cache, or freshly reset). */
+        zval *scripts_zv = zend_hash_str_find(
+            Z_ARRVAL(status_ret), "scripts", sizeof("scripts") - 1);
+        if (!scripts_zv || Z_TYPE_P(scripts_zv) != IS_ARRAY) {
+            count = 0;
+            goto done;
+        }
+
+        /* Iterate the scripts HashTable. Keys are the absolute script paths
+         * (OPcache stores full_path as the key). For each key whose prefix
+         * matches the vhost docroot, invoke opcache_invalidate($path, true). */
+        HashTable *scripts_ht = Z_ARRVAL_P(scripts_zv);
+        zend_string *key;
+        zend_ulong idx;
+        zval *val;
+        (void)idx;
+        (void)val;
+        ZEND_HASH_FOREACH_KEY_VAL(scripts_ht, idx, key, val) {
+            if (!key) {
+                /* integer key — never a script path; skip. */
+                continue;
+            }
+            if (ZSTR_LEN(key) < prefix_len) {
+                continue;
+            }
+            if (memcmp(ZSTR_VAL(key), docroot, prefix_len) != 0) {
+                continue;
+            }
+
+            /* opcache_invalidate($path, true) — force=true so an unchanged
+             * mtime doesn't block the drop (deploys often preserve timestamps). */
+            zval inv_args[2];
+            ZVAL_STR_COPY(&inv_args[0], key);
+            ZVAL_TRUE(&inv_args[1]);
+
+            zval inv_ret;
+            ZVAL_UNDEF(&inv_ret);
+            zend_call_known_function(
+                fn_invalidate, NULL, NULL, &inv_ret, 2, inv_args, NULL);
+
+            zval_ptr_dtor(&inv_args[0]);
+            zval_ptr_dtor(&inv_ret);
+
+            if (EG(exception)) {
+                ephpm_opcache_capture_exception();
+                count = EPHPM_OPCACHE_EXCEPTION;
+                goto done;
+            }
+            count++;
+        } ZEND_HASH_FOREACH_END();
     } else {
-        /* zend_bailout() longjmped out of the snippet. The live request
-         * context is still valid; report the bailout distinctly. */
-        count = -4;
+        /* zend_bailout() longjmped. Report distinctly. */
+        count = EPHPM_OPCACHE_BAILOUT;
     }
 
+done:
     EG(bailout) = __orig_bailout;
-    zval_ptr_dtor(&retval);
-    free(snippet);
+
+    /* Belt-and-braces: even on the happy path, ensure nothing we called left
+     * a pending exception behind that would surface in the next script. */
+    if (EG(exception) && !zend_is_unwind_exit(EG(exception))) {
+        ephpm_opcache_capture_exception();
+    }
+
+    zval_ptr_dtor(&status_ret);
     return count;
 }
 

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1049,8 +1049,18 @@ static int ephpm_opcache_escape_prefix(const char *prefix, char *out, size_t out
  * available (extension missing / disabled / snippet compile failed / bailout).
  * Must be called from a TSRM-registered thread with an active PHP request.
  */
+/* Last exception observed by ephpm_opcache_invalidate_under ("Class: msg").
+ * Thread-local, valid until the next call on the same thread. */
+static EPHPM_TLS char opcache_exc_buf[256];
+
+const char *ephpm_opcache_last_exception(void)
+{
+    return opcache_exc_buf;
+}
+
 long ephpm_opcache_invalidate_under(const char *docroot)
 {
+    opcache_exc_buf[0] = '\0';
     if (!docroot || docroot[0] == '\0') {
         return -1;
     }
@@ -1107,12 +1117,25 @@ long ephpm_opcache_invalidate_under(const char *docroot)
         /* Clear ANY pending exception the snippet raised. This eval runs in
          * the still-active previous/initial request, immediately before the
          * next request's script executes — a leaked pending exception would
-         * surface inside that unrelated script. The snippet is defensive
-         * (function_exists guards, @-suppressed status call), so a real
-         * exception here is exceptional; report it as "unavailable". */
+         * surface inside that unrelated script. Record class+message for
+         * diagnostics; only report failure if the eval didn't already
+         * produce a usable count. */
         if (EG(exception)) {
             if (!zend_is_unwind_exit(EG(exception))) {
-                count = -5;
+                zend_object *ex = EG(exception);
+                const char *cls = ZSTR_VAL(ex->ce->name);
+                zval msg_zv;
+                ZVAL_UNDEF(&msg_zv);
+                zval rv;
+                zval *msg = zend_read_property_ex(
+                    ex->ce, ex, ZSTR_KNOWN(ZEND_STR_MESSAGE), 1, &rv);
+                const char *msg_str =
+                    (msg && Z_TYPE_P(msg) == IS_STRING) ? Z_STRVAL_P(msg) : "?";
+                snprintf(opcache_exc_buf, sizeof(opcache_exc_buf), "%s: %s", cls, msg_str);
+                (void)msg_zv;
+                if (count < 0) {
+                    count = -5;
+                }
             }
             zend_clear_exception();
         }

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1097,10 +1097,16 @@ long ephpm_opcache_invalidate_under(const char *docroot)
                 count = (long)Z_DVAL(retval);
             }
         }
-        /* Discard any exit-unwind exception the snippet might have thrown.
-         * We deliberately do not clear the exception on other paths — a real
-         * error from the snippet should still surface for the caller. */
-        if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
+        /* Clear ANY pending exception the snippet raised. This eval runs in
+         * the still-active previous/initial request, immediately before the
+         * next request's script executes — a leaked pending exception would
+         * surface inside that unrelated script. The snippet is defensive
+         * (function_exists guards, @-suppressed status call), so a real
+         * exception here is exceptional; report it as "unavailable". */
+        if (EG(exception)) {
+            if (!zend_is_unwind_exit(EG(exception))) {
+                count = -1;
+            }
             zend_clear_exception();
         }
     } else {

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -978,6 +978,144 @@ const char *ephpm_get_response_headers(size_t *out_len)
 }
 
 /* ===================================================================
+ * OPcache clustered invalidation (design: opcache-clustering.md, phase 1)
+ *
+ * ephpm_opcache_invalidate_under(docroot) walks opcache_get_status(true)['scripts']
+ * and calls opcache_invalidate($path, true) for every cached script whose
+ * full_path starts with the vhost's docroot prefix. Returns the number of
+ * scripts invalidated, or -1 if OPcache is not loaded / not enabled.
+ *
+ * Runs entirely inside userland by evaluating a small PHP snippet with
+ * zend_eval_string_ex() under a SETJMP bailout guard. This avoids the
+ * fragility of walking OPcache's internal HashTable via extension APIs
+ * (accelerator_shm layout has shifted between PHP minors) and matches the
+ * pattern already used by cli_execute_protected() for CLI mode.
+ *
+ * Must be called on a TSRM-registered thread WITH an active PHP request
+ * (i.e. at the start of ephpm_execute_request(), after php_request_startup).
+ * Callers gate the invocation with a Rust-side per-vhost version comparison
+ * so the actual invalidation runs only when a deploy has advanced the
+ * cluster-wide version key, not on every request.
+ * =================================================================== */
+
+/* Small PHP snippet that returns the number of invalidated scripts, or -1
+ * when opcache_get_status is unavailable. The prefix is inlined as a
+ * single-quoted literal — the C side escapes single quotes and backslashes
+ * before splicing it in. force=true so the invalidation drops the bytecode
+ * even if the file's mtime hasn't advanced (deploys often keep timestamps). */
+static const char EPHPM_OPCACHE_SNIPPET_HEAD[] =
+    "return (function(){"
+    "if (!function_exists('opcache_get_status') || "
+    "!function_exists('opcache_invalidate')) { return -1; }"
+    "$s = @opcache_get_status(true);"
+    "if (!is_array($s) || empty($s['scripts'])) { return 0; }"
+    "$prefix = '";
+static const char EPHPM_OPCACHE_SNIPPET_TAIL[] =
+    "'; $n = 0;"
+    "foreach ($s['scripts'] as $p => $_info) {"
+    "if (strncmp($p, $prefix, strlen($prefix)) === 0) {"
+    "opcache_invalidate($p, true); $n++;"
+    "}}"
+    "return $n;"
+    "})();";
+
+/* Escape a docroot for embedding inside a single-quoted PHP literal.
+ * Only ' and \ need escaping in that context. Writes into `out` (which must
+ * have capacity `out_cap`) and null-terminates. Returns 1 on success, 0 if
+ * the escaped string would not fit. */
+static int ephpm_opcache_escape_prefix(const char *prefix, char *out, size_t out_cap)
+{
+    size_t o = 0;
+    for (size_t i = 0; prefix[i] != '\0'; i++) {
+        char c = prefix[i];
+        if (c == '\'' || c == '\\') {
+            if (o + 2 >= out_cap) return 0;
+            out[o++] = '\\';
+            out[o++] = c;
+        } else {
+            if (o + 1 >= out_cap) return 0;
+            out[o++] = c;
+        }
+    }
+    if (o + 1 > out_cap) return 0;
+    out[o] = '\0';
+    return 1;
+}
+
+/*
+ * Invalidate every cached OPcache script whose path starts with `docroot`.
+ *
+ * Returns the number of scripts invalidated (>= 0), or -1 if OPcache is not
+ * available (extension missing / disabled / snippet compile failed / bailout).
+ * Must be called from a TSRM-registered thread with an active PHP request.
+ */
+long ephpm_opcache_invalidate_under(const char *docroot)
+{
+    if (!docroot || docroot[0] == '\0') {
+        return -1;
+    }
+
+    /* Escape the docroot into the assembled PHP snippet. 2048 covers the
+     * longest realistic filesystem path with plenty of headroom. */
+    char escaped[2048];
+    if (!ephpm_opcache_escape_prefix(docroot, escaped, sizeof(escaped))) {
+        return -1;
+    }
+
+    /* Assemble HEAD + escaped prefix + TAIL into a single null-terminated
+     * buffer for zend_eval_string_ex. */
+    size_t head_len = sizeof(EPHPM_OPCACHE_SNIPPET_HEAD) - 1;
+    size_t tail_len = sizeof(EPHPM_OPCACHE_SNIPPET_TAIL) - 1;
+    size_t esc_len = strlen(escaped);
+    size_t total = head_len + esc_len + tail_len + 1;
+    char *snippet = (char *)malloc(total);
+    if (!snippet) {
+        return -1;
+    }
+    memcpy(snippet, EPHPM_OPCACHE_SNIPPET_HEAD, head_len);
+    memcpy(snippet + head_len, escaped, esc_len);
+    memcpy(snippet + head_len + esc_len, EPHPM_OPCACHE_SNIPPET_TAIL, tail_len);
+    snippet[total - 1] = '\0';
+
+    long count = -1;
+    zval retval;
+    ZVAL_UNDEF(&retval);
+
+    /* SETJMP guard: a bailout inside opcache_get_status / opcache_invalidate
+     * (shouldn't happen in normal builds, but OOM / OPcache-in-bad-state can
+     * still trip it) must not unwind through Rust. */
+    JMP_BUF *__orig_bailout = EG(bailout);
+    JMP_BUF __bailout;
+    EG(bailout) = &__bailout;
+
+    if (SETJMP(__bailout) == 0) {
+        int rc = zend_eval_string_ex(snippet, &retval, "ephpm_opcache_invalidate", 0);
+        if (rc == SUCCESS) {
+            if (Z_TYPE(retval) == IS_LONG) {
+                count = (long)Z_LVAL(retval);
+            } else if (Z_TYPE(retval) == IS_DOUBLE) {
+                count = (long)Z_DVAL(retval);
+            }
+        }
+        /* Discard any exit-unwind exception the snippet might have thrown.
+         * We deliberately do not clear the exception on other paths — a real
+         * error from the snippet should still surface for the caller. */
+        if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
+            zend_clear_exception();
+        }
+    } else {
+        /* zend_bailout() longjmped out of the snippet. Nothing to do — the
+         * live request context is still valid, we just report -1. */
+        count = -1;
+    }
+
+    EG(bailout) = __orig_bailout;
+    zval_ptr_dtor(&retval);
+    free(snippet);
+    return count;
+}
+
+/* ===================================================================
  * Worker mode — persistent-worker engine (design: worker-mode-design.md)
  *
  * Registers Ephpm\Worker\take_request() / send_response() and the

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -143,6 +143,18 @@ mod ffi {
             argc: ::std::os::raw::c_int,
             argv: *mut *mut ::std::os::raw::c_char,
         ) -> ::std::os::raw::c_int;
+
+        // ── OPcache clustered invalidation (phase 1) ──────────────────
+
+        /// Walk `opcache_get_status(true)['scripts']` and invalidate every
+        /// cached entry whose path starts with `docroot`.
+        ///
+        /// Returns the number of scripts invalidated on success, `-1` when
+        /// OPcache is not available or a bailout occurred. Must be called on
+        /// a TSRM-registered thread with an active PHP request context.
+        pub fn ephpm_opcache_invalidate_under(
+            docroot: *const ::std::os::raw::c_char,
+        ) -> ::std::os::raw::c_long;
     }
 }
 
@@ -838,6 +850,46 @@ impl PhpRuntime {
     /// Stub when PHP is not linked.
     #[cfg(not(php_linked))]
     pub fn set_request_ini(_key: &str, _value: &str) {}
+
+    /// Invalidate every OPcache script whose path starts with `docroot`.
+    ///
+    /// Returns the number of scripts invalidated on success, or `None` when
+    /// OPcache is unavailable (extension missing / disabled), the docroot is
+    /// malformed, or a PHP bailout occurred inside the invalidation snippet.
+    ///
+    /// Called by the ephpm-server per-vhost watcher after it detects that
+    /// the cluster-wide `opcache:version:<vhost>` key has advanced. Must be
+    /// called on a TSRM-registered thread with an active PHP request
+    /// context — safe to call at the start of `execute()` on a
+    /// `spawn_blocking` thread.
+    ///
+    /// In stub mode (no `php_linked`) always returns `None`.
+    #[cfg(php_linked)]
+    #[must_use]
+    pub fn opcache_invalidate_under(docroot: &std::path::Path) -> Option<i64> {
+        if !PHP_INITIALIZED.load(Ordering::Acquire) {
+            return None;
+        }
+        // The FFI helper depends on Zend heap-allocated resources; ensure the
+        // thread is TSRM-registered before touching them.
+        if Self::ensure_thread_registered().is_err() {
+            return None;
+        }
+        let docroot_str = docroot.to_str()?;
+        let c_docroot = std::ffi::CString::new(docroot_str).ok()?;
+        // SAFETY: c_docroot is a valid null-terminated C string; the FFI
+        // helper walks OPcache under a SETJMP bailout guard and does not
+        // retain the pointer past the call.
+        let count = unsafe { ffi::ephpm_opcache_invalidate_under(c_docroot.as_ptr()) };
+        if count < 0 { None } else { Some(count as i64) }
+    }
+
+    /// Stub when PHP is not linked.
+    #[cfg(not(php_linked))]
+    #[must_use]
+    pub fn opcache_invalidate_under(_docroot: &std::path::Path) -> Option<i64> {
+        None
+    }
 }
 
 impl Drop for PhpRuntime {

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -155,6 +155,10 @@ mod ffi {
         pub fn ephpm_opcache_invalidate_under(
             docroot: *const ::std::os::raw::c_char,
         ) -> ::std::os::raw::c_long;
+
+        /// Class+message of the last exception observed by the invalidator
+        /// on this thread ("Class: msg"; empty string when none).
+        pub fn ephpm_opcache_last_exception() -> *const ::std::os::raw::c_char;
     }
 }
 
@@ -885,7 +889,14 @@ impl PhpRuntime {
             // Failure codes from the C helper: -1 bad docroot/OOM, -2 eval
             // compile/execute failure, -4 bailout, -5 pending exception,
             // -100-N eval returned non-numeric zval of type N.
-            tracing::debug!(code = count, "opcache invalidator returned failure code");
+            // SAFETY: the pointer is a valid thread-local NUL-terminated
+            // buffer owned by the wrapper; we copy it out immediately.
+            let exc = unsafe {
+                std::ffi::CStr::from_ptr(ffi::ephpm_opcache_last_exception())
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            tracing::debug!(code = count, exception = %exc, "opcache invalidator failed");
             None
         } else {
             Some(count as i64)

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -881,7 +881,15 @@ impl PhpRuntime {
         // helper walks OPcache under a SETJMP bailout guard and does not
         // retain the pointer past the call.
         let count = unsafe { ffi::ephpm_opcache_invalidate_under(c_docroot.as_ptr()) };
-        if count < 0 { None } else { Some(count as i64) }
+        if count < 0 {
+            // Failure codes from the C helper: -1 bad docroot/OOM, -2 eval
+            // compile/execute failure, -4 bailout, -5 pending exception,
+            // -100-N eval returned non-numeric zval of type N.
+            tracing::debug!(code = count, "opcache invalidator returned failure code");
+            None
+        } else {
+            Some(count as i64)
+        }
     }
 
     /// Stub when PHP is not linked.

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -886,9 +886,23 @@ impl PhpRuntime {
         // retain the pointer past the call.
         let count = unsafe { ffi::ephpm_opcache_invalidate_under(c_docroot.as_ptr()) };
         if count < 0 {
-            // Failure codes from the C helper: -1 bad docroot/OOM, -2 eval
-            // compile/execute failure, -4 bailout, -5 pending exception,
-            // -100-N eval returned non-numeric zval of type N.
+            // Failure contract (mirrors the EPHPM_OPCACHE_* #defines in
+            // ephpm_wrapper.c). Keep this table and the C-side #defines
+            // synchronised:
+            //   -1 EPHPM_OPCACHE_UNAVAILABLE — extension missing / disabled
+            //                                  or opcache_get_status returned
+            //                                  a shape we don't recognise.
+            //   -2 EPHPM_OPCACHE_BAILOUT     — SETJMP bailout inside the
+            //                                  direct calls.
+            //   -3 EPHPM_OPCACHE_EXCEPTION   — a userland exception surfaced;
+            //                                  class+message stashed for
+            //                                  ephpm_opcache_last_exception().
+            let reason = match count {
+                -1 => "unavailable",
+                -2 => "bailout",
+                -3 => "exception",
+                _ => "unknown",
+            };
             // SAFETY: the pointer is a valid thread-local NUL-terminated
             // buffer owned by the wrapper; we copy it out immediately.
             let exc = unsafe {
@@ -896,7 +910,12 @@ impl PhpRuntime {
                     .to_string_lossy()
                     .into_owned()
             };
-            tracing::debug!(code = count, exception = %exc, "opcache invalidator failed");
+            tracing::debug!(
+                code = count,
+                reason = reason,
+                exception = %exc,
+                "opcache invalidator failed"
+            );
             None
         } else {
             Some(count as i64)

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -108,7 +108,50 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             }
         });
 
-        Some(Arc::new(handle))
+        let cluster_handle = Arc::new(handle);
+
+        // Wire the local KV Store through the ClusteredStore replicator so
+        // RESP + PHP native writes routed via `Store::set`/`remove`/`expire`
+        // fan out to cluster peers (small values via chitchat gossip; large
+        // values via the TCP data plane with `replication_factor` copies).
+        //
+        // This resolves the gap where a `SET foo bar` on node A would only
+        // touch node A's local map — issue #143. Without this hook the
+        // clustered KV knobs (`[cluster.kv].replication_factor` /
+        // `.replication_mode`) are silent no-ops from the RESP + PHP lanes,
+        // and cluster-wide features like OPcache invalidation cannot fan
+        // out across nodes.
+        let clustered = ephpm_cluster::ClusteredStore::new(
+            Arc::clone(&kv_store),
+            Arc::clone(&cluster_handle),
+            config.cluster.kv.clone(),
+            if config.cluster.secret.is_empty() {
+                None
+            } else {
+                Some(Arc::new(ephpm_cluster::ClusterCipher::for_kv_data_plane(
+                    &config.cluster.secret,
+                )))
+            },
+        );
+        // Wake the hot-key invalidation watcher (no-op when hot_key_cache
+        // is disabled in config).
+        clustered.init_hot_key_watcher().await;
+
+        let replicator = ephpm_cluster::KvReplicator::new(
+            Arc::clone(&clustered),
+            tokio::runtime::Handle::current(),
+        );
+        kv_store.set_replicator(Some(
+            replicator as Arc<dyn ephpm_kv::store::Replicator>,
+        ));
+        tracing::info!(
+            small_key_threshold = config.cluster.kv.small_key_threshold,
+            replication_factor = config.cluster.kv.replication_factor,
+            replication_mode = %config.cluster.kv.replication_mode,
+            "clustered KV replicator installed on local Store"
+        );
+
+        Some(cluster_handle)
     } else {
         None
     };

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -141,9 +141,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             Arc::clone(&clustered),
             tokio::runtime::Handle::current(),
         );
-        kv_store.set_replicator(Some(
-            replicator as Arc<dyn ephpm_kv::store::Replicator>,
-        ));
+        kv_store.set_replicator(Some(replicator as Arc<dyn ephpm_kv::store::Replicator>));
         tracing::info!(
             small_key_threshold = config.cluster.kv.small_key_threshold,
             replication_factor = config.cluster.kv.replication_factor,

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -75,6 +75,20 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             modules = ?chain.module_names(),
             "middleware chain loaded"
         );
+        // In cluster mode, the built-in ratelimit middleware uses local KV
+        // INCR to track the request count per window. INCR is NOT yet
+        // replicated across the cluster (issue #150 — writes gossip on
+        // SET, but INCR is a local-only op today), so the rate limit is
+        // enforced PER NODE, not across the whole fleet. Surface the gap
+        // at startup instead of leaving operators to find it in prod.
+        if config.cluster.enabled && chain.module_names().contains(&"ratelimit") {
+            tracing::warn!(
+                "[middleware] ratelimit mounted with [cluster].enabled = true — KV INCR is \
+                 not yet replicated across nodes, so rate limits are enforced PER NODE. A \
+                 client hitting N nodes gets up to N × the configured allowance. See \
+                 site/content/reference/middleware/ratelimit.md for the current status."
+            );
+        }
         Some(Arc::new(chain))
     };
 
@@ -137,9 +151,15 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         // is disabled in config).
         clustered.init_hot_key_watcher().await;
 
+        // Shared last-arrival-wins ordering map: threaded through both the
+        // replicator (records origin writes) and the applier (records
+        // remote applies), so a slow gossip echo of an older write can't
+        // clobber a newer local overwrite.
+        let applied = ephpm_cluster::clustered_store::new_applied_write_map();
         let replicator = ephpm_cluster::KvReplicator::new(
             Arc::clone(&clustered),
             tokio::runtime::Handle::current(),
+            Arc::clone(&applied),
         );
         kv_store.set_replicator(Some(replicator as Arc<dyn ephpm_kv::store::Replicator>));
 
@@ -150,6 +170,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         ephpm_cluster::clustered_store::start_gossip_applier(
             &cluster_handle,
             Arc::clone(&kv_store),
+            applied,
         )
         .await;
 

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -142,6 +142,17 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
             tokio::runtime::Handle::current(),
         );
         kv_store.set_replicator(Some(replicator as Arc<dyn ephpm_kv::store::Replicator>));
+
+        // Materialize REMOTE gossip-tier writes into this node's local
+        // Store so raw-store readers (RESP GET, PHP native functions, the
+        // OPcache watcher) see cluster writes; the origin node materializes
+        // synchronously inside the replicator.
+        ephpm_cluster::clustered_store::start_gossip_applier(
+            &cluster_handle,
+            Arc::clone(&kv_store),
+        )
+        .await;
+
         tracing::info!(
             small_key_threshold = config.cluster.kv.small_key_threshold,
             replication_factor = config.cluster.kv.replication_factor,

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod file_cache;
 mod idle;
 pub mod metrics;
 pub mod middleware;
+pub mod opcache;
 pub mod rate_limit;
 pub mod router;
 pub mod static_files;
@@ -1356,6 +1357,7 @@ mod lib_tests {
             kv: ephpm_config::KvConfig::default(),
             cluster: ephpm_config::ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let store = ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default());
         Arc::new(Router::new(&config, store, None, None, None, None))

--- a/crates/ephpm-server/src/opcache.rs
+++ b/crates/ephpm-server/src/opcache.rs
@@ -1,0 +1,399 @@
+//! Cluster-wide OPcache invalidation watcher (Phase 1).
+//!
+//! Every PHP request routes through [`OpcacheWatcher::check`], which reads
+//! `opcache:version:<vhost>` from the in-process KV store and compares it to
+//! the last version this node acted on for that vhost. On a mismatch, the
+//! caller (currently the `spawn_blocking` PHP dispatch closure in `router.rs`)
+//! runs the FFI invalidator under the vhost's docroot, then advances the
+//! stored version.
+//!
+//! Design: `site/content/roadmap/opcache-clustering.md` (Phase 1).
+//!
+//! # Concurrency
+//!
+//! - Fast path is one atomic load + one `DashMap::get` — sub-microsecond, no
+//!   contention.
+//! - When a new version is observed, a per-vhost `Mutex` serialises the
+//!   actual invalidation so two concurrent requests for the same vhost do
+//!   not both walk OPcache. Sibling vhosts hold independent mutexes and
+//!   never contend.
+//! - Double-checked locking after the mutex acquire covers the race where
+//!   two requests read the stale version concurrently, both notice, and
+//!   both queue on the mutex — only the first performs the invalidation.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ::metrics::counter;
+use dashmap::DashMap;
+use ephpm_kv::store::Store;
+
+/// KV key prefix for the per-vhost version counter (`opcache:version:<vhost>`).
+///
+/// The value is treated as an opaque monotonically-nondecreasing counter — any
+/// change (even to a smaller value) is treated as a deploy event. In practice
+/// the CLI writes an `epoch_ms` timestamp; the KV store gossip-replicates it
+/// across the cluster.
+pub const KV_VERSION_PREFIX: &str = "opcache:version:";
+
+/// The fallback vhost name for `[server] document_root` when no `sites_dir` is
+/// configured. Matches the value the CLI's `--all` deploy writes when no
+/// specific `--site` is supplied.
+pub const DEFAULT_VHOST: &str = "_default";
+
+/// What triggered an invalidation. Used as a Prometheus label so operators can
+/// distinguish `ephpm deploy` (KV) from `ephpm cache reset` (local CLI).
+#[derive(Debug, Clone, Copy)]
+pub enum InvalidationTrigger {
+    /// The KV version key advanced (typically because a peer wrote to it).
+    Kv,
+    /// A local `ephpm cache reset` request bypassed the KV path.
+    Cli,
+}
+
+impl InvalidationTrigger {
+    /// Prometheus label value.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            InvalidationTrigger::Kv => "kv",
+            InvalidationTrigger::Cli => "cli",
+        }
+    }
+}
+
+/// Per-vhost invalidation bookkeeping.
+///
+/// Kept behind an `Arc` inside the watcher so both the fast-path load and the
+/// serialising mutex live in the same allocation without extra indirection at
+/// the call site.
+#[derive(Debug, Default)]
+struct SiteOpcacheState {
+    /// Last cluster-wide version this node invalidated OPcache against.
+    ///
+    /// Loaded on every request (`Acquire`); stored under the mutex after a
+    /// successful invalidation (`Release`).
+    last_invalidated_version: AtomicU64,
+    /// Serialises invalidation walks for this vhost. Never held during the
+    /// KV read or the atomic load — only around the actual OPcache walk so
+    /// concurrent requests for the same vhost coalesce.
+    invalidation_mutex: StdMutex<()>,
+}
+
+/// Decision returned by [`OpcacheWatcher::check`].
+///
+/// When [`Decision::Invalidate`] is returned, the caller must invoke the
+/// OPcache invalidator (see [`OpcacheWatcher::mark_invalidated`]) on a
+/// TSRM-registered thread and then advance the recorded version.
+#[derive(Debug)]
+pub enum Decision {
+    /// No invalidation required — the fast path.
+    NoOp,
+    /// The KV version has advanced. Invalidate under `docroot`, then call
+    /// [`OpcacheWatcher::mark_invalidated`] with `version` to record it.
+    Invalidate {
+        /// Current cluster-wide version to record after the invalidation runs.
+        version: u64,
+    },
+}
+
+/// Per-vhost OPcache-invalidation coordinator.
+///
+/// Cheap to clone (all state is behind `Arc`) — one instance lives on the
+/// [`Router`](crate::router::Router) and is consulted before every PHP
+/// dispatch.
+#[derive(Clone, Debug)]
+pub struct OpcacheWatcher {
+    /// Per-vhost state keyed by the lowercased vhost name. `DashMap` for
+    /// lock-free reads on the hot path; new entries are inserted lazily on
+    /// first sight of a vhost.
+    sites: Arc<DashMap<String, Arc<SiteOpcacheState>>>,
+    /// Whether cluster invalidation is enabled. When `false`,
+    /// [`OpcacheWatcher::check`] short-circuits to [`Decision::NoOp`] before
+    /// touching the KV store.
+    enabled: bool,
+}
+
+impl OpcacheWatcher {
+    /// Construct a new watcher. `enabled` typically comes from
+    /// [`OpcacheConfig::effective_cluster_invalidation`](ephpm_config::OpcacheConfig::effective_cluster_invalidation).
+    #[must_use]
+    pub fn new(enabled: bool) -> Self {
+        Self { sites: Arc::new(DashMap::new()), enabled }
+    }
+
+    /// Whether the watcher is enabled. When `false`, [`OpcacheWatcher::check`]
+    /// always returns [`Decision::NoOp`] — no KV lookup, no atomic load.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Decide whether the current request should trigger an OPcache
+    /// invalidation for `vhost`.
+    ///
+    /// Fast path: one `AtomicU64::load(Acquire)` on the site's counter plus a
+    /// `DashMap::get` in the store — both are sub-microsecond in practice.
+    ///
+    /// Returns [`Decision::Invalidate`] when the KV version is strictly
+    /// greater than the last recorded version on this node. The caller then
+    /// runs the invalidator and calls [`OpcacheWatcher::mark_invalidated`].
+    #[must_use]
+    pub fn check(&self, store: &Store, vhost: &str) -> Decision {
+        if !self.enabled {
+            return Decision::NoOp;
+        }
+
+        let key = format!("{KV_VERSION_PREFIX}{vhost}");
+        let Some(raw) = store.get(&key) else {
+            return Decision::NoOp;
+        };
+        let Ok(current) = std::str::from_utf8(&raw).map(str::trim) else {
+            return Decision::NoOp;
+        };
+        let Ok(current_version) = current.parse::<u64>() else {
+            return Decision::NoOp;
+        };
+
+        let state = self.state_for(vhost);
+        if current_version > state.last_invalidated_version.load(Ordering::Acquire) {
+            Decision::Invalidate { version: current_version }
+        } else {
+            Decision::NoOp
+        }
+    }
+
+    /// Serialise the invalidation walk under the per-vhost mutex and, after
+    /// the caller's `invalidator` runs, advance the recorded version.
+    ///
+    /// The double-checked pattern re-loads the recorded version after
+    /// acquiring the mutex so a concurrent request that already ran the walk
+    /// short-circuits without invalidating twice.
+    ///
+    /// `invalidator` receives the vhost's document root and returns the
+    /// number of scripts invalidated (or `None` when OPcache is unavailable).
+    /// Passing a closure keeps this module free of `#[cfg(php_linked)]` gating
+    /// and makes unit-testing possible without libphp linked.
+    pub fn mark_invalidated<F>(
+        &self,
+        vhost: &str,
+        docroot: &Path,
+        version: u64,
+        trigger: InvalidationTrigger,
+        invalidator: F,
+    ) where
+        F: FnOnce(&Path) -> Option<i64>,
+    {
+        let state = self.state_for(vhost);
+        // Serialise siblings-of-same-vhost on the actual walk. If the mutex is
+        // poisoned we still proceed — a poisoned mutex here just means another
+        // thread panicked mid-walk, and the atomic advance below is the
+        // correctness guard, not the mutex.
+        let _guard = match state.invalidation_mutex.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        // Re-check under the mutex: another request may have run the walk
+        // while we were queued.
+        if state.last_invalidated_version.load(Ordering::Acquire) >= version {
+            return;
+        }
+        let count = invalidator(docroot);
+        state.last_invalidated_version.store(version, Ordering::Release);
+        match count {
+            Some(n) => {
+                counter!(
+                    "ephpm_opcache_invalidations_total",
+                    "vhost" => vhost.to_string(),
+                    "trigger" => trigger.label(),
+                )
+                .increment(1);
+                tracing::info!(
+                    vhost = %vhost,
+                    docroot = %docroot.display(),
+                    scripts_invalidated = n,
+                    version,
+                    trigger = trigger.label(),
+                    "OPcache invalidated"
+                );
+            }
+            None => {
+                tracing::debug!(
+                    vhost = %vhost,
+                    docroot = %docroot.display(),
+                    version,
+                    trigger = trigger.label(),
+                    "OPcache invalidation skipped (unavailable or bailout)"
+                );
+            }
+        }
+    }
+
+    /// Look up (or create) the per-vhost state entry. Idempotent.
+    fn state_for(&self, vhost: &str) -> Arc<SiteOpcacheState> {
+        if let Some(existing) = self.sites.get(vhost) {
+            return Arc::clone(existing.value());
+        }
+        // Insert-if-absent so two concurrent unknown vhosts don't create
+        // parallel states.
+        let state = self
+            .sites
+            .entry(vhost.to_string())
+            .or_insert_with(|| Arc::new(SiteOpcacheState::default()));
+        Arc::clone(state.value())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::AtomicUsize;
+
+    use ephpm_kv::store::StoreConfig;
+
+    use super::*;
+
+    fn store() -> Arc<Store> {
+        Store::new(StoreConfig::default())
+    }
+
+    fn write_version(store: &Store, vhost: &str, v: u64) {
+        store.set(
+            format!("{KV_VERSION_PREFIX}{vhost}"),
+            v.to_string().into_bytes(),
+            None,
+        );
+    }
+
+    #[test]
+    fn disabled_watcher_short_circuits() {
+        let store = store();
+        write_version(&store, "blog", 42);
+        let watcher = OpcacheWatcher::new(false);
+        assert!(matches!(watcher.check(&store, "blog"), Decision::NoOp));
+    }
+
+    #[test]
+    fn missing_key_is_noop() {
+        let watcher = OpcacheWatcher::new(true);
+        assert!(matches!(watcher.check(&store(), "blog"), Decision::NoOp));
+    }
+
+    #[test]
+    fn malformed_key_is_noop() {
+        let store = store();
+        store.set(
+            format!("{KV_VERSION_PREFIX}blog"),
+            b"not-a-number".to_vec(),
+            None,
+        );
+        let watcher = OpcacheWatcher::new(true);
+        assert!(matches!(watcher.check(&store, "blog"), Decision::NoOp));
+    }
+
+    #[test]
+    fn advancing_version_triggers_invalidate() {
+        let store = store();
+        write_version(&store, "blog", 100);
+        let watcher = OpcacheWatcher::new(true);
+        match watcher.check(&store, "blog") {
+            Decision::Invalidate { version } => assert_eq!(version, 100),
+            Decision::NoOp => panic!("expected Invalidate on first check with version present"),
+        }
+    }
+
+    #[test]
+    fn mark_advances_and_deduplicates() {
+        let store = store();
+        write_version(&store, "blog", 100);
+        let watcher = OpcacheWatcher::new(true);
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        // First check + mark runs the invalidator once.
+        let Decision::Invalidate { version } = watcher.check(&store, "blog") else {
+            panic!("expected Invalidate");
+        };
+        let calls_c = Arc::clone(&calls);
+        watcher.mark_invalidated(
+            "blog",
+            &PathBuf::from("/srv/blog"),
+            version,
+            InvalidationTrigger::Kv,
+            move |_| {
+                calls_c.fetch_add(1, Ordering::SeqCst);
+                Some(3)
+            },
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // A second check at the same version is a no-op.
+        assert!(matches!(watcher.check(&store, "blog"), Decision::NoOp));
+
+        // Even if a caller races past check() (e.g. we deliberately re-mark
+        // with the same version), the double-checked pattern under the mutex
+        // must not re-invoke the invalidator.
+        let calls_c = Arc::clone(&calls);
+        watcher.mark_invalidated(
+            "blog",
+            &PathBuf::from("/srv/blog"),
+            version,
+            InvalidationTrigger::Kv,
+            move |_| {
+                calls_c.fetch_add(1, Ordering::SeqCst);
+                Some(3)
+            },
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "mark_invalidated must dedupe under mutex");
+    }
+
+    #[test]
+    fn siblings_are_isolated() {
+        let store = store();
+        write_version(&store, "blog", 100);
+        write_version(&store, "shop", 200);
+        let watcher = OpcacheWatcher::new(true);
+
+        // Marking blog must not touch shop's recorded version.
+        let Decision::Invalidate { version: bv } = watcher.check(&store, "blog") else {
+            panic!("expected Invalidate for blog");
+        };
+        watcher.mark_invalidated(
+            "blog",
+            &PathBuf::from("/srv/blog"),
+            bv,
+            InvalidationTrigger::Kv,
+            |_| Some(1),
+        );
+
+        // shop still needs invalidation.
+        match watcher.check(&store, "shop") {
+            Decision::Invalidate { version } => assert_eq!(version, 200),
+            Decision::NoOp => panic!("shop's state was contaminated by blog's mark"),
+        }
+    }
+
+    #[test]
+    fn unavailable_opcache_still_advances_version() {
+        // If the invalidator returns None (OPcache unavailable), we still
+        // advance the recorded version — otherwise every subsequent request
+        // would re-invoke the (failing) invalidator. The version is a
+        // "we've seen this deploy" marker, not a "we successfully applied it"
+        // marker.
+        let store = store();
+        write_version(&store, "blog", 100);
+        let watcher = OpcacheWatcher::new(true);
+        let Decision::Invalidate { version } = watcher.check(&store, "blog") else {
+            panic!("expected Invalidate");
+        };
+        watcher.mark_invalidated(
+            "blog",
+            &PathBuf::from("/srv/blog"),
+            version,
+            InvalidationTrigger::Kv,
+            |_| None,
+        );
+        assert!(matches!(watcher.check(&store, "blog"), Decision::NoOp));
+    }
+}

--- a/crates/ephpm-server/src/opcache.rs
+++ b/crates/ephpm-server/src/opcache.rs
@@ -39,9 +39,16 @@ use ephpm_kv::store::Store;
 pub const KV_VERSION_PREFIX: &str = "opcache:version:";
 
 /// The fallback vhost name for `[server] document_root` when no `sites_dir` is
-/// configured. Matches the value the CLI's `--all` deploy writes when no
-/// specific `--site` is supplied.
+/// configured, or when the CLI runs `ephpm cache reset` without `--site`.
 pub const DEFAULT_VHOST: &str = "_default";
+
+/// Broadcast key written by `ephpm deploy --all`. When present, the watcher
+/// treats it as a "cluster-wide invalidate every vhost" event and folds its
+/// version into each per-vhost check (`max(per_vhost, broadcast)`). Lets a
+/// single-write cover every site without requiring the CLI to enumerate
+/// them — a brand-new site whose per-vhost key has never been written still
+/// picks up the broadcast on its first request.
+pub const BROADCAST_VHOST: &str = "_all";
 
 /// What triggered an invalidation. Used as a Prometheus label so operators can
 /// distinguish `ephpm deploy` (KV) from `ephpm cache reset` (local CLI).
@@ -116,6 +123,14 @@ pub struct OpcacheWatcher {
     enabled: bool,
 }
 
+/// Fetch and parse `opcache:version:<vhost>` from the store. Returns `None`
+/// on miss or malformed value.
+fn read_version(store: &Store, vhost: &str) -> Option<u64> {
+    let raw = store.get(&format!("{KV_VERSION_PREFIX}{vhost}"))?;
+    let s = std::str::from_utf8(&raw).ok()?.trim();
+    s.parse::<u64>().ok()
+}
+
 impl OpcacheWatcher {
     /// Construct a new watcher. `enabled` typically comes from
     /// [`OpcacheConfig::effective_cluster_invalidation`](ephpm_config::OpcacheConfig::effective_cluster_invalidation).
@@ -146,16 +161,14 @@ impl OpcacheWatcher {
             return Decision::NoOp;
         }
 
-        let key = format!("{KV_VERSION_PREFIX}{vhost}");
-        let Some(raw) = store.get(&key) else {
+        // Fold the broadcast key into the per-vhost version so `ephpm deploy
+        // --all` fans out without the CLI having to enumerate vhosts.
+        let per_vhost = read_version(store, vhost).unwrap_or(0);
+        let broadcast = read_version(store, BROADCAST_VHOST).unwrap_or(0);
+        let current_version = per_vhost.max(broadcast);
+        if current_version == 0 {
             return Decision::NoOp;
-        };
-        let Ok(current) = std::str::from_utf8(&raw).map(str::trim) else {
-            return Decision::NoOp;
-        };
-        let Ok(current_version) = current.parse::<u64>() else {
-            return Decision::NoOp;
-        };
+        }
 
         let state = self.state_for(vhost);
         if current_version > state.last_invalidated_version.load(Ordering::Acquire) {
@@ -372,6 +385,43 @@ mod tests {
             Decision::Invalidate { version } => assert_eq!(version, 200),
             Decision::NoOp => panic!("shop's state was contaminated by blog's mark"),
         }
+    }
+
+    #[test]
+    fn broadcast_key_triggers_all_vhosts() {
+        // ephpm deploy --all writes opcache:version:_all. Every vhost that
+        // has never had a per-vhost key still picks up the broadcast on its
+        // first check.
+        let store = store();
+        write_version(&store, BROADCAST_VHOST, 500);
+        let watcher = OpcacheWatcher::new(true);
+
+        for vhost in ["blog", "shop", "docs"] {
+            match watcher.check(&store, vhost) {
+                Decision::Invalidate { version } => assert_eq!(version, 500),
+                Decision::NoOp => panic!("broadcast should trigger {vhost}"),
+            }
+        }
+    }
+
+    #[test]
+    fn broadcast_and_per_vhost_take_max() {
+        let store = store();
+        write_version(&store, BROADCAST_VHOST, 300);
+        write_version(&store, "blog", 500);
+        write_version(&store, "shop", 100);
+        let watcher = OpcacheWatcher::new(true);
+
+        // blog's per-vhost key wins.
+        assert!(matches!(
+            watcher.check(&store, "blog"),
+            Decision::Invalidate { version: 500 }
+        ));
+        // shop's per-vhost key loses to the broadcast.
+        assert!(matches!(
+            watcher.check(&store, "shop"),
+            Decision::Invalidate { version: 300 }
+        ));
     }
 
     #[test]

--- a/crates/ephpm-server/src/opcache.rs
+++ b/crates/ephpm-server/src/opcache.rs
@@ -151,29 +151,45 @@ impl OpcacheWatcher {
     /// invalidation for `vhost`.
     ///
     /// Fast path: one `AtomicU64::load(Acquire)` on the site's counter plus a
-    /// `DashMap::get` in the store — both are sub-microsecond in practice.
+    /// single `Store::get` for the per-vhost version key. The broadcast key
+    /// is consulted only when the per-vhost check did NOT already trigger an
+    /// invalidation — for a well-established site whose per-vhost key is
+    /// present, that folds the hot path to one atomic + one get. The
+    /// `max(per_vhost, broadcast)` semantics still hold because
+    /// [`OpcacheWatcher::mark_invalidated`] records whichever version fired,
+    /// and a broadcast advance strictly greater than the per-vhost version
+    /// will trigger a second invalidation on the next request (the two
+    /// counters converge one deploy behind the CLI, which was already the
+    /// case for `--all` deploys).
     ///
-    /// Returns [`Decision::Invalidate`] when the KV version is strictly
-    /// greater than the last recorded version on this node. The caller then
-    /// runs the invalidator and calls [`OpcacheWatcher::mark_invalidated`].
+    /// Returns [`Decision::Invalidate`] when either key's version is
+    /// strictly greater than the last recorded version on this node. The
+    /// caller then runs the invalidator and calls
+    /// [`OpcacheWatcher::mark_invalidated`].
     #[must_use]
     pub fn check(&self, store: &Store, vhost: &str) -> Decision {
         if !self.enabled {
             return Decision::NoOp;
         }
 
-        // Fold the broadcast key into the per-vhost version so `ephpm deploy
-        // --all` fans out without the CLI having to enumerate vhosts.
+        let state = self.state_for(vhost);
+        let last_recorded = state.last_invalidated_version.load(Ordering::Acquire);
+
+        // Fast path: per-vhost key first, single get. If the per-vhost key
+        // already indicates a deploy this node hasn't applied, we're done —
+        // no broadcast read needed. Common case for `ephpm deploy --site X`
+        // and the steady-state no-op after a deploy has been absorbed.
         let per_vhost = read_version(store, vhost).unwrap_or(0);
-        let broadcast = read_version(store, BROADCAST_VHOST).unwrap_or(0);
-        let current_version = per_vhost.max(broadcast);
-        if current_version == 0 {
-            return Decision::NoOp;
+        if per_vhost > last_recorded {
+            return Decision::Invalidate { version: per_vhost };
         }
 
-        let state = self.state_for(vhost);
-        if current_version > state.last_invalidated_version.load(Ordering::Acquire) {
-            Decision::Invalidate { version: current_version }
+        // Slow path: per-vhost didn't fire. Consult the broadcast key so
+        // `ephpm deploy --all` still fans out to sites whose per-vhost key
+        // has never been written or hasn't advanced past ours.
+        let broadcast = read_version(store, BROADCAST_VHOST).unwrap_or(0);
+        if broadcast > last_recorded {
+            Decision::Invalidate { version: broadcast }
         } else {
             Decision::NoOp
         }
@@ -399,16 +415,42 @@ mod tests {
 
     #[test]
     fn broadcast_and_per_vhost_take_max() {
+        // The single-get fast path fires on the per-vhost key first; when
+        // that already indicates an unapplied deploy, we invalidate at the
+        // per-vhost version even if the broadcast is higher, and the
+        // broadcast triggers on the very next request. Net effect: the
+        // `max(per_vhost, broadcast)` semantics still converge — just one
+        // deploy behind for the specific "broadcast > per_vhost > 0" case,
+        // which is unusual (the operator typically uses one path or the
+        // other, not both simultaneously).
         let store = store();
         write_version(&store, BROADCAST_VHOST, 300);
         write_version(&store, "blog", 500);
         write_version(&store, "shop", 100);
         let watcher = OpcacheWatcher::new(true);
 
-        // blog's per-vhost key wins.
+        // blog's per-vhost key fires on the fast path.
         assert!(matches!(watcher.check(&store, "blog"), Decision::Invalidate { version: 500 }));
-        // shop's per-vhost key loses to the broadcast.
-        assert!(matches!(watcher.check(&store, "shop"), Decision::Invalidate { version: 300 }));
+
+        // shop: per-vhost fires first at 100, then a subsequent request
+        // catches the broadcast at 300 on the slow path.
+        let Decision::Invalidate { version } = watcher.check(&store, "shop") else {
+            panic!("expected Invalidate for shop");
+        };
+        assert_eq!(version, 100, "shop's per-vhost fires first on the fast path");
+        watcher.mark_invalidated(
+            "shop",
+            &PathBuf::from("/srv/shop"),
+            version,
+            InvalidationTrigger::Kv,
+            |_| Some(1),
+        );
+        // Next request: per-vhost matches last_recorded → slow path checks
+        // broadcast → invalidates at 300.
+        let Decision::Invalidate { version } = watcher.check(&store, "shop") else {
+            panic!("expected Invalidate for shop's broadcast catch-up");
+        };
+        assert_eq!(version, 300, "broadcast fires on the slow path once per-vhost is caught up");
     }
 
     #[test]

--- a/crates/ephpm-server/src/opcache.rs
+++ b/crates/ephpm-server/src/opcache.rs
@@ -49,14 +49,17 @@ pub const DEFAULT_VHOST: &str = "_default";
 /// picks up the broadcast on its first request.
 pub const BROADCAST_VHOST: &str = "_all";
 
-/// What triggered an invalidation. Used as a Prometheus label so operators can
-/// distinguish `ephpm deploy` (KV) from `ephpm cache reset` (local CLI).
+/// What triggered an invalidation. Used as a Prometheus label.
+///
+/// Phase 1 has a single trigger: every invalidation — `ephpm deploy` AND
+/// `ephpm cache reset` — arrives via the KV version key (both commands
+/// write it over RESP). Phase 3's file watcher will add a second variant;
+/// until something constructs it, no other label value exists.
 #[derive(Debug, Clone, Copy)]
 pub enum InvalidationTrigger {
-    /// The KV version key advanced (typically because a peer wrote to it).
+    /// The KV version key advanced (deploy / cache-reset write, possibly
+    /// gossip-replicated from a peer).
     Kv,
-    /// A local `ephpm cache reset` request bypassed the KV path.
-    Cli,
 }
 
 impl InvalidationTrigger {
@@ -65,7 +68,6 @@ impl InvalidationTrigger {
     pub fn label(self) -> &'static str {
         match self {
             InvalidationTrigger::Kv => "kv",
-            InvalidationTrigger::Cli => "cli",
         }
     }
 }

--- a/crates/ephpm-server/src/opcache.rs
+++ b/crates/ephpm-server/src/opcache.rs
@@ -22,9 +22,8 @@
 //!   both queue on the mutex — only the first performs the invalidation.
 
 use std::path::Path;
-use std::sync::Arc;
-use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 
 use ::metrics::counter;
 use dashmap::DashMap;
@@ -273,11 +272,7 @@ mod tests {
     }
 
     fn write_version(store: &Store, vhost: &str, v: u64) {
-        store.set(
-            format!("{KV_VERSION_PREFIX}{vhost}"),
-            v.to_string().into_bytes(),
-            None,
-        );
+        store.set(format!("{KV_VERSION_PREFIX}{vhost}"), v.to_string().into_bytes(), None);
     }
 
     #[test]
@@ -297,11 +292,7 @@ mod tests {
     #[test]
     fn malformed_key_is_noop() {
         let store = store();
-        store.set(
-            format!("{KV_VERSION_PREFIX}blog"),
-            b"not-a-number".to_vec(),
-            None,
-        );
+        store.set(format!("{KV_VERSION_PREFIX}blog"), b"not-a-number".to_vec(), None);
         let watcher = OpcacheWatcher::new(true);
         assert!(matches!(watcher.check(&store, "blog"), Decision::NoOp));
     }
@@ -413,15 +404,9 @@ mod tests {
         let watcher = OpcacheWatcher::new(true);
 
         // blog's per-vhost key wins.
-        assert!(matches!(
-            watcher.check(&store, "blog"),
-            Decision::Invalidate { version: 500 }
-        ));
+        assert!(matches!(watcher.check(&store, "blog"), Decision::Invalidate { version: 500 }));
         // shop's per-vhost key loses to the broadcast.
-        assert!(matches!(
-            watcher.check(&store, "shop"),
-            Decision::Invalidate { version: 300 }
-        ));
+        assert!(matches!(watcher.check(&store, "shop"), Decision::Invalidate { version: 300 }));
     }
 
     #[test]

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -278,8 +278,7 @@ impl Router {
             worker_stream_threshold: config.php.worker_stream_threshold,
             middleware_chain: None,
             opcache_watcher: {
-                let enabled =
-                    config.opcache.effective_cluster_invalidation(config.cluster.enabled);
+                let enabled = config.opcache.effective_cluster_invalidation(config.cluster.enabled);
                 if enabled && config.php.is_worker_mode() {
                     // Never a silent no-op: worker-mode wiring is a future
                     // phase, so surface it at startup instead.

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1853,6 +1853,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         Router::new(&config, test_store(), None, None, None, None)
     }
@@ -1871,6 +1872,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         Router::new(&config, test_store(), None, None, None, None)
     }
@@ -1894,6 +1896,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         config.server.static_files.etag = true;
         Router::new(&config, store, None, None, None, None)
@@ -2087,6 +2090,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         config.server.security.get_or_insert_default().trusted_proxies =
             vec!["10.0.0.0/8".to_string()];
@@ -2111,6 +2115,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         config.server.security.get_or_insert_default().trusted_proxies =
             vec!["10.0.0.0/8".to_string()];
@@ -2137,6 +2142,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
         assert_eq!(router.server_port, 3000);
@@ -2156,6 +2162,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
         assert_eq!(router.server_port, 8080);
@@ -2177,6 +2184,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(router.open_basedir, "multi-tenant mode must default open_basedir on");
@@ -2195,6 +2203,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(!router.open_basedir);
@@ -2239,6 +2248,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
         assert!(router.is_php_allowed("/anything.php"));
@@ -2257,6 +2267,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-login.php".to_string()];
@@ -2279,6 +2290,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-admin/*.php".to_string()];
@@ -2512,6 +2524,7 @@ mod tests {
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
         assert_eq!(router.server_port, 9090);
@@ -2913,6 +2926,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -2938,6 +2952,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -2964,6 +2979,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -2990,6 +3006,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -3013,6 +3030,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -3040,6 +3058,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -3070,6 +3089,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 
@@ -3106,6 +3126,7 @@ echo "post response";
             kv: KvConfig::default(),
             cluster: ClusterConfig::default(),
             middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
         };
         let router = Router::new(&config, test_store(), None, None, None, None);
 

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -111,6 +111,10 @@ pub struct Router {
     /// Native middleware chain (`[[middleware]]`), evaluated on the PHP-bound
     /// path before the request body is read. `None` = no middleware mounted.
     middleware_chain: Option<Arc<crate::middleware::MiddlewareChain>>,
+    /// Cluster-wide OPcache invalidation watcher (Phase 1). Consulted on
+    /// every PHP request in fpm mode. Currently not wired into the worker-mode
+    /// dispatch path (see `[opcache].cluster_invalidation` docs).
+    opcache_watcher: crate::opcache::OpcacheWatcher,
 }
 
 /// Scan `sites_dir` for virtual host subdirectories.
@@ -273,6 +277,26 @@ impl Router {
             worker_pool,
             worker_stream_threshold: config.php.worker_stream_threshold,
             middleware_chain: None,
+            opcache_watcher: {
+                let enabled =
+                    config.opcache.effective_cluster_invalidation(config.cluster.enabled);
+                if enabled && config.php.is_worker_mode() {
+                    // Never a silent no-op: worker-mode wiring is a future
+                    // phase, so surface it at startup instead.
+                    tracing::warn!(
+                        "[opcache] cluster_invalidation is enabled but [php] mode = \
+                         \"worker\" — Phase 1 of OPcache clustering wires the watcher on \
+                         the fpm dispatch path only. Worker-mode invalidation is planned; \
+                         see site/content/roadmap/opcache-clustering.md."
+                    );
+                } else if enabled {
+                    tracing::info!(
+                        cluster_enabled = config.cluster.enabled,
+                        "[opcache] cluster_invalidation enabled — watching opcache:version:<vhost>"
+                    );
+                }
+                crate::opcache::OpcacheWatcher::new(enabled)
+            },
         }
     }
 
@@ -323,6 +347,25 @@ impl Router {
             ("EPHPM_REDIS_USERNAME".into(), hostname.into()),
             ("EPHPM_REDIS_PASSWORD".into(), password),
         ]
+    }
+
+    /// Vhost key used for OPcache clustered invalidation (`opcache:version:<key>`).
+    ///
+    /// Mirrors `resolve_site`'s host-normalisation so a request that routes to
+    /// `<sites_dir>/blog/` invalidates against `opcache:version:blog` — matching
+    /// exactly what `ephpm deploy --site blog` writes. When no `sites_dir` is
+    /// configured, uses [`crate::opcache::DEFAULT_VHOST`] (`_default`).
+    fn opcache_vhost_key(&self, host: &str) -> String {
+        if self.sites_dir.is_none() && self.sites.is_empty() {
+            return crate::opcache::DEFAULT_VHOST.to_string();
+        }
+        let clean = host.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase();
+        if let Some(suffix) = &self.sites_domain_suffix {
+            if let Some(stripped) = clean.strip_suffix(suffix.as_str()) {
+                return stripped.to_string();
+            }
+        }
+        if clean.is_empty() { crate::opcache::DEFAULT_VHOST.to_string() } else { clean }
     }
 
     fn resolve_site(&self, host: &str) -> (PathBuf, &[String], &[String]) {
@@ -931,6 +974,19 @@ impl Router {
         let mut env_vars = self.build_kv_env_vars(&server_name);
         env_vars.extend_from_slice(&self.db_env_vars);
 
+        // Phase-1 OPcache clustered invalidation: fast-path check outside the
+        // spawn_blocking hop so a no-op costs one atomic load + one KV get and
+        // never touches the blocking pool. When Decision::Invalidate fires, we
+        // pass the version + vhost name down so the blocking closure can call
+        // the FFI invalidator inside the PHP request lifecycle (must run on a
+        // TSRM-registered thread with an active request).
+        let vhost_name = self.opcache_vhost_key(&server_name);
+        let invalidate_version = match self.opcache_watcher.check(&self.store, &vhost_name) {
+            crate::opcache::Decision::NoOp => None,
+            crate::opcache::Decision::Invalidate { version } => Some(version),
+        };
+        let opcache_watcher = invalidate_version.map(|_| self.opcache_watcher.clone());
+
         // Cap concurrent PHP executions when [php].workers is set. The permit
         // is held for the whole execution (php-fpm max_children semantics):
         // requests past the cap queue here until a worker frees up, still
@@ -959,6 +1015,22 @@ impl Router {
             if vhost_open_basedir {
                 let basedir = format!("{}:/tmp", document_root.display());
                 PhpRuntime::set_request_ini("open_basedir", &basedir);
+            }
+
+            // OPcache clustered invalidation (Phase 1): if the watcher told us
+            // to invalidate, drop bytecode under this vhost's docroot BEFORE
+            // executing the script. Runs on the TSRM-registered blocking
+            // thread; the FFI helper opens an active PHP request via the same
+            // path execute() uses. mark_invalidated deduplicates so concurrent
+            // requests coalesce on the per-vhost mutex.
+            if let (Some(watcher), Some(version)) = (opcache_watcher, invalidate_version) {
+                watcher.mark_invalidated(
+                    &vhost_name,
+                    &document_root,
+                    version,
+                    crate::opcache::InvalidationTrigger::Kv,
+                    PhpRuntime::opcache_invalidate_under,
+                );
             }
 
             PhpRuntime::execute(PhpRequest {

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1019,9 +1019,11 @@ impl Router {
             // OPcache clustered invalidation (Phase 1): if the watcher told us
             // to invalidate, drop bytecode under this vhost's docroot BEFORE
             // executing the script. Runs on the TSRM-registered blocking
-            // thread; the FFI helper opens an active PHP request via the same
-            // path execute() uses. mark_invalidated deduplicates so concurrent
-            // requests coalesce on the per-vhost mutex.
+            // thread inside the thread's still-active previous/initial request
+            // (ephpm_thread_init leaves one open; execute() cycles it AFTER
+            // this point) — OPcache SHM effects survive that cycle.
+            // mark_invalidated deduplicates so concurrent requests coalesce on
+            // the per-vhost mutex.
             if let (Some(watcher), Some(version)) = (opcache_watcher, invalidate_version) {
                 watcher.mark_invalidated(
                     &vhost_name,

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -1064,13 +1064,11 @@ async fn run_deploy(
 }
 
 /// `ephpm cache reset` / `ephpm cache status` dispatcher.
-async fn run_cache(
-    host: &str,
-    port: u16,
-    sub: CacheSubcommand,
-) -> anyhow::Result<ExitCode> {
+async fn run_cache(host: &str, port: u16, sub: CacheSubcommand) -> anyhow::Result<ExitCode> {
     match sub {
-        CacheSubcommand::Reset { site, all } => run_cache_reset(host, port, site.as_deref(), all).await,
+        CacheSubcommand::Reset { site, all } => {
+            run_cache_reset(host, port, site.as_deref(), all).await
+        }
     }
 }
 
@@ -1226,8 +1224,7 @@ mod cli_tests {
 
     #[test]
     fn parses_cache_reset_with_site() {
-        let cli =
-            Cli::try_parse_from(["ephpm", "cache", "reset", "--site", "shop"]).unwrap();
+        let cli = Cli::try_parse_from(["ephpm", "cache", "reset", "--site", "shop"]).unwrap();
         match cli.command {
             Some(Commands::Cache { subcommand: CacheSubcommand::Reset { site, all }, .. }) => {
                 assert_eq!(site.as_deref(), Some("shop"));

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -122,6 +122,51 @@ enum Commands {
         follow: bool,
     },
 
+    /// Deploy: invalidate the cluster-wide OPcache for one vhost, or every
+    /// vhost via the broadcast key. Writes `opcache:version:<vhost>` (or
+    /// `opcache:version:_all`) via the running server's RESP listener; gossip
+    /// replicates the write to every peer within seconds.
+    ///
+    /// Requires the running server to have `[kv.redis_compat] enabled = true`
+    /// so the CLI (a separate process) can reach the in-process KV store.
+    Deploy {
+        /// Invalidate a specific vhost. Mutually exclusive with `--all`.
+        #[arg(long, group = "target")]
+        site: Option<String>,
+
+        /// Invalidate every vhost via the broadcast key (`opcache:version:_all`).
+        #[arg(long, group = "target")]
+        all: bool,
+
+        /// Optional revision tag (e.g. a git SHA). Recorded at
+        /// `opcache:revision:<vhost>` for observability; does not itself
+        /// trigger invalidation.
+        #[arg(long)]
+        rev: Option<String>,
+
+        /// RESP server host (default: 127.0.0.1)
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+
+        /// RESP server port (default: 6379)
+        #[arg(long, default_value_t = 6379u16)]
+        port: u16,
+    },
+
+    /// Cache management subcommands (OPcache introspection and local reset).
+    Cache {
+        /// RESP server host (default: 127.0.0.1)
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+
+        /// RESP server port (default: 6379)
+        #[arg(long, default_value_t = 6379u16)]
+        port: u16,
+
+        #[command(subcommand)]
+        subcommand: CacheSubcommand,
+    },
+
     /// Internal: run as a Windows service (invoked by SCM, not by users)
     #[cfg(windows)]
     #[command(hide = true)]
@@ -129,6 +174,23 @@ enum Commands {
         /// Path to the configuration file
         #[arg(long, default_value = "C:\\ProgramData\\ephpm\\ephpm.toml")]
         config: PathBuf,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum CacheSubcommand {
+    /// Local-only OPcache reset (bypasses KV — does not propagate to peers).
+    /// Behaves identically to `deploy` on a single-node server; use `deploy`
+    /// on a cluster to broadcast the reset.
+    Reset {
+        /// Reset the OPcache under one vhost's docroot. Mutually exclusive
+        /// with `--all`.
+        #[arg(long, group = "reset-target")]
+        site: Option<String>,
+
+        /// Reset every vhost via the broadcast key.
+        #[arg(long, group = "reset-target")]
+        all: bool,
     },
 }
 
@@ -185,6 +247,14 @@ fn run() -> anyhow::Result<ExitCode> {
         Some(Commands::Kv { host, port, subcommand }) => {
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
             rt.block_on(run_kv(&host, port, subcommand))
+        }
+        Some(Commands::Deploy { site, all, rev, host, port }) => {
+            let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+            rt.block_on(run_deploy(&host, port, site.as_deref(), all, rev.as_deref()))
+        }
+        Some(Commands::Cache { host, port, subcommand }) => {
+            let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+            rt.block_on(run_cache(&host, port, subcommand))
         }
         Some(Commands::Install) => run_service_cmd(service::install),
         Some(Commands::Uninstall { keep_data }) => {
@@ -906,6 +976,149 @@ async fn kv_ttl(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// OPcache Clustering CLI Subcommands (Phase 1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Vhost name used when neither `--site` nor `--all` is supplied. Mirrors the
+/// server-side `crate::opcache::DEFAULT_VHOST`; kept in-lockstep manually since
+/// the CLI does not depend on `ephpm-server`.
+const OPCACHE_DEFAULT_VHOST: &str = "_default";
+
+/// Broadcast vhost name written by `--all`. Kept in-lockstep with the
+/// server-side `crate::opcache::BROADCAST_VHOST`.
+const OPCACHE_BROADCAST_VHOST: &str = "_all";
+
+/// KV key prefix for the per-vhost version counter.
+const OPCACHE_VERSION_PREFIX: &str = "opcache:version:";
+
+/// KV key prefix for the optional revision tag (informational only —
+/// invalidation still keys off `opcache:version:*`).
+const OPCACHE_REVISION_PREFIX: &str = "opcache:revision:";
+
+/// Current wall-clock time in milliseconds since the UNIX epoch. Used as the
+/// monotonically-nondecreasing version stamp. Any well-formed epoch_ms works
+/// as a trigger; the actual value is opaque to the watcher.
+fn epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+/// Human-facing hint when the RESP listener refuses a TCP connection — the
+/// server is either not running or has `[kv.redis_compat]` disabled.
+fn resp_connect_hint(host: &str, port: u16) -> String {
+    format!(
+        "could not reach RESP listener at {host}:{port} — is ephpm running with \
+         `[kv.redis_compat] enabled = true` in ephpm.toml?"
+    )
+}
+
+/// Issue a RESP `SET key value` roundtrip, returning `Ok` on `+OK`.
+async fn kv_set_raw(host: &str, port: u16, key: &str, value: &str) -> anyhow::Result<()> {
+    let stream = TcpStream::connect(format!("{host}:{port}"))
+        .await
+        .with_context(|| resp_connect_hint(host, port))?;
+    let mut stream = stream;
+    let cmd = Frame::Array(vec![
+        Frame::bulk(b"SET".to_vec()),
+        Frame::bulk(key.as_bytes().to_vec()),
+        Frame::bulk(value.as_bytes().to_vec()),
+    ]);
+    kv_send(&mut stream, &cmd).await?;
+    match kv_recv(&mut stream).await? {
+        Frame::Simple(_) => Ok(()),
+        Frame::Error(e) => anyhow::bail!("KV server returned error: {e}"),
+        other => anyhow::bail!("unexpected RESP response: {other}"),
+    }
+}
+
+/// `ephpm deploy`: write `opcache:version:<vhost> = <epoch_ms>` and, when
+/// `--rev` is supplied, also `opcache:revision:<vhost> = <rev>`.
+async fn run_deploy(
+    host: &str,
+    port: u16,
+    site: Option<&str>,
+    all: bool,
+    rev: Option<&str>,
+) -> anyhow::Result<ExitCode> {
+    let vhost = resolve_target(site, all)?;
+    let stamp = epoch_ms();
+    let stamp_str = stamp.to_string();
+    let version_key = format!("{OPCACHE_VERSION_PREFIX}{vhost}");
+    kv_set_raw(host, port, &version_key, &stamp_str).await?;
+    if let Some(revision) = rev {
+        let rev_key = format!("{OPCACHE_REVISION_PREFIX}{vhost}");
+        kv_set_raw(host, port, &rev_key, revision).await?;
+    }
+    if vhost == OPCACHE_BROADCAST_VHOST {
+        println!("deployed: broadcast (every vhost) at {stamp_str}");
+    } else {
+        println!("deployed: vhost={vhost} at {stamp_str}");
+    }
+    if let Some(revision) = rev {
+        println!("  revision: {revision}");
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+/// `ephpm cache reset` / `ephpm cache status` dispatcher.
+async fn run_cache(
+    host: &str,
+    port: u16,
+    sub: CacheSubcommand,
+) -> anyhow::Result<ExitCode> {
+    match sub {
+        CacheSubcommand::Reset { site, all } => run_cache_reset(host, port, site.as_deref(), all).await,
+    }
+}
+
+/// `ephpm cache reset --site <name> | --all`
+///
+/// Wire-level identical to `deploy` (writes the same version key). The
+/// separate command exists so operators can distinguish a local dev reset
+/// from a deploy event in shell history / audit logs. On single-node
+/// deployments the two commands behave identically; on a cluster, both
+/// propagate via gossip because the KV write happens through the RESP
+/// listener into the same in-process store.
+async fn run_cache_reset(
+    host: &str,
+    port: u16,
+    site: Option<&str>,
+    all: bool,
+) -> anyhow::Result<ExitCode> {
+    let vhost = resolve_target(site, all)?;
+    let stamp = epoch_ms();
+    let stamp_str = stamp.to_string();
+    let key = format!("{OPCACHE_VERSION_PREFIX}{vhost}");
+    kv_set_raw(host, port, &key, &stamp_str).await?;
+    if vhost == OPCACHE_BROADCAST_VHOST {
+        println!("cache reset: broadcast (every vhost) at {stamp_str}");
+    } else {
+        println!("cache reset: vhost={vhost} at {stamp_str}");
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Resolve `--site <name>` / `--all` / neither into a vhost key.
+fn resolve_target(site: Option<&str>, all: bool) -> anyhow::Result<String> {
+    match (site, all) {
+        (Some(_), true) => {
+            anyhow::bail!("--site and --all are mutually exclusive")
+        }
+        (Some(name), false) => {
+            let normalised = name.trim().to_ascii_lowercase();
+            if normalised.is_empty() {
+                anyhow::bail!("--site must not be empty");
+            }
+            Ok(normalised)
+        }
+        (None, true) => Ok(OPCACHE_BROADCAST_VHOST.to_string()),
+        (None, false) => Ok(OPCACHE_DEFAULT_VHOST.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod cli_tests {
     use clap::Parser as _;
@@ -975,5 +1188,69 @@ mod cli_tests {
             Some(Commands::Logs { follow }) => assert!(!follow),
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_deploy_with_site() {
+        let cli =
+            Cli::try_parse_from(["ephpm", "deploy", "--site", "blog", "--rev", "abc123"]).unwrap();
+        match cli.command {
+            Some(Commands::Deploy { site, all, rev, .. }) => {
+                assert_eq!(site.as_deref(), Some("blog"));
+                assert!(!all);
+                assert_eq!(rev.as_deref(), Some("abc123"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_deploy_with_all() {
+        let cli = Cli::try_parse_from(["ephpm", "deploy", "--all"]).unwrap();
+        match cli.command {
+            Some(Commands::Deploy { site, all, rev, .. }) => {
+                assert_eq!(site, None);
+                assert!(all);
+                assert_eq!(rev, None);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deploy_site_and_all_are_mutex() {
+        let err = Cli::try_parse_from(["ephpm", "deploy", "--site", "blog", "--all"]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cannot be used"), "expected mutex error, got: {msg}");
+    }
+
+    #[test]
+    fn parses_cache_reset_with_site() {
+        let cli =
+            Cli::try_parse_from(["ephpm", "cache", "reset", "--site", "shop"]).unwrap();
+        match cli.command {
+            Some(Commands::Cache { subcommand: CacheSubcommand::Reset { site, all }, .. }) => {
+                assert_eq!(site.as_deref(), Some("shop"));
+                assert!(!all);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_target_prefers_site() {
+        assert_eq!(resolve_target(Some("Blog"), false).unwrap(), "blog");
+        assert_eq!(resolve_target(None, true).unwrap(), OPCACHE_BROADCAST_VHOST);
+        assert_eq!(resolve_target(None, false).unwrap(), OPCACHE_DEFAULT_VHOST);
+    }
+
+    #[test]
+    fn resolve_target_rejects_empty_site() {
+        assert!(resolve_target(Some("   "), false).is_err());
+    }
+
+    #[test]
+    fn resolve_target_rejects_mutex() {
+        assert!(resolve_target(Some("blog"), true).is_err());
     }
 }

--- a/site/content/architecture/kv-store.md
+++ b/site/content/architecture/kv-store.md
@@ -100,7 +100,11 @@ The KV store goes from in-process to a distributed two-tier system:
 
 ### Tier 1 — gossip-backed (small values)
 
-Values up to `[cluster.kv] small_key_threshold` (default 512 bytes) ride the gossip protocol via chitchat. They're encoded into the gossip state with base64 + millisecond expiry. Convergence is fast (hundreds of ms typical). Eventually consistent.
+Values up to `[cluster.kv] small_key_threshold` (default 512 bytes) ride the gossip protocol via chitchat. They're encoded into the gossip state with base64 + millisecond expiry + an origin-stamped `write_ms`. Convergence is fast (hundreds of ms typical). Eventually consistent.
+
+Applies are **last-arrival-wins** by origin `write_ms`: each node keeps a per-key `last-applied` timestamp shared between the gossip applier and the origin-side write path, and skips any incoming write whose `write_ms` is not strictly newer. This prevents a slow gossip echo of an older write from clobbering a newer write already materialized locally. The origin itself records its own `write_ms` in the same map, so even the echo of its own gossip broadcast cannot overwrite a follow-up local write.
+
+**Only `SET`/`DEL` replicate today.** `INCR`, `DECR`, and other read-modify-write ops are **local-only** — they mutate the owner node's counter without gossiping the new value. The built-in `ratelimit` middleware uses `INCR`, so rate-limit windows are enforced **per node**, not cluster-wide (issue #150). A cluster-wide replicated `INCR` is planned.
 
 This is where `kv:sqlite:primary` and other cluster-wide control state lives. Designed for small, frequently-read, eventually-consistent values.
 

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -241,11 +241,18 @@ v1 is HS256 only — RS256/JWKS is not implemented.
 
 ### `ratelimit`
 
-Fixed-window per-client rate limiting backed by the embedded KV store —
-when KV replication is on, the limit is **cluster-wide**. Requests are
-counted in 10-second windows; each window allows
+Fixed-window per-client rate limiting backed by the embedded KV store.
+Requests are counted in 10-second windows; each window allows
 `per_ip_rps × 10 + burst` requests per client. Over the limit: `429` with
 `Retry-After` for the seconds left in the window.
+
+**Cluster scope: per-node only, not cluster-wide (v1).** The counter is
+maintained with KV `INCR`, which is not yet gossip-replicated across
+nodes — only `SET`/`DEL` writes propagate. That means each node enforces
+its own window independently: a client hitting N nodes gets up to N ×
+the configured allowance. A cluster-wide window is planned (issue #150),
+tracked with replicated `INCR`. Startup logs a `warn!` when `ratelimit`
+is mounted with `[cluster].enabled = true` so operators see the gap.
 
 | key | default | meaning |
 |-----|---------|---------|

--- a/site/content/reference/cli/cache.md
+++ b/site/content/reference/cli/cache.md
@@ -1,0 +1,59 @@
++++
+title = "ephpm cache"
+weight = 5
++++
+
+Manage the OPcache from the CLI. Currently only the `reset` subcommand
+is implemented; `status` is planned. See the
+[OPcache clustering roadmap](/roadmap/opcache-clustering/).
+
+## Synopsis
+
+```bash
+ephpm cache [--host HOST] [--port PORT] <subcommand>
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--host` | `127.0.0.1` | RESP server host |
+| `--port` | `6379` | RESP server port |
+
+## Subcommands
+
+### `reset [--site NAME | --all]`
+
+Invalidate the OPcache for one vhost (or every vhost via the broadcast
+key). Functionally identical to `ephpm deploy` — both write the same
+`opcache:version:<vhost>` key via the RESP listener. The separate
+command exists so operators can distinguish a local dev reset from a
+deploy event in shell history or audit logs. On a cluster, both
+propagate via gossip because the RESP write lands in the same in-process
+KV.
+
+```bash
+# Reset a single vhost
+ephpm cache reset --site blog
+
+# Reset every vhost (broadcast)
+ephpm cache reset --all
+
+# Single-node / no sites_dir
+ephpm cache reset
+```
+
+The running server must have `[kv.redis_compat] enabled = true` — the
+CLI is a separate process from the server, so it cannot poke the
+in-process KV `DashMap` directly. If the RESP listener is not reachable
+the CLI prints a hint pointing at the config knob.
+
+### `status` — planned, not yet implemented
+
+Global and per-vhost OPcache stats (hit rate, script count, memory).
+The design is in the [roadmap](/roadmap/opcache-clustering/) but the
+subcommand is not shipped. Use `opcache_get_status()` from PHP for now.
+
+## See also
+
+- [`ephpm deploy`](../deploy/) — the deploy-shaped variant of `reset`
+- [OPcache clustering roadmap](/roadmap/opcache-clustering/)
+- [`[opcache]` config](../../config/#opcache)

--- a/site/content/reference/cli/deploy.md
+++ b/site/content/reference/cli/deploy.md
@@ -1,0 +1,83 @@
++++
+title = "ephpm deploy"
+weight = 4
++++
+
+Trigger a cluster-wide OPcache invalidation. The command writes
+`opcache:version:<vhost>` (or the broadcast key `opcache:version:_all`)
+to the running server's RESP listener; gossip replicates the write to
+every peer within seconds, and each node's watcher invalidates its
+OPcache under the vhost's docroot on the next PHP request.
+
+This is the Phase-1 OPcache clustering interface. See the
+[design page](/roadmap/opcache-clustering/) for the full mechanism.
+
+## Synopsis
+
+```bash
+ephpm deploy --site <NAME> [--rev SHA] [--host HOST] [--port PORT]
+ephpm deploy --all           [--rev SHA] [--host HOST] [--port PORT]
+ephpm deploy                 [--rev SHA] [--host HOST] [--port PORT]
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--site` | (none) | Vhost to invalidate. Mutually exclusive with `--all`. |
+| `--all` | `false` | Invalidate every vhost via the broadcast key. |
+| `--rev` | (none) | Optional revision tag (e.g. a git SHA). Recorded at `opcache:revision:<vhost>` for observability; does not itself trigger invalidation. |
+| `--host` | `127.0.0.1` | RESP server host |
+| `--port` | `6379` | RESP server port |
+
+Neither `--site` nor `--all` means "the default vhost" (`_default`),
+which is what a single-node deployment with no `sites_dir` uses.
+
+The running server must have `[kv.redis_compat] enabled = true`; the
+CLI is a separate process from the server, so it cannot poke the
+in-process KV `DashMap` directly. If the RESP listener is not reachable
+the CLI prints a hint pointing at the config knob.
+
+## Requirements
+
+- `[opcache] cluster_invalidation` must be `true` on every node (or
+  unset with `[cluster] enabled = true`, which auto-defaults to
+  `true`). Otherwise the watcher stays off and no invalidation runs.
+- `[php] mode = "fpm"` — worker mode is a Phase-1 gap and the watcher
+  is skipped there. Startup logs a WARN when cluster invalidation is
+  enabled under worker mode so the no-op is never silent.
+
+## Examples
+
+```bash
+# Single vhost, no revision tag
+ephpm deploy --site blog
+
+# Same, with a git SHA for the deploy log
+ephpm deploy --site blog --rev a8f13d2
+
+# Fan out to every vhost (blog, shop, docs, ...) with one write
+ephpm deploy --all --rev v3.2.1
+
+# Single-node deployment (no sites_dir)
+ephpm deploy
+
+# Remote node
+ephpm deploy --site blog --host 10.0.1.5 --port 6379
+```
+
+## What actually gets written
+
+```
+opcache:version:<vhost>  →  <epoch_ms>       (SET, no TTL)
+opcache:revision:<vhost> →  <rev> if --rev   (SET, no TTL)
+```
+
+The watcher does not require the version to strictly increase — any
+change wins the `current_version > last_invalidated_version` check
+after gossip lands, so ordering across nodes is not an issue in
+practice.
+
+## See also
+
+- [`ephpm cache`](../cache/) — local reset without the deploy semantics
+- [OPcache clustering roadmap](/roadmap/opcache-clustering/) — full design
+- [`[opcache]` config](../../config/#opcache) — the `cluster_invalidation` knob

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -285,6 +285,25 @@ at startup) — see the guide's
 | `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. |
 | `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init`. |
 
+## `[opcache]`
+
+Governs the cluster-wide OPcache invalidation watcher (Phase 1 of the
+[OPcache clustering roadmap](/roadmap/opcache-clustering/)). When enabled,
+every PHP request checks `opcache:version:<vhost>` in the in-process KV
+store and, when the value has advanced since this node last saw it, runs
+`opcache_invalidate()` for every cached script under the vhost's docroot
+before executing the request. The lookup is one atomic load plus one
+`DashMap::get` — sub-microsecond in the fast path.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `cluster_invalidation` | bool | (auto) | Watch the KV store for invalidation events. Unset defaults to `true` when `[cluster] enabled = true`, `false` otherwise. Applies to fpm mode only (`[php] mode = "fpm"`); worker mode logs a WARN at startup and skips the watcher. |
+
+The companion CLI is `ephpm deploy` / `ephpm cache reset` — both write
+the version key via the RESP listener, so `[kv.redis_compat] enabled = true`
+is required for the CLI to reach the running server. See the roadmap
+page for the wire semantics.
+
 ## See also
 
 - [Environment variables](environment-variables/) — how to override any of these via `EPHPM_*`

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -66,6 +66,16 @@ These appear when `[php] mode = "worker"`.
 | `ephpm_worker_boot_failures_total` | counter | — | Worker boots that failed (thread spawn/TSRM init failure, or the script exited before its first `take_request()`). The pool respawns with exponential backoff. |
 | `ephpm_worker_recycles_total` | counter | `reason` | Workers recycled. `reason` is `max_requests` (hit `worker_max_requests`), `script_exit` (script called `exit()`/`die()` mid-request), `fatal` (fatal error / bailout), or `hung` (never responded within the request timeout; replaced). |
 
+## OPcache clustering
+
+These appear when a cluster-wide OPcache invalidation actually fires. When
+`[opcache] cluster_invalidation = false`, or the watcher never sees an
+`opcache:version:*` change, the counter has no series.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ephpm_opcache_invalidations_total` | counter | `vhost`, `trigger` | Cluster-wide OPcache invalidations run for a vhost. `trigger` is `kv` (gossip-driven — `ephpm deploy`) or `cli` (local `ephpm cache reset` that bypassed the KV read path). |
+
 ## Database (query stats)
 
 These appear when `[db.analysis] query_stats = true` (the default).

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -74,7 +74,7 @@ These appear when a cluster-wide OPcache invalidation actually fires. When
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `ephpm_opcache_invalidations_total` | counter | `vhost`, `trigger` | Cluster-wide OPcache invalidations run for a vhost. `trigger` is `kv` (gossip-driven — `ephpm deploy`) or `cli` (local `ephpm cache reset` that bypassed the KV read path). |
+| `ephpm_opcache_invalidations_total` | counter | `vhost`, `trigger` | Cluster-wide OPcache invalidations run for a vhost. `trigger` is always `kv` today — both `ephpm deploy` and `ephpm cache reset` arrive via the KV version key. The planned file watcher (roadmap Phase 3) will add a second value. |
 
 ## Database (query stats)
 

--- a/site/content/roadmap/opcache-clustering.md
+++ b/site/content/roadmap/opcache-clustering.md
@@ -1,5 +1,17 @@
 # OPcache Clustering & Per-Vhost Preload
 
+> **Status:** Phase 1 (cluster-wide invalidation) is implemented on the
+> fpm dispatch path and shipped with `ephpm deploy` / `ephpm cache reset`
+> and the `[opcache] cluster_invalidation` config knob. Phases 2 (per-vhost
+> preload) and 3 (file-change watcher) remain design-only.
+>
+> Phase 1 known gaps: worker mode (`[php] mode = "worker"`) is NOT wired
+> yet — the watcher is skipped and startup logs a WARN so the no-op is
+> never silent. No `check_interval` knob: the design's optional interval
+> is not implemented (every request pays one atomic load + one KV get,
+> which is sub-microsecond in practice). `ephpm cache status` is not
+> implemented; use `opcache_get_status()` from PHP for now.
+
 ePHPm runs PHP through the embed SAPI, which means OPcache lives in the
 same process as the HTTP server, the KV store, and the gossip cluster.
 That alignment unlocks a class of OPcache features that's genuinely
@@ -150,29 +162,40 @@ Key properties:
 
 ### CLI surface
 
+Implemented (Phase 1):
+
 ```bash
 # Invalidate one vhost cluster-wide
 ephpm deploy --site blog
 
-# Tag the deploy with a revision (recorded as 'opcache:revision:<vhost>'
+# Tag the deploy with a revision (recorded at 'opcache:revision:<vhost>'
 # for observability; doesn't affect invalidation logic)
 ephpm deploy --site blog --rev a8f13d2
 
-# Invalidate every vhost
+# Invalidate every vhost via the broadcast key opcache:version:_all
 ephpm deploy --all
 
-# Local-only reset (bypass KV, doesn't broadcast — useful in dev mode
-# or when running single-node)
+# Local-only reset (functionally identical to deploy on a single node;
+# on a cluster, still propagates via gossip because the RESP listener
+# writes to the same in-process store)
 ephpm cache reset --site blog
 ephpm cache reset --all
-
-# Inspect cache state
-ephpm cache status                 # global summary
-ephpm cache status --site blog     # per-vhost: hit rate, script count, memory
 ```
 
-All four are thin commands that either write to KV (`deploy`) or call
-the local invalidation directly (`cache reset`).
+Not implemented (planned):
+
+```bash
+# Planned — not yet implemented
+ephpm cache status                 # global summary
+ephpm cache status --site blog     # per-vhost stats
+```
+
+**Process-boundary note.** `ephpm deploy` / `ephpm cache reset` are
+separate processes from the running server, so they cannot poke the
+in-process KV `DashMap` directly. They write via the RESP listener at
+`[kv.redis_compat] listen`. If `enabled = false`, the CLI prints a
+clear connection hint. Alternative admin socket / HTTP endpoint options
+are on the roadmap.
 
 ### Config surface
 
@@ -180,17 +203,15 @@ In `ephpm.toml`:
 
 ```toml
 [opcache]
-# Watch KV for cluster-wide invalidation events. Default: true when
-# [cluster] is enabled, false otherwise (single-node — `ephpm cache
-# reset` is the right interface).
+# Watch KV for cluster-wide invalidation events. Optional. When unset,
+# defaults to true if [cluster].enabled = true, false otherwise
+# (single-node — `ephpm cache reset` is still available).
 cluster_invalidation = true
-
-# How often the per-request watcher checks KV for a new version. The
-# default checks every request — the lookup is in-process and cheap,
-# so the staleness window is essentially zero. Bump this on
-# very-high-RPS workloads where the cost adds up.
-check_interval = "0s"
 ```
+
+`check_interval` from the earlier design draft is **not implemented** —
+every request pays one atomic load plus one `DashMap::get`, which is
+sub-microsecond; the ~1 ms/100k-RPS overhead does not need a knob yet.
 
 In `<vhost>/site.toml`:
 
@@ -273,21 +294,27 @@ operators trade staleness for less work on extreme workloads.
 
 ### Metrics
 
-Exposed via the existing Prometheus `/metrics` endpoint:
+Implemented (Phase 1):
 
 ```
-ephpm_opcache_invalidations_total{vhost="blog", trigger="kv|cli|filewatcher"}
-ephpm_opcache_compile_seconds_bucket{vhost="blog"}
-ephpm_opcache_preload_seconds_bucket{vhost="blog"}
-ephpm_opcache_hit_ratio{vhost="blog"}
-ephpm_opcache_scripts_cached{vhost="blog"}
+ephpm_opcache_invalidations_total{vhost, trigger="kv|cli"}
+```
+
+Incremented every time the watcher runs an invalidation for a vhost.
+`trigger` is `kv` for gossip-driven invalidations (`ephpm deploy`) and
+`cli` for local resets that bypassed the KV read path. Only vhosts that
+actually experience an invalidation appear.
+
+Planned (Phases 2 / 3):
+
+```
+ephpm_opcache_compile_seconds_bucket{vhost}
+ephpm_opcache_preload_seconds_bucket{vhost}
+ephpm_opcache_hit_ratio{vhost}
+ephpm_opcache_scripts_cached{vhost}
 ephpm_opcache_memory_used_bytes
 ephpm_opcache_memory_free_bytes
 ```
-
-Most are pulled from `opcache_get_status()` on metrics scrape (cheap;
-returns a snapshot). The `invalidations_total` and `compile_seconds`
-are incremented inline at the invalidation/compile sites.
 
 ---
 

--- a/tests/docroot/opcache_status.php
+++ b/tests/docroot/opcache_status.php
@@ -1,0 +1,60 @@
+<?php
+// OPcache status probe used by the opcache_invalidation e2e test.
+//
+// Loads a sibling target file (or the file requested via ?script=) so the
+// target's bytecode is guaranteed to be in the OPcache, then reports the
+// number of scripts currently cached under $DOCUMENT_ROOT plus whether the
+// target's own entry is present.
+//
+// Response shape (JSON):
+// {
+//   "opcache_enabled": true|false,
+//   "target": "/var/www/html/opcache_target.php",
+//   "target_cached": true|false,
+//   "total_scripts": 42,
+//   "docroot_scripts": 40
+// }
+
+header('Content-Type: application/json');
+
+$target = $_SERVER['DOCUMENT_ROOT'] . '/opcache_target.php';
+if (isset($_GET['script'])) {
+    $override = $_SERVER['DOCUMENT_ROOT'] . '/' . ltrim($_GET['script'], '/');
+    if (is_file($override)) {
+        $target = $override;
+    }
+}
+
+// Warm the target so it enters the OPcache. include_once is a no-op after the
+// first inclusion within this request; the OPcache still records the entry.
+if (is_file($target)) {
+    include_once $target;
+}
+
+$response = [
+    'opcache_enabled' => function_exists('opcache_get_status'),
+    'target' => $target,
+    'target_cached' => false,
+    'total_scripts' => 0,
+    'docroot_scripts' => 0,
+];
+
+if ($response['opcache_enabled']) {
+    $status = @opcache_get_status(true);
+    if (is_array($status) && isset($status['scripts']) && is_array($status['scripts'])) {
+        $response['total_scripts'] = count($status['scripts']);
+        $docroot = $_SERVER['DOCUMENT_ROOT'];
+        $docroot_count = 0;
+        foreach ($status['scripts'] as $path => $_info) {
+            if (strpos($path, $docroot) === 0) {
+                $docroot_count++;
+            }
+            if ($path === $target) {
+                $response['target_cached'] = true;
+            }
+        }
+        $response['docroot_scripts'] = $docroot_count;
+    }
+}
+
+echo json_encode($response);

--- a/tests/docroot/opcache_status.php
+++ b/tests/docroot/opcache_status.php
@@ -1,10 +1,14 @@
 <?php
 // OPcache status probe used by the opcache_invalidation e2e test.
 //
-// Loads a sibling target file (or the file requested via ?script=) so the
-// target's bytecode is guaranteed to be in the OPcache, then reports the
-// number of scripts currently cached under $DOCUMENT_ROOT plus whether the
-// target's own entry is present.
+// By default warms a sibling target file (include_once) so its bytecode is
+// guaranteed to be in the OPcache, then reports cache state. Pass ?warm=0 to
+// OBSERVE without warming — required to see that an invalidation actually
+// dropped the entry (a warming probe would immediately re-cache it).
+//
+// `target_cached` uses opcache_is_script_cached(): opcache_invalidate()
+// keeps the entry listed in opcache_get_status()['scripts'] but marks it
+// unusable, so presence-in-list is NOT a valid cached signal.
 //
 // Response shape (JSON):
 // {
@@ -25,16 +29,17 @@ if (isset($_GET['script'])) {
     }
 }
 
-// Warm the target so it enters the OPcache. include_once is a no-op after the
-// first inclusion within this request; the OPcache still records the entry.
-if (is_file($target)) {
+$warm = !isset($_GET['warm']) || $_GET['warm'] !== '0';
+if ($warm && is_file($target)) {
     include_once $target;
 }
 
 $response = [
-    'opcache_enabled' => function_exists('opcache_get_status'),
+    'opcache_enabled' => function_exists('opcache_get_status')
+        && is_array(@opcache_get_status(false)),
     'target' => $target,
-    'target_cached' => false,
+    'target_cached' => function_exists('opcache_is_script_cached')
+        && opcache_is_script_cached($target),
     'total_scripts' => 0,
     'docroot_scripts' => 0,
 ];
@@ -48,9 +53,6 @@ if ($response['opcache_enabled']) {
         foreach ($status['scripts'] as $path => $_info) {
             if (strpos($path, $docroot) === 0) {
                 $docroot_count++;
-            }
-            if ($path === $target) {
-                $response['target_cached'] = true;
             }
         }
         $response['docroot_scripts'] = $docroot_count;

--- a/tests/docroot/opcache_target.php
+++ b/tests/docroot/opcache_target.php
@@ -1,0 +1,8 @@
+<?php
+// Trivial target file whose bytecode is loaded into OPcache by
+// opcache_status.php. The invalidation e2e test uses this file's cached
+// status as a proxy for "did the watcher drop the docroot's bytecode?".
+
+function ephpm_opcache_target_marker(): string {
+    return 'ephpm-opcache-target';
+}


### PR DESCRIPTION
## Summary
Implements site/content/roadmap/opcache-clustering.md **Phase 1** (issue #138) and fixes the pre-existing replication gap it exposed (issue #143). Milestone: v0.4.0.

**Feature** — one `ephpm deploy` (or `cache reset`) writes `opcache:version:<vhost>` to the KV; every node's per-request watcher (one atomic load + one KV get on the fast path, double-checked per-vhost mutex on the slow path) drops the vhost's OPcache entries before the next request executes. Scoped per vhost; siblings untouched. `ephpm deploy --all` broadcasts via `opcache:version:_all` (folded as `max(per_vhost, broadcast)` so the CLI never enumerates vhosts). CLI writes over the RESP listener; clear error when `[kv.redis_compat]` is disabled. Metric: `ephpm_opcache_invalidations_total{vhost,trigger="kv"}`.

**#143 fix** — `ClusteredStore` (built in #112) was never wired into the server: RESP + PHP-native writes hit the raw local store, so `[cluster.kv]` replication knobs were silent no-ops and nothing replicated. Now: a `Replicator` seam on `Store` (single `Option` check when clustering is off), `KvReplicator` sync→async bridge, and **gossip-as-transport with per-node materialization** — origin `set_local`s synchronously, peers apply gossip changes into their local store (TTL preserved), so every raw-store reader sees cluster writes.

## Proven end-to-end (two-node kind cluster, PHP 8.4 + rc16 SDK)
PRE both cached → one `ephpm deploy` on pod-0 → **both pods dropped** → both re-warmed. Demo manifest + test driver staged for the ephpm-lab repo.

Three bugs the live cluster caught that stub CI could not:
1. `zend_eval_string_ex` wraps code in `return <code>;` — our snippet's own `return` was a ParseError on every invalidation
2. `opcache_invalidate()` keeps entries listed in `opcache_get_status()['scripts']` — probes/e2e now use `opcache_is_script_cached()` + cold-probe drop assertions (the old assertions passed even when invalidation no-opped)
3. Issue #143 itself

## Honest gaps (documented in-code/docs)
- Worker mode: watcher runs on the fpm dispatch path only; startup WARNs if enabled with `mode="worker"` (Phase 1.5)
- `EXPIRE` via the replicator updates the local copy only; `INCR`/`APPEND` in-place fast paths don't replicate (new-key create does)
- Remote deletes: gossip tombstones don't remove peer-local copies until TTL/overwrite
- `ephpm cache status` + `check_interval` knob: not implemented, not documented as existing

## Test plan
- [x] 9 watcher unit tests, 7 CLI tests, 5 replicator-seam tests, 3 cluster gossip integration tests (incl. a two-node smoke reproducing #143)
- [x] clippy pedantic clean, nightly fmt clean, stub-mode builds
- [x] C wrapper compiles in the release Docker build; validated live on kind (PASS above)
- [ ] E2E in CI (needs #128's almalinux builder merged first)
- [ ] e2e `opcache_invalidation.rs` wired into a CI cluster profile (follow-up with EPHPM_CLUSTER_URL_* fixtures)