### PR TITLE
docs(roadmap): worker dispatch Phase 0 config fixes shipped in #159

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
 name: CI
 
+# Docs-only changes (site/, docs/, markdown) skip CI entirely — nothing
+# they touch is compiled or tested by these jobs, and the fleet is small.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,11 +5,21 @@
 
 name: E2E Tests
 
+# Docs-only changes skip E2E — see ci.yml; doubly important here since
+# each E2E run occupies the serialized repo-wide concurrency group.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**.md"
 
 # Serialize E2E across the whole repo. Each E2E job runs a full Kind cluster
 # plus a Rust release build inside ephemerd's shared 16 GB Linux VM; several

--- a/site/content/roadmap/worker-dispatch-fastpath.md
+++ b/site/content/roadmap/worker-dispatch-fastpath.md
@@ -45,18 +45,24 @@ effort gets wasted.
 
 ## Design
 
-### Phase 0 — measure, then config wins (v0.4.1-sized)
+### Phase 0 — measure, then config wins ✅ config portion SHIPPED (v0.4.1)
 
-- Flamegraph the worker path under c=16 load (perf inside the container;
-  dhat for the Rust allocs) and validate the decomposition above.
-- **Quota-aware `worker_count` derivation**: the default derives from
-  host parallelism, which overshoots inside CPU-limited containers — the
-  knob matrix measured 1 worker beating the derived 2 by ~24% at 0.25
-  CPU (2,100 vs 1,690 rps). Derive from the cgroup CPU quota
-  (`cpu.max`) when present, host cores otherwise.
-- **Recycle default**: `worker_max_requests = 500` forces a worker
-  reboot every ~0.25 s at 2,000 rps. Raise the default and log recycle
-  frequency so the cost is visible.
+The two config fixes landed within hours of this page being written
+(PR #159):
+
+- **Quota-aware `worker_count` derivation** — shipped. `worker_count =
+  0` now reads the cgroup CPU quota (v2 `cpu.max`, v1
+  `cfs_quota_us`/`cfs_period_us`) and derives `ceil(quota_cpus)`,
+  falling back to host parallelism without a quota. The knob matrix
+  that motivated it: 1 worker beat the derived 2 by ~24% at 0.25 CPU
+  (2,100 vs 1,690 rps). Startup logs the derivation source.
+- **Recycle default** — shipped. `worker_max_requests` default raised
+  500 → 10,000 (500 forced a worker reboot every ~0.25 s at 2,000 rps);
+  each recycle logs worker id, requests served, and uptime.
+
+Still open from Phase 0: flamegraph the worker path under c=16 load
+(perf inside the container; dhat for the Rust allocs) and validate the
+decomposition above before investing in Phases 1–2.
 
 ### Phase 1 — lazy Envelope
 


### PR DESCRIPTION
Truth-sync: the roadmap page listed the quota-aware worker_count derivation and worker_max_requests default raise as planned; both shipped in #159. Flamegraph item stays open. Docs-only.