### PR TITLE
build(php): resolver_shim.c for modern glibc (Ubuntu 22.04+/Debian 13+)

### DIFF
--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -7,6 +7,7 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(php_linked)");
     println!("cargo::rerun-if-changed=wrapper.h");
     println!("cargo::rerun-if-changed=ephpm_wrapper.c");
+    println!("cargo::rerun-if-changed=resolver_shim.c");
     println!("cargo::rerun-if-env-changed=PHP_SDK_PATH");
 
     println!(
@@ -312,6 +313,16 @@ fn compile_wrapper(include_dir: &Path, target_os: &str) {
         .include(&include_zend)
         .include(&include_tsrm)
         .include(&include_sapi);
+
+    // ext/standard/dns.c inside libphp.a references the underscored resolver
+    // names (__dn_expand, __dn_skipname, __res_nsearch). Ubuntu 22.04+
+    // (glibc 2.35+) drops the unversioned compat aliases; newer linkers
+    // (rust-lld, GNU ld ≥ 2.38) won't silently match the unversioned refs to
+    // the versioned `__dn_expand@GLIBC_2.2.5`. resolver_shim.c provides
+    // tail-call wrappers on Linux only.
+    if target_os == "linux" {
+        build.file("resolver_shim.c");
+    }
 
     // PHP headers use GNU extensions (memrchr, mempcpy). Define _GNU_SOURCE
     // on every Unix target so the libc headers expose the declarations.

--- a/crates/ephpm-php/resolver_shim.c
+++ b/crates/ephpm-php/resolver_shim.c
@@ -1,0 +1,31 @@
+/* Resolver compat shim.
+ *
+ * PHP's ext/standard/dns.c references the underscored resolver names
+ * (`__dn_expand`, `__dn_skipname`, `__res_nsearch`) which glibc historically
+ * exported as unversioned compatibility aliases alongside the public
+ * `dn_expand` / `dn_skipname` / `res_nsearch`. Ubuntu 22.04+ (glibc 2.35+)
+ * strips the unversioned aliases: only versioned `__dn_expand@GLIBC_2.2.5`
+ * remains, and rust-lld / newer GNU ld will not silently match an
+ * unversioned reference to a versioned definition.
+ *
+ * Rebuilding libphp.a inside the SDK against a newer glibc would fix it
+ * upstream; until that lands, this shim provides the underscored names as
+ * thin wrappers over the still-exported public entry points. Runtime cost
+ * is a single tail call. No behavior change.
+ */
+
+#include <resolv.h>
+
+int __dn_expand(const unsigned char *msg, const unsigned char *eomorig,
+                const unsigned char *comp_dn, char *exp_dn, int length) {
+    return dn_expand(msg, eomorig, comp_dn, exp_dn, length);
+}
+
+int __dn_skipname(const unsigned char *comp_dn, const unsigned char *eom) {
+    return dn_skipname(comp_dn, eom);
+}
+
+int __res_nsearch(res_state statp, const char *dname, int class, int type,
+                  unsigned char *answer, int anslen) {
+    return res_nsearch(statp, dname, class, type, answer, anslen);
+}


### PR DESCRIPTION
## Summary

Local `cargo xtask release` fails on Ubuntu 22.04+ / Debian 13+ hosts with:

```
rust-lld: error: undefined symbol: __dn_expand
rust-lld: error: undefined symbol: __dn_skipname
rust-lld: error: undefined symbol: __res_nsearch
```

The prebuilt PHP SDK ships `libphp.a` built on almalinux:8 (glibc 2.28), whose `ext/standard/dns.o` references the underscored resolver names unversioned. Modern distros (glibc ≥ 2.35) drop the unversioned compat aliases; only `__dn_expand@GLIBC_2.2.5` remains. Rust 1.94's default `rust-lld` and GNU ld ≥ 2.38 both refuse to silently match unversioned references to versioned definitions.

CI is unaffected because its base image runs the older glibc; only local hosts on modern Linux distros hit this.

## Fix

`resolver_shim.c` — 20 lines. Provides tail-call wrappers over the still-exported public `dn_expand` / `dn_skipname` / `res_nsearch` entry points. Compiled on Linux only via `cc::Build` in `build.rs`. Zero runtime cost (single JMP each).

## Test plan

- [x] `cargo xtask release 8.4` succeeds on Ubuntu 22.04 (glibc 2.35) — was failing before
- [x] Resulting binary boots cleanly and serves worker-mode hello at 1400 RPS c=16
- [ ] CI matrix stays green (no glibc change on CI side)
