### PR TITLE
perf: canonical docroot cache + Cow fallback expansion (v0.4.0 quick wins)

### DIFF
--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -111,6 +111,10 @@ pub struct Router {
     /// Native middleware chain (`[[middleware]]`), evaluated on the PHP-bound
     /// path before the request body is read. `None` = no middleware mounted.
     middleware_chain: Option<Arc<crate::middleware::MiddlewareChain>>,
+    /// Canonicalized document roots, keyed by the as-configured root path.
+    /// Roots are constant for the process lifetime, so caching removes a
+    /// `canonicalize()` syscall from every static-file hit (issue #132).
+    canonical_roots: dashmap::DashMap<PathBuf, PathBuf>,
 }
 
 /// Scan `sites_dir` for virtual host subdirectories.
@@ -273,7 +277,21 @@ impl Router {
             worker_pool,
             worker_stream_threshold: config.php.worker_stream_threshold,
             middleware_chain: None,
+            canonical_roots: dashmap::DashMap::new(),
         }
+    }
+
+    /// Canonicalized form of a site's document root, cached for the process
+    /// lifetime (roots never change at runtime). Returns `None` when the
+    /// root does not exist — the caller treats that as 404, matching the
+    /// previous per-request `canonicalize()` behavior.
+    fn canonical_root(&self, root: &Path) -> Option<PathBuf> {
+        if let Some(hit) = self.canonical_roots.get(root) {
+            return Some(hit.clone());
+        }
+        let canon = root.canonicalize().ok()?;
+        self.canonical_roots.insert(root.to_path_buf(), canon.clone());
+        Some(canon)
     }
 
     /// Attach the native middleware chain loaded in `serve()` at startup.
@@ -602,10 +620,10 @@ impl Router {
                     } else {
                         (error_response(StatusCode::FORBIDDEN, "403 Forbidden"), "error")
                     }
-                } else {
+                } else if let Some(canonical_root) = self.canonical_root(&site_root) {
                     (
                         static_files::serve_file(
-                            &site_root,
+                            &canonical_root,
                             &fs_path,
                             accepts_gzip,
                             accepts_br,
@@ -618,6 +636,8 @@ impl Router {
                         .await,
                         "static",
                     )
+                } else {
+                    (error_response(StatusCode::NOT_FOUND, "404 Not Found"), "error")
                 }
             }
             Resolved::Status(code) => {
@@ -1725,8 +1745,18 @@ fn is_php_file(path: &Path) -> bool {
 }
 
 /// Expand `$uri` and `$query_string` variables in a `fallback` entry.
-fn expand_variables(entry: &str, uri_path: &str, query_string: &str) -> String {
-    entry.replace("$uri", uri_path).replace("$query_string", query_string)
+///
+/// Borrows when the entry has no `$` placeholders — the common case for
+/// literal fallback entries, probed on every request.
+fn expand_variables<'a>(
+    entry: &'a str,
+    uri_path: &str,
+    query_string: &str,
+) -> std::borrow::Cow<'a, str> {
+    if !entry.contains('$') {
+        return std::borrow::Cow::Borrowed(entry);
+    }
+    std::borrow::Cow::Owned(entry.replace("$uri", uri_path).replace("$query_string", query_string))
 }
 
 /// Split an expanded path into the path component and optional query string.

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[allow(unused_imports)]
 use ::metrics::{counter, gauge, histogram};
@@ -111,11 +111,21 @@ pub struct Router {
     /// Native middleware chain (`[[middleware]]`), evaluated on the PHP-bound
     /// path before the request body is read. `None` = no middleware mounted.
     middleware_chain: Option<Arc<crate::middleware::MiddlewareChain>>,
-    /// Canonicalized document roots, keyed by the as-configured root path.
-    /// Roots are constant for the process lifetime, so caching removes a
-    /// `canonicalize()` syscall from every static-file hit (issue #132).
-    canonical_roots: dashmap::DashMap<PathBuf, PathBuf>,
+    /// Canonicalized document roots, keyed by the as-configured root path,
+    /// with the instant they were resolved. Caching removes a
+    /// `canonicalize()` syscall from every static-file hit (issue #132),
+    /// but entries are revalidated after a short TTL: `canonicalize()`
+    /// resolves symlinks, and atomic-deploy layouts flip a symlinked
+    /// docroot to a new release directory — an immortal cache would pin
+    /// the OLD release forever.
+    canonical_roots: dashmap::DashMap<PathBuf, (PathBuf, Instant)>,
 }
+
+/// How long a cached canonicalized docroot stays valid before the next
+/// request re-resolves it. Long enough to amortize the syscall away at any
+/// realistic request rate, short enough that a symlink-flip deploy is
+/// picked up almost immediately.
+const CANONICAL_ROOT_TTL: Duration = Duration::from_secs(2);
 
 /// Scan `sites_dir` for virtual host subdirectories.
 ///
@@ -281,16 +291,22 @@ impl Router {
         }
     }
 
-    /// Canonicalized form of a site's document root, cached for the process
-    /// lifetime (roots never change at runtime). Returns `None` when the
-    /// root does not exist — the caller treats that as 404, matching the
-    /// previous per-request `canonicalize()` behavior.
+    /// Canonicalized form of a site's document root, cached with a short
+    /// TTL ([`CANONICAL_ROOT_TTL`]). The TTL matters: `canonicalize()`
+    /// resolves symlinks, and atomic-deploy layouts (docroot → symlink →
+    /// `releases/N`) flip that symlink on deploy — a permanent cache would
+    /// keep serving the old release. Returns `None` when the root does not
+    /// exist — the caller treats that as 404, matching the previous
+    /// per-request `canonicalize()` behavior.
     fn canonical_root(&self, root: &Path) -> Option<PathBuf> {
         if let Some(hit) = self.canonical_roots.get(root) {
-            return Some(hit.clone());
+            let (canon, resolved_at) = hit.value();
+            if resolved_at.elapsed() < CANONICAL_ROOT_TTL {
+                return Some(canon.clone());
+            }
         }
         let canon = root.canonicalize().ok()?;
-        self.canonical_roots.insert(root.to_path_buf(), canon.clone());
+        self.canonical_roots.insert(root.to_path_buf(), (canon.clone(), Instant::now()));
         Some(canon)
     }
 

--- a/crates/ephpm-server/src/static_files.rs
+++ b/crates/ephpm-server/src/static_files.rs
@@ -16,11 +16,17 @@ use crate::body::{self, ServerBody};
 /// The router has already verified the file exists and resolved it via
 /// `fallback`. We still validate path traversal for defense in depth.
 ///
+/// `canonical_root` must be the document root already passed through
+/// `Path::canonicalize()` — the router caches that per site (the root is
+/// constant for the process lifetime), saving a syscall on every static
+/// hit. The per-request file path is still canonicalized here: that is
+/// the traversal/symlink check and doubles as the existence probe.
+///
 /// When `etag` is enabled, computes a hash-based `ETag` for the content.
 /// If `if_none_match` contains a matching `ETag`, returns 304 Not Modified.
 #[allow(clippy::too_many_arguments)]
 pub async fn serve_file(
-    document_root: &Path,
+    canonical_root: &Path,
     file_path: &Path,
     accepts_gzip: bool,
     accepts_br: bool,
@@ -31,13 +37,10 @@ pub async fn serve_file(
     file_cache: Option<&crate::file_cache::FileCache>,
 ) -> Response<ServerBody> {
     // Security: ensure the resolved path is within the document root
-    let Ok(canonical_root) = document_root.canonicalize() else {
-        return not_found();
-    };
     let Ok(canonical_file) = file_path.canonicalize() else {
         return not_found();
     };
-    if !canonical_file.starts_with(&canonical_root) {
+    if !canonical_file.starts_with(canonical_root) {
         tracing::warn!(
             path = %file_path.display(),
             "path traversal attempt blocked"
@@ -347,9 +350,24 @@ mod tests {
     }
 
     /// Helper: serve a file using `serve_file` with default settings.
+    ///
+    /// Mirrors the router's contract: the document root is canonicalized
+    /// once by the caller (the router caches it), not inside `serve_file`.
     async fn serve_test(docroot: &Path, filename: &str) -> Response<ServerBody> {
+        let canonical_root = docroot.canonicalize().expect("canonicalize test docroot");
         let file_path = docroot.join(filename);
-        serve_file(docroot, &file_path, false, false, "", no_compression(), false, None, None).await
+        serve_file(
+            &canonical_root,
+            &file_path,
+            false,
+            false,
+            "",
+            no_compression(),
+            false,
+            None,
+            None,
+        )
+        .await
     }
 
     #[tokio::test]
@@ -410,10 +428,20 @@ mod tests {
         // Create a file outside docroot
         fs::write(parent.path().join("secret.txt"), "secret").unwrap();
 
+        let canonical_root = docroot.canonicalize().unwrap();
         let file_path = docroot.join("..").join("secret.txt");
-        let resp =
-            serve_file(&docroot, &file_path, false, false, "", no_compression(), false, None, None)
-                .await;
+        let resp = serve_file(
+            &canonical_root,
+            &file_path,
+            false,
+            false,
+            "",
+            no_compression(),
+            false,
+            None,
+            None,
+        )
+        .await;
         // Should be 403 (path resolves outside docroot) or 404 (canonicalize fails)
         let status = resp.status();
         assert!(


### PR DESCRIPTION
## Summary
Two contained wins from the perf sweep (#132 + a #140 item), scoped small enough to ride into v0.4.0 tonight:

- **Canonical docroot cache**: `serve_file` required a `document_root.canonicalize()` syscall per static hit; roots are constant for the process lifetime, so the router now canonicalizes once per site (DashMap cache) and passes the canonical form down. Traversal defense unchanged — the per-request FILE canonicalize (the actual security check) stays.
- **`expand_variables` → `Cow`**: literal fallback entries (no `$` placeholders) no longer pay two `String::replace` allocations per probe per request.

Deliberately excluded: the sweep's `service_fn` inner-`Arc::clone` item is a false positive — hyper 1.x service futures must be `'static`, that clone is load-bearing. Noted on #140.

## Test plan
- [x] `cargo test -p ephpm-server` — 171 passing (static_files tests updated to the pre-canonicalized contract, incl. traversal-blocked)
- [x] clippy workspace `-D warnings`, nightly fmt
- [ ] E2E (static-file suite covers the serving path end-to-end)