### PR TITLE
docs(roadmap): clustered KV v2, benchmarks-as-artifact, NTS prefork, deploy story

### DIFF
--- a/site/content/roadmap/benchmarks.md
+++ b/site/content/roadmap/benchmarks.md
@@ -1,0 +1,80 @@
+# Benchmarks as a Release Artifact
+
+> **Status: DESIGN — not yet implemented.** The tooling exists in
+> scattered, proven form (the ePHPm-lab k6 profiles, the opcache e2e);
+> this page designs its consolidation into a per-release discipline.
+
+## Why this page exists
+
+Two facts from July 2026:
+
+1. **Every ePHPm 8.3/8.4 binary ever shipped before 0.3.0 ran with
+   OPcache silently disabled** — the embed SAPI wasn't on OPcache's
+   allowlist, so drop-in mode was benchmarked (by us and by users) at
+   roughly 17× its intended latency on framework workloads. No test
+   caught it, because no test asserted a *performance property*.
+2. The bug was found by an outside user's benchmark report — which also
+   showed that a motivated evaluator will test the wrong mode, get the
+   wrong numbers, and publish them. Their (fair) ask: *"publish
+   benchmark recipes that compare against realistic PHP-FPM baselines
+   with OPcache and Redis."*
+
+Correctness CI cannot catch a 17× regression that returns correct
+bytes. Only a measured baseline can.
+
+## Design
+
+### 1. `bench/` — recipes in-tree
+
+A directory of self-contained, pinned benchmark profiles (k6 scripts +
+fixtures + compose/k8s manifests), each with a named baseline pairing:
+
+| Profile | ePHPm side | Baseline side |
+|---|---|---|
+| `tiny-scripts` | fpm mode, defaults | nginx + php-fpm (OPcache on) |
+| `laravel-worker` | worker mode + native KV | nginx + php-fpm + Redis (Predis) |
+| `static-files` | fpm mode | nginx alone |
+| `deploy-blip` | 2-node cluster + `ephpm deploy` | 2-replica fpm + rolling restart |
+
+The first three reproduce the shapes from the external lab report; the
+fourth is the cluster demo already validated in ePHPm-lab. Recipes
+double as user documentation — "here is exactly how to reproduce our
+numbers."
+
+### 2. Per-release numbers in the release notes
+
+The release pipeline (or a manually-triggered `bench.yml`) runs the
+profiles against the release candidate image on a pinned runner class
+and emits a comparison table. Numbers are published with hardware
+context and honest caveats — the July lab exchange demonstrated that
+disclosed-limitation numbers build more trust than cherry-picked ones.
+
+### 3. The regression gate (the actual point)
+
+A stored baseline JSON per profile (median + p95, refreshed each
+release). CI compares the candidate against the previous release's
+numbers on identical hardware:
+
+- **> 20% median regression on any profile → red check.** Wide enough
+  to ignore runner noise, narrow enough that opcache-off (≈ 300%+)
+  or a static-file path regression (≈ 10×) can never ship silently.
+- Improvements auto-update the stored baseline on release.
+
+The performance-*property* assertions stay in e2e where they belong
+(`opcache_is_enabled_over_http` already guards the specific July
+failure); the gate guards the failures nobody has imagined yet.
+
+### 4. Hardware honesty
+
+Self-hosted runner numbers are only comparable to themselves. The gate
+compares same-runner-class release-over-release deltas, never absolute
+numbers across environments. Published tables state the runner spec.
+
+## Sizing
+
+Most of this exists: the k6 profiles, fixtures, and manifests were
+built and validated for the ePHPm-lab PRs; the summary-extraction
+tooling was written for the deploy-blip driver. Remaining work is
+consolidation into `bench/`, a workflow, and the baseline-comparison
+script — days, not weeks. Highest value-to-effort item on this page's
+shelf.

--- a/site/content/roadmap/clustered-kv-v2.md
+++ b/site/content/roadmap/clustered-kv-v2.md
@@ -1,0 +1,99 @@
+# Clustered KV v2 — Replicated Counters, Deletes, and Cluster-Aware Rate Limiting
+
+> **Status: DESIGN — not yet implemented.** v0.4.0 shipped KV replication
+> v1: `SET`/`DEL` route through a `Replicator` seam on the store, small
+> values gossip to every node with write-timestamp ordering, large values
+> replicate via the TCP data plane. This page designs what v1 deliberately
+> left out.
+
+## What v1 does not do (and warns about)
+
+Three gaps shipped in v0.4.0, each documented and — where it bites —
+guarded by a startup warning:
+
+1. **`INCR`/`APPEND` in-place mutations do not replicate.** Only the
+   new-key creation path routes through `Store::set`. Consequence: the
+   rate-limit middleware's counters are **per-node** in a cluster — a
+   client at the limit on node A is fresh on node B. Startup warns when
+   `[cluster].enabled` coexists with a ratelimit mount.
+2. **`EXPIRE` updates only the local copy.** Remote copies keep their
+   write-time TTL.
+3. **Deletes don't propagate to materialized copies.** `gossip_del`
+   tombstones aren't applied by peers; a deleted key lingers remotely
+   until TTL expiry or overwrite.
+
+For v0.4.0's flagship consumer — the monotonic `opcache:version:*`
+keys — none of this matters (pure `SET`, overwrite-only, no TTL games).
+For general-purpose clustered KV it's the difference between "replicated
+cache" and "replicated data structure".
+
+## Design
+
+### Replicated counters: owner-routed increments
+
+CRDT G-counters would replicate increments without coordination, but
+rate limiting needs *bounded* counters with TTL windows — merge
+semantics get hairy. Simpler and sufficient: **route the increment to
+the key's owner**.
+
+- `hash(key) % alive_nodes` already defines an owner (the v1 data-plane
+  placement function).
+- `INCR` on a non-owner forwards over the existing TCP data plane
+  (new `OP_INCR` frame: key, delta, optional TTL-on-create) and returns
+  the owner's authoritative value. Owner applies locally, then
+  gossips/replicates the new value using the v1 machinery.
+- Owner-local `INCR` is what it is today, plus fan-out.
+- One in-flight round trip per increment on non-owners (~data-plane
+  RTT, sub-millisecond in-cluster). The ratelimit middleware's
+  25-INCR-per-request bench pattern would amortize by batching
+  (`OP_INCRBY` with delta 25 — the PHP `ephpm_kv_incr` loop collapses
+  server-side).
+
+**Failure mode:** owner unreachable → increment applies locally with a
+`degraded` flag and a warning metric; the window self-heals on the next
+ring change. Rate limiting degrades to per-node rather than failing
+requests — the same behavior as v1, now as a *fallback* instead of the
+steady state.
+
+### Deletes: tombstone application
+
+The gossip wire format v2 (`{expiry_ms}:{write_ms}:{b64}`) has room for
+a tombstone marker (empty payload + `write_ms`). The applier that
+materializes remote SETs also applies tombstones — `remove_local` when
+the tombstone's `write_ms` beats the last applied write for that key.
+The existing per-key `AppliedWriteMap` already provides the ordering;
+this is the missing quarter of that design.
+
+### `EXPIRE`: piggyback on the same ordering
+
+`OP_EXPIRE` frame to the owner + gossip of a TTL-update event with
+`write_ms`. Peers holding a materialized copy apply the shorter of
+(current TTL, new TTL) when the event is fresher than their last write.
+
+### Cluster-aware rate limiting (the user-facing payoff)
+
+With owner-routed `INCR` + TTL-on-create, the ratelimit middleware
+becomes cluster-correct with **zero configuration change** — the
+middleware already calls `kv_incr_ttl`, which routes through the store.
+Remove the startup warning; add
+`ephpm_ratelimit_degraded_windows_total` for the fallback path.
+
+## What this deliberately does not attempt
+
+- **No quorum, no consensus.** Same posture as v1: best-effort
+  replication with honest documentation. Bank-grade rate limiting needs
+  a real coordination system; web-tier abuse throttling does not.
+- **No cross-node transactions or multi-key atomicity.**
+- **No pubsub.** Still unjustified by any current consumer.
+
+## Sizing
+
+| Piece | Effort |
+|---|---|
+| `OP_INCR`/`OP_INCRBY`/`OP_EXPIRE` data-plane frames + owner routing | the bulk |
+| Tombstone gossip + applier | small (machinery exists) |
+| Ratelimit warning removal + degraded metric | trivial |
+| Two-node e2e: cross-node limit enforcement, delete propagation | moderate |
+
+Roughly one focused week. Prerequisite for anyone selling "cluster" as
+more than an OPcache feature; not a blocker for anything shipped today.

--- a/site/content/roadmap/deploy-warmup.md
+++ b/site/content/roadmap/deploy-warmup.md
@@ -1,0 +1,77 @@
+# The Deploy Story — Warmup, Doctor, and `cache status`
+
+> **Status: DESIGN — not yet implemented.** `ephpm deploy` shipped in
+> 0.4.0 as cluster-wide OPcache invalidation. This page designs the
+> rest of the deploy lifecycle around it.
+
+## The gap, measured
+
+The 0.4.0 deploy-blip benchmark (ePHPm-lab, two-node kind cluster,
+50 req/s) showed the shape of the remaining problem: after
+`ephpm deploy`, the first request per script per node pays a visible
+recompile spike (max latency roughly 2–3× steady-state on a 31-file
+fixture; a real Symfony/Laravel tree is thousands of files). php-fpm's
+rolling restart pays a *bigger* cold-cache window — but ours is still
+nonzero, and it is fixable, because we know exactly when a deploy
+happened and exactly which vhost it touched.
+
+## Pieces
+
+### 1. Post-invalidation warmup (OPcache Clustering Phase 2, activated)
+
+The [per-vhost preload design](/roadmap/opcache-clustering/) already
+specifies `[opcache.preload] files` compiled via
+`opcache_compile_file()` on vhost discovery. Extend the trigger: the
+invalidation watcher, after dropping a vhost's scripts, queues the same
+preload set on a background thread. Result: `ephpm deploy` becomes
+**invalidate + rewarm** — the blip shrinks from "first request per
+script" to near-zero, and the k6 deploy-blip profile can prove it
+release over release.
+
+### 2. `ephpm cache status`
+
+Already stubbed in docs as planned. Design: the CLI (a separate
+process) queries a tiny status endpoint (`/_ephpm/opcache-status`,
+loopback/internal-exempt like the health endpoints) that the server
+answers from `opcache_get_status()` — per-vhost script counts, memory,
+hit rate, last invalidation version + revision string from
+`opcache:revision:<vhost>`. Gives deploys a verification step:
+`deploy → cache status --site blog` shows the new revision and a warm
+cache.
+
+### 3. `ephpm doctor <framework>`
+
+Requested verbatim by the July lab report ("a command like
+`ephpm doctor laravel` could catch missing functions, path issues, and
+worker setup problems"). Design: a check-runner with per-framework
+profiles —
+
+- **common**: required extensions present (`mb_split` et al.),
+  `$argv` registration sanity, docroot/index resolution, OPcache
+  active, KV functions when config expects them;
+- **laravel**: `document_root` points at the project (not `public/`)
+  in worker mode, `vendor/bin/ephpm-octane-worker` resolvable,
+  `APP_KEY` set, storage writable;
+- **wordpress**: `wp-config.php` reachable, DB connectivity via the
+  configured mode, object-cache drop-in consistency.
+
+Output is a pass/warn/fail table with one-line fixes. The July lab
+user lost hours to exactly the failures this would catch in seconds;
+it is the cheapest trust-building feature on the roadmap.
+
+### 4. Deploy hooks (thin)
+
+`ephpm deploy --exec "php artisan config:cache"` — run a command per
+node after invalidation, before rewarm. Deliberately thin: not a CD
+system, just the missing glue between "bytecode dropped" and "app
+caches rebuilt". Needs the same cluster command-fanout primitive as
+warmup (a `deploy:hook` KV event consumed once per node), so it rides
+along nearly free.
+
+## Sequencing
+
+Warmup (1) is the natural headliner — it completes the story the
+benchmark tells, reuses the Phase-2 design nearly verbatim, and has a
+measurable before/after. Doctor (3) is independent and could ship any
+release. Status (2) is small and unblocks deploy verification. Hooks
+(4) ride on warmup's fanout primitive.

--- a/site/content/roadmap/nts-prefork.md
+++ b/site/content/roadmap/nts-prefork.md
@@ -1,0 +1,88 @@
+# NTS Prefork Mode — Trading Features for the Last Few Percent
+
+> **Status: DESIGN, gated on a measurement.** Not scheduled. This page
+> exists so the "why not NTS?" question every RoadRunner/Swoole-aware
+> evaluator asks has a considered answer — and so the decision, when
+> made, is made on numbers.
+
+## The question
+
+ePHPm's Linux/macOS builds are ZTS: one process, concurrent PHP on
+tokio's blocking pool, per-thread TSRM contexts. ZTS costs an
+in-PHP tax — measured at roughly **5–10%** vs NTS php-fpm on tiny
+scripts (July 2026, with `ZEND_ENABLE_STATIC_TSRMLS_CACHE` active) —
+because every `EG()`/`CG()` access goes through thread-local
+indirection.
+
+Some users bring their own Redis and database, don't touch the
+in-process KV, middleware, or clustering — and would trade all of it
+for pure per-request PHP speed. Can we serve them an NTS build without
+forking the codebase?
+
+## Feasibility: the codebase already compiles both
+
+**Windows ships NTS today** — `ZTS=0`, one request at a time behind a
+mutex. The C wrapper, the `EPHPM_TLS` per-request statics, and the
+build plumbing are all bi-modal already. The php-sdk pipeline builds
+NTS for Windows; a `linux-<arch>-nts-gnu` tarball is one matrix entry.
+Nothing about an NTS Linux artifact is destructive; it is additive
+`cfg` + artifacts.
+
+The hard part is not the build — it is that NTS means **one PHP
+request at a time per process**, so a useful NTS Linux mode is
+*prefork*:
+
+## Design sketch
+
+`ephpm serve --prefork N` (or `[server] prefork = N`, NTS builds only):
+
+- N processes, each: full ephpm (async HTTP, static files) + one NTS
+  PHP runtime, `SO_REUSEPORT` on the listen socket, kernel balances
+  connections. No IPC, no master/worker protocol — each process is
+  just ephpm with PHP concurrency 1.
+- **Worker mode composes perfectly**: NTS + boot-once persistent app
+  per process ≡ the classic RoadRunner/FrankenPHP worker shape. This
+  is where prefork's numbers would be strongest.
+- **Feature gating, honest by construction**: `[cluster]` and the RESP
+  listener refuse to start in prefork mode (per-process KV across N
+  processes is a correctness trap, not a feature); `[php] workers`
+  ignored; startup banner states the mode's contract plainly.
+
+### The two genuinely hard problems
+
+1. **OPcache memory.** php-fpm children *share* one opcache SHM via
+   fork-inherited mmap. N independent ephpm processes each pay a full
+   opcache (128 MB × 16 processes is real memory). The fix — fork
+   workers after PHP init so the SHM is inherited — collides with
+   Rust: forking a threaded tokio process is UB territory. The safe
+   variant (fork before any runtime/thread starts, init PHP after)
+   loses the sharing. Options, in order of preference: measure whether
+   per-process opcache is simply acceptable (it usually is at ≤ 16
+   workers); explicit `opcache.file_cache` on tmpfs as a warm-start
+   compromise; early-fork with post-fork PHP init and shared-nothing
+   opcache. No fork-after-tokio under any circumstance.
+2. **Ops story dilution.** "One process, one binary" is a core pitch;
+   prefork makes ePHPm a process *family*. Signals, logs, metrics
+   (per-process `/metrics` needs aggregation or a `--metrics-socket`
+   design), graceful reload — each is small, together they are the
+   real cost.
+
+## The gate: measure before building
+
+PGO for the SDK (php-sdk#35) plausibly returns 5–10% to **both** ZTS
+and NTS builds at a fraction of this complexity — potentially erasing
+the entire motivation. Therefore:
+
+1. Cut one `linux-x86_64-nts-gnu` SDK tarball (one matrix entry).
+2. Build ephpm against it with the existing Windows-style serialized
+   path — no prefork work at all.
+3. A/B single-stream `hello.php` / `cpu.php` / one framework profile,
+   ZTS vs NTS, same host, after PGO lands.
+
+**Decision rule:** real tax < 5% after PGO → close this page as
+"considered, declined — PGO ate the motivation." Tax ≥ 10% → prefork
+graduates to a scheduled milestone. In between → judgment call with
+numbers on the table.
+
+The experiment is an afternoon with the existing bench tooling; the
+full prefork build-out is 1–2 focused weeks. Spend the afternoon first.

--- a/site/content/roadmap/opcache-clustering.md
+++ b/site/content/roadmap/opcache-clustering.md
@@ -334,7 +334,26 @@ ephpm_opcache_memory_free_bytes
 
 Phase 1 is the foundational piece — everything else builds on the
 KV-driven contract and the FFI helper. Roughly a long weekend's work
-end-to-end including tests.
+end-to-end including tests. **Shipped in 0.4.0** — see the
+[user guide](/guides/opcache-cluster-invalidation/).
+
+### Phase 1.5 — Worker-mode invalidation (not yet implemented)
+
+Phase 1 wires the watcher into the fpm dispatch path only; with
+`[php] mode = "worker"` the watcher is skipped (startup WARNs so the
+no-op is never silent). Closing it: run the same
+`OpcacheWatcher::check` at the top of the worker `take_request` loop —
+the worker thread is TSRM-registered with an active request, satisfying
+the invalidator's context contract, and the per-vhost mutex already
+coalesces concurrent workers. One design question to settle: a
+persistent worker holds the booted framework's classes in memory
+regardless of OPcache, so invalidation alone does not swap code in a
+running worker — it must pair with worker recycling
+(`worker_max_requests`-style drain) for a full deploy. Document the
+semantics: invalidation refreshes what workers *compile next*
+(templates, lazily-loaded classes); a code swap of the booted core
+needs recycle-on-deploy, which is the natural companion knob
+(`[opcache] recycle_workers_on_deploy = true`).
 
 ### Phase 2 — Per-vhost preload
 


### PR DESCRIPTION
Four new roadmap designs + the Phase 1.5 section on the opcache page, all derived from the 0.3.0/0.4.0 release cycle's measurements and the external lab-report exchange. All marked DESIGN / not implemented per the docs taxonomy. Left open for review — read at leisure:

- **clustered-kv-v2.md** — what KV replication v1 deliberately skipped (INCR/EXPIRE/deletes) and the owner-routed design that makes rate limiting cluster-correct with zero config change
- **benchmarks.md** — bench/ recipes as a per-release artifact + a >20% median regression gate, so an opcache-class silent slowdown structurally cannot ship again
- **nts-prefork.md** — the full considered design with the honest hard parts (opcache SHM sharing vs fork-safety, ops-story dilution) and a measure-first decision rule gated on PGO
- **deploy-warmup.md** — post-invalidation rewarm (activates Phase 2), ephpm doctor <framework> (verbatim lab-report request), cache status, thin deploy hooks
- **opcache-clustering.md** — Phase 1 marked shipped + new Phase 1.5 spelling out worker-mode invalidation semantics (invalidation vs. the booted core; recycle-on-deploy pairing)