### PR TITLE
fix: five P1 bugs - install config, KV CLI auth, vhost keyspace split, two silent no-op knobs

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -2354,7 +2354,10 @@ impl AutoTune {
         // there: dev mode (no derivation at all) and serve mode on
         // macOS/Windows (no detectable memory budget). PHP then fell back to
         // its own compiled default and the configured value vanished.
-        lines.push(("memory_limit".to_string(), self.memory_limit.value.clone()));
+        // Passing a non-`Default` origin is what forces emission; a bare
+        // `lines.push` here cannot compile, because `push_if_set` holds a
+        // mutable borrow of `lines` that is still live for the calls below.
+        push_if_set("memory_limit", Origin::Explicit, self.memory_limit.value.clone());
         push_if_set(
             "realpath_cache_size",
             self.realpath_cache_size.origin,

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -2077,10 +2077,11 @@ impl PhpConfig {
     /// OPcache/engine ini directives to write into the generated php.ini.
     ///
     /// Layers the full resource-aware autotuning profile (see
-    /// [`Self::autotune`]): `opcache.validate_timestamps` (always), plus every
-    /// tunable whose value came from explicit config **or** a serve-mode
-    /// derivation. Values that resolved to the PHP stock default are omitted so
-    /// the engine's own default applies (keeping dev mode's php.ini minimal).
+    /// [`Self::autotune`]): `opcache.validate_timestamps` and `memory_limit`
+    /// (both always), plus every tunable whose value came from explicit config
+    /// **or** a serve-mode derivation. Values that resolved to the PHP stock
+    /// default are omitted so the engine's own default applies (keeping dev
+    /// mode's php.ini minimal).
     /// All lines are emitted *before* user `ini_overrides`, so an operator can
     /// still override any of them through `ini_overrides` as the final lever.
     #[must_use]
@@ -2278,10 +2279,12 @@ impl AutoTune {
     /// The ini `(key, value)` pairs to write, before user `ini_overrides`.
     ///
     /// `opcache.validate_timestamps` is always emitted (its default is
-    /// mode-dependent, not a PHP stock value). Every other tunable is emitted
-    /// only when its origin is [`Origin::Explicit`] or [`Origin::Derived`];
-    /// values left at the PHP stock default are omitted so the engine default
-    /// applies and dev-mode php.ini stays minimal.
+    /// mode-dependent, not a PHP stock value), and so is `memory_limit` (its
+    /// bottom tier is the `[php] memory_limit` field, not a PHP stock value).
+    /// Every other tunable is emitted only when its origin is
+    /// [`Origin::Explicit`] or [`Origin::Derived`]; values left at the PHP
+    /// stock default are omitted so the engine default applies and dev-mode
+    /// php.ini stays minimal.
     #[must_use]
     pub fn ini_lines(&self) -> Vec<(String, String)> {
         let mut lines: Vec<(String, String)> = Vec::new();
@@ -2324,7 +2327,17 @@ impl AutoTune {
             self.max_accelerated_files.origin,
             format!("{}", self.max_accelerated_files.value),
         );
-        push_if_set("memory_limit", self.memory_limit.origin, self.memory_limit.value.clone());
+        // `memory_limit` is emitted unconditionally, unlike every other
+        // tunable above. Its bottom resolution tier is the `[php] memory_limit`
+        // field, which serde always populates (defaulting to `128M`) and which
+        // an operator may have pinned — it is *not* a PHP stock value the
+        // engine would apply on its own. Routing it through `push_if_set`
+        // dropped the line whenever the origin came out `Origin::Default`,
+        // which is exactly the case where the operator's own value lives
+        // there: dev mode (no derivation at all) and serve mode on
+        // macOS/Windows (no detectable memory budget). PHP then fell back to
+        // its own compiled default and the configured value vanished.
+        lines.push(("memory_limit".to_string(), self.memory_limit.value.clone()));
         push_if_set(
             "realpath_cache_size",
             self.realpath_cache_size.origin,
@@ -3986,10 +3999,17 @@ sites_dir = "/var/www/sites"
     #[test]
     fn test_opcache_ini_lines_dev_default() {
         // Dev mode derives nothing — only the mode-appropriate
-        // validate_timestamps line is emitted, keeping the dev php.ini minimal.
+        // validate_timestamps line plus the always-emitted memory_limit,
+        // keeping the dev php.ini minimal.
         let cfg = PhpConfig::default();
         let lines = cfg.opcache_ini_lines(true);
-        assert_eq!(lines, vec![("opcache.validate_timestamps".to_string(), "1".to_string())]);
+        assert_eq!(
+            lines,
+            vec![
+                ("opcache.validate_timestamps".to_string(), "1".to_string()),
+                ("memory_limit".to_string(), "128M".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -4006,7 +4026,53 @@ sites_dir = "/var/www/sites"
             vec![
                 ("opcache.validate_timestamps".to_string(), "1".to_string()),
                 ("opcache.revalidate_freq".to_string(), "60".to_string()),
+                ("memory_limit".to_string(), "128M".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn test_memory_limit_emitted_in_dev_mode() {
+        // Regression: `[php] memory_limit` resolves through the bottom
+        // ("stock default") tier of the three-tier resolver, so it used to be
+        // filtered out of the generated php.ini as `Origin::Default`. Dev mode
+        // derives nothing, so this is where the drop always bit.
+        let cfg = PhpConfig { memory_limit: "512M".to_string(), ..PhpConfig::default() };
+        let lines = cfg.opcache_ini_lines(true);
+        assert!(
+            lines.contains(&("memory_limit".to_string(), "512M".to_string())),
+            "dev-mode php.ini must carry [php] memory_limit, got: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn test_memory_limit_emitted_when_origin_is_default() {
+        // Platform-independent form of the same regression: whatever the host
+        // detects, a memory_limit that resolved to the bottom tier must still
+        // reach the generated ini. This is the serve-mode path on macOS and
+        // Windows, where `read_total_system_memory()` returns `None` so
+        // `derive_tuning` produces no `memory_limit`.
+        let mut at = PhpConfig::default().autotune(true);
+        at.memory_limit = TunedValue { value: "384M".to_string(), origin: Origin::Default };
+        let lines = at.ini_lines();
+        assert!(
+            lines.contains(&("memory_limit".to_string(), "384M".to_string())),
+            "Origin::Default memory_limit must still be emitted, got: {lines:?}"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn test_memory_limit_emitted_in_serve_mode_without_memory_budget() {
+        // On non-Linux hosts `detect_memory_budget()` yields `None`, so serve
+        // mode derives no memory_limit and the configured value lands in the
+        // bottom tier — the second half of the same regression.
+        let cfg = PhpConfig { memory_limit: "512M".to_string(), ..PhpConfig::default() };
+        let lines = cfg.opcache_ini_lines(false);
+        assert!(
+            lines.contains(&("memory_limit".to_string(), "512M".to_string())),
+            "serve-mode php.ini must carry [php] memory_limit when nothing is \
+             derived, got: {lines:?}"
         );
     }
 

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1301,7 +1301,24 @@ impl Default for KvRedisCompatConfig {
 /// PHP runtime configuration.
 #[derive(Debug, Deserialize)]
 pub struct PhpConfig {
-    /// Maximum execution time in seconds for a single PHP request.
+    /// Planned: not yet implemented — parsed but not acted upon.
+    ///
+    /// Nothing reads this field. It is **not** written into the generated
+    /// php.ini either: that file carries only `extension=` lines, the
+    /// `ini_file` body, the autotuned opcache/engine lines, `ini_overrides`,
+    /// and `disable_functions`.
+    ///
+    /// Emitting it would not help. PHP enforces `max_execution_time` with a
+    /// `SIGPROF` timer whose handler ePHPm deliberately neutralizes on Linux
+    /// (`crates/ephpm/build.rs` `--wrap`s `zend_signal_*` to no-ops, because
+    /// the signal lands on whichever thread is running and dereferences NULL
+    /// on a tokio worker). So the directive would be advisory at best.
+    ///
+    /// The per-request deadline that *is* enforced is
+    /// `[server.timeouts] request` (default `300` seconds), applied at the
+    /// HTTP layer. Setting this knob logs a warning at startup.
+    ///
+    /// Default: `30`.
     #[serde(default = "default_max_execution_time")]
     pub max_execution_time: u32,
 

--- a/crates/ephpm-kv/src/multi_tenant.rs
+++ b/crates/ephpm-kv/src/multi_tenant.rs
@@ -164,6 +164,49 @@ mod tests {
     }
 
     #[test]
+    fn clones_share_the_same_site_stores() {
+        // `Clone` shares the `sites` map, so handing one instance to the PHP
+        // path and a clone to the RESP listener keeps a vhost on one keyspace.
+        let default = Store::new(StoreConfig::default());
+        let php_side = MultiTenantStore::new(default, test_config());
+        let resp_side = php_side.clone();
+
+        let from_php = php_side.get_site_store("alice.com");
+        let from_resp = resp_side.get_site_store("alice.com");
+        assert!(Arc::ptr_eq(&from_php, &from_resp));
+
+        from_php.set("k".into(), b"v".to_vec(), None);
+        assert_eq!(resp_side.get_site_store("alice.com").get("k").as_deref(), Some(&b"v"[..]));
+        assert_eq!(php_side.site_count(), 1);
+        assert_eq!(resp_side.site_count(), 1);
+    }
+
+    #[test]
+    fn separate_instances_do_not_share_site_stores() {
+        // Why `Clone` (above) is mandatory rather than merely convenient:
+        // `new()` always allocates a fresh `sites` map, so two instances over
+        // the same default store still give a vhost two disjoint keyspaces.
+        let default = Store::new(StoreConfig::default());
+        let one = MultiTenantStore::new(Arc::clone(&default), test_config());
+        let two = MultiTenantStore::new(default, test_config());
+
+        let from_one = one.get_site_store("alice.com");
+        let from_two = two.get_site_store("alice.com");
+        assert!(!Arc::ptr_eq(&from_one, &from_two));
+
+        from_one.set("k".into(), b"v".to_vec(), None);
+        assert_eq!(from_two.get("k"), None);
+    }
+
+    #[test]
+    fn site_stores_inherit_the_template_config() {
+        let default = Store::new(StoreConfig::default());
+        let mt = MultiTenantStore::new(default, test_config());
+        let site = mt.get_site_store("alice.com");
+        assert_eq!(site.config().memory_limit, test_config().memory_limit);
+    }
+
+    #[test]
     fn site_data_not_visible_from_default() {
         let default = Store::new(StoreConfig::default());
         let mt = MultiTenantStore::new(default, test_config());

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -251,6 +251,18 @@ impl Store {
         })
     }
 
+    /// The [`StoreConfig`] this store was built with.
+    ///
+    /// Memory limit, eviction policy, and compression are fixed at
+    /// construction, so this is read-only. Exposed so a caller that hands a
+    /// config template to a
+    /// [`MultiTenantStore`](crate::multi_tenant::MultiTenantStore) can check
+    /// that the per-site stores actually inherited it.
+    #[must_use]
+    pub fn config(&self) -> &StoreConfig {
+        &self.config
+    }
+
     /// Install a [`Replicator`] hook so subsequent [`Store::set`],
     /// [`Store::remove`], and [`Store::expire`] calls delegate the write to
     /// it (typically a clustered store that decides gossip vs local tier and

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -990,6 +990,18 @@ async fn shutdown_signal() {
     }
 }
 
+/// What [`start_kv_service`] hands back: the process-wide default store, the
+/// per-vhost store when `sites_dir` is configured, and the RESP listener's
+/// join handle.
+///
+/// Named rather than written inline so the signature stays under
+/// `clippy::type_complexity`.
+type KvService = (
+    Arc<ephpm_kv::store::Store>,
+    Option<ephpm_kv::multi_tenant::MultiTenantStore>,
+    Option<tokio::task::JoinHandle<()>>,
+);
+
 /// Start the KV store with optional RESP server.
 ///
 /// Returns the process-wide default [`Store`](ephpm_kv::store::Store), the
@@ -1002,13 +1014,7 @@ async fn shutdown_signal() {
 /// to be handed this same instance. Constructing a second one gives each
 /// consumer its own lazily-populated map, and `ephpm_kv_set()` from PHP then
 /// lands in a different `Store` than a Predis `SET` on the same vhost.
-fn start_kv_service(
-    config: &Config,
-) -> anyhow::Result<(
-    Arc<ephpm_kv::store::Store>,
-    Option<ephpm_kv::multi_tenant::MultiTenantStore>,
-    Option<tokio::task::JoinHandle<()>>,
-)> {
+fn start_kv_service(config: &Config) -> anyhow::Result<KvService> {
     // Create the KV store
     let store_config = ephpm_kv::store::StoreConfig {
         memory_limit: parse_memory_size(&config.kv.memory_limit)?,

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -60,7 +60,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     };
 
     // Start background services.
-    let (kv_store, _kv_handle) = start_kv_service(&config)?;
+    let (kv_store, multi_tenant_kv, _kv_handle) = start_kv_service(&config)?;
 
     // Wire the KV store into the middleware host table (a no-op when no
     // middleware is mounted), then load the chain — fail fast at startup on
@@ -231,9 +231,15 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // empty and auto-derived), else None (Router falls back to config).
     let effective_node_id = cluster_handle.as_ref().map(|h| h.self_node().id.clone());
 
-    let listeners =
-        bind_listeners(&config, kv_store, metrics_handle, middleware_chain, effective_node_id)
-            .await?;
+    let listeners = bind_listeners(
+        &config,
+        kv_store,
+        multi_tenant_kv,
+        metrics_handle,
+        middleware_chain,
+        effective_node_id,
+    )
+    .await?;
 
     let _db_handles = start_db_proxies(&config, cluster_handle.as_ref(), &query_stats).await?;
 
@@ -281,6 +287,10 @@ struct ConnSettings {
 async fn bind_listeners(
     config: &Config,
     kv_store: Arc<ephpm_kv::store::Store>,
+    // The one `MultiTenantStore` built by `start_kv_service`. `Some` exactly
+    // when `[server] sites_dir` is set; shared with the RESP listener so PHP
+    // and RESP clients see one keyspace per vhost.
+    multi_tenant_kv: Option<ephpm_kv::multi_tenant::MultiTenantStore>,
     metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
     middleware_chain: Option<Arc<middleware::MiddlewareChain>>,
     // Effective cluster node id (from the running gossip handle), injected into
@@ -432,6 +442,7 @@ async fn bind_listeners(
         Router::new(
             config,
             kv_store,
+            multi_tenant_kv,
             metrics_handle,
             limiter.clone(),
             file_cache.clone(),
@@ -980,9 +991,24 @@ async fn shutdown_signal() {
 }
 
 /// Start the KV store with optional RESP server.
+///
+/// Returns the process-wide default [`Store`](ephpm_kv::store::Store), the
+/// per-vhost [`MultiTenantStore`](ephpm_kv::multi_tenant::MultiTenantStore)
+/// when `sites_dir` is configured, and the RESP listener's join handle.
+///
+/// The multi-tenant store is built **here and only here**. Its `sites` map is
+/// what makes two vhost keyspaces distinct, so every consumer — the PHP path
+/// (`Router` → `kv_bridge::set_site_store`) and the RESP listener alike — has
+/// to be handed this same instance. Constructing a second one gives each
+/// consumer its own lazily-populated map, and `ephpm_kv_set()` from PHP then
+/// lands in a different `Store` than a Predis `SET` on the same vhost.
 fn start_kv_service(
     config: &Config,
-) -> anyhow::Result<(Arc<ephpm_kv::store::Store>, Option<tokio::task::JoinHandle<()>>)> {
+) -> anyhow::Result<(
+    Arc<ephpm_kv::store::Store>,
+    Option<ephpm_kv::multi_tenant::MultiTenantStore>,
+    Option<tokio::task::JoinHandle<()>>,
+)> {
     // Create the KV store
     let store_config = ephpm_kv::store::StoreConfig {
         memory_limit: parse_memory_size(&config.kv.memory_limit)?,
@@ -995,14 +1021,24 @@ fn start_kv_service(
             min_size: config.kv.compression_min_size,
         },
     };
-    let store = ephpm_kv::store::Store::new(store_config);
+    let store = ephpm_kv::store::Store::new(store_config.clone());
 
     // Wire the store into PHP native functions (ephpm_kv_get, etc.)
     ephpm_php::PhpRuntime::set_kv_store(&store);
 
+    // Per-vhost stores inherit the `[kv]` block (memory_limit, eviction_policy,
+    // compression) rather than `StoreConfig::default()` — otherwise every vhost
+    // silently ran on the hardcoded 256 MiB / allkeys-lru / no-compression
+    // defaults no matter what the operator configured.
+    let multi_tenant = if config.server.sites_dir.is_some() {
+        Some(ephpm_kv::multi_tenant::MultiTenantStore::new(Arc::clone(&store), store_config))
+    } else {
+        None
+    };
+
     if !config.kv.redis_compat.enabled {
         tracing::debug!("KV store initialized (RESP server disabled)");
-        return Ok((store, None));
+        return Ok((store, multi_tenant, None));
     }
 
     // Start RESP server if enabled
@@ -1038,25 +1074,23 @@ fn start_kv_service(
         );
     }
 
-    // Build multi-tenant store for HMAC auth if secret + sites_dir are both set.
-    let multi_tenant = if secret.is_some() && config.server.sites_dir.is_some() {
-        Some(ephpm_kv::multi_tenant::MultiTenantStore::new(
-            Arc::clone(&store),
-            ephpm_kv::store::StoreConfig::default(),
-        ))
-    } else {
-        None
-    };
+    // Hand the RESP listener the *same* multi-tenant handle the router gets,
+    // so `AUTH <hostname> <derived>` resolves to the identical `Arc<Store>`
+    // that PHP's `ephpm_kv_*` functions write through for that vhost. Only
+    // wired when a secret exists: without one the listener has no way to
+    // derive per-site credentials and stays on the shared default store
+    // (warned about just above).
+    let resp_multi_tenant = if secret.is_some() { multi_tenant.clone() } else { None };
 
     let store_for_resp = Arc::clone(&store);
     let handle = tokio::spawn(async move {
-        match ephpm_kv::server::run(store_for_resp, server_config, multi_tenant).await {
+        match ephpm_kv::server::run(store_for_resp, server_config, resp_multi_tenant).await {
             Ok(()) => tracing::info!("KV RESP server stopped"),
             Err(e) => tracing::error!("KV RESP server error: {e:#}"),
         }
     });
 
-    Ok((store, Some(handle)))
+    Ok((store, multi_tenant, Some(handle)))
 }
 
 /// Start database proxies (`MySQL`, `PostgreSQL`, `TDS`, embedded `SQLite`).
@@ -1599,6 +1633,71 @@ mod lib_tests {
         assert!(err.to_string().contains("not a valid engine"), "{err}");
     }
 
+    // ── KV service wiring ───────────────────────────────────────────────────
+
+    #[test]
+    fn kv_service_has_no_multi_tenant_store_without_sites_dir() {
+        let config = Config::default();
+        let (_store, multi_tenant, handle) = start_kv_service(&config).expect("start kv service");
+        assert!(multi_tenant.is_none(), "single-site mode needs no per-vhost stores");
+        assert!(handle.is_none(), "[kv.redis_compat] is off by default");
+    }
+
+    #[test]
+    fn kv_service_site_stores_inherit_the_kv_config() {
+        // Per-vhost stores are templated from the `[kv]` block, not
+        // `StoreConfig::default()`. They previously ran on the hardcoded
+        // 256 MiB / allkeys-lru / no-compression defaults no matter what the
+        // operator configured.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = Config {
+            server: ephpm_config::ServerConfig {
+                sites_dir: Some(dir.path().to_path_buf()),
+                ..ephpm_config::ServerConfig::default()
+            },
+            kv: ephpm_config::KvConfig {
+                memory_limit: "8MB".to_string(),
+                ..ephpm_config::KvConfig::default()
+            },
+            ..Config::default()
+        };
+
+        let (default_store, multi_tenant, _handle) =
+            start_kv_service(&config).expect("start kv service");
+        let multi_tenant = multi_tenant.expect("sites_dir set, so a per-vhost store exists");
+
+        assert_eq!(default_store.config().memory_limit, 8 * 1024 * 1024);
+        assert_eq!(
+            multi_tenant.get_site_store("blog.example.com").config().memory_limit,
+            8 * 1024 * 1024,
+            "site stores must inherit [kv] memory_limit"
+        );
+    }
+
+    #[test]
+    fn kv_service_multi_tenant_clone_shares_site_stores() {
+        // The handle handed to the router and the one handed to the RESP
+        // listener are clones of one instance, so a vhost resolves to the same
+        // `Arc<Store>` on both paths. Two `MultiTenantStore::new` calls would
+        // not — that was the split-keyspace bug.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = Config {
+            server: ephpm_config::ServerConfig {
+                sites_dir: Some(dir.path().to_path_buf()),
+                ..ephpm_config::ServerConfig::default()
+            },
+            ..Config::default()
+        };
+
+        let (_store, multi_tenant, _handle) = start_kv_service(&config).expect("start kv service");
+        let router_side = multi_tenant.expect("sites_dir set, so a per-vhost store exists");
+        let resp_side = router_side.clone();
+
+        let a = router_side.get_site_store("blog.example.com");
+        let b = resp_side.get_site_store("blog.example.com");
+        assert!(Arc::ptr_eq(&a, &b), "PHP and RESP must share one store per vhost");
+    }
+
     // ── idle timeout ────────────────────────────────────────────────────────
 
     /// Minimal router serving `dir` with a static-only fallback (no PHP).
@@ -1617,7 +1716,7 @@ mod lib_tests {
             opcache: ephpm_config::OpcacheConfig::default(),
         };
         let store = ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default());
-        Arc::new(Router::new(&config, store, None, None, None, None))
+        Arc::new(Router::new(&config, store, None, None, None, None, None))
     }
 
     /// Bind a listener and serve exactly one connection with `settings`.

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -210,6 +210,10 @@ pub struct Router {
     /// so we don't repeat the parse per response.
     response_headers: Vec<(hyper::header::HeaderName, hyper::header::HeaderValue)>,
     store: Arc<Store>,
+    /// Per-vhost KV stores. Cloned from the single instance `start_kv_service`
+    /// builds and shares with the RESP listener, so a vhost's keyspace is the
+    /// same `Arc<Store>` whether it is reached from PHP or over RESP.
+    /// `None` outside multi-tenant mode.
     multi_tenant_kv: Option<ephpm_kv::multi_tenant::MultiTenantStore>,
     open_basedir: bool,
     php_etag_cache_config: ephpm_config::PhpETagCacheConfig,
@@ -401,10 +405,21 @@ fn scan_sites_dir(
 }
 
 impl Router {
+    /// Build the router.
+    ///
+    /// `multi_tenant_kv` must be the process-wide instance created by
+    /// `start_kv_service` — the same handle the RESP listener is given. The
+    /// router does **not** create its own: a `MultiTenantStore` owns the
+    /// hostname → `Arc<Store>` map that defines a vhost's keyspace, so a
+    /// second instance would give the PHP path a different set of stores than
+    /// RESP clients get for the same hostnames. Pass `None` when
+    /// `[server] sites_dir` is unset (single-site mode, where every request
+    /// uses `store` directly) or in tests that never exercise per-vhost KV.
     #[must_use]
     pub fn new(
         config: &Config,
         store: Arc<Store>,
+        multi_tenant_kv: Option<ephpm_kv::multi_tenant::MultiTenantStore>,
         metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
         limiter: Option<Arc<crate::rate_limit::Limiter>>,
         file_cache: Option<Arc<crate::file_cache::FileCache>>,
@@ -528,14 +543,7 @@ impl Router {
                 })
                 .collect(),
             open_basedir,
-            multi_tenant_kv: if config.server.sites_dir.is_some() {
-                Some(ephpm_kv::multi_tenant::MultiTenantStore::new(
-                    Arc::clone(&store),
-                    ephpm_kv::store::StoreConfig::default(),
-                ))
-            } else {
-                None
-            },
+            multi_tenant_kv,
             store,
             php_etag_cache_config: config.server.php_etag_cache.clone(),
             metrics_handle,
@@ -2538,7 +2546,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        Router::new(&config, test_store(), None, None, None, None)
+        Router::new(&config, test_store(), None, None, None, None, None)
     }
 
     // ── Ingest header hygiene (Finding 3) ────────────────────────────────
@@ -2635,7 +2643,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        Router::new(&config, test_store(), None, None, None, None)
+        Router::new(&config, test_store(), None, None, None, None, None)
     }
 
     #[allow(dead_code)]
@@ -2660,7 +2668,7 @@ mod tests {
             opcache: ephpm_config::OpcacheConfig::default(),
         };
         config.server.static_files.etag = true;
-        Router::new(&config, store, None, None, None, None)
+        Router::new(&config, store, None, None, None, None, None)
     }
 
     fn default_compression() -> CompressionSettings {
@@ -2865,7 +2873,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().trusted_proxies =
             vec!["10.0.0.0/8".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         // 203.0.113.50 is the real client, 10.0.0.1 is the proxy
         let xff = "203.0.113.50, 10.0.0.1";
@@ -2890,7 +2898,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().trusted_proxies =
             vec!["10.0.0.0/8".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let xff = "10.0.0.2, 10.0.0.1";
         let ip = router.resolve_xff(xff);
@@ -2943,7 +2951,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert_eq!(router.server_port, 3000);
     }
 
@@ -2963,7 +2971,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert_eq!(router.server_port, 8080);
     }
 
@@ -2985,7 +2993,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert!(router.open_basedir, "multi-tenant mode must default open_basedir on");
     }
 
@@ -3004,7 +3012,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert!(!router.open_basedir);
     }
 
@@ -3049,7 +3057,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert!(router.is_php_allowed("/anything.php"));
     }
 
@@ -3070,7 +3078,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-login.php".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert!(router.is_php_allowed("/index.php"));
         assert!(router.is_php_allowed("/wp-login.php"));
         assert!(!router.is_php_allowed("/evil.php"));
@@ -3093,7 +3101,7 @@ mod tests {
         };
         config.server.security.get_or_insert_default().allowed_php_paths =
             vec!["/index.php".to_string(), "/wp-admin/*.php".to_string()];
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert!(router.is_php_allowed("/index.php"));
         assert!(router.is_php_allowed("/wp-admin/admin.php"));
         assert!(router.is_php_allowed("/wp-admin/options.php"));
@@ -3325,7 +3333,7 @@ mod tests {
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert_eq!(router.server_port, 9090);
     }
 
@@ -3727,7 +3735,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("example.com");
         assert_eq!(doc_root, site_dir);
@@ -3753,7 +3761,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("unknown.com");
         assert_eq!(doc_root, dir.path());
@@ -3780,7 +3788,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("example.com:8080");
         assert_eq!(doc_root, site_dir);
@@ -3807,7 +3815,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("Example.COM");
         assert_eq!(doc_root, site_dir);
@@ -3831,7 +3839,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let (doc_root, _, _) = router.resolve_site("anything.com");
         assert_eq!(doc_root, dir.path());
@@ -3859,7 +3867,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         let (doc_root, index_files, fallback) = router.resolve_site("myblog.com");
         let resolved = router.resolve_fallback("/", "", &doc_root, index_files, fallback);
@@ -3890,7 +3898,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         // Host doesn't exist yet — should fall back to default.
         let (doc_root, _, _) = router.resolve_site("new-site.com");
@@ -3936,7 +3944,7 @@ echo "post response";
             middleware: Vec::new(),
             opcache: ephpm_config::OpcacheConfig::default(),
         };
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
 
         // Site exists — should resolve.
         let (doc_root, _, _) = router.resolve_site("temp-site.com");
@@ -4202,14 +4210,14 @@ data: two
         };
 
         config.server.timeouts.request = 0;
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert!(
             router.request_timeout.is_zero(),
             "request = 0 must disable the per-request deadline"
         );
 
         config.server.timeouts.request = 30;
-        let router = Router::new(&config, test_store(), None, None, None, None);
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert_eq!(router.request_timeout, Duration::from_secs(30));
     }
 }

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -45,8 +45,9 @@ fn main() {
         // tarball is a static-php-cli `--build-embed` build — no DLL). There
         // is no delay-loaded DLL to set up, and MSVC link.exe does not
         // support GNU ld's `--wrap`, so the zend_signal_* SIGPROF wrapping
-        // applied on Linux is a no-op here (ephpm enforces max_execution_time
-        // at the tokio layer, so PHP's SIGPROF handler should never fire).
+        // applied on Linux is a no-op here (ephpm bounds a request at the
+        // tokio layer via [server.timeouts] request and never sets PHP's
+        // max_execution_time, so PHP's SIGPROF handler should never fire).
         //
         // /FORCE:MULTIPLE: libintl_a and libiconv_a are both whole-archived
         // (see ephpm-php/build.rs::link_windows_static_deps) and each bundles
@@ -76,8 +77,8 @@ fn main() {
         // resolution order). It only matters if SIGPROF on tokio
         // worker threads ever fires — PHP installs the handler in
         // zend_signal_startup but typically only delivers it under
-        // max_execution_time, which ephpm enforces at the tokio layer
-        // instead and shouldn't trigger.
+        // max_execution_time, which ephpm never sets — it bounds a request
+        // at the tokio layer via [server.timeouts] request instead.
         println!("cargo::rustc-link-arg={}", lib_dir.join("libphp.a").display());
         for static_lib in macos_static_libs() {
             let archive = lib_dir.join(format!("lib{static_lib}.a"));

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -108,6 +108,20 @@ enum Commands {
         #[arg(long, default_value_t = 6379u16)]
         port: u16,
 
+        /// Password sent as RESP AUTH before the first command. Needed
+        /// whenever the server sets [kv.redis_compat] password or [kv] secret
+        /// — without it every command is refused with NOAUTH. Falls back to
+        /// the EPHPM_KV_PASSWORD environment variable.
+        #[arg(long)]
+        password: Option<String>,
+
+        /// First argument of the two-argument AUTH <user> <password> form.
+        /// Under per-site HMAC auth ([kv] secret with [server] sites_dir) this
+        /// is the vhost hostname, and the connection is scoped to that vhost's
+        /// store. Requires --password.
+        #[arg(long)]
+        user: Option<String>,
+
         #[command(subcommand)]
         subcommand: KvSubcommand,
     },
@@ -170,6 +184,12 @@ enum Commands {
         /// RESP server port (default: 6379)
         #[arg(long, default_value_t = 6379u16)]
         port: u16,
+
+        /// Password sent as RESP AUTH before the first command. Needed
+        /// whenever the server sets [kv.redis_compat] password. Falls back to
+        /// the EPHPM_KV_PASSWORD environment variable.
+        #[arg(long)]
+        password: Option<String>,
     },
 
     /// Cache management subcommands (OPcache introspection and local reset).
@@ -181,6 +201,12 @@ enum Commands {
         /// RESP server port (default: 6379)
         #[arg(long, default_value_t = 6379u16)]
         port: u16,
+
+        /// Password sent as RESP AUTH before the first command. Needed
+        /// whenever the server sets [kv.redis_compat] password. Falls back to
+        /// the EPHPM_KV_PASSWORD environment variable.
+        #[arg(long)]
+        password: Option<String>,
 
         #[command(subcommand)]
         subcommand: CacheSubcommand,
@@ -263,17 +289,20 @@ fn run() -> anyhow::Result<ExitCode> {
 
     match cli.command {
         Some(Commands::Php { args }) => run_php(&args),
-        Some(Commands::Kv { host, port, subcommand }) => {
+        Some(Commands::Kv { host, port, password, user, subcommand }) => {
+            let auth = KvAuth::resolve(user, password)?;
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-            rt.block_on(run_kv(&host, port, subcommand))
+            rt.block_on(run_kv(&host, port, &auth, subcommand))
         }
-        Some(Commands::Deploy { site, all, rev, host, port }) => {
+        Some(Commands::Deploy { site, all, rev, host, port, password }) => {
+            let auth = KvAuth::resolve(None, password)?;
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-            rt.block_on(run_deploy(&host, port, site.as_deref(), all, rev.as_deref()))
+            rt.block_on(run_deploy(&host, port, &auth, site.as_deref(), all, rev.as_deref()))
         }
-        Some(Commands::Cache { host, port, subcommand }) => {
+        Some(Commands::Cache { host, port, password, subcommand }) => {
+            let auth = KvAuth::resolve(None, password)?;
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-            rt.block_on(run_cache(&host, port, subcommand))
+            rt.block_on(run_cache(&host, port, &auth, subcommand))
         }
         Some(Commands::Install) => run_service_cmd(service::install),
         Some(Commands::Uninstall { keep_data }) => {
@@ -884,27 +913,110 @@ fn load_serve_config(command: Option<Commands>) -> anyhow::Result<(ephpm_config:
 // KV Store CLI Subcommands
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Dispatcher for all KV subcommands.
-async fn run_kv(host: &str, port: u16, sub: KvSubcommand) -> anyhow::Result<ExitCode> {
-    match sub {
-        KvSubcommand::Ping => kv_ping(host, port).await,
-        KvSubcommand::Keys { pattern } => kv_keys(host, port, &pattern).await,
-        KvSubcommand::Get { key } => kv_get(host, port, &key).await,
-        KvSubcommand::Set { key, value, ttl } => kv_set(host, port, &key, &value, ttl).await,
-        KvSubcommand::Del { keys } => kv_del(host, port, &keys).await,
-        KvSubcommand::Incr { key, by } => kv_incr(host, port, &key, by).await,
-        KvSubcommand::Ttl { key } => kv_ttl(host, port, &key).await,
+/// RESP credentials used for the CLI's short-lived connections.
+///
+/// The server turns `AUTH` on when either `[kv.redis_compat] password` or
+/// `[kv] secret` is set, and until a connection authenticates it answers every
+/// command except `AUTH` and `QUIT` with `-NOAUTH Authentication required`.
+/// There are two server-side modes:
+///
+/// - **Legacy single password** (`[kv.redis_compat] password`) — satisfied by
+///   `--password` alone, which sends `AUTH <password>`.
+/// - **Per-site HMAC** (`[kv] secret` together with `[server] sites_dir`) — the
+///   server expects `AUTH <hostname> <HMAC-SHA256(secret, hostname)>` and
+///   scopes the connection to that vhost's store. Satisfied by
+///   `--user <hostname> --password <derived>`; the derived value is exactly
+///   what ePHPm injects into PHP as `EPHPM_REDIS_PASSWORD`. Note that
+///   `deploy` / `cache reset` write keys the server reads from the *default*
+///   store, which a site-scoped connection cannot reach — those two commands
+///   only work under legacy-password mode.
+#[derive(Debug, Clone)]
+struct KvAuth {
+    /// First `AUTH` argument — the vhost hostname under per-site HMAC auth.
+    user: Option<String>,
+    /// The password. `None` means send no `AUTH` command at all.
+    password: Option<String>,
+}
+
+impl KvAuth {
+    /// Resolve credentials from the CLI flags, falling back to the
+    /// `EPHPM_KV_PASSWORD` environment variable when `--password` is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `--user` is given with no password, since the
+    /// two-argument `AUTH` form cannot be built from a username alone.
+    fn resolve(user: Option<String>, password: Option<String>) -> anyhow::Result<Self> {
+        let password =
+            password.or_else(|| std::env::var("EPHPM_KV_PASSWORD").ok()).filter(|p| !p.is_empty());
+        if user.is_some() && password.is_none() {
+            anyhow::bail!(
+                "--user requires a password — pass --password, or set the \
+                 EPHPM_KV_PASSWORD environment variable"
+            );
+        }
+        Ok(Self { user, password })
+    }
+
+    /// The `AUTH` frame to send before the first command, or `None` when no
+    /// credentials were supplied.
+    fn frame(&self) -> Option<Frame> {
+        let password = self.password.as_ref()?;
+        let mut args = vec![Frame::bulk(b"AUTH".to_vec())];
+        if let Some(user) = &self.user {
+            args.push(Frame::bulk(user.as_bytes().to_vec()));
+        }
+        args.push(Frame::bulk(password.as_bytes().to_vec()));
+        Some(Frame::Array(args))
     }
 }
 
-/// TCP connection helper.
-async fn kv_connect(host: &str, port: u16) -> anyhow::Result<TcpStream> {
+/// Dispatcher for all KV subcommands.
+async fn run_kv(
+    host: &str,
+    port: u16,
+    auth: &KvAuth,
+    sub: KvSubcommand,
+) -> anyhow::Result<ExitCode> {
+    match sub {
+        KvSubcommand::Ping => kv_ping(host, port, auth).await,
+        KvSubcommand::Keys { pattern } => kv_keys(host, port, auth, &pattern).await,
+        KvSubcommand::Get { key } => kv_get(host, port, auth, &key).await,
+        KvSubcommand::Set { key, value, ttl } => kv_set(host, port, auth, &key, &value, ttl).await,
+        KvSubcommand::Del { keys } => kv_del(host, port, auth, &keys).await,
+        KvSubcommand::Incr { key, by } => kv_incr(host, port, auth, &key, by).await,
+        KvSubcommand::Ttl { key } => kv_ttl(host, port, auth, &key).await,
+    }
+}
+
+/// TCP connection helper. Authenticates before returning, so every caller
+/// gets a stream that is ready for real commands.
+async fn kv_connect(host: &str, port: u16, auth: &KvAuth) -> anyhow::Result<TcpStream> {
     let addr: std::net::SocketAddr = format!("{host}:{port}")
         .parse()
         .with_context(|| format!("invalid address: {host}:{port}"))?;
-    TcpStream::connect(addr)
+    let mut stream = TcpStream::connect(addr)
         .await
-        .with_context(|| format!("could not connect to KV server at {host}:{port}"))
+        .with_context(|| format!("could not connect to KV server at {host}:{port}"))?;
+    kv_authenticate(&mut stream, auth).await?;
+    Ok(stream)
+}
+
+/// Send `AUTH` and check the reply.
+///
+/// A no-op when no password was supplied: the server only demands `AUTH` when
+/// it is configured with credentials, and sending one unprompted is harmless
+/// but pointless.
+async fn kv_authenticate(stream: &mut TcpStream, auth: &KvAuth) -> anyhow::Result<()> {
+    let Some(frame) = auth.frame() else {
+        return Ok(());
+    };
+    kv_send(stream, &frame).await?;
+    match kv_recv(stream).await? {
+        Frame::Simple(_) => Ok(()),
+        Frame::Error(e) => anyhow::bail!("KV authentication failed: {e}"),
+        other => anyhow::bail!("unexpected AUTH response: {other}"),
+    }
 }
 
 /// Send a RESP frame to the server.
@@ -929,16 +1041,16 @@ async fn kv_recv(stream: &mut TcpStream) -> anyhow::Result<Frame> {
 }
 
 /// Send a command and receive the response in one connection.
-async fn kv_roundtrip(host: &str, port: u16, cmd: Frame) -> anyhow::Result<Frame> {
-    let mut stream = kv_connect(host, port).await?;
+async fn kv_roundtrip(host: &str, port: u16, auth: &KvAuth, cmd: Frame) -> anyhow::Result<Frame> {
+    let mut stream = kv_connect(host, port, auth).await?;
     kv_send(&mut stream, &cmd).await?;
     kv_recv(&mut stream).await
 }
 
 /// PING command.
-async fn kv_ping(host: &str, port: u16) -> anyhow::Result<ExitCode> {
+async fn kv_ping(host: &str, port: u16, auth: &KvAuth) -> anyhow::Result<ExitCode> {
     let cmd = Frame::Array(vec![Frame::bulk(b"PING".to_vec())]);
-    match kv_roundtrip(host, port, cmd).await? {
+    match kv_roundtrip(host, port, auth, cmd).await? {
         Frame::Simple(s) => {
             println!("{s}");
             Ok(ExitCode::SUCCESS)
@@ -952,10 +1064,10 @@ async fn kv_ping(host: &str, port: u16) -> anyhow::Result<ExitCode> {
 }
 
 /// KEYS command.
-async fn kv_keys(host: &str, port: u16, pattern: &str) -> anyhow::Result<ExitCode> {
+async fn kv_keys(host: &str, port: u16, auth: &KvAuth, pattern: &str) -> anyhow::Result<ExitCode> {
     let cmd =
         Frame::Array(vec![Frame::bulk(b"KEYS".to_vec()), Frame::bulk(pattern.as_bytes().to_vec())]);
-    match kv_roundtrip(host, port, cmd).await? {
+    match kv_roundtrip(host, port, auth, cmd).await? {
         Frame::Array(items) => {
             if items.is_empty() {
                 println!("(empty)");
@@ -978,10 +1090,10 @@ async fn kv_keys(host: &str, port: u16, pattern: &str) -> anyhow::Result<ExitCod
 }
 
 /// GET command.
-async fn kv_get(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
+async fn kv_get(host: &str, port: u16, auth: &KvAuth, key: &str) -> anyhow::Result<ExitCode> {
     let cmd =
         Frame::Array(vec![Frame::bulk(b"GET".to_vec()), Frame::bulk(key.as_bytes().to_vec())]);
-    match kv_roundtrip(host, port, cmd).await? {
+    match kv_roundtrip(host, port, auth, cmd).await? {
         Frame::Bulk(data) => {
             match std::str::from_utf8(&data) {
                 Ok(s) => println!("{s}"),
@@ -1005,6 +1117,7 @@ async fn kv_get(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
 async fn kv_set(
     host: &str,
     port: u16,
+    auth: &KvAuth,
     key: &str,
     value: &str,
     ttl: Option<u64>,
@@ -1019,7 +1132,7 @@ async fn kv_set(
         args.push(Frame::bulk(secs.to_string().into_bytes()));
     }
     let cmd = Frame::Array(args);
-    match kv_roundtrip(host, port, cmd).await? {
+    match kv_roundtrip(host, port, auth, cmd).await? {
         Frame::Simple(s) => {
             println!("{s}");
             Ok(ExitCode::SUCCESS)
@@ -1037,13 +1150,13 @@ async fn kv_set(
 }
 
 /// DEL command.
-async fn kv_del(host: &str, port: u16, keys: &[String]) -> anyhow::Result<ExitCode> {
+async fn kv_del(host: &str, port: u16, auth: &KvAuth, keys: &[String]) -> anyhow::Result<ExitCode> {
     let mut args = vec![Frame::bulk(b"DEL".to_vec())];
     for key in keys {
         args.push(Frame::bulk(key.as_bytes().to_vec()));
     }
     let cmd = Frame::Array(args);
-    match kv_roundtrip(host, port, cmd).await? {
+    match kv_roundtrip(host, port, auth, cmd).await? {
         Frame::Integer(n) => {
             println!("(integer) {n}");
             Ok(ExitCode::SUCCESS)
@@ -1057,7 +1170,13 @@ async fn kv_del(host: &str, port: u16, keys: &[String]) -> anyhow::Result<ExitCo
 }
 
 /// INCR command.
-async fn kv_incr(host: &str, port: u16, key: &str, by: i64) -> anyhow::Result<ExitCode> {
+async fn kv_incr(
+    host: &str,
+    port: u16,
+    auth: &KvAuth,
+    key: &str,
+    by: i64,
+) -> anyhow::Result<ExitCode> {
     let cmd = if by == 1 {
         Frame::Array(vec![Frame::bulk(b"INCR".to_vec()), Frame::bulk(key.as_bytes().to_vec())])
     } else {
@@ -1067,7 +1186,7 @@ async fn kv_incr(host: &str, port: u16, key: &str, by: i64) -> anyhow::Result<Ex
             Frame::bulk(by.to_string().into_bytes()),
         ])
     };
-    match kv_roundtrip(host, port, cmd).await? {
+    match kv_roundtrip(host, port, auth, cmd).await? {
         Frame::Integer(n) => {
             println!("(integer) {n}");
             Ok(ExitCode::SUCCESS)
@@ -1081,8 +1200,8 @@ async fn kv_incr(host: &str, port: u16, key: &str, by: i64) -> anyhow::Result<Ex
 }
 
 /// TTL command.
-async fn kv_ttl(host: &str, port: u16, key: &str) -> anyhow::Result<ExitCode> {
-    let mut stream = kv_connect(host, port).await?;
+async fn kv_ttl(host: &str, port: u16, auth: &KvAuth, key: &str) -> anyhow::Result<ExitCode> {
+    let mut stream = kv_connect(host, port, auth).await?;
 
     // Send TTL
     kv_send(
@@ -1156,11 +1275,18 @@ fn resp_connect_hint(host: &str, port: u16) -> String {
 }
 
 /// Issue a RESP `SET key value` roundtrip, returning `Ok` on `+OK`.
-async fn kv_set_raw(host: &str, port: u16, key: &str, value: &str) -> anyhow::Result<()> {
+async fn kv_set_raw(
+    host: &str,
+    port: u16,
+    auth: &KvAuth,
+    key: &str,
+    value: &str,
+) -> anyhow::Result<()> {
     let stream = TcpStream::connect(format!("{host}:{port}"))
         .await
         .with_context(|| resp_connect_hint(host, port))?;
     let mut stream = stream;
+    kv_authenticate(&mut stream, auth).await?;
     let cmd = Frame::Array(vec![
         Frame::bulk(b"SET".to_vec()),
         Frame::bulk(key.as_bytes().to_vec()),
@@ -1169,6 +1295,10 @@ async fn kv_set_raw(host: &str, port: u16, key: &str, value: &str) -> anyhow::Re
     kv_send(&mut stream, &cmd).await?;
     match kv_recv(&mut stream).await? {
         Frame::Simple(_) => Ok(()),
+        Frame::Error(e) if e.starts_with("NOAUTH") => anyhow::bail!(
+            "KV server requires authentication ({e}) — pass --password or set \
+             EPHPM_KV_PASSWORD to the value of [kv.redis_compat] password"
+        ),
         Frame::Error(e) => anyhow::bail!("KV server returned error: {e}"),
         other => anyhow::bail!("unexpected RESP response: {other}"),
     }
@@ -1179,6 +1309,7 @@ async fn kv_set_raw(host: &str, port: u16, key: &str, value: &str) -> anyhow::Re
 async fn run_deploy(
     host: &str,
     port: u16,
+    auth: &KvAuth,
     site: Option<&str>,
     all: bool,
     rev: Option<&str>,
@@ -1187,10 +1318,10 @@ async fn run_deploy(
     let stamp = epoch_ms();
     let stamp_str = stamp.to_string();
     let version_key = format!("{OPCACHE_VERSION_PREFIX}{vhost}");
-    kv_set_raw(host, port, &version_key, &stamp_str).await?;
+    kv_set_raw(host, port, auth, &version_key, &stamp_str).await?;
     if let Some(revision) = rev {
         let rev_key = format!("{OPCACHE_REVISION_PREFIX}{vhost}");
-        kv_set_raw(host, port, &rev_key, revision).await?;
+        kv_set_raw(host, port, auth, &rev_key, revision).await?;
     }
     if vhost == OPCACHE_BROADCAST_VHOST {
         println!("deployed: broadcast (every vhost) at {stamp_str}");
@@ -1204,10 +1335,15 @@ async fn run_deploy(
 }
 
 /// `ephpm cache reset` / `ephpm cache status` dispatcher.
-async fn run_cache(host: &str, port: u16, sub: CacheSubcommand) -> anyhow::Result<ExitCode> {
+async fn run_cache(
+    host: &str,
+    port: u16,
+    auth: &KvAuth,
+    sub: CacheSubcommand,
+) -> anyhow::Result<ExitCode> {
     match sub {
         CacheSubcommand::Reset { site, all } => {
-            run_cache_reset(host, port, site.as_deref(), all).await
+            run_cache_reset(host, port, auth, site.as_deref(), all).await
         }
     }
 }
@@ -1223,6 +1359,7 @@ async fn run_cache(host: &str, port: u16, sub: CacheSubcommand) -> anyhow::Resul
 async fn run_cache_reset(
     host: &str,
     port: u16,
+    auth: &KvAuth,
     site: Option<&str>,
     all: bool,
 ) -> anyhow::Result<ExitCode> {
@@ -1230,7 +1367,7 @@ async fn run_cache_reset(
     let stamp = epoch_ms();
     let stamp_str = stamp.to_string();
     let key = format!("{OPCACHE_VERSION_PREFIX}{vhost}");
-    kv_set_raw(host, port, &key, &stamp_str).await?;
+    kv_set_raw(host, port, auth, &key, &stamp_str).await?;
     if vhost == OPCACHE_BROADCAST_VHOST {
         println!("cache reset: broadcast (every vhost) at {stamp_str}");
     } else {
@@ -1372,6 +1509,84 @@ mod cli_tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_kv_password_flag() {
+        // Parent-level flags come before the subcommand, same as --host/--port.
+        let args = ["ephpm", "kv", "--password", "s3cr3t", "ping"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(Commands::Kv { password, user, .. }) => {
+                assert_eq!(password.as_deref(), Some("s3cr3t"));
+                assert_eq!(user, None);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_kv_user_flag() {
+        let args = ["ephpm", "kv", "--user", "blog", "--password", "pw", "ping"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(Commands::Kv { user, .. }) => assert_eq!(user.as_deref(), Some("blog")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_deploy_password_flag() {
+        let args = ["ephpm", "deploy", "--all", "--password", "pw"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(Commands::Deploy { password, .. }) => assert_eq!(password.as_deref(), Some("pw")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_cache_password_flag() {
+        let args = ["ephpm", "cache", "--password", "pw", "reset", "--all"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(Commands::Cache { password, .. }) => assert_eq!(password.as_deref(), Some("pw")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kv_auth_without_credentials_sends_no_auth_frame() {
+        let auth = KvAuth { user: None, password: None };
+        assert!(auth.frame().is_none());
+    }
+
+    #[test]
+    fn kv_auth_password_only_uses_single_argument_form() {
+        let auth = KvAuth::resolve(None, Some("pw".to_string())).unwrap();
+        let want = Frame::Array(vec![Frame::bulk("AUTH"), Frame::bulk("pw")]);
+        assert_eq!(auth.frame(), Some(want));
+    }
+
+    #[test]
+    fn kv_auth_with_user_uses_two_argument_form() {
+        // What the server's per-site HMAC mode expects on the wire:
+        // AUTH <hostname> <HMAC-SHA256(secret, hostname)>.
+        let auth = KvAuth::resolve(Some("h".to_string()), Some("p".to_string())).unwrap();
+        let want = Frame::Array(vec![Frame::bulk("AUTH"), Frame::bulk("h"), Frame::bulk("p")]);
+        assert_eq!(auth.frame(), Some(want));
+    }
+
+    #[test]
+    fn kv_auth_rejects_user_without_password() {
+        let err = KvAuth::resolve(Some("h".to_string()), None).unwrap_err();
+        assert!(err.to_string().contains("--user requires a password"), "got: {err}");
+    }
+
+    #[test]
+    fn kv_auth_ignores_an_empty_password() {
+        let auth = KvAuth::resolve(None, Some(String::new())).unwrap();
+        assert!(auth.frame().is_none());
     }
 
     #[test]

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -514,6 +514,64 @@ fn warn_if_runtime_extension_flag(args: &[String]) {
     }
 }
 
+/// Warn once at startup for every config knob that is parsed but not acted
+/// upon, so a silently-ignored setting can never look like it took effect.
+///
+/// Each field is compared against its own section's `Default`, so an untouched
+/// config stays quiet and only a deliberate override produces a line. Whenever
+/// one of these knobs gains a real implementation, delete its branch here and
+/// the matching "Planned: not yet implemented" doc comment in `ephpm-config`.
+fn warn_unimplemented_knobs(config: &ephpm_config::Config) {
+    let php_defaults = ephpm_config::PhpConfig::default();
+    if config.php.max_execution_time != php_defaults.max_execution_time {
+        tracing::warn!(
+            max_execution_time = config.php.max_execution_time,
+            request_timeout = config.server.timeouts.request,
+            "[php] max_execution_time is not enforced — the value is not \
+             written into the generated php.ini, and PHP's own SIGPROF-based \
+             timer is deliberately disabled because that handler crashes when \
+             the signal lands on a tokio worker thread. The per-request \
+             deadline actually in force is [server.timeouts] request."
+        );
+    }
+
+    let rw_defaults = ephpm_config::ReadWriteSplitConfig::default();
+    if config.db.read_write_split.strategy != rw_defaults.strategy {
+        tracing::warn!(
+            strategy = %config.db.read_write_split.strategy,
+            "[db.read_write_split] strategy is parsed but not acted upon — the \
+             proxy always behaves as \"{}\" (reads stick to the primary for \
+             sticky_duration after a write)",
+            rw_defaults.strategy
+        );
+    }
+    if config.db.read_write_split.max_replica_lag != rw_defaults.max_replica_lag {
+        tracing::warn!(
+            max_replica_lag = %config.db.read_write_split.max_replica_lag,
+            "[db.read_write_split] max_replica_lag is parsed but not acted \
+             upon — replica lag is never measured, so no replica is skipped"
+        );
+    }
+
+    let analysis_defaults = ephpm_config::DbAnalysisConfig::default();
+    if config.db.analysis.auto_explain != analysis_defaults.auto_explain {
+        tracing::warn!(
+            auto_explain = config.db.analysis.auto_explain,
+            "[db.analysis] auto_explain is parsed but not acted upon — slow \
+             queries are still logged via [db.analysis] slow_query_threshold, \
+             but EXPLAIN is never run"
+        );
+    }
+    if config.db.analysis.auto_explain_target != analysis_defaults.auto_explain_target {
+        tracing::warn!(
+            auto_explain_target = %config.db.analysis.auto_explain_target,
+            "[db.analysis] auto_explain_target is parsed but not acted upon — \
+             EXPLAIN analysis is not implemented, so nothing is written to any \
+             target"
+        );
+    }
+}
+
 /// Convert a PHP exit code (i32) to a Rust `ExitCode`.
 fn exit_code_from(code: i32) -> ExitCode {
     if code == 0 { ExitCode::SUCCESS } else { ExitCode::from(u8::try_from(code).unwrap_or(1)) }
@@ -630,6 +688,9 @@ fn run_with_config(
         document_root = %config.server.document_root.display(),
         "starting ePHPm"
     );
+
+    // Never let a parsed-but-unimplemented knob look like it took effect.
+    warn_unimplemented_knobs(&config);
 
     // Build the effective PHP ini file. If the user specified ini_overrides
     // in the config, we have to materialize them on disk and load them via

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -175,12 +175,17 @@ impl Paths {
 /// `document_root` is the path written into the generated `[server]` section so
 /// that Windows installs reference `C:\ProgramData\ephpm\www` and Unix installs
 /// reference `/var/www/html`.
+///
+/// The body must round-trip through `Config::load` + `Config::validate` — the
+/// installer writes this file and then *starts* the service, so anything
+/// `validate()` rejects turns a fresh install into a service that dies on
+/// boot. `default_config_parses_and_validates` pins that.
 #[must_use]
 pub fn default_config_toml(document_root: &Path) -> String {
     let document_root_str = document_root.display().to_string();
     let escaped = document_root_str.replace('\\', "\\\\");
     format!(
-        "[server]\nlisten = \"0.0.0.0:8080\"\ndocument_root = \"{escaped}\"\nindex_files = [\"index.php\", \"index.html\"]\n\n[php]\nmode = \"embedded\"\nmax_execution_time = 30\nmemory_limit = \"128M\"\n"
+        "[server]\nlisten = \"0.0.0.0:8080\"\ndocument_root = \"{escaped}\"\nindex_files = [\"index.php\", \"index.html\"]\n\n[php]\nmode = \"fpm\"\nmax_execution_time = 30\nmemory_limit = \"128M\"\n"
     )
 }
 
@@ -524,8 +529,29 @@ mod tests {
         assert!(toml.contains("listen = \"0.0.0.0:8080\""));
         assert!(toml.contains("document_root = \"/var/www/html\""));
         assert!(toml.contains("[php]"));
+        assert!(toml.contains("mode = \"fpm\""));
         assert!(toml.contains("memory_limit = \"128M\""));
         assert!(toml.contains("max_execution_time = 30"));
+    }
+
+    #[test]
+    fn default_config_parses_and_validates() {
+        // `install()` writes this file and then immediately starts the
+        // service, so the generated body must survive exactly what the serve
+        // path does to it: `Config::load` followed by `Config::validate`.
+        // Asserting on substrings alone previously let `mode = "embedded"`
+        // ship — a value `validate()` rejects, so every fresh install came up
+        // dead.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ephpm.toml");
+        std::fs::write(&path, default_config_toml(Path::new("/var/www/html")))
+            .expect("write generated config");
+
+        let config = ephpm_config::Config::load(&path).expect("generated config must parse");
+        config.validate().expect("generated config must pass validate()");
+        assert_eq!(config.php.mode, "fpm");
+        assert_eq!(config.php.max_execution_time, 30);
+        assert_eq!(config.php.memory_limit, "128M");
     }
 
     #[test]

--- a/site/content/reference/cli/cache.md
+++ b/site/content/reference/cli/cache.md
@@ -10,13 +10,16 @@ is implemented; `status` is planned. See the
 ## Synopsis
 
 ```bash
-ephpm cache [--host HOST] [--port PORT] <subcommand>
+ephpm cache [--host HOST] [--port PORT] [--password PW] <subcommand>
 ```
 
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--host` | `127.0.0.1` | RESP server host |
 | `--port` | `6379` | RESP server port |
+| `--password` | `$EPHPM_KV_PASSWORD` | Password sent as RESP `AUTH` before the write. Required when the server sets `[kv.redis_compat] password`. See [`ephpm kv`](/reference/cli/kv/#authentication) for the two auth modes and the per-site HMAC limitation. |
+
+These are flags of `ephpm cache` itself, so they go **before** the subcommand.
 
 ## Subcommands
 

--- a/site/content/reference/cli/deploy.md
+++ b/site/content/reference/cli/deploy.md
@@ -15,9 +15,9 @@ This is the Phase-1 OPcache clustering interface. See the
 ## Synopsis
 
 ```bash
-ephpm deploy --site <NAME> [--rev SHA] [--host HOST] [--port PORT]
-ephpm deploy --all           [--rev SHA] [--host HOST] [--port PORT]
-ephpm deploy                 [--rev SHA] [--host HOST] [--port PORT]
+ephpm deploy --site <NAME> [--rev SHA] [--host HOST] [--port PORT] [--password PW]
+ephpm deploy --all           [--rev SHA] [--host HOST] [--port PORT] [--password PW]
+ephpm deploy                 [--rev SHA] [--host HOST] [--port PORT] [--password PW]
 ```
 
 | Flag | Default | Purpose |
@@ -27,6 +27,7 @@ ephpm deploy                 [--rev SHA] [--host HOST] [--port PORT]
 | `--rev` | (none) | Optional revision tag (e.g. a git SHA). Recorded at `opcache:revision:<vhost>` for observability; does not itself trigger invalidation. |
 | `--host` | `127.0.0.1` | RESP server host |
 | `--port` | `6379` | RESP server port |
+| `--password` | `$EPHPM_KV_PASSWORD` | Password sent as RESP `AUTH` before the write. Required when the server sets `[kv.redis_compat] password`. See [`ephpm kv`](/reference/cli/kv/#authentication) for the two auth modes and the per-site HMAC limitation. |
 
 Neither `--site` nor `--all` means "the default vhost" (`_default`),
 which is what a single-node deployment with no `sites_dir` uses.

--- a/site/content/reference/cli/kv.md
+++ b/site/content/reference/cli/kv.md
@@ -8,15 +8,42 @@ Inspect or manipulate the KV store on a running ePHPm server. Speaks the RESP2 p
 ## Synopsis
 
 ```bash
-ephpm kv [--host HOST] [--port PORT] <subcommand> [args]
+ephpm kv [--host HOST] [--port PORT] [--password PW] [--user NAME] <subcommand> [args]
 ```
 
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--host` | `127.0.0.1` | KV server host |
 | `--port` | `6379` | KV server port |
+| `--password` | `$EPHPM_KV_PASSWORD` | Password sent as RESP `AUTH` before the first command |
+| `--user` | (none) | First argument of the two-argument `AUTH <user> <password>` form. Requires `--password`. |
+
+Like `--host` and `--port`, these are flags of `ephpm kv` itself, so they go **before** the subcommand.
 
 The server must be configured with `[kv.redis_compat] enabled = true` for these commands to connect.
+
+## Authentication
+
+The RESP listener requires `AUTH` as soon as either `[kv.redis_compat] password` or `[kv] secret` is set — until a connection authenticates, every command except `AUTH` and `QUIT` is answered with `-NOAUTH Authentication required`. There are two server-side modes:
+
+**Single password** (`[kv.redis_compat] password`) — pass `--password`, or set `EPHPM_KV_PASSWORD` and leave the flag off:
+
+```bash
+ephpm kv --password "$KV_PASSWORD" keys '*'
+
+export EPHPM_KV_PASSWORD=...
+ephpm kv keys '*'
+```
+
+**Per-site HMAC** (`[kv] secret` together with `[server] sites_dir`) — the server expects `AUTH <hostname> <HMAC-SHA256(secret, hostname)>` and scopes the connection to that vhost's store. The derived password is the same value ePHPm injects into PHP as `EPHPM_REDIS_PASSWORD`, so pass it with `--user`:
+
+```bash
+ephpm kv --user blog.example.com --password "$DERIVED" keys '*'
+```
+
+The CLI does not derive that value itself — it never reads `[kv] secret`.
+
+**Limitation:** `ephpm deploy` and `ephpm cache reset` accept `--password` but not `--user`. They write `opcache:version:*`, which the server's OPcache watcher reads from the *default* store, and a site-scoped HMAC connection can only reach one vhost's store. Under per-site HMAC auth there is currently no CLI route to those keys.
 
 ## Subcommands
 
@@ -98,6 +125,9 @@ ephpm kv keys 'session:*' | xargs -r ephpm kv del
 
 # Connect to a remote instance
 ephpm kv --host 10.0.1.5 --port 6379 keys '*'
+
+# Connect to a password-protected listener
+ephpm kv --host 10.0.1.5 --password "$KV_PASSWORD" keys '*'
 ```
 
 ## See also


### PR DESCRIPTION
Five verified P1 bugs on `main`, one focused commit each. None relate to the Turso CDC work.

> **Nothing in this PR was compiled or tested locally** — there is no working Rust toolchain on the machine it was written on (no MSVC linker), so `cargo check`/`clippy`/`test`/`fmt` all fail at link time. Everything was written by reading surrounding source. Treat the first CI run as the real review.

---

### 1. `ephpm service install` wrote a config that cannot boot
`crates/ephpm/src/service/mod.rs`

`default_config_toml()` emitted `[php] mode = "embedded"`, which `Config::validate()` rejects (only `"fpm"` and `"worker"` are accepted). `install()` writes that file and then *starts* the service, so every fresh install died immediately with `invalid configuration: [php] mode must be "fpm" or "worker", got "embedded"`. The existing unit test only asserted on substrings, so it never noticed.

`"embedded"` → `"fpm"`, plus a new test that writes the generated body to a tempfile and runs the real `Config::load` + `validate()` on it. That test is the point of the change.

The same dead value in the repo-root `ephpm.toml` and `README.md` is being fixed separately in a docs pass and is deliberately untouched here.

### 2. Securing the RESP listener locked the CLI out entirely
`crates/ephpm/src/main.rs`, `site/content/reference/cli/{kv,deploy,cache}.md`

The CLI connected and sent its command immediately — it had no `AUTH` support at all. The server sets `auth_required` as soon as `[kv.redis_compat] password` or `[kv] secret` is present, then answers every non-`AUTH`/`QUIT` command with `-NOAUTH Authentication required`. So setting `[kv] secret` — which the server itself tells multi-tenant operators to set — broke `ephpm kv`, `ephpm deploy`, and `ephpm cache reset`. Under `ephpm serve` the latter two are the only way to refresh cached code, since opcache timestamp validation defaults off there.

- `--password` on `kv`, `deploy`, and `cache`, falling back to `EPHPM_KV_PASSWORD`.
- `--user` on `kv` for the two-argument `AUTH <hostname> <derived>` form the per-site HMAC mode expects.
- `AUTH` is sent from `kv_connect` / `kv_set_raw` before the first command; a `NOAUTH` reply on the deploy path now names the flag to pass.

Two limitations are documented rather than faked: the CLI never reads `[kv] secret`, so it cannot derive HMAC passwords itself (pass the value ePHPm injects as `EPHPM_REDIS_PASSWORD`); and `deploy` / `cache reset` write keys the OPcache watcher reads from the **default** store, which a site-scoped HMAC connection cannot reach — so under per-site HMAC auth there is currently no CLI route to those keys.

### 3. In vhost mode, PHP and RESP saw different keyspaces
`crates/ephpm-server/src/{lib,router}.rs`, `crates/ephpm-kv/`

`MultiTenantStore::new` allocates a fresh `sites` map on every call and `get_site_store()` lazily creates a `Store` per hostname inside *that* instance's map. Two instances existed — one in `Router::new` for the PHP path, one in `start_kv_service` for the RESP listener — sharing only `default_store` (used solely for the empty-hostname case). With `sites_dir` set, `ephpm_kv_set()` from PHP was invisible to Predis / `ephpm kv` on the same vhost and vice versa, falsifying the "one shared store" promise in the kv-store architecture page, the kv-from-php guide, and the kv CLI reference. Single-site mode was unaffected.

Built once in `start_kv_service` and handed to both consumers; `Router::new` takes it as a parameter instead of minting its own.

Folds in the related P2: both call sites passed `StoreConfig::default()` as the per-site template, so every vhost store ignored the `[kv]` block and ran on the hardcoded 256 MiB / allkeys-lru / no-compression defaults. The config-derived `StoreConfig` is now threaded through. Adds `Store::config()` so that is assertable.

### 4. `[php] max_execution_time` was a silent no-op
`crates/ephpm-config/src/lib.rs`, `crates/ephpm/src/main.rs`, `crates/ephpm/build.rs`

Read by nothing and not emitted into the generated php.ini. Emitting it would not help either — PHP's `SIGPROF`-based enforcement is deliberately neutralized because that handler crashes on tokio worker threads. A mod_php user setting `30` silently got `[server.timeouts] request` (300s).

Takes the honest option per CLAUDE.md: the doc comment now says it is not enforced and points at the knob that is, and a new `warn_unimplemented_knobs()` (modelled on `warn_if_runtime_extension_flag`) warns at startup. It also covers the four knobs that already had a "Planned" doc comment but no warning: `[db.read_write_split]` `strategy` and `max_replica_lag`, `[db.analysis]` `auto_explain` and `auto_explain_target`. Each compares against its own section default, so an untouched config stays quiet.

Two `build.rs` comments claiming ePHPm enforces `max_execution_time` at the tokio layer are corrected — what it enforces there is `[server.timeouts] request`.

The `site/content/reference/config.md` doc-table half is being handled separately and is untouched here.

### 5. `[php] memory_limit` silently dropped in dev mode and on macOS/Windows
`crates/ephpm-config/src/lib.rs`

`autotune()` resolves `memory_limit` as explicit `php_memory_limit` → derived → `[php] memory_limit`. The last tier is the resolver's "PHP stock default" slot, so it comes out `Origin::Default`, and `ini_lines()` omits every `Origin::Default` value. But that bottom tier is *not* a stock value — serde always populates it and an operator may have pinned it. The line therefore vanished whenever nothing was derived: dev mode always, and serve mode on macOS/Windows where `read_total_system_memory()` is `None`.

`memory_limit` is now emitted unconditionally. Regression tests cover the dev-mode path, the `Origin::Default` mechanism directly, and a `cfg(not(target_os = "linux"))` serve-mode case. Two existing exact-vector assertions were updated for the extra line.

---

### Tests added

| Bug | Tests |
|-----|-------|
| 1 | `default_config_parses_and_validates` (real `Config::load` + `validate()` round-trip); `mode = "fpm"` assertion in the existing test |
| 2 | 4 clap-parse tests + 5 `KvAuth` frame/resolve tests |
| 3 | `clones_share_the_same_site_stores`, `separate_instances_do_not_share_site_stores`, `site_stores_inherit_the_template_config` (ephpm-kv); `kv_service_has_no_multi_tenant_store_without_sites_dir`, `kv_service_site_stores_inherit_the_kv_config`, `kv_service_multi_tenant_clone_shares_site_stores` (ephpm-server) |
| 4 | none — the change is a log line; asserting on `tracing` output needs a capturing subscriber this crate has no harness for |
| 5 | `test_memory_limit_emitted_in_dev_mode`, `test_memory_limit_emitted_when_origin_is_default`, `test_memory_limit_emitted_in_serve_mode_without_memory_budget` |

### Where CI is most likely to bite

- **rustfmt** on the reflowed function signatures in `main.rs` (the `kv_*` / `run_*` functions gained an `auth` parameter) and on the new `bind_listeners(...)` call in `serve()`. Widths were computed by hand against `max_width = 100` / `use_small_heuristics = "Max"`; `kv_del`'s signature lands on exactly 100.
- **`Router::new` gained a 7th parameter** — 23 call sites in `router.rs` tests plus one in `lib.rs` tests were updated by exact-string replace. `too_many_arguments` is `allow` at workspace level.
- **Clippy pedantic** on the new `KvAuth` (private to the bin crate, so `must_use_candidate` should not fire) and on `Store::config()` (public, so `#[must_use]` was added).
- **`tracing::warn!` field types** in `warn_unimplemented_knobs` (`u32`, `u64`, `bool`, `%`-Display) and the one call that mixes named fields with a positional `{}` format arg.
