### PR TITLE
fix(security): RESP recursion crash, unbounded allocations, rate-limiter counters, DB listener exposure

### DIFF
--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -207,9 +207,10 @@ async fn read_request(
         if value_len > MAX_VALUE_LEN {
             anyhow::bail!("value length {value_len} exceeds maximum {MAX_VALUE_LEN}");
         }
-        let mut value_buf = vec![0u8; value_len as usize];
-        stream.read_exact(&mut value_buf).await?;
-        Some(value_buf)
+        // Chunked: on the plaintext path the peer is unauthenticated, so
+        // a bare `vec![0u8; value_len]` is a 64 MiB allocation for the
+        // cost of a 9-byte header.
+        Some(read_exact_chunked(stream, value_len as usize).await?)
     } else {
         None
     };
@@ -272,11 +273,35 @@ async fn read_frame(stream: &mut TcpStream, cipher: &ClusterCipher) -> anyhow::R
              (peer sending plaintext to an encrypted data plane?)"
         );
     }
-    let mut frame = vec![0u8; frame_len as usize];
-    stream.read_exact(&mut frame).await?;
+    // Chunked, because this runs *before* `cipher.open()` — the peer is
+    // still unauthenticated here. Allocating `frame_len` up front would
+    // hand any host that can reach the port a 64 MiB allocation per
+    // 4-byte header, with no need to send a single byte of payload.
+    let frame = read_exact_chunked(stream, frame_len as usize).await?;
     cipher.open(&frame).ok_or_else(|| {
         anyhow::anyhow!("failed to authenticate KV data plane frame (wrong cluster secret?)")
     })
+}
+
+/// Read exactly `len` bytes, growing the buffer as data actually arrives.
+///
+/// Every length on this wire is peer-supplied and read before its
+/// payload, so `vec![0u8; len]` charges us the peer's *claim* rather than
+/// what they send. Reading in chunks bounds the cost of a lie to one
+/// chunk plus whatever was really transferred, while a legitimate
+/// transfer still ends up in a single contiguous `Vec`.
+async fn read_exact_chunked(stream: &mut TcpStream, len: usize) -> anyhow::Result<Vec<u8>> {
+    /// Bytes pulled off the socket per read before growing the buffer.
+    const CHUNK: usize = 64 * 1024;
+
+    let mut buf = Vec::with_capacity(len.min(CHUNK));
+    while buf.len() < len {
+        let start = buf.len();
+        let want = (len - start).min(CHUNK);
+        buf.resize(start + want, 0);
+        stream.read_exact(&mut buf[start..]).await?;
+    }
+    Ok(buf)
 }
 
 /// Fetch a value from a remote node's KV data plane.
@@ -316,8 +341,15 @@ pub async fn fetch_remote(
     if value_len == NOT_FOUND_SENTINEL {
         return Ok(None);
     }
-    let mut buf = vec![0u8; value_len as usize];
-    stream.read_exact(&mut buf).await?;
+    // The encrypted path above is bounded by MAX_FRAME_LEN before anything
+    // is allocated; the plaintext path had no bound at all — which is
+    // exactly the deployment with no `[cluster] secret`, where the
+    // responder is not authenticated either. Bound it the same way the
+    // server bounds an inbound value, then read it in chunks.
+    if value_len > MAX_VALUE_LEN {
+        anyhow::bail!("peer advertised value length {value_len} exceeding maximum {MAX_VALUE_LEN}");
+    }
+    let buf = read_exact_chunked(&mut stream, value_len as usize).await?;
     Ok(Some(buf))
 }
 
@@ -631,6 +663,45 @@ mod tests {
         assert!(parse_request(&[]).is_err());
         assert!(parse_request(&[OP_GET]).is_err());
         assert!(parse_request(&[OP_GET, 0, 0, 0, 5, b'a']).is_err());
+    }
+
+    /// Values larger than one read chunk must reassemble byte-exactly:
+    /// the chunked reader is on the path of every plaintext SET and GET.
+    #[tokio::test]
+    async fn multi_chunk_value_round_trip() {
+        let store = Arc::new(Store::new(ephpm_kv::store::StoreConfig::default()));
+        let addr = spawn_multi_handler(Arc::clone(&store), None).await;
+
+        // 200 KiB spans four 64 KiB read chunks.
+        let value: Vec<u8> =
+            (0..200 * 1024).map(|i| u8::try_from(i % 251).expect("i % 251 < 256")).collect();
+
+        assert!(store_remote(addr, "big", &value, None).await.unwrap());
+        let fetched = fetch_remote(addr, "big", None).await.unwrap();
+        assert_eq!(fetched, Some(value));
+    }
+
+    /// A peer that advertises a value length past the cap is rejected on
+    /// the header, before any memory is committed on its behalf.
+    #[tokio::test]
+    async fn oversized_value_len_rejected_before_allocating() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            read_request(&mut stream, None).await
+        });
+
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        client.write_u8(OP_SET).await.unwrap();
+        client.write_u32(3).await.unwrap();
+        client.write_all(b"key").await.unwrap();
+        // Claim far more than the cap, then send no payload at all.
+        client.write_u32(MAX_VALUE_LEN + 1).await.unwrap();
+        client.flush().await.unwrap();
+
+        let err = server.await.unwrap().unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"), "got {err}");
     }
 
     #[test]

--- a/crates/ephpm-cluster/src/kv_data_plane.rs
+++ b/crates/ephpm-cluster/src/kv_data_plane.rs
@@ -700,7 +700,12 @@ mod tests {
         client.write_u32(MAX_VALUE_LEN + 1).await.unwrap();
         client.flush().await.unwrap();
 
-        let err = server.await.unwrap().unwrap_err();
+        // `unwrap_err()` would require `Request: Debug` for the Ok variant, and
+        // `Request` carries the key and value bytes — deriving Debug on it puts
+        // stored values one stray `{:?}` away from the logs. Match instead.
+        let Err(err) = server.await.unwrap() else {
+            panic!("expected an oversized-length error, got a parsed request");
+        };
         assert!(err.to_string().contains("exceeds maximum"), "got {err}");
     }
 

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -58,6 +58,22 @@ const MSG_COPY_IN_RESPONSE: u8 = b'G';
 /// `CopyBothResponse` — backend entered bidirectional copy mode.
 const MSG_COPY_BOTH_RESPONSE: u8 = b'W';
 
+// ── Protocol limits ──────────────────────────────────────────────────────────
+
+/// Largest PG message payload `read_pg_message` will buffer (64 MiB).
+///
+/// The length prefix is peer-controlled and arrives before any payload,
+/// so an unbounded `vec![0u8; len - 4]` lets five bytes (`Q` followed by
+/// `0x7FFFFFFF`) zero-fill 2 GiB of memory; a handful of connections then
+/// OOM the whole server process. `read_startup_message` has always
+/// bounded its own length field — this applies the same treatment to the
+/// per-message path, with a limit generous enough for real queries and
+/// bind parameters. Backend-side callers only read control messages
+/// (auth exchange, `DISCARD ALL`, `SELECT 1`) through this path; query
+/// results are streamed by `forward_pg_message` in 8 KiB chunks and are
+/// unaffected by this bound.
+const MAX_PG_MESSAGE_LEN: i32 = 64 * 1024 * 1024;
+
 // ── Auth types ───────────────────────────────────────────────────────────────
 
 const AUTH_OK: i32 = 0;
@@ -703,7 +719,7 @@ fn generate_nonce() -> String {
 async fn read_pg_message(stream: &mut TcpStream) -> Result<(u8, Vec<u8>), DbError> {
     let tag = stream.read_u8().await?;
     let len = stream.read_i32().await?;
-    if len < 4 {
+    if !(4..=MAX_PG_MESSAGE_LEN).contains(&len) {
         return Err(DbError::Protocol(format!("invalid PG message length: {len}")));
     }
     let payload_len = usize::try_from(len - 4)

--- a/crates/ephpm-kv/src/resp/parse.rs
+++ b/crates/ephpm-kv/src/resp/parse.rs
@@ -2,8 +2,29 @@
 //!
 //! Reads frames incrementally from a `BytesMut` buffer. Returns
 //! `Ok(None)` when more data is needed (incomplete frame).
+//!
+//! Parsing is two-phase. `scan_frame` walks the buffer by index and
+//! produces a `FrameSpec` tree in which bulk payloads are recorded as
+//! byte ranges, without copying or consuming anything. Only once a whole
+//! frame is known to be present does [`parse_frame`] split it off the
+//! buffer and materialise the [`Frame`], slicing bulk payloads out of the
+//! frozen `Bytes` (still zero-copy).
+//!
+//! Two properties fall out of that split, both of which the previous
+//! recursive-on-`BytesMut` parser got wrong:
+//!
+//! - Array elements are scanned against an index, so an N-element array
+//!   costs O(N) work. The old parser copied the entire remaining buffer
+//!   into a fresh `BytesMut` per element — quadratic, and repeated on
+//!   every socket read while the array was still incomplete.
+//! - Nesting is capped at `MAX_ARRAY_DEPTH` (32). Without a cap, ~40 KiB of
+//!   repeated `*1\r\n` (far below `max_input_buffer`) recursed thousands
+//!   of frames deep and overflowed the tokio worker stack, taking down
+//!   the whole process rather than the one connection.
 
-use bytes::BytesMut;
+use std::ops::Range;
+
+use bytes::{Bytes, BytesMut};
 
 use super::frame::Frame;
 
@@ -30,15 +51,44 @@ const MAX_BULK_LEN: usize = 512 * 1024 * 1024;
 /// incomplete). Pre-reserve only a small amount and let the vector grow.
 const MAX_ARRAY_PREALLOC: usize = 1024;
 
+/// Maximum nesting depth allowed for RESP arrays.
+///
+/// Mirrors Redis's hardcoded `PROTO_NESTED_MULTIBULK_DEPTH` (32). Nesting
+/// is attacker-controlled and each level costs a stack frame in
+/// [`scan_frame`], so without a cap a small packet of repeated `*1\r\n`
+/// overflows the thread stack — which aborts the entire process, not just
+/// the offending connection. Real RESP2 client traffic is one level deep.
+const MAX_ARRAY_DEPTH: usize = 32;
+
 /// Errors that can occur while parsing RESP frames.
+///
+/// An incomplete frame is not an error — [`parse_frame`] reports it as
+/// `Ok(None)` so the caller reads more from the socket and retries.
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
-    /// The frame is incomplete — need more data from the socket.
-    #[error("incomplete frame")]
-    Incomplete,
     /// The frame contains invalid data.
     #[error("protocol error: {0}")]
     Protocol(String),
+}
+
+/// A frame that has been located in the buffer but not yet materialised.
+///
+/// Bulk payloads are held as byte ranges into the buffer that was scanned,
+/// so scanning allocates nothing per payload and copies nothing.
+#[derive(Debug)]
+enum FrameSpec {
+    /// `+<line>\r\n`
+    Simple(String),
+    /// `-<line>\r\n`
+    Error(String),
+    /// `:<int>\r\n`
+    Integer(i64),
+    /// A null bulk string (`$-1\r\n`) or null array (`*-1\r\n`).
+    Null,
+    /// `$<len>\r\n<payload>\r\n` — the range covers `<payload>`.
+    Bulk(Range<usize>),
+    /// `*<count>\r\n<elements...>`
+    Array(Vec<FrameSpec>),
 }
 
 /// Try to parse a complete RESP frame from `buf`.
@@ -49,20 +99,37 @@ pub enum ParseError {
 ///
 /// # Errors
 ///
-/// Returns [`ParseError::Protocol`] when the buffer contains invalid RESP data.
+/// Returns [`ParseError::Protocol`] when the buffer contains invalid RESP
+/// data, including an array nested deeper than `MAX_ARRAY_DEPTH` (32).
 pub fn parse_frame(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
-    if buf.is_empty() {
+    // Phase 1: locate the frame without consuming or copying anything.
+    let Some((spec, end)) = scan_frame(&buf[..], 0, 0)? else {
         return Ok(None);
-    }
+    };
 
-    // Peek at the type byte without consuming.
-    match buf[0] {
-        b'+' => parse_simple(buf),
-        b'-' => parse_error(buf),
-        b':' => parse_integer(buf),
-        b'$' => parse_bulk(buf),
-        b'*' => parse_array(buf),
-        byte => Err(ParseError::Protocol(format!("unexpected type byte: {byte:#04x}"))),
+    // Phase 2: the frame is known-complete, so take exactly its bytes.
+    // `split_to().freeze()` reuses the existing allocation, and every
+    // bulk payload is a `Bytes` slice of it — no payload is ever copied.
+    let data = buf.split_to(end).freeze();
+    Ok(Some(materialize(spec, &data)))
+}
+
+/// Turn a scanned [`FrameSpec`] into a [`Frame`], slicing bulk payloads
+/// out of `data` (the frozen bytes the spec was scanned against).
+///
+/// Recursion is bounded by [`MAX_ARRAY_DEPTH`], enforced during scanning.
+/// Every range came from [`scan_bulk`], which only emits ranges fully
+/// inside the scanned region, so the slices are always in bounds.
+fn materialize(spec: FrameSpec, data: &Bytes) -> Frame {
+    match spec {
+        FrameSpec::Simple(s) => Frame::Simple(s),
+        FrameSpec::Error(s) => Frame::Error(s),
+        FrameSpec::Integer(n) => Frame::Integer(n),
+        FrameSpec::Null => Frame::Null,
+        FrameSpec::Bulk(range) => Frame::Bulk(data.slice(range)),
+        FrameSpec::Array(items) => {
+            Frame::Array(items.into_iter().map(|item| materialize(item, data)).collect())
+        }
     }
 }
 
@@ -78,11 +145,13 @@ fn find_crlf(buf: &[u8], offset: usize) -> Option<usize> {
     None
 }
 
-/// Parse a line ending in `\r\n`, returning the content between `start`
-/// and the `\r`. Returns `Incomplete` if no CRLF found yet.
-fn read_line(buf: &[u8], start: usize) -> Result<(usize, &[u8]), ParseError> {
-    let crlf = find_crlf(buf, start).ok_or(ParseError::Incomplete)?;
-    Ok((crlf + 2, &buf[start..crlf]))
+/// Read a line ending in `\r\n`, returning the index just past the CRLF
+/// and the content between `start` and the `\r`.
+///
+/// Returns `None` when the buffer does not yet contain a full line.
+fn read_line(buf: &[u8], start: usize) -> Option<(usize, &[u8])> {
+    let crlf = find_crlf(buf, start)?;
+    Some((crlf + 2, &buf[start..crlf]))
 }
 
 /// Parse the integer in a RESP line (used for lengths and `:` frames).
@@ -92,55 +161,54 @@ fn parse_line_int(line: &[u8]) -> Result<i64, ParseError> {
     s.parse::<i64>().map_err(|_| ParseError::Protocol(format!("invalid integer: {s}")))
 }
 
-fn parse_simple(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
-    match read_line(buf, 1) {
-        Ok((end, line)) => {
-            let s = String::from_utf8_lossy(line).into_owned();
-            let _ = buf.split_to(end);
-            Ok(Some(Frame::Simple(s)))
-        }
-        Err(ParseError::Incomplete) => Ok(None),
-        Err(e) => Err(e),
+/// Locate one frame starting at `start`, without consuming `buf`.
+///
+/// Returns the frame's spec and the index just past its last byte, or
+/// `None` when the buffer does not yet hold the whole frame. `depth` is
+/// the array nesting level of this frame (0 at the top level).
+fn scan_frame(
+    buf: &[u8],
+    start: usize,
+    depth: usize,
+) -> Result<Option<(FrameSpec, usize)>, ParseError> {
+    if start >= buf.len() {
+        return Ok(None);
+    }
+
+    match buf[start] {
+        b'+' => Ok(scan_line(buf, start).map(|(s, end)| (FrameSpec::Simple(s), end))),
+        b'-' => Ok(scan_line(buf, start).map(|(s, end)| (FrameSpec::Error(s), end))),
+        b':' => scan_integer(buf, start),
+        b'$' => scan_bulk(buf, start),
+        b'*' => scan_array(buf, start, depth),
+        byte => Err(ParseError::Protocol(format!("unexpected type byte: {byte:#04x}"))),
     }
 }
 
-fn parse_error(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
-    match read_line(buf, 1) {
-        Ok((end, line)) => {
-            let s = String::from_utf8_lossy(line).into_owned();
-            let _ = buf.split_to(end);
-            Ok(Some(Frame::Error(s)))
-        }
-        Err(ParseError::Incomplete) => Ok(None),
-        Err(e) => Err(e),
-    }
+/// Scan a `\r\n`-terminated payload line (`+`/`-` frames).
+fn scan_line(buf: &[u8], start: usize) -> Option<(String, usize)> {
+    let (end, line) = read_line(buf, start + 1)?;
+    Some((String::from_utf8_lossy(line).into_owned(), end))
 }
 
-fn parse_integer(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
-    match read_line(buf, 1) {
-        Ok((end, line)) => {
-            let n = parse_line_int(line)?;
-            let _ = buf.split_to(end);
-            Ok(Some(Frame::Integer(n)))
-        }
-        Err(ParseError::Incomplete) => Ok(None),
-        Err(e) => Err(e),
-    }
+fn scan_integer(buf: &[u8], start: usize) -> Result<Option<(FrameSpec, usize)>, ParseError> {
+    let Some((end, line)) = read_line(buf, start + 1) else {
+        return Ok(None);
+    };
+    let n = parse_line_int(line)?;
+    Ok(Some((FrameSpec::Integer(n), end)))
 }
 
-fn parse_bulk(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
-    let (after_len_line, len_line) = match read_line(buf, 1) {
-        Ok(v) => v,
-        Err(ParseError::Incomplete) => return Ok(None),
-        Err(e) => return Err(e),
+fn scan_bulk(buf: &[u8], start: usize) -> Result<Option<(FrameSpec, usize)>, ParseError> {
+    let Some((after_len_line, len_line)) = read_line(buf, start + 1) else {
+        return Ok(None);
     };
 
     let len = parse_line_int(len_line)?;
 
     // Null bulk string: $-1\r\n
     if len < 0 {
-        let _ = buf.split_to(after_len_line);
-        return Ok(Some(Frame::Null));
+        return Ok(Some((FrameSpec::Null, after_len_line)));
     }
 
     let len = usize::try_from(len)
@@ -148,36 +216,39 @@ fn parse_bulk(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
     if len > MAX_BULK_LEN {
         return Err(ParseError::Protocol("invalid bulk length".into()));
     }
-    let total = after_len_line + len + 2; // data + \r\n
 
-    if buf.len() < total {
+    let data_end = after_len_line + len;
+    let end = data_end + 2; // data + \r\n
+    if buf.len() < end {
         return Ok(None);
     }
 
-    // Drain the bulk payload straight out of the input buffer as a
-    // zero-copy `Bytes` slice. `BytesMut::split_to` reuses the
-    // underlying allocation, so we avoid the `.to_vec()` memcpy the old
-    // path did — matters for large PUT bodies from PHP session writes.
-    let head = buf.split_to(after_len_line);
-    let data = buf.split_to(len).freeze();
-    let _ = buf.split_to(2); // trailing \r\n
-    drop(head);
-    Ok(Some(Frame::Bulk(data)))
+    Ok(Some((FrameSpec::Bulk(after_len_line..data_end), end)))
 }
 
-fn parse_array(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
-    let (after_len_line, len_line) = match read_line(buf, 1) {
-        Ok(v) => v,
-        Err(ParseError::Incomplete) => return Ok(None),
-        Err(e) => return Err(e),
+fn scan_array(
+    buf: &[u8],
+    start: usize,
+    depth: usize,
+) -> Result<Option<(FrameSpec, usize)>, ParseError> {
+    // Reject before recursing: this is the only thing standing between a
+    // few kilobytes of `*1\r\n` and a stack overflow that kills the
+    // process. See `MAX_ARRAY_DEPTH`.
+    if depth >= MAX_ARRAY_DEPTH {
+        return Err(ParseError::Protocol(format!(
+            "array nesting deeper than {MAX_ARRAY_DEPTH} levels"
+        )));
+    }
+
+    let Some((after_len_line, len_line)) = read_line(buf, start + 1) else {
+        return Ok(None);
     };
 
     let count = parse_line_int(len_line)?;
 
     // Null array: *-1\r\n
     if count < 0 {
-        let _ = buf.split_to(after_len_line);
-        return Ok(Some(Frame::Null));
+        return Ok(Some((FrameSpec::Null, after_len_line)));
     }
 
     let count = usize::try_from(count)
@@ -186,34 +257,24 @@ fn parse_array(buf: &mut BytesMut) -> Result<Option<Frame>, ParseError> {
         return Err(ParseError::Protocol("invalid multibulk length".into()));
     }
 
-    // We need to speculatively parse sub-frames without consuming `buf`
-    // until we know the entire array is complete. Work on a snapshot of
-    // the remaining bytes. Reserve only a bounded amount up front: the
-    // advertised `count` is trusted only as far as `MAX_ARRAY_LEN`, and even
-    // then the array may be incomplete, so we let the vector grow rather than
-    // allocating `count` slots from an unverified header.
+    // Reserve only a bounded amount up front: the advertised `count` is
+    // trusted only as far as `MAX_ARRAY_LEN`, and even then the array may
+    // be incomplete, so we let the vector grow rather than allocating
+    // `count` slots from an unverified header.
     let mut cursor = after_len_line;
     let mut items = Vec::with_capacity(count.min(MAX_ARRAY_PREALLOC));
 
     for _ in 0..count {
-        if cursor >= buf.len() {
+        // Elements are scanned in place against an index — no per-element
+        // copy of the remaining buffer.
+        let Some((item, end)) = scan_frame(buf, cursor, depth + 1)? else {
             return Ok(None);
-        }
-
-        let mut sub = BytesMut::from(&buf[cursor..]);
-        match parse_frame(&mut sub) {
-            Ok(Some(frame)) => {
-                let consumed = buf.len() - cursor - sub.len();
-                cursor += consumed;
-                items.push(frame);
-            }
-            Ok(None) => return Ok(None),
-            Err(e) => return Err(e),
-        }
+        };
+        items.push(item);
+        cursor = end;
     }
 
-    let _ = buf.split_to(cursor);
-    Ok(Some(Frame::Array(items)))
+    Ok(Some((FrameSpec::Array(items), cursor)))
 }
 
 #[cfg(test)]
@@ -339,6 +400,86 @@ mod tests {
     fn huge_bulk_len_rejected() {
         let over = format!("${}\r\n", MAX_BULK_LEN + 1);
         assert!(matches!(parse(over.as_bytes()), Err(ParseError::Protocol(_))));
+    }
+
+    /// Nesting exactly at the cap still parses: 32 levels of single-element
+    /// arrays wrapping a simple string.
+    #[test]
+    fn nesting_at_depth_cap_parses() {
+        let mut input = "*1\r\n".repeat(MAX_ARRAY_DEPTH);
+        input.push_str("+OK\r\n");
+        let frame = parse(input.as_bytes()).unwrap();
+        assert!(frame.is_some(), "nesting at the cap must parse");
+    }
+
+    /// One level past the cap is a protocol error, not a deeper recursion.
+    #[test]
+    fn nesting_past_depth_cap_rejected() {
+        let mut input = "*1\r\n".repeat(MAX_ARRAY_DEPTH + 1);
+        input.push_str("+OK\r\n");
+        let err = parse(input.as_bytes()).unwrap_err();
+        assert!(matches!(err, ParseError::Protocol(_)), "got {err:?}");
+    }
+
+    /// The DoS shape: ~40 KiB of repeated `*1\r\n` — well under the 1 MiB
+    /// `max_input_buffer`, but ~10,000 frames deep. Before the depth cap
+    /// this overflowed the tokio worker stack and SIGSEGV'd the whole
+    /// process. It must now be a plain protocol error on one connection.
+    #[test]
+    fn deeply_nested_array_does_not_overflow_stack() {
+        let input = "*1\r\n".repeat(10_000);
+        let err = parse(input.as_bytes()).unwrap_err();
+        assert!(matches!(err, ParseError::Protocol(_)), "got {err:?}");
+    }
+
+    /// Bulk payloads inside an array are slices of the input allocation,
+    /// not copies — the property the index-based scan exists to preserve.
+    #[test]
+    fn nested_bulk_payloads_are_zero_copy_slices() {
+        let mut buf = BytesMut::from(&b"*1\r\n$3\r\nabc\r\n"[..]);
+        let base = buf.as_ptr() as usize;
+        let frame = parse_frame(&mut buf).unwrap().unwrap();
+        let Frame::Array(items) = frame else { panic!("expected an array") };
+        let Frame::Bulk(ref data) = items[0] else { panic!("expected a bulk") };
+        assert_eq!(&data[..], b"abc");
+        // The payload points into the original buffer's allocation at the
+        // offset where "abc" sits (4 bytes of "*1\r\n" + 4 of "$3\r\n").
+        assert_eq!(data.as_ptr() as usize, base + 8, "bulk payload was copied");
+    }
+
+    /// A partially received array must not consume anything: the caller
+    /// re-parses the same buffer after the next socket read.
+    #[test]
+    fn incomplete_array_leaves_buffer_untouched() {
+        let mut buf = BytesMut::from(&b"*2\r\n$3\r\nGET\r\n"[..]);
+        let before = buf.len();
+        assert!(parse_frame(&mut buf).unwrap().is_none());
+        assert_eq!(buf.len(), before, "incomplete frame must not be consumed");
+
+        // Completing it yields the whole array.
+        buf.extend_from_slice(b"$3\r\nkey\r\n");
+        let frame = parse_frame(&mut buf).unwrap().unwrap();
+        assert_eq!(
+            frame,
+            Frame::Array(vec![
+                Frame::Bulk(bytes::Bytes::from_static(b"GET")),
+                Frame::Bulk(bytes::Bytes::from_static(b"key")),
+            ])
+        );
+        assert!(buf.is_empty());
+    }
+
+    /// Nested arrays round-trip with their elements intact.
+    #[test]
+    fn nested_array_round_trip() {
+        let frame = parse(b"*2\r\n*1\r\n:1\r\n$2\r\nhi\r\n").unwrap().unwrap();
+        assert_eq!(
+            frame,
+            Frame::Array(vec![
+                Frame::Array(vec![Frame::Integer(1)]),
+                Frame::Bulk(bytes::Bytes::from_static(b"hi")),
+            ])
+        );
     }
 
     /// The exact fuzzer crash input must parse without panicking — every

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1196,6 +1196,81 @@ fn start_kv_service(config: &Config) -> anyhow::Result<KvService> {
     Ok((store, multi_tenant, Some(handle)))
 }
 
+/// Warn about every database listener bound to a non-loopback address.
+///
+/// None of the SQL frontends authenticate anyone. The `[db.mysql]` proxy
+/// reads the client handshake and discards it without validating
+/// credentials; the `[db.postgres]` proxy answers any startup message
+/// with `AuthenticationOk`; litewire's `MySQL`/Hrana/`PostgreSQL`/TDS
+/// frontends in front of embedded `SQLite` do no authentication either.
+/// That is by design — the whole model assumes the listener is reachable
+/// only by PHP running in this same process. A routable bind address
+/// therefore publishes unauthenticated read/write access to the database
+/// to anyone who can reach the port.
+///
+/// This warns rather than refusing to start. Unlike `[cluster] secret`
+/// there is no credential an operator could configure to make the
+/// listener safe, and binding `0.0.0.0` inside a container that is
+/// firewalled by a network policy is a legitimate deployment.
+fn warn_on_exposed_db_listeners(config: &Config) {
+    // Defaults mirror the ones applied where each proxy is started below.
+    if let Some(mysql) = &config.db.mysql {
+        warn_if_db_listener_exposed(
+            "[db.mysql] listen",
+            mysql.listen.as_deref().unwrap_or("127.0.0.1:3306"),
+        );
+    }
+    if let Some(pg) = &config.db.postgres {
+        warn_if_db_listener_exposed(
+            "[db.postgres] listen",
+            pg.listen.as_deref().unwrap_or("127.0.0.1:5432"),
+        );
+    }
+    if let Some(sqlite) = &config.db.sqlite {
+        let proxy = &sqlite.proxy;
+        warn_if_db_listener_exposed("[db.sqlite.proxy] mysql_listen", &proxy.mysql_listen);
+        let optional = [
+            ("[db.sqlite.proxy] hrana_listen", proxy.hrana_listen.as_deref()),
+            ("[db.sqlite.proxy] postgres_listen", proxy.postgres_listen.as_deref()),
+            ("[db.sqlite.proxy] tds_listen", proxy.tds_listen.as_deref()),
+        ];
+        for (key, addr) in optional {
+            if let Some(addr) = addr {
+                warn_if_db_listener_exposed(key, addr);
+            }
+        }
+    }
+}
+
+/// Emit the exposure warning for one listener, if it is in fact exposed.
+fn warn_if_db_listener_exposed(key: &str, addr: &str) {
+    if let Some(exposure) = db_listen_exposure(addr) {
+        tracing::warn!(
+            "{key} = \"{addr}\" listens on {exposure}. The SQL wire frontends do NOT \
+             authenticate clients — any host that can reach this port gets full read/write \
+             access to the database. Bind a loopback address unless this port is firewalled \
+             from untrusted networks."
+        );
+    }
+}
+
+/// Classify a listen address for the exposure warning.
+///
+/// Returns a description of how the address is exposed, or `None` when it
+/// is loopback-only. Addresses that are not IP literals (`localhost:3306`,
+/// `db.internal:3306`) also return `None`: classifying them would require
+/// a DNS lookup at startup, and a wrong warning is worse than no warning.
+fn db_listen_exposure(addr: &str) -> Option<&'static str> {
+    let socket: SocketAddr = addr.trim().parse().ok()?;
+    if socket.ip().is_loopback() {
+        None
+    } else if socket.ip().is_unspecified() {
+        Some("all network interfaces")
+    } else {
+        Some("a non-loopback address")
+    }
+}
+
 /// Start database proxies (`MySQL`, `PostgreSQL`, `TDS`, embedded `SQLite`).
 async fn start_db_proxies(
     config: &Config,
@@ -1204,6 +1279,8 @@ async fn start_db_proxies(
     query_stats: &ephpm_query_stats::QueryStats,
 ) -> anyhow::Result<Vec<tokio::task::JoinHandle<()>>> {
     let mut handles = vec![];
+
+    warn_on_exposed_db_listeners(config);
 
     // MySQL proxy
     if let Some(mysql_config) = &config.db.mysql {
@@ -1705,6 +1782,31 @@ mod lib_tests {
     #[test]
     fn parse_memory_size_zero() {
         assert_eq!(parse_memory_size("0").unwrap(), 0);
+    }
+
+    #[test]
+    fn db_listen_exposure_allows_loopback() {
+        assert!(db_listen_exposure("127.0.0.1:3306").is_none());
+        assert!(db_listen_exposure("127.0.0.2:3306").is_none());
+        assert!(db_listen_exposure("[::1]:3306").is_none());
+        assert!(db_listen_exposure(" 127.0.0.1:3306 ").is_none());
+    }
+
+    #[test]
+    fn db_listen_exposure_flags_wildcard_and_routable() {
+        assert_eq!(db_listen_exposure("0.0.0.0:3306"), Some("all network interfaces"));
+        assert_eq!(db_listen_exposure("[::]:3306"), Some("all network interfaces"));
+        assert_eq!(db_listen_exposure("10.0.0.5:3306"), Some("a non-loopback address"));
+        assert_eq!(db_listen_exposure("203.0.113.7:5432"), Some("a non-loopback address"));
+    }
+
+    #[test]
+    fn db_listen_exposure_skips_addresses_it_cannot_classify() {
+        // Hostnames would need a DNS lookup to classify; warning on a
+        // guess would be worse than staying quiet.
+        assert!(db_listen_exposure("localhost:3306").is_none());
+        assert!(db_listen_exposure("db.internal:3306").is_none());
+        assert!(db_listen_exposure("").is_none());
     }
 
     fn make_sqlite_config(role: &str) -> ephpm_config::SqliteConfig {

--- a/crates/ephpm-server/src/rate_limit.rs
+++ b/crates/ephpm-server/src/rate_limit.rs
@@ -15,9 +15,28 @@ use std::time::Instant;
 use dashmap::DashMap;
 use ephpm_config::LimitsConfig;
 
-/// Maximum number of tracked IPs before we stop inserting new entries.
-/// Prevents unbounded memory growth under DDoS with spoofed source IPs.
+/// Maximum number of tracked IPs.
+///
+/// Once the map holds this many entries, requests and connections from
+/// IPs that are not already tracked are refused outright — no new entry
+/// is created. Refusing is what actually bounds the map: the previous
+/// code inserted a zero-token entry for over-cap IPs, so the map kept
+/// growing past the "cap" *and* every new IP was pinned at a permanent
+/// 429 until the sweep evicted it.
+///
+/// This is fail-closed by design. Reaching 100,000 distinct source IPs
+/// within one 30s sweep window is a spoofed-source flood, not organic
+/// traffic, and an untracked IP would otherwise bypass the limiter
+/// entirely.
 const MAX_TRACKED_IPS: usize = 100_000;
+
+/// One token-bucket consumption step, for `AtomicU64::fetch_update`.
+///
+/// Takes one token (1000 scaled units), or returns `None` when the bucket
+/// is empty so the update is refused instead of wrapping the counter.
+fn take_one_token(tokens: u64) -> Option<u64> {
+    tokens.checked_sub(1000)
+}
 
 /// Per-IP state: connection count and token bucket for rate limiting.
 struct IpState {
@@ -47,13 +66,25 @@ pub struct Limiter {
 pub struct ConnectionGuard {
     limiter: std::sync::Arc<Limiter>,
     ip: IpAddr,
+    /// Whether this guard incremented the per-IP connection counter.
+    ///
+    /// The per-IP counter is only incremented when a per-IP entry exists
+    /// at acquire time. Decrementing unconditionally on drop underflowed
+    /// the `AtomicUsize` whenever the entry was created *later* by
+    /// `check_rate` — with `per_ip_max_connections = 0` (the default)
+    /// that is the ordinary sequence. The counter wrapped to `usize::MAX`,
+    /// so `cleanup_stale` (which keeps anything with `conns > 0`) could
+    /// never evict the entry again.
+    counted: bool,
 }
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         self.limiter.global_connections.fetch_sub(1, Ordering::Relaxed);
-        if let Some(state) = self.limiter.per_ip.get(&self.ip) {
-            state.connections.fetch_sub(1, Ordering::Relaxed);
+        if self.counted {
+            if let Some(state) = self.limiter.per_ip.get(&self.ip) {
+                state.connections.fetch_sub(1, Ordering::Relaxed);
+            }
         }
     }
 }
@@ -97,31 +128,52 @@ impl Limiter {
             self.global_connections.fetch_add(1, Ordering::Relaxed);
         }
 
-        // Check per-IP limit.
-        if self.config.per_ip_max_connections > 0 {
-            let state = self.get_or_create_ip(ip);
+        // Check per-IP limit. `counted` records whether we incremented the
+        // per-IP counter, so `ConnectionGuard::drop` decrements exactly
+        // what it took and never underflows an entry it never touched.
+        let counted = if self.config.per_ip_max_connections > 0 {
+            let Some(state) = self.get_or_create_ip(ip) else {
+                // At the tracked-IP cap we cannot account for this IP's
+                // connections, so refuse rather than let it slip past the
+                // per-IP limit untracked.
+                self.global_connections.fetch_sub(1, Ordering::Relaxed);
+                return None;
+            };
             let current = state.connections.fetch_add(1, Ordering::Relaxed);
             if current >= self.config.per_ip_max_connections {
                 state.connections.fetch_sub(1, Ordering::Relaxed);
                 self.global_connections.fetch_sub(1, Ordering::Relaxed);
                 return None;
             }
+            true
         } else if let Some(state) = self.per_ip.get(&ip) {
             state.connections.fetch_add(1, Ordering::Relaxed);
-        }
+            true
+        } else {
+            // No per-IP limit configured and no entry to charge. An entry
+            // may be created later by `check_rate`; it must not be
+            // decremented on drop.
+            false
+        };
 
-        Some(ConnectionGuard { limiter: std::sync::Arc::clone(self), ip })
+        Some(ConnectionGuard { limiter: std::sync::Arc::clone(self), ip, counted })
     }
 
     /// Check if a request from the given IP is allowed under the rate limit.
     ///
     /// Uses a token bucket algorithm. Returns `true` if allowed.
+    ///
+    /// Returns `false` for an untracked IP once the tracked-IP cap
+    /// (`MAX_TRACKED_IPS`) is reached — see that constant for why this is
+    /// deliberately fail-closed.
     pub fn check_rate(&self, ip: IpAddr) -> bool {
         if self.config.per_ip_rate <= 0.0 {
             return true;
         }
 
-        let state = self.get_or_create_ip(ip);
+        let Some(state) = self.get_or_create_ip(ip) else {
+            return false;
+        };
         let now_ms = self.epoch.elapsed().as_millis() as u64;
         let burst_tokens = u64::from(self.config.per_ip_burst) * 1000;
 
@@ -143,22 +195,26 @@ impl Limiter {
                     Ordering::Relaxed,
                 );
 
-                let old = state.tokens.fetch_add(new_tokens, Ordering::Relaxed);
-                // Cap at burst limit.
-                if old + new_tokens > burst_tokens {
-                    state.tokens.store(burst_tokens, Ordering::Relaxed);
-                }
+                // Add and cap in one atomic update. The old `fetch_add`
+                // followed by a conditional `store` could overflow the
+                // `old + new_tokens` sum (a panic in debug builds) and
+                // raced with concurrent refills of the same bucket.
+                let _ = state.tokens.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |tokens| {
+                    Some(tokens.saturating_add(new_tokens).min(burst_tokens))
+                });
             }
         }
 
-        // Try to consume one token (1000 scaled units).
-        let current = state.tokens.load(Ordering::Relaxed);
-        if current >= 1000 {
-            state.tokens.fetch_sub(1000, Ordering::Relaxed);
-            true
-        } else {
-            false
-        }
+        // Consume one token (1000 scaled units), atomically.
+        //
+        // This must be a compare-and-swap, not `load` then `fetch_sub`:
+        // with the latter, two threads that both observe the last token
+        // both subtract, wrapping the `AtomicU64` to ~`u64::MAX` — which
+        // silently disables rate limiting for that IP until the entry is
+        // swept, the exact opposite of the intended behaviour under load.
+        // `take_one_token` returns `None` when the bucket is empty, which
+        // `fetch_update` reports as `Err` without writing.
+        state.tokens.fetch_update(Ordering::Relaxed, Ordering::Relaxed, take_one_token).is_ok()
     }
 
     /// Remove stale per-IP entries to prevent memory growth.
@@ -180,35 +236,44 @@ impl Limiter {
         self.global_connections.load(Ordering::Relaxed)
     }
 
-    /// Get or create per-IP state. Returns a DashMap ref.
-    fn get_or_create_ip(&self, ip: IpAddr) -> dashmap::mapref::one::Ref<'_, IpAddr, IpState> {
-        if let Some(state) = self.per_ip.get(&ip) {
-            return state;
-        }
+    /// Get or create per-IP state.
+    ///
+    /// Returns `None` when the IP is not already tracked and the map is at
+    /// [`MAX_TRACKED_IPS`] — callers treat that as "deny". No entry is
+    /// inserted in that case, which is what keeps the map bounded.
+    fn get_or_create_ip(
+        &self,
+        ip: IpAddr,
+    ) -> Option<dashmap::mapref::one::Ref<'_, IpAddr, IpState>> {
+        // Bounded retry: `cleanup_stale` can evict the freshly inserted
+        // entry (full bucket, no connections) between the insert and the
+        // read-back. Re-inserting once or twice is cheaper and more
+        // correct than holding a write guard across the whole hot path.
+        for _ in 0..3 {
+            if let Some(state) = self.per_ip.get(&ip) {
+                return Some(state);
+            }
 
-        // Fail-closed: if we're tracking too many IPs, reject new ones.
-        if self.per_ip.len() >= MAX_TRACKED_IPS {
-            // Return an entry that will deny the request (0 tokens).
+            if self.per_ip.len() >= MAX_TRACKED_IPS {
+                return None;
+            }
+
+            let burst_tokens = u64::from(self.config.per_ip_burst) * 1000;
             self.per_ip.entry(ip).or_insert_with(|| IpState {
                 connections: AtomicUsize::new(0),
-                tokens: AtomicU64::new(0),
+                tokens: AtomicU64::new(burst_tokens),
                 last_refill_ms: AtomicU64::new(self.epoch.elapsed().as_millis() as u64),
             });
-            return self.per_ip.get(&ip).expect("just inserted");
         }
 
-        let burst_tokens = u64::from(self.config.per_ip_burst) * 1000;
-        self.per_ip.entry(ip).or_insert_with(|| IpState {
-            connections: AtomicUsize::new(0),
-            tokens: AtomicU64::new(burst_tokens),
-            last_refill_ms: AtomicU64::new(self.epoch.elapsed().as_millis() as u64),
-        });
-        self.per_ip.get(&ip).expect("just inserted")
+        None
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+
     use super::*;
 
     fn test_config(rate: f64, burst: u32, max_conn: usize) -> LimitsConfig {
@@ -306,6 +371,97 @@ mod tests {
             0,
             "fully replenished idle entry should be removed by cleanup"
         );
+    }
+
+    /// An exhausted bucket must stay exhausted. `load` + `fetch_sub` let a
+    /// denied request subtract anyway on the next racing caller, wrapping
+    /// the counter to ~`u64::MAX` and disabling the limit for that IP.
+    #[test]
+    fn exhausted_bucket_does_not_wrap() {
+        let limiter = Limiter::new(test_config(0.001, 5, 0));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+
+        for _ in 0..5 {
+            assert!(limiter.check_rate(ip));
+        }
+        for _ in 0..100 {
+            assert!(!limiter.check_rate(ip), "empty bucket must keep denying");
+        }
+
+        let tokens = limiter.per_ip.get(&ip).unwrap().tokens.load(Ordering::Relaxed);
+        assert!(tokens < 1000, "token counter wrapped instead of emptying: {tokens}");
+    }
+
+    /// Concurrent consumption must hand out exactly `burst` permits, never
+    /// more. The rate is small enough that refill contributes nothing over
+    /// the lifetime of the test, so the expected count is exact.
+    #[test]
+    fn concurrent_consumption_never_exceeds_burst() {
+        let limiter = Limiter::new(test_config(0.001, 100, 0));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let allowed = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                scope.spawn(|| {
+                    for _ in 0..200 {
+                        if limiter.check_rate(ip) {
+                            allowed.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                });
+            }
+        });
+
+        assert_eq!(allowed.load(Ordering::Relaxed), 100, "exactly `burst` requests may pass");
+        let tokens = limiter.per_ip.get(&ip).unwrap().tokens.load(Ordering::Relaxed);
+        assert!(tokens < 1000, "token counter wrapped under contention: {tokens}");
+    }
+
+    /// With `per_ip_max_connections = 0` (the default) a guard acquired
+    /// before the IP has an entry must not decrement the entry that
+    /// `check_rate` creates later — that underflows to `usize::MAX` and
+    /// makes the entry permanently un-evictable.
+    #[test]
+    fn guard_does_not_decrement_a_counter_it_never_incremented() {
+        let limiter = std::sync::Arc::new(Limiter::new(test_config(10.0, 5, 0)));
+        let ip: IpAddr = "10.1.2.3".parse().unwrap();
+
+        let guard = limiter.try_acquire_connection(ip).expect("no connection limit configured");
+        // The per-IP entry comes into existence only now, via the rate path.
+        assert!(limiter.check_rate(ip));
+        drop(guard);
+
+        let conns = limiter.per_ip.get(&ip).unwrap().connections.load(Ordering::Relaxed);
+        assert_eq!(conns, 0, "guard underflowed a counter it never incremented");
+
+        // An underflowed counter would keep this entry alive forever, since
+        // `cleanup_stale` retains anything with connections > 0.
+        let burst_tokens = u64::from(limiter.config.per_ip_burst) * 1000;
+        limiter.per_ip.get(&ip).unwrap().tokens.store(burst_tokens, Ordering::Relaxed);
+        limiter.cleanup_stale();
+        assert_eq!(limiter.per_ip.len(), 0, "idle entry must be evictable");
+    }
+
+    /// At `MAX_TRACKED_IPS` the map must stop growing: new IPs are denied
+    /// without an entry being inserted, and tracked IPs keep working.
+    #[test]
+    fn tracked_ip_cap_bounds_the_map() {
+        let limiter = Limiter::new(test_config(10.0, 5, 0));
+
+        for i in 0..MAX_TRACKED_IPS {
+            let ip = IpAddr::V4(Ipv4Addr::from(u32::try_from(i).expect("index fits in u32")));
+            assert!(limiter.check_rate(ip));
+        }
+        assert_eq!(limiter.per_ip.len(), MAX_TRACKED_IPS);
+
+        // Well outside the range generated above, so genuinely untracked.
+        let fresh: IpAddr = "203.0.113.7".parse().unwrap();
+        assert!(!limiter.check_rate(fresh), "untracked IP must be denied at the cap");
+        assert_eq!(limiter.per_ip.len(), MAX_TRACKED_IPS, "the cap must bound the map");
+
+        // Already-tracked IPs are unaffected.
+        assert!(limiter.check_rate(IpAddr::V4(Ipv4Addr::from(0))));
     }
 
     #[test]

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -216,6 +216,11 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `reset_strategy` | string | `"smart"` | `"smart"` (reset after non-SELECT), `"always"`, `"never"`. |
 | `replicas.urls` | array of strings | `[]` | Read replica URLs. Reads distributed across; writes go to primary. |
 
+> **The proxy listener is unauthenticated — keep it on loopback.**
+> The proxy does not validate client credentials. The MySQL proxy reads the client handshake response and discards it; the PostgreSQL proxy answers any startup message with `AuthenticationOk`. The real credentials in `url` are used only for the proxy's own pooled connections to the backend, and are never required of the client.
+>
+> Binding `listen` to a non-loopback address therefore gives full read/write access to your database to any host that can reach the port. ePHPm logs a startup warning when `listen` is a non-loopback IP literal (`0.0.0.0:3306`, `10.0.0.5:3306`, …), but does **not** refuse to start — binding `0.0.0.0` inside a container that is firewalled by a network policy is a legitimate deployment. Addresses given as hostnames (`localhost:3306`, `db.internal:3306`) are not classified, because that would require a DNS lookup at startup; no warning is logged for them either way.
+
 ### `[db.sqlite]`
 
 | Key | Type | Default | Description |
@@ -231,6 +236,8 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `hrana_listen` | string | (none) | Hrana HTTP API listener. |
 | `postgres_listen` | string | (none) | PostgreSQL wire protocol listener. |
 | `tds_listen` | string | (none) | TDS (SQL Server) wire protocol listener. |
+
+> **These listeners are unauthenticated too.** litewire's MySQL, Hrana, PostgreSQL, and TDS frontends accept any client — the PostgreSQL frontend is explicitly wired to a no-op startup handler, and the others never ask for credentials. The design assumes only PHP inside this process reaches them. As with `[db.mysql]`, each of these four keys is checked at startup and a non-loopback IP literal logs a warning naming the risk; startup is not blocked. Bind loopback unless the port is firewalled from untrusted networks.
 
 #### `[db.sqlite.sqld]` (clustered mode only)
 


### PR DESCRIPTION
Four pre-release security defects, one commit each. All were confirmed against source in the v0.6.0 audit.

### S1 — RESP array parser: unbounded recursion crashed the process
`crates/ephpm-kv/src/resp/parse.rs`

`parse_array` → `parse_frame` → `parse_array` had no depth cap. ~40 KB of repeated `*1\r\n` — far under the 1 MiB `max_input_buffer` — recursed ~10,000 deep and overflowed the tokio worker stack, **SIGSEGV-ing the whole process**, not just the connection. Nesting is now capped at 32 (Redis's `PROTO_NESTED_MULTIBULK_DEPTH`) and rejected as a protocol error.

The same function also memcpy'd the entire remaining buffer **per array element** (`BytesMut::from(&buf[cursor..])`), so one 1 MiB multibulk cost tens of GB of memcpy, redone on every socket read while the array was incomplete. **Both are fixed here**, not just the crash: parsing is now two-phase — `scan_frame` locates a frame by index without copying or consuming, recording bulk payloads as ranges; `parse_frame` then splits exactly that many bytes off and slices payloads out of the frozen `Bytes`. Payloads stay zero-copy including nested ones (the value in `*3 SET key <value>`), and an N-element array is O(N).

`ParseError::Incomplete` is removed — it was an internal signal `parse_frame` always converted to `Ok(None)`, never observable by a caller, and nothing in the tree constructs or matches it.

### S2 — allocations sized from untrusted length fields
`crates/ephpm-db/src/postgres.rs`, `crates/ephpm-cluster/src/kv_data_plane.rs`

- `read_pg_message` did `vec![0u8; len - 4]` from a client-supplied i32 — five bytes (`Q` + `0x7FFFFFFF`) zero-fill 2 GiB. Now capped at 64 MiB, matching what `read_startup_message` already did. Query results stream through `forward_pg_message` in 8 KiB chunks and are unaffected.
- `read_frame` allocated up to ~64 MiB **before** `cipher.open()`, i.e. for an unauthenticated peer, one 4-byte header per allocation.
- `fetch_remote` applied no bound at all on the **plaintext** path — exactly the deployments with no `[cluster] secret`. Now bounded by `MAX_VALUE_LEN`.

Data-plane payloads now go through `read_exact_chunked`, which grows the buffer as bytes actually arrive, so a lie costs one 64 KiB chunk rather than the full claim.

### S3 — rate limiter silently disabled itself
`crates/ephpm-server/src/rate_limit.rs`

1. Token consumption was `load` then `fetch_sub`. Two threads that both see the last token both subtract, wrapping the `AtomicU64` to ~`u64::MAX` — **rate limiting silently off for that IP** until the 30s sweep. Now one `fetch_update` with `checked_sub`. Refill is likewise a single `fetch_update` with `saturating_add(..).min(burst)`, replacing a `fetch_add` + conditional `store` that could overflow `old + new_tokens` (a debug-build panic) and raced with concurrent refills.
2. `MAX_TRACKED_IPS` bounded nothing — the over-cap branch still inserted a zero-token entry, so the map grew past the cap *and* every new IP got a permanent 429, while the doc claimed it "prevents unbounded memory growth". Over the cap we now insert nothing and deny; the doc says what the code does.
3. `ConnectionGuard::drop` decremented a per-IP counter it had not always incremented. With `per_ip_max_connections = 0` (the default), acquire → `check_rate` creates the entry → drop underflowed a `usize` to `usize::MAX`, and `cleanup_stale` keeps anything with `conns > 0`, so the entry was never evictable. The guard now records whether it incremented.

### S4 — no exposure guardrail on the DB listeners
`crates/ephpm-server/src/lib.rs`, `site/content/reference/config.md`

There was not one call to `is_loopback()`/`is_unspecified()` in the tree, so `EPHPM_DB__SQLITE__PROXY__MYSQL_LISTEN=0.0.0.0:3306` published an unauthenticated SQL endpoint with no error and no warning. Unauthenticated is literal: the `[db.mysql]` proxy reads the client handshake and discards it, the `[db.postgres]` proxy answers any startup message with `AuthenticationOk`, and litewire's PostgreSQL frontend is wired to pgwire's `NoopStartupHandler` (its MySQL/Hrana/TDS frontends never ask for credentials at all).

`start_db_proxies` now classifies every DB listen address at startup and warns, naming the risk. **A warning, not a hard failure** — unlike `[cluster] secret` there is no credential to configure that makes it safe, and `0.0.0.0` behind a network policy is a legitimate container deployment. No `allow_insecure` knob. Hostname listen addresses are left unclassified rather than guessed at (that would need a DNS lookup at startup).

## Tests

- **S1**: nesting at the cap parses, one past is rejected, the 10,000-deep DoS input is a protocol error instead of a crash, nested bulk payloads asserted to be slices of the input allocation (zero-copy), incomplete array leaves the buffer untouched.
- **S2**: 200 KiB value (four chunks) round-trips byte-exactly; a peer advertising past `MAX_VALUE_LEN` is rejected on the header.
- **S3**: exhausted bucket keeps denying without wrapping; eight threads racing a 100-token bucket get exactly 100 permits; guard acquired before the entry existed leaves the counter at 0 and the entry evictable; at the cap a new IP is denied without the map growing.
- **S4**: listen-address classification (loopback v4/v6, wildcard, routable, hostnames).

## Not done

Nothing deferred — S1's O(n²) copy is fixed in this PR rather than filed.

⚠️ **Nothing here was compiled or tested**: this machine has no Rust toolchain (no MSVC linker), so `cargo build`/`test`/`clippy`/`fmt` all fail at link time. CI is the first real check.
