### PR TITLE
ci(release): thin LTO for linux-aarch64 (fat-LTO link OOMs the arm64 host)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,18 @@ jobs:
             image: latest
             triple: x86_64-unknown-linux-gnu
             sdk: linux-x86_64
+            lto: fat
           - runner: arm64
             image: latest-arm64
             triple: aarch64-unknown-linux-gnu
             sdk: linux-aarch64
+            # Thin LTO on arm64: the fat-LTO final link of the ephpm binary
+            # (libphp.a + ICU + everything, codegen-units=1) exceeds the
+            # arm64 build host's memory — rustc gets SIGKILLed by the OOM
+            # killer even running as the only job. Thin LTO cuts link-time
+            # memory to a fraction for a ~1% perf delta on a target where
+            # we publish no benchmark numbers anyway.
+            lto: thin
     steps:
       - uses: actions/checkout@v4
 
@@ -69,6 +77,10 @@ jobs:
           echo "EPHPM_RELEASE_VERSION=${REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Build ephpm
+        env:
+          # Overrides profile.release.lto from Cargo.toml per-arch (see the
+          # matrix `lto` values — arm64 must use thin to fit in host memory).
+          CARGO_PROFILE_RELEASE_LTO: ${{ matrix.arch.lto }}
         run: cargo xtask release ${{ matrix.php.minor }}
 
       - name: Package archive


### PR DESCRIPTION
## Summary

Linux aarch64 release legs died with rustc `(signal: 9, SIGKILL)` during the final binary link on **three consecutive matrix runs** — including one where the leg ran alone on the host. The v0.4.2 release-profile tuning (`lto=fat` + `codegen-units=1`, from #171) pushes the single-link memory of ephpm (libphp.a + ICU + all statics) beyond the arm64 build host's RAM. v0.4.1 built fine because it predates the profile change.

## Fix

Per-arch `CARGO_PROFILE_RELEASE_LTO` env override wired through the existing arch matrix:
- **x64: `fat`** — unchanged, artifacts identical
- **arm64: `thin`** — fraction of the link memory, ~1% perf delta on a target we publish no benchmark numbers for

## Evidence

```
process didn't exit successfully: `rustc --crate-name ephpm ... -C lto=fat -C codegen-units=1 ...` (signal: 9, SIGKILL: kill)
```
(run 29173960920, job 86599670689 — ran solo, still killed)

## Test plan
- [ ] CI green (workflow-only change, no code)
- [ ] After merge: retag v0.4.2 → aarch64 legs should link