### PR TITLE
fix(deps): bump litewire to the identifier-sanitization fix (litewire#12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "anyhow",
  "futures",
@@ -2600,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2632,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "async-trait",
  "futures",
@@ -2661,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=699e6345d539#699e6345d539a59c56475974eabdec64c229ef1c"
+source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
 dependencies = [
  "async-trait",
  "litewire-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,16 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ 699e6345 — framework wire-compat: WP + Laravel over MySQL frontend (litewire#11)
-# (ephpm/litewire#9).
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "699e6345d539", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+# litewire main @ 7a0b59c4 — identifier sanitization in the metadata translator
+# (litewire#12), on top of framework wire-compat (litewire#11).
+#
+# SECURITY: do not move this pin backwards. 699e6345 and earlier interpolate the
+# client-supplied table name straight into SQL text in
+# litewire-translate/src/metadata.rs, and detect_metadata_query() runs before
+# sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
+# DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
+# applies it at every extraction site.
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "7a0b59c40ce6", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 
 # Release-profile tuning for v0.4.2 perf release.
 #


### PR DESCRIPTION
## Summary

`main` pins litewire **`699e6345`** — the commit immediately **before** the upstream SQL-injection fix. `7a0b59c4` is its **direct child** and contains that fix and nothing else.

The fix is already on `feat/turso-cdc-replication`. It has never landed on `main`, so **shipped code is the vulnerable one while a feature branch is patched.**

```
699e634  ← main pins this          0 × sanitize_identifier
7a0b59c  ← direct child, the fix   4 × sanitize_identifier
```

## The vulnerability

`litewire-translate/src/metadata.rs` interpolates the client-supplied table name straight into SQL text at nine sites:

```rust
Self::ShowCreateTable { table } => format!(
    "SELECT sql AS 'Create Table' FROM sqlite_master WHERE type='table' AND name='{table}'"
)
```

The name comes from `extract_table_name()`, which strips only leading/trailing backticks, quotes, brackets and semicolons, and splits on whitespace — so `/**/` survives. `translate()` calls `detect_metadata_query()` **before** sqlparser, so the payload never reaches a parser.

Reachable from all three SQL frontends (`litewire-mysql`, `litewire-postgres`, `litewire-tds`).

## Why this matters even though the frontends are unauthenticated

A direct wire client gains nothing — it could already run arbitrary SQL. The real impact is that **litewire converts an identifier position that real MySQL treats as inert into an injectable SQL-text position.**

Against MySQL, `` SHOW CREATE TABLE `x' UNION SELECT ...` `` is just an invalid table name. Against litewire it is arbitrary SQL.

ePHPm's pitch is "run WordPress/Laravel unmodified", and those interpolate table names into `SHOW` / `DESCRIBE` / `information_schema` queries as a matter of course — which is precisely why this translation path exists. **An application hardened against MySQL semantics is not hardened here.**

## Scope of the change

Beyond the `rev`, this is lockfile-only. litewire's own workspace `Cargo.toml` is byte-identical between the two revs, so all eight `litewire-*` lock entries need just the rev/hash swap. The resulting `Cargo.lock` source line is **byte-identical to the one cargo generated on `feat/turso-cdc-replication`**, which already carries this pin.

Added a `SECURITY:` note above the dependency so the pin isn't moved backwards.

## Verification caveat

There is no working Rust toolchain on this machine (no MSVC linker), so **this was not compiled locally.** The lockfile edit is cross-checked against cargo's own output on the CDC branch. CI is the first real check.

## Follow-up (not in this PR)

The single-node audit that surfaced this also found: no wire frontend authenticates at all (by design, loopback-only) but **there is no `is_loopback()` check anywhere in the tree**, so binding a DB listener to `0.0.0.0` publishes an unauthenticated SQL endpoint with no warning — unlike `[cluster] secret`, which is fail-closed. Tracking separately.