### PR TITLE
ci: skip CI and E2E for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
 name: CI
 
+# Docs-only changes (site/, docs/, markdown) skip CI entirely — nothing
+# they touch is compiled or tested by these jobs, and the fleet is small.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,11 +5,21 @@
 
 name: E2E Tests
 
+# Docs-only changes skip E2E — see ci.yml; doubly important here since
+# each E2E run occupies the serialized repo-wide concurrency group.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
 
 # Serialize E2E across the whole repo. Each E2E job runs a full Kind cluster
 # plus a Rust release build inside ephemerd's shared 16 GB Linux VM; several


### PR DESCRIPTION
## Summary
- paths-ignore for site/**, docs/**, **.md on both CI and E2E triggers.
- Docs-only PRs stop consuming the 3-runner fleet and, more importantly, stop entering the serialized ephpm-e2e concurrency group (a docs-triggered E2E run contributed to today's queue wedge).
- Mixed PRs (code + docs) still run everything - paths-ignore only skips when ALL changed files match.

## Test plan
- [ ] This PR itself still triggers CI (it touches workflows, not docs)