### PR TITLE
docs(benchmarking): new section — methodology, results, findings

### DIFF
--- a/site/content/benchmarking/_index.md
+++ b/site/content/benchmarking/_index.md
@@ -1,0 +1,46 @@
++++
+title = "Benchmarking"
+type = "docs"
+weight = 10
++++
+
+How ePHPm is measured, what the numbers actually mean, and the findings
+that came out of measuring it. This section is descriptive, not
+aspirational — every number here was measured on a real artifact, and
+where something is unproven it says so.
+
+## The discipline
+
+Performance claims in ePHPm follow three rules, learned the hard way:
+
+1. **Measured before merged.** A change is not "a 200× win" until a
+   benchmark says so. Estimates are labeled as estimates.
+2. **Verified on the artifact.** Headline numbers are re-measured on the
+   *built release image*, not a dev build — because the two can differ in
+   ways that silently erase the win (see
+   [Findings → When measurement caught a bug](findings/#when-measurement-caught-a-bug)).
+3. **Guarded after shipping.** Silent-regression classes get CI guards
+   (the SHA-NI symbol check, the opcache-enabled e2e) so a win can't
+   quietly evaporate in a later build.
+
+## Pages
+
+- **[Methodology](methodology/)** — the harness, the tools, container CPU
+  quotas, and the traps that taint a run (rate limiters, the wrong image
+  config, throughput-vs-latency confusion).
+- **[Results](results/)** — the measured numbers across releases, with the
+  before/after that each change produced.
+- **[Findings](findings/)** — the technical discoveries: where latency
+  hid, why some "obvious" wins didn't materialize, and what the data
+  ruled out.
+
+## The one-paragraph version
+
+ePHPm is an all-in-one PHP application server, so its performance story
+spans HTTP dispatch, PHP execution, an embedded database wire proxy, and
+a KV store — each with its own hot path. The biggest single win to date
+was **removing a ~44 ms-per-query Nagle/delayed-ACK stall** on the
+database path (208× on point-SELECTs). The biggest *surprise* was that a
+JIT and an allocator swap — both "obviously faster" — did little or
+nothing for the workloads we tested, while a one-line socket option did
+more. Measurement, not intuition, drove every one of those calls.

--- a/site/content/benchmarking/findings.md
+++ b/site/content/benchmarking/findings.md
@@ -1,0 +1,122 @@
++++
+title = "Findings"
+type = "docs"
+weight = 3
++++
+
+The technical discoveries behind the numbers — including the ones where
+the data contradicted the intuition.
+
+## Nagle's algorithm hides everywhere
+
+The single most productive class of finding was **TCP_NODELAY on
+small-response paths**. ePHPm speaks several small-frame protocols, and
+each accepted-connection socket needs `TCP_NODELAY` or Nagle +
+delayed-ACK adds a ~40 ms stall to multi-segment responses under
+keep-alive:
+
+- **Database wire (litewire MySQL frontend)** — the big one. The stall
+  was on the *response*: multi-packet result sets deadlocked against the
+  php `mysqlnd` client's Nagle. Server-side `set_nodelay` alone did **not**
+  fix it — the client's Nagle mattered — so the real fix was **coalescing
+  the whole result set into a single write** in litewire. 208× on
+  point-SELECTs.
+- **KV RESP listener** — set from the start, with an explicit "~40 ms
+  stall" comment. This is the precedent that made the other gaps obvious.
+- **DB proxy, cluster data-plane** — fixed in the same pass.
+- **The main HTTP listener** — *missed initially* on the assumption that
+  "hyper sets nodelay itself." It does not. Found by a hot-path audit for
+  v0.4.2; contributes the −13% p99 / −8.6% c=1 p50 above.
+
+Lesson: any `accept()` loop that serves sub-MSS responses under keep-alive
+should set `TCP_NODELAY`. Don't assume the framework does it.
+
+## The INSERT-fast / SELECT-slow fingerprint
+
+When a database benchmark shows single-row INSERTs fast (~1 ms) but
+SELECTs pinned at a fixed ~44 ms, that fixed timer is delayed-ACK, and
+the asymmetry localizes it precisely: a single-packet response (INSERT
+OK) can't trigger the deadlock, a multi-packet response (a result set)
+can. The fingerprint pointed straight at the response-write path.
+
+## SHA-NI was off for the life of the project
+
+Every 8.3/8.4 build shipped without SHA-NI (hardware sha256), because a
+`-fvisibility-inlines-hidden` flag (C++-only) leaked into the C compiler
+flags, produced a stderr warning, and made an autoconf
+function-attribute probe fail — which undefined the macro that gates the
+SHA-NI code path. sha256 ran at ~2.7× its potential cost. The fix was an
+SDK build change plus a **hard build guard** (`nm | grep
+SHA256_Transform_shani`) so it can never silently regress again. A config
+field existing, or a feature "being enabled," does not mean the machine
+code is present — grep the symbol.
+
+## When measurement caught a bug
+
+Twice, the release verification pass caught a "shipped win" that wasn't:
+
+- **The reverted nodelay.** A rebase conflict during a stacked-PR merge
+  silently dropped the litewire `set_nodelay` lines (the commit was in
+  history; its changes were overwritten by a `--theirs` resolution). The
+  DB benchmark on the release candidate still showed the full 44 ms
+  stall. Had we tagged on "the code merged, CI is green," we'd have
+  shipped a headline that was false on the flagship path.
+- **The wrong SDK in the matrix.** The release workflow pinned an older
+  PHP patch version in three of four build jobs, so the artifacts would
+  have shipped the pre-SHA-NI SDK under the new version string. Caught by
+  re-measuring sha256 on the built image, not the tarball.
+
+This is why rule 2 (*verify on the artifact*) exists. Correct source and
+green CI are necessary, not sufficient.
+
+## Things the data ruled OUT
+
+Equally valuable: changes that "should" have helped and didn't.
+
+### JIT made a builtin-heavy workload 17% slower
+
+Enabling `opcache.jit=tracing` on `cpu.php` produced **−17% RPS** (p50
++45%). `cpu.php` is dominated by the `hash()` C builtin; JIT compiles PHP
+*bytecode*, so it can't touch the hot code and its tracing/compilation
+overhead is pure cost. Conclusions:
+
+- **Never auto-enable JIT.** ePHPm's resource-aware autotuning sizes the
+  JIT buffer but leaves JIT *off* by default — this result is the
+  justification. Auto-on would regress builtin-heavy apps.
+- JIT is a per-application decision that helps *pure-PHP compute*
+  (arithmetic, arrays, tight interpreter loops). Bench your app.
+- **JIT is not the lever for the cpu-vs-Swoole gap** — see below.
+
+### mimalloc + fat LTO barely moved CPU-bound work
+
+A global-allocator swap (mimalloc) plus fat LTO gave ~+2% on `cpu.php`
+and ~+6% on `hello`. Real, kept, no regression — but it also means the
+allocator was *not* the bottleneck on those paths, and it **retired a
+backlog of allocation-shaving micro-optimizations**: if a whole new
+allocator buys 2%, hand-trimming individual `String` clones buys less. A
+profile would have to justify that work now.
+
+### The Swoole cpu gap is the ZTS tax, not JIT or allocation
+
+Swoole leads ePHPm worker-mode on `cpu.php` (~206 vs ~149 RPS in the lab).
+Neither runtime JITs by default, and allocation isn't the bottleneck
+(above). The gap maps to **ZTS overhead** — thread-safe PHP measured
+~50% slower than NTS on an isolated hash loop (1.65 ms vs 1.10 ms). The
+lever is therefore an **NTS-prefork mode**, gated on a post-PGO
+measurement — not anything in the v0.4.2 line.
+
+## Throughput vs latency, again
+
+The `TCP_NODELAY` HTTP win looked like "nothing" (+6% RPS) in a
+throughput-bound c=16 test and like a clear win (−8.6% p50, −13% p99) once
+measured latency-bound at c=1. Same change, same build — the *test* was
+the variable. If a latency optimization reads as a no-op, check whether
+the test is saturated before concluding it didn't work.
+
+## Meta-lesson
+
+The wins that mattered were structural and cheap (a socket option, a
+single coalesced write, a restored compiler flag). The "obviously fast"
+levers (JIT, a faster allocator) were marginal or negative on real
+workloads. Intuition ranked these exactly backwards; measurement
+corrected it every time.

--- a/site/content/benchmarking/methodology.md
+++ b/site/content/benchmarking/methodology.md
@@ -1,0 +1,103 @@
++++
+title = "Methodology"
+type = "docs"
+weight = 1
++++
+
+How to run an ePHPm benchmark that produces a number you can trust.
+
+## The harness
+
+Two complementary setups are used:
+
+- **Local single-node** (podman/Docker): one container per runtime, a load
+  generator container on the same network, fixtures mounted read-only.
+  Fast to iterate; used for A/B comparisons between ePHPm versions and
+  against php-fpm. The [ePHPm-lab](https://github.com/tinfoyle/ePHPm-lab)
+  `RUNTIMES-BENCH` recipe is the reference form.
+- **Kubernetes (LKE)**: the lab's k6 suites for realistic app workloads
+  (Krayin CRM, Laravel, WordPress/WooCommerce). Not locally reproducible;
+  these carry the worker-mode application story.
+
+A local control run of a known version should **reproduce the lab's
+recorded baseline** (e.g. hello p50 within noise, cpu RPS within a few
+percent). If it doesn't, the hardware isn't comparable and cross-machine
+claims are invalid — check this before trusting any A/B.
+
+## Fixtures
+
+Three canonical workloads, each measuring a different subsystem:
+
+| Fixture | Code | Measures |
+|---|---|---|
+| `hello.php` | one `json_encode` | HTTP dispatch + SAPI round-trip overhead (allocation, request setup) |
+| `cpu.php` | `hash('sha256', …)` × 5000 | PHP execution + the hash builtin (**not** pure PHP bytecode — see below) |
+| `db.php` | 10 sequential PDO `SELECT`s | the database wire path (proxy/litewire + PHP `pdo_mysql`) |
+
+**`cpu.php` measures the hash builtin, not the interpreter.** `hash()` is
+a C function; most of its time is in the (SHA-NI-accelerated) C
+implementation, not PHP bytecode. This makes `cpu.php` a good proxy for
+"is the CPU intrinsic wired up" but a **poor proxy for JIT** (which
+compiles bytecode, not builtins). Use a pure-PHP-compute fixture to
+evaluate JIT.
+
+## Load generation
+
+- Tools: `oha` or `hey` (keep-alive HTTP load). Match whatever the lab
+  recorded with for comparability.
+- **Warmup first**, then a 15–30 s measured run, repeated ≥2×, report best.
+- Record **RPS, p50, p99** — never RPS alone. p99 is where tail-latency
+  bugs (Nagle stalls, GC pauses, worker recycling) show up while p50 and
+  RPS look fine.
+
+## Container CPU quota matters
+
+Run under the CPU quota you care about (`--cpus 0.25` locally mirrors a
+`250m` k8s pod). ePHPm derives `worker_count` from the cgroup quota, and
+the whole worker-vs-request tradeoff changes with it. A win measured at
+`--cpus 1` may not hold at `0.25` and vice versa — state the quota with
+every number.
+
+## Throughput-bound vs latency-bound
+
+This distinction has caused more misreadings than any other:
+
+- At **high concurrency on a small CPU quota**, the workload is
+  **throughput-bound**: p50 ≈ concurrency ÷ RPS (it's queue time, not
+  service time). A latency optimization (e.g. `TCP_NODELAY`) barely moves
+  p50 here — it shows up in **p99** and in **low-concurrency (c=1) p50**.
+- To measure a *latency* change, run **c=1** (or below saturation). To
+  measure a *throughput* change (worker count, dispatch cost), run at
+  saturation and read RPS.
+
+Measuring a latency fix with a throughput-bound test will make a real win
+look like nothing. Always run both c=1 and c=16.
+
+## Traps that taint a run (check every time)
+
+1. **The rate limiter.** ePHPm's default image config can enable a per-IP
+   rate limiter. A single-IP load test then gets flooded with `429`s and
+   the "throughput" number is meaningless. **Verify 100% `2xx` in every
+   cell** before believing it. This has silently corrupted results more
+   than once.
+2. **The wrong image config.** The published image ships a config tuned
+   for its e2e tests, not for benchmarking. Mount a known bench config;
+   don't inherit the image default.
+3. **musl vs glibc.** musl's allocator is markedly slower on
+   allocation-heavy loops (~3–4× on some microbenchmarks). Compare
+   glibc-to-glibc; ePHPm's Linux release is glibc-dynamic.
+4. **ZTS vs NTS.** ePHPm runs ZTS (thread-safe) PHP; several competitors
+   run NTS. The ZTS tax is real (~50% on tight hash loops in isolation,
+   5–10% on realistic scripts). A ZTS-vs-NTS comparison is measuring the
+   build mode as much as the server.
+5. **RTT-bound ceilings.** Under nested virtualization (podman on WSL2),
+   loopback RTT can cap absolute RPS well below a bare-metal or cluster
+   number. Version-to-version *deltas* stay valid; absolute ceilings do
+   not transfer.
+
+## Tooling note (Windows hosts)
+
+The MINGW/git-bash shell mangles some tool flags (`grep -E`, `head -n`),
+which can silently produce empty or wrong filtered output — a benchmark
+"failure" that is actually a shell bug. Parse results with `awk` or
+PowerShell, and always sanity-check that a result file is non-empty.

--- a/site/content/benchmarking/results.md
+++ b/site/content/benchmarking/results.md
@@ -1,0 +1,69 @@
++++
+title = "Results"
+type = "docs"
+weight = 2
++++
+
+Measured numbers by release. Each was taken on the built release image
+(or, where noted, a release-candidate build), 100% `2xx` verified.
+
+## v0.4.0 → v0.4.1
+
+The v0.4.1 headline was **database latency**. Measured on the release
+image; the v0.4.0 control reproduced the lab's recorded baselines, so the
+comparison is apples-to-apples.
+
+| Workload | v0.4.0 | v0.4.1 | Change |
+|---|---|---|---|
+| Single-node SQLite point-SELECT p50 | 44.010 ms | **0.211 ms** | **208×** |
+| Single-node SQLite INSERT p50 | 1.07 ms | **0.267 ms** | 4× |
+| `db.php` (10 queries) per request p50 | ~444 ms | **~4.4 ms** | **101×** |
+| sha256 (per digest) | 306 ns | **133 ns** | **2.3×** |
+| cpu.php c=16 RPS | 78.7 | **147.9** | 1.88× (flips a loss vs php-fpm to a win) |
+| hello.php c=16 RPS | 730 | 781 | +7% |
+
+**Where the DB number came from:** php's `mysqlnd` client does not set
+`TCP_NODELAY`; the litewire MySQL frontend wrote each result-set packet
+separately. The two together produced a Nagle + delayed-ACK deadlock on
+every multi-packet response — a fixed ~44 ms stall. Coalescing the
+result-set into a single write removed it. INSERTs (single OK packet)
+were never affected, which is exactly why SELECT was slow and INSERT was
+fast — the diagnostic fingerprint.
+
+**Where the sha256 number came from:** a C++-only compiler flag in the SDK
+build silently disabled the compiler's function-attribute detection,
+which disabled the SHA-NI code path. Restoring it roughly halved sha256
+cost and flipped `cpu.php` from a ~2× loss to php-fpm into a win.
+
+Against php-fpm on the local runtimes suite, v0.4.1 wins every category
+measured: cpu (was the clearest loss), database (by construction), and
+small-script throughput.
+
+## v0.4.2 (in progress)
+
+Measured on a v0.4.2-dev image (wave-1 changes + the HTTP `TCP_NODELAY`
+fix) vs published v0.4.1, `--cpus 1`.
+
+| Cell | v0.4.1 | v0.4.2-dev | Change |
+|---|---|---|---|
+| hello c=1 p50 (latency-bound) | 1.79 ms | 1.64 ms | −8.6% |
+| hello c=16 RPS (throughput) | 842 | 895 | +6.3% |
+| hello c=16 p99 | 29.3 ms | 25.4 ms | **−13%** |
+| cpu c=16 RPS | 559 | 570 | +2% |
+
+The `−13%` p99 and `−8.6%` c=1 p50 are the `TCP_NODELAY` signature (tail
+and single-request latency); the modest RPS gain is the combined effect
+of that plus wave-1. Worker-dispatch and further items are still being
+measured — see [Findings](findings/) for what the data ruled in and out.
+
+## How to read these
+
+- **Absolute numbers are environment-specific.** The db.php p50 was
+  measured differently (single-node reproduction) from the raw
+  point-SELECT p50; both are real, both are labeled. RPS ceilings under
+  podman/WSL are RTT-capped and do not transfer to a cluster.
+- **Deltas are the durable claim.** "208×" and "−13% p99" hold across
+  environments; "895 RPS" does not.
+- **php-fpm comparisons** use the official `php:8.4-fpm` image with an
+  opcache+JIT ini overlay, nginx front, same fixtures. The fpm control
+  also reproduces the lab's recorded fpm numbers.

--- a/site/content/benchmarking/results.md
+++ b/site/content/benchmarking/results.md
@@ -56,6 +56,53 @@ and single-request latency); the modest RPS gain is the combined effect
 of that plus wave-1. Worker-dispatch and further items are still being
 measured — see [Findings](findings/) for what the data ruled in and out.
 
+## v0.5.0 — resource-aware autotuning (in progress)
+
+v0.5.0's headline is **container-derived PHP tuning**: on boot in serve
+mode, ePHPm reads the cgroup CPU and memory limits and derives an opcache
+/ memory / realpath / assertions profile, with `opcache.validate_timestamps`
+off (deploys become events via `ephpm deploy` / `ephpm cache reset`).
+Operator config overrides any derived value.
+
+**Setup (reproducible):** a **300-file `require_once` app** (`index.php`
+includes 300 tiny class files each request — deliberately stat-heavy),
+`--cpus 1 --memory 512m`, `oha` at c=16, 15 s, warmup first, 100% `2xx`.
+v0.4.2 runs stock PHP ini; v0.5.0 auto-derives.
+
+**The profile v0.5.0 derived for this box (its own startup log):**
+
+```
+autotune (serve): cpu_quota=1.00 mem=512MiB (cgroup v2) ->
+  workers=1[cgroup_quota] opcache.memory_consumption=92MB memory_limit=356M
+  interned=8MB jit_buffer=32MB (buffer-only, jit off) max_files=20000
+  realpath=16M/ttl=600 validate_timestamps=0 assertions=-1
+```
+
+(It also logs the deploys-are-events contract, and — because this bench
+config left the RESP listener disabled — correctly WARNs that
+`ephpm deploy` can't reach the server.)
+
+**Result:**
+
+| | v0.4.2 (stock ini) | v0.5.0 (autotuned) | Change |
+|---|---|---|---|
+| RPS | 874 | **1144** | **+31%** |
+| p50 | 15.0 ms | 14.8 ms | −1% |
+| p99 | 20.6 ms | 19.2 ms | −7% |
+
+**+31% throughput with zero operator tuning**, driven mainly by
+`validate_timestamps=0` eliminating ~300 `stat()` syscalls per request on
+this include-heavy workload, plus the realpath cache and compiled-out
+assertions.
+
+**Honest bounds:** this app is deliberately near the *upper* end of what
+autotuning buys (300 includes/request). A single-file `hello.php` shows
+~0% (it has nothing to stat and fits any opcache). A real framework app
+lands **between** — wherever its file count and filesystem cost sit, and
+higher on container overlay / network filesystems where `stat()` is
+pricier. The number is a demonstrated ceiling-ish case, not a promise for
+every app.
+
 ## How to read these
 
 - **Absolute numbers are environment-specific.** The db.php p50 was

--- a/site/content/roadmap/benchmarks.md
+++ b/site/content/roadmap/benchmarks.md
@@ -3,6 +3,10 @@
 > **Status: DESIGN — not yet implemented.** The tooling exists in
 > scattered, proven form (the ePHPm-lab k6 profiles, the opcache e2e);
 > this page designs its consolidation into a per-release discipline.
+>
+> For the numbers and findings measured **so far**, see the
+> [Benchmarking](/benchmarking/) section — this page is the plan for
+> making that a repeatable per-release artifact.
 
 ## Why this page exists
 


### PR DESCRIPTION
Adds a top-level **Benchmarking** section capturing what the performance campaign found, so the detail lives in the docs instead of scattered across PRs and sessions.

## Pages
- **_index** — the measure-before-merged / verify-on-artifact / guard-after-shipping discipline.
- **methodology** — harness, fixtures (incl. *why cpu.php is a poor JIT proxy*), CPU-quota sensitivity, the **throughput-vs-latency** distinction that causes the most misreadings, and the taint traps (rate limiter → 429s, wrong image config, musl/ZTS, podman/WSL RTT ceilings, MINGW flag-eating).
- **results** — v0.4.0→v0.4.1 (DB **208×**, sha256 **2.3×**, cpu loss→win) and in-progress v0.4.2, with deltas-are-durable / absolutes-aren't.
- **findings** — Nagle everywhere + the INSERT-fast/SELECT-slow fingerprint; SHA-NI off for the project's life; the two times release verification caught a *false* shipped win; and what the data **ruled out** (JIT −17% on builtin code, mimalloc marginal, Swoole gap = ZTS tax).

Descriptive, not aspirational — every number was measured on a real artifact; unproven items say so. Cross-linked from the aspirational `roadmap/benchmarks` design page. Docs-only.