### PR TITLE
ci(release): set RUST_MIN_STACK for windows build (sqlparser rustc stack overflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,6 +367,13 @@ jobs:
           # single-digit perf delta on a target with no published benchmark
           # numbers. Same trade as linux-aarch64. Revisit once VM memory grows.
           CARGO_PROFILE_RELEASE_LTO: "off"
+          # Bump rustc's thread stack: with LTO off the Windows build gets
+          # far enough to compile sqlparser (a turso #183 dependency), whose
+          # deeply-recursive AST types overflow rustc's default thread stack
+          # on the Windows toolchain (STATUS_STACK_OVERFLOW, 0xc00000fd),
+          # made heavier by codegen-units=1 + opt-level=3. 32 MiB clears it.
+          # linux-aarch64 compiles sqlparser fine, so this is windows-only.
+          RUST_MIN_STACK: "33554432"
         run: cargo xtask release ${{ matrix.php_minor }} --target windows --no-sqld
 
       - name: Package archive


### PR DESCRIPTION
## Summary
Add `RUST_MIN_STACK=32MiB` to the windows-x86_64 release build step. This is the **second** and final windows blocker for v0.5.1.

## Why
With LTO disabled (#198), the windows build no longer OOM-kills the runner - but it now compiles far enough to hit a *different* wall:
```
thread 'rustc' has overflowed its stack
error: could not compile `sqlparser` (lib)  ... STATUS_STACK_OVERFLOW (0xc00000fd)
```
`sqlparser v0.57.0` (pulled in by the turso engine, #183) has deeply-recursive AST types that overflow rustc's default thread stack on the windows MSVC toolchain, made heavier by `codegen-units=1` + `opt-level=3`. Bumping `RUST_MIN_STACK` to 32 MiB gives rustc enough headroom.

Confirmed on release run 30054549666: **linux-aarch64 x3 all green** (the LTO-off fix worked), macOS x3 green, and windows x3 fail with the sqlparser stack overflow. aarch64 compiles sqlparser fine, so this is **windows-only**.

## Change
- windows `Build ephpm.exe` step: add `RUST_MIN_STACK: "33554432"` to env (alongside the existing `CARGO_PROFILE_RELEASE_LTO: "off"`).

## After merge
Move the `v0.5.1` tag onto the new main head (same as #198 - draft release, 0 assets, safe), re-running the matrix. With this in, all windows legs should compile, and every leg (linux-x64/aarch64, macOS, windows, Docker) should go green and publish.

## Test plan
- [ ] CI green on this PR
- [ ] After tag move: windows-x86_64 x3 compile + package without stack overflow
- [ ] v0.5.1 publishes with 13 assets