### PR TITLE
test(e2e): raw-socket path traversal coverage (+ CDC 2-node e2e scope note)

### DIFF
--- a/crates/ephpm-e2e/tests/path_traversal.rs
+++ b/crates/ephpm-e2e/tests/path_traversal.rs
@@ -1,0 +1,357 @@
+//! Path-traversal tests driven over a **raw TCP socket**.
+//!
+//! # Why this suite exists at all
+//!
+//! `GET /../b/index.php` used to join onto `<docroot>/../b/index.php` and
+//! *execute* it — cross-tenant PHP execution under `sites_dir` vhosting. The
+//! fix lives in `ephpm-server`'s router: `percent_decode_path()` rejects any
+//! `..` segment (after decoding, and treating `\` as a separator too), and
+//! `Router::php_script_contained()` re-checks the resolved script against the
+//! canonicalized site root.
+//!
+//! Every other E2E suite drives the server with `reqwest`, which normalizes
+//! `../` away **client-side** before the bytes ever hit the wire — see the
+//! note in `hidden_files.rs::dot_dot_not_treated_as_hidden`. That means an
+//! ordinary HTTP client *structurally cannot express the attack*, and the
+//! existing suite could never catch a regression here.
+//!
+//! So this file writes the request line itself onto a [`TcpStream`]. Nothing
+//! between the test and hyper touches the path.
+//!
+//! # How this suite avoids passing vacuously
+//!
+//! A traversal test trivially "passes" if the server is down, the URL is
+//! wrong, or the target simply does not exist (404 is not 200). Three
+//! guardrails:
+//!
+//! 1. Every attack test first calls [`probe_control`], which asserts that
+//!    `GET /index.php` over the same raw socket returns **200** with PHP-
+//!    generated output. A dead or misconfigured server fails there, loudly,
+//!    before any traversal assertion runs.
+//! 2. The attack assertions require **exactly 400**, not merely "not 200".
+//!    404 (target missing), 403 (blocked later, by the second layer) and 500
+//!    (`open_basedir` refusing the include) all fail. Only an active reject by
+//!    `percent_decode_path` passes.
+//! 3. [`dot_dot_back_into_document_root_rejected`] attacks a path whose target
+//!    is `index.php` itself — the very file the control just executed. It
+//!    cannot be 400 for want of a target.
+//!
+//! # Environment variables
+//!
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`).
+//!   Set by both the bare-process harness and the Kind job, so this suite
+//!   needs no classification in `xtask/src/e2e_bare.rs` — it runs against the
+//!   shared single node like every other unclassified suite.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use ephpm_e2e::required_env;
+
+/// Emitted by `tests/docroot/index.php`. Its presence proves PHP ran.
+const CONTROL_MARKER: &str = "Hello from ePHPm!";
+
+/// Emitted by `tests/php/traversal_canary.php`, which lives OUTSIDE the
+/// document root the bare-process harness serves. Seeing this in any response
+/// body means a request escaped the document root and executed PHP.
+const CANARY_MARKER: &str = "EPHPM_TRAVERSAL_CANARY_a41f7c2e";
+
+/// Relative request target for the out-of-docroot canary, as seen from
+/// `tests/docroot` (the bare-process harness's document root).
+///
+/// In the Kind/container harness the document root is `/var/www/html` and this
+/// file is not present — which does not weaken anything, because the reject
+/// happens in `percent_decode_path` *before* the path ever reaches the
+/// filesystem. The assertion is 400 either way.
+const CANARY_TARGET: &str = "php/traversal_canary.php";
+
+/// A parsed HTTP/1.1 response read off a raw socket.
+struct RawResponse {
+    status: u16,
+    raw: String,
+}
+
+impl RawResponse {
+    /// Whole response text (status line, headers, body). Body matching uses
+    /// `contains` on this rather than a parsed body because hyper may frame
+    /// the PHP response as `Transfer-Encoding: chunked`, which would
+    /// interleave chunk sizes with the payload.
+    fn contains(&self, needle: &str) -> bool {
+        self.raw.contains(needle)
+    }
+}
+
+/// `host[:port]` to connect to, and the value to send in the `Host` header.
+///
+/// `EPHPM_URL` is `http://127.0.0.1:18100` under the bare harness and
+/// `http://ephpm:8080` under Kind. `Router::check_trusted_host` compares both
+/// the full header and the port-stripped form, so sending the authority
+/// verbatim is trusted in both.
+fn authority() -> String {
+    let base = required_env("EPHPM_URL");
+    let rest = base.strip_prefix("http://").unwrap_or_else(|| {
+        panic!("EPHPM_URL must be a plain http:// URL for raw-socket tests, got {base:?}")
+    });
+    let authority = rest.split('/').next().unwrap_or(rest).trim_end_matches('/');
+    assert!(!authority.is_empty(), "EPHPM_URL {base:?} has no authority");
+    if authority.contains(':') { authority.to_string() } else { format!("{authority}:80") }
+}
+
+/// Send a hand-written request line and read the whole response.
+///
+/// `target` is written to the wire **verbatim** — no parsing, no
+/// normalization, no percent-encoding. That is the entire point of this
+/// module.
+///
+/// Returns `None` when the peer closed without sending a byte. That is still
+/// a refusal (nothing was executed), but it is reported distinctly so a test
+/// can say so rather than silently counting it as a pass.
+fn raw_get(authority: &str, target: &str) -> Option<RawResponse> {
+    let mut stream = TcpStream::connect(authority)
+        .unwrap_or_else(|e| panic!("connect to {authority} failed: {e}"));
+    stream.set_read_timeout(Some(Duration::from_secs(10))).expect("set read timeout");
+    stream.set_write_timeout(Some(Duration::from_secs(10))).expect("set write timeout");
+
+    let request = format!(
+        "GET {target} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\
+         User-Agent: ephpm-e2e-raw\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .unwrap_or_else(|e| panic!("write {target:?} to {authority} failed: {e}"));
+    stream.flush().unwrap_or_else(|e| panic!("flush {target:?} failed: {e}"));
+
+    let mut buf = Vec::new();
+    // `Connection: close` means the server hangs up when it is done, so read
+    // to EOF. A read timeout surfaces as an error and is treated as EOF —
+    // whatever arrived so far is what we assert on.
+    let _ = stream.read_to_end(&mut buf);
+    if buf.is_empty() {
+        return None;
+    }
+
+    let raw = String::from_utf8_lossy(&buf).into_owned();
+    let status_line = raw.lines().next().unwrap_or_default();
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|c| c.parse().ok())
+        .unwrap_or_else(|| panic!("no HTTP status in response to {target:?}: {status_line:?}"));
+
+    Some(RawResponse { status, raw })
+}
+
+/// Assert the server is alive and *does* execute an in-docroot PHP script.
+///
+/// Called at the top of every attack test. Without this, a traversal
+/// assertion can pass simply because nothing is listening or the docroot is
+/// empty — the failure mode this suite is least able to afford.
+fn probe_control(authority: &str) {
+    let resp = raw_get(authority, "/index.php")
+        .unwrap_or_else(|| panic!("control request GET /index.php got no response at all"));
+    assert_eq!(
+        resp.status, 200,
+        "control: raw GET /index.php must return 200 (is the fixture node up, and is \
+         tests/docroot/index.php present?) — got {}",
+        resp.status
+    );
+    assert!(
+        resp.contains(CONTROL_MARKER),
+        "control: raw GET /index.php returned 200 but no PHP output — expected {CONTROL_MARKER:?}. \
+         PHP is not actually executing, so every traversal assertion below would be vacuous."
+    );
+}
+
+/// Assert a hand-written traversal target is rejected with 400 and leaks
+/// nothing.
+///
+/// 400 specifically, not "any non-200": `percent_decode_path` returning `None`
+/// is what the router maps to 400. A 403 would mean the first layer regressed
+/// and only `php_script_contained` caught it; a 404 would mean the path was
+/// resolved against the filesystem before being rejected; a 500 would mean PHP
+/// was reached and something else (e.g. `open_basedir`) stopped it. All three
+/// are regressions worth failing on.
+fn assert_traversal_rejected(authority: &str, target: &str, why: &str) {
+    let Some(resp) = raw_get(authority, target) else {
+        // A peer that hangs up without a response has certainly not executed
+        // anything, so this is not a failure — but say so, so it is never
+        // mistaken for a clean 400.
+        eprintln!("note: {target:?} ({why}) — server closed the connection with no response");
+        return;
+    };
+    assert_eq!(
+        resp.status, 400,
+        "{why}: raw GET {target:?} must be rejected with 400 by percent_decode_path, got {}\n\
+         --- response ---\n{}\n--- end ---",
+        resp.status, resp.raw
+    );
+    assert!(
+        !resp.contains(CANARY_MARKER),
+        "{why}: raw GET {target:?} leaked the out-of-docroot canary {CANARY_MARKER:?} — \
+         PHP outside the document root was executed"
+    );
+    assert!(
+        !resp.contains(CONTROL_MARKER),
+        "{why}: raw GET {target:?} executed PHP (saw {CONTROL_MARKER:?}) instead of being rejected"
+    );
+}
+
+/// The headline case: a literal `../` in the request line, reaching a real
+/// `.php` file that sits outside the document root.
+///
+/// Under the bare-process harness the document root is `<repo>/tests/docroot`,
+/// so this resolves to `<repo>/tests/php/traversal_canary.php` — a file that
+/// exists and would execute. `reqwest` cannot send this; a socket can.
+#[test]
+fn literal_dot_dot_to_php_outside_document_root_rejected() {
+    let authority = authority();
+    probe_control(&authority);
+
+    assert_traversal_rejected(
+        &authority,
+        &format!("/../{CANARY_TARGET}"),
+        "literal ../ escaping the document root",
+    );
+    assert_traversal_rejected(
+        &authority,
+        &format!("/subdir/../../{CANARY_TARGET}"),
+        "literal ../../ from a real subdirectory",
+    );
+    assert_traversal_rejected(&authority, "/../../../../etc/passwd", "deep literal traversal");
+}
+
+/// The non-vacuity anchor.
+///
+/// `/subdir/../index.php` resolves *back into* the document root, onto the
+/// exact file `probe_control` just executed. `php_script_contained` would
+/// happily allow it (it canonicalizes inside the root), so a 400 here can only
+/// come from `percent_decode_path`'s `..`-segment rejection. And it cannot be
+/// a 400-for-want-of-a-target: the target demonstrably exists and runs.
+#[test]
+fn dot_dot_back_into_document_root_rejected() {
+    let authority = authority();
+    probe_control(&authority);
+
+    assert_traversal_rejected(
+        &authority,
+        "/subdir/../index.php",
+        "dot-segment resolving back inside the document root",
+    );
+}
+
+/// `%2e%2e` — the ordering case.
+///
+/// `percent_decode_path` decodes first and *then* runs the `..` check, so an
+/// encoded dot pair must be caught. A regression that checked the raw string
+/// would let these through.
+#[test]
+fn percent_encoded_dot_dot_rejected() {
+    let authority = authority();
+    probe_control(&authority);
+
+    assert_traversal_rejected(
+        &authority,
+        &format!("/%2e%2e/{CANARY_TARGET}"),
+        "lowercase %2e%2e escaping the document root",
+    );
+    assert_traversal_rejected(
+        &authority,
+        &format!("/%2E%2E/{CANARY_TARGET}"),
+        "uppercase %2E%2E escaping the document root",
+    );
+    assert_traversal_rejected(
+        &authority,
+        "/subdir/%2e%2e/index.php",
+        "encoded dot-segment resolving back inside the document root",
+    );
+    assert_traversal_rejected(&authority, "/subdir/.%2e/index.php", "half-encoded dot pair");
+}
+
+/// An encoded separator must not be able to manufacture a new path segment.
+///
+/// `percent_decode_path` rejects `%2f` / `%5c` outright rather than decoding
+/// them, so `..%2f` never becomes a traversal in the first place.
+#[test]
+fn percent_encoded_separator_rejected() {
+    let authority = authority();
+    probe_control(&authority);
+
+    assert_traversal_rejected(
+        &authority,
+        &format!("/..%2f{CANARY_TARGET}"),
+        "encoded forward slash after a dot pair",
+    );
+    assert_traversal_rejected(
+        &authority,
+        "/subdir%2f..%2findex.php",
+        "fully encoded separators around a dot segment",
+    );
+    assert_traversal_rejected(
+        &authority,
+        &format!("/..%5c{CANARY_TARGET}"),
+        "encoded backslash after a dot pair",
+    );
+}
+
+/// Backslash is a separator too.
+///
+/// `has_dot_dot_segment` splits on both `/` and `\` because a URI path is
+/// joined onto the document root before it reaches the filesystem, and Windows
+/// treats `\` as a real separator — so `/a\..\b` traverses exactly like
+/// `/a/../b`. The assertion is the same on every platform: the router must not
+/// resolve it, regardless of what the host filesystem would have done.
+#[test]
+fn backslash_dot_dot_rejected() {
+    let authority = authority();
+    probe_control(&authority);
+
+    assert_traversal_rejected(
+        &authority,
+        "/subdir\\..\\index.php",
+        "backslash dot-segment resolving back inside the document root",
+    );
+    assert_traversal_rejected(
+        &authority,
+        "/a\\..\\..\\php\\traversal_canary.php",
+        "backslash traversal escaping the document root",
+    );
+}
+
+/// The over-broad-fix guard.
+///
+/// If a future tightening of `percent_decode_path` starts rejecting ordinary
+/// paths, every test above would still pass (everything would be 400) while
+/// the server was completely broken. This is the test that fails in that case.
+#[test]
+fn ordinary_php_and_static_requests_still_served() {
+    let authority = authority();
+
+    // In-docroot PHP over the same raw socket the attacks use.
+    probe_control(&authority);
+
+    // A path with a single dot segment (`.`, not `..`) is legal and must not
+    // be swept up by the `..` check.
+    let resp = raw_get(&authority, "/./index.php").expect("GET /./index.php got no response");
+    assert_ne!(
+        resp.status, 400,
+        "a single-dot segment is not traversal and must not be rejected as such"
+    );
+
+    // Nested static file, no dot segments at all.
+    let resp = raw_get(&authority, "/subdir/index.html").expect("GET /subdir/index.html hung up");
+    assert_eq!(
+        resp.status, 200,
+        "ordinary nested static request must still be served, got {}\n--- response ---\n{}",
+        resp.status, resp.raw
+    );
+
+    // Percent-decoding itself must still work — `%2E` is a legitimate `.`
+    // inside a filename, and is the case `http_edge.rs` covers via reqwest.
+    let resp = raw_get(&authority, "/test%2Ehtml").expect("GET /test%2Ehtml hung up");
+    assert_eq!(
+        resp.status, 200,
+        "percent-decoding must still resolve /test%2Ehtml to /test.html, got {}",
+        resp.status
+    );
+}

--- a/tests/php/traversal_canary.php
+++ b/tests/php/traversal_canary.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Fixture for the path-traversal E2E suite
+ * (crates/ephpm-e2e/tests/path_traversal.rs).
+ *
+ * This file lives OUTSIDE tests/docroot/ on purpose. The bare-process E2E
+ * harness (xtask/src/e2e_bare.rs) serves tests/docroot/ as the document root,
+ * so `tests/php/` is a sibling directory that is reachable ONLY by escaping
+ * that document root — exactly the shape of the vulnerability the suite pins.
+ *
+ * If the marker below ever appears in an HTTP response body, a request
+ * traversed out of the document root and executed PHP outside it.
+ */
+echo "EPHPM_TRAVERSAL_CANARY_a41f7c2e\n";

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -95,6 +95,19 @@ fn suite_needs_fresh_node(name: &str) -> bool {
 /// or gate them individually.
 const SKIP_SUITES: &[&str] = &[];
 
+// Deliberately unclassified suites — i.e. ones where "runs against the
+// long-lived shared single node" is a decision rather than an oversight.
+// Nothing reads this note; it exists so a future reader does not "fix" the
+// omission by moving a suite onto its own fixture.
+//
+// - `path_traversal` — drives hand-written request lines over a raw TcpStream
+//   (reqwest normalizes `../` client-side, so the attack is not expressible
+//   with an ordinary client). It asserts against the standard docroot
+//   (`/index.php`, `/subdir/index.html`, `/test.html`) and attempts to reach
+//   `tests/php/traversal_canary.php`, which sits OUTSIDE that docroot in the
+//   sibling `tests/php/`. No bespoke config and no DB state, so the shared
+//   node is the right fixture; an isolated node would only cost a spawn.
+
 pub fn run(args: &[String]) -> ExitCode {
     if args.iter().any(|a| a == "--help" || a == "-h" || a == "help") {
         print_usage();


### PR DESCRIPTION
## E1 — path traversal, end to end, over a raw socket

`percent_decode_path()` and `Router::php_script_contained()` closed a hole where
`GET /../b/index.php` joined onto `doc_root/../b/index.php` and **executed it** —
cross-tenant PHP execution under `sites_dir` vhosting. Until now the only tests
were at the routing-helper level.

There was a structural reason for that gap: `reqwest` normalizes `../`
client-side before the bytes reach the wire (explicitly acknowledged in
`hidden_files.rs:34-36`), so no ordinary HTTP client in the suite can express
the attack. The existing E2E suite could never have caught a regression here.

New suite `crates/ephpm-e2e/tests/path_traversal.rs` hand-writes the request
line onto a `TcpStream`. Nothing between the test and hyper touches the path.

**Covered**

| Case | Target | Expect |
|---|---|---|
| literal `../` to a `.php` outside the docroot | `/../php/traversal_canary.php` | 400 |
| literal `../../` from a real subdirectory | `/subdir/../../php/traversal_canary.php` | 400 |
| deep literal traversal | `/../../../../etc/passwd` | 400 |
| dot-segment resolving back *inside* the docroot | `/subdir/../index.php` | 400 |
| `%2e%2e` / `%2E%2E` (decode-then-check ordering) | `/%2e%2e/...`, `/%2E%2E/...` | 400 |
| half-encoded dot pair | `/subdir/.%2e/index.php` | 400 |
| encoded separators `%2f` / `%5c` | `/..%2f...`, `/subdir%2f..%2findex.php`, `/..%5c...` | 400 |
| backslash separator | `/subdir\..\index.php`, `/a\..\..\php\traversal_canary.php` | 400 |
| **control** — ordinary PHP, nested static, legit percent-decoding | `/index.php`, `/subdir/index.html`, `/test%2Ehtml`, `/./index.php` | 200 |

Every expectation matches the router's own unit-test corpus
(`router.rs:3004-3027`: `/a%2Fb` → `None`, `/a%5Cb` → `None`,
`/../b/index.php` → `None`, `/%2e%2e/b/index.php` → `None`, `/a\..\b` → `None`).

**Guards against a vacuous pass** — the failure mode that matters most here:

1. Every attack test first calls `probe_control`, asserting raw `GET /index.php`
   returns **200 containing `Hello from ePHPm!`**. A dead or misconfigured
   server fails there, loudly, before any traversal assertion runs.
2. Attacks assert **exactly 400**, not "not 200". A 404 (target missing) fails.
   So does 403 (first layer regressed, only `php_script_contained` caught it),
   and 500 (`open_basedir` refusing the include after PHP was reached).
3. `dot_dot_back_into_document_root_rejected` attacks `/subdir/../index.php` —
   which resolves onto the very file the control just executed.
   `php_script_contained` would *allow* it (it canonicalizes back inside the
   root), so a 400 there can only come from the `..`-segment rejection, and it
   cannot be a 400 for want of a target.
4. `ordinary_php_and_static_requests_still_served` is the over-broad-fix guard:
   without it, a change that rejected *everything* would leave all the attack
   tests green.

**Fixture**: `tests/php/traversal_canary.php` — a sibling of `tests/docroot/`,
so under the bare-process harness it is a real, executable `.php` reachable only
by escaping the document root. Its marker appearing in any response body fails
the suite.

**Harness wiring**: the suite is deliberately *unclassified* in
`xtask/src/e2e_bare.rs` — it wants the standard docroot and no bespoke config,
so the shared single node is the correct fixture and it is picked up
automatically by `shared_suites`. A comment now records that as a decision
rather than an omission. It also runs unchanged under the Kind harness
(`EPHPM_URL` is the only env it reads, and the traversal rejects happen before
the path reaches the filesystem, so the canary's absence there is harmless).

---

## E2 — two-node CDC replication: feasibility verdict, **not built**

**Verdict: do not build now. It is a separate piece of work.**

The good news first, since it changes the shape of the problem:

- The Turso engine **is** compiled into the release binary. `turso` is an
  unconditional litewire feature (`Cargo.toml:97`), `turso.workspace = true` is
  non-optional in `ephpm-server`, there is no `[features]` table outside
  `ephpm-middleware`, and `xtask`'s `release_native` never passes `--features`.
  No build changes needed.
- Election needs no quorum and no sqld. `should_be_primary`
  (`sqlite_election.rs:199-207`) is `min_by(id)` over alive nodes — works at
  n=2. The CDC path substitutes the channel advertise address for the sqld gRPC
  URL and never spawns sqld.
- Opt-in is three keys: `engine = "turso"`, `cdc_experimental = true`,
  `[cluster] enabled = true` (+ a `secret`).

What makes it a separate piece of work is the harness, not the config:

1. **Cold-replica bootstrap blocks startup past the health deadline.**
   `maybe_bootstrap_cold_replica` is *awaited* before litewire starts
   (`turso_cdc.rs:511`) and retries `30 × 2s` = **up to 60 s**, then returns
   `Err` → `start_db_proxies` fails → `serve()` fails → **the process exits**
   (`turso_cdc.rs:1348-1378`). `accept_loop` runs *after* `start_db_proxies`, so
   `/_ephpm/health` does not answer while this is retrying — and both existing
   fixtures use a 15–20 s deadline. This needs changed bring-up semantics
   (raise the deadline to ≥75 s, or health-poll node 0 to completion *before*
   spawning node 1), not a config tweak. Today's fixture spawns all nodes then
   waits, which is exactly backwards for this path.
2. **Latent port collision.** `[cluster.channel] listen` defaults to
   gossip + 2 (`cluster_channel.rs:536-538`). The fixture assigns gossip
   `18200 + i`, so node 0 derives **18202** — node 2's gossip port. It is not
   live today only because `maybe_start` keeps the listener closed unless a
   channel feature is enabled (`cluster_channel.rs:465-471`), and `cdc` is the
   only feature. Turning CDC on lights it up. A CDC fixture must set
   `listen` explicitly in an unclaimed band.
3. **There is no assertion channel.** Zero CDC metrics exist — no
   `counter!`/`gauge!`/`histogram!` anywhere in `turso_cdc.rs`, and no endpoint
   exposes watermark or replication state. The e2e crate has no MySQL client.
   And the docroot PHP scripts can't reach the DB in cluster mode: `db.php`
   et al. read `getenv('DB_HOST')`, but `build_db_env_vars`
   (`router.rs:2108-2123`) only injects for `[db.mysql]`/`[db.postgres]` —
   `SqliteConfig` has no `inject_env` at all, and the cluster fixture puts
   MySQL on `13306 + i`. The workable path is adding `hrana_listen` per node
   (the CDC path does honor it, `turso_cdc.rs:1641-1644`) and asserting over
   Hrana HTTP — a transport no cluster suite currently uses.
4. **The election has a genuine race.** Before gossip converges both nodes can
   see only themselves and elect themselves primary, then demote via the role
   watcher. It settles (`bare-node-0` sorts first) but it is racy, not
   deterministic — a flaky-by-construction suite.

Concrete scope if someone picks this up: a `CDC_CLUSTER_NODE_TEMPLATE`; a
parameterized `ClusterSpawn::start` (template + node count + two new port
bands); a `CDC_CLUSTER_SUITES` class and a third dispatch arm; a new `env()`;
changed health-wait ordering; and a new `cdc_cluster.rs` asserting over Hrana
plus the negative case (a replica write must *not* propagate,
`turso_cdc.rs:761-767`). Worth doing — and worth doing after CDC metrics exist,
which would make the assertion cheap and is independently valuable. Shipping a
racy 60-s-bootstrap cluster suite into CI immediately before a v0.6.0 tag is a
worse outcome than the current gap.

The existing in-process tests (there are **three**, not four) remain genuine
coverage and are not duplicated here.
`turso_cdc_cluster_integration.rs` already uses real gossip stacks and the real
`SqliteElection`, though it is gated behind `EPHPM_CLUSTER_INTEG=1` and so is
off in normal CI. All three re-implement the `Frame` wire enum inline because
the production one is private.

The roadmap item (`site/content/roadmap/turso-engine.md:180-182`) stays open.

---

## Not compiled, not run

**Nothing in this PR was compiled or executed.** This machine has no MSVC
linker, so `cargo build`/`test`/`clippy` fail at link time. CI is first contact.
The E2E suites only run via the `e2e.yml` workflow.

Residual risk, in the order I'd worry about it:

- **The suite doesn't run at all.** It relies on being unclassified in
  `e2e_bare.rs` and on `discover_test_binaries` deriving the stem
  `path_traversal` from `path_traversal-<hex>`. Worth confirming
  `==> Running suite: path_traversal` appears in the first CI log.
- **Backslash targets.** These assume hyper/`httparse` accept `\` (0x5C) in a
  request target and hand it to the router rather than 400-ing at parse time.
  If hyper rejects earlier it also emits 400, so the assertion holds either
  way — but for a different reason than intended.
- **`raw_get` returning `None`** (peer hung up with no response) is treated as
  a pass. It cannot mean "PHP executed", and `probe_control` proves the server
  answers normally on the same socket, but it is the one path that does not
  assert.
- `crates/ephpm-e2e` is workspace-excluded, so neither `cargo clippy
  --workspace` nor `cargo +nightly fmt --all` covers the new test file.
  Formatting was matched by hand.
