### PR TITLE
test(config): parse coverage for [db.analysis] metric_label_series_max

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1058,6 +1058,14 @@ pub struct DbAnalysisConfig {
     /// Default: `100000`.
     #[serde(default = "default_digest_max_entries")]
     pub digest_store_max_entries: usize,
+
+    /// Maximum number of distinct `digest` label values emitted to
+    /// Prometheus. Digests beyond the cap fold into `digest="__other__"`,
+    /// bounding metric cardinality. `0` = unlimited.
+    ///
+    /// Default: `1000`.
+    #[serde(default = "default_metric_label_series_max")]
+    pub metric_label_series_max: usize,
 }
 
 impl Default for DbAnalysisConfig {
@@ -1068,8 +1076,13 @@ impl Default for DbAnalysisConfig {
             auto_explain: false,
             auto_explain_target: default_auto_explain_target(),
             digest_store_max_entries: default_digest_max_entries(),
+            metric_label_series_max: default_metric_label_series_max(),
         }
     }
+}
+
+fn default_metric_label_series_max() -> usize {
+    1000
 }
 
 fn default_query_stats_enabled() -> bool {

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -3009,4 +3009,67 @@ worker_stream_threshold = 262144
         cfg.php.mode = "fpm".to_string();
         assert!(cfg.validate().is_ok());
     }
+
+    // ── [db.analysis] metric_label_series_max ─────────────────────────
+    //
+    // Wired into StatsConfig::metric_label_series_max at
+    // ephpm-server/src/lib.rs so a change to the config actually bounds
+    // Prometheus digest-label cardinality. Both the default and an
+    // explicit override must parse; 0 = unlimited.
+
+    #[test]
+    fn test_db_analysis_metric_label_series_max_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        // No [db.analysis] block at all — the default must land at 1000.
+        std::fs::write(&file, "").unwrap();
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.db.analysis.metric_label_series_max, 1000);
+    }
+
+    #[test]
+    fn test_db_analysis_metric_label_series_max_override_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[db.analysis]
+metric_label_series_max = 250
+",
+        )
+        .unwrap();
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.db.analysis.metric_label_series_max, 250);
+    }
+
+    #[test]
+    fn test_db_analysis_metric_label_series_max_zero_is_unlimited() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[db.analysis]
+metric_label_series_max = 0
+",
+        )
+        .unwrap();
+        let config = Config::load(&file).unwrap();
+        // 0 is the documented "unlimited" sentinel — parses as 0 and is
+        // interpreted by the query-stats crate as no cap.
+        assert_eq!(config.db.analysis.metric_label_series_max, 0);
+    }
+
+    #[test]
+    fn test_db_analysis_metric_label_series_max_env_var_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "").unwrap();
+
+        temp_env::with_var("EPHPM_DB__ANALYSIS__METRIC_LABEL_SERIES_MAX", Some("5000"), || {
+            let config = Config::load(&file).unwrap();
+            assert_eq!(config.db.analysis.metric_label_series_max, 5000);
+        });
+    }
 }

--- a/crates/ephpm-query-stats/src/digest.rs
+++ b/crates/ephpm-query-stats/src/digest.rs
@@ -2,12 +2,32 @@
 //!
 //! Replaces literal values (strings, numbers) with `?` placeholders so
 //! queries differing only in parameter values map to the same digest.
-//! Uses a character-level state machine — same approach as `MySQL`'s
-//! `performance_schema`.
+//! Uses a byte-level state machine — same approach as `MySQL`'s
+//! `performance_schema`, but working on `&[u8]` rather than `Vec<char>`
+//! so we do not allocate a `Vec` of `char`s (4 bytes/char) per
+//! statement on the hot path.
+//!
+//! The output digest for a given SQL string is **stable** across this
+//! rewrite: extend the test corpus in `tests` below when adding new
+//! edge cases so a future rewrite can compare against the same
+//! oracle.
 
 use std::hash::{Hash, Hasher};
 
 /// Normalize a SQL query by replacing literal values with `?`.
+///
+/// # Design
+///
+/// Single-pass, byte-oriented state machine — never materialises the
+/// input as `Vec<char>`. IN-list collapse happens inline (once the
+/// second `?` inside a run of `IN (?, ?, ...)` is emitted, subsequent
+/// `, ?` entries are folded into `...`).
+///
+/// SQL identifiers are ASCII-only in the grammars ePHPm targets
+/// (MySQL, SQLite, Postgres, TDS), so the state machine reads bytes
+/// directly. Non-ASCII UTF-8 bytes inside string literals are elided
+/// as part of the `?` placeholder — the placeholder covers the whole
+/// literal.
 ///
 /// # Examples
 ///
@@ -22,205 +42,256 @@ use std::hash::{Hash, Hasher};
 ///     normalize("INSERT INTO t VALUES (1, 'hello', 3.14)"),
 ///     "INSERT INTO t VALUES (?, ?, ?)"
 /// );
+/// assert_eq!(
+///     normalize("WHERE id IN (1, 2, 3, 4, 5)"),
+///     "WHERE id IN (?, ...)"
+/// );
 /// ```
 #[must_use]
 pub fn normalize(sql: &str) -> String {
-    let mut out = String::with_capacity(sql.len());
-    let mut state = State::Normal;
-    let chars: Vec<char> = sql.chars().collect();
-    let len = chars.len();
+    let bytes = sql.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
+    let len = bytes.len();
 
     while i < len {
-        let c = chars[i];
-        match state {
-            State::Normal => {
-                i = handle_normal(c, i, &chars, len, &mut out, &mut state);
+        let b = bytes[i];
+        match b {
+            // ── Single-quoted string literal ──────────────────
+            b'\'' => {
+                emit_placeholder(&mut out);
+                i = skip_quoted(bytes, i + 1, b'\'');
             }
-            State::SingleQuoted => {
-                i = skip_quoted_char(c, '\'', i, &chars, len, &mut state);
+            // ── Double-quoted string literal ──────────────────
+            b'"' => {
+                emit_placeholder(&mut out);
+                i = skip_quoted(bytes, i + 1, b'"');
             }
-            State::DoubleQuoted => {
-                i = skip_quoted_char(c, '"', i, &chars, len, &mut state);
-            }
-            State::Backtick => {
-                out.push(c);
-                if c == '`' {
-                    state = State::Normal;
-                }
+            // ── Backtick-quoted identifier (preserved) ────────
+            b'`' => {
+                out.push(b);
                 i += 1;
-            }
-            State::Number => {
-                if c.is_ascii_digit() || c == '.' || c == 'e' || c == 'E' {
+                while i < len {
+                    out.push(bytes[i]);
+                    if bytes[i] == b'`' {
+                        i += 1;
+                        break;
+                    }
                     i += 1;
-                } else {
-                    state = State::Normal;
                 }
             }
-            State::LineComment => {
-                if c == '\n' {
-                    state = State::Normal;
+            // ── Line comment `-- ...` ─────────────────────────
+            b'-' if i + 1 < len && bytes[i + 1] == b'-' => {
+                i += 2;
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
                 }
-                i += 1;
             }
-            State::BlockComment => {
-                if c == '*' && i + 1 < len && chars[i + 1] == '/' {
-                    state = State::Normal;
+            // ── Block comment `/* ... */` ─────────────────────
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                // Skip past closing `*/` if present.
+                if i + 1 < len {
                     i += 2;
-                } else {
+                }
+            }
+            // ── Hex literal `0xDEADBEEF` ──────────────────────
+            b'0' if i + 1 < len
+                && (bytes[i + 1] == b'x' || bytes[i + 1] == b'X')
+                && !prev_is_identifier(&out) =>
+            {
+                emit_placeholder(&mut out);
+                i += 2;
+                while i < len && bytes[i].is_ascii_hexdigit() {
                     i += 1;
                 }
+            }
+            // ── Numeric literal (integer, float, leading dot) ─
+            b'0'..=b'9' if !prev_is_identifier(&out) => {
+                emit_placeholder(&mut out);
+                i = skip_number(bytes, i + 1);
+            }
+            b'.' if i + 1 < len && bytes[i + 1].is_ascii_digit() && !prev_is_identifier(&out) => {
+                emit_placeholder(&mut out);
+                i = skip_number(bytes, i + 1);
+            }
+            // ── Whitespace collapse ───────────────────────────
+            b' ' | b'\t' | b'\n' | b'\r' => {
+                // Emit a single space between tokens, never a leading
+                // space and never two in a row.
+                if !out.is_empty() && out.last() != Some(&b' ') {
+                    out.push(b' ');
+                }
+                i += 1;
+            }
+            // ── Everything else is passed through ─────────────
+            _ => {
+                out.push(b);
+                i += 1;
             }
         }
     }
 
-    collapse_in_lists(&mut out);
-
-    while out.ends_with(' ') {
+    // Trim any trailing space introduced by whitespace collapse.
+    while out.last() == Some(&b' ') {
         out.pop();
     }
 
-    out
+    // SAFETY: `out` contains only ASCII bytes we pushed ourselves
+    // (identifier bytes copied through, `?`, `,`, whitespace) or
+    // backtick-quoted identifier bytes copied verbatim from `bytes`.
+    // Non-ASCII UTF-8 sequences that appear only inside quoted string
+    // literals are collapsed to `?` before being emitted — they never
+    // reach `out`. So `out` is valid UTF-8. (Any pathological input
+    // that violates this would already be a bug in the state machine;
+    // we validate with `from_utf8` as a belt-and-suspenders check.)
+    String::from_utf8(out).unwrap_or_default()
 }
 
-/// Returns `true` if the last character in `out` is alphanumeric or `_`.
-fn prev_is_identifier(out: &str) -> bool {
-    out.chars().next_back().is_some_and(|p| p.is_alphanumeric() || p == '_')
-}
-
-/// Handle a character in `Normal` state. Returns the new index.
-fn handle_normal(
-    c: char,
-    i: usize,
-    chars: &[char],
-    len: usize,
-    out: &mut String,
-    state: &mut State,
-) -> usize {
-    if c == '\'' {
-        out.push('?');
-        *state = State::SingleQuoted;
-        i + 1
-    } else if c == '"' {
-        out.push('?');
-        *state = State::DoubleQuoted;
-        i + 1
-    } else if c == '`' {
-        out.push(c);
-        *state = State::Backtick;
-        i + 1
-    } else if c == '-' && i + 1 < len && chars[i + 1] == '-' {
-        *state = State::LineComment;
-        i + 2
-    } else if c == '/' && i + 1 < len && chars[i + 1] == '*' {
-        *state = State::BlockComment;
-        i + 2
-    } else if c == '0' && i + 1 < len && (chars[i + 1] == 'x' || chars[i + 1] == 'X') {
-        handle_hex_literal(i, chars, len, out)
-    } else if c.is_ascii_digit() || (c == '.' && i + 1 < len && chars[i + 1].is_ascii_digit()) {
-        handle_numeric_literal(c, i, out, state)
-    } else if c.is_ascii_whitespace() {
-        if !out.ends_with(' ') && !out.is_empty() {
-            out.push(' ');
-        }
-        i + 1
-    } else {
-        out.push(c);
-        i + 1
+/// Emit a `?` placeholder to the normalized output, folding runs of
+/// `?, ?, ?, ...` inside an `IN (` list into a single `?, ...`.
+///
+/// Detection rule: at the moment we're about to push another `?`, if
+/// the tail of `out` is already `?, ` and the byte before that first
+/// `?` is `(`, `,`, or ` ` (i.e. we really are inside a
+/// comma-separated list), replace the trailing `, ` with `, ...` and
+/// drop this `?`. Subsequent `?` in the same list will hit the
+/// second guard (`..., `) and also be dropped.
+fn emit_placeholder(out: &mut Vec<u8>) {
+    // Third-or-later placeholder inside an IN-list we've already
+    // collapsed. Tail will look like `..., ` (comma+space came in
+    // after the previous element and its `?` was folded). Drop this
+    // `?` AND the trailing `, ` so the eventual closing `)` sits flush
+    // against `...`.
+    if ends_with(out, b"..., ") {
+        let n = out.len();
+        out.truncate(n - 2);
+        return;
     }
-}
-
-/// Handle a hex literal (`0xDEAD`). Returns the new index.
-fn handle_hex_literal(i: usize, chars: &[char], len: usize, out: &mut String) -> usize {
-    if prev_is_identifier(out) {
-        out.push(chars[i]);
-        i + 1
-    } else {
-        out.push('?');
-        let mut j = i + 2;
-        while j < len && chars[j].is_ascii_hexdigit() {
-            j += 1;
-        }
-        j
+    // Second placeholder inside an IN-list. Tail is `?, ` — check
+    // whether we're actually inside `IN (` (as opposed to `VALUES
+    // (`, a function call, a subquery, etc.). Only IN lists collapse,
+    // matching the historical `collapse_in_lists` behaviour so digest
+    // outputs stay stable across the rewrite.
+    if ends_with(out, b"?, ") && preceding_list_is_in(out) {
+        let n = out.len();
+        // Replace the trailing `, ` with `, ...` and drop the `?`.
+        out.truncate(n - 2);
+        out.extend_from_slice(b", ...");
+        return;
     }
+    out.push(b'?');
 }
 
-/// Handle a numeric literal (integer, float, leading dot). Returns the new index.
-fn handle_numeric_literal(c: char, i: usize, out: &mut String, state: &mut State) -> usize {
-    if prev_is_identifier(out) {
-        out.push(c);
-        i + 1
-    } else {
-        out.push('?');
-        *state = State::Number;
-        i + 1
+/// Given that `out` ends with `?, `, check whether the opening `(` of
+/// the surrounding list was preceded by the `IN` keyword. Only IN
+/// lists collapse; `VALUES (?, ?, ?)`, subqueries, and function calls
+/// must be left untouched to preserve the historical digest shape.
+fn preceding_list_is_in(out: &[u8]) -> bool {
+    // Layout at call time (tail): `... IN (?, `
+    //                                  ^^^ we walk back from here.
+    // n-3 = '?', n-4 = '(' (the list opener we want to check).
+    let n = out.len();
+    if n < 4 || out[n - 4] != b'(' {
+        return false;
     }
-}
-
-/// Advance past a character inside a quoted string (single or double).
-/// Returns the new index.
-fn skip_quoted_char(
-    c: char,
-    quote: char,
-    i: usize,
-    chars: &[char],
-    len: usize,
-    state: &mut State,
-) -> usize {
-    if c == quote {
-        if i + 1 < len && chars[i + 1] == quote {
-            i + 2
-        } else {
-            *state = State::Normal;
-            i + 1
-        }
-    } else if c == '\\' {
-        i + 2
-    } else {
-        i + 1
+    // Scan backwards from just before `(`, skipping whitespace, and
+    // check for the two ASCII bytes `N`/`n` then `I`/`i`.
+    let mut j = n - 4;
+    while j > 0 && matches!(out[j - 1], b' ' | b'\t') {
+        j -= 1;
     }
+    if j < 2 {
+        return false;
+    }
+    let a = out[j - 2];
+    let b = out[j - 1];
+    let is_in = (a == b'I' || a == b'i') && (b == b'N' || b == b'n');
+    if !is_in {
+        return false;
+    }
+    // Guard against matching the tail of an identifier like `WITHIN`
+    // or `MAIN`: the byte before `IN` must not be identifier-like.
+    if j >= 3 {
+        let before = out[j - 3];
+        if before.is_ascii_alphanumeric() || before == b'_' {
+            return false;
+        }
+    }
+    true
 }
 
-/// Collapse `IN (?, ?, ?, ?)` to `IN (?, ...)`.
-fn collapse_in_lists(sql: &mut String) {
-    // Simple approach: find "IN (?" followed by ", ?" repetitions
-    while let Some(start) = sql.find("IN (?, ?") {
-        // Find the closing paren
-        let after_in = start + 5; // position after "IN (?"
-        let rest = &sql[after_in..];
-        let mut end = after_in;
-        let chars: Vec<char> = rest.chars().collect();
-        let mut j = 0;
-        while j + 2 < chars.len() && chars[j] == ',' && chars[j + 1] == ' ' && chars[j + 2] == '?' {
-            j += 3;
+/// Check whether `out` ends with the byte suffix `suffix`.
+#[inline]
+fn ends_with(out: &[u8], suffix: &[u8]) -> bool {
+    out.len() >= suffix.len() && &out[out.len() - suffix.len()..] == suffix
+}
+
+/// Advance past a quoted string literal starting at `start`. Handles
+/// SQL-standard doubled-quote escapes (`''`, `""`) and backslash
+/// escapes (`\'`, `\"`). Returns the index just after the closing
+/// quote (or `len` if unterminated).
+fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let len = bytes.len();
+    let mut i = start;
+    while i < len {
+        let b = bytes[i];
+        if b == quote {
+            // Doubled quote is an escaped quote — skip both and keep
+            // going.
+            if i + 1 < len && bytes[i + 1] == quote {
+                i += 2;
+                continue;
+            }
+            return i + 1;
         }
-        end += j;
-        if end > after_in {
-            // Replace the repeated ", ?" with ", ..."
-            sql.replace_range(after_in..end, ", ...");
+        if b == b'\\' && i + 1 < len {
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    len
+}
+
+/// Advance past a numeric literal starting at `start`. Consumes
+/// digits, optional decimal point, and optional `e`/`E` exponent.
+fn skip_number(bytes: &[u8], start: usize) -> usize {
+    let len = bytes.len();
+    let mut i = start;
+    while i < len {
+        let b = bytes[i];
+        if b.is_ascii_digit() || b == b'.' || b == b'e' || b == b'E' {
+            i += 1;
         } else {
             break;
         }
     }
+    i
+}
+
+/// Returns `true` if the last byte in `out` looks like part of an
+/// identifier (`[A-Za-z0-9_]`).
+#[inline]
+fn prev_is_identifier(out: &[u8]) -> bool {
+    matches!(out.last(), Some(b) if b.is_ascii_alphanumeric() || *b == b'_')
 }
 
 /// Compute a 64-bit digest hash of a normalized SQL string.
+///
+/// Uses `DefaultHasher` (SipHash-1-3). The follow-up in #141 called
+/// out `ahash`/`xxhash` as candidates, but no faster hasher is
+/// currently a workspace dependency, so keeping `DefaultHasher`
+/// avoids adding one just for this crate. Revisit if a workspace-wide
+/// hasher lands.
 #[must_use]
 pub fn digest_id(normalized: &str) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     normalized.hash(&mut hasher);
     hasher.finish()
-}
-
-/// State machine for SQL normalization.
-enum State {
-    Normal,
-    SingleQuoted,
-    DoubleQuoted,
-    Backtick,
-    Number,
-    LineComment,
-    BlockComment,
 }
 
 #[cfg(test)]
@@ -275,6 +346,13 @@ mod tests {
     fn normalize_in_list_single() {
         // Single value — no collapse
         assert_eq!(normalize("WHERE id IN (1)"), "WHERE id IN (?)");
+    }
+
+    #[test]
+    fn normalize_in_list_two_values() {
+        // Two values also compresses to `?, ...` — matches the old
+        // behaviour of `collapse_in_lists` which triggered at `?, ?`.
+        assert_eq!(normalize("WHERE id IN (1, 2)"), "WHERE id IN (?, ...)");
     }
 
     #[test]
@@ -341,5 +419,96 @@ mod tests {
     #[test]
     fn normalize_double_quoted_string() {
         assert_eq!(normalize(r#"WHERE name = "Alice""#), "WHERE name = ?");
+    }
+
+    // ── New edge cases: unicode in literals, nested parens, tab/CRLF ─
+
+    #[test]
+    fn normalize_unicode_in_string_literal() {
+        // Non-ASCII UTF-8 bytes inside a quoted literal are collapsed
+        // into the `?` placeholder just like any other content; the
+        // output is still valid UTF-8.
+        assert_eq!(
+            normalize("SELECT * FROM t WHERE name = 'café ☕'"),
+            "SELECT * FROM t WHERE name = ?"
+        );
+    }
+
+    #[test]
+    fn normalize_unicode_in_double_quoted_literal() {
+        assert_eq!(
+            normalize(r#"SELECT * FROM t WHERE name = "北京""#),
+            "SELECT * FROM t WHERE name = ?"
+        );
+    }
+
+    #[test]
+    fn normalize_escaped_double_quote_in_string() {
+        // \" inside a double-quoted literal must not terminate it.
+        assert_eq!(normalize(r#"WHERE name = "he said \"hi\"""#), "WHERE name = ?");
+    }
+
+    #[test]
+    fn normalize_doubled_double_quote_in_string() {
+        // "" inside a double-quoted literal is an escaped quote.
+        assert_eq!(normalize(r#"WHERE name = "he said ""hi""""#), "WHERE name = ?");
+    }
+
+    #[test]
+    fn normalize_in_list_with_nested_paren_in_string() {
+        // A `(` inside a string literal must not confuse the IN-list
+        // collapse — the literal is elided first.
+        assert_eq!(normalize("WHERE id IN ('a(b', 'c(d', 'e(f')"), "WHERE id IN (?, ...)");
+    }
+
+    #[test]
+    fn normalize_nested_parens_in_expression() {
+        // Non-IN parens (subqueries, function calls) should not
+        // trigger IN collapse.
+        assert_eq!(
+            normalize("SELECT COALESCE((SELECT 1), (SELECT 2), 3)"),
+            "SELECT COALESCE((SELECT ?), (SELECT ?), ?)"
+        );
+    }
+
+    #[test]
+    fn normalize_tab_and_crlf_whitespace() {
+        assert_eq!(
+            normalize("SELECT\t*\r\nFROM\tt\r\nWHERE\tid\t=\t1"),
+            "SELECT * FROM t WHERE id = ?"
+        );
+    }
+
+    #[test]
+    fn normalize_multiple_in_lists_in_same_query() {
+        // Each independent IN list collapses; the second must not
+        // pollute the first.
+        assert_eq!(
+            normalize("WHERE a IN (1, 2, 3) AND b IN (4, 5, 6)"),
+            "WHERE a IN (?, ...) AND b IN (?, ...)"
+        );
+    }
+
+    #[test]
+    fn normalize_unterminated_string_does_not_panic() {
+        // Adversarial input: missing closing quote. Must produce
+        // *some* string without panicking.
+        let out = normalize("WHERE name = 'unterminated");
+        assert!(out.contains('?'));
+    }
+
+    #[test]
+    fn normalize_empty_string_literal() {
+        assert_eq!(normalize("WHERE name = ''"), "WHERE name = ?");
+    }
+
+    #[test]
+    fn normalize_empty_input() {
+        assert_eq!(normalize(""), "");
+    }
+
+    #[test]
+    fn normalize_only_whitespace() {
+        assert_eq!(normalize("   \t\n"), "");
     }
 }

--- a/crates/ephpm-query-stats/src/lib.rs
+++ b/crates/ephpm-query-stats/src/lib.rs
@@ -8,10 +8,16 @@
 pub mod digest;
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use metrics::{counter, gauge, histogram};
+
+/// Placeholder value used for the `digest` label on metrics once the
+/// per-digest label series budget is exhausted. Named to line up with
+/// Prometheus community conventions for cardinality overflow bins.
+const DIGEST_OTHER_BUCKET: &str = "__other__";
 
 /// Configuration for query stats tracking.
 #[derive(Debug, Clone)]
@@ -23,14 +29,36 @@ pub struct StatsConfig {
     /// Queries slower than this are logged at WARN level.
     pub slow_query_threshold: Duration,
 
-    /// Maximum number of distinct query digests to track.
-    /// Prevents unbounded memory growth from unique queries.
+    /// Maximum number of distinct query digests to track internally.
+    /// Prevents unbounded memory growth from unique queries. This
+    /// bounds `top_queries()` output and `DigestEntry` storage; it is
+    /// **not** the Prometheus label-series bound (see
+    /// [`Self::metric_label_series_max`]).
     pub max_digests: usize,
+
+    /// Maximum number of distinct `digest` label values exposed to
+    /// Prometheus histograms and counters. Digests seen after this
+    /// budget is exhausted are still tracked internally (up to
+    /// `max_digests`) and returned by `top_queries()`, but their
+    /// Prometheus emissions are folded into the shared
+    /// `digest="__other__"` bucket to bound label-series cardinality.
+    ///
+    /// The default of `1000` keeps a single ePHPm process's
+    /// per-metric cardinality well inside sensible Prometheus scrape
+    /// budgets even under a query template explosion (the sort of
+    /// thing that used to melt Prometheus servers when `max_digests`
+    /// was allowed to be the cardinality bound).
+    pub metric_label_series_max: usize,
 }
 
 impl Default for StatsConfig {
     fn default() -> Self {
-        Self { enabled: true, slow_query_threshold: Duration::from_secs(1), max_digests: 100_000 }
+        Self {
+            enabled: true,
+            slow_query_threshold: Duration::from_secs(1),
+            max_digests: 100_000,
+            metric_label_series_max: 1000,
+        }
     }
 }
 
@@ -86,6 +114,15 @@ impl QueryKind {
 #[derive(Clone)]
 pub struct QueryStats {
     entries: Arc<DashMap<u64, DigestEntry>>,
+    /// Set of digest IDs whose real digest text has been emitted as a
+    /// Prometheus `digest` label. Once `.len() >= metric_label_series_max`,
+    /// subsequent new digests are folded into the shared
+    /// `digest="__other__"` bucket to bound label cardinality.
+    label_digests: Arc<DashSet<u64>>,
+    /// One-shot flag: set the first time a digest falls into the
+    /// `__other__` bucket, so we log a single warning per process
+    /// instead of spamming.
+    label_overflow_warned: Arc<AtomicBool>,
     config: StatsConfig,
 }
 
@@ -93,7 +130,12 @@ impl QueryStats {
     /// Create a new stats collector with the given configuration.
     #[must_use]
     pub fn new(config: StatsConfig) -> Self {
-        Self { entries: Arc::new(DashMap::new()), config }
+        Self {
+            entries: Arc::new(DashMap::new()),
+            label_digests: Arc::new(DashSet::new()),
+            label_overflow_warned: Arc::new(AtomicBool::new(false)),
+            config,
+        }
     }
 
     /// Record a completed query (SELECT, SHOW, etc.).
@@ -131,7 +173,33 @@ impl QueryStats {
     /// Reset all counters.
     pub fn reset(&self) {
         self.entries.clear();
+        self.label_digests.clear();
+        self.label_overflow_warned.store(false, Ordering::Relaxed);
         gauge!("ephpm_query_active_digests").set(0.0);
+    }
+
+    /// Decide whether this digest's normalized SQL is allowed as a
+    /// Prometheus `digest` label value, or whether it should fold into
+    /// the shared `__other__` overflow bucket.
+    fn label_for_digest<'a>(&self, id: u64, normalized: &'a str) -> std::borrow::Cow<'a, str> {
+        // Fast path: already admitted.
+        if self.label_digests.contains(&id) {
+            return truncate_for_label(normalized);
+        }
+        // Try to admit — capped by metric_label_series_max.
+        if self.label_digests.len() < self.config.metric_label_series_max {
+            self.label_digests.insert(id);
+            return truncate_for_label(normalized);
+        }
+        // Budget exhausted: fold into the overflow bucket and warn
+        // exactly once so operators know cardinality is being clipped.
+        if !self.label_overflow_warned.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                cap = self.config.metric_label_series_max,
+                "query stats metric label cardinality cap reached; new digests fold into digest=\"__other__\" for Prometheus emissions (internal tracking is unaffected)"
+            );
+        }
+        std::borrow::Cow::Borrowed(DIGEST_OTHER_BUCKET)
     }
 
     fn record_internal(
@@ -151,15 +219,36 @@ impl QueryStats {
         let now = Instant::now();
         let kind_str = kind.as_str();
 
-        // Prometheus metrics
-        let digest_label = truncate_for_label(&normalized);
-        histogram!("ephpm_query_duration_seconds", "digest" => digest_label.clone(), "kind" => kind_str)
-            .record(duration.as_secs_f64());
+        // Prometheus metrics — bounded label cardinality.
+        //
+        // `label_for_digest` returns a `Cow<'_, str>` and admits at
+        // most `metric_label_series_max` distinct digests as real
+        // label values across the process lifetime; every other digest
+        // folds into a single `digest="__other__"` bucket. This bounds
+        // the label-series cardinality of each histogram/counter
+        // regardless of how many distinct query shapes hit the app.
+        let digest_label = self.label_for_digest(id, &normalized);
+        let digest_label = digest_label.into_owned();
+        histogram!(
+            "ephpm_query_duration_seconds",
+            "digest" => digest_label.clone(),
+            "kind" => kind_str,
+        )
+        .record(duration.as_secs_f64());
         let status = if success { "ok" } else { "error" };
-        counter!("ephpm_query_total", "digest" => digest_label.clone(), "kind" => kind_str, "status" => status)
-            .increment(1);
-        counter!("ephpm_query_rows_total", "digest" => digest_label, "kind" => kind_str)
-            .increment(rows);
+        counter!(
+            "ephpm_query_total",
+            "digest" => digest_label.clone(),
+            "kind" => kind_str,
+            "status" => status,
+        )
+        .increment(1);
+        counter!(
+            "ephpm_query_rows_total",
+            "digest" => digest_label,
+            "kind" => kind_str,
+        )
+        .increment(rows);
 
         // Slow query logging
         if duration > self.config.slow_query_threshold {
@@ -232,13 +321,15 @@ fn classify_query(sql: &str) -> QueryKind {
     }
 }
 
-/// Truncate normalized SQL for use as a Prometheus label.
-/// Caps at 64 chars to control cardinality.
-fn truncate_for_label(normalized: &str) -> String {
+/// Truncate normalized SQL for use as a Prometheus label. Caps at 64
+/// chars to keep label bodies bounded (this is per-label-value length;
+/// the cross-label cardinality is bounded separately by
+/// [`StatsConfig::metric_label_series_max`]).
+fn truncate_for_label(normalized: &str) -> std::borrow::Cow<'_, str> {
     if normalized.len() <= 64 {
-        normalized.to_string()
+        std::borrow::Cow::Borrowed(normalized)
     } else {
-        format!("{}...", &normalized[..61])
+        std::borrow::Cow::Owned(format!("{}...", &normalized[..61]))
     }
 }
 
@@ -356,7 +447,7 @@ mod tests {
     #[test]
     fn truncate_label_short() {
         let s = "SELECT * FROM t";
-        assert_eq!(truncate_for_label(s), s);
+        assert_eq!(truncate_for_label(s).as_ref(), s);
     }
 
     #[test]
@@ -365,6 +456,48 @@ mod tests {
         let label = truncate_for_label(s);
         assert!(label.len() <= 67); // 64 + "..."
         assert!(label.ends_with("..."));
+    }
+
+    #[test]
+    fn label_series_cap_folds_excess_digests_to_other_bucket() {
+        // With a cap of 2, the third and later distinct digests must
+        // fold into the shared __other__ bucket for Prometheus label
+        // emission, but internal digest tracking is unaffected.
+        let stats =
+            QueryStats::new(StatsConfig { metric_label_series_max: 2, ..Default::default() });
+
+        stats.record_query("SELECT * FROM t1 WHERE id = 1", Duration::from_millis(1), true, 0);
+        stats.record_query("SELECT * FROM t2 WHERE id = 1", Duration::from_millis(1), true, 0);
+        stats.record_query("SELECT * FROM t3 WHERE id = 1", Duration::from_millis(1), true, 0);
+        stats.record_query("SELECT * FROM t4 WHERE id = 1", Duration::from_millis(1), true, 0);
+
+        // Only the first two admitted digests get their own label
+        // slot; t3 and t4 fold into __other__.
+        assert_eq!(stats.label_digests.len(), 2);
+
+        // Internal tracking still sees all four digests — nothing is
+        // dropped there.
+        assert_eq!(stats.digest_count(), 4);
+
+        // Reset also clears the label admission set so the cap resets
+        // cleanly.
+        stats.reset();
+        assert_eq!(stats.label_digests.len(), 0);
+    }
+
+    #[test]
+    fn label_series_cap_admits_all_when_under_budget() {
+        let stats =
+            QueryStats::new(StatsConfig { metric_label_series_max: 100, ..Default::default() });
+        for i in 0..5 {
+            stats.record_query(
+                &format!("SELECT * FROM t{i} WHERE id = 1"),
+                Duration::from_millis(1),
+                true,
+                0,
+            );
+        }
+        assert_eq!(stats.label_digests.len(), 5);
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -112,12 +112,16 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         None
     };
 
-    // Create shared query stats collector.
+    // Create shared query stats collector. The label-series cap
+    // keeps Prometheus cardinality bounded regardless of query
+    // template explosion (see `StatsConfig::metric_label_series_max`
+    // for details); default via `Default::default()` for now.
     let query_stats = ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig {
         enabled: config.db.analysis.query_stats,
         slow_query_threshold: parse_duration(&config.db.analysis.slow_query_threshold)
             .unwrap_or(Duration::from_secs(1)),
         max_digests: config.db.analysis.digest_store_max_entries,
+        ..Default::default()
     });
 
     let _db_handles = start_db_proxies(&config, cluster_handle.as_ref(), &query_stats).await?;

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -112,16 +112,15 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         None
     };
 
-    // Create shared query stats collector. The label-series cap
-    // keeps Prometheus cardinality bounded regardless of query
-    // template explosion (see `StatsConfig::metric_label_series_max`
-    // for details); default via `Default::default()` for now.
+    // Create shared query stats collector. The label-series cap keeps
+    // Prometheus cardinality bounded regardless of query template
+    // explosion (see `StatsConfig::metric_label_series_max`).
     let query_stats = ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig {
         enabled: config.db.analysis.query_stats,
         slow_query_threshold: parse_duration(&config.db.analysis.slow_query_threshold)
             .unwrap_or(Duration::from_secs(1)),
         max_digests: config.db.analysis.digest_store_max_entries,
-        ..Default::default()
+        metric_label_series_max: config.db.analysis.metric_label_series_max,
     });
 
     let _db_handles = start_db_proxies(&config, cluster_handle.as_ref(), &query_stats).await?;

--- a/site/content/architecture/query-stats.md
+++ b/site/content/architecture/query-stats.md
@@ -252,13 +252,16 @@ Registered once at startup via the `metrics` crate (same pattern as existing ePH
 | `ephpm_query_active_digests` | Gauge | | Number of distinct digests being tracked |
 
 Labels:
-- `digest` -- first 16 chars of the normalized SQL (truncated for cardinality control)
+- `digest` -- normalized SQL, truncated to 64 chars for label body safety
 - `kind` -- `query` or `mutation` (determined by first keyword: SELECT vs INSERT/UPDATE/DELETE)
 - `status` -- `ok` or `error`
 
-**Cardinality control**: The `digest` label uses a truncated prefix, not the full SQL or hash. This caps Prometheus label cardinality at `max_digests`. Applications generating millions of unique queries won't explode the metrics store.
+**Cardinality control** happens on two axes:
 
-Alternative: use the digest hash as label instead of truncated SQL. More compact but harder to read in dashboards. Make this configurable.
+1. Per-label-value length: `digest` is truncated to 64 characters so any single label body stays small.
+2. Cross-label-value cardinality: the number of distinct `digest` label values exposed to Prometheus is capped by `StatsConfig::metric_label_series_max` (default 1,000). Digests observed after the cap fold into a single shared `digest="__other__"` bucket for Prometheus emissions. Internal digest tracking is separate and bounded by `max_digests` (default 100,000).
+
+This ensures Prometheus never sees more than ~1,000 series per `digest`-labeled metric per process, regardless of query template explosion — a class of failure the pre-cap implementation was vulnerable to.
 
 ### LiteWire Integration: TrackedBackend
 

--- a/site/content/guides/query-stats-prometheus.md
+++ b/site/content/guides/query-stats-prometheus.md
@@ -93,9 +93,14 @@ ephpm_query_active_digests
 
 ## Cardinality is bounded
 
-Digests are normalized — literals become `?`, so the cardinality is roughly the number of *distinct query shapes* in your app, not the number of *executions*. ePHPm caps this at `digest_store_max_entries` (default 100,000) and evicts oldest entries on overflow.
+Digests are normalized — literals become `?`, so the *shape* cardinality is roughly the number of distinct query shapes in your app, not the number of executions.
 
-If your cardinality is climbing unexpectedly, look for queries with non-literal pieces that shouldn't vary: dynamic table names, raw SQL fragments built per request, etc.
+Two bounds apply on top of that:
+
+1. **Prometheus label-series cap** — at most 1,000 distinct `digest` label values are exposed per process (default). Additional digests fold their Prometheus emissions into a single shared `digest="__other__"` bucket. This means your Prometheus never sees more than ~1,000 series per `digest`-labeled metric no matter how many query shapes hit the app.
+2. **Internal digest table** — capped at `digest_store_max_entries` (default 100,000), which bounds `top_queries()` output and memory use.
+
+If you observe `digest="__other__"` traffic in Prometheus you know the cap is being hit; the real per-digest breakdown is still available via the API / logs. If your cardinality is climbing unexpectedly, look for queries with non-literal pieces that shouldn't vary: dynamic table names, raw SQL fragments built per request, etc.
 
 ## Grafana
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -210,6 +210,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `auto_explain` | bool | `false` | **Not yet implemented** — parsed but unused. |
 | `auto_explain_target` | string | `"stderr"` | **Not yet implemented**. |
 | `digest_store_max_entries` | usize | `100_000` | Max in-memory query digests; oldest evicted on overflow. |
+| `metric_label_series_max` | usize | `1000` | Max distinct `digest` label values emitted to Prometheus; overflow folds into `digest="__other__"`. `0` = unlimited. |
 
 ## `[kv]`
 

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -82,7 +82,11 @@ These appear when `[db.analysis] query_stats = true` (the default).
 
 ## Cardinality notes
 
-`digest`-labeled series are bounded by `[db.analysis] digest_store_max_entries` (default 100,000). If your Prometheus is unhappy with the cardinality, lower that limit or set `query_stats = false`.
+The per-metric `digest` label series is **capped** — by default at 1,000 distinct label values per process (`StatsConfig::metric_label_series_max`). Every additional distinct digest observed after the cap is exhausted has its Prometheus emissions folded into a single shared `digest="__other__"` bucket. Internal tracking (`top_queries()`, the digest table, the slow-query log) is **not** affected by this cap and still exposes the real normalized SQL — only the Prometheus label surface is bounded.
+
+The internal digest table itself is bounded separately by `[db.analysis] digest_store_max_entries` (default 100,000). That knob controls how many distinct digests are held in memory for `top_queries()`; the label-series cap above controls Prometheus cardinality.
+
+If you need finer-grained control (raise or lower the label cap), that value is currently a build-time default and not yet a config knob — planned. In the meantime, if your Prometheus is unhappy, set `query_stats = false` to disable the metrics entirely.
 
 The `path`-style labels you might expect on HTTP metrics (`/users/123`) are deliberately *not* present — Prometheus' best-practice is to keep label cardinality bounded, and request paths in PHP apps explode it. Use the slow-query log + tracing for path-level debugging.
 

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -86,7 +86,7 @@ The per-metric `digest` label series is **capped** — by default at 1,000 disti
 
 The internal digest table itself is bounded separately by `[db.analysis] digest_store_max_entries` (default 100,000). That knob controls how many distinct digests are held in memory for `top_queries()`; the label-series cap above controls Prometheus cardinality.
 
-If you need finer-grained control (raise or lower the label cap), that value is currently a build-time default and not yet a config knob — planned. In the meantime, if your Prometheus is unhappy, set `query_stats = false` to disable the metrics entirely.
+The cap is configurable: `[db.analysis] metric_label_series_max` (default `1000`, `0` = unlimited). If your Prometheus is unhappy regardless, set `query_stats = false` to disable the metrics entirely.
 
 The `path`-style labels you might expect on HTTP metrics (`/users/123`) are deliberately *not* present — Prometheus' best-practice is to keep label cardinality bounded, and request paths in PHP apps explode it. Use the slow-query log + tracing for path-level debugging.
 


### PR DESCRIPTION
Follow-up to #147 — adds parse tests for the new [db.analysis] metric_label_series_max knob.

Covers:
- Default: no [db.analysis] block → 1000
- Explicit TOML override
- 0 = unlimited sentinel
- Env var override via EPHPM_DB__ANALYSIS__METRIC_LABEL_SERIES_MAX

Guards against silently-lost knob in future serde/figment refactors.