### PR TITLE
feat(xtask): bump-php-pin + sdk-bump.yml reconciliation workflow

### DIFF
--- a/.github/workflows/sdk-bump.yml
+++ b/.github/workflows/sdk-bump.yml
@@ -1,0 +1,177 @@
+name: SDK Bump
+
+# Opens a pin-bump PR when a new, COMPLETE PHP SDK release exists at
+# ephpm/php-sdk. Auto-PR ONLY — merging stays manual (auto-merge is Phase 3,
+# explicitly out of scope).
+#
+# Trigger paths:
+#   - repository_dispatch (sdk-release-complete): receiving side of the
+#     Phase 3 plumbing. Nothing sends this event yet — php-sdk's
+#     watch-php.yml cannot fire cross-repo repository_dispatch with its
+#     default GITHUB_TOKEN; that needs a GitHub App token (Phase 3).
+#   - workflow_dispatch (php_version): manual bump for a specific version.
+#   - daily schedule: reconciliation — polls php-sdk releases and discovers
+#     complete SDKs the pins have not caught up to. Until Phase 3 wires the
+#     cross-repo dispatch, this poll is the primary discovery path.
+#
+# Token note: the default GITHUB_TOKEN can push branches and open PRs in
+# this repo, but PRs it opens do NOT trigger CI workflows (GitHub's
+# recursion guard). Until the Phase 3 App token replaces it, close/reopen
+# the PR or push an empty commit to get a CI run.
+
+on:
+  repository_dispatch:
+    types: [sdk-release-complete]
+  workflow_dispatch:
+    inputs:
+      php_version:
+        description: "Full PHP version to check/bump to (e.g. 8.5.8). Empty = reconcile every pinned minor."
+        required: false
+        type: string
+  schedule:
+    # Daily reconciliation, offset from the top of the hour.
+    - cron: "41 5 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sdk-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full default branch history not needed; we branch from origin/main.
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Reconcile PHP SDK pins
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SDK_REPO: ephpm/php-sdk
+          # workflow_dispatch input, or the repository_dispatch payload
+          # (client_payload.php_version), or empty = reconcile all minors.
+          EXPLICIT_VERSION: ${{ inputs.php_version || github.event.client_payload.php_version || '' }}
+        run: |
+          set -u
+
+          fail() { echo "::error::$*"; exit 1; }
+
+          # The SDK platform tarballs ephpm consumes. Keep in sync with
+          # ephpm/php-sdk versions.json (.platforms_required) — hardcoded
+          # here because this job runs from a bare ephpm checkout and the
+          # manifest lives in the other repo.
+          REQUIRED_PLATFORMS="linux-x86_64-gnu linux-aarch64-gnu macos-aarch64 windows-x86_64"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Current pins, parsed from the PHP_SDK_VERSIONS table:
+          #   ("8.3", "8.3.31") -> "8.3 8.3.31" per line.
+          pins=$(grep -oE '\("8\.[0-9]+", "8\.[0-9]+\.[0-9]+"\)' xtask/src/main.rs \
+            | tr -d '()",')
+          [ -n "$pins" ] || fail "could not parse PHP_SDK_VERSIONS from xtask/src/main.rs"
+          echo "current pins:"; echo "$pins" | sed 's/^/  /'
+
+          rc=0
+          # Read the pin list on fd 3 so commands inside the loop (cargo,
+          # gh, git) can't swallow the remaining lines from stdin.
+          while read -r minor current <&3; do
+            # Resolve the candidate version for this minor.
+            if [ -n "$EXPLICIT_VERSION" ]; then
+              case "$EXPLICIT_VERSION" in
+                "$minor".*) latest="$EXPLICIT_VERSION" ;;
+                *) continue ;;
+              esac
+            else
+              latest=$(gh release list --repo "$SDK_REPO" --limit 200 \
+                --json tagName --jq '.[].tagName' \
+                | grep -E "^v${minor//./\\.}\.[0-9]+$" | sed 's/^v//' \
+                | sort -V | tail -1)
+              if [ -z "$latest" ]; then
+                echo "==> ${minor}: no SDK releases found — skipping"
+                continue
+              fi
+            fi
+
+            # Pin already current (or ahead — never downgrade)?
+            if [ "$latest" = "$current" ] || \
+               [ "$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -1)" != "$latest" ]; then
+              echo "==> ${minor}: pin ${current} is current (newest SDK: ${latest})"
+              continue
+            fi
+            echo "==> ${minor}: pin ${current} is outdated; newest SDK is ${latest}"
+
+            # Completeness gate: every required platform tarball must be
+            # attached to the SDK release before we bump to it.
+            assets=$(gh api "repos/${SDK_REPO}/releases/tags/v${latest}" \
+              --jq '.assets[].name' 2>/dev/null || true)
+            [ -n "$assets" ] || { echo "    v${latest} release/tag not found — skipping"; continue; }
+            missing=""
+            for plat in $REQUIRED_PLATFORMS; do
+              echo "$assets" | grep -qxF "php-sdk-${latest}-${plat}.tar.gz" \
+                || missing="$missing $plat"
+            done
+            if [ -n "$missing" ]; then
+              echo "    v${latest} is INCOMPLETE (missing:${missing}) — not bumping"
+              continue
+            fi
+
+            # Marker-branch idempotency (no labels by design): one branch
+            # per target version. Skip if the branch or an open PR exists.
+            branch="bump/php-${latest}"
+            if [ "$(gh pr list --head "$branch" --state open --json number --jq length)" != "0" ]; then
+              echo "    open PR from ${branch} already exists — skipping"
+              continue
+            fi
+            if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+              echo "    branch ${branch} already exists on origin — skipping"
+              continue
+            fi
+
+            echo "    creating ${branch} and bumping pins..."
+            git checkout -B "$branch" origin/main
+            cargo run -q -p xtask -- bump-php-pin "$minor" "$latest" \
+              || fail "cargo xtask bump-php-pin ${minor} ${latest} failed"
+
+            git add xtask/src/main.rs .github/workflows/release.yml \
+              docker/Dockerfile site/content/developer/architecture-overview.md
+            git commit -m "chore(php): bump PHP ${minor} pin to ${latest}" \
+              || fail "nothing to commit after bump-php-pin — pin sites out of sync?"
+            git push origin "$branch" || fail "pushing ${branch} failed"
+
+            body_file=$(mktemp)
+            {
+              echo "Automated pin bump: PHP ${minor} \`${current}\` -> \`${latest}\`."
+              echo
+              echo "SDK release: https://github.com/${SDK_REPO}/releases/tag/v${latest}"
+              echo
+              echo "Asset inventory on \`v${latest}\` (all required platforms verified present):"
+              echo '```'
+              echo "$assets"
+              echo '```'
+              echo
+              echo "Opened by \`sdk-bump.yml\`. Auto-PR only — review and merge manually"
+              echo "(auto-merge is Phase 3). Note: PRs opened with the default"
+              echo "GITHUB_TOKEN do not trigger CI; close/reopen or push to the"
+              echo "branch to get a run."
+            } > "$body_file"
+            gh pr create --base main --head "$branch" \
+              --title "chore(php): bump PHP ${minor} pin to ${latest}" \
+              --body-file "$body_file" \
+              || fail "opening PR for ${branch} failed"
+            echo "    PR opened for ${branch}"
+
+            # Back to a clean base for the next minor.
+            git checkout --detach origin/main
+          done 3<<EOF
+          $pins
+          EOF
+
+          exit "$rc"

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -807,7 +807,7 @@ This is the same approach FrankenPHP uses.
 | PHP 8.1 | EOL (December 2025) | Not supported |
 | PHP 8.2 | Security-only (until Dec 2026) | Best-effort |
 | PHP 8.3 | Active support (until Dec 2026) | **Supported — in CI (pinned 8.3.31)** |
-| PHP 8.4 | Active support (until Dec 2027) | **Supported — in CI (pinned 8.4.22)** |
+| PHP 8.4 | Active support (until Dec 2027) | **Supported — in CI (pinned 8.4.23)** |
 | PHP 8.5 | Active support | **Supported — in CI (pinned 8.5.7)** |
 
 ### Release Naming

--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -1,0 +1,332 @@
+//! `cargo xtask bump-php-pin` — update or verify every PHP SDK pin site.
+//!
+//! The pinned full PHP version for a given minor lives in several places
+//! that must stay in lockstep:
+//!
+//! 1. `xtask/src/main.rs` — the `PHP_SDK_VERSIONS` table (source of truth)
+//! 2. `.github/workflows/release.yml` — 4 matrix sites (linux / macos /
+//!    windows / docker), one entry per minor in each
+//! 3. `docker/Dockerfile` — `ARG PHP_SDK_VERSION` default (+ its inline
+//!    example), only for the default minor
+//! 4. `site/content/developer/architecture-overview.md` — the support table
+//!    listing the CI-pinned full versions
+//!
+//! A missed pin site has broken a release before, so every substitution
+//! asserts its exact expected match count and the command refuses to write
+//! anything (all-or-nothing) if any count mismatches. `--check` runs the
+//! same counting against the current pins as a drift detector for CI.
+
+use std::fs;
+use std::process::ExitCode;
+
+use crate::{DEFAULT_PHP_MINOR, PHP_SDK_VERSIONS, workspace_root};
+
+/// One exact-substring substitution in one file, with a required match count.
+struct Substitution {
+    /// Path relative to the workspace root.
+    path: &'static str,
+    /// Exact substring that must occur exactly `expected` times in the file.
+    needle: String,
+    /// Text written in place of every `needle` occurrence.
+    replacement: String,
+    /// Required occurrence count — any other count aborts the whole run.
+    expected: usize,
+}
+
+/// Build the full substitution set for moving `minor` from `old_full` to
+/// `new_full`. With `old_full == new_full` this doubles as the site list for
+/// `--check` (counting only, replacement is a no-op).
+fn substitutions(minor: &str, old_full: &str, new_full: &str) -> Vec<Substitution> {
+    let mut subs = vec![
+        // The PHP_SDK_VERSIONS table entry itself.
+        Substitution {
+            path: "xtask/src/main.rs",
+            needle: format!("(\"{minor}\", \"{old_full}\")"),
+            replacement: format!("(\"{minor}\", \"{new_full}\")"),
+            expected: 1,
+        },
+        // The 4 release matrix sites (build-linux inline map, build-macos,
+        // build-windows, docker-image). Matching the bare quoted version is
+        // unambiguous — a full version string can only belong to one minor —
+        // and the count assert catches any structural change to the matrix.
+        Substitution {
+            path: ".github/workflows/release.yml",
+            needle: format!("\"{old_full}\""),
+            replacement: format!("\"{new_full}\""),
+            expected: 4,
+        },
+        // The PHP support table ("Supported — in CI (pinned X.Y.Z)").
+        Substitution {
+            path: "site/content/developer/architecture-overview.md",
+            needle: format!("(pinned {old_full})"),
+            replacement: format!("(pinned {new_full})"),
+            expected: 1,
+        },
+    ];
+    // The Dockerfile only pins the default minor: once as the ARG default
+    // and once in the comment example right above it ("e.g., v8.5.7").
+    if minor == DEFAULT_PHP_MINOR {
+        subs.push(Substitution {
+            path: "docker/Dockerfile",
+            needle: old_full.to_string(),
+            replacement: new_full.to_string(),
+            expected: 2,
+        });
+    }
+    subs
+}
+
+/// Apply one substitution to file contents (pure — no I/O, unit-tested).
+///
+/// Errors (instead of writing a partial result) when the occurrence count
+/// differs from `sub.expected` — the count assert is the whole point: a
+/// silently missed pin site broke a release before.
+fn apply(contents: &str, sub: &Substitution) -> Result<String, String> {
+    let found = contents.matches(&sub.needle).count();
+    if found == sub.expected {
+        Ok(contents.replace(&sub.needle, &sub.replacement))
+    } else {
+        Err(format!(
+            "{}: expected exactly {} occurrence(s) of `{}`, found {} — \
+             pin sites changed shape; update xtask/src/bump.rs to match",
+            sub.path, sub.expected, sub.needle, found
+        ))
+    }
+}
+
+/// Validate that `full` is a plausible patch release of `minor`
+/// (e.g. minor "8.4" accepts "8.4.23" but not "8.5.1" or "8.4.x").
+fn is_patch_of(minor: &str, full: &str) -> bool {
+    full.strip_prefix(minor)
+        .and_then(|rest| rest.strip_prefix('.'))
+        .is_some_and(|patch| !patch.is_empty() && patch.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Entry point for `cargo xtask bump-php-pin [<minor> <full>] [--check]`.
+pub fn bump_php_pin(args: &[String]) -> ExitCode {
+    let check = args.iter().any(|a| a == "--check");
+    let positional: Vec<&str> =
+        args.iter().filter(|a| !a.starts_with('-')).map(String::as_str).collect();
+
+    if check {
+        // Optional <minor> <full>: assert the table itself maps minor → full
+        // before verifying that all sites agree with the table.
+        if let [minor, full, ..] = positional[..] {
+            match PHP_SDK_VERSIONS.iter().find(|(m, _)| *m == minor) {
+                Some((_, pinned)) if *pinned == full => {}
+                Some((_, pinned)) => {
+                    eprintln!(
+                        "error: PHP_SDK_VERSIONS pins {minor} at {pinned}, not {full} — \
+                         run `cargo xtask bump-php-pin {minor} {full}` to move it"
+                    );
+                    return ExitCode::FAILURE;
+                }
+                None => {
+                    eprintln!("error: unknown PHP minor '{minor}' (not in PHP_SDK_VERSIONS)");
+                    return ExitCode::FAILURE;
+                }
+            }
+        }
+        return check_all();
+    }
+
+    let [minor, new_full] = positional[..] else {
+        eprintln!("usage: cargo xtask bump-php-pin <minor> <full>   (e.g. 8.4 8.4.24)");
+        eprintln!("       cargo xtask bump-php-pin [<minor> <full>] --check");
+        return ExitCode::FAILURE;
+    };
+    let Some((_, old_full)) = PHP_SDK_VERSIONS.iter().find(|(m, _)| *m == minor) else {
+        eprintln!("error: unknown PHP minor '{minor}'");
+        eprintln!(
+            "       supported minors: {:?}",
+            PHP_SDK_VERSIONS.iter().map(|(m, _)| *m).collect::<Vec<_>>()
+        );
+        return ExitCode::FAILURE;
+    };
+    if !is_patch_of(minor, new_full) {
+        eprintln!("error: '{new_full}' is not a patch release of minor {minor}");
+        return ExitCode::FAILURE;
+    }
+    if *old_full == new_full {
+        // Idempotent success so automation can re-run harmlessly.
+        eprintln!("==> {minor} is already pinned at {new_full} — nothing to do");
+        return ExitCode::SUCCESS;
+    }
+
+    // Two-phase: apply everything in memory first, write only if ALL sites
+    // matched. A partial bump (some files moved, some not) is exactly the
+    // broken state this command exists to prevent.
+    let root = workspace_root();
+    let mut staged: Vec<(std::path::PathBuf, &'static str, String)> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    for sub in substitutions(minor, old_full, new_full) {
+        let path = root.join(sub.path);
+        match fs::read_to_string(&path) {
+            Ok(contents) => match apply(&contents, &sub) {
+                Ok(updated) => staged.push((path, sub.path, updated)),
+                Err(e) => errors.push(e),
+            },
+            Err(e) => errors.push(format!("{}: cannot read: {e}", sub.path)),
+        }
+    }
+    if !errors.is_empty() {
+        eprintln!("error: refusing to bump — no files were modified:");
+        for e in &errors {
+            eprintln!("  - {e}");
+        }
+        return ExitCode::FAILURE;
+    }
+    for (path, rel, contents) in staged {
+        if let Err(e) = fs::write(&path, contents) {
+            eprintln!("error: failed to write {rel}: {e}");
+            return ExitCode::FAILURE;
+        }
+        eprintln!("==> updated {rel}");
+    }
+    eprintln!("==> PHP {minor} pin bumped: {old_full} → {new_full}");
+    eprintln!("    (PHP_SDK_VERSIONS in xtask/src/main.rs was rewritten — recompile picks it up)");
+    ExitCode::SUCCESS
+}
+
+/// `--check`: verify every pin site agrees with `PHP_SDK_VERSIONS` for every
+/// minor. Pure drift detector — reads files, writes nothing.
+fn check_all() -> ExitCode {
+    let root = workspace_root();
+    let mut errors: Vec<String> = Vec::new();
+    for (minor, full) in PHP_SDK_VERSIONS {
+        for sub in substitutions(minor, full, full) {
+            let path = root.join(sub.path);
+            match fs::read_to_string(&path) {
+                Ok(contents) => {
+                    if let Err(e) = apply(&contents, &sub) {
+                        errors.push(e);
+                    }
+                }
+                Err(e) => errors.push(format!("{}: cannot read: {e}", sub.path)),
+            }
+        }
+    }
+    if errors.is_empty() {
+        eprintln!("==> all PHP SDK pin sites agree with PHP_SDK_VERSIONS:");
+        for (minor, full) in PHP_SDK_VERSIONS {
+            eprintln!("    {minor} → {full}");
+        }
+        ExitCode::SUCCESS
+    } else {
+        eprintln!("error: PHP SDK pin drift detected:");
+        for e in &errors {
+            eprintln!("  - {e}");
+        }
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_replaces_exact_count() {
+        let sub = Substitution {
+            path: "test.yml",
+            needle: "\"1.2.3\"".into(),
+            replacement: "\"1.2.4\"".into(),
+            expected: 2,
+        };
+        let input = "a: \"1.2.3\"\nb: \"1.2.3\"\n";
+        assert_eq!(apply(input, &sub).unwrap(), "a: \"1.2.4\"\nb: \"1.2.4\"\n");
+    }
+
+    #[test]
+    fn apply_rejects_too_few_matches() {
+        let sub = Substitution {
+            path: "test.yml",
+            needle: "\"1.2.3\"".into(),
+            replacement: "\"1.2.4\"".into(),
+            expected: 4,
+        };
+        let err = apply("only one \"1.2.3\" here", &sub).unwrap_err();
+        assert!(err.contains("expected exactly 4"), "unexpected message: {err}");
+        assert!(err.contains("found 1"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn apply_rejects_too_many_matches() {
+        let sub = Substitution {
+            path: "Dockerfile",
+            needle: "1.2.3".into(),
+            replacement: "1.2.4".into(),
+            expected: 2,
+        };
+        let err = apply("1.2.3 1.2.3 1.2.3", &sub).unwrap_err();
+        assert!(err.contains("found 3"), "unexpected message: {err}");
+    }
+
+    #[test]
+    fn apply_check_mode_is_noop_on_match() {
+        // --check builds substitutions with old == new; contents must be
+        // returned unchanged when the count matches.
+        let sub = Substitution {
+            path: "test.md",
+            needle: "(pinned 8.4.23)".into(),
+            replacement: "(pinned 8.4.23)".into(),
+            expected: 1,
+        };
+        let input = "| PHP 8.4 | Active | **Supported — in CI (pinned 8.4.23)** |";
+        assert_eq!(apply(input, &sub).unwrap(), input);
+    }
+
+    #[test]
+    fn release_yml_fixture_hits_all_four_matrix_sites() {
+        let fixture = r#"
+          - { minor: "8.4", full: "8.4.23" }
+          - php_minor: "8.4"
+            php_full: "8.4.23"
+          - php_minor: "8.4"
+            php_full: "8.4.23"
+          - php_minor: "8.4"
+            php_full: "8.4.23"
+"#;
+        let subs = substitutions("8.4", "8.4.23", "8.4.30");
+        let yml = subs.iter().find(|s| s.path.ends_with("release.yml")).unwrap();
+        let out = apply(fixture, yml).unwrap();
+        assert_eq!(out.matches("\"8.4.30\"").count(), 4);
+        assert!(!out.contains("8.4.23"));
+    }
+
+    #[test]
+    fn main_rs_needle_is_the_table_pair() {
+        let subs = substitutions("8.3", "8.3.31", "8.3.32");
+        let rs = subs.iter().find(|s| s.path.ends_with("main.rs")).unwrap();
+        let fixture =
+            r#"const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.23")];"#;
+        let out = apply(fixture, rs).unwrap();
+        assert!(out.contains(r#"("8.3", "8.3.32")"#));
+        assert!(out.contains(r#"("8.4", "8.4.23")"#), "other minors must be untouched");
+    }
+
+    #[test]
+    fn dockerfile_site_only_for_default_minor() {
+        assert!(
+            substitutions("8.3", "8.3.31", "8.3.32").iter().all(|s| s.path != "docker/Dockerfile"),
+            "non-default minor must not touch the Dockerfile"
+        );
+        let default_subs = substitutions(DEFAULT_PHP_MINOR, "8.5.7", "8.5.8");
+        let docker = default_subs.iter().find(|s| s.path == "docker/Dockerfile").unwrap();
+        let fixture = "# releases (e.g., v8.5.7). The default mirrors\nARG PHP_SDK_VERSION=8.5.7\n";
+        let out = apply(fixture, docker).unwrap();
+        assert!(out.contains("ARG PHP_SDK_VERSION=8.5.8"));
+        assert!(out.contains("v8.5.8"));
+    }
+
+    #[test]
+    fn is_patch_of_validates_shape() {
+        assert!(is_patch_of("8.4", "8.4.23"));
+        assert!(is_patch_of("8.4", "8.4.0"));
+        assert!(!is_patch_of("8.4", "8.5.1"));
+        assert!(!is_patch_of("8.4", "8.4"));
+        assert!(!is_patch_of("8.4", "8.4."));
+        assert!(!is_patch_of("8.4", "8.4.x"));
+        assert!(!is_patch_of("8.4", "8.40.1"));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 use std::{env, fs};
 
+mod bump;
 mod doctor;
 
 /// Pinned full PHP versions per supported minor.
@@ -37,6 +38,7 @@ fn main() -> ExitCode {
         Some("e2e-install") => e2e_install(),
         Some("docs") => docs(&args[1..]),
         Some("doctor") => doctor::doctor(&args[1..]),
+        Some("bump-php-pin") => bump::bump_php_pin(&args[1..]),
         Some("help" | "--help" | "-h") | None => {
             print_usage();
             ExitCode::SUCCESS
@@ -63,6 +65,7 @@ Commands:
   e2e-install                       Download kind, tilt, kubectl to ./bin (no global install needed)
   docs <subcommand>                 Build/serve the Hugo + Hextra documentation site
   doctor [--target windows]         Check build prerequisites (toolchains, PHP SDK cache, optional tools)
+  bump-php-pin <minor> <full>       Update every PHP SDK pin site for <minor> (--check: verify pin drift)
 
 The PHP SDK is downloaded from github.com/ephpm/php-sdk releases. Pass a minor
 shorthand (e.g. \"8.5\") to use the pinned patch release, or a full version


### PR DESCRIPTION
## Summary

ephpm side of the php-sdk release automation (Phases 1+2). Companions: ephpm/php-sdk#37 (completeness gate + versions.json + test-tag isolation) and ephpm/php-sdk#38 (watch-php poller).

### Phase 1 — `cargo xtask bump-php-pin <minor> <full>`

Updates every PHP SDK pin site in one shot, all-or-nothing:

- `PHP_SDK_VERSIONS` table in `xtask/src/main.rs`
- the 4 matrix sites in `.github/workflows/release.yml` (linux / macos / windows / docker), found by pattern
- `docker/Dockerfile` `ARG PHP_SDK_VERSION` (+ its inline example) — only when bumping the default 8.5 minor
- the pin table in `site/content/developer/architecture-overview.md`

Every substitution **asserts its exact expected match count** and the command exits non-zero without writing anything if any count mismatches — a silently missed pin site broke a release before; the assert is the point. `--check` verifies all sites agree with `PHP_SDK_VERSIONS` (drift detector for CI later). Substitution logic is a pure function over file contents with unit tests; I/O stays thin.

The drift detector immediately caught real drift: `architecture-overview.md` listed the 8.4 CI pin as 8.4.22 while CI pins 8.4.23 — fixed here.

### Phase 2 — `.github/workflows/sdk-bump.yml`

`repository_dispatch` (type `sdk-release-complete`) + `workflow_dispatch(php_version)` + daily schedule reconciliation:

- Re-verifies SDK completeness per version via the GitHub API against the 4 required platforms (hardcoded list with a comment pointing at php-sdk's `versions.json`).
- If a pin is outdated and no open PR / marker branch `bump/php-X.Y.Z` exists: branch, `cargo xtask bump-php-pin`, commit, push, open PR titled `chore(php): bump PHP <minor> pin to <full>` with the SDK release link + asset inventory.
- **Auto-PR only — no auto-merge** (Phase 3 is out of scope).
- Nothing sends the `repository_dispatch` event yet: cross-repo dispatch from php-sdk's `watch-php.yml` needs a GitHub App token (Phase 3 plumbing). Until then the daily reconciliation poll is the discovery path.

## Validation

- `cargo test -p xtask` (7 new unit tests), `cargo clippy -p xtask --all-targets -- -D warnings`, `cargo +nightly fmt` — all clean
- `cargo xtask bump-php-pin 8.4 8.4.23 --check` and bare `--check` pass against current pins
- Dry bump `8.5 -> 8.5.99`: hit exactly 1 table entry, 4 release.yml matrix sites, 2 Dockerfile sites, 1 doc table row; reverted (no modified pins in this branch beyond the doc-drift fix)