### PR TITLE
perf(worker): drop double $_SERVER build in worker dispatch

### DIFF
--- a/crates/ephpm-php/src/request.rs
+++ b/crates/ephpm-php/src/request.rs
@@ -71,64 +71,119 @@ impl PhpRequest {
     /// - `PHP_SELF` = same as `SCRIPT_NAME`
     #[must_use]
     pub fn server_variables(&self) -> Vec<(String, String)> {
-        // Derive SCRIPT_NAME from the resolved script_filename relative to
-        // document_root. This is correct even after fallback rewrites.
-        let script_name = self
-            .script_filename
-            .strip_prefix(&self.document_root)
-            .map_or_else(|_| self.path.clone(), |rel| format!("/{}", rel.to_string_lossy()));
-
-        let mut vars = vec![
-            ("REQUEST_METHOD".into(), self.method.clone()),
-            ("REQUEST_URI".into(), self.uri.clone()),
-            ("SCRIPT_FILENAME".into(), self.script_filename.to_string_lossy().into_owned()),
-            ("SCRIPT_NAME".into(), script_name.clone()),
-            ("DOCUMENT_ROOT".into(), self.document_root.to_string_lossy().into_owned()),
-            ("SERVER_NAME".into(), self.server_name.clone()),
-            ("SERVER_PORT".into(), self.server_port.to_string()),
-            ("SERVER_SOFTWARE".into(), "ePHPm/0.1.0".into()),
-            ("SERVER_PROTOCOL".into(), self.protocol.clone()),
-            ("GATEWAY_INTERFACE".into(), "CGI/1.1".into()),
-            ("QUERY_STRING".into(), self.query_string.clone()),
-            ("PHP_SELF".into(), script_name),
-            ("REMOTE_ADDR".into(), self.remote_addr.ip().to_string()),
-            ("REMOTE_PORT".into(), self.remote_addr.port().to_string()),
-            ("REDIRECT_STATUS".into(), "200".into()),
-        ];
-
-        if self.is_https {
-            vars.push(("HTTPS".into(), "on".into()));
-        }
-
-        // Map HTTP headers to $_SERVER variables.
-        //
-        // Formerly built the CGI-style key with two String allocs per
-        // header (`to_uppercase()` then `.replace('-','_')`). Header
-        // names are ASCII by RFC 7230, so we can do a single byte
-        // pass — one allocation per non-canonicalised header, with
-        // the `HTTP_` prefix filled in place.
-        for (name, value) in &self.headers {
-            let key = cgi_header_key(name);
-            vars.push((key, value.clone()));
-        }
-
-        // Append extra environment variables (e.g. EPHPM_REDIS_* credentials).
-        for (key, value) in &self.env_vars {
-            vars.push((key.clone(), value.clone()));
-        }
-
-        vars
+        build_server_variables(
+            &self.method,
+            &self.uri,
+            &self.query_string,
+            &self.script_filename,
+            &self.document_root,
+            &self.path,
+            &self.server_name,
+            self.server_port,
+            &self.protocol,
+            self.remote_addr,
+            self.is_https,
+            &self.headers,
+            &self.env_vars,
+        )
     }
 
     /// Extract the cookie string from the request headers.
     #[must_use]
     pub fn cookie_string(&self) -> String {
-        self.headers
-            .iter()
-            .find(|(name, _)| name.eq_ignore_ascii_case("cookie"))
-            .map(|(_, value)| value.clone())
-            .unwrap_or_default()
+        cookie_string_from_headers(&self.headers)
     }
+}
+
+/// Build the `$_SERVER` variables from borrowed request fields.
+///
+/// This is the single source of truth for `$_SERVER` derivation, shared by
+/// both [`PhpRequest::server_variables`] (fpm path) and the worker dispatch
+/// path in `ephpm-server`. Keeping it a free function lets the worker path
+/// build `$_SERVER` directly from its owned locals without allocating a
+/// throwaway [`PhpRequest`].
+///
+/// Key distinction when fallback rewrites happen (e.g. `/blog/hello` → `/index.php`):
+/// - `REQUEST_URI` = original URI (`/blog/hello`) — what the client asked for
+/// - `SCRIPT_NAME` = resolved script (`/index.php`) — what PHP is executing
+/// - `PHP_SELF` = same as `SCRIPT_NAME`
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn build_server_variables(
+    method: &str,
+    uri: &str,
+    query_string: &str,
+    script_filename: &std::path::Path,
+    document_root: &std::path::Path,
+    path: &str,
+    server_name: &str,
+    server_port: u16,
+    protocol: &str,
+    remote_addr: SocketAddr,
+    is_https: bool,
+    headers: &[(String, String)],
+    env_vars: &[(String, String)],
+) -> Vec<(String, String)> {
+    // Derive SCRIPT_NAME from the resolved script_filename relative to
+    // document_root. This is correct even after fallback rewrites.
+    let script_name = script_filename
+        .strip_prefix(document_root)
+        .map_or_else(|_| path.to_owned(), |rel| format!("/{}", rel.to_string_lossy()));
+
+    let mut vars = vec![
+        ("REQUEST_METHOD".into(), method.to_owned()),
+        ("REQUEST_URI".into(), uri.to_owned()),
+        ("SCRIPT_FILENAME".into(), script_filename.to_string_lossy().into_owned()),
+        ("SCRIPT_NAME".into(), script_name.clone()),
+        ("DOCUMENT_ROOT".into(), document_root.to_string_lossy().into_owned()),
+        ("SERVER_NAME".into(), server_name.to_owned()),
+        ("SERVER_PORT".into(), server_port.to_string()),
+        ("SERVER_SOFTWARE".into(), "ePHPm/0.1.0".into()),
+        ("SERVER_PROTOCOL".into(), protocol.to_owned()),
+        ("GATEWAY_INTERFACE".into(), "CGI/1.1".into()),
+        ("QUERY_STRING".into(), query_string.to_owned()),
+        ("PHP_SELF".into(), script_name),
+        ("REMOTE_ADDR".into(), remote_addr.ip().to_string()),
+        ("REMOTE_PORT".into(), remote_addr.port().to_string()),
+        ("REDIRECT_STATUS".into(), "200".into()),
+    ];
+
+    if is_https {
+        vars.push(("HTTPS".into(), "on".into()));
+    }
+
+    // Map HTTP headers to $_SERVER variables.
+    //
+    // Formerly built the CGI-style key with two String allocs per
+    // header (`to_uppercase()` then `.replace('-','_')`). Header
+    // names are ASCII by RFC 7230, so we can do a single byte
+    // pass — one allocation per non-canonicalised header, with
+    // the `HTTP_` prefix filled in place.
+    for (name, value) in headers {
+        let key = cgi_header_key(name);
+        vars.push((key, value.clone()));
+    }
+
+    // Append extra environment variables (e.g. EPHPM_REDIS_* credentials).
+    for (key, value) in env_vars {
+        vars.push((key.clone(), value.clone()));
+    }
+
+    vars
+}
+
+/// Extract the cookie string from request headers (first `Cookie` header,
+/// case-insensitive; empty string if absent).
+///
+/// Shared by [`PhpRequest::cookie_string`] and the worker dispatch path so
+/// both derive the cookie data identically.
+#[must_use]
+pub fn cookie_string_from_headers(headers: &[(String, String)]) -> String {
+    headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("cookie"))
+        .map(|(_, value)| value.clone())
+        .unwrap_or_default()
 }
 
 /// Build the CGI-style `$_SERVER` key for an HTTP header name in one
@@ -359,5 +414,66 @@ mod tests {
         let req = make_request();
         let vars = req.server_variables();
         assert!(find_var(&vars, "EPHPM_REDIS_HOST").is_none());
+    }
+
+    /// The worker dispatch path in `ephpm-server` builds `$_SERVER` by calling
+    /// [`build_server_variables`] directly from its owned locals rather than
+    /// constructing a `PhpRequest`. This test guards that both derivations
+    /// produce byte-identical output for the same synthetic request — if this
+    /// ever diverges, worker mode and fpm mode would present PHP with
+    /// different `$_SERVER`, which is a correctness bug.
+    #[test]
+    fn test_worker_path_server_variables_match_request_mode() {
+        // A request that exercises every interesting branch: HTTPS on, a
+        // fallback rewrite (uri != script), custom + canonical headers, and
+        // injected env vars.
+        let mut req = make_request();
+        req.uri = "/blog/hello?preview=true".into();
+        req.path = "/blog/hello".into();
+        req.query_string = "preview=true".into();
+        req.is_https = true;
+        req.headers = vec![
+            ("host".into(), "example.com".into()),
+            ("accept-encoding".into(), "gzip, deflate".into()),
+            ("content-type".into(), "application/json".into()),
+            ("content-length".into(), "42".into()),
+            ("x-custom-header".into(), "value".into()),
+            ("cookie".into(), "session=abc123".into()),
+        ];
+        req.env_vars = vec![
+            ("EPHPM_REDIS_HOST".into(), "127.0.0.1".into()),
+            ("EPHPM_REDIS_PORT".into(), "6379".into()),
+        ];
+
+        // fpm path: via PhpRequest::server_variables().
+        let request_mode = req.server_variables();
+
+        // worker path: the exact call `handle_php_worker` makes, built from
+        // borrowed/owned fields with no intermediate PhpRequest.
+        let worker_mode = build_server_variables(
+            &req.method,
+            &req.uri,
+            &req.query_string,
+            &req.script_filename,
+            &req.document_root,
+            &req.path,
+            &req.server_name,
+            req.server_port,
+            &req.protocol,
+            req.remote_addr,
+            req.is_https,
+            &req.headers,
+            &req.env_vars,
+        );
+
+        // Byte-identical, including order.
+        assert_eq!(worker_mode, request_mode);
+    }
+
+    #[test]
+    fn test_worker_path_cookie_matches_request_mode() {
+        let mut req = make_request();
+        req.headers.push(("Cookie".into(), "session=abc123".into()));
+        assert_eq!(cookie_string_from_headers(&req.headers), req.cookie_string());
     }
 }

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1324,39 +1324,44 @@ impl Router {
         accepts_gzip: bool,
         accepts_br: bool,
     ) -> Response<ServerBody> {
-        // Reuse PhpRequest's $_SERVER / cookie derivation so worker mode and
-        // fpm mode present PHP with identical request metadata. The body is not
-        // used by server_variables()/cookie_string(), so pass an empty one —
-        // the real (possibly streaming) body travels in `owned.body`.
+        // Build $_SERVER and the cookie string with the *same* derivation the
+        // fpm path uses (via the shared free functions in ephpm_php::request),
+        // so worker mode and fpm mode present PHP with byte-identical request
+        // metadata. We build directly from the owned/borrowed locals here
+        // rather than constructing a throwaway `PhpRequest` — that intermediate
+        // built $_SERVER a second time and cloned method/uri/query/headers/
+        // content_type on the hot path for no reason.
         let mut env_vars = self.build_kv_env_vars(&server_name);
         env_vars.extend_from_slice(&self.db_env_vars);
 
-        let php_request = PhpRequest {
-            method: method.clone(),
-            uri: uri.clone(),
-            path,
-            query_string: query_string.clone(),
-            script_filename: script_filename.to_path_buf(),
-            document_root,
-            headers: headers.clone(),
-            body: Vec::new(),
-            content_type: content_type.clone(),
-            remote_addr,
-            server_name,
+        let cookie_data = ephpm_php::request::cookie_string_from_headers(&headers);
+        let server_vars = ephpm_php::request::build_server_variables(
+            &method,
+            &uri,
+            &query_string,
+            script_filename,
+            &document_root,
+            &path,
+            &server_name,
             server_port,
+            &protocol,
+            remote_addr,
             is_https,
-            protocol,
-            env_vars,
-        };
+            &headers,
+            &env_vars,
+        );
 
+        // `method`, `uri`, `query_string`, and `headers` are owned locals that
+        // are no longer read below — move them into the owned request instead
+        // of cloning.
         let owned = ephpm_php::worker_bridge::WorkerRequestOwned {
             method,
             uri,
             query_string,
-            cookie_data: php_request.cookie_string(),
+            cookie_data,
             content_type,
             body,
-            server_vars: php_request.server_variables(),
+            server_vars,
             headers,
         };
 


### PR DESCRIPTION
## What this targets

Worker-dispatch per-request cost — one lever for the v0.4.2 throughput gap vs Swoole/php-fpm. A recent bench confirmed the gap is **dispatch overhead**, not allocation (mimalloc gave only +2%) or codegen (JIT hurt builtin code), so this trims redundant work on the worker request path itself.

**Magnitude needs a worker-throughput bench to confirm — no % is claimed here.** The orchestrator will run it.

## The problem

`handle_php_worker` (`crates/ephpm-server/src/router.rs`) constructed a full throwaway `PhpRequest` purely to call `server_variables()` and `cookie_string()`, then cloned `method`/`uri`/`query_string`/`headers`/`content_type` into `WorkerRequestOwned`. Per request this:

- built the `$_SERVER` data effectively twice (the `PhpRequest` fields, then `server_variables()` re-deriving from them), and
- cloned 5+ owned strings that were already owned locals in the function.

## The fix

Extract the `$_SERVER` and cookie derivation out of `PhpRequest` into shared **free functions** in `ephpm_php::request`:

- `build_server_variables(...)` — borrowed-field `$_SERVER` builder
- `cookie_string_from_headers(...)` — cookie scan

`PhpRequest::server_variables()` / `::cookie_string()` now delegate to them (single source of truth — fpm path unchanged). The worker path calls them directly from its borrowed/owned locals and **moves** (no longer clones) `method`/`uri`/`query_string`/`headers` into `WorkerRequestOwned`.

## This does NOT change what PHP sees

The refactor is a pure Rust-side dedup — the CGI header keys, `REQUEST_METHOD`, `QUERY_STRING`, `CONTENT_TYPE`, `SCRIPT_NAME` derivation, env-var injection, and ordering are all produced by the same code path as before.

Proof: new test `test_worker_path_server_variables_match_request_mode` builds a synthetic request exercising every branch (HTTPS on, a fallback rewrite where `uri != script`, canonical `host`/`content-type`/`content-length` headers, a custom header, and injected `EPHPM_REDIS_*` env vars) and asserts the worker-path `$_SERVER` is **byte-identical** (including order) to the fpm-path `$_SERVER`. `test_worker_path_cookie_matches_request_mode` does the same for the cookie string.

## Verification

- `cargo build -p ephpm-server -p ephpm-php` — clean (stub mode)
- `cargo test -p ephpm-php --lib request` — 16 passed (incl. the 2 new)
- `cargo clippy -p ephpm-server -p ephpm-php --all-targets -- -D warnings` — zero warnings
- `cargo +nightly fmt --all -- --check` — clean

## Relation to #160

Adjacent code but no textual overlap (this edits the Rust dispatch caller + `request.rs`; #160 edits the C accessor / worker bridge). Based on `main`. If both land, either merge order works — no conflict is expected in the worker-path hunk.