### PR TITLE
feat(db): experimental [db.sqlite] engine = "turso" knob + Phase 1 gate evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "aegis"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07d39d15384924b35b70d7b8fa1f9a2934101dd3fa4722ede163cc4f9b7b960"
+dependencies = [
+ "cc",
+ "softaes",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +105,12 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
 name = "android_system_properties"
@@ -131,6 +172,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +209,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "aristo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdeefa800110050103e2459a2f8dbdbd560ad046e30f1f87e24ce19c2cb8bde"
+dependencies = [
+ "aristo-macros",
+]
+
+[[package]]
+name = "aristo-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64a66d21a80182b35b1741997a6d2456911f54b7eb1918aa4e2382fc205268d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -206,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +326,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -423,6 +506,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -436,8 +542,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
- "shlex",
+ "rustc-hash 2.1.1",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -515,6 +621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +692,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -592,14 +721,14 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -622,6 +751,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chacha20"
@@ -838,6 +973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1065,6 +1218,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "env_filter",
+ "log",
+]
 
 [[package]]
 name = "ephpm"
@@ -1227,7 +1400,7 @@ name = "ephpm-php"
 version = "0.1.0"
 dependencies = [
  "async-channel",
- "bindgen",
+ "bindgen 0.72.1",
  "bytes",
  "cc",
  "ephpm-kv",
@@ -1360,6 +1533,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -1600,6 +1784,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1865,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,7 +1923,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash",
 ]
@@ -1762,6 +1986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1907,56 +2140,107 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
+name = "icu_collator"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.1.1"
+name = "icu_locale"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.1.1"
+name = "icu_locale_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1968,18 +2252,20 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2048,6 +2334,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2374,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2152,6 +2467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2541,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,7 +2581,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "anyhow",
  "futures",
@@ -2244,6 +2591,7 @@ dependencies = [
  "litewire-postgres",
  "litewire-tds",
  "litewire-translate",
+ "litewire-turso",
  "tokio",
  "tracing",
 ]
@@ -2251,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2268,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2283,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2297,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "async-trait",
  "futures",
@@ -2312,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2325,13 +2673,25 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=fbbfe8d60ff4c74558fb4a8126ef21c343debada#fbbfe8d60ff4c74558fb4a8126ef21c343debada"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "sqlparser",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "litewire-turso"
+version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+dependencies = [
+ "async-trait",
+ "litewire-backend",
+ "tokio",
+ "tracing",
+ "turso",
 ]
 
 [[package]]
@@ -2348,6 +2708,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -2417,6 +2790,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2843,28 @@ dependencies = [
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2558,7 +2962,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "twox-hash",
+ "twox-hash 1.6.3",
  "url",
 ]
 
@@ -2570,7 +2974,7 @@ checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
 dependencies = [
  "base64 0.21.7",
  "bigdecimal",
- "bindgen",
+ "bindgen 0.72.1",
  "bitflags",
  "bitvec",
  "btoi",
@@ -2732,6 +3136,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pack1"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +3178,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pear"
@@ -2901,7 +3326,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2911,6 +3336,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
@@ -2959,6 +3396,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -3041,6 +3480,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,7 +3558,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3116,7 +3578,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -3244,12 +3706,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3452,6 +3932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,9 +3975,34 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -3500,6 +4015,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3507,7 +4035,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3658,6 +4186,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3819,6 +4353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,6 +4396,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_pcg",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,6 +4442,15 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "siphasher"
@@ -3920,6 +4495,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "softaes"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
 
 [[package]]
 name = "sqlparser"
@@ -3973,6 +4554,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subprocess"
@@ -4056,7 +4659,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4151,11 +4754,12 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -4474,6 +5078,197 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "turso"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac8d131650c1bf6a2721202208b3dfba218be25c975f48bebda766173fbdc3b"
+dependencies = [
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77f2106de5a3014261be18283999fde0d06c24ae5d4cb85a6eff1aaeaff453d"
+dependencies = [
+ "aegis",
+ "aes",
+ "aes-gcm",
+ "allocator-api2 0.4.0",
+ "antithesis_sdk",
+ "arc-swap",
+ "aristo",
+ "bigdecimal",
+ "bitflags",
+ "branches",
+ "bumpalo",
+ "bytemuck",
+ "cfg_aliases",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "either",
+ "fallible-iterator 0.3.0",
+ "fastbloom",
+ "hex",
+ "icu_collator",
+ "icu_locale",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "pastey",
+ "polling",
+ "rand 0.9.2",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.1",
+ "rustix 1.1.4",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simsimd",
+ "smallvec",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash 2.1.2",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d367d863b095a9893690fc6c52bbf27edf422c135a58ba5ed2b03dbec8faac"
+dependencies = [
+ "chrono",
+ "getrandom 0.4.2",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a817815d9ca218cb971ed2a0a41a89a5160966b5b4bd103c82792fd2f230f1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad90c0e6eea7ab131214804c70edad5372acecdcad8d4ccc75b0ded55b0df8f"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "miette",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea1abf8f42cf5c40f9777982c8dfda776242397250eb48f99d524c383b1b641a"
+dependencies = [
+ "bindgen 0.69.5",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_ext",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372ce1889d2729223886f805638a4357f389756d6b64e26487af5a78b3e92e2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4157da3af3730e3cf5109668dc29b58b673f99fbbac3db3a682a4b87d56b9c4a"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "genawaiter",
+ "http",
+ "libc",
+ "prost",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa3b4dee7f50c671ca757d1ac1ea7c99a7a9dec819a98bb1ad6a055e7d0234f"
+dependencies = [
+ "bindgen 0.69.5",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,6 +5277,15 @@ dependencies = [
  "cfg-if",
  "rand 0.8.5",
  "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -4533,6 +5337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,6 +5383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4590,7 +5406,9 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -4793,6 +5611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -5119,6 +5949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5171,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5182,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5241,21 +6077,23 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -5263,9 +6101,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,7 +2109,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2581,7 +2581,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "anyhow",
  "futures",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2645,7 +2645,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "async-trait",
  "futures",
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=1cff10501350af64ef38f7fb82066a2b1a886d34#1cff10501350af64ef38f7fb82066a2b1a886d34"
+source = "git+https://github.com/ephpm/litewire.git?rev=0ff501e5767c#0ff501e5767c4aaed3c6d324d2ffc057a58e99da"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3560,7 +3560,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3597,7 +3597,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,11 +82,9 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-#
-# NOTE(feat/db-engine-turso-experimental): temporarily pinned to the
-# litewire feat/turso-backend branch head. Re-pin to litewire main once
-# ephpm/litewire#<turso-backend PR> merges.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "1cff10501350af64ef38f7fb82066a2b1a886d34", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+# litewire main @ 0ff501e — includes the experimental turso backend
+# (ephpm/litewire#9).
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "0ff501e5767c", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 
 # Release-profile tuning for v0.4.2 perf release.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,11 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "fbbfe8d60ff4c74558fb4a8126ef21c343debada", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client"] }
+#
+# NOTE(feat/db-engine-turso-experimental): temporarily pinned to the
+# litewire feat/turso-backend branch head. Re-pin to litewire main once
+# ephpm/litewire#<turso-backend PR> merges.
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "1cff10501350af64ef38f7fb82066a2b1a886d34", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 
 # Release-profile tuning for v0.4.2 perf release.
 #

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -774,6 +774,19 @@ pub struct SqliteConfig {
     #[serde(default = "default_sqlite_path")]
     pub path: String,
 
+    /// Database engine: `"sqlite"` (default) or `"turso"` (**experimental**).
+    ///
+    /// - `"sqlite"` — the genuine `SQLite` C engine (rusqlite, bundled).
+    ///   This is the default and the only production-supported engine.
+    /// - `"turso"` — the Turso Database engine, a ground-up Rust rewrite
+    ///   of `SQLite` that is **Beta upstream**. Single-node mode only:
+    ///   combining `engine = "turso"` with clustered `SQLite` is rejected
+    ///   at startup. Startup logs a warning when this engine is selected.
+    ///
+    /// Any other value is rejected at startup.
+    #[serde(default = "default_sqlite_engine")]
+    pub engine: String,
+
     /// Wire protocol proxy settings.
     #[serde(default)]
     pub proxy: SqliteProxyConfig,
@@ -2348,6 +2361,10 @@ fn default_sqlite_path() -> String {
     "ephpm.db".to_string()
 }
 
+fn default_sqlite_engine() -> String {
+    "sqlite".to_string()
+}
+
 fn default_sqlite_mysql_listen() -> String {
     "127.0.0.1:3306".to_string()
 }
@@ -3551,6 +3568,26 @@ path = "app.db"
         assert_eq!(sqlite.sqld.grpc_listen, "0.0.0.0:5001");
         assert_eq!(sqlite.replication.role, "auto");
         assert!(sqlite.replication.primary_grpc_url.is_empty());
+        assert_eq!(sqlite.engine, "sqlite", "engine must default to the genuine SQLite C engine");
+    }
+
+    #[test]
+    fn test_sqlite_engine_turso_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[db.sqlite]
+path = "app.db"
+engine = "turso"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let sqlite = config.db.sqlite.expect("sqlite should be present");
+        assert_eq!(sqlite.engine, "turso");
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1166,15 +1166,39 @@ async fn start_db_proxies(
     // Embedded SQLite via litewire
     if let Some(sqlite_config) = &config.db.sqlite {
         let is_clustered = is_clustered_sqlite(sqlite_config, cluster.is_some());
+        validate_sqlite_engine(&sqlite_config.engine, is_clustered)?;
 
         if is_clustered {
             start_clustered_sqlite(sqlite_config, cluster, query_stats, &mut handles).await?;
         } else {
-            start_single_node_sqlite(sqlite_config, query_stats, &mut handles)?;
+            start_single_node_sqlite(sqlite_config, query_stats, &mut handles).await?;
         }
     }
 
     Ok(handles)
+}
+
+/// Validate the `[db.sqlite].engine` knob.
+///
+/// `"sqlite"` is always valid. `"turso"` (experimental) is valid only in
+/// single-node mode — clustered SQLite replicates through the sqld sidecar,
+/// which requires the genuine SQLite C engine (Turso-engine clustering is
+/// Phase 2 of the roadmap, not implemented). Anything else is a hard error
+/// so a typo can never silently fall back to a different engine.
+fn validate_sqlite_engine(engine: &str, is_clustered: bool) -> anyhow::Result<()> {
+    match engine {
+        "turso" if is_clustered => anyhow::bail!(
+            "[db.sqlite] engine = \"turso\" is not supported in clustered mode \
+             (sqld replication requires engine = \"sqlite\"; Turso-engine \
+             clustering is planned for Phase 2 of the Turso engine roadmap). \
+             Set engine = \"sqlite\" or disable clustering/replication."
+        ),
+        "sqlite" | "turso" => Ok(()),
+        other => anyhow::bail!(
+            "[db.sqlite] engine = \"{other}\" is not a valid engine; \
+             valid values: \"sqlite\" (default), \"turso\" (experimental)"
+        ),
+    }
 }
 
 /// Check if clustered SQLite mode should be used.
@@ -1183,19 +1207,59 @@ fn is_clustered_sqlite(sqlite_config: &ephpm_config::SqliteConfig, cluster_enabl
     role == "primary" || role == "replica" || (role == "auto" && cluster_enabled)
 }
 
-/// Start single-node SQLite (in-process rusqlite, no sqld).
-fn start_single_node_sqlite(
+/// Start single-node SQLite (in-process engine, no sqld).
+///
+/// The engine is selected by `[db.sqlite].engine` (validated upstream by
+/// `validate_sqlite_engine`): `"sqlite"` uses rusqlite (the genuine SQLite
+/// C engine, the default), `"turso"` uses the experimental Turso Database
+/// engine via `litewire-turso`.
+async fn start_single_node_sqlite(
     sqlite_config: &ephpm_config::SqliteConfig,
     query_stats: &ephpm_query_stats::QueryStats,
     handles: &mut Vec<tokio::task::JoinHandle<()>>,
 ) -> anyhow::Result<()> {
     let db_path = &sqlite_config.path;
-    let backend = litewire::backend::Rusqlite::open(db_path)
-        .with_context(|| format!("failed to open SQLite database: {db_path}"))?;
-    tracing::info!(path = %db_path, "opened embedded SQLite database (single-node)");
+    if sqlite_config.engine == "turso" {
+        tracing::warn!(
+            path = %db_path,
+            "[db.sqlite] engine = \"turso\" is EXPERIMENTAL: the Turso Database \
+             engine is Beta upstream and not yet a production SQLite replacement. \
+             Do not use it for data you cannot recreate. VACUUM and multi-process \
+             access are unsupported. See the Turso engine roadmap page."
+        );
+        let backend = litewire::Turso::open(db_path)
+            .await
+            .with_context(|| format!("failed to open database with Turso engine: {db_path}"))?;
+        tracing::info!(
+            path = %db_path,
+            engine = "turso",
+            "opened embedded database (single-node, experimental Turso engine)"
+        );
+        spawn_single_node_litewire(
+            sqlite_config,
+            tracked_backend::TrackedBackend::new(backend, query_stats.clone()),
+            handles,
+        );
+    } else {
+        let backend = litewire::backend::Rusqlite::open(db_path)
+            .with_context(|| format!("failed to open SQLite database: {db_path}"))?;
+        tracing::info!(path = %db_path, "opened embedded SQLite database (single-node)");
+        spawn_single_node_litewire(
+            sqlite_config,
+            tracked_backend::TrackedBackend::new(backend, query_stats.clone()),
+            handles,
+        );
+    }
+    Ok(())
+}
 
-    let tracked = tracked_backend::TrackedBackend::new(backend, query_stats.clone());
-    let mut builder = litewire::LiteWire::new(tracked);
+/// Wire the configured frontends onto a litewire builder and spawn it.
+fn spawn_single_node_litewire(
+    sqlite_config: &ephpm_config::SqliteConfig,
+    backend: impl litewire::backend::Backend,
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+) {
+    let mut builder = litewire::LiteWire::new(backend);
     builder = builder.mysql(&sqlite_config.proxy.mysql_listen);
     tracing::info!(
         listen = %sqlite_config.proxy.mysql_listen,
@@ -1223,7 +1287,6 @@ fn start_single_node_sqlite(
             Err(e) => tracing::error!("litewire error: {e:#}"),
         }
     }));
-    Ok(())
 }
 
 /// Start clustered SQLite (sqld sidecar + litewire with Hrana client backend).
@@ -1439,6 +1502,7 @@ mod lib_tests {
     fn make_sqlite_config(role: &str) -> ephpm_config::SqliteConfig {
         ephpm_config::SqliteConfig {
             path: "test.db".into(),
+            engine: "sqlite".into(),
             proxy: ephpm_config::SqliteProxyConfig::default(),
             sqld: ephpm_config::SqldConfig::default(),
             replication: ephpm_config::ReplicationConfig {
@@ -1472,6 +1536,31 @@ mod lib_tests {
         let config = make_sqlite_config("replica");
         assert!(is_clustered_sqlite(&config, false));
         assert!(is_clustered_sqlite(&config, true));
+    }
+
+    // ── [db.sqlite].engine validation ───────────────────────────────────────
+
+    #[test]
+    fn sqlite_engine_default_always_valid() {
+        assert!(validate_sqlite_engine("sqlite", false).is_ok());
+        assert!(validate_sqlite_engine("sqlite", true).is_ok());
+    }
+
+    #[test]
+    fn turso_engine_valid_single_node_only() {
+        assert!(validate_sqlite_engine("turso", false).is_ok());
+    }
+
+    #[test]
+    fn turso_engine_rejected_in_clustered_mode() {
+        let err = validate_sqlite_engine("turso", true).unwrap_err();
+        assert!(err.to_string().contains("not supported in clustered mode"), "{err}");
+    }
+
+    #[test]
+    fn unknown_engine_rejected() {
+        let err = validate_sqlite_engine("sqlite3", false).unwrap_err();
+        assert!(err.to_string().contains("not a valid engine"), "{err}");
     }
 
     // ── idle timeout ────────────────────────────────────────────────────────

--- a/docs/turso-phase1-results.md
+++ b/docs/turso-phase1-results.md
@@ -1,0 +1,155 @@
+# Turso Engine — Phase 1 Gate Evidence
+
+Evidence for decision gates 2–4 of the
+[Turso engine roadmap](../site/content/roadmap/turso-engine.md).
+Phase 1 delivers *data*, not adoption: the experimental backend exists to
+be measured. Everything below is reproducible with the harness shipped in
+litewire (`crates/litewire-turso/examples/phase1_gates.rs`).
+
+## Environment
+
+| | |
+|---|---|
+| Date | 2026-07-14 |
+| Host | AMD Ryzen 9 3950X (16C), Linux 6.18.33 x86_64 (WSL2), native ext4 |
+| Build | `cargo build --release`, litewire `feat/turso-backend` @ `1cff105` |
+| Turso engine | `turso` crate **=0.7.0** (first non-pre release of the 0.7 line; engine is Beta upstream) |
+| SQLite baseline | rusqlite 0.32 (`bundled` SQLite), litewire's production backend |
+| Seam measured | litewire `Backend`/`BackendConn` — the exact layer ePHPm's `TrackedBackend` wraps |
+
+Caveats, stated up front:
+
+- The rusqlite numbers **include** its `spawn_blocking` thread-pool hop and
+  per-session mutex. That is its real production execution path in
+  litewire/ePHPm, so it is the right comparison for us — but it is *not* a
+  raw engine-vs-engine measurement. The Turso backend is async-native and
+  pays no such hop.
+- Both engines run `synchronous=NORMAL` per session (see finding F1) and
+  WAL journaling. Same machine, same harness, same SQL, back-to-back runs.
+- WSL2, not bare metal; single run per cell, microbenchmark scale. Treat
+  the numbers as strong directional evidence, not lab-grade.
+- This is **not** Gate 5 (WordPress/Laravel e2e) and not an
+  endurance/soak test.
+
+## Gate 2 — latency matrix (single connection)
+
+1000-row table, warm cache, prepared statements with parameters.
+
+| op | engine | p50 µs | p95 µs | p99 µs | samples |
+|----|--------|--------|--------|--------|---------|
+| point SELECT | rusqlite | 81.2 | 144.8 | 183.8 | 5000 |
+| point SELECT | **turso** | **2.9** | **3.0** | **3.7** | 5000 |
+| INSERT (autocommit) | rusqlite | 138.5 | 228.6 | 308.1 | 2000 |
+| INSERT (autocommit) | **turso** | **17.3** | **31.3** | **79.6** | 2000 |
+| 10-query page | rusqlite | 840.1 | 1274.1 | 1521.5 | 500 |
+| 10-query page | **turso** | **30.2** | **44.0** | **76.4** | 500 |
+
+Turso is parity-or-better on every row including tails — at this seam. The
+~28× point-SELECT gap is dominated by the rusqlite backend's
+`spawn_blocking` round-trip (~80 µs on this host), which the async-native
+engine simply doesn't pay. The INSERT gap (~8×) survives even though both
+engines fsync at `NORMAL`.
+
+## Gate 2 — concurrent writers (N=8 sessions, MVCC vs WAL+busy_timeout)
+
+8 independent `BackendConn`s (one per simulated wire connection), each
+inserting 250 rows (200-byte payload), autocommit. busy_timeout=5000 ms on
+both engines.
+
+| engine | conns | inserts | wall s | inserts/s | busy errors | other errors |
+|--------|-------|---------|--------|-----------|-------------|--------------|
+| rusqlite | 8 | 2000 | 0.55 | 3609 | 0 | 0 |
+| **turso** | 8 | 2000 | **0.14** | **14451** | 0 | 0 |
+
+The roadmap's headline claim ("MVCC should beat WAL + busy_timeout") holds
+at this seam: ~4× throughput, zero busy errors on either engine (the
+busy-handler absorbed all contention in both cases; the difference is pure
+throughput, not error behavior).
+
+## Finding F1 — the engine's synchronous default is FULL (and it matters)
+
+First run of this matrix used the engine's defaults and produced *bad*
+Turso write numbers:
+
+| op (turso, `synchronous=FULL` — engine default) | p50 µs | p95 µs | p99 µs |
+|---|---|---|---|
+| INSERT (autocommit) | 1815.7 | 5310.2 | 8407.3 |
+| concurrent writers | 351 inserts/s (41× slower than the final number) | | |
+
+Root cause (verified in `turso_core` 0.7.0 source): the engine's default
+sync mode is `Full`, while litewire's rusqlite backend has always set
+`synchronous=NORMAL` per session. The Turso backend now sets
+`PRAGMA synchronous = NORMAL` per session for parity, which is what the
+final tables above measure. Anyone benchmarking Turso against a tuned
+SQLite should check this first.
+
+## Gate 3 — file-format round-trip
+
+Harness: 500 rows of adversarial data (i64::MIN/MAX, negative floats near
+±1e308, NULLs in every column, UTF-8 text with combining/CJK chars, blobs,
+two indexes incl. UNIQUE), WAL mode, row-value checksums, both directions.
+
+| step | rusqlite→turso→rusqlite | turso→rusqlite→turso |
+|---|---|---|
+| reader checksum vs writer | **MATCH** | **MATCH** |
+| reader inserts 100 rows + UPDATEs | ok | ok |
+| writer reopens: checksum + 600 rows | **MATCH** | **MATCH** |
+| `PRAGMA integrity_check` (rusqlite) | ok | ok |
+| `PRAGMA integrity_check` (turso) | ok | ok |
+
+Both directions clean, including the case where the genuine SQLite C
+engine must recover/read a database whose latest state lives in a
+Turso-written WAL. Caveat: 600-row databases, one WAL cycle — this
+verifies format compatibility, not migration of a multi-GB WordPress DB.
+
+## Gate 4 — crash-recovery smoke (kill -9, 10 iterations)
+
+A child process runs a tight Turso-engine insert loop; the parent SIGKILLs
+it mid-loop at a varied interval (300–1200 ms), reopens the database with
+the Turso engine (count + write probe), and cross-checks the file with the
+SQLite C engine's `PRAGMA integrity_check`.
+
+Result: **10/10 clean.** Row counts monotonically increasing
+(15,552 → 214,223 across iterations), Turso reopen+write ok every time,
+SQLite `integrity_check` = `ok` every time. Caveat: this is a smoke, not
+the "soak" gate 4 ultimately requires; it exercises WAL-recovery after
+process death, not power loss or torn writes.
+
+## Unsupported / missing, as hit in practice
+
+- **`VACUUM`** — incomplete upstream, gated behind an experimental flag we
+  do not enable; the backend rejects it with a clear error.
+- **Multi-process access** — not supported by the engine (experimental
+  `multiprocess_wal` flag exists upstream, not enabled). One process owns
+  the file. Fine for ePHPm's embedded model; fatal for sidecar-style tools
+  (e.g. running `sqlite3` against a *live* database).
+- **`ATTACH`/`DETACH`** — behind an experimental upstream flag, not enabled.
+- **Non-UTF-8 `TEXT`** — the Rust API surfaces TEXT as `String`; the
+  rusqlite backend round-trips invalid-UTF-8 text as blobs. Not observed in
+  testing, noted as a semantic difference.
+- `PRAGMA integrity_check` **is** supported by the engine (used above) —
+  previously unverified.
+
+## Gate status after Phase 1
+
+| Gate | Status |
+|---|---|
+| 1. Upstream GA | **Not met.** 0.7.0 is a non-pre release but upstream still positions the engine as Beta; multiprocess + vacuum remain experimental/incomplete. |
+| 2. Benchmarks parity-or-better incl. tails | **Met at the litewire seam** for this micro-matrix (with the caveats above). MySQL-baseline and PHP end-to-end comparisons not yet run. |
+| 3. File-format round-trip | **Verified** at small scale, both directions, checksummed. |
+| 4. Crash-recovery | **Smoke clean (10/10).** Full soak still required. |
+| 5. WordPress + Laravel e2e | **Not attempted** (out of Phase 1 scope). |
+
+Default engine remains `"sqlite"` — nothing here changes that.
+
+## Reproducing
+
+```bash
+# in the litewire repo, branch feat/turso-backend
+cargo build --release -p litewire-turso --example phase1_gates
+B=target/release/examples/phase1_gates
+$B bench   /tmp/gates        # gate 2 latency matrix
+$B writers /tmp/gates 8      # gate 2 concurrent writers
+$B gate3   /tmp/gates        # gate 3 round-trip
+$B crash   /tmp/gates 10     # gate 4 crash smoke
+```

--- a/docs/turso-phase2-cdc-design.md
+++ b/docs/turso-phase2-cdc-design.md
@@ -1,0 +1,98 @@
+# Turso Engine Phase 2 — CDC-Native Replication (design notes)
+
+Design notes only — no code. Companion to
+[turso-phase1-results.md](turso-phase1-results.md) and the
+[roadmap page](../site/content/roadmap/turso-engine.md). Phase 2 is gated
+on upstream GA (roadmap gate 1, currently **not met**).
+
+## The verified CDC API (turso 0.7.0 source, not docs)
+
+- Enablement is **per-connection**:
+  `PRAGMA capture_data_changes_conn('<mode>[,<table>]')`. As of 0.7.0 this
+  is the *stable* pragma name; `unstable_capture_data_changes_conn` remains
+  as a deprecated alias. Modes: `off | id | before | after | full`
+  (`full` = before-image + after-image + column-level updates).
+- Captured changes are written **transactionally into a regular table**
+  (default `turso_cdc`), so the log commits/rolls back atomically with the
+  data it describes, and is readable with plain SQL. Schema is versioned
+  via a `turso_cdc_version` table; current version **v2** (9 columns:
+  `change_id, change_time, change_type, table_name, id, before, after,
+  updates, change_txn_id`), where v2 adds `change_txn_id` and explicit
+  COMMIT records (`change_type = 2`) — i.e. transaction boundaries are in
+  the stream.
+- Stability: the API surface is young (v1→v2 schema bump already happened;
+  the pragma was renamed within the 0.7 line). Pin exactly and
+  version-detect via `turso_cdc_version` before tailing.
+- Upstream's own sync engine (`turso_sync_engine`, same repo, MIT) is
+  built on these primitives plus the open sync wire protocol
+  (`/v2/pipeline`, `/pull-updates`) — a reference consumer we can crib
+  from or adopt outright.
+
+## Proposed shape
+
+```
+            primary node                              replica nodes
+┌─────────────────────────────────┐        ┌───────────────────────────────┐
+│ PHP → wire → litewire → Turso   │        │ litewire → Turso engine (RO*) │
+│  every write session:           │        │                               │
+│  PRAGMA capture_data_changes_   │        │  apply loop: per-txn batches  │
+│   conn('full') (Backend::connect)│        │  in order, one transaction    │
+│  CdcTailer (litewire-turso):    │  ePHPm │  per change_txn_id; advance   │
+│  SELECT * FROM turso_cdc        │ cluster│  watermark table atomically   │
+│   WHERE change_id > ?cursor ────┼──data──┼─▶ with the applied rows       │
+│  batch on COMMIT records        │  plane │                               │
+└─────────────────────────────────┘        └───────────────────────────────┘
+```
+
+- **litewire side (new, small):** a `CdcTailer` in `litewire-turso` that
+  (a) ensures every write session enables CDC in `Backend::connect`, and
+  (b) polls `turso_cdc` past a cursor, emitting complete transactions
+  (delimited by the v2 COMMIT records). This replaces nothing in the
+  `Backend` trait — it is a sidecar API on the `Turso` factory.
+- **ePHPm side (reuse):** the cluster layer already owns membership
+  (chitchat gossip), primary election (`sqlite_election.rs` — unchanged),
+  and a replication data plane (`KvReplicator`'s transport pattern). Phase
+  2 adds a DB replication channel alongside KV replication: primary
+  publishes CDC transaction batches; replicas apply them through their
+  local Turso engine and record the applied `change_id` watermark in the
+  same transaction (exactly-once apply by construction).
+- **What dies:** the sqld sidecar — child-process management, binary
+  embedding (`include_bytes!` of a 100MB+ binary), health polling, and the
+  Hrana client hop on replicas. Failover becomes "stop applying, start
+  capturing" with no process restarts.
+- **Alternative transport:** self-host Turso's open sync protocol using
+  `turso_sync_engine` instead of our own batching. Decide on measured
+  simplicity (roadmap language): our transport is fewer new dependencies;
+  theirs solves bootstrap + partial sync already.
+
+## Open questions (must be answered before any Phase 2 code)
+
+1. **DDL:** does CDC capture schema changes (`CREATE TABLE`/`ALTER`), or
+   only row changes? WordPress installs/plugins run DDL at runtime. If
+   uncaptured, replicas need a separate schema-sync path (the sync engine's
+   answer here is the thing to study first).
+2. **API churn:** the pragma was renamed and the schema bumped v1→v2
+   within one minor line. What is our compatibility policy when v3 lands —
+   dual-read, or hard-pin per litewire release?
+3. **Replica writes:** how do we enforce read-only replicas at the
+   litewire seam (reject non-SELECT on replicas vs forward-to-primary),
+   and what do PHP apps see during failover?
+4. **Bootstrap:** new replica joins — full-file snapshot (checkpoint +
+   copy + cursor handoff) vs replaying the sync protocol from genesis.
+   CDC alone can't bootstrap unless `turso_cdc` is retained forever.
+5. **Retention/pruning:** `turso_cdc` is a regular table and grows
+   unboundedly; pruning must wait for the slowest replica's watermark
+   (gossip the min watermark, delete below it) — and what happens when a
+   replica is offline for a week?
+6. **Ordering under MVCC:** with concurrent writers, is `change_id` order
+   guaranteed to be a valid serialization to replay? (COMMIT records
+   suggest yes per-transaction; cross-transaction ordering needs a
+   definitive upstream answer.)
+7. **Failover watermark:** on primary death, the new primary's `turso_cdc`
+   starts fresh — replicas promoted from different watermarks must agree
+   on a common prefix. Likely needs the election to include "highest
+   applied change_id wins" (same shape as Raft's log-completeness vote).
+8. **Cost:** `full` mode roughly doubles write volume (data + before/after
+   images). Phase 1's write-path advantage (4× concurrent throughput)
+   needs re-measuring with CDC on before claiming the sidecar-free story
+   is also the faster one.

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -220,6 +220,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `path` | string | `"ephpm.db"` | SQLite database file path. |
+| `engine` | string | `"sqlite"` | **Experimental knob.** `"sqlite"` = the genuine SQLite C engine (default, production-supported). `"turso"` = the [Turso Database](https://github.com/tursodatabase/turso) engine (Rust rewrite of SQLite, **Beta upstream — experimental, not for production data**; single-node only, rejected at startup in clustered mode; `VACUUM` and multi-process access unsupported). See the [Turso engine roadmap](/roadmap/turso-engine/). |
 
 #### `[db.sqlite.proxy]`
 

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -53,13 +53,25 @@ black-box sidecar ever was.
   (`/v2/pipeline`, `/pull-updates`) with a reference local server —
   self-hosting is a supported premise, not a loophole.
 - Near-complete SQLite surface compatibility; **missing: multiprocess
-  support, vacuum**. Beta, `v0.7.0-pre` release line.
+  support, vacuum**. Beta, `v0.7.0-pre` release line. (Update
+  2026-07-14: `v0.7.0` non-pre is out on crates.io; upstream positioning
+  is still Beta and multiprocess/vacuum are still experimental flags —
+  gate 1 remains open.)
 - SQLite file-format compatibility is claimed; must be verified by us
   (see gates) before any migration story is written.
 
 ## Plan
 
 ### Phase 1 — experimental backend (can start before GA)
+
+> **Status: SHIPPED (experimental), 2026-07.** litewire has a
+> `litewire-turso` backend (facade feature `turso`, off by default;
+> engine pinned `turso =0.7.0`) and ePHPm exposes it as
+> `[db.sqlite] engine = "turso"` — single-node only, rejected in
+> clustered mode, warns at startup. Gate 2–4 evidence lives in
+> `docs/turso-phase1-results.md`; Phase 2 design notes in
+> `docs/turso-phase2-cdc-design.md`. Gates 1 and 5 remain open and the
+> default engine is unchanged.
 
 A `turso-backend` crate in litewire beside `rusqlite-backend`, behind a
 feature flag and an explicit opt-in config knob marked **experimental**


### PR DESCRIPTION
## Summary

Phase 1 of the [Turso engine roadmap](site/content/roadmap/turso-engine.md): an explicit, opt-in, **experimental** engine knob plus the gate 2-4 evidence the roadmap demands. Additive knob, v0.4.x-compatible; **no default changes, no sqld/cluster code touched.**

- `[db.sqlite] engine = "sqlite" (default) | "turso" (experimental)` — read and enforced in this PR: validated in `start_db_proxies()`, the single-node branch constructs litewire's Turso backend when selected, startup `tracing::warn!`s that the engine is experimental, clustered + `engine = "turso"` is a hard startup error, and unknown values are startup errors (no silent fallback).
- `docs/turso-phase1-results.md` — honest gate evidence (Linux, litewire `Backend` seam, turso 0.7.0 vs rusqlite): point SELECT p50 2.9 us vs 81.2 us; INSERT p50 17.3 us vs 138.5 us; 8 concurrent writers 14,451/s vs 3,609/s (0 errors both); file-format round-trip checksum-MATCH both directions; kill -9 crash smoke 10/10 clean. Includes the `synchronous=FULL` engine-default finding (unfixed it makes Turso writes look 40x worse). Gates 1 (upstream GA) and 5 (WP/Laravel e2e) remain open.
- `docs/turso-phase2-cdc-design.md` — CDC-native replication design notes (~1 page, no code). CDC pragma/table/schema verified in turso 0.7.0 source, not marketing. Eight open questions listed.
- `reference/config.md` row marked **Experimental** with roadmap link; roadmap page status updated.

## Blocked on

**ephpm/litewire#9** (`feat/turso-backend`). `Cargo.toml` temporarily pins litewire to that branch head (`1cff105`). **After litewire#9 merges: re-pin `litewire` to the litewire main merge commit and `cargo update -p litewire` before merging this PR.**

## Test plan

- [x] `cargo test -p ephpm-config -- --test-threads=1` (79 passed; default + turso parse tests)
- [x] `cargo test -p ephpm-server` (185 passed; engine validation unit tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` and `cargo +nightly fmt --all -- --check` green
- [x] Boot smoke (stub build): `engine = "turso"` starts, warns, opens Turso engine, MySQL frontend listens; clustered + turso exits with the clear startup error; default config unchanged
- [ ] Re-pin litewire to main after litewire#9 merges, re-run CI
