### PR TITLE
chore(nightly): drop reference to a doc that does not exist

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,6 @@
 # Failures still surface on the run page; only the summary check ignores them.
 # Re-tighten by removing continue-on-error and re-adding the job to the
 # nightly-summary fail gate.
-#
-# See docs/testing/nightly.md for the full nightly test plan.
 
 name: Nightly
 


### PR DESCRIPTION
`.github/workflows/nightly.yml` header pointed at `docs/testing/nightly.md` for "the full nightly test plan". **That file has never existed in `main`.**

It was written on a long-unmerged branch, along with the rest of a `docs/testing/` tree that never landed, so the reference has been dangling the entire time.

The gating policy it purported to elaborate on is already stated in full in the comment block immediately above it, so removing the pointer loses nothing.

Two comment lines. No behaviour change.