### PR TITLE
docs(sessions): clustered-mode caveats - destroy and TTL-refresh are not replicated (KV v1)

### DIFF
--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -185,6 +185,35 @@ ahead of the gossip fan-out. In practice this only matters for sub-second
 redirects against brand-new sessions; for any normal browsing flow the gap
 is invisible.
 
+### Clustered-mode caveats (KV replication v1)
+
+Two session behaviors degrade in clustered mode because of gaps that
+KV replication v1 shipped with (both documented in the
+[clustered KV v2 roadmap](/roadmap/clustered-kv-v2/), which fixes them):
+
+- **`session_destroy()` is not cluster-wide.** Destroy removes the
+  session on the node that handled the request, but copies already
+  materialized on other nodes are not deleted — replication v1's delete
+  tombstones are not applied by peers. A destroyed session id keeps
+  working on other nodes until its TTL expires
+  (`session.gc_maxlifetime`, default 1440 s = 24 minutes). Treat logout
+  and privilege-revocation as *eventually* effective, not immediate. If
+  immediate cluster-wide logout is a hard requirement today, use sticky
+  sessions at your load balancer or run single-node.
+
+- **Idle-timeout refresh is local.** With `session.lazy_write = 1`
+  (PHP's default), a request that reads but doesn't change the session
+  refreshes the TTL via `EXPIRE` — which v1 does not replicate. A
+  read-mostly user bounced across nodes can lose their session on a
+  node whose copy still carries the original TTL, despite being
+  active. Mitigation: `session.lazy_write = 0` in clustered mode —
+  every request rewrites the blob, and writes *do* replicate with a
+  fresh TTL (cost: one KV set per request). Sessions that write on
+  most requests are unaffected either way.
+
+Single-node and multi-tenant (non-clustered) deployments are unaffected
+by both.
+
 ## Limitations
 
 - **Memory eviction.** The KV store has a configurable `memory_limit` and an

--- a/site/content/architecture/clustering.md
+++ b/site/content/architecture/clustering.md
@@ -335,6 +335,8 @@ The session handler implements PHP's `SessionHandlerInterface` at the C level:
 
 With clustering, sessions are accessible from any node — no sticky sessions required at the load balancer. Ownership is a deterministic `hash(session_id) % alive_nodes`, so within a stable cluster reads-after-writes for a session hit the same owner (read-your-writes for free). Large session blobs are additionally replicated to `replication_factor` nodes, so a session survives owner loss.
 
+> **KV v1 caveats:** `session_destroy()` and lazy-write TTL refresh are not replicated cluster-wide — see the [clustered KV v2 roadmap](/roadmap/clustered-kv-v2/) and the sessions doc's clustered-mode caveats.
+
 ### 3. Direct SAPI Functions — Maximum Performance
 
 **Priority: implement third.** For applications that want the absolute fastest KV access — 1,000-10,000x faster than RESP for local keys. Requires ephpm-specific PHP code.
@@ -829,7 +831,7 @@ Most WordPress page views are anonymous and return identical content. Skipping P
 
 ### Session Storage
 
-PHP sessions stored in the KV store instead of the filesystem. With clustering, sessions are accessible from any node — no sticky sessions required at the load balancer.
+PHP sessions stored in the KV store instead of the filesystem. With clustering, sessions are accessible from any node — no sticky sessions required at the load balancer (but note the KV v1 caveats: `session_destroy()` and lazy-write TTL refresh are not replicated — see the [clustered KV v2 roadmap](/roadmap/clustered-kv-v2/)).
 
 #### How PHP Sessions Work
 


### PR DESCRIPTION
## Summary

- Adds a "Clustered-mode caveats (KV replication v1)" subsection at the end of the Cluster section in `docs/features/sessions.md`, documenting that `session_destroy()` is not cluster-wide and that lazy-write TTL refresh (`EXPIRE`) is node-local, with the `session.lazy_write = 0` mitigation. Links the [clustered KV v2 roadmap](https://github.com/ephpm/ephpm/blob/main/site/content/roadmap/clustered-kv-v2.md), which fixes both.
- `site/content/architecture/clustering.md` claimed "sessions are accessible from any node — no sticky sessions required" without caveats in two places (Session Handler and Session Storage sections); added a one-line cross-reference at each.

## Verification (claims checked against source)

- **Destroy gap:** `crates/ephpm-cluster/src/clustered_store.rs:850-852` — applier doc comment: "Known v1 gap: `gossip_del` tombstones do not decode as values, so remote deletions do not remove the local copy until TTL expiry". `ClusteredStore::remove` (`clustered_store.rs:433-451`) does `gossip_del` + `remove_local` only — no data-plane peer delete either.
- **EXPIRE gap:** `crates/ephpm-kv/src/store/mod.rs:542-547` — `Store::expire` delegates to the Replicator seam, but the clustered impl `replicate_expire` (`crates/ephpm-cluster/src/clustered_store.rs:800-810`) only calls `expire_local`; its comment: "remote copies keep their originally-set TTL. Document this v1 gap."
- **update_timestamp uses EXPIRE:** `crates/ephpm-php/ephpm_wrapper.c:2757-2790` — `PS_UPDATE_TIMESTAMP_FUNC(ephpm)` calls `g_kv_ops.expire(kv_key, ttl_ms)` (with a full-write fallback only if the key vanished).
- **TTL source:** `ephpm_wrapper.c:2388-2396` — `ephpm_session_ttl_ms()` reads `PS(gc_maxlifetime)` (seconds x 1000); 1440 s is PHP's ini default.

## Wording adjustment from the approved block

One phrase adjusted for accuracy: "replication v1 has no tombstones" -> "replication v1's delete tombstones are not applied by peers". Tombstones do exist at the gossip layer (`gossip_del` marks deletion in chitchat state, `gossip_kv.rs:169-180`); the gap is that the applier never applies them — matching both the code comment and the roadmap page's own phrasing ("tombstones aren't applied by peers"). The user-visible claim (copies on other nodes are not deleted) is unchanged and confirmed.