### PR TITLE
docs(claude): litewire is a git dep, not a path dep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,11 @@ The `ephpm-e2e` crate is **excluded from the workspace** and has different depen
 
 | Dependency | Location | Purpose |
 |-----------|----------|---------|
-| **litewire** | `../litewire/crates/litewire` (path dep) | MySQL/Hrana wire protocol → SQLite translation proxy |
+| **litewire** | Git dep on `github.com/ephpm/litewire`, pinned by `rev` in the workspace `Cargo.toml` | MySQL/Hrana wire protocol → SQLite translation proxy |
 | **PHP SDK** | Downloaded by `cargo xtask php-sdk` from `github.com/ephpm/php-sdk` releases | Prebuilt `libphp.a` (Linux/macOS) or `php8embed.{dll,lib}` (Windows) plus PHP headers. Pinned per minor in `xtask/src/main.rs::PHP_SDK_VERSIONS` |
 | **sqld** | Embedded via `include_bytes!()` at build time | SQLite replication server for clustered mode (v0.24.32 pinned in xtask) |
 
-litewire is a standalone project at `github.com/ephpm/litewire`. It's used as a library — ePHPm calls `LiteWire::new(backend).mysql(addr).serve()`.
+litewire is a standalone project at `github.com/ephpm/litewire`. It's used as a library — ePHPm calls `LiteWire::new(backend).mysql(addr).serve()`. Bumping it means updating the `rev` in the workspace `Cargo.toml` and running `cargo update -p litewire`. To work against a sibling checkout without changing the pin, add a `[patch."https://github.com/ephpm/litewire.git"]` entry pointing at `../litewire/crates/litewire` in your local config — see the comment above the dependency in `Cargo.toml`.
 
 The PHP SDK is built by a separate pipeline at `github.com/ephpm/php-sdk` (uses static-php-cli internally). ePHPm itself doesn't depend on static-php-cli at all — it just consumes the resulting tarballs.
 


### PR DESCRIPTION
## What

`CLAUDE.md`'s External Dependencies table described litewire as a path dep at `../litewire/crates/litewire`. It has been a **git dep pinned by `rev`** in the workspace `Cargo.toml` since litewire moved to its own repo.

## Why it matters

The documented location was wrong in a way that misleads: a fresh clone following CLAUDE.md would look for a sibling checkout that isn't required and isn't there. The actual pin lives in `Cargo.toml`:

```toml
litewire = { git = "https://github.com/ephpm/litewire.git", rev = "...", ... }
```

## Changes

- Correct the External Dependencies table row.
- Record how to bump it (update `rev`, `cargo update -p litewire`) and the `[patch."https://github.com/ephpm/litewire.git"]` escape hatch for developing against a sibling checkout. Both were already documented in `Cargo.toml` but not discoverable from `CLAUDE.md`.

Docs only — no code change.