### PR TITLE
ci(release): disable LTO for linux-aarch64 + windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
       - name: Build ephpm
         env:
           # Overrides profile.release.lto from Cargo.toml per-arch (see the
-          # matrix `lto` values — arm64 must use thin to fit in host memory).
+          # matrix `lto` value). linux-x64 keeps fat LTO -- it builds fine on
+          # the x64 hosts. The memory-constrained targets (linux-aarch64,
+          # windows) run in their own jobs below with LTO disabled.
           CARGO_PROFILE_RELEASE_LTO: ${{ matrix.arch.lto }}
         run: cargo xtask release ${{ matrix.php.minor }}
 
@@ -133,13 +135,16 @@ jobs:
 
       - name: Build ephpm
         env:
-          # Thin LTO on arm64: the fat-LTO final link of the ephpm binary
-          # (libphp.a + ICU + everything, codegen-units=1) exceeds the
-          # arm64 build host's memory — rustc gets SIGKILLed by the OOM
-          # killer even running as the only job. Thin LTO cuts link-time
-          # memory to a fraction for a ~1% perf delta on a target where
-          # we publish no benchmark numbers anyway.
-          CARGO_PROFILE_RELEASE_LTO: thin
+          # LTO off on arm64: the fat-LTO final link of the ephpm binary
+          # (libphp.a + ICU + everything, codegen-units=1 from profile.release
+          # per #171) exceeds the arm64 build host's memory -- rustc gets
+          # SIGKILLed by the OOM killer even running as the only job. Thin LTO
+          # (#181) held for a while, but the turso engine (#183, linked by
+          # default) grew the binary past what thin-LTO fits on this host in
+          # the v0.5.1 arc. Disabling LTO cuts link-time memory the most, for
+          # a low single-digit perf delta on a target with no published
+          # benchmark numbers. Revisit thin/fat once the VM memory is raised.
+          CARGO_PROFILE_RELEASE_LTO: "off"
         run: cargo xtask release ${{ matrix.php.minor }}
 
       - name: Package archive
@@ -352,12 +357,16 @@ jobs:
       - name: Build ephpm.exe
         shell: powershell
         env:
-          # Thin LTO on Windows: the fat-LTO final link (libphp static lib +
-          # everything, codegen-units=1) OOMs rustc-LLVM on the ephemerd
-          # worker VMs ("rustc-LLVM ERROR: out of memory", v0.5.1 run).
-          # Same trade as linux-aarch64 (#181): ~1% perf delta on a target
-          # with no published benchmark numbers.
-          CARGO_PROFILE_RELEASE_LTO: thin
+          # LTO off on Windows: the fat-LTO final link (libphp static lib +
+          # everything, codegen-units=1 from profile.release per #171) OOMs
+          # rustc-LLVM on the ephemerd worker VMs ("rustc-LLVM ERROR: out of
+          # memory"). Windows built fine on fat-LTO through v0.5.0; the turso
+          # engine (#183, linked by default) grew the binary enough to OOM in
+          # the v0.5.1 arc, and thin-LTO (#193) was not enough either.
+          # Disabling LTO cuts link-time memory the most, for a low
+          # single-digit perf delta on a target with no published benchmark
+          # numbers. Same trade as linux-aarch64. Revisit once VM memory grows.
+          CARGO_PROFILE_RELEASE_LTO: "off"
         run: cargo xtask release ${{ matrix.php_minor }} --target windows --no-sqld
 
       - name: Package archive


### PR DESCRIPTION
## Summary
Disable LTO (`CARGO_PROFILE_RELEASE_LTO: off`) for the **linux-aarch64** and **windows-x86_64** release legs. `linux-x64` keeps fat LTO. This unblocks the v0.5.1 release, whose aarch64 + Windows legs have OOM-killed mid-link across every attempt (throttle, orphan-timeout, Mac-mini resize).

## Why (root cause, confirmed by git history)
Two changes in the last ~10 days made the final link exceed the memory ceiling on the two constrained build hosts:

1. **#171** (merged Jul 10, first in v0.4.2) flipped `[profile.release]` to `lto = "fat"` + `codegen-units = 1`. Fat LTO holds the whole program's LLVM IR in memory at link and optimizes it as one unit; `codegen-units = 1` removes the parallelism that would otherwise spread that memory. Everything through v0.4.1 used cargo's cheap defaults and built fine.
2. **#183** (merged Jul 14, first in v0.5.1) added the `turso` engine crate, linked by default (`litewire` "turso" feature). That grew the IR the fat-LTO link must hold.

Timeline confirms the tipping point: Windows built fine on fat-LTO through **v0.5.0** (pre-turso) and only started OOMing in **v0.5.1** (post-turso) — which is why the thin-LTO band-aids (#181 arm64, #193 windows) were no longer enough. Both legs die ~20-35 min into the Build step, rustc SIGKILLed, no log upload (OOM signature).

## Change
- `build-linux-arm64` Build step: `CARGO_PROFILE_RELEASE_LTO` thin -> off
- `build-windows` Build step: `CARGO_PROFILE_RELEASE_LTO` thin -> off
- Refreshed the now-stale comment on the `build-linux` (x64) job that still referenced arm64 using thin.

Disabling LTO cuts peak link memory the most, for a low single-digit perf delta on targets with no published benchmark numbers. This is the reliable unblock; restoring thin/fat is a follow-up once the arm64 VM + Windows worker memory is raised.

## After merge
Move the `v0.5.1` tag to the new `main` head (the draft release has 0 assets / never published, so moving the tag is safe), which re-runs the matrix. The green macOS + linux-x64 + Docker legs rebuild too, but should stay green.

## Test plan
- [ ] CI (fmt/clippy/test) green on this PR
- [ ] After merge + tag move: linux-aarch64 x3 and windows-x86_64 x3 build to completion (no OOM)
- [ ] `Create Release` publishes v0.5.1 with 13 assets