### PR TITLE
feat(server): streaming brotli for worker streamed responses (SSE)

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -273,6 +273,30 @@ pub struct ResponseConfig {
     #[serde(default = "default_compression_min_size")]
     pub compression_min_size: usize,
 
+    /// Streaming (worker-mode `send_response_stream`) response compression.
+    ///
+    /// Values: `"off"`, `"sse"`, `"all"`.
+    ///
+    /// - `"off"` — streamed responses go out identity-encoded; the code
+    ///   path is byte-for-byte identical to releases without this knob.
+    /// - `"sse"` — streamed responses with Content-Type
+    ///   `text/event-stream` are brotli-compressed with one encoder whose
+    ///   window persists for the stream's lifetime, flushed per chunk so
+    ///   each SSE event is decodable the moment it arrives. Repeated
+    ///   re-renders of similar markup compress to tiny wire deltas.
+    /// - `"all"` — every streamed worker response is compressed this way
+    ///   (including binary downloads — usually wasteful; prefer `"sse"`).
+    ///
+    /// Only applies when `compression = true` and the client sent
+    /// `Accept-Encoding: br`; otherwise the stream passes through
+    /// untouched. Unknown values log a startup warning and behave as
+    /// `"off"`. Buffered (fpm and worker `send_response`) responses are
+    /// unaffected — they keep the existing whole-body compression.
+    ///
+    /// Default: `"off"`.
+    #[serde(default = "default_compression_streaming")]
+    pub compression_streaming: String,
+
     /// Custom headers added to every response (both PHP and static).
     ///
     /// Useful for security headers like HSTS, CSP, X-Frame-Options, CORS.
@@ -1817,6 +1841,7 @@ impl Default for ResponseConfig {
             compression: default_compression(),
             compression_level: default_compression_level(),
             compression_min_size: default_compression_min_size(),
+            compression_streaming: default_compression_streaming(),
             headers: Vec::new(),
         }
     }
@@ -2918,6 +2943,10 @@ fn default_compression_min_size() -> usize {
     1024
 }
 
+fn default_compression_streaming() -> String {
+    "off".to_string()
+}
+
 fn default_hidden_files() -> String {
     "deny".to_string()
 }
@@ -3338,6 +3367,37 @@ ttl_secs = -1
         let config = Config::load(&file).unwrap();
         assert!(config.server.php_etag_cache.enabled);
         assert_eq!(config.server.php_etag_cache.ttl_secs, -1);
+    }
+
+    #[test]
+    fn test_compression_streaming_defaults_off() {
+        let config = Config::default_config().unwrap();
+        assert_eq!(config.server.response.compression_streaming, "off");
+    }
+
+    #[test]
+    fn test_compression_streaming_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server.response]
+compression_streaming = "sse"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.response.compression_streaming, "sse");
+    }
+
+    #[test]
+    fn test_env_var_overrides_compression_streaming() {
+        temp_env::with_var("EPHPM_SERVER__RESPONSE__COMPRESSION_STREAMING", Some("all"), || {
+            let config = Config::default_config().unwrap();
+            assert_eq!(config.server.response.compression_streaming, "all");
+        });
     }
 
     #[test]

--- a/crates/ephpm-server/src/file_cache.rs
+++ b/crates/ephpm-server/src/file_cache.rs
@@ -202,7 +202,12 @@ mod tests {
     }
 
     fn test_compression() -> CompressionSettings {
-        CompressionSettings { enabled: true, level: 1, min_size: 1024 }
+        CompressionSettings {
+            enabled: true,
+            level: 1,
+            min_size: 1024,
+            streaming: crate::router::StreamingCompression::Off,
+        }
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod opcache;
 pub mod rate_limit;
 pub mod router;
 pub mod static_files;
+pub mod stream_compress;
 pub mod tls;
 pub mod tracked_backend;
 pub mod worker_pool;

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -45,6 +45,44 @@ pub struct CompressionSettings {
     pub level: u32,
     /// Minimum response size in bytes to compress.
     pub min_size: usize,
+    /// Streamed worker-response compression mode.
+    pub streaming: StreamingCompression,
+}
+
+/// Streamed worker-response compression mode
+/// (`[server.response] compression_streaming`).
+///
+/// Applies only to worker-mode `send_response_stream` bodies. Buffered
+/// responses keep the whole-body brotli/gzip path regardless of this
+/// setting.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum StreamingCompression {
+    /// Streamed responses pass through identity-encoded. The code path is
+    /// identical to releases before this knob existed: no encoder, task,
+    /// or extra channel is created.
+    #[default]
+    Off,
+    /// Brotli-compress streamed responses whose Content-Type is
+    /// `text/event-stream`, flushing per chunk so every SSE event decodes
+    /// as it arrives (see [`crate::stream_compress`]).
+    Sse,
+    /// Brotli-compress every streamed worker response.
+    All,
+}
+
+impl StreamingCompression {
+    /// Parse the config string (`"off"` / `"sse"` / `"all"`,
+    /// case-insensitive). Returns `None` for unknown values so the caller
+    /// can warn — a typo must never become a silent no-op.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "off" => Some(Self::Off),
+            "sse" => Some(Self::Sse),
+            "all" => Some(Self::All),
+            _ => None,
+        }
+    }
 }
 
 /// How long a "no site directory for this host" answer is cached
@@ -357,6 +395,17 @@ impl Router {
                 enabled: config.server.response.compression,
                 level: config.server.response.compression_level,
                 min_size: config.server.response.compression_min_size,
+                streaming: StreamingCompression::parse(
+                    &config.server.response.compression_streaming,
+                )
+                .unwrap_or_else(|| {
+                    tracing::warn!(
+                        value = %config.server.response.compression_streaming,
+                        "unknown [server.response] compression_streaming value \
+                         (expected \"off\", \"sse\", or \"all\") — falling back to \"off\""
+                    );
+                    StreamingCompression::Off
+                }),
             },
             hidden_files: config.server.static_files.hidden_files.clone(),
             cache_control: config.server.static_files.cache_control.clone(),
@@ -1425,10 +1474,17 @@ impl Router {
                 )
             }
             // Streamed response (Phase 3): flush chunks to the client as PHP
-            // produces them. No compression (would require buffering) and no
-            // content-length (unknown up front) — chunked transfer.
+            // produces them. No content-length (unknown up front) — chunked
+            // transfer. Optionally wrapped in a flush-per-chunk brotli
+            // encoder when `[server.response] compression_streaming` says so.
             ephpm_php::worker_bridge::WorkerResponse::Streaming { status, headers, body_rx } => {
-                build_streamed_worker_response(status, headers, body_rx)
+                build_streamed_worker_response(
+                    status,
+                    headers,
+                    body_rx,
+                    accepts_br,
+                    self.compression,
+                )
             }
         }
     }
@@ -1967,13 +2023,24 @@ fn stream_request_body(
 
 /// Build a chunked, streamed HTTP response from a worker-mode streaming
 /// response (Phase 3). Status + headers are known now; the body flows from the
-/// channel as PHP produces it. No compression / content-length (the length is
-/// unknown up front) — hyper uses chunked transfer encoding.
+/// channel as PHP produces it. No content-length (the length is unknown up
+/// front) — hyper uses chunked transfer encoding.
+///
+/// Compression: gated by `[server.response] compression_streaming`. With the
+/// default `Off` (or a client without `Accept-Encoding: br`, or a body PHP
+/// already encoded) the body channel is passed to hyper untouched — the exact
+/// pre-knob code path, no wrapper allocated. Otherwise the channel is wrapped
+/// in a flush-per-chunk brotli encoder task ([`crate::stream_compress`]) and
+/// `Content-Encoding: br` + `Vary: Accept-Encoding` are added.
 fn build_streamed_worker_response(
     status: u16,
     headers: Vec<(String, String)>,
     body_rx: tokio::sync::mpsc::Receiver<Bytes>,
+    accepts_br: bool,
+    compression: CompressionSettings,
 ) -> Response<ServerBody> {
+    let compress = streamed_response_wants_brotli(&headers, accepts_br, compression.streaming);
+
     let status = StatusCode::from_u16(status).unwrap_or(StatusCode::OK);
     let mut resp = Response::builder().status(status);
     for (name, value) in &headers {
@@ -1984,9 +2051,45 @@ fn build_streamed_worker_response(
         }
         resp = resp.header(name.as_str(), value.as_str());
     }
-    resp.body(body::channel_body(body_rx)).unwrap_or_else(|_| {
+
+    let body = if compress {
+        resp = resp.header("content-encoding", "br").header("vary", "Accept-Encoding");
+        body::channel_body(crate::stream_compress::brotli_stream_body(body_rx))
+    } else {
+        body::channel_body(body_rx)
+    };
+    resp.body(body).unwrap_or_else(|_| {
         error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
     })
+}
+
+/// Decide whether a streamed worker response gets the brotli wrapper.
+///
+/// Requires all of:
+/// - mode != `Off`;
+/// - the client advertised brotli support (`accepts_br` — which already
+///   folds in the master `[server.response] compression` switch);
+/// - PHP did not set its own `Content-Encoding` (never double-encode);
+/// - for `Sse` mode, a `text/event-stream` Content-Type.
+fn streamed_response_wants_brotli(
+    headers: &[(String, String)],
+    accepts_br: bool,
+    mode: StreamingCompression,
+) -> bool {
+    if mode == StreamingCompression::Off || !accepts_br {
+        return false;
+    }
+    if headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("content-encoding")) {
+        return false;
+    }
+    match mode {
+        StreamingCompression::Off => false,
+        StreamingCompression::All => true,
+        StreamingCompression::Sse => headers.iter().any(|(k, v)| {
+            k.eq_ignore_ascii_case("content-type")
+                && v.trim_start().to_ascii_lowercase().starts_with("text/event-stream")
+        }),
+    }
 }
 
 fn build_php_response(
@@ -2256,7 +2359,12 @@ mod tests {
     }
 
     fn default_compression() -> CompressionSettings {
-        CompressionSettings { enabled: true, level: 1, min_size: 1024 }
+        CompressionSettings {
+            enabled: true,
+            level: 1,
+            min_size: 1024,
+            streaming: StreamingCompression::Off,
+        }
     }
 
     /// Test helper: call resolve_fallback with the router's own defaults.
@@ -2422,7 +2530,12 @@ mod tests {
 
     #[test]
     fn test_gzip_compress_custom_min_size() {
-        let settings = CompressionSettings { enabled: true, level: 1, min_size: 4096 };
+        let settings = CompressionSettings {
+            enabled: true,
+            level: 1,
+            min_size: 4096,
+            streaming: StreamingCompression::Off,
+        };
         let data = "a".repeat(2048);
         // 2048 bytes < 4096 min_size — should not compress
         assert!(gzip_compress(data.as_bytes(), "text/html", settings).is_none());
@@ -3502,5 +3615,170 @@ echo "post response";
         // Should fall back to default now.
         let (doc_root, _, _) = router.resolve_site("temp-site.com");
         assert_eq!(doc_root, dir.path());
+    }
+    // ── streaming compression (worker send_response_stream) ────────
+
+    fn compression_with(streaming: StreamingCompression) -> CompressionSettings {
+        CompressionSettings { enabled: true, level: 1, min_size: 1024, streaming }
+    }
+
+    fn sse_headers() -> Vec<(String, String)> {
+        vec![
+            ("Content-Type".to_string(), "text/event-stream".to_string()),
+            ("Cache-Control".to_string(), "no-store".to_string()),
+        ]
+    }
+
+    #[test]
+    fn streaming_compression_parse() {
+        assert_eq!(StreamingCompression::parse("off"), Some(StreamingCompression::Off));
+        assert_eq!(StreamingCompression::parse("sse"), Some(StreamingCompression::Sse));
+        assert_eq!(StreamingCompression::parse("all"), Some(StreamingCompression::All));
+        assert_eq!(StreamingCompression::parse("SSE"), Some(StreamingCompression::Sse));
+        assert_eq!(StreamingCompression::parse("gzip"), None, "unknown must not parse");
+        assert_eq!(StreamingCompression::parse(""), None);
+    }
+
+    #[test]
+    fn streamed_brotli_predicate() {
+        let sse = sse_headers();
+        let html = vec![("Content-Type".to_string(), "text/html".to_string())];
+        let encoded = vec![
+            ("Content-Type".to_string(), "text/event-stream".to_string()),
+            ("Content-Encoding".to_string(), "gzip".to_string()),
+        ];
+
+        // Off: never, regardless of everything else.
+        assert!(!streamed_response_wants_brotli(&sse, true, StreamingCompression::Off));
+        // No client brotli support: never.
+        assert!(!streamed_response_wants_brotli(&sse, false, StreamingCompression::Sse));
+        assert!(!streamed_response_wants_brotli(&sse, false, StreamingCompression::All));
+        // Sse: only text/event-stream.
+        assert!(streamed_response_wants_brotli(&sse, true, StreamingCompression::Sse));
+        assert!(!streamed_response_wants_brotli(&html, true, StreamingCompression::Sse));
+        // All: any content type.
+        assert!(streamed_response_wants_brotli(&html, true, StreamingCompression::All));
+        // Never double-encode a body PHP already encoded.
+        assert!(!streamed_response_wants_brotli(&encoded, true, StreamingCompression::Sse));
+        assert!(!streamed_response_wants_brotli(&encoded, true, StreamingCompression::All));
+        // Charset suffix on the content type still matches.
+        let sse_charset =
+            vec![("content-type".to_string(), "text/event-stream; charset=utf-8".to_string())];
+        assert!(streamed_response_wants_brotli(&sse_charset, true, StreamingCompression::Sse));
+    }
+
+    /// The zero-behavior-change contract: with the default `Off` the
+    /// response has no compression headers and the body bytes pass
+    /// through untouched, even for a brotli-capable client.
+    #[tokio::test]
+    async fn streamed_response_off_is_identity() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let resp = build_streamed_worker_response(
+            200,
+            sse_headers(),
+            rx,
+            true,
+            compression_with(StreamingCompression::Off),
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().get("content-encoding").is_none(), "Off must not set an encoding");
+
+        tx.send(Bytes::from_static(
+            b"data: one
+
+",
+        ))
+        .await
+        .unwrap();
+        tx.send(Bytes::from_static(
+            b"data: two
+
+",
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            &body[..],
+            b"data: one
+
+data: two
+
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_response_sse_compresses_and_round_trips() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let resp = build_streamed_worker_response(
+            200,
+            sse_headers(),
+            rx,
+            true,
+            compression_with(StreamingCompression::Sse),
+        );
+        assert_eq!(
+            resp.headers().get("content-encoding").and_then(|v| v.to_str().ok()),
+            Some("br")
+        );
+        assert_eq!(
+            resp.headers().get("vary").and_then(|v| v.to_str().ok()),
+            Some("Accept-Encoding")
+        );
+        // PHP-supplied headers survive.
+        assert_eq!(
+            resp.headers().get("cache-control").and_then(|v| v.to_str().ok()),
+            Some("no-store")
+        );
+
+        tx.send(Bytes::from_static(
+            b"data: one
+
+",
+        ))
+        .await
+        .unwrap();
+        tx.send(Bytes::from_static(
+            b"data: two
+
+",
+        ))
+        .await
+        .unwrap();
+        drop(tx);
+        let wire = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(!wire.is_empty());
+
+        let mut plain = Vec::new();
+        let mut dec = brotli::Decompressor::new(&wire[..], 4096);
+        std::io::Read::read_to_end(&mut dec, &mut plain).expect("valid brotli stream");
+        assert_eq!(
+            &plain[..],
+            b"data: one
+
+data: two
+
+"
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_response_sse_mode_leaves_non_sse_alone() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let headers = vec![("Content-Type".to_string(), "application/octet-stream".to_string())];
+        let resp = build_streamed_worker_response(
+            200,
+            headers,
+            rx,
+            true,
+            compression_with(StreamingCompression::Sse),
+        );
+        assert!(resp.headers().get("content-encoding").is_none());
+        tx.send(Bytes::from_static(b" raw")).await.unwrap();
+        drop(tx);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b" raw");
     }
 }

--- a/crates/ephpm-server/src/static_files.rs
+++ b/crates/ephpm-server/src/static_files.rs
@@ -341,7 +341,12 @@ mod tests {
 
     /// Default compression settings (disabled) for tests.
     fn no_compression() -> crate::router::CompressionSettings {
-        crate::router::CompressionSettings { enabled: false, level: 6, min_size: 1024 }
+        crate::router::CompressionSettings {
+            enabled: false,
+            level: 6,
+            min_size: 1024,
+            streaming: crate::router::StreamingCompression::Off,
+        }
     }
 
     /// Collect a response body into a `Vec<u8>`.

--- a/crates/ephpm-server/src/stream_compress.rs
+++ b/crates/ephpm-server/src/stream_compress.rs
@@ -1,0 +1,257 @@
+//! Streaming brotli compression for worker-mode streamed responses.
+//!
+//! Wraps the `body_rx` channel of a streamed worker response
+//! (`send_response_stream`) in a brotli encoder task: each chunk PHP
+//! produces is fed through one long-lived encoder and flushed
+//! (`BROTLI_OPERATION_FLUSH`, via [`brotli::CompressorWriter::flush`]) so
+//! the compressed bytes emitted so far always decode to exactly the
+//! plaintext chunks so far. The client can therefore decode every SSE
+//! event the moment its frame arrives — no buffering until stream end —
+//! while the encoder *window* persists across the whole stream.
+//!
+//! That persistent window is the point: Datastar-style SSE re-renders
+//! send near-identical markup over and over, so after the first render
+//! each subsequent event compresses against the previous ones and
+//! shrinks to a small delta on the wire.
+//!
+//! # Zero cost when off
+//!
+//! This module is only entered when `[server.response]
+//! compression_streaming` matches the response (see
+//! `Router`/`build_streamed_worker_response`). With the default `"off"`,
+//! no encoder, task, or channel is created — the response body is the
+//! original channel, identical to previous releases.
+//!
+//! # Quality / window choice (fixed, not knobs)
+//!
+//! Quality **5**, `lgwin` **22** (4 MiB window):
+//! - Flushing per event forfeits most of what higher qualities buy
+//!   (they win by buffering more input before emitting), while their CPU
+//!   cost per flush grows steeply. q5 keeps per-event encode cost in the
+//!   microseconds for KB-scale events.
+//! - The 4 MiB window is what makes event N compress against events
+//!   N-1, N-2, … for any realistic SSE session; it matches the lgwin the
+//!   buffered brotli path already uses (`router::brotli_compress`).
+//!
+//! The buffered-path `compression_level` knob is deliberately not reused
+//! here: it defaults to 1 (tuned for one-shot whole-body gzip), which
+//! would gut the cross-event ratio that motivates this feature.
+
+use std::io::Write;
+
+use hyper::body::Bytes;
+use tokio::sync::mpsc;
+
+/// Brotli quality for streamed responses. See module docs for rationale.
+const STREAM_QUALITY: u32 = 5;
+/// Brotli window (log2) for streamed responses: 4 MiB shared across the
+/// stream's lifetime.
+const STREAM_LGWIN: u32 = 22;
+/// Encoder scratch buffer size (same as the buffered path).
+const ENCODER_BUF: usize = 4096;
+
+/// Wrap a streamed-response body channel in a brotli encoder task.
+///
+/// Returns a new receiver carrying the compressed frames. One brotli
+/// flush is issued per input chunk, so chunk boundaries (one chunk = one
+/// SSE event from PHP's `send_response_stream` pump) remain
+/// independently decodable.
+///
+/// Lifecycle mirrors the uncompressed path:
+/// - upstream close (PHP finished) → encoder is finished and the final
+///   frame + close propagate downstream;
+/// - downstream close (client gone) → the task drops the upstream
+///   receiver, which is what stops the PHP `response_chunk` pump.
+#[must_use]
+pub fn brotli_stream_body(mut body_rx: mpsc::Receiver<Bytes>) -> mpsc::Receiver<Bytes> {
+    // Same depth as the worker body channel: keeps the end-to-end
+    // backpressure behavior (PHP → encoder → hyper) equivalent to the
+    // uncompressed PHP → hyper pipeline.
+    let (tx, compressed_rx) = mpsc::channel::<Bytes>(ephpm_php::worker_bridge::BODY_CHANNEL_DEPTH);
+
+    tokio::spawn(async move {
+        let mut encoder =
+            brotli::CompressorWriter::new(Vec::new(), ENCODER_BUF, STREAM_QUALITY, STREAM_LGWIN);
+
+        while let Some(chunk) = body_rx.recv().await {
+            // Writing to a Vec sink cannot fail; treat an encoder error as
+            // a fatal stream abort (client sees a truncated brotli stream
+            // and the chunked body ends — same failure surface as an
+            // aborted uncompressed stream).
+            if encoder.write_all(&chunk).is_err() || encoder.flush().is_err() {
+                tracing::warn!("streaming brotli encoder failed — aborting stream");
+                return;
+            }
+            // After a flush every compressed byte for the input so far is
+            // in the sink; steal it and forward one frame per input chunk.
+            let frame = std::mem::take(encoder.get_mut());
+            if !frame.is_empty() && tx.send(Bytes::from(frame)).await.is_err() {
+                // Client disconnected. Dropping `body_rx` (and the encoder)
+                // closes the worker's channel, stopping the PHP pump.
+                return;
+            }
+        }
+
+        // Upstream finished cleanly — emit the brotli end-of-stream frame.
+        let tail = encoder.into_inner();
+        if !tail.is_empty() {
+            let _ = tx.send(Bytes::from(tail)).await;
+        }
+    });
+
+    compressed_rx
+}
+
+#[cfg(test)]
+mod tests {
+    use brotli::enc::StandardAlloc;
+    use brotli::{BrotliDecompressStream, BrotliResult, BrotliState};
+
+    use super::*;
+
+    /// Decode `input` (a prefix of a brotli stream) with a streaming
+    /// decoder, returning everything decodable from it. Panics on corrupt
+    /// input; `NeedsMoreInput` (an unfinished stream) is fine — that is
+    /// exactly the mid-stream situation a flushed prefix represents.
+    fn decode_prefix(input: &[u8]) -> Vec<u8> {
+        let mut state = BrotliState::new(
+            StandardAlloc::default(),
+            StandardAlloc::default(),
+            StandardAlloc::default(),
+        );
+        let mut output = Vec::new();
+        let mut buf = vec![0u8; 16 * 1024];
+        let mut available_in = input.len();
+        let mut input_offset = 0;
+        loop {
+            let mut available_out = buf.len();
+            let mut output_offset = 0;
+            let mut written = 0;
+            let res = BrotliDecompressStream(
+                &mut available_in,
+                &mut input_offset,
+                input,
+                &mut available_out,
+                &mut output_offset,
+                &mut buf,
+                &mut written,
+                &mut state,
+            );
+            output.extend_from_slice(&buf[..output_offset]);
+            match res {
+                BrotliResult::ResultSuccess | BrotliResult::NeedsMoreInput => {
+                    if available_in == 0 && output_offset == 0 {
+                        return output;
+                    }
+                }
+                BrotliResult::NeedsMoreOutput => {}
+                BrotliResult::ResultFailure => panic!("corrupt brotli prefix"),
+            }
+        }
+    }
+
+    /// Each event must be decodable as soon as its compressed frame
+    /// arrives — the per-chunk-flush guarantee this module exists for.
+    #[tokio::test]
+    async fn chunks_decode_incrementally() {
+        let (tx, rx) = mpsc::channel::<Bytes>(8);
+        let mut out = brotli_stream_body(rx);
+
+        let events = [
+            "event: patch\ndata: elements <div id=\"grid\">aaaa</div>\n\n",
+            "event: patch\ndata: elements <div id=\"grid\">aaab</div>\n\n",
+            ": keepalive\n\n",
+            "event: patch\ndata: elements <div id=\"grid\">aaac</div>\n\n",
+        ];
+
+        let mut wire = Vec::new();
+        let mut plain = Vec::new();
+        for event in events {
+            tx.send(Bytes::from_static(event.as_bytes())).await.unwrap();
+            let frame = out.recv().await.expect("one compressed frame per event");
+            wire.extend_from_slice(&frame);
+            plain.extend_from_slice(event.as_bytes());
+            // The wire bytes so far — an UNFINISHED brotli stream — must
+            // already decode to the full plaintext so far.
+            assert_eq!(
+                decode_prefix(&wire),
+                plain,
+                "event not decodable at its own frame boundary"
+            );
+        }
+
+        // Clean end of stream: sender drop finishes the encoder.
+        drop(tx);
+        while let Some(frame) = out.recv().await {
+            wire.extend_from_slice(&frame);
+        }
+        assert_eq!(decode_prefix(&wire), plain, "final stream must round-trip");
+    }
+
+    /// The persistent window is the headline: repeated similar events
+    /// must compress far better than the first one.
+    #[tokio::test]
+    async fn window_persists_across_events() {
+        let (tx, rx) = mpsc::channel::<Bytes>(8);
+        let mut out = brotli_stream_body(rx);
+
+        // A pixelboard-style ~5 KB re-render with one cell changed per event.
+        let render = |n: usize| {
+            use std::fmt::Write as _;
+            let mut cells = String::from("event: patch\ndata: elements <div id=\"grid\">");
+            for i in 0..144 {
+                let color = if i == n { "#22c55e" } else { "#27272a" };
+                let _ =
+                    write!(cells, "<button id=\"c-{i}\" style=\"background:{color}\"></button>");
+            }
+            cells.push_str("</div>\n\n");
+            cells
+        };
+
+        tx.send(Bytes::from(render(0))).await.unwrap();
+        let first = out.recv().await.unwrap().len();
+
+        let mut later = Vec::new();
+        for n in 1..20 {
+            tx.send(Bytes::from(render(n))).await.unwrap();
+            later.push(out.recv().await.unwrap().len());
+        }
+        let avg_later = later.iter().sum::<usize>() / later.len();
+
+        assert!(
+            avg_later * 5 < first,
+            "window sharing should shrink repeat events ≥5x: first={first}B, avg_later={avg_later}B"
+        );
+    }
+
+    /// Client disconnect (downstream receiver dropped) must close the
+    /// upstream channel so the PHP pump stops.
+    #[tokio::test]
+    async fn downstream_drop_closes_upstream() {
+        let (tx, rx) = mpsc::channel::<Bytes>(8);
+        let out = brotli_stream_body(rx);
+        drop(out);
+
+        // The encoder task exits after its next recv/send cycle; the
+        // sender then observes a closed channel.
+        tx.send(Bytes::from_static(b"data: x\n\n")).await.ok();
+        tokio::time::timeout(std::time::Duration::from_secs(5), tx.closed())
+            .await
+            .expect("upstream must close after downstream drop");
+    }
+
+    /// Empty input stream: no frames, clean close (brotli's empty-stream
+    /// terminator is still emitted so the client sees valid brotli).
+    #[tokio::test]
+    async fn empty_stream_closes_cleanly() {
+        let (tx, rx) = mpsc::channel::<Bytes>(8);
+        let mut out = brotli_stream_body(rx);
+        drop(tx);
+
+        let mut wire = Vec::new();
+        while let Some(frame) = out.recv().await {
+            wire.extend_from_slice(&frame);
+        }
+        assert_eq!(decode_prefix(&wire), b"", "empty stream must decode to empty");
+    }
+}

--- a/ephpm.toml
+++ b/ephpm.toml
@@ -25,6 +25,7 @@ index_files = ["index.php", "index.html"]
 # compression = true       # gzip for text responses
 # compression_level = 1    # 1 = fast, 9 = best ratio
 # compression_min_size = 1024  # minimum bytes to compress
+# compression_streaming = "off"  # worker streamed responses: "off" | "sse" (brotli SSE w/ per-event flush) | "all"
 # headers = []             # custom response headers applied to all responses
 #                          # e.g. [["X-Frame-Options", "DENY"], ["Strict-Transport-Security", "max-age=63072000"]]
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -42,6 +42,7 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 | `compression` | bool | `true` | Enable compression for text responses — brotli when the client accepts it, gzip fallback. |
 | `compression_level` | u32 | `1` | Compression level (1=fastest, 9=best). |
 | `compression_min_size` | usize (bytes) | `1024` | Minimum response size before compression applies. |
+| `compression_streaming` | string | `"off"` | Streamed worker-response (`send_response_stream`) compression: `"off"` (identity, byte-for-byte the previous behavior), `"sse"` (brotli with a per-event flush and a stream-lifetime window for `text/event-stream` responses), `"all"` (every streamed response). Needs `compression = true` and a client `Accept-Encoding: br`; unknown values warn at startup and act as `"off"`. Buffered responses are unaffected. |
 | `headers` | array of `[string, string]` | `[]` | Custom headers added to every response. |
 
 ### `[server.static]`

--- a/site/content/roadmap/_index.md
+++ b/site/content/roadmap/_index.md
@@ -12,6 +12,7 @@ These pages describe targets, not currently-shipped behavior. For what works tod
 - **[Worker Dispatch Fast Path](worker-dispatch-fastpath/)** — closing the measured gap to in-process runtimes: lazy Envelope, handoff economics, quota-aware defaults.
 - **[Turso Engine](turso-engine/)** — one engine for both modes: the Rust SQLite rewrite replacing rusqlite and the sqld sidecar, gated on upstream GA.
 - **[Clustered KV v2](clustered-kv-v2/)** — owner-routed counters and cluster-correct rate limiting (delete tombstones and TTL replication shipped as v1.1).
+- **[SSE & Realtime](sse-realtime/)** — `ephpm_kv_wait()` and streaming brotli **shipped**; the render-once/fan-out SSE hub that decouples viewer count from `worker_count` is the v0.6.0 target.
 - **[Benchmarks as a Release Artifact](benchmarks/)** — in-tree bench recipes, per-release numbers, and a regression gate.
 - **[NTS Prefork Mode](nts-prefork/)** — trading features for pure per-request PHP speed, gated on a post-PGO measurement.
 - **[The Deploy Story](deploy-warmup/)** — post-invalidation warmup, `ephpm doctor <framework>`, `cache status`, thin deploy hooks.

--- a/site/content/roadmap/sse-realtime.md
+++ b/site/content/roadmap/sse-realtime.md
@@ -2,8 +2,8 @@
 
 > **Status:** the two enabling primitives — `ephpm_kv_wait()` and
 > streaming brotli compression — **shipped** (PRs
-> [#183](https://github.com/ephpm/ephpm/pull/183) and
-> [#184](https://github.com/ephpm/ephpm/pull/184)). The SSE hub
+> [#184](https://github.com/ephpm/ephpm/pull/184) and
+> [#185](https://github.com/ephpm/ephpm/pull/185)). The SSE hub
 > described in the second half is **Planned — not yet implemented**,
 > targeted at v0.6.0.
 

--- a/site/content/roadmap/sse-realtime.md
+++ b/site/content/roadmap/sse-realtime.md
@@ -1,0 +1,87 @@
+# SSE & Realtime — Hypermedia Push on ePHPm
+
+> **Status:** the two enabling primitives — `ephpm_kv_wait()` and
+> streaming brotli compression — **shipped** (PRs
+> [#183](https://github.com/ephpm/ephpm/pull/183) and
+> [#184](https://github.com/ephpm/ephpm/pull/184)). The SSE hub
+> described in the second half is **Planned — not yet implemented**,
+> targeted at v0.6.0.
+
+## Why realtime is suddenly ePHPm-shaped
+
+Hypermedia frameworks built on Server-Sent Events —
+[Datastar](https://data-star.dev), htmx SSE, Turbo Streams — turn the
+backend into a render-and-push loop: state changes, the server
+re-renders a fragment, every connected browser morphs it into the DOM.
+That workload is awkward on classic PHP-FPM (no long-lived connections,
+no shared state, an external Redis for pub/sub, a proxy that buffers)
+and almost native on ePHPm: worker mode already carries long-lived
+streamed responses (`send_response_stream`), and the in-process KV
+store already gives every worker thread the same state at ~100 ns per
+op. The Pixelboard demo
+([ephpm/datastar-demo](https://github.com/ephpm/datastar-demo)) proved
+a real multiplayer Datastar app runs on a stock v0.5.0 binary with no
+server changes at all.
+
+Two gaps kept it from being *great*. Both are now closed:
+
+## Shipped: `ephpm_kv_wait()` — push, not poll
+
+Before: the only fan-out pattern was version polling — every SSE
+connection's worker polled a KV version key every ~100 ms
+(latency floor = poll interval, idle CPU ∝ connected clients).
+
+Now: `ephpm_kv_wait(string $key, int $last_version, int $timeout_ms)`
+blocks the worker until the key is written (sub-millisecond wakeup) or
+the timeout fires (keepalive tick). Idle cost is zero for the waiting
+connections *and* zero for KV writers that nobody is waiting on — the
+write path pays a single atomic load until the first wait in the
+process. See the [KV guide](/guides/kv-from-php/) for semantics and the
+SSE loop idiom.
+
+## Shipped: streaming brotli for SSE
+
+Before: streamed worker responses always went out identity-encoded, so
+a Datastar "fat re-render" paid its full size on the wire every event.
+
+Now: `[server.response] compression_streaming = "sse"` wraps
+`text/event-stream` responses in a single brotli encoder whose window
+persists for the stream's lifetime, flushed per event so every event
+decodes the moment it arrives. Because successive re-renders of the
+same elements are nearly identical, event N compresses against events
+N−1, N−2, … and collapses to a small delta — the demo's ~5 KB grid
+re-render drops to tens of bytes after the first event. Default is
+`"off"`, which keeps the streamed path byte-for-byte identical to
+v0.5.0. See the [configuration reference](/reference/config/).
+
+## Planned — not yet implemented: the SSE hub (v0.6.0 target)
+
+The remaining constraint is structural: **one SSE connection parks one
+worker thread** for its whole lifetime, so `[php] worker_count` caps
+concurrent viewers, and short action requests compete with streams for
+the same pool. Fine for tens-to-hundreds of clients; wrong shape for
+thousands of dashboard viewers who all see the *same* rendered
+fragments.
+
+A PHP execution context is thread-bound, so "detaching" a stream from
+its worker is off the table. The design that fits ePHPm's architecture
+is a **server-side SSE hub**:
+
+- **Rust owns the connections.** A new SAPI surface (sketch:
+  `ephpm_sse_publish(topic, event)` plus a router-level topic-subscribe
+  endpoint) lets hyper hold the N client connections directly — no
+  worker parked per viewer.
+- **Render once, fan out.** On a KV change (via the same watch
+  machinery behind `ephpm_kv_wait`), the hub asks *one* worker to
+  render the fragment once, then broadcasts the resulting bytes to all
+  N subscribers — through the per-connection streaming brotli encoders
+  shipped above.
+- **Viewers decouple from `worker_count`.** Worker threads go back to
+  being a render pool; connection count becomes a hyper/file-descriptor
+  problem, which Rust is good at.
+
+Open design questions (why this is a page and not a PR): topic
+registry lifecycle and auth, per-subscriber backpressure policy (drop
+vs. coalesce vs. disconnect slow readers), event replay/last-event-id
+semantics, and how per-vhost isolation maps onto topics in
+multi-tenant mode. Nothing below this heading exists in the code today.

--- a/site/content/roadmap/sse-realtime.md
+++ b/site/content/roadmap/sse-realtime.md
@@ -49,8 +49,9 @@ Now: `[server.response] compression_streaming = "sse"` wraps
 persists for the stream's lifetime, flushed per event so every event
 decodes the moment it arrives. Because successive re-renders of the
 same elements are nearly identical, event N compresses against events
-N−1, N−2, … and collapses to a small delta — the demo's ~5 KB grid
-re-render drops to tens of bytes after the first event. Default is
+N−1, N−2, … and collapses to a small delta — measured on the demo: a
+60 s session of ~15.6 KB re-renders averaged ~37 bytes per event on the
+wire (~420× fewer bytes; numbers in PR #185). Default is
 `"off"`, which keeps the streamed path byte-for-byte identical to
 v0.5.0. See the [configuration reference](/reference/config/).
 


### PR DESCRIPTION
## Summary

Streaming brotli compression for worker-mode streamed responses (`send_response_stream`) — the missing half of the Datastar/SSE story (see `ephpm/datastar-demo` spec §3 and #184 for the other half):

```toml
[server.response]
compression_streaming = "off"   # default | "sse" | "all"
```

- **`"off"` (default): byte-for-byte the v0.5.0 code path.** `build_streamed_worker_response` hands the original `body_rx` channel to hyper exactly as before — no encoder, no task, no extra channel, no header changes. Proven by the off-mode identity test and the A/B bench below.
- **`"sse"`**: `text/event-stream` streamed responses get ONE brotli encoder task between `body_rx` and hyper. Each chunk (= one SSE event from the PHP pump) is flushed with `BROTLI_OPERATION_FLUSH`, so every event decodes the instant its frame arrives — while the encoder **window persists across the stream**, which is the entire point: successive fat re-renders compress against each other and collapse to tiny deltas.
- **`"all"`**: every streamed worker response (documented as usually wasteful for binaries; `"sse"` is the recommended setting).

Guards (all tested): master `compression = true` and client `Accept-Encoding: br` required — otherwise the wrapper is skipped entirely; never double-encodes a body PHP already set a `Content-Encoding` for; adds `Content-Encoding: br` + `Vary: Accept-Encoding` only when wrapping; unknown knob values `tracing::warn!` at startup and behave as `"off"` (no silent typo no-op, per the add-config-knob rules). Buffered responses keep the existing whole-body path untouched.

Quality is fixed at **q5 / lgwin 22** (module docs in `stream_compress.rs` carry the full rationale): per-event flushing forfeits most of what higher qualities buy while their per-flush CPU grows steeply, and the 4 MiB window — same lgwin as the buffered brotli path — is what makes event N compress against events N−1, N−2, …. The buffered `compression_level` knob (default 1, tuned for one-shot gzip) is deliberately not reused.

Lifecycle mirrors the uncompressed path: upstream close → encoder FINISH frame + downstream close; client disconnect → encoder task drops `body_rx`, which is what stops the PHP `response_chunk` pump.

## The headline number

Pixelboard demo (`ephpm/datastar-demo`), release build (PHP 8.4), 60 s session: 120 paints, each triggering a fat ~15.6 KB signals+grid re-render to an open SSE stream:

| | wire bytes | per event |
|---|---|---|
| identity (`off`, today's behavior) | 1,889,173 (121 events) | ~15.6 KB |
| `compression_streaming = "sse"` | **4,504** (122 events) | **~37 B** |

**~420× fewer wire bytes**, and the captured brotli stream decodes back to all 1.9 MB / 122 events. Live checks: `curl -N --compressed` showed each painted-cell event decoded mid-stream; a client without `Accept-Encoding: br` got an identity stream with no `content-encoding` header from the same server.

## No-latency proof (off-path A/B)

`main` release binary vs this branch's release binary with the knob at its default `"off"`. Same box (WSL2 glibc, 24 cores), oha, 5 s warmup + 2×15 s runs, best shown, **100% 2xx in every cell**:

| workload | main | this PR (off) |
|---|---|---|
| hello.php (fpm) c=1 | 3,102 rps, p50 0.282 ms | 3,067 rps, p50 0.289 ms |
| hello.php (fpm) c=16 | 38,675 rps, p99 0.764 ms | 39,392 rps, p99 0.744 ms |
| worker-hello c=1 | 3,026 rps, p50 0.295 ms | 2,980 rps, p50 0.295 ms |
| worker-hello c=16 | 30,775 rps, p50 0.398 ms, p99 1.724 ms | 30,764 rps, p50 0.398 ms, p99 1.727 ms |

The saturation worker cell — the one this PR's code path sits on — differs by 0.04% with matching p50/p99; the other cells straddle zero within run-to-run variance. Per the benchmarking methodology, absolute ceilings are rig-specific; the deltas are what matters.

## Tests

- `stream_compress.rs`: per-event incremental decodability proven with a streaming brotli decoder against *unfinished-stream prefixes* after each frame; ≥5× shrink of repeated re-renders (window persistence); downstream-drop closes upstream (PHP pump stops); clean empty-stream termination.
- `router.rs`: wrapper predicate matrix (off/sse/all × accepts_br × content-type incl. charset suffix × pre-encoded), off-mode identity (no headers added, bytes pass through), sse-mode round-trip with header assertions, non-SSE passthrough. `StreamingCompression::parse` rejects unknowns.
- `ephpm-config`: default `"off"`, TOML, and `EPHPM_SERVER__RESPONSE__COMPRESSION_STREAMING` env override.

## Docs

- `site/content/reference/config.md` — `[server.response]` row.
- `ephpm.toml` — commented example.
- **New roadmap page** `site/content/roadmap/sse-realtime.md` (+ index entry): what shipped (this PR + #184) and the render-once/fan-out SSE hub design sketch, explicitly marked "Planned — not yet implemented", targeted v0.6.0.
