### PR TITLE
docs(benchmarking): Turso vs SQLite performance, measured

### DIFF
--- a/site/content/benchmarking/findings.md
+++ b/site/content/benchmarking/findings.md
@@ -113,6 +113,85 @@ measured latency-bound at c=1. Same change, same build — the *test* was
 the variable. If a latency optimization reads as a no-op, check whether
 the test is saturated before concluding it didn't work.
 
+## `SQLITE_BUSY` is the clustered write ceiling
+
+Benchmarking the two clustered SQLite paths against each other for
+v0.6.0 turned up a hard limit in the **shipping** one. Clustered SQLite
+(the sqld sidecar) does not degrade gracefully under concurrent writes —
+it falls off a cliff:
+
+| concurrency | RPS | p50 | p99 | HTTP 500s |
+|---|---|---|---|---|
+| 1 | 458 | 2.12 ms | 2.99 ms | 0 |
+| 2 | 635 | 3.04 ms | 4.63 ms | 0 |
+| **4** | **744** ← peak | 4.99 ms | 12.96 ms | 2 |
+| 8 | 453 | 9.6 ms | 29.8 ms | 8 |
+| 16 | **37** | 20.4 ms | **5.04 s** | 0 (stalls instead) |
+
+Throughput peaks at **c=4**, halves by c=8, and collapses at c=16. In one
+20 s run at c=16, *zero* requests completed — all sixteen connections hung
+to the deadline. The error behind it, captured from a request body under
+load:
+
+```
+SQLSTATE[HY000]: General error: 1205
+  SQLite error: [SQLITE_BUSY] SQLite error: database is locked
+```
+
+That is single-writer serialization: SQLite takes one write lock, sqld
+serializes writers behind it, and past a handful of concurrent writers
+connections either time out into a 500 or wait indefinitely.
+
+**Two things make this worse than the raw numbers suggest.** First, the
+failure is **silent server-side** — the primary logs nothing at all: no
+lock, busy, timeout, or error line. The only evidence is on the client.
+Second, the mode it degrades into is *hanging*, not erroring, so a health
+check that only looks for 5xx sees a healthy node.
+
+**The MVCC claim, verified rather than assumed.** The [Turso engine
+roadmap](/roadmap/turso-engine/) listed a concurrent-writers benchmark as
+a Phase 1 deliverable, with the explicit caveat that MVCC beating
+WAL + `busy_timeout` was "the headline claim to verify, not assume."
+Measured on the same harness, same machine, same fixture: CDC-native
+clustered Turso sustained **694 RPS at c=16 with no `SQLITE_BUSY` and no
+stalls**, against 37 RPS for clustered SQLite. That is the claim
+verified — on this fixture and this quota, with the engine still Beta
+upstream and the remaining gates still open.
+
+**Lesson:** benchmark the *write* path at concurrency before trusting a
+replication design. Lane C looks fine at c=1 (458 RPS, 2 ms p50) and only
+reveals the ceiling above c=4 — and a read-only benchmark would never
+have found it at all, because on a primary a `SELECT` never touches
+replication.
+
+## Lazily-created tables make "absent" look like "broken"
+
+The same v0.6.0 pass found a cold-start defect in CDC replication worth
+generalizing. Turso creates its `turso_cdc` log table **lazily, on the
+first captured write** — not when CDC is enabled, and not when a session
+connects. A freshly provisioned cluster that has served no traffic
+therefore has no log table, and the primary's tailer was treating "table
+does not exist" as a fatal poll error: it dropped the subscriber, the
+replica redialed 2 s later, and the cycle repeated indefinitely.
+
+Two nodes idling with **zero** requests for 40 s produced 21 subscriber
+attach/disconnect cycles on the primary and 24 resubscribes on the
+replica. A single write ended it permanently.
+
+Nothing was lost — replication converges as soon as any write lands — but
+an operator standing up a cluster sees a continuous error loop and
+reasonably concludes replication is broken.
+
+Two lessons. **"Absent" and "empty" are the same answer** when the
+absence is just laziness: zero rows to ship either way. The snapshot path
+in the same module already encoded exactly that (returning watermark 0 on
+a missing table); only the subscriber path disagreed. **And a test that
+re-implements the code under test proves nothing about it** — the 2-node
+e2e tests hand-rolled their own copy of the primary's serving loop, so
+the production function had no direct coverage, which is precisely why
+this survived a full security-review pass. Making it testable found the
+bug the copy could not.
+
 ## Meta-lesson
 
 The wins that mattered were structural and cheap (a socket option, a

--- a/site/content/benchmarking/results.md
+++ b/site/content/benchmarking/results.md
@@ -114,6 +114,98 @@ higher on container overlay / network filesystems where `stat()` is
 pricier. The number is a demonstrated ceiling-ish case, not a promise for
 every app.
 
+## v0.6.0 — the Turso engine, measured against SQLite
+
+v0.6.0 ships the [Turso engine](/roadmap/turso-engine/) as an
+**experimental, opt-in** backend (`[db.sqlite] engine = "turso"`) and an
+experimental CDC-native clustered mode (`cdc_experimental = true`). This
+is the first measurement of both against the shipping SQLite paths.
+
+**Setup:** one machine, one session, podman on WSL2, four lanes, each
+node `--cpus 1`. `oha`, 8 s warmup then 2 × 20 s measured, best rep
+reported with *its own* p50/p99. 100% `2xx` verified per cell. Fixtures
+are the canonical [`db.php`](/benchmarking/methodology/#fixtures) (10
+sequential PDO `SELECT`s) and a single-`INSERT` write fixture. Rate
+limiting and `query_stats` were disabled identically in every lane.
+
+| Lane | Engine | Mode | Replication |
+|---|---|---|---|
+| **A** | `sqlite` | single | — (rusqlite, the shipping default) |
+| **B** | `turso` | single | — |
+| **C** | `sqlite` | cluster | sqld sidecar, WAL frames over gRPC (the shipping clustered path) |
+| **D** | `turso` | cluster | CDC-native over the cluster channel, no sidecar |
+
+### Read path — `db.php`, 10 sequential SELECTs
+
+| Lane | c=1 RPS | p50 | p99 | c=16 RPS | p50 | p99 |
+|---|---|---|---|---|---|---|
+| A sqlite single | 331 | 2.98 ms | 3.48 ms | 566 | 26.95 ms | 42.58 ms |
+| **B turso single** | **388** | **2.54 ms** | **3.06 ms** | **598** | 26.86 ms | **31.09 ms** |
+| C sqlite cluster | 168 | 5.89 ms | 6.61 ms | 250 | 78.35 ms | 91.28 ms |
+| **D turso cluster** | **344** | **2.81 ms** | 4.16 ms | **531** | 30.12 ms | **36.08 ms** |
+
+### Write path — one INSERT per request
+
+| Lane | c=1 RPS | p50 | p99 | c=16 RPS | p50 | p99 |
+|---|---|---|---|---|---|---|
+| A sqlite single | 596 | 1.64 ms | 2.06 ms | 879 | 18.37 ms | **24.34 ms** |
+| B turso single | 618 | 1.57 ms | 2.27 ms | **899** | 17.80 ms | 32.33 ms |
+| C sqlite cluster | 398 | 2.42 ms | 3.42 ms | **0.8 / 52** | — | ~1.5 s |
+| **D turso cluster** | **523** | **1.82 ms** | 3.06 ms | **694** | 22.75 ms | 40.82 ms |
+
+### What the data says
+
+**Single-node reads: Turso wins, including the tail.** +17% RPS at c=1
+with −12% p99, and at c=16 a **−27% p99** (31.09 vs 42.58 ms) for a
+modest +6% RPS. Turso is faster *and* steadier on the read path.
+
+**Single-node writes: throughput parity, worse tail.** +2–4% RPS is
+inside the noise this harness resolves, and Turso's c=16 write p99 is
+**worse** — 32.33 ms vs 24.34 ms, and worse in both reps (39.83 vs
+27.25 ms). This is not a clean sweep, and the write tail is the cell to
+watch as the engine matures.
+
+**Clustered: the gap is large.** CDC-native replication beats the sqld
+sidecar **2.1×** on read throughput (531 vs 250 RPS) with a p99 of
+36 ms against 91 ms, and **~13×** on concurrent writes.
+
+**The cost of replication is the sharpest contrast.** Measured against
+each engine's *own* single-node baseline at c=16 writes, clustered Turso
+retains **77%** of its throughput (694 of 899) while shipping every
+change to a replica. Clustered SQLite retains **6%** (52 of 879).
+
+**Clustered SQLite collapses under concurrent writes.** Lane C peaks at
+c=4 and falls off a cliff: 744 RPS at c=4 → 453 at c=8 → **37 at c=16**,
+with a p99 of 5.04 s, `SQLITE_BUSY` surfacing to PHP as HTTP 500, and
+connections that never get served at all. See
+[Findings](findings/#sqlite_busy-is-the-clustered-write-ceiling). This is
+the *shipping* clustered path, not the experimental one.
+
+**CDC kept pace under sustained load.** The replica finished the write
+lanes holding 57,634 rows after a ~57k-row benchmark. Treat that as
+strong evidence CDC kept up, **not** as proven exact equality — the
+instantaneous primary count was not captured at the same moment. The
+5-row convergence gate run before every clustered lane *was* exact, and
+a lane that failed it was discarded rather than reported.
+
+### Honest bounds on these numbers
+
+- **The engine is Beta upstream and experimental here.** These numbers
+  are evidence for the roadmap's decision gates, not a recommendation to
+  move production data onto Turso. Gates 1, 3, 4 and 5 remain open.
+- **No lab control run was taken for these DB fixtures**, so per
+  [Methodology](methodology/), the *absolute* RPS values do not transfer
+  to other hardware. Every lane ran on the same machine in the same
+  session, so the **A/B deltas are the durable claim**; the absolute
+  ceilings are not.
+- **The write fixture is one INSERT per request**, each its own implicit
+  transaction. That is the shape a PHP app produces and the shape CDC
+  batches on, but it is not a bulk-load or long-transaction benchmark.
+- **`--cpus 1` per node.** Per methodology, a result at one quota need
+  not hold at another.
+- **No MySQL/PostgreSQL baseline** was measured in this pass, so this is
+  a SQLite-lineage comparison only.
+
 ## How to read these
 
 - **Absolute numbers are environment-specific.** The db.php p50 was

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -81,11 +81,22 @@ seam this needs. Deliverable is *data*, not adoption:
 
 - The existing DB latency matrix (point SELECT, insert, connect) —
   Turso engine vs rusqlite vs MySQL baselines.
+  **Partially done (2026-08-01):** SELECT and INSERT measured against
+  rusqlite; **connect latency and the MySQL baselines are not yet
+  measured.**
 - A concurrent-writers benchmark (N wire connections inserting), where
   MVCC should beat WAL + busy_timeout — this is the headline claim to
   verify, not assume.
+  **Done (2026-08-01) — claim verified.** At c=16 single-INSERT writes,
+  CDC-native clustered Turso sustained 694 RPS with no `SQLITE_BUSY`,
+  against 37 RPS for clustered SQLite via sqld, which surfaced
+  `SQLITE_BUSY` as HTTP 500 and hung connections. Numbers and bounds in
+  [Results](/benchmarking/results/#v060--the-turso-engine-measured-against-sqlite);
+  the failure mode in
+  [Findings](/benchmarking/findings/#sqlite_busy-is-the-clustered-write-ceiling).
 - A durability/crash-recovery smoke (kill -9 mid-write, reopen,
   integrity check) — beta engines earn trust here or nowhere.
+  **Not started.**
 
 ### Phase 2 — CDC-native replication (**experimental implementation available; gated on GA for default**)
 
@@ -180,6 +191,12 @@ path is a **single ordered stream** with no schema-sync side channel.
 - 2-node podman/kind e2e test running the full ephpm binary against a
   real MySQL wire client. The in-process integration test proves the
   replication pipeline; the podman lift is largely test-orchestration.
+  **Manually validated 2026-08-01, still not automated.** Two release
+  containers on a podman network completed cold snapshot bootstrap
+  (watermark 24) → CDC subscribe → convergence, driven by PHP `pdo_mysql`
+  through litewire, and the replica held 57,634 rows after a ~57k-row
+  write benchmark. That was a scripted one-off during benchmarking, not
+  a checked-in test — nothing in CI covers it yet.
 - Wire-frontend session capture without the factory-level flag: capture
   is enabled on every node's wire factory (`enable_cdc_on_connect =
   true`, so a node promoted mid-life still captures), but a session
@@ -201,7 +218,14 @@ is a new-minor (or larger) event, never a patch.
 1. Upstream GA: a stable (non-pre) release and upstream's own
    production-readiness statement; multiprocess + vacuum landed.
 2. Phase 1 benchmarks at parity-or-better on our matrix, including
-   tails.
+   tails. **Partially evidenced (2026-08-01), gate still open.** On the
+   `db.php` read path Turso is better on both throughput and tails
+   (+17% RPS / −12% p99 at c=1; −27% p99 at c=16). On single-node writes
+   throughput is at parity but the **c=16 write p99 is worse** than
+   rusqlite (32.3 ms vs 24.3 ms, worse in both reps) — the one cell where
+   Turso loses, and the reason this gate is not closed. `connect`
+   latency and the MySQL baselines are still unmeasured. See
+   [Results](/benchmarking/results/#v060--the-turso-engine-measured-against-sqlite).
 3. File-format round-trip verified by us (SQLite-written DB opened by
    Turso and back, checksummed).
 4. Crash-recovery soak clean.


### PR DESCRIPTION
First measurement of the experimental Turso engine against the shipping SQLite paths — four lanes, `sqlite`/`turso` × single/clustered, one machine, one session, `--cpus 1` per node, 100% `2xx` verified per cell.

## The compelling part

**Single-node reads:** Turso beats rusqlite on throughput *and* tails — +17% RPS with −12% p99 at c=1, and **−27% p99** at c=16.

**Clustered:** CDC-native replication beats the sqld sidecar **2.1×** on read throughput (531 vs 250 RPS, p99 36 ms vs 91 ms) and **~13×** on concurrent writes.

**The sharpest contrast** — cost of replication measured against each engine's *own* single-node baseline at c=16 writes:

| | retains |
|---|---|
| clustered Turso (CDC) | **77%** (694 of 899 RPS) |
| clustered SQLite (sqld) | **6%** (52 of 879 RPS) |

This verifies a claim the roadmap explicitly flagged as unverified: *"MVCC should beat WAL + busy_timeout — this is the headline claim to verify, not assume."* It now has a number.

## The failure mode behind that gap

Clustered SQLite — **the shipping path, not the experimental one** — peaks at c=4 and collapses:

```
c=1: 458   c=2: 635   c=4: 744 (peak)   c=8: 453   c=16: 37 RPS, p99 5.04s
SQLSTATE[HY000]: General error: 1205 SQLite error: [SQLITE_BUSY] database is locked
```

In one 20 s run at c=16, **zero** requests completed — all sixteen connections hung to the deadline. The primary logs nothing: no lock, busy, timeout, or error line. And it degrades into *hanging* rather than erroring, so a health check that only looks for 5xx sees a healthy node.

## What this deliberately does NOT claim

- **Gate 2 is not closed.** Turso's c=16 single-node **write p99 is worse** than rusqlite — 32.3 ms vs 24.3 ms, worse in both reps. That's recorded as the one cell where Turso loses and the stated reason the gate stays open.
- `connect` latency and MySQL/PostgreSQL baselines are unmeasured; the crash-recovery smoke is not started.
- **No lab control run** was taken for these fixtures, so absolute RPS does not transfer to other hardware. All four lanes ran on one machine in one session, so the **A/B deltas are the durable claim** — consistent with [Methodology](https://ephpm.dev/benchmarking/methodology/).
- The 57,634-row replica figure is **evidence** CDC kept pace, not proven exact equality; the 5-row convergence gate before each lane *was* exact.
- The engine is **Beta upstream and experimental here**. These are inputs to the decision gates, not a recommendation to move production data onto Turso.

## Also updated

The roadmap's deferred 2-node podman e2e is now marked **manually validated but explicitly not automated** — a scripted one-off during benchmarking (cold snapshot bootstrap at watermark 24 → CDC subscribe → convergence through real `pdo_mysql`), with nothing in CI covering it.

A second finding generalizes the CDC cold-start defect (#215): lazily-created tables make "absent" look like "broken", and a test that re-implements the code under test proves nothing about it.

## Note on validation

`.github/workflows/docs.yml` triggers on **push to main only**, not on PRs — so the Hugo build is not exercised by this PR. Changes are pure markdown content (no frontmatter or shortcode edits); fences and tables were checked manually, and heading anchors follow Hugo's GitHub-style convention.
