### PR TITLE
perf(net): TCP_NODELAY on the HTTP accept path

### DIFF
--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -532,6 +532,13 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
         tokio::select! {
             result = main.accept() => {
                 let (stream, remote_addr) = result.context("failed to accept connection")?;
+                // HTTP responses (JSON APIs, small pages, 304s) are frequently
+                // sub-MSS; without nodelay, Nagle holds the response tail until
+                // the client ACKs, which delayed-ACK defers ~40ms — surfacing as
+                // p50 latency under keep-alive/concurrency. hyper's server does
+                // not set this; the KV RESP listener already does for the same
+                // reason (ephpm-kv server.rs).
+                let _ = stream.set_nodelay(true);
                 let guard = acquire_connection(&limiter, &stream, remote_addr).await;
                 dispatch_main_connection(
                     stream, remote_addr, &tls_mode, tls_listener.is_some(),
@@ -543,6 +550,9 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
                 tls_listener.as_ref().expect("guarded by is_some").accept().await
             }, if tls_listener.is_some() => {
                 let (stream, remote_addr) = result.context("failed to accept TLS connection")?;
+                // Same rationale as the plain-HTTP accept above; set on the raw
+                // TCP stream before the TLS handshake wraps it.
+                let _ = stream.set_nodelay(true);
                 let guard = acquire_connection(&limiter, &stream, remote_addr).await;
                 dispatch_tls_connection(stream, remote_addr, &tls_mode, conn, &router, guard, &in_flight);
             }


### PR DESCRIPTION
## Finding
The DB proxy, KV RESP, and cluster data-plane listeners all set `TCP_NODELAY` (#161) — but the **main HTTP listener never did**. hyper's server does not set it, so accepted HTTP connections ran with Nagle enabled. Sub-MSS responses (JSON APIs, small pages, 304s) have their tail held until the client ACKs; delayed-ACK defers that ~40ms, surfacing as **p50 latency under keep-alive/concurrency**.

This is almost certainly the lab's one remaining loss to php-fpm: hello.php at c=16 shows fpm ~1.4ms vs ePHPm ~16ms p50, while c=1 is fine (~1.8ms) — the classic Nagle-under-concurrency signature.

## Change
`stream.set_nodelay(true)` on both the plain-HTTP and TLS accept paths (raw TCP stream, before the TLS handshake wraps it), mirroring the KV listener's existing rationale (`ephpm-kv/src/server.rs:154`). One-time per connection; no per-request cost; can only reduce latency.

## Verification
Build + clippy clean. **Value needs a hello c=16 p50 bench to size** — folded into the v0.4.2 measurement pass (expected to close or shrink the fpm gap). Found by a hot-path audit for v0.4.2.