### PR TITLE
feat(kv): ephpm_kv_wait() — blocking versioned key watch (push, not poll)

### DIFF
--- a/crates/ephpm-e2e/tests/kv.rs
+++ b/crates/ephpm-e2e/tests/kv.rs
@@ -268,3 +268,117 @@ async fn kv_overwrite_returns_latest() {
         "get after overwrite must return the latest value"
     );
 }
+
+// ── ephpm_kv_wait (blocking versioned wait) ─────────────────────────────
+//
+// The fixture's `wait` op passes `val` as last_version and `ttl` as the
+// timeout in MILLISECONDS, printing "timeout" or "<version>:<value>".
+
+#[tokio::test]
+async fn kv_wait_zero_returns_snapshot_immediately() {
+    let base = required_env("EPHPM_URL");
+
+    let (s, _) = kv(&base, "op=set&key=wait_snap&val=hello&ttl=0").await;
+    assert_eq!(s, 200);
+
+    // last_version=0 registers the watch and snapshots without blocking,
+    // even with a long timeout.
+    let start = std::time::Instant::now();
+    let (s, body) = kv(&base, "op=wait&key=wait_snap&val=0&ttl=10000").await;
+    assert_eq!(s, 200);
+    let (ver, value) = body
+        .split_once(':')
+        .unwrap_or_else(|| panic!("expected '<version>:<value>', got {body:?}"));
+    assert!(ver.parse::<u64>().unwrap() >= 1, "version must be >= 1, got {ver}");
+    assert_eq!(value, "hello");
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "snapshot wait must not block for the full timeout"
+    );
+}
+
+#[tokio::test]
+async fn kv_wait_times_out_without_writes() {
+    let base = required_env("EPHPM_URL");
+
+    // Learn the current version, then wait past it with a short timeout.
+    let (_, snap) = kv(&base, "op=wait&key=wait_to&val=0&ttl=1000").await;
+    let ver = snap.split(':').next().expect("snapshot must include a version");
+
+    let start = std::time::Instant::now();
+    let (s, body) = kv(&base, &format!("op=wait&key=wait_to&val={ver}&ttl=300")).await;
+    assert_eq!(s, 200);
+    assert_eq!(body, "timeout", "no writes → wait must time out");
+    assert!(
+        start.elapsed() >= Duration::from_millis(300),
+        "timeout must not fire early"
+    );
+}
+
+#[tokio::test]
+async fn kv_wait_wakes_on_concurrent_set() {
+    let base = required_env("EPHPM_URL");
+
+    let (s, _) = kv(&base, "op=set&key=wait_wake&val=old&ttl=0").await;
+    assert_eq!(s, 200);
+    let (_, snap) = kv(&base, "op=wait&key=wait_wake&val=0&ttl=1000").await;
+    let ver: u64 = snap
+        .split(':')
+        .next()
+        .and_then(|v| v.parse().ok())
+        .expect("snapshot must include a version");
+
+    // Start a long wait on one connection, then write from another.
+    let waiter = {
+        let base = base.clone();
+        tokio::spawn(async move {
+            kv(&base, &format!("op=wait&key=wait_wake&val={ver}&ttl=15000")).await
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let write_at = std::time::Instant::now();
+    let (s, _) = kv(&base, "op=set&key=wait_wake&val=new&ttl=0").await;
+    assert_eq!(s, 200);
+
+    let (s, body) = waiter.await.expect("waiter task must not panic");
+    let wake_latency = write_at.elapsed();
+    assert_eq!(s, 200);
+    let (new_ver, value) = body
+        .split_once(':')
+        .unwrap_or_else(|| panic!("expected '<version>:<value>', got {body:?}"));
+    assert!(new_ver.parse::<u64>().unwrap() > ver, "version must advance past {ver}");
+    assert_eq!(value, "new", "waiter must observe the written value");
+    // The whole point vs. polling: wakeup is push-driven, far below the
+    // 15 s timeout (generous bound for CI jitter).
+    assert!(
+        wake_latency < Duration::from_secs(5),
+        "wakeup took {wake_latency:?} — should be push-driven, not timeout-driven"
+    );
+}
+
+#[tokio::test]
+async fn kv_wait_observes_delete_as_null() {
+    let base = required_env("EPHPM_URL");
+
+    let (s, _) = kv(&base, "op=set&key=wait_del&val=doomed&ttl=0").await;
+    assert_eq!(s, 200);
+    let (_, snap) = kv(&base, "op=wait&key=wait_del&val=0&ttl=1000").await;
+    let ver = snap.split(':').next().expect("snapshot must include a version").to_owned();
+
+    let waiter = {
+        let base = base.clone();
+        tokio::spawn(async move {
+            kv(&base, &format!("op=wait&key=wait_del&val={ver}&ttl=15000")).await
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let (s, _) = kv(&base, "op=del&key=wait_del").await;
+    assert_eq!(s, 200);
+
+    let (s, body) = waiter.await.expect("waiter task must not panic");
+    assert_eq!(s, 200);
+    assert!(
+        body.ends_with(":null"),
+        "deleted key must surface as '<version>:null', got {body:?}"
+    );
+}

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -5,6 +5,7 @@
 //! approximate memory tracking.
 
 mod entry;
+mod watch;
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -16,6 +17,7 @@ use bytes::Bytes;
 use dashmap::{DashMap, DashSet};
 pub use entry::Entry;
 use tracing::{debug, trace};
+use watch::WatchSlot;
 
 /// Eviction policy when the memory limit is reached.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -204,6 +206,16 @@ pub struct Store {
     /// shard *read* lock instead of taking the write lock via
     /// `get_mut`. 584 years of headroom in `u64::MAX` nanos.
     anchor: Instant,
+    /// Per-key watch slots backing [`Store::wait_for_change`]
+    /// (`ephpm_kv_wait()` from PHP). Created lazily on first wait, never
+    /// reclaimed — see the [`watch`] module docs for the design and the
+    /// zero-cost-when-unused invariant.
+    watchers: DashMap<String, Arc<WatchSlot>>,
+    /// Number of live entries in `watchers`. Write paths check this with
+    /// a single atomic load before doing any watch-related work, so
+    /// deployments that never call `wait_for_change` pay exactly one
+    /// uncontended `Acquire` load per write — nothing else.
+    watch_slots: AtomicUsize,
 }
 
 impl std::fmt::Debug for Store {
@@ -216,6 +228,8 @@ impl std::fmt::Debug for Store {
             .field("config", &self.config)
             .field("replicator_installed", &self.replicator.read().is_ok_and(|g| g.is_some()))
             .field("anchor", &self.anchor)
+            .field("watchers_len", &self.watchers.len())
+            .field("watch_slots", &self.watch_slots.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -232,6 +246,8 @@ impl Store {
             config,
             replicator: std::sync::RwLock::new(None),
             anchor: Instant::now(),
+            watchers: DashMap::new(),
+            watch_slots: AtomicUsize::new(0),
         })
     }
 
@@ -386,6 +402,97 @@ impl Store {
         result
     }
 
+    // ── Key watches (blocking wait) ──────────────────────────────
+
+    /// Block until `key`'s watch version exceeds `last_version`, or
+    /// `timeout` elapses. This is the engine behind PHP's
+    /// `ephpm_kv_wait()`.
+    ///
+    /// Returns `Some((new_version, value))` when the version advanced
+    /// (`value` is `None` if the key is absent/deleted at wakeup time),
+    /// or `None` on timeout.
+    ///
+    /// The first call for a key creates its watch slot at version `1`,
+    /// so `wait_for_change(key, 0, _)` returns immediately with the
+    /// current value — the race-free "register + snapshot" step. See the
+    /// [`watch`] module docs for the full protocol and versioning rules.
+    ///
+    /// # Blocking
+    ///
+    /// Parks the calling OS thread. Callers are PHP worker threads or
+    /// the tokio `spawn_blocking` pool — never call this from an async
+    /// task.
+    ///
+    /// # Clustering
+    ///
+    /// Wakeups fire when the **local** copy of the key is written
+    /// (`set_local` / `remove_local` / in-place mutations), so on a
+    /// clustered store a waiter observes changes as they land on its own
+    /// node.
+    #[must_use]
+    pub fn wait_for_change(
+        &self,
+        key: &str,
+        last_version: u64,
+        timeout: Duration,
+    ) -> Option<(u64, Option<Bytes>)> {
+        let slot = self.watch_slot(key);
+        let version = slot.wait_past(last_version, timeout)?;
+        Some((version, self.get(key)))
+    }
+
+    /// Number of live watch slots (keys that have ever been waited on).
+    #[must_use]
+    pub fn watch_slot_count(&self) -> usize {
+        self.watch_slots.load(Ordering::Acquire)
+    }
+
+    /// Get or lazily create the watch slot for `key`.
+    fn watch_slot(&self, key: &str) -> Arc<WatchSlot> {
+        if let Some(slot) = self.watchers.get(key) {
+            return Arc::clone(&slot);
+        }
+        match self.watchers.entry(key.to_string()) {
+            dashmap::Entry::Occupied(occ) => Arc::clone(occ.get()),
+            dashmap::Entry::Vacant(vac) => {
+                let slot = Arc::new(WatchSlot::new());
+                // Publish the count BEFORE the slot becomes visible in the
+                // map (we hold the shard write lock here): a writer that
+                // sees the slot must also see a non-zero count, so it never
+                // skips a notify for a visible slot. The reverse (count
+                // visible, slot not yet) only makes a writer do one wasted
+                // lookup.
+                self.watch_slots.fetch_add(1, Ordering::Release);
+                vac.insert(Arc::clone(&slot));
+                slot
+            }
+        }
+    }
+
+    /// Look up the watch slot for `key`, gated by the fast-path count
+    /// check. Returns `None` — at the cost of a single `Acquire` load —
+    /// when no key has ever been waited on.
+    ///
+    /// Write paths that consume the key by value call this *before* the
+    /// map insert (borrowing the key) and bump the returned slot *after*
+    /// the write is visible, so a woken waiter always reads the new value.
+    #[inline]
+    fn watch_slot_if_any(&self, key: &str) -> Option<Arc<WatchSlot>> {
+        if self.watch_slots.load(Ordering::Acquire) == 0 {
+            return None;
+        }
+        self.watchers.get(key).map(|slot| Arc::clone(&slot))
+    }
+
+    /// Bump the watch version for `key` if it is being watched. Called by
+    /// write paths that still hold the key by reference after the write.
+    #[inline]
+    fn notify_write(&self, key: &str) {
+        if let Some(slot) = self.watch_slot_if_any(key) {
+            slot.bump();
+        }
+    }
+
     // ── Write operations ─────────────────────────────────────────
 
     /// Set a key to a value with an optional TTL.
@@ -456,7 +563,14 @@ impl Store {
         } else {
             self.ttl_keys.remove(&key);
         }
+        // Snapshot the watch slot BEFORE `key` moves into the insert; bump
+        // AFTER the insert so a woken waiter always reads the new value.
+        // One Acquire load when nothing is watched (the common case).
+        let watch = self.watch_slot_if_any(&key);
         self.data.insert(key, entry);
+        if let Some(slot) = watch {
+            slot.bump();
+        }
         true
     }
 
@@ -546,10 +660,12 @@ impl Store {
         };
         if inserted {
             if has_ttl {
-                self.ttl_keys.insert(key_ref);
+                self.ttl_keys.insert(key_ref.clone());
             } else {
                 self.ttl_keys.remove(&key_ref);
             }
+            // Wake any waiters — the insert is visible at this point.
+            self.notify_write(&key_ref);
         }
         inserted
     }
@@ -581,7 +697,14 @@ impl Store {
             false
         };
         let hash_removed = self.hash_remove(key);
-        string_removed || hash_removed
+        let removed = string_removed || hash_removed;
+        if removed {
+            // A delete is a state change: wake waiters so they observe the
+            // key as absent (covers explicit del, lazy-expiry reaps, and
+            // LRU eviction — all funnel through remove_local).
+            self.notify_write(key);
+        }
+        removed
     }
 
     /// Set an expiry on an existing key. Returns `false` if the key doesn't exist.
@@ -723,6 +846,9 @@ impl Store {
                 } else {
                     self.mem_sub(old_mem - new_mem);
                 }
+                // In-place update — wake waiters (the create path below
+                // notifies via set → set_local).
+                self.notify_write(key);
                 return Ok(new_val);
             }
         }
@@ -784,6 +910,9 @@ impl Store {
                 } else {
                     self.mem_sub(old_mem - new_mem);
                 }
+                // In-place append — wake waiters (the create path below
+                // notifies via set → set_local).
+                self.notify_write(key);
                 return final_len;
             }
         }
@@ -970,6 +1099,15 @@ impl Store {
         self.hashes.clear();
         self.ttl_keys.clear();
         self.mem_used.store(0, Ordering::Relaxed);
+        // A flush changes every key — wake all waiters so they observe the
+        // now-empty store. Watch slots themselves survive the flush (their
+        // versions must stay monotonic for the process lifetime; see the
+        // `watch` module docs).
+        if self.watch_slots.load(Ordering::Acquire) != 0 {
+            for slot in &self.watchers {
+                slot.value().bump();
+            }
+        }
     }
 
     // ── Background maintenance ───────────────────────────────────
@@ -2489,5 +2627,183 @@ mod tests {
             "unhooked set must write locally"
         );
         assert_eq!(rep.sets.lock().unwrap().len(), 1, "replicator must not see the direct write");
+    }
+
+    // ── Key watches (wait_for_change) ───────────────────────────────
+
+    #[test]
+    fn writes_never_create_watch_slots() {
+        // The zero-cost invariant: a store that is never waited on must
+        // not grow any watch state, no matter how much it is written.
+        let s = test_store();
+        for i in 0..100 {
+            s.set(format!("k{i}"), b"v".to_vec(), None);
+            let _ = s.incr_by("counter", 1);
+            s.remove(&format!("k{i}"));
+        }
+        assert_eq!(s.watch_slot_count(), 0, "writes must not allocate watch slots");
+        assert!(s.watchers.is_empty());
+    }
+
+    #[test]
+    fn wait_zero_returns_snapshot_immediately() {
+        let s = test_store();
+        s.set("k".into(), b"initial".to_vec(), None);
+        let start = Instant::now();
+        // last_version = 0 → fresh slot at version 1 already exceeds it:
+        // register + snapshot without blocking.
+        let (ver, val) = s.wait_for_change("k", 0, Duration::from_secs(30)).unwrap();
+        assert!(start.elapsed() < Duration::from_secs(1), "must not block");
+        assert_eq!(ver, 1);
+        assert_eq!(val.as_deref(), Some(&b"initial"[..]));
+        assert_eq!(s.watch_slot_count(), 1);
+    }
+
+    #[test]
+    fn wait_snapshot_on_missing_key_has_no_value() {
+        let s = test_store();
+        let (ver, val) = s.wait_for_change("ghost", 0, Duration::from_secs(1)).unwrap();
+        assert_eq!(ver, 1);
+        assert_eq!(val, None);
+    }
+
+    #[test]
+    fn wait_times_out_without_writes() {
+        let s = test_store();
+        let (ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+        let start = Instant::now();
+        assert!(s.wait_for_change("k", ver, Duration::from_millis(60)).is_none());
+        assert!(start.elapsed() >= Duration::from_millis(60));
+    }
+
+    #[test]
+    fn set_wakes_waiter_with_new_value() {
+        let s = test_store();
+        s.set("k".into(), b"old".to_vec(), None);
+        let (ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+
+        let waiter = {
+            let s = Arc::clone(&s);
+            std::thread::spawn(move || s.wait_for_change("k", ver, Duration::from_secs(10)))
+        };
+        std::thread::sleep(Duration::from_millis(50));
+        s.set("k".into(), b"new".to_vec(), None);
+
+        let (new_ver, val) = waiter.join().unwrap().expect("waiter must wake on set");
+        assert!(new_ver > ver);
+        assert_eq!(val.as_deref(), Some(&b"new"[..]));
+    }
+
+    #[test]
+    fn del_wakes_waiter_with_absent_value() {
+        let s = test_store();
+        s.set("k".into(), b"v".to_vec(), None);
+        let (ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+
+        let waiter = {
+            let s = Arc::clone(&s);
+            std::thread::spawn(move || s.wait_for_change("k", ver, Duration::from_secs(10)))
+        };
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(s.remove("k"));
+
+        let (new_ver, val) = waiter.join().unwrap().expect("waiter must wake on del");
+        assert!(new_ver > ver);
+        assert_eq!(val, None, "deleted key must surface as absent");
+    }
+
+    #[test]
+    fn incr_wakes_waiter() {
+        let s = test_store();
+        let (ver, _) = s.wait_for_change("counter", 0, Duration::from_secs(1)).unwrap();
+
+        let waiter = {
+            let s = Arc::clone(&s);
+            std::thread::spawn(move || s.wait_for_change("counter", ver, Duration::from_secs(10)))
+        };
+        std::thread::sleep(Duration::from_millis(50));
+        assert_eq!(s.incr_by("counter", 1), Ok(1));
+
+        let (_, val) = waiter.join().unwrap().expect("waiter must wake on incr");
+        assert_eq!(val.as_deref(), Some(&b"1"[..]));
+    }
+
+    #[test]
+    fn expire_does_not_bump_version() {
+        // TTL-only changes are not value changes; the eventual expiry
+        // reap (a remove_local) is what wakes waiters.
+        let s = test_store();
+        s.set("k".into(), b"v".to_vec(), None);
+        let (ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+        assert!(s.expire("k", Duration::from_secs(3600)));
+        assert!(
+            s.wait_for_change("k", ver, Duration::from_millis(60)).is_none(),
+            "expire must not bump the watch version"
+        );
+    }
+
+    #[test]
+    fn writes_to_other_keys_do_not_wake_waiter() {
+        let s = test_store();
+        let (ver, _) = s.wait_for_change("watched", 0, Duration::from_secs(1)).unwrap();
+        s.set("unrelated".into(), b"v".to_vec(), None);
+        assert!(
+            s.wait_for_change("watched", ver, Duration::from_millis(60)).is_none(),
+            "unrelated writes must not bump the watched key's version"
+        );
+    }
+
+    #[test]
+    fn flush_wakes_waiters_and_keeps_slots() {
+        let s = test_store();
+        s.set("k".into(), b"v".to_vec(), None);
+        let (ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+
+        let waiter = {
+            let s = Arc::clone(&s);
+            std::thread::spawn(move || s.wait_for_change("k", ver, Duration::from_secs(10)))
+        };
+        std::thread::sleep(Duration::from_millis(50));
+        s.flush();
+
+        let (new_ver, val) = waiter.join().unwrap().expect("waiter must wake on flush");
+        assert!(new_ver > ver);
+        assert_eq!(val, None, "flushed key must surface as absent");
+        // Slots survive the flush — versions must stay monotonic.
+        assert_eq!(s.watch_slot_count(), 1);
+    }
+
+    #[test]
+    fn versions_are_monotonic_across_writes() {
+        let s = test_store();
+        let (mut ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+        for i in 0..5 {
+            s.set("k".into(), format!("v{i}").into_bytes(), None);
+            let (new_ver, val) =
+                s.wait_for_change("k", ver, Duration::from_secs(1)).expect("version advanced");
+            assert!(new_ver > ver, "versions must strictly increase");
+            assert_eq!(val.as_deref(), Some(format!("v{i}").as_bytes()));
+            ver = new_ver;
+        }
+    }
+
+    #[test]
+    fn multiple_waiters_all_wake_on_one_write() {
+        let s = test_store();
+        let (ver, _) = s.wait_for_change("k", 0, Duration::from_secs(1)).unwrap();
+
+        let waiters: Vec<_> = (0..4)
+            .map(|_| {
+                let s = Arc::clone(&s);
+                std::thread::spawn(move || s.wait_for_change("k", ver, Duration::from_secs(10)))
+            })
+            .collect();
+        std::thread::sleep(Duration::from_millis(50));
+        s.set("k".into(), b"fanout".to_vec(), None);
+
+        for w in waiters {
+            let (_, val) = w.join().unwrap().expect("every waiter must wake");
+            assert_eq!(val.as_deref(), Some(&b"fanout"[..]));
+        }
     }
 }

--- a/crates/ephpm-kv/src/store/watch.rs
+++ b/crates/ephpm-kv/src/store/watch.rs
@@ -1,0 +1,183 @@
+//! Versioned key watches — the blocking-wait primitive behind
+//! `ephpm_kv_wait()`.
+//!
+//! # Design
+//!
+//! Each watched key owns a [`WatchSlot`]: a monotonically increasing
+//! per-key version guarded by a `Mutex`, plus a `Condvar` that wakes
+//! blocked waiters. Slots are created **lazily on the first wait** for a
+//! key and live for the rest of the process — they are intentionally
+//! never reclaimed (see *Slot lifecycle* below).
+//!
+//! # The zero-cost invariant (why per-key slots, not a global sequence)
+//!
+//! The KV write path is one of ePHPm's hottest code paths (sessions,
+//! rate-limit counters, cache writes). This feature must cost nothing
+//! for deployments that never call `ephpm_kv_wait()`:
+//!
+//! - Writes check a single store-level atomic counter of live slots
+//!   ([`Store::notify_write`](super::Store)) — one `Acquire` load. While
+//!   the counter is zero (no key has ever been waited on), that load is
+//!   the *entire* added cost: no map lookup, no lock, no allocation.
+//! - Only once a slot exists does a write pay a `DashMap` lookup in the
+//!   (tiny) watch registry, and only a write to a *watched* key pays the
+//!   version bump + `notify_all`.
+//!
+//! A store-global write sequence (`AtomicU64` bumped on every write) was
+//! rejected: it would put an unconditional `fetch_add` — a contended
+//! cache-line write under multi-core load — on every write forever, to
+//! serve a feature most deployments don't use.
+//!
+//! # Version semantics
+//!
+//! A slot is created with version `1`, which represents "the state of
+//! the key at the moment the watch began". Every subsequent write to the
+//! key (set / setnx-insert / del / incr / decr / append / lazy-expiry
+//! reap / flush) increments the version. Versions therefore only advance
+//! for writes made **after** the first wait on that key — which is
+//! exactly what the wait protocol needs:
+//!
+//! 1. `wait(key, 0, _)` — since the fresh slot's version (`1`) already
+//!    exceeds `0`, this returns immediately with the current value and
+//!    version. This is the race-free "register + snapshot" step: any
+//!    write that lands after this call finds the slot and bumps it.
+//! 2. `wait(key, v, timeout)` — blocks until the version exceeds `v`
+//!    (returning the new value + version) or the timeout expires.
+//!
+//! Watches observe **string keys only**. Hash-field writes (`hset` /
+//! `hdel`) do not bump versions; deleting a hash key via `remove` does
+//! (the delete wakes waiters, whose value read then returns "absent").
+//! TTL-only changes (`expire` / `persist`) do not bump versions — the
+//! value did not change; the eventual expiry reap does.
+//!
+//! # Slot lifecycle
+//!
+//! Slots are never removed. Reclaiming a slot would reset its version to
+//! `1` on re-creation, and a client still holding a higher version from
+//! the previous slot incarnation would block past real writes — a lost
+//! wakeup. Keeping slots alive makes versions monotonic for the process
+//! lifetime. The expected cardinality is small (one slot per pub/sub-ish
+//! topic, e.g. one per SSE channel); each slot costs ~the key string
+//! plus two words. An app waiting on unbounded random keys would grow
+//! the registry without bound — documented as an anti-pattern in the KV
+//! guide.
+
+use std::sync::{Condvar, Mutex, PoisonError};
+use std::time::Duration;
+
+/// Per-key watch state: a version counter and the condvar that wakes
+/// waiters when it advances.
+#[derive(Debug)]
+pub(super) struct WatchSlot {
+    /// Monotonic per-key version. Starts at 1 ("state at watch start");
+    /// incremented once per observed write. Guarded by the mutex so a
+    /// bump-then-notify can never slip between a waiter's version check
+    /// and its `Condvar` sleep (the classic lost-wakeup race).
+    version: Mutex<u64>,
+    /// Wakes all waiters after a version bump.
+    cond: Condvar,
+}
+
+impl WatchSlot {
+    /// New slot at version 1 — "current state at watch start".
+    pub(super) fn new() -> Self {
+        Self { version: Mutex::new(1), cond: Condvar::new() }
+    }
+
+    /// Increment the version and wake every waiter.
+    pub(super) fn bump(&self) {
+        // Poison recovery: a panic in some other waiter's closure can't
+        // corrupt a plain u64 — take the guard and proceed.
+        let mut v = self.version.lock().unwrap_or_else(PoisonError::into_inner);
+        *v = v.saturating_add(1);
+        drop(v);
+        self.cond.notify_all();
+    }
+
+    /// Current version.
+    #[cfg(test)]
+    pub(super) fn version(&self) -> u64 {
+        *self.version.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Block until the version exceeds `last_version` or `timeout`
+    /// elapses. Returns `Some(new_version)` on change, `None` on timeout.
+    ///
+    /// Designed to be called from dedicated worker OS threads or the
+    /// tokio `spawn_blocking` pool — never from an async task.
+    pub(super) fn wait_past(&self, last_version: u64, timeout: Duration) -> Option<u64> {
+        let guard = self.version.lock().unwrap_or_else(PoisonError::into_inner);
+        if *guard > last_version {
+            return Some(*guard);
+        }
+        let (guard, _timed_out) = self
+            .cond
+            .wait_timeout_while(guard, timeout, |v| *v <= last_version)
+            .unwrap_or_else(PoisonError::into_inner);
+        // Re-check the predicate rather than trusting the timeout flag:
+        // a bump can land between the timeout firing and the lock being
+        // reacquired, and reporting it is strictly better.
+        if *guard > last_version { Some(*guard) } else { None }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Instant;
+
+    use super::*;
+
+    #[test]
+    fn new_slot_starts_at_one() {
+        let slot = WatchSlot::new();
+        assert_eq!(slot.version(), 1);
+    }
+
+    #[test]
+    fn wait_past_zero_returns_immediately() {
+        let slot = WatchSlot::new();
+        let start = Instant::now();
+        // Version 1 > 0 — must not block even with a long timeout.
+        assert_eq!(slot.wait_past(0, Duration::from_secs(30)), Some(1));
+        assert!(start.elapsed() < Duration::from_secs(1), "must not have blocked");
+    }
+
+    #[test]
+    fn wait_past_current_times_out() {
+        let slot = WatchSlot::new();
+        let start = Instant::now();
+        assert_eq!(slot.wait_past(1, Duration::from_millis(50)), None);
+        assert!(start.elapsed() >= Duration::from_millis(50));
+    }
+
+    #[test]
+    fn bump_wakes_waiter() {
+        let slot = Arc::new(WatchSlot::new());
+        let waiter = {
+            let slot = Arc::clone(&slot);
+            thread::spawn(move || slot.wait_past(1, Duration::from_secs(10)))
+        };
+        // Give the waiter a moment to actually block, then bump.
+        thread::sleep(Duration::from_millis(50));
+        slot.bump();
+        assert_eq!(waiter.join().unwrap(), Some(2));
+    }
+
+    #[test]
+    fn bump_wakes_all_waiters() {
+        let slot = Arc::new(WatchSlot::new());
+        let waiters: Vec<_> = (0..4)
+            .map(|_| {
+                let slot = Arc::clone(&slot);
+                thread::spawn(move || slot.wait_past(1, Duration::from_secs(10)))
+            })
+            .collect();
+        thread::sleep(Duration::from_millis(50));
+        slot.bump();
+        for w in waiters {
+            assert_eq!(w.join().unwrap(), Some(2));
+        }
+    }
+}

--- a/crates/ephpm-kv/tests/write_overhead.rs
+++ b/crates/ephpm-kv/tests/write_overhead.rs
@@ -1,0 +1,77 @@
+//! Manual microbenchmark for the KV hot paths (`set` / `get` / `incr_by`).
+//!
+//! Used as the before/after harness for changes that touch the write path
+//! (e.g. the `ephpm_kv_wait` watch hooks): the file only uses the public
+//! `Store` API, so the *identical* file can be dropped into a baseline
+//! checkout of `main` and compared same-box, same-toolchain.
+//!
+//! Not a unit test — ignored by default. Run with:
+//!
+//! ```sh
+//! cargo test -p ephpm-kv --release --test write_overhead -- --ignored --nocapture
+//! ```
+//!
+//! Numbers are single-threaded ns/op; compare medians of the printed
+//! rounds, not absolute values across machines.
+
+use std::time::Instant;
+
+use ephpm_kv::store::{Store, StoreConfig};
+
+const ROUNDS: usize = 5;
+const KEYS: usize = 512;
+const SET_ITERS: usize = 2_000_000;
+const GET_ITERS: usize = 4_000_000;
+const INCR_ITERS: usize = 2_000_000;
+
+fn keyset() -> Vec<String> {
+    (0..KEYS).map(|i| format!("bench:key:{i}")).collect()
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn report(label: &str, iters: usize, elapsed: std::time::Duration) {
+    let ns_per_op = elapsed.as_nanos() as f64 / iters as f64;
+    let mops = iters as f64 / elapsed.as_secs_f64() / 1_000_000.0;
+    println!("{label}: {iters} iters in {elapsed:?} -> {ns_per_op:.1} ns/op ({mops:.2} Mops/s)");
+}
+
+#[test]
+#[ignore = "manual microbenchmark — run with --release --ignored --nocapture"]
+fn set_get_incr_throughput() {
+    let store = Store::new(StoreConfig { memory_limit: 0, ..StoreConfig::default() });
+    let keys = keyset();
+    let value = b"0123456789abcdef0123456789abcdef"; // 32 B, below compress min
+
+    // Warmup: populate every key and fault in the map shards.
+    for key in &keys {
+        store.set(key.clone(), value.to_vec(), None);
+    }
+
+    for round in 1..=ROUNDS {
+        println!("── round {round}/{ROUNDS} ──");
+
+        let start = Instant::now();
+        for i in 0..SET_ITERS {
+            let key = &keys[i % KEYS];
+            store.set(key.clone(), value.to_vec(), None);
+        }
+        report("set (overwrite)", SET_ITERS, start.elapsed());
+
+        let start = Instant::now();
+        let mut hits = 0usize;
+        for i in 0..GET_ITERS {
+            let key = &keys[i % KEYS];
+            if store.get(key).is_some() {
+                hits += 1;
+            }
+        }
+        assert_eq!(hits, GET_ITERS, "every get must hit");
+        report("get (hit)", GET_ITERS, start.elapsed());
+
+        let start = Instant::now();
+        for _ in 0..INCR_ITERS {
+            store.incr_by("bench:counter", 1).expect("counter must stay an integer");
+        }
+        report("incr_by", INCR_ITERS, start.elapsed());
+    }
+}

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -2233,6 +2233,11 @@ typedef struct {
     int  (*expire)(const char *key, long long ttl_ms);
     long long (*pttl)(const char *key);
     int  (*flush_all)(void);
+    /* Blocking versioned wait. Returns 0 = timeout, 1 = changed with a
+     * value (in the get_result buffer), 2 = changed but key absent.
+     * Must stay LAST-appended: the layout mirrors kv_bridge.rs. */
+    int  (*wait)(const char *key, long long last_version, long long timeout_ms,
+                 long long *new_version);
 } EphpmKvOps;
 
 static EphpmKvOps g_kv_ops = {0};
@@ -2411,6 +2416,58 @@ PHP_FUNCTION(ephpm_kv_flush_all)
     RETURN_BOOL(g_kv_ops.flush_all());
 }
 
+/* ephpm_kv_wait(string $key, int $last_version, int $timeout_ms): array|false
+ *
+ * Block until $key's watch version exceeds $last_version, or $timeout_ms
+ * elapses. On change returns ['value' => string|null, 'version' => int]
+ * ('value' is null when the key was deleted or has expired); on timeout
+ * returns false (the SSE idiom: emit a keepalive and re-wait).
+ *
+ * The version is per-key and monotonic for the process lifetime; it only
+ * advances for writes made AFTER the first wait on that key. Always seed
+ * the protocol with $last_version = 0 — that first call registers the
+ * watch and returns the current value+version immediately (race-free
+ * snapshot), never trusting a version you didn't get from a prior call.
+ * Negative $last_version/$timeout_ms are treated as 0; $timeout_ms = 0 is
+ * a non-blocking poll.
+ *
+ * Blocking is intentional and safe: in worker mode this parks the
+ * dedicated worker OS thread (the intended SSE pattern — replaces
+ * poll+usleep loops with zero idle CPU and sub-ms wakeup); in fpm mode it
+ * parks a spawn_blocking thread, so keep $timeout_ms well below
+ * [server.timeouts] request there. Watches observe string keys only
+ * (set/setnx/del/incr/decr/incr_by/append/expiry-reap/flush bump the
+ * version; hset/hdel and TTL-only changes do not). */
+PHP_FUNCTION(ephpm_kv_wait)
+{
+    char *key; size_t key_len;
+    zend_long last_version;
+    zend_long timeout_ms;
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_STRING(key, key_len)
+        Z_PARAM_LONG(last_version)
+        Z_PARAM_LONG(timeout_ms)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (!g_kv_ops.wait) { RETURN_FALSE; }
+
+    long long new_version = 0;
+    int rc = g_kv_ops.wait(key, (long long)last_version, (long long)timeout_ms,
+                           &new_version);
+    if (rc == 0) { RETURN_FALSE; } /* timeout */
+
+    array_init(return_value);
+    add_assoc_long(return_value, "version", (zend_long)new_version);
+    if (rc == 1) {
+        const char *ptr; size_t len;
+        g_kv_ops.get_result(&ptr, &len);
+        add_assoc_stringl(return_value, "value", ptr, len);
+    } else {
+        /* rc == 2: version advanced but the key is absent (deleted). */
+        add_assoc_null(return_value, "value");
+    }
+}
+
 /* ── Argument info for reflection (arginfo) ──────────────────── */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_get, 0, 0, 1)
@@ -2466,6 +2523,12 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_flush_all, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_wait, 0, 0, 3)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, last_version)
+    ZEND_ARG_INFO(0, timeout_ms)
+ZEND_END_ARG_INFO()
+
 /* ── Function entry table (null-terminated) ──────────────────── */
 
 static const zend_function_entry ephpm_kv_functions[] = {
@@ -2481,6 +2544,7 @@ static const zend_function_entry ephpm_kv_functions[] = {
     PHP_FE(ephpm_kv_ttl,       arginfo_ephpm_kv_ttl)
     PHP_FE(ephpm_kv_pttl,      arginfo_ephpm_kv_pttl)
     PHP_FE(ephpm_kv_flush_all, arginfo_ephpm_kv_flush_all)
+    PHP_FE(ephpm_kv_wait,      arginfo_ephpm_kv_wait)
     PHP_FE_END
 };
 

--- a/crates/ephpm-php/src/kv_bridge.rs
+++ b/crates/ephpm-php/src/kv_bridge.rs
@@ -137,6 +137,26 @@ pub struct EphpmKvOps {
     /// global). Backs Redis-style `FLUSHDB` / `FLUSHALL` from PHP userland.
     /// Returns 1 on success, 0 if no store is registered.
     pub flush_all: Option<unsafe extern "C" fn() -> std::os::raw::c_int>,
+
+    /// Block until the key's watch version exceeds `last_version` or
+    /// `timeout_ms` elapses (see `Store::wait_for_change`). Returns:
+    /// - `0` — timeout (or no store registered); `*new_version` untouched.
+    /// - `1` — version advanced and the key holds a value: `*new_version`
+    ///   receives the version and the value is in the thread-local get
+    ///   buffer (retrieve via `get_result`, same contract as `get`).
+    /// - `2` — version advanced but the key is absent (deleted/expired):
+    ///   `*new_version` receives the version; the get buffer is untouched.
+    ///
+    /// Blocking is safe here: callers are PHP worker OS threads or the
+    /// tokio `spawn_blocking` pool, never async tasks.
+    pub wait: Option<
+        unsafe extern "C" fn(
+            key: *const std::os::raw::c_char,
+            last_version: std::os::raw::c_longlong,
+            timeout_ms: std::os::raw::c_longlong,
+            new_version: *mut std::os::raw::c_longlong,
+        ) -> std::os::raw::c_int,
+    >,
 }
 
 // ── Callback implementations ────────────────────────────────────────────
@@ -342,6 +362,51 @@ unsafe extern "C" fn kv_flush_all() -> std::os::raw::c_int {
     1
 }
 
+#[cfg(php_linked)]
+unsafe extern "C" fn kv_wait(
+    key: *const std::os::raw::c_char,
+    last_version: std::os::raw::c_longlong,
+    timeout_ms: std::os::raw::c_longlong,
+    new_version: *mut std::os::raw::c_longlong,
+) -> std::os::raw::c_int {
+    // Safety: `key` is a null-terminated C string provided by PHP's
+    // zend_parse_parameters. Valid for the duration of this call.
+    let key_str = unsafe { CStr::from_ptr(key) };
+    let Ok(key_str) = key_str.to_str() else {
+        return 0;
+    };
+    let Some(store) = effective_store() else {
+        return 0;
+    };
+
+    // Negative inputs clamp to 0: last_version 0 = "register + snapshot",
+    // timeout 0 = non-blocking poll.
+    let last = u64::try_from(last_version).unwrap_or(0);
+    let timeout = Duration::from_millis(u64::try_from(timeout_ms).unwrap_or(0));
+
+    match store.wait_for_change(key_str, last, timeout) {
+        Some((version, value)) => {
+            // Safety: `new_version` points to a valid `long long` local in
+            // our C wrapper code (PHP_FUNCTION(ephpm_kv_wait)).
+            unsafe {
+                *new_version = std::os::raw::c_longlong::try_from(version).unwrap_or(i64::MAX)
+            };
+            match value {
+                Some(val) => {
+                    KV_GET_BUF.with(|buf| {
+                        let mut buf = buf.borrow_mut();
+                        buf.clear();
+                        buf.extend_from_slice(&val);
+                    });
+                    1
+                }
+                None => 2,
+            }
+        }
+        None => 0,
+    }
+}
+
 // ── Static ops table ────────────────────────────────────────────────────
 
 /// The C-compatible function pointer table, ready to pass to
@@ -358,6 +423,7 @@ pub static KV_OPS: EphpmKvOps = EphpmKvOps {
     expire: Some(kv_expire),
     pttl: Some(kv_pttl),
     flush_all: Some(kv_flush_all),
+    wait: Some(kv_wait),
 };
 
 // ── Public API ──────────────────────────────────────────────────────────
@@ -727,6 +793,96 @@ mod tests {
 
         // Reset thread-local state so it doesn't leak into other serial tests.
         set_site_store(None);
+    }
+
+    // ── kv_wait ─────────────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn wait_with_zero_last_version_snapshots_immediately() {
+        let store = init_store();
+        store.set("bridge_wait_snap".into(), b"current".to_vec(), None);
+
+        let key = cstr("bridge_wait_snap");
+        let mut new_version: std::os::raw::c_longlong = 0;
+        // Safety: key and new_version are valid for the duration of the call.
+        let rc = unsafe { kv_wait(key.as_ptr(), 0, 5_000, &mut new_version) };
+        assert_eq!(rc, 1, "snapshot must report a present value");
+        assert!(new_version >= 1);
+
+        let mut ptr: *const std::os::raw::c_char = std::ptr::null();
+        let mut len: usize = 0;
+        // Safety: ptr and len are valid stack variables.
+        unsafe { kv_get_result(&mut ptr, &mut len) };
+        let got = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) };
+        assert_eq!(got, b"current");
+    }
+
+    #[test]
+    #[serial]
+    fn wait_snapshot_on_missing_key_returns_absent() {
+        init_store();
+        let key = cstr("bridge_wait_missing");
+        let mut new_version: std::os::raw::c_longlong = 0;
+        // Safety: key and new_version are valid.
+        let rc = unsafe { kv_wait(key.as_ptr(), 0, 1_000, &mut new_version) };
+        assert_eq!(rc, 2, "missing key must report changed-but-absent");
+        assert!(new_version >= 1);
+    }
+
+    #[test]
+    #[serial]
+    fn wait_times_out_when_nothing_changes() {
+        let store = init_store();
+        store.set("bridge_wait_to".into(), b"v".to_vec(), None);
+        let key = cstr("bridge_wait_to");
+
+        // Snapshot to learn the current version.
+        let mut ver: std::os::raw::c_longlong = 0;
+        // Safety: key and ver are valid.
+        assert_eq!(unsafe { kv_wait(key.as_ptr(), 0, 1_000, &mut ver) }, 1);
+
+        // Waiting past the current version with no writes must time out.
+        let start = std::time::Instant::now();
+        let mut unused: std::os::raw::c_longlong = 0;
+        // Safety: key and unused are valid.
+        let rc = unsafe { kv_wait(key.as_ptr(), ver, 80, &mut unused) };
+        assert_eq!(rc, 0, "must time out");
+        assert!(start.elapsed() >= Duration::from_millis(80));
+    }
+
+    #[test]
+    #[serial]
+    fn wait_wakes_on_concurrent_set() {
+        let store = init_store();
+        store.set("bridge_wait_wake".into(), b"old".to_vec(), None);
+        let key = cstr("bridge_wait_wake");
+
+        let mut ver: std::os::raw::c_longlong = 0;
+        // Safety: key and ver are valid.
+        assert_eq!(unsafe { kv_wait(key.as_ptr(), 0, 1_000, &mut ver) }, 1);
+
+        let writer = {
+            let store = Arc::clone(&store);
+            thread::spawn(move || {
+                thread::sleep(Duration::from_millis(50));
+                store.set("bridge_wait_wake".into(), b"new".to_vec(), None);
+            })
+        };
+
+        let mut new_ver: std::os::raw::c_longlong = 0;
+        // Safety: key and new_ver are valid.
+        let rc = unsafe { kv_wait(key.as_ptr(), ver, 10_000, &mut new_ver) };
+        writer.join().unwrap();
+
+        assert_eq!(rc, 1, "waiter must wake with a value");
+        assert!(new_ver > ver);
+        let mut ptr: *const std::os::raw::c_char = std::ptr::null();
+        let mut len: usize = 0;
+        // Safety: ptr and len are valid stack variables.
+        unsafe { kv_get_result(&mut ptr, &mut len) };
+        let got = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) };
+        assert_eq!(got, b"new");
     }
 
     // ── Thread safety of the get buffer ─────────────────────────────────

--- a/site/content/guides/kv-from-php.md
+++ b/site/content/guides/kv-from-php.md
@@ -35,10 +35,63 @@ ephpm_kv_pttl("session:abc");                  // ~60000
 // returns -1 if no expiry, -2 if missing
 ```
 
+### Blocking waits — `ephpm_kv_wait()`
+
+```php
+ephpm_kv_wait(string $key, int $last_version, int $timeout_ms): array|false
+```
+
+Blocks the calling PHP thread until `$key` is written again (its watch
+version exceeds `$last_version`) or `$timeout_ms` elapses. On change it
+returns `['value' => string|null, 'version' => int]` — `value` is `null`
+when the key was deleted or expired. On timeout it returns `false`.
+
+Semantics you can rely on:
+
+- **Versions are per-key and monotonic** for the process lifetime. They
+  only advance for writes made *after* the first wait on that key, so
+  always start the protocol with `$last_version = 0`: that first call
+  registers the watch and returns the current value + version
+  immediately (a race-free snapshot), without blocking.
+- **What bumps the version:** `set`, `setnx` (on insert), `del`, `incr`
+  / `decr` / `incr_by`, `append` (via RESP), expiry reaping, and
+  `flush_all`. TTL-only changes (`expire`) and hash-field ops (RESP
+  `HSET`/`HDEL`) do **not**.
+- **Negative arguments clamp to 0**; `$timeout_ms = 0` is a
+  non-blocking poll.
+- **Cost when unused: zero.** Writes pay a single atomic load until the
+  first `ephpm_kv_wait()` in the process; only writes to a *watched* key
+  pay a version bump + wakeup. Watch slots are never reclaimed, so wait
+  on a small set of well-known channel keys, not on unbounded
+  per-request keys.
+
+The intended use is worker-mode SSE fan-out — replacing a
+poll-and-`usleep()` loop with zero idle CPU and sub-millisecond wakeup:
+
+```php
+// One SSE connection: snapshot once, then block until state changes.
+$r = ephpm_kv_wait('board:state', 0, 0);        // register + snapshot
+send_event(render($r['value']));
+$ver = $r['version'];
+while (true) {
+    $r = ephpm_kv_wait('board:state', $ver, 15000);
+    if ($r === false) { send_keepalive(); continue; }   // timeout tick
+    $ver = $r['version'];
+    send_event(render($r['value']));
+}
+```
+
+Blocking is safe in worker mode (the wait parks that connection's
+dedicated worker thread — which is exactly what a poll loop did, minus
+the burn). In fpm mode the whole request runs under
+`[server.timeouts] request` (default 300 s), so keep `$timeout_ms` well
+below that.
+
 ### When to use SAPI
 
 - High-frequency operations (logging, hit counters, rate limit hot path)
 - Simple key/value patterns
+- Realtime push (SSE) via `ephpm_kv_wait` — there is no RESP equivalent
 - You don't care about portability to standalone Redis
 
 ## RESP protocol (Predis / phpredis)

--- a/tests/docroot/kv.php
+++ b/tests/docroot/kv.php
@@ -53,6 +53,18 @@ switch ($op) {
         }
         echo "ok";
         break;
+    case 'wait':
+        // Blocking versioned wait. val = last_version; ttl is reused as the
+        // timeout in MILLISECONDS here (unlike the seconds of the other
+        // ops). Prints "timeout" or "<version>:<value>" ("<version>:null"
+        // when the key is absent at wakeup).
+        $r = ephpm_kv_wait($key, (int) $val, $ttl);
+        if ($r === false) {
+            echo "timeout";
+        } else {
+            echo $r['version'] . ':' . ($r['value'] ?? 'null');
+        }
+        break;
     case 'mget':
         // key = "k1,k2,..."
         $out = [];


### PR DESCRIPTION
## Summary

New PHP native function — the blocking-wait primitive for SSE/realtime fan-out:

```php
ephpm_kv_wait(string $key, int $last_version, int $timeout_ms): array|false
```

Blocks the calling worker thread until `$key`'s watch version exceeds `$last_version`, returning `['value' => string|null, 'version' => int]`, or `false` on timeout (the SSE keepalive tick). `wait($key, 0, _)` is a race-free register+snapshot: the slot is created at version 1, so the first call returns the current state immediately and every later write is guaranteed to be observed.

Replaces the poll+`usleep` idiom (the only fan-out pattern previously available — see `ephpm/datastar-demo`'s spec doc §4): idle CPU drops to zero and wakeup latency drops from the poll interval (~100 ms) to sub-millisecond.

### Design: zero cost for the write path when unused

`crates/ephpm-kv/src/store/watch.rs` module docs carry the full rationale. Short version:

- Per-key `WatchSlot` (`Mutex<u64>` version + `Condvar`), created lazily on the **first wait** for a key, never reclaimed (reclaim would reset versions and lose wakeups; expected cardinality is a handful of channel keys).
- Every write path checks one store-level `AtomicUsize` slot counter before doing *any* watch work. Until the first `ephpm_kv_wait()` in the process, that single `Acquire` load is the entire added cost — no lookup, no lock, no allocation. Verified structurally by the `writes_never_create_watch_slots` test.
- A store-global write sequence was rejected: it would put an unconditional `fetch_add` (a contended cache-line RMW) on every write, forever, for everyone.
- Version bumps: `set`/`setnx`-insert/`del`/`incr`/`decr`/`incr_by`/`append`/expiry-reap/eviction/`flush`. TTL-only changes and hash-field ops don't bump. Notify fires **after** the write is visible (slot snapshot taken before the key moves into the map), so a woken waiter always reads the new value. Clustered mode notifies at `set_local`/`remove_local` — the choke point both modes share.

## No-latency proof (off-path A/B)

Harness: `crates/ephpm-kv/tests/write_overhead.rs` (public-API-only, so the identical file runs on `main`). Same box, same toolchain, `--release`, single-threaded, best of 10 rounds per side, interleaved runs:

| op | main (ns/op) | this PR (ns/op) | delta |
|---|---|---|---|
| `set` (overwrite, 32 B) | 151.3 | 150.2 | **-0.7%** |
| `get` (hit) — *untouched code, noise control* | 67.3 | 68.4 | +1.6% |
| `incr_by` | 112.7 | 113.3 | +0.5% |

The `get` path contains **zero new code** in this PR, so its +/-1.6% spread is the measurement noise floor of the rig — `set` and `incr_by` sit inside it (`set` came out marginally faster). Environment: WSL2 glibc, `--release`, 24-core host, interleaved main/branch passes. A Windows-native pair run earlier showed the same pattern.

## PHP surface

- `ephpm_wrapper.c`: `wait` op appended to `EphpmKvOps` (layout mirrored in `kv_bridge.rs`), `PHP_FUNCTION(ephpm_kv_wait)` + arginfo + function-table entry, semantics documented in the neighbors' comment style. Value returned through the existing thread-local get buffer.
- Blocking is safe by construction: callers are dedicated worker OS threads (worker mode) or `spawn_blocking` threads (fpm). Docs tell fpm users to keep the timeout below `[server.timeouts] request`.

## Tests

- `watch.rs` unit tests: slot lifecycle, immediate snapshot, timeout, single/multi-waiter wakeup.
- Store tests: set/del/incr wakeups (with values), delete-observed-as-absent, unrelated-key isolation, flush wakeup + slot survival, monotonic versions, `expire` non-bump, and the no-slots-without-waiters invariant.
- `kv_bridge.rs` (`php_linked`): snapshot, absent-key, timeout, cross-thread wakeup round-trips.
- e2e (`tests/kv.rs` + `wait` op in the `kv.php` fixture): snapshot, timeout, cross-request push wakeup (latency-bounded), delete→`null`.

## Live validation

Release build (`cargo xtask release 8.4`, PHP 8.4) serving the Pixelboard demo (`ephpm/datastar-demo`) on WSL2:

- `cargo test -p ephpm-php kv_bridge` against the linked SDK (8.4.23): 28/28 pass, including the four new `wait` round-trips.
- Pixelboard A/B, same binary, poll `worker.php` (v0.5.0 demo main) vs wait `worker.php` (feature-detected), 8 idle SSE clients, 60 s:
  - idle CPU: **0.21 cpu-s (0.35% of one core)** polling -> **0.01 cpu-s (0.02%)** waiting;
  - paint->event first-byte latency (incl. POST round-trip, 20 samples): **p50 100.4 ms -> p50 1.21 ms** (min 0.84 ms) — 83x, from poll-floor to push.

## Docs

`site/content/guides/kv-from-php.md`: full signature/semantics reference, the SSE loop idiom, and the "wait on well-known channel keys, not unbounded per-request keys" anti-pattern (slots are never reclaimed).
