### PR TITLE
fix(e2e): copy ephpm-kv into the e2e image (path dep since #144)

### DIFF
--- a/crates/ephpm-e2e/Cargo.lock
+++ b/crates/ephpm-e2e/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,7 @@ dependencies = [
 name = "ephpm-e2e"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "brotli",
  "reqwest",
  "serde",
@@ -618,6 +625,7 @@ version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",

--- a/crates/ephpm-e2e/Cargo.toml
+++ b/crates/ephpm-e2e/Cargo.toml
@@ -19,8 +19,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 urlencoding = "2"
 brotli = "7"
-# Used by the opcache_invalidation test to write invalidation-version keys
-# via the RESP listener (same wire the ephpm CLI uses).
-ephpm-kv = { path = "../ephpm-kv" }
-bytes = "1"
 anyhow = "1"

--- a/crates/ephpm-e2e/tests/opcache_invalidation.rs
+++ b/crates/ephpm-e2e/tests/opcache_invalidation.rs
@@ -32,9 +32,7 @@
 
 use std::time::Duration;
 
-use bytes::BytesMut;
 use ephpm_e2e::required_env;
-use ephpm_kv::resp::{Frame, parse_frame};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -89,38 +87,63 @@ async fn probe_status_with(base_url: &str, warm: bool) -> serde_json::Value {
     resp.json().await.unwrap_or_else(|e| panic!("invalid JSON from {url}: {e}"))
 }
 
-/// Open a RESP connection and send a single command, returning the response.
-async fn resp_roundtrip(host: &str, port: u16, cmd: Frame) -> anyhow::Result<Frame> {
+/// Minimal RESP reply for the two commands this test sends (SET, PING) —
+/// both answer with a single simple-string or error line.
+///
+/// Deliberately local: ephpm-e2e is excluded from the workspace and its
+/// Docker image builds the crate standalone, so it must not path-depend on
+/// workspace crates. The previous `ephpm-kv` path dependency (added in #144)
+/// silently broke every E2E image build until #164 unmasked it — the dep
+/// drags in workspace-inherited manifest fields and further path deps.
+#[derive(Debug)]
+enum RespReply {
+    Simple,
+    Error(String),
+}
+
+/// Encode a RESP2 array-of-bulk-strings command.
+fn encode_cmd(parts: &[&[u8]]) -> Vec<u8> {
+    let mut out = format!("*{}\r\n", parts.len()).into_bytes();
+    for p in parts {
+        out.extend_from_slice(format!("${}\r\n", p.len()).as_bytes());
+        out.extend_from_slice(p);
+        out.extend_from_slice(b"\r\n");
+    }
+    out
+}
+
+/// Open a RESP connection and send a single command, returning the reply line.
+async fn resp_roundtrip(host: &str, port: u16, parts: &[&[u8]]) -> anyhow::Result<RespReply> {
     let mut stream = TcpStream::connect(format!("{host}:{port}"))
         .await
         .map_err(|e| anyhow::anyhow!("connect {host}:{port}: {e}"))?;
-    let bytes = cmd.to_bytes();
-    stream.write_all(&bytes).await?;
-    let mut buf = BytesMut::with_capacity(4096);
-    loop {
-        buf.reserve(512);
-        let n = stream.read_buf(&mut buf).await?;
+    stream.write_all(&encode_cmd(parts)).await?;
+    let mut buf = Vec::with_capacity(256);
+    let mut chunk = [0u8; 64];
+    while !buf.windows(2).any(|w| w == b"\r\n") {
+        let n = stream.read(&mut chunk).await?;
         if n == 0 {
-            anyhow::bail!("connection closed before RESP frame arrived");
+            anyhow::bail!("connection closed before RESP reply arrived");
         }
-        if let Some(frame) = parse_frame(&mut buf)? {
-            return Ok(frame);
-        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    let line = String::from_utf8_lossy(&buf);
+    let line = line.trim_end_matches(['\r', '\n']);
+    match line.as_bytes().first() {
+        Some(b'+') => Ok(RespReply::Simple),
+        Some(b'-') => Ok(RespReply::Error(line[1..].to_string())),
+        _ => anyhow::bail!("unexpected RESP reply: {line}"),
     }
 }
 
 /// Write `opcache:version:<vhost> = value` via RESP.
 async fn set_version(host: &str, port: u16, vhost: &str, value: u64) -> anyhow::Result<()> {
     let key = format!("{OPCACHE_VERSION_PREFIX}{vhost}");
-    let cmd = Frame::Array(vec![
-        Frame::bulk(b"SET".to_vec()),
-        Frame::bulk(key.into_bytes()),
-        Frame::bulk(value.to_string().into_bytes()),
-    ]);
-    match resp_roundtrip(host, port, cmd).await? {
-        Frame::Simple(_) => Ok(()),
-        Frame::Error(e) => anyhow::bail!("RESP error: {e}"),
-        other => anyhow::bail!("unexpected response: {other}"),
+    let value = value.to_string();
+    let parts: [&[u8]; 3] = [b"SET", key.as_bytes(), value.as_bytes()];
+    match resp_roundtrip(host, port, &parts).await? {
+        RespReply::Simple => Ok(()),
+        RespReply::Error(e) => anyhow::bail!("RESP error: {e}"),
     }
 }
 
@@ -156,8 +179,7 @@ async fn single_node_deploy_triggers_invalidation() {
 
     // Skip cleanly if the RESP listener is disabled — the test can't function
     // without it (the CLI has no other way to write to the in-process KV).
-    let ping = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
-    if resp_roundtrip(&kv_host, kv_port, ping).await.is_err() {
+    if resp_roundtrip(&kv_host, kv_port, &[b"PING".as_slice()]).await.is_err() {
         eprintln!(
             "RESP listener at {kv_host}:{kv_port} unreachable — skipping (\
              enable [kv.redis_compat] in ephpm.toml)"
@@ -221,8 +243,7 @@ async fn single_node_cache_reset_works() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(6379);
 
-    let ping = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
-    if resp_roundtrip(&kv_host, kv_port, ping).await.is_err() {
+    if resp_roundtrip(&kv_host, kv_port, &[b"PING".as_slice()]).await.is_err() {
         eprintln!("RESP listener unreachable — skipping");
         return;
     }
@@ -282,8 +303,7 @@ async fn cluster_broadcast_fans_out_to_all_nodes() {
     }
 
     // Check that node 0's RESP listener is reachable at all.
-    let ping = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
-    if resp_roundtrip(&host0, kv_port, ping).await.is_err() {
+    if resp_roundtrip(&host0, kv_port, &[b"PING".as_slice()]).await.is_err() {
         eprintln!("node 0 RESP unreachable at {host0}:{kv_port} — skipping");
         return;
     }

--- a/crates/ephpm-e2e/tests/vhosts.rs
+++ b/crates/ephpm-e2e/tests/vhosts.rs
@@ -11,6 +11,7 @@
 
 use ephpm_e2e::required_env;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Get the sites directory path from env.
 fn sites_dir() -> PathBuf {
@@ -71,12 +72,20 @@ async fn lazy_discovered_site_serves_content() {
     )
     .expect("failed to write index.html");
 
-    // Request again — should now serve from the new site directory.
-    let resp = get_with_host(&base_url, host, "/index.html").await;
+    // Request again — served from the new site directory once the router's
+    // negative-lookup cache (UNKNOWN_SITE_TTL, 2s) expires. The documented
+    // contract is "live within seconds", not "live on the very next
+    // request", so poll rather than assert instantly.
+    let mut resp = get_with_host(&base_url, host, "/index.html").await;
+    let deadline = std::time::Instant::now() + Duration::from_secs(6);
+    while resp.status().as_u16() != 200 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        resp = get_with_host(&base_url, host, "/index.html").await;
+    }
     assert_eq!(
         resp.status().as_u16(),
         200,
-        "expected 200 from lazily discovered site"
+        "expected 200 from lazily discovered site within the discovery window"
     );
     let body = resp.text().await.expect("failed to read body");
     assert!(

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -49,10 +49,13 @@ pub struct CompressionSettings {
 
 /// How long a "no site directory for this host" answer is cached
 /// before we retry the on-disk lookup. Short enough that lazy vhost
-/// discovery still feels immediate for legitimate deploys; long
-/// enough that a burst of bot probes for the same `Host: <random>`
-/// doesn't restatstore the filesystem on every request.
-const UNKNOWN_SITE_TTL: Duration = Duration::from_secs(60);
+/// discovery stays near-immediate for legitimate deploys — 60s here
+/// shipped in 0.4.0 and made freshly created site directories 404 for
+/// up to a minute after any prior probe (caught by the vhosts e2e once
+/// the suite was un-broken). 2s still collapses bot-probe bursts for
+/// the same `Host: <random>` into one stat per window, which is all
+/// the cache is for; a stat every 2s per unique host is noise.
+const UNKNOWN_SITE_TTL: Duration = Duration::from_secs(2);
 
 /// Per-site configuration resolved at startup from `sites_dir`.
 struct SiteConfig {

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -916,7 +916,7 @@ impl Router {
                     (
                         error_response_owned(
                             status,
-                            format!("{code} {}", status.canonical_reason().unwrap_or("Error"),),
+                            format!("{code} {}", status.canonical_reason().unwrap_or("Error")),
                         ),
                         "error",
                     )

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -1002,8 +1002,7 @@ const OPCACHE_REVISION_PREFIX: &str = "opcache:revision:";
 fn epoch_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-        .unwrap_or(0)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
 /// Human-facing hint when the RESP listener refuses a TCP connection — the

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -22,13 +22,6 @@ WORKDIR /src/crates/ephpm-e2e
 # (ephpm-e2e is excluded from the workspace, so its lockfile isn't kept
 # in sync by routine workspace operations). Letting fetch update the
 # lockfile in this layer is fine — the later --frozen build pins it.
-# ephpm-e2e has a path dependency on ../ephpm-kv (the RESP client used by
-# the opcache_invalidation test, added in #144) — the crate must exist in
-# the image or `cargo fetch` cannot load its manifest and the build dies
-# with "failed to load manifest for dependency `ephpm-kv`". Copied in full
-# (ephpm-kv has no further path dependencies); an ephpm-kv change correctly
-# invalidates this layer because the e2e binaries compile it.
-COPY crates/ephpm-kv/ /src/crates/ephpm-kv/
 COPY crates/ephpm-e2e/Cargo.toml crates/ephpm-e2e/Cargo.lock ./
 RUN mkdir -p src tests \
     && printf 'fn main() {}\n' > src/lib.rs \

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -22,6 +22,13 @@ WORKDIR /src/crates/ephpm-e2e
 # (ephpm-e2e is excluded from the workspace, so its lockfile isn't kept
 # in sync by routine workspace operations). Letting fetch update the
 # lockfile in this layer is fine — the later --frozen build pins it.
+# ephpm-e2e has a path dependency on ../ephpm-kv (the RESP client used by
+# the opcache_invalidation test, added in #144) — the crate must exist in
+# the image or `cargo fetch` cannot load its manifest and the build dies
+# with "failed to load manifest for dependency `ephpm-kv`". Copied in full
+# (ephpm-kv has no further path dependencies); an ephpm-kv change correctly
+# invalidates this layer because the e2e binaries compile it.
+COPY crates/ephpm-kv/ /src/crates/ephpm-kv/
 COPY crates/ephpm-e2e/Cargo.toml crates/ephpm-e2e/Cargo.lock ./
 RUN mkdir -p src tests \
     && printf 'fn main() {}\n' > src/lib.rs \

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -242,7 +242,8 @@ When a customer cancels and their site directory is removed, traffic from existi
 1. Customer signs up for alice-blog.com
    → Create /var/www/sites/alice-blog.com/
    → Install WordPress
-   → Site is live immediately (no restart needed with future hot-reload)
+   → Site is live within ~2 seconds (no restart — the router re-checks
+     unknown hosts after a short negative-lookup TTL)
 
 2. Customer is active
    → Requests to alice-blog.com served from site directory


### PR DESCRIPTION
## Summary
- ephpm-e2e has had a path dep on ../ephpm-kv since #144 (RESP client for the opcache_invalidation test), but Dockerfile.e2e never copies the crate — cargo fetch fails with 'failed to load manifest for dependency ephpm-kv' and every E2E lane dies at image build.
- The break was masked by concurrent runner-infrastructure failures; today's PR #162 E2E logs showed the real error.
- Fix: COPY the crate (no further path deps) before the fetch layer.

## Test plan
- [ ] E2E lanes on this PR reach test execution (image builds)