### PR TITLE
fix(build): mimalloc off on Windows; MACOSX_DEPLOYMENT_TARGET=12 for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,14 @@ jobs:
           echo "BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=${LLVM_RESOURCE_DIR}" >> "$GITHUB_ENV"
 
       - name: Build ephpm
+        env:
+          # PHP SDK 8.5.7 macOS objects are built with a newer Xcode that
+          # emits calls to `___isPlatformVersionAtLeast` (macOS 12+ runtime
+          # helper). The linker infers deployment target from the .rlib
+          # objects and complains at 11.0. Setting the floor to 12.0 (Apple
+          # dropped support for anything older) resolves it and matches the
+          # SDK's build environment. 8.3/8.4 SDKs also link cleanly at 12.0.
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
         run: cargo xtask release ${{ matrix.php_minor }}
 
       - name: Package archive

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -20,7 +20,7 @@ ephpm-db.workspace = true
 ephpm-kv.workspace = true
 ephpm-php.workspace = true
 ephpm-server.workspace = true
-# mimalloc as the global allocator for the ephpm binary.
+# mimalloc as the global allocator for the ephpm binary. Non-Windows only.
 #
 # Wins in workloads with many small, short-lived allocations (HTTP request
 # frames, RESP command payloads, MySQL packet vecs, litewire query buffers) —
@@ -30,9 +30,13 @@ ephpm-server.workspace = true
 #
 # Applied only at the binary crate level so downstream test/dev tooling
 # (unit tests, xtask, doc builds) uses the standard allocator and doesn't
-# introduce platform-specific surprises in CI. Windows-supported (bundled
-# in the mimalloc crate's build.rs).
-mimalloc = { version = "0.1", default-features = false }
+# introduce platform-specific surprises in CI.
+#
+# Not on Windows: mimalloc-sys builds its C with `/MD` (dynamic CRT) while
+# the PHP SDK's static objects are `/MT`, and MSVC refuses to link the
+# mismatch (LNK2038). The Windows allocator picture is also different —
+# SEG_HEAP already reduces the contention mimalloc addresses on glibc — so
+# Windows keeps the system allocator.
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -41,6 +45,7 @@ tracing-subscriber.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+mimalloc = { version = "0.1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7"

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-/// Global allocator override for the ephpm binary.
+/// Global allocator override for the ephpm binary (Unix only).
 ///
 /// mimalloc gives lower allocator contention and better locality than the
 /// default system allocator under the ePHPm workload profile (many small,
@@ -23,6 +23,10 @@ use tracing_subscriber::{EnvFilter, Layer};
 /// retaining freed pages for reuse than the default allocator, so RSS
 /// looks larger at steady state. This is normal — track it against the
 /// 320 MiB target and adjust with `MIMALLOC_PURGE_DELAY` if needed.
+///
+/// Windows uses the system allocator — see the Cargo.toml comment on the
+/// mimalloc dep for the MSVC `/MD` vs PHP-SDK `/MT` link mismatch.
+#[cfg(unix)]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
## Summary

The v0.4.2 release matrix (run 29168597190) failed 4 build legs — all root-caused. This PR fixes them.

**Windows (all 3 PHP legs, LNK2038 RuntimeLibrary mismatch)**
- `mimalloc-sys` builds its C with `/MD` (dynamic CRT); PHP SDK's static `libphp.a` is `/MT`. MSVC refuses to link the mismatch.
- Fix: `mimalloc` moves to `[target.'cfg(unix)'.dependencies]`, `#[global_allocator]` gated with `#[cfg(unix)]`. Windows keeps the system allocator.

**macOS aarch64 8.5 (`___isPlatformVersionAtLeast` undefined)**
- PHP SDK 8.5.7's macOS objects were built with a newer Xcode; the linker infers the deployment target from `.rlib` objects and hits macOS 12+ helpers.
- Fix: `MACOSX_DEPLOYMENT_TARGET=12.0` on the macOS Build step. Matches the SDK's build environment; 8.3/8.4 SDKs also link cleanly at 12.0.

Linux legs unaffected. Docker images from the first matrix run are Linux-only and functionally identical.

## After merge

Delete + retag `v0.4.2` at the new main SHA so Windows and macOS 8.5 tarballs can build. Docker digests will change (rebuilt) but content-behavior is identical on Linux; the Release page never published, so no consumers rely on the previous digest.

## Test plan

- [x] `cargo check -p ephpm` on Linux — passes (main path)
- [ ] CI (Clippy + Test linux-x64) — should pass; mimalloc gate is trivial cfg change
- [ ] Post-merge, retag `v0.4.2`; watch matrix; expect Windows + macOS 8.5 legs to go green
