### PR TITLE
ci(release): thin LTO for windows-x86_64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,13 @@ jobs:
 
       - name: Build ephpm.exe
         shell: powershell
+        env:
+          # Thin LTO on Windows: the fat-LTO final link (libphp static lib +
+          # everything, codegen-units=1) OOMs rustc-LLVM on the ephemerd
+          # worker VMs ("rustc-LLVM ERROR: out of memory", v0.5.1 run).
+          # Same trade as linux-aarch64 (#181): ~1% perf delta on a target
+          # with no published benchmark numbers.
+          CARGO_PROFILE_RELEASE_LTO: thin
         run: cargo xtask release ${{ matrix.php_minor }} --target windows --no-sqld
 
       - name: Package archive


### PR DESCRIPTION
## Summary
- Windows release legs now build with `CARGO_PROFILE_RELEASE_LTO: thin` — the fat-LTO final link OOMs rustc-LLVM on the ephemerd worker VMs (`rustc-LLVM ERROR: out of memory`, v0.5.1 run 29677889861, all 3 legs)
- Mirrors the linux-aarch64 precedent (#181); ~1% perf delta on a target with no published benchmark numbers

## Test plan
- [ ] Next `v*` tag: windows legs link within VM memory and produce ephpm.exe