### PR TITLE
ci(nightly): disable LTO on linux-aarch64 to stop OOM-killed builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,14 +43,37 @@ jobs:
             image: latest
             triple: x86_64-unknown-linux-gnu
             sdk: linux-x86_64
+            # Plenty of headroom on the WSL2 x64 runner -- keep
+            # profile.release's fat LTO.
+            lto: fat
           - runner: arm64
             image: latest-arm64
             triple: aarch64-unknown-linux-gnu
             sdk: linux-aarch64
+            # Quoted so YAML doesn't fold it to the boolean `false`
+            # (cargo's `lto = false` means "thin-local", not "off").
+            lto: "off"
     steps:
       - uses: actions/checkout@v4
 
       - name: Build ephpm
+        env:
+          # Per-arch LTO, mirroring release.yml's build-linux-arm64 step.
+          #
+          # The fat-LTO final link of the ephpm binary (libphp.a + ICU +
+          # everything, codegen-units=1 from profile.release) exceeds the
+          # arm64 build host's memory -- rustc gets SIGKILLed by the OOM
+          # killer. That killed every linux-aarch64 nightly leg for 8+
+          # consecutive runs; often the OOM killer took the runner agent
+          # too, surfacing as "the self-hosted runner lost communication
+          # with the server" rather than a build error.
+          #
+          # Thin LTO is NOT enough here: release.yml tried it (#181) and
+          # had to drop to off once the turso engine (#183) grew the
+          # binary. Match release.yml so nightly and release build the
+          # arm64 artifact the same way. Revisit once the VM memory is
+          # raised.
+          CARGO_PROFILE_RELEASE_LTO: ${{ matrix.arch.lto }}
         run: cargo xtask release ${{ matrix.php }}
 
       - name: Run ignored integration tests


### PR DESCRIPTION
## Problem

The `linux-aarch64` legs have failed **every nightly for 8+ consecutive runs** (all of `29722404557` … `30246122626`). Every other job — macOS, Linux x86_64, Windows, fuzz, audit — passes. `Nightly Summary` fails only because it gates on `build-linux`.

Root cause is the fat-LTO final link of the `ephpm` binary: rustc is SIGKILLed by the OOM killer on the Apple Silicon host's embedded Linux VM. From the one surviving job log (`89764683205`, run `30191213719`):

```
process didn't exit successfully: `rustc --crate-name ephpm
  -C opt-level=3 -C lto=fat -C codegen-units=1
  -C link-arg=.../libicutu.a -C link-arg=.../libstdc++.a ...`  (signal: 9, SIGKILL: kill)
```

In most runs the OOM killer took the **runner agent** too, so the job reported *"The self-hosted runner lost communication with the server"* with a `null` conclusion on the Build step instead of a build error. Same failure, two different hats — which is why this read as flaky infra rather than a reproducible OOM.

Durations varied 13–46 min across runs, ruling out a timeout.

## Fix

`release.yml` already hit and solved this for its `build-linux-arm64` job (#171 → thin #181 → off). Nightly never got the same treatment.

Set `CARGO_PROFILE_RELEASE_LTO` per-arch from the matrix:

| Arch | LTO | Rationale |
|------|-----|-----------|
| `linux-x86_64` | `fat` | WSL2 runner has headroom — unchanged behavior |
| `linux-aarch64` | `"off"` | Matches the proven `release.yml` setting |

Quoted `"off"` deliberately — bare `off` folds to YAML boolean `false`, and cargo's `lto = false` means *thin-local*, not off.

**Thin LTO is deliberately not used.** `release.yml:138-147` records that thin was tried (#181) and had to be dropped once the turso engine (#183, linked by default) grew the binary past what thin-LTO fits on this host. Same binary, same VM.

Side benefit: nightly and release now build the arm64 artifact **identically**, so nightly actually exercises what ships. Previously nightly tested a fat-LTO arm64 binary that release never produces.

## Not included

- **No serialization** (`needs:` / `max-parallel: 1`) like `release.yml` uses. Nightly's `build-linux` is one combined x64+arm64 matrix, so `max-parallel` would throttle x64 too. Evidence says it isn't needed: in the last nightly the third arm64 job (08:34→09:03Z) had the Mac entirely to itself — all macOS jobs finished by 08:12Z — and still died. Memory per link, not host contention, is dominant. If it stays flaky, splitting arm64 into its own job is the follow-up.

## Revisit

This is a workaround for a memory-starved build host, not a fix. Once the arm64 VM's RAM is raised, restore fat LTO and delete the per-arch split — the comment block in the diff says exactly what to undo.

## Verification

Nightly dispatched against this branch; will report whether the three arm64 legs go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvhR7GfRkFArD9WbJyvg6S