### PR TITLE
chore(deps): litewire main (nodelay+compat+cache+isolation) + PHP SDK 8.4.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2224,7 +2224,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
  "anyhow",
  "futures",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
  "async-trait",
  "futures",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2315,8 +2315,10 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=54b5fcee0df8aaeb8c1085ca17d8c9d376e51280#54b5fcee0df8aaeb8c1085ca17d8c9d376e51280"
+source = "git+https://github.com/ephpm/litewire.git?rev=9c924044be53ed9bb252e9638c6d7cf66faee2fe#9c924044be53ed9bb252e9638c6d7cf66faee2fe"
 dependencies = [
+ "lru 0.12.5",
+ "parking_lot",
  "sqlparser",
  "thiserror 2.0.18",
  "tracing",
@@ -3077,7 +3079,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3114,7 +3116,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "54b5fcee0df8aaeb8c1085ca17d8c9d376e51280", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "9c924044be53ed9bb252e9638c6d7cf66faee2fe", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -913,7 +913,7 @@ impl Router {
                     (
                         error_response_owned(
                             status,
-                            format!("{code} {}", status.canonical_reason().unwrap_or("Error"),),
+                            format!("{code} {}", status.canonical_reason().unwrap_or("Error")),
                         ),
                         "error",
                     )

--- a/crates/ephpm-server/src/tracked_backend.rs
+++ b/crates/ephpm-server/src/tracked_backend.rs
@@ -2,17 +2,25 @@
 //!
 //! `TrackedBackend` implements the litewire [`Backend`] trait by delegating
 //! to an inner backend while recording query timing and row counts in
-//! [`QueryStats`].
+//! [`QueryStats`]. Since litewire's per-connection backend model, frontends
+//! obtain a [`BackendConn`] per wire connection via [`Backend::connect`] —
+//! so the connection handle returned here is itself a tracking wrapper
+//! ([`TrackedConn`]); otherwise per-connection traffic would bypass stats
+//! entirely.
 
 use std::time::Instant;
 
 use ephpm_query_stats::QueryStats;
-use litewire::backend::{Backend, BackendError, ExecuteResult, ResultSet, Value};
+use litewire::backend::{
+    Backend, BackendConn, BackendError, Column, ExecuteResult, ResultSet, Value,
+};
 
 /// A backend decorator that records query stats.
 ///
 /// Wraps any litewire [`Backend`] and calls [`QueryStats::record_query`] or
-/// [`QueryStats::record_mutation`] after every operation.
+/// [`QueryStats::record_mutation`] after every operation, on both the
+/// backend-level convenience methods and every connection handed out by
+/// [`Backend::connect`].
 pub struct TrackedBackend<B> {
     inner: B,
     stats: QueryStats,
@@ -25,8 +33,46 @@ impl<B> TrackedBackend<B> {
     }
 }
 
+/// A per-connection decorator that records query stats.
+pub struct TrackedConn {
+    inner: Box<dyn BackendConn>,
+    stats: QueryStats,
+}
+
+#[async_trait::async_trait]
+impl BackendConn for TrackedConn {
+    async fn query(&self, sql: &str, params: &[Value]) -> Result<ResultSet, BackendError> {
+        let start = Instant::now();
+        let result = self.inner.query(sql, params).await;
+        let duration = start.elapsed();
+        let rows = result.as_ref().map_or(0, |rs| rs.rows.len() as u64);
+        self.stats.record_query(sql, duration, result.is_ok(), rows);
+        result
+    }
+
+    async fn execute(&self, sql: &str, params: &[Value]) -> Result<ExecuteResult, BackendError> {
+        let start = Instant::now();
+        let result = self.inner.execute(sql, params).await;
+        let duration = start.elapsed();
+        let rows = result.as_ref().map_or(0, |r| r.affected_rows);
+        self.stats.record_mutation(sql, duration, result.is_ok(), rows);
+        result
+    }
+
+    async fn describe_columns(&self, sql: &str) -> Result<Vec<Column>, BackendError> {
+        // Metadata probe, not a user query — pass through without recording
+        // so prepare-time describes don't pollute the digest table.
+        self.inner.describe_columns(sql).await
+    }
+}
+
 #[async_trait::async_trait]
 impl<B: Backend> Backend for TrackedBackend<B> {
+    async fn connect(&self) -> Result<Box<dyn BackendConn>, BackendError> {
+        let conn = self.inner.connect().await?;
+        Ok(Box::new(TrackedConn { inner: conn, stats: self.stats.clone() }))
+    }
+
     async fn query(&self, sql: &str, params: &[Value]) -> Result<ResultSet, BackendError> {
         let start = Instant::now();
         let result = self.inner.query(sql, params).await;
@@ -55,8 +101,10 @@ mod tests {
     /// A minimal test backend that always succeeds.
     struct StubBackend;
 
+    struct StubConn;
+
     #[async_trait::async_trait]
-    impl Backend for StubBackend {
+    impl BackendConn for StubConn {
         async fn query(&self, _sql: &str, _params: &[Value]) -> Result<ResultSet, BackendError> {
             Ok(ResultSet { columns: vec![], rows: vec![vec![Value::Integer(1)]] })
         }
@@ -67,6 +115,13 @@ mod tests {
             _params: &[Value],
         ) -> Result<ExecuteResult, BackendError> {
             Ok(ExecuteResult { affected_rows: 1, last_insert_rowid: Some(1) })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Backend for StubBackend {
+        async fn connect(&self) -> Result<Box<dyn BackendConn>, BackendError> {
+            Ok(Box::new(StubConn))
         }
     }
 
@@ -97,11 +152,27 @@ mod tests {
         assert_eq!(top[0].total_rows, 1);
     }
 
-    /// A backend that always fails.
+    #[tokio::test]
+    async fn per_connection_queries_record_stats() {
+        // The path litewire frontends actually take since the per-connection
+        // backend model: Backend::connect() then BackendConn::query().
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        let backend = TrackedBackend::new(StubBackend, stats.clone());
+
+        let conn = backend.connect().await.unwrap();
+        conn.query("SELECT * FROM t WHERE id = 1", &[]).await.unwrap();
+        conn.execute("INSERT INTO t VALUES (2, 'x')", &[]).await.unwrap();
+
+        assert_eq!(stats.digest_count(), 2);
+    }
+
+    /// A backend whose connections always fail.
     struct FailBackend;
 
+    struct FailConn;
+
     #[async_trait::async_trait]
-    impl Backend for FailBackend {
+    impl BackendConn for FailConn {
         async fn query(&self, _sql: &str, _params: &[Value]) -> Result<ResultSet, BackendError> {
             Err(BackendError::Other("fail".into()))
         }
@@ -112,6 +183,13 @@ mod tests {
             _params: &[Value],
         ) -> Result<ExecuteResult, BackendError> {
             Err(BackendError::Other("fail".into()))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Backend for FailBackend {
+        async fn connect(&self) -> Result<Box<dyn BackendConn>, BackendError> {
+            Ok(Box::new(FailConn))
         }
     }
 

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -1002,8 +1002,7 @@ const OPCACHE_REVISION_PREFIX: &str = "opcache:revision:";
 fn epoch_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-        .unwrap_or(0)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
 /// Human-facing hint when the RESP listener refuses a TCP connection — the

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@ mod doctor;
 /// shorthand (e.g. "8.5") to the specific patch release we publish SDKs for.
 /// Users may also pass a full version explicitly (e.g. "8.5.6") and the
 /// resolver will accept it as-is.
-const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.22"), ("8.5", "8.5.7")];
+const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.23"), ("8.5", "8.5.7")];
 
 /// Default PHP minor when no version is specified on the command line.
 const DEFAULT_PHP_MINOR: &str = "8.5";


### PR DESCRIPTION
## Summary
- litewire pinned to 9c92404: TCP_NODELAY frontends, session/transaction compat (PDO::beginTransaction works on SQLite mode), real MySQL/PG error codes, LRU translate cache (139x warm), prepare_cached, per-connection backend isolation (transactions no longer share one SQLite handle).
- PHP SDK 8.4 pin -> 8.4.23: first Linux SDK with hardware intrinsics (SHA-NI sha256 measured 2.7x, PCLMUL crc32, AVX2 base64) plus the build guard that keeps them from silently regressing.
- TrackedBackend adapts to litewire's per-connection Backend trait: connect() returns a TrackedConn so the per-connection path (what frontends use now) keeps recording query stats; describe_columns passes through untracked to keep prepare-time probes out of digests. New test covers the connect() path.
- clippy 1.97 sweep (new lints in router.rs / main.rs).

## Test plan
- [x] cargo test -p ephpm-server (181 passed) incl. new per_connection_queries_record_stats
- [x] clippy --workspace --all-targets -D warnings clean on rust 1.97
- [ ] CI + E2E
- [ ] Scratch image A/B: litewire lane 44ms -> sub-ms, sha256 ns/op (numbers to follow)