### PR TITLE
perf(net): TCP_NODELAY on proxy, KV, and data-plane sockets (~44ms/query fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2224,7 +2224,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "anyhow",
  "futures",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "async-trait",
  "futures",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=33e24a3e6fe664b1be499a0147c9cae5756eb733#33e24a3e6fe664b1be499a0147c9cae5756eb733"
+source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
 dependencies = [
  "sqlparser",
  "thiserror 2.0.18",
@@ -3077,7 +3077,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3114,7 +3114,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "33e24a3e6fe664b1be499a0147c9cae5756eb733", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "54b5fcee0df8aaeb8c1085ca17d8c9d376e51280", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -763,8 +763,7 @@ impl ephpm_kv::store::Replicator for KvReplicator {
             let write_ms = u64::try_from(
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis())
-                    .unwrap_or(0),
+                    .map_or(0, |d| d.as_millis()),
             )
             .unwrap_or(u64::MAX);
             self.applied.insert(key.clone(), write_ms);

--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -117,6 +117,9 @@ pub async fn serve_on(
                 continue;
             }
         };
+        // Small framed request/response protocol — same Nagle/delayed-ACK
+        // stall as the DB proxies without this.
+        let _ = stream.set_nodelay(true);
         let store = Arc::clone(&store);
         let cipher = cipher.clone();
         tokio::spawn(async move {
@@ -293,6 +296,7 @@ pub async fn fetch_remote(
     cipher: Option<&ClusterCipher>,
 ) -> anyhow::Result<Option<Vec<u8>>> {
     let mut stream = TcpStream::connect(addr).await?;
+    let _ = stream.set_nodelay(true);
 
     // Send GET op + key.
     write_message(&mut stream, &encode_get_request(key)?, cipher).await?;
@@ -335,6 +339,7 @@ pub async fn store_remote(
     cipher: Option<&ClusterCipher>,
 ) -> anyhow::Result<bool> {
     let mut stream = TcpStream::connect(addr).await?;
+    let _ = stream.set_nodelay(true);
 
     // Send SET op + key + value.
     write_message(&mut stream, &encode_set_request(key, value)?, cipher).await?;

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -247,6 +247,9 @@ impl MySqlProxy {
                     continue;
                 }
             };
+            // Nagle + delayed ACK stalls every small request/response round
+            // trip by ~40ms on Linux loopback (measured 44ms/query, 2026-07-09).
+            let _ = client.set_nodelay(true);
             debug!(%peer, "MySQL client connected");
             let p = Arc::clone(&proxy);
             tokio::spawn(async move {
@@ -333,6 +336,7 @@ impl MySqlProxy {
 /// the initial greeting.
 async fn connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, ServerMeta), DbError> {
     let mut stream = TcpStream::connect(url.addr()).await?;
+    let _ = stream.set_nodelay(true);
 
     // Receive HandshakeV10.
     let (_, payload) = read_packet(&mut stream).await?;

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -221,6 +221,8 @@ impl PgProxy {
                     continue;
                 }
             };
+            // See mysql.rs: Nagle + delayed ACK costs ~40ms per small round trip.
+            let _ = client.set_nodelay(true);
             debug!(%peer, "PostgreSQL client connected");
             let p = Arc::clone(&proxy);
             tokio::spawn(async move {
@@ -312,6 +314,7 @@ impl PgProxy {
 /// against real PG 13 (`md5`) and PG 17 (`scram-sha-256`).
 async fn pg_connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, PgServerMeta), DbError> {
     let mut stream = TcpStream::connect(url.addr()).await?;
+    let _ = stream.set_nodelay(true);
 
     // Send StartupMessage: length (4) + protocol version (4) + key=value pairs + \0.
     let mut startup = Vec::with_capacity(128);

--- a/crates/ephpm-kv/src/server.rs
+++ b/crates/ephpm-kv/src/server.rs
@@ -149,6 +149,9 @@ pub async fn serve_on(
     loop {
         match listener.accept().await {
             Ok((mut stream, addr)) => {
+                // RESP is small request/response frames; Nagle + delayed ACK
+                // stalls each round trip ~40ms on Linux without this.
+                let _ = stream.set_nodelay(true);
                 let permit = match &conn_permits {
                     Some(sem) => match Arc::clone(sem).try_acquire_owned() {
                         Ok(permit) => Some(permit),

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -193,10 +193,7 @@ impl std::fmt::Debug for Store {
             .field("hashes_len", &self.hashes.len())
             .field("mem_used", &self.mem_used.load(Ordering::Relaxed))
             .field("config", &self.config)
-            .field(
-                "replicator_installed",
-                &self.replicator.read().is_ok_and(|g| g.is_some()),
-            )
+            .field("replicator_installed", &self.replicator.read().is_ok_and(|g| g.is_some()))
             .field("anchor", &self.anchor)
             .finish()
     }

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -195,7 +195,7 @@ impl std::fmt::Debug for Store {
             .field("config", &self.config)
             .field(
                 "replicator_installed",
-                &self.replicator.read().map(|g| g.is_some()).unwrap_or(false),
+                &self.replicator.read().is_ok_and(|g| g.is_some()),
             )
             .field("anchor", &self.anchor)
             .finish()


### PR DESCRIPTION
## Summary
- Every DB-proxy query paid a ~44ms Nagle + delayed-ACK stall per round trip on Linux loopback. Measured 44.0ms p50 per point-SELECT on BOTH the litewire SQLite lane and the MySQL proxy lane (identical value = shared cause) vs 0.19ms hitting the same MySQL directly from PHP.
- Fix: `set_nodelay(true)` on accepted client sockets + backend connects in ephpm-db (mysql, postgres), the RESP KV TCP listener, and the cluster KV data plane (accept + fetch/store connects). HTTP was never affected: hyper sets nodelay itself.
- Companion PR in litewire fixes its mysql/postgres/tds frontends (hrana rides axum, already covered).
- Very likely the dominant cause of the external lab's Krayin request-mode loss (tens of queries/page x 44ms matches the measured gap).

## Test plan
- [x] clippy pedantic clean (ephpm-db, ephpm-kv, ephpm-cluster)
- [ ] Scratch image A/B: litewire lane point-SELECT p50 44ms -> sub-ms (will attach numbers)
- [ ] Full DB matrix rerun (tmp_dbbench harness)