### PR TITLE
build: exclude .claude/ + tmp_ scratch from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ php-sdk/
 bin/
 docs/
 .github/
+.claude/
+tmp_*/


### PR DESCRIPTION
Build-context hygiene: agent worktrees under .claude/ carry multi-GB target/ dirs; two disk-full incidents and repeated context-copy EOFs traced to this. No image content change.