### PR TITLE
fix(php): flush ob buffers + shutdown functions before fpm response capture

### DIFF
--- a/crates/ephpm-e2e/tests/basic.rs
+++ b/crates/ephpm-e2e/tests/basic.rs
@@ -76,3 +76,31 @@ async fn static_file_serving() {
         "expected static HTML content, got:\n{body}"
     );
 }
+
+#[tokio::test]
+async fn ob_buffer_and_shutdown_output_are_captured() {
+    // Regression: fpm-mode capture ran before PHP flushed open ob_ buffers
+    // or ran shutdown functions, so `ob_start(); echo ...` returned an
+    // empty body and WordPress 7.0 rendered every page as 0 bytes.
+    let base_url = required_env("EPHPM_URL");
+
+    let url = format!("{base_url}/ob_shutdown.php");
+    let resp = reqwest::get(&url)
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body = resp.text().await.expect("failed to read response body");
+    assert!(
+        body.contains("OB_BODY_"),
+        "unclosed ob_start() content missing from body: {body:?}"
+    );
+    assert!(
+        body.contains("SHUTDOWN_RAN"),
+        "register_shutdown_function output missing from body: {body:?}"
+    );
+    assert!(
+        body.contains("OB_BODY_SHUTDOWN_RAN"),
+        "shutdown output must come after buffered body: {body:?}"
+    );
+}

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -943,6 +943,39 @@ int ephpm_execute_request(const char *filename)
     }
     EG(bailout) = __orig_bailout;
 
+    /* Run user shutdown functions and flush every open output buffer
+     * BEFORE capturing the response. Request teardown is lazy (top of the
+     * NEXT ephpm_execute_request), so without this, content still sitting
+     * in userland ob_ buffers at script end — and anything printed by
+     * register_shutdown_function() — never reached the ub_write capture:
+     * `ob_start(); echo "hello";` returned content-length: 0, and
+     * WordPress 7.0 (which finalizes its template-enhancement buffer on
+     * the `shutdown` action) rendered EVERY page as 0 bytes. Mirrors the
+     * worker-mode unwind-exit flush (see the php_output_end_all block in
+     * the worker loop).
+     *
+     * Shutdown functions run even after exit()/fatals — that is php-fpm
+     * behavior and WordPress' fatal handler depends on it. Both calls run
+     * under a bailout guard (shutdown functions and ob handlers execute
+     * userland code that can exit()/fatal); a bailout forfeits whatever
+     * remained, and we deliver what the capture has — same policy as
+     * worker mode.
+     *
+     * php_free_shutdown_functions() empties the list afterwards so the
+     * lazy php_request_shutdown() at the top of the next request cannot
+     * run the same shutdown functions a second time. */
+    zend_try {
+        php_call_shutdown_functions();
+    } zend_catch {
+        /* exit()/fatal inside a shutdown function — deliver what we have. */
+    } zend_end_try();
+    php_free_shutdown_functions();
+    zend_try {
+        php_output_end_all();
+    } zend_catch {
+        /* A throwing ob handler forfeits its buffer. */
+    } zend_end_try();
+
     /* Capture response data while the request is still active */
     capture_response_headers();
     response_status_code = SG(sapi_headers).http_response_code;

--- a/tests/docroot/ob_shutdown.php
+++ b/tests/docroot/ob_shutdown.php
@@ -1,0 +1,14 @@
+<?php
+// Regression fixture for the fpm shutdown-buffer bug: content in an
+// unclosed ob_start() buffer, plus output printed from a shutdown
+// function, must BOTH appear in the response. Before the fix this
+// returned content-length: 0 (the capture ran before PHP flushed
+// buffers / ran shutdown functions), which made WordPress 7.0 render
+// every page blank under fpm mode.
+ob_start();
+register_shutdown_function(static function (): void {
+    echo 'SHUTDOWN_RAN';
+});
+echo 'OB_BODY_';
+// Deliberately no ob_end_flush() — WP 7.0's template-enhancement
+// buffer relies on end-of-request finalization exactly like this.


### PR DESCRIPTION
Fixes the fpm 0-byte response bug: content in unclosed ob_start() buffers and register_shutdown_function() output never reached the capture (request teardown is lazy). WordPress 7.0 rendered EVERY page blank under fpm mode because its template-enhancement buffer finalizes on the shutdown action.

Evidence: tests/docroot/ob_shutdown.php returns len=0 on the published v0.5.0 image, OB_BODY_SHUTDOWN_RAN (len=20) on this build. exit/fatal/empty fixtures byte-identical. Mirrors worker mode's proven unwind-exit flush; ordering (shutdown fns while buffers open, even after exit/fatals) matches php-fpm.

Found by ephpm/wordpress-datastar (which carries a mu-plugin workaround to delete once this ships). Rides v0.5.1 with #184/#185.