### PR TITLE
fix: nine audit findings — PG deadlock, path traversal, ACME leader, and six hardening fixes

### DIFF
--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -108,6 +108,31 @@ struct CachedValue {
     key: String,
 }
 
+/// Approximate heap footprint accounted for one hot-cache entry.
+fn hot_entry_bytes(entry: &CachedValue) -> u64 {
+    (entry.data.len() + entry.key.len() + 64) as u64
+}
+
+/// Evict `key_hash` from the hot cache, debiting the memory counter by the
+/// footprint of the entry *this caller actually removed*.
+///
+/// The accounting must hang off the value returned by `remove`, never off a
+/// value read beforehand. `DashMap::remove` returns `Some` to exactly one
+/// caller, so this is race-free; debiting unconditionally is not. Two readers
+/// hitting the same expired entry both used to subtract, and `hot_cache_mem`
+/// is a `u64` — it wraps to ~`u64::MAX`, the budget check in
+/// [`ClusteredStore::maybe_promote_hot_key`] is then always over, and hot-key
+/// promotion is silently dead for the rest of the process's life while
+/// [`ClusteredStore::hot_cache_mem_used`] reports garbage.
+///
+/// The caller must not be holding a `DashMap` guard for `key_hash`: `remove`
+/// takes the shard write lock.
+fn evict_hot_entry(cache: &DashMap<u64, CachedValue>, mem: &AtomicU64, key_hash: u64) {
+    if let Some((_, entry)) = cache.remove(&key_hash) {
+        mem.fetch_sub(hot_entry_bytes(&entry), Ordering::Relaxed);
+    }
+}
+
 impl ClusteredStore {
     /// Create a new clustered store.
     ///
@@ -158,19 +183,20 @@ impl ClusteredStore {
                 };
 
                 // If we have a cached copy at an older version, evict it.
-                if let Some(entry) = this.hot_cache.get(&key_hash) {
-                    if entry.version < new_version {
-                        let mem = entry.data.len() + entry.key.len() + 64;
-                        drop(entry);
-                        this.hot_cache.remove(&key_hash);
-                        this.hot_cache_mem.fetch_sub(mem as u64, Ordering::Relaxed);
-                        tracing::debug!(
-                            key_hash,
-                            old_version = new_version - 1,
-                            new_version,
-                            "hot key invalidated via gossip",
-                        );
-                    }
+                // Read the stale version out and release the shard read guard
+                // before `evict_hot_entry` takes the write lock.
+                let stale_version = this
+                    .hot_cache
+                    .get(&key_hash)
+                    .and_then(|entry| (entry.version < new_version).then_some(entry.version));
+                if let Some(old_version) = stale_version {
+                    evict_hot_entry(&this.hot_cache, &this.hot_cache_mem, key_hash);
+                    tracing::debug!(
+                        key_hash,
+                        old_version,
+                        new_version,
+                        "hot key invalidated via gossip",
+                    );
                 }
             })
             .await;
@@ -200,11 +226,13 @@ impl ClusteredStore {
                 if cached.cached_at.elapsed() < ttl && cached.key == key {
                     return Some(cached.data.clone());
                 }
-                // Expired — remove it.
-                let mem = cached.data.len() + cached.key.len() + 64;
+                // Expired (or a hash collision with another key) — evict it.
+                // Drop the shard read guard first: `evict_hot_entry` takes the
+                // write lock, and it debits the counter only for the entry it
+                // actually removed, so two readers racing here cannot
+                // double-subtract.
                 drop(cached);
-                self.hot_cache.remove(&key_hash);
-                self.hot_cache_mem.fetch_sub(mem as u64, Ordering::Relaxed);
+                evict_hot_entry(&self.hot_cache, &self.hot_cache_mem, key_hash);
             }
         }
 
@@ -441,11 +469,7 @@ impl ClusteredStore {
 
         // Evict from hot cache.
         if self.config.hot_key_cache {
-            let key_hash = hash_key(key);
-            if let Some((_, entry)) = self.hot_cache.remove(&key_hash) {
-                let mem = entry.data.len() + entry.key.len() + 64;
-                self.hot_cache_mem.fetch_sub(mem as u64, Ordering::Relaxed);
-            }
+            evict_hot_entry(&self.hot_cache, &self.hot_cache_mem, hash_key(key));
         }
 
         gossip_deleted || local_deleted
@@ -560,8 +584,10 @@ impl ClusteredStore {
         };
         let entry_mem = (value.len() + key.len() + 64) as u64;
 
-        // Don't exceed memory budget.
-        if self.hot_cache_mem.load(Ordering::Relaxed) + entry_mem > max_mem {
+        // Don't exceed memory budget. `saturating_add` so a bad accounting
+        // state can never turn this check into an overflow panic in debug
+        // builds.
+        if self.hot_cache_mem.load(Ordering::Relaxed).saturating_add(entry_mem) > max_mem {
             return;
         }
 
@@ -575,10 +601,11 @@ impl ClusteredStore {
             },
         );
 
-        // Adjust memory accounting.
+        // Adjust memory accounting. `insert` returns the displaced value to
+        // exactly one caller, so debiting off `old` is race-free for the same
+        // reason `evict_hot_entry` is.
         if let Some(old_entry) = old {
-            let old_mem = (old_entry.data.len() + old_entry.key.len() + 64) as u64;
-            self.hot_cache_mem.fetch_sub(old_mem, Ordering::Relaxed);
+            self.hot_cache_mem.fetch_sub(hot_entry_bytes(&old_entry), Ordering::Relaxed);
         }
         self.hot_cache_mem.fetch_add(entry_mem, Ordering::Relaxed);
 
@@ -625,11 +652,12 @@ impl ClusteredStore {
         let ttl = Duration::from_secs(self.config.hot_key_local_ttl_secs);
         let window = Duration::from_secs(self.config.hot_key_window_secs);
 
-        // Evict expired hot cache entries.
+        // Evict expired hot cache entries. `retain` visits each entry once
+        // under its shard lock, so the debit here happens exactly once per
+        // removal — same invariant `evict_hot_entry` enforces.
         self.hot_cache.retain(|_, entry| {
             if entry.cached_at.elapsed() >= ttl {
-                let mem = (entry.data.len() + entry.key.len() + 64) as u64;
-                self.hot_cache_mem.fetch_sub(mem, Ordering::Relaxed);
+                self.hot_cache_mem.fetch_sub(hot_entry_bytes(entry), Ordering::Relaxed);
                 false
             } else {
                 true
@@ -1085,6 +1113,54 @@ mod tests {
         assert_eq!(parse_memory_size("512kb").unwrap(), 512 * 1024);
         assert_eq!(parse_memory_size("100M").unwrap(), 100 * 1024 * 1024);
         assert_eq!(parse_memory_size("2G").unwrap(), 2 * 1024 * 1024 * 1024);
+    }
+
+    // ── hot cache memory accounting ──────────────────────────────────
+
+    fn hot_entry(len: usize) -> CachedValue {
+        CachedValue {
+            data: vec![0u8; len],
+            cached_at: Instant::now(),
+            version: 1,
+            key: "hot:key".to_string(),
+        }
+    }
+
+    /// Two readers racing on the same expired entry both used to
+    /// `fetch_sub` its footprint. `hot_cache_mem` is a `u64`, so the second
+    /// subtraction wrapped it to ~`u64::MAX`, the budget check in
+    /// `maybe_promote_hot_key` was over forever after, and hot-key promotion
+    /// went silently dead for the rest of the process's life.
+    #[test]
+    fn concurrent_eviction_debits_the_counter_exactly_once() {
+        let cache: DashMap<u64, CachedValue> = DashMap::new();
+        let mem = AtomicU64::new(0);
+
+        let entry = hot_entry(1024);
+        let bytes = hot_entry_bytes(&entry);
+        cache.insert(7, entry);
+        mem.store(bytes, Ordering::Relaxed);
+
+        std::thread::scope(|scope| {
+            for _ in 0..16 {
+                scope.spawn(|| evict_hot_entry(&cache, &mem, 7));
+            }
+        });
+
+        assert!(cache.is_empty(), "the entry must be gone");
+        assert_eq!(
+            mem.load(Ordering::Relaxed),
+            0,
+            "exactly one caller may debit the counter; a second subtraction wraps the u64"
+        );
+    }
+
+    #[test]
+    fn evicting_a_missing_key_leaves_the_counter_alone() {
+        let cache: DashMap<u64, CachedValue> = DashMap::new();
+        let mem = AtomicU64::new(4096);
+        evict_hot_entry(&cache, &mem, 99);
+        assert_eq!(mem.load(Ordering::Relaxed), 4096);
     }
 
     #[test]

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -525,7 +525,14 @@ fn parse_server_greeting(payload: &[u8]) -> Result<(ServerMeta, [u8; 20]), DbErr
     // Filler.
     pos += 1;
 
-    if pos + 6 > payload.len() {
+    // Everything from here to the auth-plugin-data length is a fixed 8-byte
+    // run: capability low (2) + charset (1) + status (2) + capability high (2)
+    // + plugin data length (1). The guard has to cover all 8 — at 6 a greeting
+    // truncated to exactly `pos + 6` or `pos + 7` passed the check and then
+    // panicked indexing `payload[pos + 6]` / `payload[pos + 7]` below. That is
+    // reachable from whatever answers on the configured DB port, and inside
+    // `Pool::warm` it silently kills the detached maintenance task.
+    if pos + 8 > payload.len() {
         return Err(DbError::Protocol("greeting too short (caps)".into()));
     }
 
@@ -1609,6 +1616,43 @@ pub async fn build_proxy(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_server_greeting bounds ──────────────────────────────────
+
+    /// Build a `HandshakeV10` payload truncated to `pos + extra` bytes, where
+    /// `pos` is the offset of the capability-flags run.
+    fn truncated_greeting(extra: usize) -> Vec<u8> {
+        let mut p = vec![10u8]; // protocol version
+        p.extend_from_slice(b"8.0.0\0"); // server version
+        p.extend_from_slice(&[0, 0, 0, 0]); // connection id
+        p.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]); // auth-plugin-data part 1
+        p.push(0); // filler
+        p.resize(p.len() + extra, 0);
+        p
+    }
+
+    /// A greeting truncated to exactly the old `pos + 6` / `pos + 7` bound
+    /// passed the length check and then panicked indexing `payload[pos + 6]`
+    /// and `payload[pos + 7]`. Reachable from whatever answers on the
+    /// configured DB port.
+    #[test]
+    fn short_greeting_is_rejected_not_panicked() {
+        for extra in 0..8 {
+            let payload = truncated_greeting(extra);
+            let result = parse_server_greeting(&payload);
+            assert!(
+                matches!(result, Err(DbError::Protocol(_))),
+                "greeting with {extra} capability bytes must be rejected, not panic"
+            );
+        }
+    }
+
+    #[test]
+    fn greeting_with_full_capability_run_parses() {
+        // 8 capability-run bytes + 10 reserved + 13 auth-plugin-data part 2.
+        let payload = truncated_greeting(8 + 10 + 13);
+        assert!(parse_server_greeting(&payload).is_ok(), "a complete greeting must still parse");
+    }
 
     // ── classify_mysql_query ──────────────────────────────────────────
 

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -53,8 +53,10 @@ const MSG_ERROR_RESPONSE: u8 = b'E';
 const MSG_QUERY: u8 = b'Q';
 /// `Terminate` — frontend connection close.
 const MSG_TERMINATE: u8 = b'X';
-/// `Parse` — frontend extended query: parse a prepared statement.
-const MSG_PARSE: u8 = b'P';
+/// `CopyInResponse` — backend is waiting for the client to stream `COPY ... FROM STDIN` data.
+const MSG_COPY_IN_RESPONSE: u8 = b'G';
+/// `CopyBothResponse` — backend entered bidirectional copy mode.
+const MSG_COPY_BOTH_RESPONSE: u8 = b'W';
 
 // ── Auth types ───────────────────────────────────────────────────────────────
 
@@ -993,6 +995,24 @@ fn pg_select_pool<'a>(
 }
 
 /// Proxy loop with per-query routing and dirty-bit tracking.
+///
+/// Per-message routing is only sound for the *simple* query protocol: a
+/// `Query` message is always answered by a backend message stream that
+/// terminates in `ReadyForQuery`, so the proxy can block on the backend
+/// before reading from the client again.
+///
+/// The *extended* query protocol breaks that assumption. `Parse`, `Bind`,
+/// `Describe`, `Execute` and `Close` produce no backend output at all until
+/// the client sends `Sync` — which is a *later client* message. Forwarding a
+/// single extended-protocol message and then awaiting `ReadyForQuery`
+/// deadlocks the session on the first prepared statement, which is what every
+/// real client does (`PDO_pgsql`, `PQexecParams`, `tokio-postgres`). The same
+/// holds once the backend answers with `CopyInResponse`/`CopyBothResponse`:
+/// the next move belongs to the client, not the backend.
+///
+/// In both cases the session is pinned to one backend connection and spliced
+/// straight through for the rest of its lifetime — see
+/// [`pg_relay_pinned_session`].
 async fn pg_proxy_routing_loop(
     mut client: TcpStream,
     pool: &Pool,
@@ -1013,28 +1033,28 @@ async fn pg_proxy_routing_loop(
             break;
         }
 
-        // For simple Query messages, classify and route.
-        let query_kind = if tag == MSG_QUERY {
-            // Query payload is null-terminated SQL.
-            let sql = String::from_utf8_lossy(&payload);
-            let sql = sql.trim_end_matches('\0');
-            classify_pg_query(sql)
-        } else {
-            // Extended query protocol messages (Parse, Bind, etc.) — treat as writes
-            // unless we can inspect the SQL in Parse.
-            if tag == MSG_PARSE && payload.len() > 1 {
-                // Parse: [name\0][query\0][param_count: 2][param_oids...]
-                let name_end = payload.iter().position(|&b| b == 0).unwrap_or(0);
-                let query_start = name_end + 1;
-                let query_end = payload[query_start..]
-                    .iter()
-                    .position(|&b| b == 0)
-                    .map_or(payload.len(), |p| query_start + p);
-                let sql = String::from_utf8_lossy(&payload[query_start..query_end]);
-                classify_pg_query(&sql)
-            } else {
-                PgQueryKind::Write
+        // Anything that is not a simple `Query` belongs to the extended query
+        // protocol (or a copy sub-protocol). Pin to the primary — a replica
+        // cannot serve writes that may arrive later on the same pinned
+        // connection — and relay the remainder of the session verbatim.
+        if tag != MSG_QUERY {
+            debug!(
+                tag = %char::from(tag),
+                "extended query protocol in use; pinning session to primary"
+            );
+            let mut checkout = pool.acquire().await?;
+            let mut backend = checkout.take_stream();
+            if let Err(e) = write_pg_message(&mut backend, tag, &payload).await {
+                checkout.retire();
+                return Err(e);
             }
+            return pg_relay_pinned_session(client, backend, checkout, reset_strategy).await;
+        }
+
+        // Query payload is null-terminated SQL.
+        let query_kind = {
+            let sql = String::from_utf8_lossy(&payload);
+            classify_pg_query(sql.trim_end_matches('\0'))
         };
 
         // Update state tracking.
@@ -1056,12 +1076,23 @@ async fn pg_proxy_routing_loop(
 
         write_pg_message(&mut backend, tag, &payload).await?;
 
-        // Forward response(s) until ReadyForQuery.
+        // Forward response(s) until ReadyForQuery — or until the backend hands
+        // the conversation back to the client via a copy sub-protocol, in
+        // which case no further backend output is coming.
+        let mut copy_mode = false;
         loop {
             let resp_tag = forward_pg_message(&mut backend, &mut client).await?;
             if resp_tag == MSG_READY_FOR_QUERY {
                 break;
             }
+            if resp_tag == MSG_COPY_IN_RESPONSE || resp_tag == MSG_COPY_BOTH_RESPONSE {
+                copy_mode = true;
+                break;
+            }
+        }
+
+        if copy_mode {
+            return pg_relay_pinned_session(client, backend, checkout, reset_strategy).await;
         }
 
         // Return backend to pool.
@@ -1087,6 +1118,37 @@ async fn pg_proxy_routing_loop(
         }
     }
 
+    Ok(())
+}
+
+/// Pin an already-acquired `backend` to `client` and splice both directions
+/// until either side closes, then recycle the backend.
+///
+/// Used for the extended query protocol and the copy sub-protocols, where
+/// message boundaries do not line up with turn boundaries and the proxy
+/// therefore cannot tell when it is safe to block on the backend. Because no
+/// per-statement state can be tracked through an opaque splice, the connection
+/// is always reset before being parked unless the operator explicitly opted
+/// out with [`ResetStrategy::Never`].
+async fn pg_relay_pinned_session(
+    client: TcpStream,
+    backend: TcpStream,
+    checkout: Checkout,
+    reset_strategy: ResetStrategy,
+) -> Result<(), DbError> {
+    match pg_proxy_bidirectional(client, backend).await {
+        Ok(backend) => {
+            if matches!(reset_strategy, ResetStrategy::Never) {
+                checkout.return_to_pool(backend);
+            } else {
+                checkout.return_with_reset(backend).await;
+            }
+        }
+        Err(e) => {
+            debug!("pinned session error, discarding backend connection: {e}");
+            checkout.retire();
+        }
+    }
     Ok(())
 }
 
@@ -1397,6 +1459,72 @@ mod tests {
         assert_eq!(rdata, payload);
     }
 
+    // ── extended query protocol ─────────────────────────────────────
+
+    /// Regression test for the extended-query-protocol deadlock.
+    ///
+    /// `pg_proxy_routing_loop` used to forward exactly one client message and
+    /// then block awaiting `ReadyForQuery`. In the extended protocol the
+    /// backend stays silent until the client sends `Sync`, so the proxy never
+    /// read it and the session wedged on the first prepared statement. The
+    /// routing loop is entered whenever `reset_strategy == Smart`, which is
+    /// the default, so this was the shipped path.
+    #[tokio::test]
+    async fn extended_query_protocol_does_not_deadlock() {
+        // Fake PG backend: silent until it sees Sync ('S'), then answers
+        // ParseComplete / BindComplete / CommandComplete / ReadyForQuery.
+        let backend_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+        let backend_task = tokio::spawn(async move {
+            let (mut sock, _) = backend_listener.accept().await.unwrap();
+            while let Ok((tag, _payload)) = read_pg_message(&mut sock).await {
+                if tag == b'S' {
+                    write_pg_message(&mut sock, b'1', &[]).await.unwrap();
+                    write_pg_message(&mut sock, b'2', &[]).await.unwrap();
+                    write_pg_message(&mut sock, b'C', b"SELECT 1\0").await.unwrap();
+                    send_ready_for_query(&mut sock, b'I').await.unwrap();
+                }
+            }
+        });
+
+        let (mut client, proxy_side) = make_tcp_pair().await;
+        let rw_split =
+            PgRwSplitParams { enabled: false, sticky_duration: std::time::Duration::from_secs(1) };
+        let proxy_task = tokio::spawn(async move {
+            let pool = pool_dialing(backend_addr);
+            let rr = AtomicUsize::new(0);
+            pg_proxy_routing_loop(proxy_side, &pool, &[], &rr, &rw_split, ResetStrategy::Smart)
+                .await
+        });
+
+        // Parse / Bind / Describe / Execute / Sync — what PDO_pgsql sends for
+        // a prepared statement.
+        write_pg_message(&mut client, b'P', b"\0SELECT 1\0\0\0").await.unwrap();
+        write_pg_message(&mut client, b'B', b"\0\0\0\0\0\0\0\0").await.unwrap();
+        write_pg_message(&mut client, b'D', b"P\0").await.unwrap();
+        write_pg_message(&mut client, b'E', b"\0\0\0\0\0").await.unwrap();
+        write_pg_message(&mut client, b'S', &[]).await.unwrap();
+
+        let tags = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let mut seen = Vec::new();
+            loop {
+                let (tag, _) = read_pg_message(&mut client).await.unwrap();
+                seen.push(tag);
+                if tag == MSG_READY_FOR_QUERY {
+                    return seen;
+                }
+            }
+        })
+        .await
+        .expect("extended query protocol must not deadlock");
+
+        assert_eq!(tags, vec![b'1', b'2', b'C', MSG_READY_FOR_QUERY]);
+
+        drop(client);
+        proxy_task.abort();
+        backend_task.abort();
+    }
+
     // ── Test helpers ─────────────────────────────────────────────────
 
     /// Create a connected pair of `TcpStream` for testing.
@@ -1415,6 +1543,30 @@ mod tests {
         let connect = || -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
             Box::pin(async { Err(DbError::PoolClosed) })
         };
+        let reset = |s: TcpStream| -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
+            Box::pin(async { Ok(s) })
+        };
+        let ping = |s: TcpStream| -> crate::pool::BoxFuture<Result<(TcpStream, bool), DbError>> {
+            Box::pin(async { Ok((s, true)) })
+        };
+        let config = PoolConfig {
+            min_connections: 1,
+            max_connections: 2,
+            idle_timeout: std::time::Duration::from_secs(60),
+            max_lifetime: std::time::Duration::from_secs(300),
+            pool_timeout: std::time::Duration::from_secs(5),
+            health_check_interval: std::time::Duration::from_secs(30),
+        };
+        Pool::new(config, connect, reset, ping)
+    }
+
+    /// Create a `Pool` whose connections dial `addr` with no PG handshake.
+    fn pool_dialing(addr: std::net::SocketAddr) -> Pool {
+        let connect = move || -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
+            Box::pin(async move { TcpStream::connect(addr).await.map_err(DbError::from) })
+        };
+        // No-op reset: the fake backend in these tests does not implement
+        // `DISCARD ALL`.
         let reset = |s: TcpStream| -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
             Box::pin(async { Ok(s) })
         };

--- a/crates/ephpm-query-stats/src/lib.rs
+++ b/crates/ephpm-query-stats/src/lib.rs
@@ -369,15 +369,23 @@ fn classify_query(sql: &str) -> QueryKind {
 }
 
 /// Truncate normalized SQL for use as a Prometheus label. Caps at 64
-/// chars to keep label bodies bounded (this is per-label-value length;
+/// bytes to keep label bodies bounded (this is per-label-value length;
 /// the cross-label cardinality is bounded separately by
 /// [`StatsConfig::metric_label_series_max`]).
 fn truncate_for_label(normalized: &str) -> std::borrow::Cow<'_, str> {
     if normalized.len() <= 64 {
-        std::borrow::Cow::Borrowed(normalized)
-    } else {
-        std::borrow::Cow::Owned(format!("{}...", &normalized[..61]))
+        return std::borrow::Cow::Borrowed(normalized);
     }
+    // Byte-slicing at a fixed 61 panics when the boundary lands inside a
+    // multi-byte character. Non-ASCII does reach the normalized SQL — via
+    // backtick-quoted identifiers and the normalizer's catch-all byte copy —
+    // so any query over 64 bytes containing a UTF-8 identifier used to panic
+    // the recording call and drop the litewire connection.
+    let mut end = 61;
+    while !normalized.is_char_boundary(end) {
+        end -= 1;
+    }
+    std::borrow::Cow::Owned(format!("{}...", &normalized[..end]))
 }
 
 #[cfg(test)]
@@ -503,6 +511,29 @@ mod tests {
         let label = truncate_for_label(s);
         assert!(label.len() <= 67); // 64 + "..."
         assert!(label.ends_with("..."));
+    }
+
+    /// The truncation used to be a raw byte slice at 61, which panics when
+    /// that offset lands inside a multi-byte character. Non-ASCII reaches
+    /// the normalized SQL through backtick identifiers and the normalizer's
+    /// catch-all byte copy, so this was reachable from a query.
+    #[test]
+    fn truncate_label_does_not_split_a_utf8_character() {
+        // Byte 61 is the *second* byte of the first `é` (bytes 60..62).
+        let s = format!("{}{}", "a".repeat(60), "é".repeat(10));
+        assert!(s.len() > 64, "input must be long enough to truncate");
+        assert!(!s.is_char_boundary(61), "byte 61 must land mid-character for this test");
+
+        let label = truncate_for_label(&s);
+        let expected = format!("{}...", "a".repeat(60));
+        assert!(label.ends_with("..."));
+        assert_eq!(&*label, expected.as_str());
+    }
+
+    #[test]
+    fn truncate_label_passes_through_at_exactly_64_bytes() {
+        let s = "a".repeat(64);
+        assert_eq!(&*truncate_for_label(&s), s.as_str());
     }
 
     #[test]

--- a/crates/ephpm-server/src/acme.rs
+++ b/crates/ephpm-server/src/acme.rs
@@ -7,15 +7,31 @@
 //! ## Clustered mode
 //!
 //! When a KV store is provided, ACME operates in distributed mode:
-//! - **Leader election**: an `acme:leader` key with TTL heartbeat ensures
-//!   only one node issues/renews certificates at a time.
-//! - **Challenge tokens**: stored in the KV store so any node can respond
-//!   to HTTP-01 challenges.
+//! - **Leader election**: an `acme:leader` key with TTL heartbeat, plus a
+//!   lowest-node-id tie-break, settles on one node. Only that node drives
+//!   ordering and renewal; every other node waits for the leader's
+//!   certificate to appear in the KV store rather than ordering its own.
+//!   The gossip KV tier has no compare-and-swap, so the claim is confirmed
+//!   over two heartbeats before it is acted on — see
+//!   `try_acquire_acme_leadership`.
+//! - **Challenge tokens**: **not yet implemented.** `get_acme_challenge`
+//!   lets any node answer `/.well-known/acme-challenge/<token>` out of the
+//!   KV store, but nothing populates those keys, and the TLS-ALPN-01
+//!   challenge material this SAPI actually requests lives only in the
+//!   ordering node's in-memory resolver. Validation therefore has to reach
+//!   the leader.
 //! - **Certificate distribution**: issued certs are written to the KV
 //!   store by the leader as soon as ACME finishes ordering, then loaded
 //!   by every other node on cache miss. A local [`DirCache`] is kept
 //!   alongside the KV cache so a single-node leader can also reload
 //!   its cert after restart without paying a network round-trip.
+//!   **Not yet implemented**: a follower does not pick up a *renewed*
+//!   certificate while it is running. `rustls-acme` consults the cert cache
+//!   exactly once per `AcmeState`, and its resolver's `set_cert` is
+//!   `pub(crate)`, so a fresh certificate cannot be injected from outside
+//!   the state machine. Followers serve the certificate they loaded at
+//!   startup until they restart. Closing this needs a KV-backed
+//!   `ResolvesServerCert` of our own.
 //!
 //! The recommended low-level integration uses [`tokio_rustls::LazyConfigAcceptor`]
 //! to inspect each TLS `ClientHello`: ACME challenge connections are handled
@@ -25,13 +41,14 @@ use std::convert::Infallible;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use ephpm_config::TlsConfig;
 use ephpm_kv::store::Store;
 use rustls::ServerConfig;
 use rustls_acme::caches::DirCache;
-use rustls_acme::{AccountCache, AcmeConfig, AcmeState, CertCache};
+use rustls_acme::{AccountCache, AcmeConfig, AcmeState, CertCache, EventOk};
 use sha2::{Digest, Sha256};
 use tokio_stream::StreamExt;
 
@@ -82,8 +99,14 @@ pub fn start_acme(tls_config: &TlsConfig, store: Option<Arc<Store>>) -> anyhow::
     let clustered = store.is_some();
     let (challenge_config, default_config) = match store {
         Some(kv_store) => {
-            let cache =
-                LayeredCache::new(KvCache::new(Arc::clone(&kv_store)), DirCache::new(cache_dir));
+            // Shared with the event loop below. The cache needs to know
+            // whether this node currently holds ACME leadership, because
+            // reporting a cache miss to rustls-acme is what makes it place an
+            // order — and only the leader may do that.
+            let leader_flag = Arc::new(AtomicBool::new(false));
+            let kv_cache = KvCache::new(Arc::clone(&kv_store));
+            let cache = LayeredCache::new(kv_cache, DirCache::new(cache_dir))
+                .with_leader_gate(Arc::clone(&leader_flag));
             let config = base.cache(cache);
             let config = if let Some(email) = email {
                 config.contact_push(format!("mailto:{email}"))
@@ -96,7 +119,7 @@ pub fn start_acme(tls_config: &TlsConfig, store: Option<Arc<Store>>) -> anyhow::
             if let Some(cfg) = Arc::get_mut(&mut default_config) {
                 cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
             }
-            tokio::spawn(drive_clustered_acme_events(state, kv_store));
+            tokio::spawn(drive_clustered_acme_events(state, kv_store, leader_flag));
             (challenge_config, default_config)
         }
         None => {
@@ -157,6 +180,17 @@ const ACME_LEADER_KEY: &str = "acme:leader";
 const ACME_LEADER_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 /// Heartbeat interval for the ACME leader (must be less than TTL).
 const ACME_LEADER_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Consecutive confirmed heartbeats required before a node acts as leader.
+///
+/// The gossip KV tier is eventually consistent, so during the second or so it
+/// takes a write to propagate, two nodes can each win their *local* claim.
+/// Requiring the claim to survive another heartbeat gives the deterministic
+/// tie-break in [`try_acquire_acme_leadership`] time to settle before anything
+/// talks to Let's Encrypt.
+const ACME_LEADER_CONFIRMATIONS: u32 = 2;
+/// How often a follower re-checks the KV store for the leader's certificate
+/// while holding a `load_cert` open.
+const ACME_FOLLOWER_CERT_POLL: std::time::Duration = std::time::Duration::from_secs(5);
 /// KV key prefix for ACME challenge tokens.
 const ACME_CHALLENGE_PREFIX: &str = "acme:challenge:";
 /// KV key prefix for stored certificates.
@@ -172,15 +206,41 @@ fn acme_node_id() -> String {
 
 /// Drive ACME events with distributed leader election via the KV store.
 ///
-/// Only the leader node processes ACME events (certificate ordering/renewal).
-/// When the leader obtains a certificate, it distributes the cert to all nodes
-/// via the KV store so they can hot-load it.
+/// Only the leader orders and renews certificates. The leader's cache layer
+/// publishes each new certificate into the KV store, and followers pick it up
+/// on their one and only `load_cert`.
+///
+/// ## Why followers poll at all
+///
+/// `rustls-acme` builds its `load_cert` future once, in `AcmeState::new`, and
+/// consumes it on the first poll. A node that never polls therefore never
+/// installs *any* certificate in its resolver and cannot serve HTTPS. So a
+/// follower is allowed to poll until it has deployed a certificate — and
+/// [`LayeredCache`] holds that load open instead of reporting a miss, which
+/// is the only way a poll can fall through to placing an order.
+///
+/// Once a follower has deployed, it stops polling entirely. That freezes its
+/// renewal timer, which is what keeps it off Let's Encrypt for good.
+///
+/// ## Known limitation
+///
+/// A follower therefore does *not* pick up the leader's renewed certificate:
+/// `AcmeState` consults the cert cache exactly once, and its resolver's
+/// `set_cert` is `pub(crate)`, so there is no way to inject a fresh
+/// certificate from outside the state machine. Followers serve the
+/// certificate they loaded at startup until they restart. Closing that gap
+/// needs a KV-backed `ResolvesServerCert` of our own; it is tracked as the
+/// remaining clustered-ACME work.
 async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
     mut state: AcmeState<EC, EA>,
     store: Arc<Store>,
+    leader_flag: Arc<AtomicBool>,
 ) {
     let node_id = acme_node_id();
     let mut is_leader = false;
+    let mut confirmations: u32 = 0;
+    // Set once this node has a certificate installed in its resolver.
+    let mut deployed = false;
     let mut heartbeat_interval = tokio::time::interval(ACME_LEADER_HEARTBEAT);
     heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -188,16 +248,33 @@ async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
         tokio::select! {
             // Heartbeat: try to acquire or maintain leadership.
             _ = heartbeat_interval.tick() => {
-                is_leader = try_acquire_acme_leadership(&store, &node_id);
-                if is_leader {
+                if try_acquire_acme_leadership(&store, &node_id) {
+                    confirmations = confirmations.saturating_add(1);
+                } else {
+                    confirmations = 0;
+                }
+                let now_leader = confirmations >= ACME_LEADER_CONFIRMATIONS;
+                if now_leader != is_leader {
+                    is_leader = now_leader;
+                    leader_flag.store(is_leader, Ordering::Release);
+                    if is_leader {
+                        tracing::info!(node_id, "this node is now the ACME leader");
+                    } else {
+                        tracing::info!(node_id, "this node is no longer the ACME leader");
+                    }
+                } else if is_leader {
                     tracing::debug!("ACME leader heartbeat maintained");
                 }
             }
-            // Process ACME events (only meaningful if we're the leader,
-            // but we always poll to keep the state machine alive).
-            event = state.next() => {
+            // Drive the state machine only while it cannot place an order we
+            // do not want: always on the leader, and on a follower only until
+            // it has a certificate deployed.
+            event = state.next(), if is_leader || !deployed => {
                 match event {
                     Some(Ok(ref ev)) => {
+                        if matches!(ev, EventOk::DeployedCachedCert | EventOk::DeployedNewCert) {
+                            deployed = true;
+                        }
                         if is_leader {
                             // The cache layer wired into AcmeConfig
                             // pushes new certs into the KV store as part
@@ -206,14 +283,14 @@ async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
                             // already replicated cluster-wide.
                             tracing::info!(?ev, "ACME certificate event (leader, distributed via KV)");
                         } else {
-                            tracing::debug!(?ev, "ACME certificate event (follower)");
+                            tracing::info!(?ev, "ACME certificate event (follower, loaded from KV)");
                         }
                     }
                     Some(Err(ref err)) => {
                         if is_leader {
                             tracing::error!(?err, "ACME error (leader)");
                         } else {
-                            tracing::debug!(?err, "ACME error (follower)");
+                            tracing::warn!(?err, "ACME error (follower)");
                         }
                     }
                     None => {
@@ -226,41 +303,60 @@ async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
     }
 }
 
-/// Try to acquire ACME leadership via the KV store.
+/// Try to acquire or renew ACME leadership via the KV store.
 ///
-/// Uses a simple compare-and-set pattern: if the `acme:leader` key
-/// doesn't exist or was set by us, we (re)claim it with a TTL.
+/// Returns `true` if this node holds the `acme:leader` key.
 ///
-/// Returns `true` if this node is now the leader.
+/// # This is not a true distributed lock
+///
+/// [`Store::set_nx`] is a genuine atomic test-and-set *within one process*,
+/// which is why it replaces the previous get-then-set. Across the cluster
+/// there is no equivalent: the gossip KV tier
+/// (`ClusterHandle::gossip_set`/`gossip_get` in `ephpm-cluster`) offers only
+/// last-write-wins set / get / delete over eventually consistent chitchat
+/// state — it has no compare-and-swap primitive to build on. Two nodes
+/// starting together can therefore both win their local claim for the second
+/// or so it takes the write to propagate.
+///
+/// What makes it converge is the tie-break below: a node that sees a
+/// *different* holder yields unless its own id sorts lower, in which case it
+/// takes the key over. The comparison is total and every node eventually
+/// applies it to the same converged value, so exactly one node survives —
+/// the same "lowest id wins" rule `ephpm-cluster::sqlite_election` uses.
+/// The caller additionally waits [`ACME_LEADER_CONFIRMATIONS`] heartbeats
+/// before acting on a claim, so the pre-convergence window cannot turn into
+/// duplicate certificate orders.
 fn try_acquire_acme_leadership(store: &Store, node_id: &str) -> bool {
-    let current = store.get(ACME_LEADER_KEY);
-    match current {
-        None => {
-            // No leader — claim it.
-            store.set(
-                ACME_LEADER_KEY.to_string(),
-                node_id.as_bytes().to_vec(),
-                Some(ACME_LEADER_TTL),
-            );
-            tracing::info!(node_id, "acquired ACME leadership");
-            true
-        }
-        Some(existing) => {
-            let existing_id = String::from_utf8_lossy(&existing);
-            if existing_id == node_id {
-                // We're already the leader — renew the TTL.
-                store.set(
-                    ACME_LEADER_KEY.to_string(),
-                    node_id.as_bytes().to_vec(),
-                    Some(ACME_LEADER_TTL),
-                );
-                true
-            } else {
-                // Another node is the leader.
-                false
-            }
-        }
+    let key = ACME_LEADER_KEY.to_string();
+    let claim = node_id.as_bytes().to_vec();
+
+    // `set_nx` is atomic within this process: only one caller creates the key.
+    if store.set_nx(key.clone(), claim.clone(), Some(ACME_LEADER_TTL)) {
+        tracing::info!(node_id, "acquired ACME leadership");
+        return true;
     }
+
+    let Some(existing) = store.get(ACME_LEADER_KEY) else {
+        // Expired between the `set_nx` and this read. Leave it to the next
+        // heartbeat rather than racing.
+        return false;
+    };
+    let existing_id = String::from_utf8_lossy(&existing);
+    if existing_id == node_id {
+        // We already hold it — renew the TTL.
+        store.set(key, claim, Some(ACME_LEADER_TTL));
+        return true;
+    }
+    if node_id < &*existing_id {
+        tracing::info!(
+            node_id,
+            %existing_id,
+            "taking over ACME leadership (lower node id wins the tie-break)"
+        );
+        store.set(key, claim, Some(ACME_LEADER_TTL));
+        return true;
+    }
+    false
 }
 
 /// Store an ACME challenge token in the KV store for any node to serve.
@@ -486,13 +582,37 @@ impl AccountCache for KvCache {
 pub struct LayeredCache {
     kv: KvCache,
     dir: DirCache<PathBuf>,
+    /// When present, a miss in *both* tiers is held open unless this node is
+    /// the ACME leader. See [`LayeredCache::with_leader_gate`].
+    leader: Option<Arc<AtomicBool>>,
 }
 
 impl LayeredCache {
     /// Construct a new layered cache from its KV and disk components.
+    ///
+    /// Without [`LayeredCache::with_leader_gate`] a cache miss is reported to
+    /// rustls-acme as-is, which is the correct behaviour for a single node.
     #[must_use]
     pub fn new(kv: KvCache, dir: DirCache<PathBuf>) -> Self {
-        Self { kv, dir }
+        Self { kv, dir, leader: None }
+    }
+
+    /// Gate cache misses on ACME leadership.
+    ///
+    /// `rustls-acme` reads `Ok(None)` from `load_cert` as "no certificate
+    /// exists, place an order". In a cluster that must only ever happen on
+    /// one node: five duplicate orders for the same domain set in a week is a
+    /// hard Let's Encrypt lockout with no way to shorten it. With the gate
+    /// installed, a node that is not the leader waits for the leader's
+    /// certificate to land in the KV store instead of reporting a miss, so it
+    /// can never fall through to ordering.
+    ///
+    /// `flag` is written by the ACME event loop as leadership changes, so a
+    /// node that is promoted mid-wait stops waiting and takes over ordering.
+    #[must_use]
+    pub fn with_leader_gate(mut self, flag: Arc<AtomicBool>) -> Self {
+        self.leader = Some(flag);
+        self
     }
 }
 
@@ -505,18 +625,34 @@ impl CertCache for LayeredCache {
         domains: &[String],
         directory_url: &str,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
-        // Try KV first so cluster-wide rollouts win over stale local disk.
-        match self.kv.load_cert(domains, directory_url).await {
-            Ok(Some(bytes)) => return Ok(Some(bytes)),
-            Ok(None) => {}
-            Err(_unreachable) => {} // Infallible
-        }
-        match self.dir.load_cert(domains, directory_url).await {
-            Ok(value) => Ok(value),
-            Err(err) => {
-                tracing::warn!(?err, "ACME DirCache cert load failed — treating as miss");
-                Ok(None)
+        loop {
+            // Try KV first so cluster-wide rollouts win over stale local disk.
+            match self.kv.load_cert(domains, directory_url).await {
+                Ok(Some(bytes)) => return Ok(Some(bytes)),
+                Ok(None) => {}
+                Err(_unreachable) => {} // Infallible
             }
+            match self.dir.load_cert(domains, directory_url).await {
+                Ok(Some(bytes)) => return Ok(Some(bytes)),
+                Ok(None) => {}
+                Err(err) => {
+                    tracing::warn!(?err, "ACME DirCache cert load failed — treating as miss");
+                }
+            }
+
+            // Both tiers missed. Reporting the miss is what makes rustls-acme
+            // place an order, so only the leader is allowed to do it; see
+            // [`LayeredCache::with_leader_gate`].
+            let may_order = self.leader.as_ref().is_none_or(|f| f.load(Ordering::Acquire));
+            if may_order {
+                return Ok(None);
+            }
+            tracing::debug!(
+                ?domains,
+                "ACME certificate not cached and this node is not the ACME leader — \
+                 waiting for the leader to publish instead of ordering"
+            );
+            tokio::time::sleep(ACME_FOLLOWER_CERT_POLL).await;
         }
     }
 
@@ -658,6 +794,98 @@ mod tests {
     fn acme_cert_missing_returns_none() {
         let store = test_store();
         assert!(get_acme_cert(&store, "missing.com").is_none());
+    }
+
+    #[test]
+    fn acme_leader_lower_node_id_takes_over() {
+        // Both nodes can win their *local* claim while the gossip write is
+        // in flight, so the tie-break has to be deterministic once the value
+        // converges: the lower id keeps the key, the higher id yields.
+        let store = test_store();
+        assert!(try_acquire_acme_leadership(&store, "node-z"));
+        assert!(
+            try_acquire_acme_leadership(&store, "node-a"),
+            "a lower node id must take the key over once it observes the holder"
+        );
+        assert_eq!(store.get(ACME_LEADER_KEY).as_deref(), Some(b"node-a".as_slice()));
+        assert!(
+            !try_acquire_acme_leadership(&store, "node-z"),
+            "the higher node id must yield on its next heartbeat"
+        );
+    }
+
+    #[test]
+    fn acme_leader_election_converges_regardless_of_claim_order() {
+        // Models the pre-convergence window: several nodes each won their
+        // local claim, then gossip settled on an arbitrary one of them. One
+        // heartbeat round across every node must land on the same answer no
+        // matter which claim gossip happened to keep.
+        for first in ["node-c", "node-a", "node-b"] {
+            let store = test_store();
+            assert!(try_acquire_acme_leadership(&store, first));
+            for id in ["node-c", "node-a", "node-b"] {
+                try_acquire_acme_leadership(&store, id);
+            }
+            assert_eq!(
+                store.get(ACME_LEADER_KEY).as_deref(),
+                Some(b"node-a".as_slice()),
+                "one heartbeat round must converge on the lowest node id (first claim: {first})"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn layered_cache_follower_waits_instead_of_reporting_a_miss() {
+        // A cache miss is what makes rustls-acme place an order. On a
+        // follower it must never be reported: N nodes reporting a miss is N
+        // duplicate Let's Encrypt orders and a week-long rate-limit lockout.
+        let store = test_store();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let leader = Arc::new(AtomicBool::new(false));
+        let cache = LayeredCache::new(KvCache::new(store), DirCache::new(tmp.path().to_path_buf()))
+            .with_leader_gate(Arc::clone(&leader));
+
+        let domains = ["absent.example.com".to_string()];
+        let waited = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            cache.load_cert(&domains, TEST_DIRECTORY),
+        )
+        .await;
+        assert!(waited.is_err(), "a follower must hold the load open, not report a miss");
+
+        // Promoted to leader: the miss is now allowed through so this node
+        // can order.
+        leader.store(true, Ordering::Release);
+        let loaded = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            cache.load_cert(&domains, TEST_DIRECTORY),
+        )
+        .await
+        .expect("the leader must not be gated")
+        .expect("infallible");
+        assert!(loaded.is_none());
+    }
+
+    #[tokio::test]
+    async fn layered_cache_follower_returns_the_leaders_cert() {
+        let store = test_store();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let domains = vec!["published.example.com".to_string()];
+        let cert = b"cert-published-by-the-leader";
+        KvCache::new(Arc::clone(&store))
+            .store_cert(&domains, TEST_DIRECTORY, cert)
+            .await
+            .expect("infallible");
+
+        let cache = LayeredCache::new(KvCache::new(store), DirCache::new(tmp.path().to_path_buf()))
+            .with_leader_gate(Arc::new(AtomicBool::new(false)));
+
+        let loaded = cache.load_cert(&domains, TEST_DIRECTORY).await.expect("infallible");
+        assert_eq!(
+            loaded.as_deref(),
+            Some(cert.as_slice()),
+            "the gate must not delay a cert that is already published",
+        );
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -517,6 +517,46 @@ async fn bind_listeners(
     })
 }
 
+/// Pause after an `accept()` failure that is likely to repeat immediately.
+///
+/// Long enough that a wedged listener cannot spin a core, short enough that a
+/// transient descriptor shortage clears without a visible stall.
+const ACCEPT_BACKOFF_MS: u64 = 50;
+
+/// Decide what to do about a failed `accept()`.
+///
+/// An accept error is never fatal to the server. Descriptor exhaustion
+/// (`EMFILE`/`ENFILE`) and an aborted handshake (`ECONNABORTED`) are
+/// transient, per-connection conditions; propagating either out of
+/// [`accept_loop`] used to terminate the loop and shut the whole process
+/// down over one bad connection.
+///
+/// Returns `Some(backoff)` when the caller should pause before accepting
+/// again. Errors that clearly concern a single connection retry immediately;
+/// everything else — including descriptor exhaustion, which has no stable
+/// [`std::io::ErrorKind`] and would otherwise busy-loop — backs off first.
+fn handle_accept_error(err: &std::io::Error, listener: &str) -> Option<Duration> {
+    match err.kind() {
+        std::io::ErrorKind::ConnectionAborted
+        | std::io::ErrorKind::ConnectionReset
+        | std::io::ErrorKind::Interrupted => {
+            tracing::debug!(
+                error = %err,
+                "{listener} accept failed for one connection; continuing"
+            );
+            None
+        }
+        _ => {
+            tracing::warn!(
+                error = %err,
+                backoff_ms = ACCEPT_BACKOFF_MS,
+                "{listener} accept failed; backing off and continuing"
+            );
+            Some(Duration::from_millis(ACCEPT_BACKOFF_MS))
+        }
+    }
+}
+
 /// Run the accept loop, dispatching connections to the appropriate handler.
 async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
     let Listeners {
@@ -567,7 +607,15 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
     loop {
         tokio::select! {
             result = main.accept() => {
-                let (stream, remote_addr) = result.context("failed to accept connection")?;
+                let (stream, remote_addr) = match result {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        if let Some(backoff) = handle_accept_error(&e, "HTTP") {
+                            tokio::time::sleep(backoff).await;
+                        }
+                        continue;
+                    }
+                };
                 // HTTP responses (JSON APIs, small pages, 304s) are frequently
                 // sub-MSS; without nodelay, Nagle holds the response tail until
                 // the client ACKs, which delayed-ACK defers ~40ms — surfacing as
@@ -585,7 +633,15 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
             result = async {
                 tls_listener.as_ref().expect("guarded by is_some").accept().await
             }, if tls_listener.is_some() => {
-                let (stream, remote_addr) = result.context("failed to accept TLS connection")?;
+                let (stream, remote_addr) = match result {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        if let Some(backoff) = handle_accept_error(&e, "HTTPS") {
+                            tokio::time::sleep(backoff).await;
+                        }
+                        continue;
+                    }
+                };
                 // Same rationale as the plain-HTTP accept above; set on the raw
                 // TCP stream before the TLS handshake wraps it.
                 let _ = stream.set_nodelay(true);
@@ -1717,5 +1773,28 @@ mod lib_tests {
             .expect("read response");
         assert!(n > 0, "expected response bytes on a still-open connection");
         assert!(buf.starts_with(b"HTTP/1.1"), "expected an HTTP/1.1 response line");
+    }
+
+    // ── accept() error handling ──────────────────────────────────────
+
+    /// An accept error must never be fatal. Both of these used to be
+    /// `result.context(..)?` out of `accept_loop`, so one aborted handshake
+    /// or a momentary descriptor shortage took the whole process down.
+    #[test]
+    fn aborted_handshake_retries_without_backoff() {
+        let err = std::io::Error::from(std::io::ErrorKind::ConnectionAborted);
+        assert_eq!(handle_accept_error(&err, "HTTP"), None);
+    }
+
+    #[test]
+    fn unrecognised_accept_error_backs_off_instead_of_spinning() {
+        // Descriptor exhaustion (EMFILE/ENFILE) has no stable `ErrorKind`, so
+        // it lands in the catch-all arm. Retrying instantly would busy-loop a
+        // core while the process is already degraded.
+        let err = std::io::Error::other("simulated descriptor exhaustion");
+        assert_eq!(
+            handle_accept_error(&err, "HTTP"),
+            Some(Duration::from_millis(ACCEPT_BACKOFF_MS))
+        );
     }
 }

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1456,7 +1456,7 @@ impl Router {
             // "must-be-tighter-than-current" check, since each site's path
             // is a peer rather than a subset of the previous one.
             if vhost_open_basedir {
-                let basedir = format!("{}:/tmp", document_root.display());
+                let basedir = vhost_open_basedir_value(&document_root);
                 PhpRuntime::set_request_ini("open_basedir", &basedir);
             }
 
@@ -2448,6 +2448,23 @@ fn build_php_response(
     }
 }
 
+/// Build the per-vhost `open_basedir` value: the site's document root plus
+/// the system temp directory.
+///
+/// PHP splits `open_basedir` on the platform's `PATH_SEPARATOR` — `:` on
+/// Unix, `;` on Windows. Hardcoding `:` produced a single bogus Windows
+/// entry (`C:\sites\blog:/tmp`) that matches no path, so every file access
+/// under a vhost was denied. `/tmp` is Unix-only for the same reason;
+/// `std::env::temp_dir()` is the portable equivalent and honours `TMPDIR`.
+///
+/// `ServerConfig::effective_open_basedir` defaults to `true` whenever
+/// `sites_dir` is set, so this value is what a default Windows vhost
+/// deployment runs with.
+fn vhost_open_basedir_value(document_root: &Path) -> String {
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    format!("{}{separator}{}", document_root.display(), std::env::temp_dir().display())
+}
+
 /// Check if a filesystem path is a PHP file.
 fn is_php_file(path: &Path) -> bool {
     path.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("php"))
@@ -3354,6 +3371,34 @@ mod tests {
     fn has_hidden_segment_deep_nesting() {
         assert!(has_hidden_segment("/a/b/c/.secret/d"));
         assert!(!has_hidden_segment("/a/b/c/d/e"));
+    }
+
+    // ── per-vhost open_basedir ──────────────────────────────────────
+
+    /// PHP splits `open_basedir` on the platform `PATH_SEPARATOR`. The value
+    /// used to be `format!("{}:/tmp", document_root.display())`, so on
+    /// Windows — where the separator is `;` and the docroot itself contains
+    /// a drive-letter colon — a vhost got one bogus entry matching nothing
+    /// and every file access was denied.
+    #[test]
+    fn vhost_open_basedir_uses_platform_separator_and_real_temp_dir() {
+        let temp = std::env::temp_dir();
+        let root = temp.join("ephpm-basedir-test");
+        let value = vhost_open_basedir_value(&root);
+
+        let separator = if cfg!(windows) { ';' } else { ':' };
+        let parts: Vec<&str> = value.split(separator).collect();
+        assert_eq!(parts.len(), 2, "expected exactly docroot + temp dir, got {value}");
+        assert_eq!(
+            parts[0],
+            root.display().to_string(),
+            "the document root must survive verbatim (drive-letter colon included)"
+        );
+        assert_eq!(
+            parts[1],
+            temp.display().to_string(),
+            "the second entry must be the real temp dir, not a literal /tmp"
+        );
     }
 
     // ── is_php_file edge cases ──────────────────────────────────────

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -603,6 +603,37 @@ impl Router {
         Some(canon)
     }
 
+    /// Require a resolved PHP script to live inside its site's document root.
+    ///
+    /// The static branch gets this for free from `static_files::serve_file`,
+    /// which canonicalizes the file and checks
+    /// `starts_with(canonical_root)`. The PHP branch had only
+    /// [`Router::is_php_allowed`], a URI *prefix* test that cannot see
+    /// symlinks or dot segments — so a script reachable through a symlink
+    /// pointing out of the docroot executed anyway, which under `sites_dir`
+    /// vhosting is cross-tenant code execution.
+    ///
+    /// Canonicalizing the root goes through the cached [`Router::canonical_root`];
+    /// only the script itself costs a `canonicalize()` per request, the same
+    /// price the static path already pays.
+    fn php_script_contained(&self, fs_path: &Path, site_root: &Path) -> bool {
+        let Some(canonical_root) = self.canonical_root(site_root) else {
+            return false;
+        };
+        let Ok(canonical_script) = fs_path.canonicalize() else {
+            return false;
+        };
+        if !canonical_script.starts_with(&canonical_root) {
+            tracing::warn!(
+                path = %fs_path.display(),
+                root = %canonical_root.display(),
+                "PHP path traversal attempt blocked"
+            );
+            return false;
+        }
+        true
+    }
+
     /// Attach the native middleware chain loaded in `serve()` at startup.
     /// Kept out of `new()`'s signature so its many existing call sites (all
     /// middleware-free) stay unchanged.
@@ -970,7 +1001,9 @@ impl Router {
         ) {
             Resolved::File(fs_path) => {
                 if is_php_file(&fs_path) {
-                    if self.is_php_allowed(&uri_path) {
+                    if self.is_php_allowed(&uri_path)
+                        && self.php_script_contained(&fs_path, &site_root)
+                    {
                         let is_cacheable = (method_ref == hyper::Method::GET
                             || method_ref == hyper::Method::HEAD)
                             && self.php_etag_cache_config.enabled;
@@ -1804,12 +1837,25 @@ fn has_hidden_segment(uri_path: &str) -> bool {
     })
 }
 
+/// Returns `true` if any segment of `path` is exactly `..`.
+///
+/// Both `/` and `\` count as separators: once the URI path is joined onto a
+/// document root, Windows treats the backslash as a real separator, so
+/// `/a\..\b` traverses exactly like `/a/../b`.
+fn has_dot_dot_segment(path: &str) -> bool {
+    path.split(['/', '\\']).any(|segment| segment == "..")
+}
+
 /// Percent-decode a URI path so static-file lookup and routing work
 /// against the literal characters the client meant.
 ///
 /// Returns `None` if the input is malformed (truncated `%`, non-hex
-/// digits) or contains an encoded `/` / `\` — those would let percent
-/// encoding bypass path-traversal checks and prefix-based blocks like
+/// digits), contains an encoded `/` / `\`, or contains a `..` path
+/// segment — all three would let the request address a file the URI-level
+/// checks never saw. Nothing downstream normalizes dot segments: the joined
+/// path goes straight to the filesystem, so `/../b/index.php` on a raw
+/// socket (browsers normalize it away, `curl --path-as-is` does not) would
+/// otherwise escape the document root and bypass prefix-based blocks like
 /// `/vendor/*`. Callers should treat `None` as a 400.
 ///
 /// The output is validated as UTF-8; an invalid sequence also yields
@@ -1821,7 +1867,7 @@ fn percent_decode_path(raw: &str) -> Option<String> {
     // can hand back an owned copy without the byte-by-byte scan, the
     // `Vec<u8>` build, or the trailing `from_utf8` re-validation.
     if !bytes.contains(&b'%') {
-        return Some(raw.to_owned());
+        return if has_dot_dot_segment(raw) { None } else { Some(raw.to_owned()) };
     }
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -1843,7 +1889,13 @@ fn percent_decode_path(raw: &str) -> Option<String> {
             i += 1;
         }
     }
-    String::from_utf8(out).ok()
+    let decoded = String::from_utf8(out).ok()?;
+    // `%2e%2e` decodes to `..`, so the dot-segment check has to run on the
+    // decoded form, not the raw one.
+    if has_dot_dot_segment(&decoded) {
+        return None;
+    }
+    Some(decoded)
 }
 
 fn hex_nibble(b: u8) -> Option<u8> {
@@ -2923,6 +2975,65 @@ mod tests {
         assert_eq!(percent_decode_path("/a%"), None);
         assert_eq!(percent_decode_path("/a%2"), None);
         assert_eq!(percent_decode_path("/a%zz"), None);
+    }
+
+    #[test]
+    fn percent_decode_rejects_dot_dot_segments() {
+        // Nothing downstream normalizes dot segments, and `has_hidden_segment`
+        // explicitly exempts `..`, so a literal `../` used to be joined
+        // straight onto the document root. Browsers normalize it away; a raw
+        // socket or `curl --path-as-is` does not.
+        assert_eq!(percent_decode_path("/../b/index.php"), None);
+        assert_eq!(percent_decode_path("/a/../../etc/passwd"), None);
+        assert_eq!(percent_decode_path("/a/.."), None);
+        // `%2e%2e` decodes to `..` — the check must run after decoding.
+        assert_eq!(percent_decode_path("/%2e%2e/b/index.php"), None);
+        // Backslash is a separator once the path is joined on Windows.
+        assert_eq!(percent_decode_path("/a\\..\\b"), None);
+        // `..` inside a segment is an ordinary filename, not a traversal.
+        assert_eq!(percent_decode_path("/a..b/c").as_deref(), Some("/a..b/c"));
+        assert_eq!(percent_decode_path("/...").as_deref(), Some("/..."));
+    }
+
+    // ── PHP document-root containment ────────────────────────────────
+
+    /// The PHP branch used to run `handle_php` on whatever
+    /// `doc_root.join(path)` produced, guarded only by `is_php_allowed`
+    /// (a URI prefix test). Under `sites_dir` vhosting that is cross-tenant
+    /// code execution.
+    #[test]
+    fn php_script_outside_document_root_is_rejected() {
+        let outer = tempfile::tempdir().unwrap();
+        let docroot = outer.path().join("site-a");
+        let sibling = outer.path().join("site-b");
+        std::fs::create_dir_all(&docroot).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+        std::fs::write(docroot.join("index.php"), "<?php echo 'a';").unwrap();
+        std::fs::write(sibling.join("index.php"), "<?php echo 'b';").unwrap();
+
+        let router = test_router(&docroot);
+
+        // Exactly what `probe_path` builds for `GET /../site-b/index.php`.
+        let escaped = docroot.join("../site-b/index.php");
+        assert!(escaped.is_file(), "traversal target must exist for this test to mean anything");
+        assert!(
+            !router.php_script_contained(&escaped, &docroot),
+            "a PHP script resolving outside the document root must not execute"
+        );
+
+        assert!(
+            router.php_script_contained(&docroot.join("index.php"), &docroot),
+            "a PHP script inside the document root must still execute"
+        );
+    }
+
+    #[test]
+    fn php_script_missing_file_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let router = test_router(dir.path());
+        // `canonicalize()` fails on a nonexistent path; treat that as
+        // "not contained" rather than trusting the unresolved join.
+        assert!(!router.php_script_contained(&dir.path().join("nope.php"), dir.path()));
     }
 
     // ── port parsing ─────────────────────────────────────────────────

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1217,6 +1217,13 @@ impl Router {
         document_root: PathBuf,
     ) -> Response<ServerBody> {
         let method = req.method().to_string();
+        // `method` is the client's raw verb and belongs in PHP's `$_SERVER`,
+        // never in a Prometheus label — that is exactly what
+        // `method_metric_label` exists to prevent (see `handle`): standard
+        // verbs map to a `&'static str`, everything else collapses to
+        // `"OTHER"`, so random verbs can't explode the series count or cost
+        // a `String` allocation per request on the hot path.
+        let method_label: &'static str = method_metric_label(req.method());
         let mut uri = req.uri().to_string();
         let mut path = req.uri().path().to_string();
         let query_string = req.uri().query().unwrap_or("").to_string();
@@ -1329,7 +1336,7 @@ impl Router {
                     }
                 };
                 #[allow(clippy::cast_precision_loss)]
-                histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
+                histogram!("ephpm_http_request_body_bytes", "method" => method_label)
                     .record(bytes.len() as f64);
                 (ephpm_php::worker_bridge::WorkerBody::Buffered(bytes), None)
             };
@@ -1392,7 +1399,7 @@ impl Router {
             }
         };
         #[allow(clippy::cast_precision_loss)]
-        histogram!("ephpm_http_request_body_bytes", "method" => method.clone())
+        histogram!("ephpm_http_request_body_bytes", "method" => method_label)
             .record(body.len() as f64);
 
         let multi_tenant_kv = self.multi_tenant_kv.clone();

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -37,6 +37,12 @@ ephpm-server.workspace = true
 # mismatch (LNK2038). The Windows allocator picture is also different —
 # SEG_HEAP already reduces the contention mimalloc addresses on glibc — so
 # Windows keeps the system allocator.
+#
+# tempfile is a runtime dependency, not just a test one: the generated
+# php.ini is materialised into a private mkdtemp directory (see
+# `run_with_config`), because a predictable path under a shared /tmp is
+# attacker-plantable.
+tempfile = "3"
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -58,7 +64,6 @@ windows-sys = { version = "0.59", features = [
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
-tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -519,24 +519,6 @@ fn exit_code_from(code: i32) -> ExitCode {
     if code == 0 { ExitCode::SUCCESS } else { ExitCode::from(u8::try_from(code).unwrap_or(1)) }
 }
 
-/// Removes a temp file when dropped. Used to clean up the generated
-/// php.ini we materialise from `[php] ini_overrides`.
-struct TempFileGuard {
-    path: PathBuf,
-}
-
-impl TempFileGuard {
-    fn new(path: PathBuf) -> Self {
-        Self { path }
-    }
-}
-
-impl Drop for TempFileGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
 /// Initialize PHP and start the HTTP server.
 ///
 /// PHP must be initialized BEFORE the tokio runtime is created. PHP's
@@ -669,7 +651,7 @@ fn run_with_config(
         || vhost_disable_shell
         || worker_mode;
 
-    let (effective_ini_path, _generated_ini_guard): (Option<PathBuf>, Option<TempFileGuard>) =
+    let (effective_ini_path, _generated_ini_guard): (Option<PathBuf>, Option<tempfile::TempDir>) =
         if want_generated_ini {
             use std::fmt::Write as _;
 
@@ -713,12 +695,53 @@ fn run_with_config(
                     "disable_functions=exec,passthru,shell_exec,system,proc_open,popen,pcntl_exec"
                 );
             }
-            let temp_path =
-                std::env::temp_dir().join(format!("ephpm-{}-overrides.ini", std::process::id()));
-            std::fs::write(&temp_path, content).with_context(|| {
-                format!("failed to write generated php.ini at {}", temp_path.display())
-            })?;
-            (Some(temp_path.clone()), Some(TempFileGuard::new(temp_path)))
+            // This file inlines the operator's entire `[php] ini_file` plus
+            // every `ini_override`, and PHP reads it back during MINIT — as
+            // root on most deployments. A fixed, PID-derived name under a
+            // shared /tmp is attacker-reachable: `fs::write` follows symlinks
+            // and truncates, so a pre-planted symlink turns startup into an
+            // arbitrary-file truncation, and the window between the write and
+            // PHP's read is enough to swap in `extension=` or
+            // `auto_prepend_file=`.
+            //
+            // Same shape as the sqld binary extraction in `ephpm-sqld`:
+            // mkdtemp (O_EXCL, never a reused path), 0700, then `create_new`
+            // so the open still refuses to follow a symlink or clobber an
+            // existing file. The `TempDir` guard owns the cleanup and must
+            // outlive PHP's read, so it is what the caller holds on to.
+            use std::io::Write as _;
+
+            let dir = tempfile::Builder::new()
+                .prefix("ephpm-ini-")
+                .tempdir()
+                .context("failed to create a private temp dir for the generated php.ini")?;
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+                    .context("failed to lock down the generated php.ini directory")?;
+            }
+
+            let temp_path = dir.path().join("overrides.ini");
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)
+                .context("failed to create the generated php.ini")?;
+            file.write_all(content.as_bytes()).context("failed to write the generated php.ini")?;
+            file.sync_all().context("failed to flush the generated php.ini")?;
+            drop(file);
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o600))
+                    .context("failed to lock down the generated php.ini")?;
+            }
+
+            tracing::debug!(path = %temp_path.display(), "wrote generated php.ini");
+            (Some(temp_path), Some(dir))
         } else {
             (config.php.ini_file.clone(), None)
         };

--- a/site/content/architecture/_index.md
+++ b/site/content/architecture/_index.md
@@ -577,9 +577,11 @@ For local keys, ePHPm's KV is **1,000-10,000x faster than Redis** because there'
 
 ### TLS Certificate Management in a Cluster
 
-The clustered KV store backs ePHPm's TLS certificate storage, locking, and ACME challenge coordination. This solves three HA problems that naive auto-TLS implementations get wrong.
+The clustered KV store backs ePHPm's TLS certificate storage and issuance coordination. This section frames three HA problems that naive auto-TLS implementations get wrong.
 
-#### Problem 1: Cert Issuance Race Condition
+> **Implementation status.** Problem 3 (renewal stampede) is solved as described below, in `crates/ephpm-server/src/acme.rs`. Problems 1 and 2 are **design sketches, not implemented**, and the `KvStore.lock` / `KvStore.unlock` and `certs:<domain>:*` primitives they use do not exist. Read them for the shape of the problem, not for current behaviour. What actually ships is: one elected leader drives the whole `rustls-acme` state machine (which subsumes Problem 1 — there is no separate per-domain issuance lock because only one node ever orders), and TLS-ALPN-01 challenge material is *not* shared across nodes, so Let's Encrypt's validation connection must reach the leader.
+
+#### Problem 1: Cert Issuance Race Condition (design sketch — not implemented)
 
 Without coordination, multiple nodes all detect that no cert exists for `example.com` and simultaneously request one from Let's Encrypt. This wastes ACME quota (50 certs/domain/week rate limit) and may trigger rate-limiting bans.
 
@@ -607,7 +609,7 @@ Node B: lock released, checks KvStore → cert exists → done, no issuance need
 
 The lock has a TTL (default 5 minutes) to prevent deadlock if a node crashes mid-issuance. If the lock holder dies, another node acquires the lock after TTL expiry and retries.
 
-#### Problem 2: ACME Challenge Routing
+#### Problem 2: ACME Challenge Routing (design sketch — not implemented)
 
 Let's Encrypt validates domain ownership by making an HTTP request to `http://example.com/.well-known/acme-challenge/<token>`. In a multi-node setup behind a load balancer, the challenge request may hit any node — not necessarily the one that initiated the ACME order.
 
@@ -637,65 +639,62 @@ Let's Encrypt requests: GET http://example.com/.well-known/acme-challenge/abc123
    Let's Encrypt: challenge passed ✓
 ```
 
-This works for HTTP-01 challenges. For TLS-ALPN-01 challenges, the same approach applies — the challenge certificate is stored in the KV store and any node can present it during the TLS handshake.
+**Timing:** Gossip replication typically completes in ~100-200ms. The ACME protocol has a built-in delay between creating the challenge and checking it (the server tells the client to poll for status), so propagation latency would not be the obstacle.
 
-**Timing:** Gossip replication typically completes in ~100-200ms. The ACME protocol has a built-in delay between creating the challenge and checking it (the server tells the client to poll for status), so propagation latency is not an issue.
+**What ships today:** ePHPm requests TLS-ALPN-01, and `rustls-acme` holds that challenge certificate in the ordering node's in-memory resolver — nothing writes it to the KV store, so no other node can present it. `ephpm-server` does serve `/.well-known/acme-challenge/<token>` out of `acme:challenge:<token>`, but nothing populates those keys either. Until challenge sharing is built, point the domain at one node during issuance or use manual TLS.
 
-#### Problem 3: Renewal Stampede
+#### Problem 3: Renewal Stampede (implemented)
 
 All nodes notice the cert for `example.com` expires in 29 days. Without coordination, all nodes attempt renewal simultaneously.
 
 **Solution: Leader election for cert renewal.**
 
-One node is responsible for certificate renewals at any given time. Election uses the KV store:
+One node is responsible for certificate renewals at any given time. Election uses the KV store (`crates/ephpm-server/src/acme.rs`):
 
 ```
-KvStore.set("acme:leader", node_id="A", ttl=60s)
-  → Node A is the cert renewal leader
-  → Node A refreshes the TTL every 30s (heartbeat)
-  → Node A checks all certs, renews any expiring within 30 days
+SETNX "acme:leader" = <node_id>, ttl=30s
+  → claim is atomic within a process; the gossip tier has no compare-and-swap
+  → holder refreshes the TTL every 10s (heartbeat)
+  → a node that sees a different holder yields unless its own id sorts lower
+  → a claim must survive 2 consecutive heartbeats before the node acts on it
 
-If Node A dies:
-  → TTL expires after 60s
-  → Node B or C acquires leadership
-  → New leader picks up renewal duties
+If the leader dies:
+  → the key expires after 30s
+  → another node's SETNX succeeds
+  → after 2 confirming heartbeats it starts driving ordering and renewal
 ```
 
-Only the leader initiates renewals. All other nodes receive the renewed certs via KV replication. This reduces ACME requests to the minimum necessary (one request per cert, regardless of cluster size).
+Only the leader drives the `rustls-acme` state machine, so only the leader can place an order. A follower's cache lookup is held open rather than reported as a miss, and a miss is the only thing that makes `rustls-acme` order — so N nodes can never turn into N duplicate orders. Renewal timing itself is `rustls-acme`'s: 2/3 of certificate validity, hardcoded, roughly 30 days before expiry for a 90-day Let's Encrypt certificate.
 
-#### Full Cert Lifecycle
+**Not yet implemented:** a running follower does not pick up a *renewed* certificate. `rustls-acme` consults its cert cache exactly once per `AcmeState`, and its resolver's `set_cert` is `pub(crate)`, so nothing outside the state machine can install a fresh certificate. Followers serve the certificate they loaded at startup until they restart. Closing this needs a KV-backed `ResolvesServerCert` of ePHPm's own.
+
+#### Full Cert Lifecycle (as implemented)
 
 ```
-1. First HTTPS request arrives for example.com
+1. Every node starts its ACME event loop and begins the leadership heartbeat
        │
        ▼
-2. Node checks KvStore for "certs:example.com:cert"
-   ├── Found → use it, serve request with TLS
-   └── Not found ↓
+2. One node's claim survives 2 consecutive heartbeats → it is the leader
        │
-3. Acquire lock: KvStore.lock("acme:lock:example.com")
-   ├── Lock held by another node → wait, then goto 2
-   └── Lock acquired ↓
+       ▼
+3. rustls-acme asks LayeredCache for a cached cert (KV tier, then local DirCache)
+   ├── Hit  → deploy into the resolver, sleep until 2/3 of validity
+   ├── Miss on the leader   → report the miss; rustls-acme places an order
+   └── Miss on a follower   → hold the lookup open, re-check every 5s
        │
-4. Create ACME order (Let's Encrypt)
+4. Leader orders from Let's Encrypt and answers the TLS-ALPN-01 challenge
+   (validation must reach the leader — challenge material is not shared yet)
        │
-5. Store challenge token: KvStore.set("acme:challenge:<token>", response)
-       │ (replicated to all nodes via gossip)
+5. Leader deploys the new cert and its cache writes the PEM to
+   "acme:cert:<domains>:cert:<directory-hash>" plus the local DirCache
+       │ (KV entry replicated to all nodes via gossip)
        │
-6. Tell Let's Encrypt to verify → challenge request hits any node → passes
+6. Each follower's held-open lookup now returns the cert → deployed locally
        │
-7. Download issued cert
-       │
-8. Store cert: KvStore.set("certs:example.com:cert", cert_pem)
-   Store key:  KvStore.set("certs:example.com:key", key_pem)
-       │ (replicated to all nodes via gossip)
-       │
-9. Release lock: KvStore.unlock("acme:lock:example.com")
-       │
-10. All nodes now have the cert locally (replica) → zero-latency TLS handshakes
+7. Renewal: the leader's timer fires at 2/3 validity → back to step 4
 ```
 
-No external cert store (Redis, S3, etcd) needed. No external lock service (etcd, Consul) needed. Zero-config clustered HTTPS using ePHPm's built-in KV store and gossip protocol.
+No external cert store (Redis, S3, etcd) and no external lock service (etcd, Consul) are needed — ePHPm's built-in KV store and gossip protocol carry the certificate and the election. Two gaps remain before this is hands-off in a cluster: TLS-ALPN-01 challenge material is not shared between nodes, and a running follower does not pick up a renewed certificate until it restarts.
 
 ---
 

--- a/site/content/architecture/http.md
+++ b/site/content/architecture/http.md
@@ -260,20 +260,24 @@ cache_dir = "/var/lib/ephpm/certs"
 # staging = true  # use for testing to avoid rate limits
 ```
 
-**Clustered** (Phase 2 — requires KV store and gossip): In a multi-node deployment, naive ACME creates several problems that the clustered KV store solves:
+**Clustered** (requires KV store and gossip): In a multi-node deployment, naive ACME creates several problems that the clustered KV store addresses. The implementation lives in `crates/ephpm-server/src/acme.rs`.
 
-| Problem | What happens | Solution |
+| Problem | What happens | What ePHPm does |
 |---------|-------------|----------|
-| **Renewal stampede** | N nodes all try to renew simultaneously, hitting Let's Encrypt rate limits (50 certs/domain/week) | Distributed lock via KV (`acme:lock:<domain>` key with TTL). One node wins, renews, others wait. |
-| **Challenge routing** | Let's Encrypt connects to the domain, DNS round-robins to any node, but only the initiating node has the challenge token | Share challenge tokens via KV (`acme:challenge:<token>` keys). Any node can respond. |
-| **Cert distribution** | After one node obtains the cert, all nodes need it immediately | Store cert in KV (`certs:<domain>` key), replicate via gossip. All nodes pick it up. |
-| **Leader election** | Only one node should drive renewals to avoid redundant work | KV-based leader (`acme:leader` key with TTL heartbeat). Leader renews, followers watch. |
+| **Renewal stampede** | N nodes all try to renew simultaneously; five duplicate certificates for the same domain set in a week is a hard Let's Encrypt lockout | Only the elected leader drives the `rustls-acme` state machine. A follower's cache lookup is held open instead of reporting a miss, and a miss is the only thing that makes `rustls-acme` place an order. |
+| **Challenge routing** | Let's Encrypt connects to the domain, DNS round-robins to any node, but only the ordering node holds the challenge material | **Not yet implemented.** ePHPm uses TLS-ALPN-01, and `rustls-acme` keeps that challenge certificate in the ordering node's in-memory resolver — it is not shared. Validation succeeds only when Let's Encrypt's connection reaches the leader. Point the domain at a single node, or use manual TLS, until challenge sharing lands. (`ephpm-server` can serve an HTTP-01 response out of `acme:challenge:<token>`, but nothing writes those keys yet.) |
+| **Cert distribution** | After one node obtains the cert, all nodes need it | The leader's cache writes the PEM to the KV store (`acme:cert:<domains>:cert:<directory-hash>`) as part of the `rustls-acme` state machine; gossip replicates it, and each follower loads it on its own first cache lookup. |
+| **Leader election** | Only one node should drive ordering and renewal | `acme:leader` key with a TTL heartbeat, plus a lowest-node-id tie-break. |
 
-The `rustls-acme` crate has a pluggable `Cache` trait — swap `DirCache` for a `KvCache` implementation when clustering is built. Zero changes to the ACME logic itself.
+**Leader election is not a strict lock.** The gossip KV tier exposes only last-write-wins set/get/delete over eventually consistent state — there is no compare-and-swap to build a real distributed lock on. The claim is atomic within a process (`SETNX`), and across nodes it converges via the tie-break: a node that observes a different holder yields unless its own id sorts lower. A claim must survive two consecutive heartbeats before the node acts on it, which keeps the ~1-3s gossip propagation window from turning into duplicate orders.
+
+**Not yet implemented — follower renewal pickup.** A follower loads the leader's certificate once, at startup. `rustls-acme` consults its cert cache exactly once per `AcmeState`, and its resolver's `set_cert` is `pub(crate)`, so a renewed certificate cannot be pushed into a running follower from outside the state machine. Followers keep serving the certificate they started with until they restart. Closing this requires a KV-backed `ResolvesServerCert` implementation of our own.
+
+The `rustls-acme` crate has a pluggable `Cache` trait, which is what makes this possible: `LayeredCache` writes through to both a `KvCache` (cluster-wide) and the local `DirCache`, and prefers the KV tier on read.
 
 ```
-Phase 1 (single-node):  AcmeConfig → DirCache (filesystem)
-Phase 2 (clustered):    AcmeConfig → KvCache (gossip-replicated KV store)
+Single-node:  AcmeConfig → DirCache (filesystem)
+Clustered:    AcmeConfig → LayeredCache → KvCache (gossip-replicated) + DirCache (local)
 ```
 
 ## Compression

--- a/site/content/architecture/metrics.md
+++ b/site/content/architecture/metrics.md
@@ -38,7 +38,7 @@ EPHPM_SERVER__METRICS__PATH="/metrics"
 | `ephpm_http_request_duration_seconds` | histogram | `method`, `handler` | End-to-end request duration (includes PHP execution for PHP requests). |
 | `ephpm_http_requests_in_flight` | gauge | — | Number of requests currently being processed. |
 | `ephpm_http_timeouts_total` | counter | `stage` | Requests that hit the timeout. `stage` is `"request"`. |
-| `ephpm_http_request_body_bytes` | histogram | `method` | Request body size in bytes. |
+| `ephpm_http_request_body_bytes` | histogram | `method` | Request body size in bytes. `method` is a standard verb or `OTHER`, never the client's raw verb. |
 | `ephpm_http_response_body_bytes` | histogram | `handler` | Response body size in bytes (before compression). |
 | `ephpm_http_compression_ratio` | histogram | — | Compression ratio (compressed / original). Values near 0 = excellent compression. |
 | `ephpm_rate_limited_total` | counter | — | Requests rejected by rate limiting. |

--- a/site/content/architecture/security.md
+++ b/site/content/architecture/security.md
@@ -27,7 +27,7 @@ This document describes the threat model, trust boundaries, and security design 
 
 The controls that exist today, in one place:
 
-- **Per-vhost `open_basedir`** — in multi-site mode, PHP filesystem access is restricted per-request to the site's directory (+ `/tmp`)
+- **Per-vhost `open_basedir`** — in multi-site mode, PHP filesystem access is restricted per-request to the site's directory plus the system temp directory (`std::env::temp_dir()`, so `TMPDIR` is honoured and Windows gets its real temp path). Entries are joined with the platform's `PATH_SEPARATOR` (`:` on Unix, `;` on Windows).
 - **`disable_shell_exec`** — `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`, `pcntl_exec` disabled via the php.ini generated at startup (default on in multi-site mode)
 - **`blocked_paths`** — glob patterns matched against the URI path (patterns must start with `/`); matches return 403
 - **`trusted_hosts`** — Host header validation; non-matching hosts get 421. Internal endpoints (`/_ephpm/health`, `/_ephpm/ready`, the metrics path) are exempt so Kubernetes probes and Prometheus scrapes can address the pod by raw IP

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -28,7 +28,7 @@ Metrics are emitted via the [`metrics`](https://docs.rs/metrics/) façade and ex
 | `ephpm_http_requests_total` | counter | `method`, `status`, `handler` | Total HTTP requests handled. `handler` is the route class (e.g. `php`, `static`, `error`). To keep series cardinality bounded, `method` is one of the standard verbs (`GET`, `POST`, ...) or `OTHER` for any non-standard verb, and `status` is the numeric code for the common statuses this server and typical apps emit or `other` for uncommon codes. |
 | `ephpm_http_requests_in_flight` | gauge | — | Currently in-flight HTTP requests. |
 | `ephpm_http_request_duration_seconds` | histogram | `method`, `handler` | Request handling time, end-to-end (no `status` label). |
-| `ephpm_http_request_body_bytes` | histogram | `method` | Request body size. |
+| `ephpm_http_request_body_bytes` | histogram | `method` | Request body size. `method` is bounded the same way as above (standard verb or `OTHER`). |
 | `ephpm_http_response_body_bytes` | histogram | `handler` | Response body size before compression. Recorded on the PHP path only (`handler="php"`). |
 | `ephpm_http_compression_ratio` | histogram | — | Compressed-to-original ratio; covers both Brotli and gzip responses. |
 | `ephpm_http_timeouts_total` | counter | `stage` | Requests killed by the request timeout. Only value: `request`. |


### PR DESCRIPTION
Nine fixes from the pre-release audit. All verified against source before implementing.

## Serious

**1. Postgres proxy deadlocked on the extended query protocol** — `ephpm-db/src/postgres.rs`
`pg_proxy_routing_loop` wrote one client message then blocked awaiting `ReadyForQuery`; in the extended protocol the backend says nothing until `Sync`, which is the *next* client message and was never read. Any client doing real prepares (PDO_pgsql, `PQexecParams`, tokio-postgres) hung on its first one. `needs_routing` is true whenever `reset_strategy == Smart` — the **default** — so this was the shipped path.

Per-message routing is only sound for the simple `Query` protocol. On the first non-`Query` frontend message the session now pins to the primary and splices client-to-backend for its remaining life. The same handoff covers `CopyInResponse`/`CopyBothResponse`, which deadlock identically. Test drives Parse/Bind/Describe/Execute/Sync against a backend that stays silent until `Sync` — it times out on the old code.

**2. Literal `../` reached the PHP handler** — `ephpm-server/src/router.rs` · security
The static branch canonicalizes and checks containment; the PHP branch only had `is_php_allowed(&uri_path)`, a URI prefix check. `has_hidden_segment` explicitly exempts `..`. So `GET /../b/index.php` on a raw socket executed `doc_root/../b/index.php` — **cross-tenant PHP execution** in `sites_dir` mode.

Two layers: `percent_decode_path` rejects any `..` segment (after decoding, so `%2e%2e` is caught; `\` treated as a separator too), which also closes the matching bypass of the blocked-path globs. Plus `php_script_contained()` adds canonicalize + `starts_with(canonical_root)`, which additionally covers symlinks out of the docroot.

**3. Clustered ACME: every node ordered certificates** — `ephpm-server/src/acme.rs` + docs
`state.next()` was polled unconditionally; `is_leader` only chose the log level. N nodes issued duplicate Let's Encrypt orders, hitting the 5-per-week duplicate limit — a **week-long lockout**.

Gating the poll purely on leadership turned out to break HTTPS on every follower: rustls-acme 0.15 builds its `load_cert` future once in `AcmeState::new`, so a node that never polls never installs *any* cert. Followers now poll only until they have deployed a cert, and `LayeredCache` holds a two-tier miss open on a follower rather than reporting it — a reported miss is the only path to "schedule order".

**The gossip KV tier has no compare-and-swap.** `ClusterHandle` exposes only `gossip_set`/`get`/`del`/`exists`/`pttl` — last-write-wins over eventually consistent chitchat. Rather than fake atomicity, the claim uses `Store::set_nx` for process-local atomicity, converges on a deterministic lowest-node-id tie-break (the same rule as `sqlite_election`), and requires two consecutive confirming heartbeats before acting.

## Hardening

| # | Fix | File |
|---|---|---|
| 4 | Generated php.ini moved to mkdtemp + 0700 dir + `create_new` 0600 file, mirroring `ephpm-sqld`. The old predictable `temp_dir()/ephpm-<pid>-overrides.ini` with `fs::write` followed symlinks | `ephpm/src/main.rs` |
| 5 | A single `accept()` error no longer shuts the server down — transient errors retry, everything else backs off 50ms so an unexpected repeat cannot spin a core | `ephpm-server/src/lib.rs` |
| 6 | Two panics reachable from network input: MySQL greeting guard `pos + 6` to `pos + 8`; `truncate_for_label` now walks to a char boundary instead of byte-slicing UTF-8 | `ephpm-db/src/mysql.rs`, `ephpm-query-stats/src/lib.rs` |
| 7 | `method` label bounded via `method_metric_label` — the raw client verb was creating unbounded Prometheus series, which the comment 500 lines up says that helper exists to prevent | `ephpm-server/src/router.rs` |
| 8 | `hot_cache_mem` underflow that wrapped to about `u64::MAX` and silently killed hot-key promotion for the process lifetime. All three eviction sites now debit off the value `remove()` returned | `ephpm-cluster/src/clustered_store.rs` |
| 9 | `open_basedir` used `:` unconditionally — on Windows, with a drive-letter colon in the docroot, every file access was denied by default in vhost mode | `ephpm-server/src/router.rs` |

## Docs corrected in the same commits

`architecture/http.md` and `architecture/_index.md` both claimed only the leader orders certificates. They also documented `acme:lock:<domain>` and `certs:<domain>` keys that do not exist, and `KvStore.lock`/`unlock` pseudocode for functions that were never implemented. Also `architecture/security.md` and both metrics pages.

## New finding — filed, not fixed

**`store_acme_challenge` has no production caller.** Its only call site is inside `#[cfg(test)]`. Meanwhile `router.rs:925` serves `/.well-known/acme-challenge/<token>` from the KV store via `get_acme_challenge` on the live request path — so the read side is wired up and the write side is exercised only by a unit test. The HTTP-01 responder can never return anything but 404. ePHPm requests TLS-ALPN-01, whose challenge lives only in the ordering node's in-memory resolver, so clustered validation succeeds only if Let's Encrypt happens to reach the leader. Labelled "not yet implemented" rather than papered over.

Also filed: a running follower still will not pick up a *renewed* cert — `AcmeState` reads the cache once and `set_cert` is `pub(crate)`. Needs a KV-backed `ResolvesServerCert`.

## Verification caveat

**Nothing here was compiled, linted, or tested locally** — no MSVC linker on the authoring machine. Highest-risk spots, in order: the `tokio::select!` branch guard in `acme.rs`; rustfmt on several hand-wrapped chains; conditional moves out of a `loop` in `postgres.rs` (the same E0382/E0499 family that #208 tripped on). `Cargo.lock` is deliberately untouched — `tempfile` was already listed under the `ephpm` package, so promoting it from dev-dep to dep needs no lock change.

## Merge order

Touches `router.rs`, which #208 also modifies. **#208 first**, then this rebases onto it.
