### PR TITLE
fix(cdc): pin litewire 23b8de63 so a cold primary holds its subscriber open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2589,7 +2589,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "anyhow",
  "futures",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2693,7 +2693,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=7a0b59c40ce6#7a0b59c40ce6727fb52e9402c6e80f713fcda265"
+source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3574,7 +3574,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3611,7 +3611,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,18 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ 7a0b59c4 — identifier sanitization in the metadata translator
-# (litewire#12), on top of framework wire-compat (litewire#11) and the Phase 2
-# CDC tail/apply API (litewire#10) this branch builds on.
+# litewire main @ 23b8de63 — CDC cold-start tolerance (litewire#14) and unbound
+# params executed as NULL (litewire#13), on top of identifier sanitization in
+# the metadata translator (litewire#12), framework wire-compat (litewire#11) and
+# the Phase 2 CDC tail/apply API (litewire#10).
+#
+# 23b8de63 (litewire#14) makes CdcTailer::poll_batch report an absent turso_cdc
+# log as Ok(None) instead of an error. Turso creates that table lazily on the
+# first captured write, so a freshly provisioned cluster has none; before the
+# fix ephpm's CDC primary treated the poll error as fatal and dropped the
+# replica's subscription every ~2s until someone wrote. ephpm no longer carries
+# a local workaround for this — `cold_primary_holds_subscriber_open_until_first_write`
+# in turso_cdc.rs fails if a pin without the fix is ever selected.
 #
 # SECURITY: do not move this pin backwards. 699e6345 and earlier interpolate the
 # client-supplied table name straight into SQL text in
@@ -94,7 +103,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 # sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
 # DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
 # applies it at every extraction site.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "7a0b59c40ce6", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "23b8de63effb", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -236,11 +236,6 @@ const SNAPSHOT_PREALLOC_CAP: u64 = 8 * 1024 * 1024;
 /// shape staying stable under the exact litewire pin.
 const WATERMARK_TABLE: &str = "__litewire_cdc_watermark";
 
-/// Name of Turso's CDC log table. Created lazily by the engine on the
-/// first captured write, which is why [`is_missing_cdc_log`] has to treat
-/// its absence as "no changes yet" rather than as a failure.
-const CDC_LOG_TABLE: &str = "turso_cdc";
-
 /// How often the primary polls `turso_cdc` for new batches. Turso 0.7.0
 /// has no wakeup signal for CDC inserts, so we poll on a schedule.
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -731,31 +726,15 @@ async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
 
     let mut tailer = CdcTailer::new(mgmt, from);
     let mut idle_since = tokio::time::Instant::now();
-    let mut logged_missing_log = false;
 
     loop {
+        // A cold primary — one whose `turso_cdc` log does not exist
+        // because it has served no captured write yet — polls as
+        // `Ok(None)`, not as an error. That tolerance lives in litewire
+        // (`CdcTailer::poll_batch`), where "absent" and "empty" are the
+        // same answer and no consumer has to know the difference.
         let batch = match tailer.poll_batch().await {
             Ok(batch) => batch,
-            // `turso_cdc` is created lazily by litewire-turso, on the
-            // first captured write — not when CDC is enabled and not
-            // when a session connects. On a freshly provisioned cluster
-            // that has served no writes yet, the table is simply absent,
-            // and "absent" is indistinguishable from "empty": both mean
-            // zero changes to ship. Treating it as a hard error tore the
-            // subscriber down on every poll, and the replica redialed
-            // every REPLICA_RECONNECT_DELAY, producing an error loop
-            // that only stopped once someone happened to write.
-            Err(e) if is_missing_cdc_log(&e) => {
-                if !logged_missing_log {
-                    logged_missing_log = true;
-                    tracing::info!(
-                        "CDC: turso_cdc does not exist yet — the primary has served no captured \
-                         write since this database was created. Holding the subscriber open; \
-                         batches will flow as soon as the first write lands."
-                    );
-                }
-                None
-            }
             Err(e) => {
                 // Drop the stream rather than skip past the failure —
                 // the replica reconnects with the same watermark and we
@@ -782,21 +761,6 @@ async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
             }
         }
     }
-}
-
-/// True when `e` is litewire reporting that the CDC log table does not
-/// exist yet.
-///
-/// This matches on the message text because it has to: litewire's
-/// `BackendError` carries only `Sqlite(String)`/`Other(String)`, so there
-/// is no typed variant to match on. The durable fix is a typed
-/// "relation missing" variant upstream in litewire plus a pin bump; until
-/// then, `serve_subscriber`'s cold-start test pins this behaviour so a
-/// message change upstream fails loudly here instead of silently
-/// restoring the reconnect loop.
-fn is_missing_cdc_log<E: std::fmt::Display>(e: &E) -> bool {
-    let msg = e.to_string();
-    msg.contains("no such table") && msg.contains(CDC_LOG_TABLE)
 }
 
 // ---------------------------------------------------------------------------
@@ -1786,22 +1750,13 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Cold-start: `turso_cdc` missing is "no changes yet", not an error.
+    // Cold-start: a primary whose `turso_cdc` log does not exist yet
+    // must hold its subscriber open, not tear it down.
     //
-    // These pin the exact message shape litewire produces today. If an
-    // upstream change alters it, `missing_cdc_log_matches_litewire_text`
-    // fails — which is the point: the reconnect loop it prevents is
-    // silent, so the guard must not be allowed to rot quietly.
+    // The tolerance itself lives in litewire; this asserts the behaviour
+    // ePHPm depends on, so a pin that lost the fix fails here rather
+    // than silently restoring a 2-second reconnect loop in production.
     // -----------------------------------------------------------------
-
-    #[test]
-    fn missing_cdc_log_matches_litewire_text() {
-        // Verbatim from a real run: the primary polled before any write
-        // had created the log. (litewire wraps turso's parse error in
-        // BackendError::Sqlite, whose Display prepends "SQLite error: ".)
-        let e = "SQLite error: Parse error: no such table: turso_cdc";
-        assert!(is_missing_cdc_log(&e), "should recognise the cold-start error");
-    }
 
     /// Drives the **production** `serve_subscriber` against a database
     /// that has never been written to, which is the state of every
@@ -1879,19 +1834,6 @@ mod tests {
         assert!(got_batch, "no CDC batch arrived on the subscriber opened before the first write");
 
         task.abort();
-    }
-
-    #[test]
-    fn missing_cdc_log_ignores_unrelated_failures() {
-        // A different missing table must NOT be swallowed — that would
-        // hide a genuinely broken replica behind an idle-looking stream.
-        assert!(!is_missing_cdc_log(&"SQLite error: Parse error: no such table: posts"));
-        // Nor should generic I/O or corruption errors.
-        assert!(!is_missing_cdc_log(&"SQLite error: database disk image is malformed"));
-        assert!(!is_missing_cdc_log(&"backend error: connection closed"));
-        // A message merely mentioning the table is not a missing-table
-        // error; both halves must be present.
-        assert!(!is_missing_cdc_log(&"SQLite error: turso_cdc is locked"));
     }
 
     // -----------------------------------------------------------------

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -236,6 +236,11 @@ const SNAPSHOT_PREALLOC_CAP: u64 = 8 * 1024 * 1024;
 /// shape staying stable under the exact litewire pin.
 const WATERMARK_TABLE: &str = "__litewire_cdc_watermark";
 
+/// Name of Turso's CDC log table. Created lazily by the engine on the
+/// first captured write, which is why [`is_missing_cdc_log`] has to treat
+/// its absence as "no changes yet" rather than as a failure.
+const CDC_LOG_TABLE: &str = "turso_cdc";
+
 /// How often the primary polls `turso_cdc` for new batches. Turso 0.7.0
 /// has no wakeup signal for CDC inserts, so we poll on a schedule.
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -707,7 +712,16 @@ async fn start_role(role: Role, mgmt: Arc<Turso>, channel: ephpm_cluster::Channe
 /// The cost is one `turso_cdc` poll per subscriber per
 /// [`POLL_INTERVAL`]. With the handful of replicas v1 targets that is
 /// the right trade against losing writes.
-async fn serve_subscriber(mut stream: ChannelStream, mgmt: &Turso) -> anyhow::Result<()> {
+///
+/// Generic over the stream so the loop can be driven directly in tests
+/// over a `tokio::io::duplex` pair. Production always passes a
+/// [`ChannelStream`]; before this was generic the only coverage of this
+/// function was a hand-rolled copy inside the e2e tests, which is how the
+/// cold-start reconnect loop went unnoticed.
+async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
+    mut stream: S,
+    mgmt: &Turso,
+) -> anyhow::Result<()> {
     let from = match read_frame(&mut stream).await.context("read subscribe frame")? {
         Frame::Subscribe { from_change_id } => from_change_id,
         other => anyhow::bail!("expected Subscribe as the first CDC frame, got {other:?}"),
@@ -717,16 +731,47 @@ async fn serve_subscriber(mut stream: ChannelStream, mgmt: &Turso) -> anyhow::Re
 
     let mut tailer = CdcTailer::new(mgmt, from);
     let mut idle_since = tokio::time::Instant::now();
+    let mut logged_missing_log = false;
 
     loop {
-        match tailer.poll_batch().await {
-            Ok(Some(batch)) => {
+        let batch = match tailer.poll_batch().await {
+            Ok(batch) => batch,
+            // `turso_cdc` is created lazily by litewire-turso, on the
+            // first captured write — not when CDC is enabled and not
+            // when a session connects. On a freshly provisioned cluster
+            // that has served no writes yet, the table is simply absent,
+            // and "absent" is indistinguishable from "empty": both mean
+            // zero changes to ship. Treating it as a hard error tore the
+            // subscriber down on every poll, and the replica redialed
+            // every REPLICA_RECONNECT_DELAY, producing an error loop
+            // that only stopped once someone happened to write.
+            Err(e) if is_missing_cdc_log(&e) => {
+                if !logged_missing_log {
+                    logged_missing_log = true;
+                    tracing::info!(
+                        "CDC: turso_cdc does not exist yet — the primary has served no captured \
+                         write since this database was created. Holding the subscriber open; \
+                         batches will flow as soon as the first write lands."
+                    );
+                }
+                None
+            }
+            Err(e) => {
+                // Drop the stream rather than skip past the failure —
+                // the replica reconnects with the same watermark and we
+                // retry from the identical cursor.
+                anyhow::bail!("CDC tail poll error: {e:#}");
+            }
+        };
+
+        match batch {
+            Some(batch) => {
                 let frame =
                     Frame::Batch { rows: batch.rows.iter().map(WireCdcRow::from).collect() };
                 write_frame(&mut stream, &frame).await?;
                 idle_since = tokio::time::Instant::now();
             }
-            Ok(None) => {
+            None => {
                 // Keep the stream warm so a replica can tell "idle
                 // primary" from "dead primary".
                 if idle_since.elapsed() >= HEARTBEAT_INTERVAL {
@@ -735,14 +780,23 @@ async fn serve_subscriber(mut stream: ChannelStream, mgmt: &Turso) -> anyhow::Re
                 }
                 tokio::time::sleep(POLL_INTERVAL).await;
             }
-            Err(e) => {
-                // Drop the stream rather than skip past the failure —
-                // the replica reconnects with the same watermark and we
-                // retry from the identical cursor.
-                anyhow::bail!("CDC tail poll error: {e:#}");
-            }
         }
     }
+}
+
+/// True when `e` is litewire reporting that the CDC log table does not
+/// exist yet.
+///
+/// This matches on the message text because it has to: litewire's
+/// `BackendError` carries only `Sqlite(String)`/`Other(String)`, so there
+/// is no typed variant to match on. The durable fix is a typed
+/// "relation missing" variant upstream in litewire plus a pin bump; until
+/// then, `serve_subscriber`'s cold-start test pins this behaviour so a
+/// message change upstream fails loudly here instead of silently
+/// restoring the reconnect loop.
+fn is_missing_cdc_log<E: std::fmt::Display>(e: &E) -> bool {
+    let msg = e.to_string();
+    msg.contains("no such table") && msg.contains(CDC_LOG_TABLE)
 }
 
 // ---------------------------------------------------------------------------
@@ -1729,6 +1783,115 @@ mod tests {
         AsyncWriteExt::write_all(&mut client, &over.to_be_bytes()).await.unwrap();
         let err = read_frame(&mut server).await.unwrap_err();
         assert!(err.to_string().contains("frame too large"), "unexpected error: {err}");
+    }
+
+    // -----------------------------------------------------------------
+    // Cold-start: `turso_cdc` missing is "no changes yet", not an error.
+    //
+    // These pin the exact message shape litewire produces today. If an
+    // upstream change alters it, `missing_cdc_log_matches_litewire_text`
+    // fails — which is the point: the reconnect loop it prevents is
+    // silent, so the guard must not be allowed to rot quietly.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn missing_cdc_log_matches_litewire_text() {
+        // Verbatim from a real run: the primary polled before any write
+        // had created the log. (litewire wraps turso's parse error in
+        // BackendError::Sqlite, whose Display prepends "SQLite error: ".)
+        let e = "SQLite error: Parse error: no such table: turso_cdc";
+        assert!(is_missing_cdc_log(&e), "should recognise the cold-start error");
+    }
+
+    /// Drives the **production** `serve_subscriber` against a database
+    /// that has never been written to, which is the state of every
+    /// freshly provisioned cluster.
+    ///
+    /// Before the cold-start guard, `poll_batch` returned "no such table:
+    /// turso_cdc", `serve_subscriber` bailed, and the replica redialed
+    /// every `REPLICA_RECONNECT_DELAY` (2s) forever — an error loop that
+    /// only ended when someone happened to write. Here that manifests as
+    /// the task completing almost immediately with an error.
+    ///
+    /// The assertion is two-part on purpose: staying alive is not enough,
+    /// the subscriber must still deliver the first real batch afterwards.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cold_primary_holds_subscriber_open_until_first_write() {
+        let db = tempfile::NamedTempFile::new().unwrap();
+        let path = db.path().to_str().unwrap().to_string();
+
+        // Mgmt factory: what the tailer reads through. Never enables
+        // CDC-on-connect, so nothing here creates turso_cdc.
+        let mgmt = Arc::new(Turso::open(&path).await.unwrap());
+
+        // Precondition: the log genuinely does not exist yet. If a future
+        // litewire creates it eagerly, this assert fires and tells us the
+        // guard is no longer load-bearing.
+        {
+            let conn = mgmt.raw_connection().unwrap();
+            let probe = conn.prepare("SELECT 1 FROM turso_cdc LIMIT 1").await;
+            assert!(probe.is_err(), "turso_cdc should not exist before any captured write");
+        }
+
+        let (mut client, server) = tokio::io::duplex(1 << 20);
+        let mgmt_for_task = Arc::clone(&mgmt);
+        let task = tokio::spawn(async move { serve_subscriber(server, &mgmt_for_task).await });
+
+        // Subscribe from the very beginning, as a cold replica does.
+        write_frame(&mut client, &Frame::Subscribe { from_change_id: 0 }).await.unwrap();
+
+        // The old behaviour ended the task here. Give it well over the
+        // poll interval to prove it does not.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert!(
+            !task.is_finished(),
+            "subscriber died on a cold database — the reconnect loop has regressed"
+        );
+
+        // Now write through a CDC-capturing session; turso_cdc springs
+        // into existence and the batch must reach the still-open stream.
+        // `connect` comes from the Backend trait, scoped here so it does
+        // not leak into the rest of the test module.
+        use litewire::backend::Backend;
+        let wire = Turso::builder(&path).enable_cdc_on_connect(true).build().await.unwrap();
+        let session = wire.connect().await.unwrap();
+        session.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", &[]).await.unwrap();
+        session.execute("INSERT INTO t VALUES (1, 'hello')", &[]).await.unwrap();
+
+        // Read frames until a non-empty Batch arrives (heartbeat Pings
+        // may interleave). The whole point is that this stream — the one
+        // opened before the table existed — is the one that delivers.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        let mut got_batch = false;
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_secs(2), read_frame(&mut client)).await {
+                Ok(Ok(Frame::Batch { rows })) if !rows.is_empty() => {
+                    got_batch = true;
+                    break;
+                }
+                Ok(Err(e)) => panic!("stream broke after the first write: {e}"),
+                // A heartbeat Ping or an empty Batch (Ok(Ok(_))), and a
+                // read that simply timed out (Err(_)): both mean "nothing
+                // yet, keep waiting until the deadline".
+                Ok(Ok(_)) | Err(_) => {}
+            }
+        }
+        assert!(got_batch, "no CDC batch arrived on the subscriber opened before the first write");
+
+        task.abort();
+    }
+
+    #[test]
+    fn missing_cdc_log_ignores_unrelated_failures() {
+        // A different missing table must NOT be swallowed — that would
+        // hide a genuinely broken replica behind an idle-looking stream.
+        assert!(!is_missing_cdc_log(&"SQLite error: Parse error: no such table: posts"));
+        // Nor should generic I/O or corruption errors.
+        assert!(!is_missing_cdc_log(&"SQLite error: database disk image is malformed"));
+        assert!(!is_missing_cdc_log(&"backend error: connection closed"));
+        // A message merely mentioning the table is not a missing-table
+        // error; both halves must be present.
+        assert!(!is_missing_cdc_log(&"SQLite error: turso_cdc is locked"));
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
Pairs with **[litewire#14](https://github.com/ephpm/litewire/pull/14)** (merged). Fixes the CDC cold-start reconnect loop **at the litewire layer**, and bumps ephpm's pin to pick it up.

## The bug

A freshly provisioned Turso CDC cluster that has served no application traffic churns a replication connection every ~2 seconds, indefinitely.

Turso creates `turso_cdc` **lazily**, on the first *captured write* — not when CDC is enabled, and not when a session connects. Until then the table is absent, `poll_batch` failed with `no such table: turso_cdc`, and `serve_subscriber` treated that as fatal and dropped the stream. The replica redialled every `REPLICA_RECONNECT_DELAY` (2s) and the cycle repeated.

Measured on two v0.6.0 containers idling with **zero requests** for 40s:

```
primary:  21 missing-table errors,  21 subscriber attach/disconnect cycles
replica:  23 stream errors,         24 resubscribes
```

A single write ended it permanently — the error count froze at 25 across the next 15s. Nothing is lost; replication converges on the first write. But an operator standing up a cluster sees a continuous error loop and reasonably concludes replication is broken.

## Why the fix lives in litewire, not here

`poll_batch`'s own documentation already says:

> *"Returns `Ok(None)` when no complete batch is pending — callers should poll again after a brief pause."*

A missing log is exactly that: "absent" and "empty" carry identical information — zero changes to ship. Returning `Err` contradicted the function's own contract, so litewire#14 is **conformance, not a feature**. It also matches what `read_watermark` already did for its own table (*"Best-effort: if the table doesn't exist, treat as 0"*), so the two CDC bookkeeping reads now agree.

The earlier version of this PR carried a local guard that matched on litewire's error text. That is the part worth deleting: the predicate had to exist in *every* consumer of `CdcTailer`, and `turso::Error` has no typed "relation missing" variant to match instead. One text match now lives in litewire; ephpm has none.

## What this PR keeps

Both are mechanism-independent, so they stay valid now that the fix moved layers:

- **`serve_subscriber` is generic over the stream.** This is what made the production loop testable at all — before it, the only coverage was a **hand-rolled copy inside the e2e tests**, which is precisely why the bug survived a full security-review pass. A test that re-implements the code under test proves nothing about it.
- **`cold_primary_holds_subscriber_open_until_first_write`** drives the production loop against a cold database and asserts both halves: the subscriber survives, *and* that same stream still delivers the first batch once a write lands.

## The test pins the pin

With the local guard removed, that test:

- **FAILS** on `7a0b59c40ce6` -> `subscriber died on a cold database — the reconnect loop has regressed`
- **PASSES** on `23b8de63effb`

So a future pin that loses the fix fails loudly in CI instead of silently restoring a 2-second reconnect loop in production.

## Note: the bump carries a second fix

`23b8de63` also brings **litewire#13** — *"unbound params executed as NULL — mysql CLI 'commands out of sync'"* — which we were not shipping. That's a behavior change riding along, so the **whole** CDC suite was re-run rather than just the cold-start test.

## Verification (on the new pin)

- 260 lib tests pass
- All four CDC tests pass, including `two_node_cross_endpoint_cdc_replication_via_real_election` under `EPHPM_CLUSTER_INTEG=1`
- `cargo clippy -p ephpm-server --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- Bug originally reproduced on real 2-node containers; litewire#14 additionally has its own cold-start integration test, verified to fail with the tolerance disabled
