### PR TITLE
docs: truth sweep — remove phantom APIs, fix dead config values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The `ephpm-e2e` crate is **excluded from the workspace** and has different depen
 | `ephpm-config` | Configuration (figment) — TOML + env var overrides (`EPHPM_` prefix) |
 | `ephpm-kv` | Embedded KV store — DashMap, RESP2 protocol, TTL/expiry, compression (gzip/zstd/brotli) |
 | `ephpm-db` | DB proxy — MySQL wire protocol, connection pooling, R/W splitting |
-| `ephpm-cluster` | Clustering — SWIM gossip (chitchat), consistent hash ring, KV replication, SQLite primary election |
+| `ephpm-cluster` | Clustering — SWIM gossip (chitchat), hashed large-value ownership (`hash(key)` mod sorted alive nodes — not a consistent-hash ring), KV replication, SQLite primary election |
 | `ephpm-sqld` | sqld embedding — binary extraction via `include_bytes!()`, child process lifecycle, health checks |
 | `ephpm-query-stats` | Query observability — SQL normalization, digest tracking, slow query logging, Prometheus metrics |
 | `xtask` | Build & test tooling — `release`, `php-sdk`, `e2e` (bare-process default), `k8s-e2e`/`k8s-e2e-up`/`k8s-e2e-down` (opt-in Kind path) |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ document_root = "/var/www/html"
 index_files = ["index.php", "index.html"]
 
 [php]
-mode = "embedded"
+mode = "fpm"
 max_execution_time = 30
 memory_limit = "128M"
 
@@ -221,14 +221,14 @@ ephpm_kv_expire('session:abc', 1800);
 ephpm_kv_del('cart:42');
 ```
 
-Available: `ephpm_kv_get`, `set`, `setnx`, `del`, `exists`, `incr`, `decr`, `incr_by`, `expire`, `ttl`, `pttl`, `flush_all`. These are the recommended API for multi-tenant deployments — the RESP listener has no per-tenant namespace filtering, so leave it disabled and let PHP go through the SAPI bridge.
+Available: `ephpm_kv_get`, `set`, `setnx`, `del`, `exists`, `incr`, `decr`, `incr_by`, `expire`, `ttl`, `pttl`, `flush_all`, `wait`. These are the lowest-latency API — a direct FFI call, no socket. The RESP listener is also safe for multi-tenant use: set `[kv] secret` and each connection is scoped to a single site's keyspace by HMAC AUTH (see below).
 
 ### 3. Need HA? Use the clustered KV tier
 
 In a cluster, the KV store becomes a two-tier distributed store with no extra moving parts — it piggybacks on the same SWIM gossip layer used for SQLite primary election.
 
-- **Small values** (< 1 KB by default) ride the **gossip tier** — eventually consistent, replicated to every node, sub-millisecond reads everywhere.
-- **Large values** live on a **consistent-hash data plane** — each key is owned by N nodes (configurable replication factor), fetched on demand via TCP, with optional hot-key promotion that caches frequently-fetched remote values locally.
+- **Small values** (< 512 bytes by default) ride the **gossip tier** — eventually consistent, replicated to every node, sub-millisecond reads everywhere.
+- **Large values** live on a **hashed data plane** — the owner is `hash(key)` modulo the sorted alive-node list (no consistent-hash ring), replicated to N nodes (configurable replication factor), fetched on demand via TCP, with optional hot-key promotion that caches frequently-fetched remote values locally.
 - **Failover** — when a node leaves the gossip view, the hash ring rebalances and owned keys migrate to the next replicas. No primary, no election — every node can read and write.
 
 ```toml
@@ -237,7 +237,7 @@ enabled = true
 join = ["ephpm-headless.default.svc.cluster.local"]
 
 [cluster.kv]
-small_key_threshold = 1024        # bytes — under this, replicate via gossip
+small_key_threshold = 512         # bytes — under this, replicate via gossip (default)
 replication_factor = 3            # large keys: 3 copies (owner + 2 replicas)
 replication_mode = "async"        # async | sync
 hot_key_cache = true              # cache hot remote values locally
@@ -246,7 +246,7 @@ hot_key_max_memory = "64MB"
 
 ### Multi-tenant security
 
-When `sites_dir` is set, each virtual host gets its own isolated keyspace. The `ephpm_kv_*` PHP functions are namespaced automatically. For the RESP endpoint, ePHPm derives a per-site password from `HMAC-SHA256(kv.secret, hostname)` and injects it into PHP `$_ENV` as `EPHPM_REDIS_PASSWORD` for each request — so `phpredis` can `AUTH` without any per-site config in your code.
+When `sites_dir` is set, each virtual host gets its own isolated keyspace. The `ephpm_kv_*` PHP functions are namespaced automatically. For the RESP endpoint, ePHPm derives a per-site password from `HMAC-SHA256(kv.secret, hostname)` and injects it into PHP `$_SERVER` as `EPHPM_REDIS_PASSWORD` for each request — so `phpredis` can `AUTH` without any per-site config in your code.
 
 ### How it works under the hood
 

--- a/ephpm.toml
+++ b/ephpm.toml
@@ -49,9 +49,9 @@ index_files = ["index.php", "index.html"]
 # level = "info"           # trace, debug, info, warn, error
 
 [php]
-# mode = "embedded" (default) — PHP linked via FFI, zero overhead
-# mode = "external" — spawn external PHP workers, use any PHP binary
-mode = "embedded"
+# mode = "fpm" (default) — php-fpm-shaped: full startup/shutdown per request
+# mode = "worker" — persistent workers holding a booted framework in memory
+mode = "fpm"
 max_execution_time = 30
 memory_limit = "128M"
 
@@ -68,10 +68,9 @@ ini_overrides = [
     ["error_reporting", "E_ALL"],
 ]
 
-# External mode settings (only used when mode = "external"):
-# binary = "/usr/bin/php"         # path to PHP binary
-# workers = 4                     # number of worker processes
-# worker_script = "vendor/ephpm/worker.php"  # worker loop script
+# Worker mode settings (only used when mode = "worker"):
+# worker_script = "vendor/ephpm/worker.php"  # worker loop script (required)
+# worker_count = 0                # persistent workers; 0 derives from CPU quota
 
 # [server.tls]
 # --- Manual mode (provide your own cert/key) ---

--- a/site/content/architecture/_index.md
+++ b/site/content/architecture/_index.md
@@ -543,10 +543,10 @@ ephpm_kv_set("session:abc", $data, ttl: 3600);
 $data = ephpm_kv_get("session:abc");
 ephpm_kv_del("session:abc");
 
-// Hash operations
-ephpm_kv_hset("user:123", "email", "user@example.com");
-$email = ephpm_kv_hget("user:123", "email");
-$all = ephpm_kv_hgetall("user:123");
+// Counters and TTL
+ephpm_kv_incr_by("hits:home", 1);
+ephpm_kv_expire("session:abc", 3600);
+$ms = ephpm_kv_pttl("session:abc");
 
 // With clustering, this is transparent:
 // - If key is local → direct memory access, ~100ns

--- a/site/content/architecture/clustering.md
+++ b/site/content/architecture/clustering.md
@@ -349,11 +349,6 @@ ephpm_kv_set("user:123:profile", $json, ttl: 3600);
 $json = ephpm_kv_get("user:123:profile");
 ephpm_kv_del("user:123:profile");
 
-// Hash operations
-ephpm_kv_hset("user:123", "email", "user@example.com");
-$email = ephpm_kv_hget("user:123", "email");
-$all = ephpm_kv_hgetall("user:123");
-
 // Atomic operations
 $count = ephpm_kv_incr("page:views");
 $exists = ephpm_kv_exists("cache:key");
@@ -1127,17 +1122,24 @@ For the common case (session key local to the node), ephpm is **1,000-10,000x fa
 
 ### Distributed Locking
 
-General-purpose distributed locks for PHP applications, built on KV with TTL:
+General-purpose distributed locks for PHP applications, built on the atomic
+`ephpm_kv_setnx()` primitive plus a TTL:
 
 ```php
-$lock = ephpm_kv_lock("deploy:mutex", ttl: 30);
-if ($lock) {
-    // critical section
-    ephpm_kv_unlock("deploy:mutex");
+// setnx() returns true only if the key did not already exist.
+if (ephpm_kv_setnx("deploy:mutex", getmypid())) {
+    ephpm_kv_expire("deploy:mutex", 30);  // never hold it forever
+    try {
+        // critical section
+    } finally {
+        ephpm_kv_del("deploy:mutex");
+    }
 }
 ```
 
-Used internally for ACME coordination, available to PHP apps for their own needs.
+ePHPm uses the same KV + TTL pattern internally to elect a single ACME
+certificate requester across the cluster, but that coordination lives in Rust
+(`crates/ephpm-server/src/acme.rs`) — it is not exposed as a PHP lock API.
 
 ### Rate Limiting
 

--- a/site/content/architecture/kv-store.md
+++ b/site/content/architecture/kv-store.md
@@ -92,7 +92,7 @@ When the RESP listener is enabled and AUTH is required, ePHPm derives per-site p
 password = HMAC-SHA256(secret, hostname)
 ```
 
-The derived password is injected into PHP's `$_ENV` as `EPHPM_REDIS_PASSWORD` for each request, so each site's PHP code can authenticate to its own scope. If `[kv] secret` is unset, nothing is auto-generated — multi-tenant HMAC AUTH is simply disabled.
+The derived password is injected into PHP's `$_SERVER` as `EPHPM_REDIS_PASSWORD` for each request, so each site's PHP code can authenticate to its own scope. If `[kv] secret` is unset, nothing is auto-generated — multi-tenant HMAC AUTH is simply disabled.
 
 ## Clustered KV (when `[cluster] enabled = true`)
 

--- a/site/content/architecture/metrics.md
+++ b/site/content/architecture/metrics.md
@@ -74,7 +74,6 @@ Custom bucket configurations are tuned for PHP workloads:
 |--------|---------|
 | `ephpm_http_request_duration_seconds` | 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s |
 | `ephpm_php_execution_duration_seconds` | 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s |
-| `ephpm_php_mutex_wait_seconds` | 0.1ms, 0.5ms, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms |
 | Body size histograms | 100B, 1KB, 10KB, 50KB, 100KB, 500KB, 1MB, 5MB, 10MB |
 | `ephpm_http_compression_ratio` | 0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9 |
 

--- a/site/content/reference/cli/serve.md
+++ b/site/content/reference/cli/serve.md
@@ -3,13 +3,14 @@ title = "ephpm serve"
 weight = 1
 +++
 
-Start the PHP application server. This is the default command — `ephpm` with no subcommand is `ephpm serve`.
+Start the PHP application server. This is the command service backends invoke.
+
+Note that `ephpm` with **no** subcommand is not `serve` — it starts the [development server](../#ephpm-dev) on port 8080. The subcommand is required for production use.
 
 ## Synopsis
 
 ```bash
 ephpm serve [-c FILE] [-l ADDR] [-d DIR] [-v...]
-ephpm                                              # equivalent
 ```
 
 ## Flags
@@ -25,7 +26,7 @@ ephpm                                              # equivalent
 
 ```bash
 # Default config, default listen
-ephpm
+ephpm serve
 
 # Explicit config file
 ephpm serve --config /etc/ephpm/ephpm.toml
@@ -33,8 +34,8 @@ ephpm serve --config /etc/ephpm/ephpm.toml
 # Quick override for a one-off serve
 ephpm serve --listen 127.0.0.1:9090 --document-root ./public
 
-# Trace logging for debugging
-ephpm -vv
+# Trace logging for debugging (-v lives on the subcommand, not the bare binary)
+ephpm serve -vv
 
 # Drop logs into a file
 RUST_LOG=info ephpm serve 2>&1 | tee /var/log/ephpm.log


### PR DESCRIPTION
Pre-v0.6.0 audit of documented claims against source. Every item below was verified against the actual definition (clap for CLI, `ephpm-config` for keys, `ephpm_wrapper.c` for SAPI functions, `counter!`/`histogram!` call sites for metrics) — not inferred.

## Config values that cannot work

- **`mode = "embedded"`** in `ephpm.toml` and `README.md`. `Config::validate()` accepts only `"fpm"` or `"worker"` (`ephpm-config/src/lib.rs:1700`) and runs on the serve path (`ephpm/src/main.rs:817`), so the shipped sample config **hard-fails at startup**. `embedded`/`external` predate the worker-mode rename (#114) and were never cleaned up.
- The **"external mode settings"** block advertised `binary = "/usr/bin/php"` — not a config key at all. Replaced with the real worker-mode knobs.

## PHP functions that do not exist

`ephpm_kv_hset` / `hget` / `hgetall` and `ephpm_kv_lock` / `unlock` were presented as shipped API. The function-entry table (`ephpm_wrapper.c:2567-2582`) registers **13** functions and none are these — hashes are RESP-only. Copy-pasting the documented snippets raises `Call to undefined function`.

The locking example now uses the real `ephpm_kv_setnx()` primitive, and the ACME note says plainly that the leader lock lives in Rust (`acme.rs`) rather than implying a PHP lock API.

## Phantom metric

`ephpm_php_mutex_wait_seconds` had a row in the histogram-buckets table with **zero** recording sites and no bucket registration anywhere in `crates/`.

## Wrong facts

| Claim | Reality |
|---|---|
| `$_ENV['EPHPM_REDIS_PASSWORD']` | It's `$_SERVER` — registered via `php_register_variable_safe` into the server-vars array, so the documented lookup returns null |
| `small_key_threshold` default 1 KB | 512 bytes (`lib.rs:2934`) |
| "consistent-hash data plane" | `hash(key)` modulo the sorted alive-node list — no ring (`clustered_store.rs:489-497`). Also fixed in CLAUDE.md's crate table |
| RESP "has no per-tenant namespace filtering, so leave it disabled" | Per-site HMAC scoping is implemented (`ephpm-kv/src/server.rs:275-289`) — and the README described it correctly 25 lines later |
| bare `ephpm` is `ephpm serve` | It runs **dev** mode on 8080 (`main.rs:303`) |
| `ephpm -vv` | Parse error — the top-level `Cli` struct has no flags, only a subcommand |

README's SAPI function list also omitted `ephpm_kv_wait`.

## Not included

`site/content/reference/config.md` fixes (the `max_execution_time` row, 13 stale "Planned for v0.5.0" markers, metric label enumerations) are held back — concurrent work is touching that file and I didn't want a conflict. Follow-up PR.

Docs only. No code changes.