### PR TITLE
docs(cli): phantom phar-tool claims in reference/cli/php.md

### DIFF
--- a/site/content/reference/cli/php.md
+++ b/site/content/reference/cli/php.md
@@ -24,16 +24,25 @@ ephpm php script.php
 ephpm php artisan migrate
 ephpm php artisan tinker
 
-# WordPress (WP-CLI)
-ephpm php wp-cli.phar plugin list
-ephpm php wp-cli.phar user list
-
-# Composer (also a phar)
-ephpm php composer.phar install
-
 # Print loaded modules
 ephpm php -m
 ```
+
+## Phar support and the SAPI caveat
+
+The `phar` extension is compiled in, and `.phar` archives load and execute:
+`ephpm php app.phar` runs the archive's stub, and `phar://` streams work.
+
+However, `ephpm php` reports `PHP_SAPI` as `ephpm`, not `cli` — and some
+popular phar tools refuse to run on any SAPI other than `cli`:
+
+- **WP-CLI** (`wp-cli.phar`) exits immediately: *"WP-CLI only works correctly
+  from the command line, using the 'cli' PHP SAPI."*
+- **Composer** (`composer.phar`) aborts: *"Composer cannot be run safely on
+  non-CLI SAPIs with register_argc_argv=On."*
+
+For those tools, use a stock `php` CLI binary. Phars that don't gate on
+`PHP_SAPI` run fine under `ephpm php`.
 
 ## Why use `ephpm php`?
 
@@ -46,7 +55,7 @@ The embedded PHP interpreter is the **same** runtime that serves HTTP requests. 
 
 ## How it works
 
-`ephpm php` runs the embedded PHP runtime (the `ephpm` SAPI) in CLI mode via FFI. It's not a wrapper around an external `php` binary. The argument list is forwarded as-is, including `-r`, `-d`, file paths, and trailing application arguments — script arguments are registered as `$argv`/`$argc` (and mirrored into `$_SERVER`, with `PHP_SELF`/`SCRIPT_NAME`/`SCRIPT_FILENAME` set to the script path) exactly as the stock `php` CLI does, so Symfony Console, artisan, and WP-CLI see their arguments. Shebang lines (`#!/usr/bin/env php`) are skipped.
+`ephpm php` runs the embedded PHP runtime (the `ephpm` SAPI) in CLI mode via FFI. It's not a wrapper around an external `php` binary. The argument list is forwarded as-is, including `-r`, `-d`, file paths, and trailing application arguments — script arguments are registered as `$argv`/`$argc` (and mirrored into `$_SERVER`, with `PHP_SELF`/`SCRIPT_NAME`/`SCRIPT_FILENAME` set to the script path) exactly as the stock `php` CLI does, so Symfony Console and artisan see their arguments. Shebang lines (`#!/usr/bin/env php`) are skipped.
 
 ## Windows note
 


### PR DESCRIPTION
## Summary

The `ephpm php` reference page claimed `ephpm php wp-cli.phar plugin list` and `ephpm php composer.phar install` work. They do not.

## What the code actually does

`ephpm php` dispatches to `PhpRuntime::cli_main` (crates/ephpm/src/main.rs `run_php`) -> `ephpm_cli_main` in ephpm_wrapper.c, running scripts under the embedded SAPI whose name is `ephpm` (`ephpm_pre_init` sets it before `php_embed_init`). Phar execution itself is fully supported (phar ext compiled in, stubs execute, `phar://` streams work) -- but WP-CLI hard-exits on any SAPI other than `cli`, and current Composer aborts on non-CLI SAPIs with `register_argc_argv=On`.

## How verified

Ran the published `ephpm-v0.5.0+php8.4.23-windows-x86_64` release binary:

- `extension_loaded('phar')` = yes, `PHP_SAPI` = `ephpm`
- `new Phar('composer.phar')` enumerates 831 files; `phar://` reads work; phar stubs execute
- `ephpm php wp-cli.phar --info` -> "WP-CLI only works correctly from the command line, using the 'cli' PHP SAPI. You're currently executing the WP-CLI binary via the 'ephpm' PHP SAPI."
- `ephpm php composer.phar --version` -> "Composer cannot be run safely on non-CLI SAPIs with register_argc_argv=On. Aborting."

## Change

Removed the two phantom examples; added a "Phar support and the SAPI caveat" section documenting what works (SAPI-agnostic phars) and what refuses (WP-CLI, Composer) with the exact messages; dropped WP-CLI from the argument-registration sentence.