### PR TITLE
fix(kv): 5s timeout on RESP max-clients refusal write

### DIFF
--- a/crates/ephpm-kv/src/server.rs
+++ b/crates/ephpm-kv/src/server.rs
@@ -154,10 +154,17 @@ pub async fn serve_on(
                         Ok(permit) => Some(permit),
                         Err(_) => {
                             debug!(peer = %addr, "refusing KV connection: max clients reached");
+                            // Bound the refusal write: a non-reading peer would
+                            // otherwise pin a spawned refusal task indefinitely,
+                            // and a flood of such peers would exhaust task
+                            // memory even though the connection cap did its
+                            // job on the accept path.
                             tokio::spawn(async move {
-                                let _ = stream
-                                    .write_all(b"-ERR max number of clients reached\r\n")
-                                    .await;
+                                let _ = tokio::time::timeout(
+                                    Duration::from_secs(5),
+                                    stream.write_all(b"-ERR max number of clients reached\r\n"),
+                                )
+                                .await;
                             });
                             continue;
                         }


### PR DESCRIPTION
## Summary
- The max-clients refusal write on the RESP accept path was a bare `write_all` in a spawned task. A non-reading peer (or a flood of them) could pin those tasks indefinitely, exhausting task memory even though the connection cap did its job on the accept path.
- Wraps the write in `tokio::time::timeout(5s)` so the spawned task always releases within a bounded interval.

## Test plan
- [x] `cargo test -p ephpm-kv connection_cap_refuses_excess_clients` — existing connection-cap test still passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no new warnings
- [x] `cargo +nightly fmt --all` — formatted