### PR TITLE
perf(db): pin litewire d1c0b341 — session workers, handle reuse, connection cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2589,7 +2589,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "anyhow",
  "futures",
@@ -2607,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "async-trait",
  "futures",
@@ -2668,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2693,7 +2693,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=23b8de63effb#23b8de63effba4fa28a29f1386bc0d17685c75a4"
+source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3574,7 +3574,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3611,7 +3611,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,13 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ 23b8de63 — CDC cold-start tolerance (litewire#14) and unbound
-# params executed as NULL (litewire#13), on top of identifier sanitization in
+# litewire main @ d1c0b341 — SQLite backend performance (litewire#15): a
+# per-session worker thread replaces per-statement spawn_blocking, an opt-in
+# handle-reuse pool (`RusqliteBuilder::handle_reuse`, enabled by ephpm's
+# single-node path — see spawn_single_node_litewire), and a `max_connections`
+# accept-time cap on the wire frontends (wired to [db.sqlite.proxy]
+# max_connections). On top of CDC cold-start tolerance (litewire#14) and unbound
+# params executed as NULL (litewire#13), identifier sanitization in
 # the metadata translator (litewire#12), framework wire-compat (litewire#11) and
 # the Phase 2 CDC tail/apply API (litewire#10).
 #
@@ -103,7 +108,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 # sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
 # DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
 # applies it at every extraction site.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "23b8de63effb", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "d1c0b3413061", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -859,6 +859,21 @@ pub struct SqliteProxyConfig {
     /// Default: disabled.
     #[serde(default)]
     pub tds_listen: Option<String>,
+
+    /// Maximum concurrent wire connections across the `MySQL`, `PostgreSQL`
+    /// and `TDS` frontends combined. `0` means unlimited.
+    ///
+    /// Connections beyond the cap are refused at accept time (`MySQL`
+    /// clients receive error 1040 "Too many connections"; other protocols
+    /// get a clean close) — never queued. Each accepted wire session holds
+    /// one OS thread in litewire's session-worker model, so this cap also
+    /// bounds those threads. The Hrana HTTP frontend is stateless and is
+    /// not counted.
+    ///
+    /// Default: `0` (unlimited), matching `[db.mysql] max_connections` and
+    /// `[server.limits] max_connections`.
+    #[serde(default)]
+    pub max_connections: usize,
 }
 
 impl Default for SqliteProxyConfig {
@@ -868,6 +883,7 @@ impl Default for SqliteProxyConfig {
             hrana_listen: None,
             postgres_listen: None,
             tds_listen: None,
+            max_connections: 0,
         }
     }
 }
@@ -3881,11 +3897,41 @@ path = "app.db"
         assert_eq!(sqlite.path, "app.db");
         assert_eq!(sqlite.proxy.mysql_listen, "127.0.0.1:3306");
         assert!(sqlite.proxy.hrana_listen.is_none());
+        assert_eq!(
+            sqlite.proxy.max_connections, 0,
+            "max_connections must default to 0 (unlimited) when [db.sqlite.proxy] is absent — \
+             a surprise cap would refuse connections on upgrade"
+        );
         assert_eq!(sqlite.sqld.http_listen, "127.0.0.1:8081");
         assert_eq!(sqlite.sqld.grpc_listen, "0.0.0.0:5001");
         assert_eq!(sqlite.replication.role, "auto");
         assert!(sqlite.replication.primary_grpc_url.is_empty());
         assert_eq!(sqlite.engine, "sqlite", "engine must default to the genuine SQLite C engine");
+    }
+
+    #[test]
+    fn test_sqlite_proxy_max_connections_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[db.sqlite]
+path = "app.db"
+
+[db.sqlite.proxy]
+max_connections = 64
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let sqlite = config.db.sqlite.expect("sqlite should be present");
+        assert_eq!(sqlite.proxy.max_connections, 64);
+        // Setting max_connections alone must not disturb sibling defaults
+        // (the section is now present, so serde section-level defaults no
+        // longer apply — each field default must hold on its own).
+        assert_eq!(sqlite.proxy.mysql_listen, "127.0.0.1:3306");
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1526,9 +1526,23 @@ async fn start_single_node_sqlite(
             handles,
         );
     } else {
-        let backend = litewire::backend::Rusqlite::open(db_path)
+        // Handle reuse is opt-in in litewire (it changes cross-session state
+        // semantics for a general-purpose library); ePHPm opts in here
+        // deliberately because PHP's connect-per-request pattern is exactly
+        // the profile it serves — without it every request pays a fresh
+        // sqlite3_open plus WAL-index attach (~280 µs measured) and starts
+        // with a cold prepared-statement cache. Idle cap 16: sessions track
+        // in-flight PHP requests, which the worker pool already bounds far
+        // below this on typical quotas.
+        let backend = litewire::backend::Rusqlite::builder(db_path)
+            .handle_reuse(16)
+            .build()
             .with_context(|| format!("failed to open SQLite database: {db_path}"))?;
-        tracing::info!(path = %db_path, "opened embedded SQLite database (single-node)");
+        tracing::info!(
+            path = %db_path,
+            handle_reuse = true,
+            "opened embedded SQLite database (single-node)"
+        );
         spawn_single_node_litewire(
             sqlite_config,
             tracked_backend::TrackedBackend::new(backend, query_stats.clone()),
@@ -1564,6 +1578,14 @@ fn spawn_single_node_litewire(
     if let Some(ref tds_addr) = sqlite_config.proxy.tds_listen {
         builder = builder.tds(tds_addr);
         tracing::info!(listen = %tds_addr, "SQLite TDS wire protocol enabled");
+    }
+
+    if sqlite_config.proxy.max_connections > 0 {
+        builder = builder.max_connections(sqlite_config.proxy.max_connections);
+        tracing::info!(
+            max_connections = sqlite_config.proxy.max_connections,
+            "SQLite wire frontends: connection cap enabled"
+        );
     }
 
     handles.push(tokio::spawn(async move {
@@ -1692,6 +1714,14 @@ async fn start_clustered_sqlite(
     if let Some(ref tds_addr) = sqlite_config.proxy.tds_listen {
         builder = builder.tds(tds_addr);
         tracing::info!(listen = %tds_addr, "SQLite TDS wire protocol enabled (clustered)");
+    }
+
+    if sqlite_config.proxy.max_connections > 0 {
+        builder = builder.max_connections(sqlite_config.proxy.max_connections);
+        tracing::info!(
+            max_connections = sqlite_config.proxy.max_connections,
+            "SQLite wire frontends: connection cap enabled (clustered)"
+        );
     }
 
     // Spawn litewire serve task. sqld is kept alive via the Arc.

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -1668,6 +1668,13 @@ fn spawn_litewire_serve<B: litewire::backend::Backend>(
         builder = builder.tds(tds_addr);
         tracing::info!(listen = %tds_addr, "SQLite TDS wire protocol enabled (CDC-replicated Turso)");
     }
+    if sqlite_config.proxy.max_connections > 0 {
+        builder = builder.max_connections(sqlite_config.proxy.max_connections);
+        tracing::info!(
+            max_connections = sqlite_config.proxy.max_connections,
+            "SQLite wire frontends: connection cap enabled (CDC-replicated Turso)"
+        );
+    }
     handles.push(tokio::spawn(async move {
         match builder.serve().await {
             Ok(()) => tracing::info!("litewire stopped (CDC-replicated Turso)"),

--- a/crates/ephpm-server/tests/turso_cdc_cluster_integration.rs
+++ b/crates/ephpm-server/tests/turso_cdc_cluster_integration.rs
@@ -166,7 +166,13 @@ async fn bring_up_node(node_id: &str, seed: Option<&str>) -> Node {
     let cluster = Arc::new(start_gossip(&cluster_cfg).await.expect("gossip start"));
 
     let channel = maybe_start_cluster_channel(
-        &ClusterChannelConfig::default(),
+        // Bind an OS-assigned port. The default (gossip port + 2) is a
+        // derived TCP port that pick_free_port() never validated -- it
+        // checks a UDP port, and even that with a close-then-rebind race.
+        // Under parallel nextest workers that collided in CI
+        // ("Address already in use"). Port 0 cannot collide, and
+        // ChannelHandle::listen_addr() reports the post-bind address.
+        &ClusterChannelConfig { listen: Some("127.0.0.1:0".to_string()), secret: None },
         &cluster_cfg.secret,
         &cluster,
         ChannelFeatureFlags { cdc: true },

--- a/crates/ephpm-server/tests/turso_cdc_e2e.rs
+++ b/crates/ephpm-server/tests/turso_cdc_e2e.rs
@@ -134,7 +134,13 @@ async fn start_channel(node_id: &str) -> (Arc<ephpm_cluster::ClusterHandle>, Cha
     };
     let cluster = Arc::new(start_gossip(&cluster_cfg).await.expect("gossip start"));
     let channel = maybe_start_cluster_channel(
-        &ClusterChannelConfig::default(),
+        // Bind an OS-assigned port. The default (gossip port + 2) is a
+        // derived TCP port that pick_free_port() never validated -- it
+        // checks a UDP port, and even that with a close-then-rebind race.
+        // Under parallel nextest workers that collided in CI
+        // ("Address already in use"). Port 0 cannot collide, and
+        // ChannelHandle::listen_addr() reports the post-bind address.
+        &ClusterChannelConfig { listen: Some("127.0.0.1:0".to_string()), secret: None },
         &cluster_cfg.secret,
         &cluster,
         ChannelFeatureFlags { cdc: true },

--- a/crates/ephpm-server/tests/turso_cdc_snapshot_bootstrap.rs
+++ b/crates/ephpm-server/tests/turso_cdc_snapshot_bootstrap.rs
@@ -135,7 +135,13 @@ async fn start_channel(node_id: &str) -> (Arc<ephpm_cluster::ClusterHandle>, Cha
     };
     let cluster = Arc::new(start_gossip(&cluster_cfg).await.expect("gossip start"));
     let channel = maybe_start_cluster_channel(
-        &ClusterChannelConfig::default(),
+        // Bind an OS-assigned port. The default (gossip port + 2) is a
+        // derived TCP port that pick_free_port() never validated -- it
+        // checks a UDP port, and even that with a close-then-rebind race.
+        // Under parallel nextest workers that collided in CI
+        // ("Address already in use"). Port 0 cannot collide, and
+        // ChannelHandle::listen_addr() reports the post-bind address.
+        &ClusterChannelConfig { listen: Some("127.0.0.1:0".to_string()), secret: None },
         &cluster_cfg.secret,
         &cluster,
         ChannelFeatureFlags { cdc: true },

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -236,6 +236,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `hrana_listen` | string | (none) | Hrana HTTP API listener. |
 | `postgres_listen` | string | (none) | PostgreSQL wire protocol listener. |
 | `tds_listen` | string | (none) | TDS (SQL Server) wire protocol listener. |
+| `max_connections` | integer | `0` (unlimited) | Cap on concurrent wire connections across the MySQL/PostgreSQL/TDS frontends combined. Beyond the cap, connections are refused at accept time (MySQL clients get error 1040 "Too many connections"), never queued. Each wire session holds one OS thread, so this also bounds those threads. Hrana (stateless HTTP) is not counted. Same semantics as `[db.mysql] max_connections`. |
 
 > **These listeners are unauthenticated too.** litewire's MySQL, Hrana, PostgreSQL, and TDS frontends accept any client — the PostgreSQL frontend is explicitly wired to a no-op startup handler, and the others never ask for credentials. The design assumes only PHP inside this process reaches them. As with `[db.mysql]`, each of these four keys is checked at startup and a non-loopback IP literal logs a warning naming the risk; startup is not blocked. Bind loopback unless the port is firewalled from untrusted networks.
 


### PR DESCRIPTION
Brings **[litewire#15](https://github.com/ephpm/litewire/pull/15)** (merged) into v0.6.0 and wires its two knobs. Companion to #215's pin pattern; targeted at the tag.

## What the pin carries

litewire#15 replaced per-statement `spawn_blocking` with a **per-session worker thread** (unconditional), added an **opt-in handle-reuse pool**, and a **`max_connections` accept-time cap** on the wire frontends. 673 litewire tests ×2 runs, negative controls, CI green — details in that PR.

## What this PR wires

**1. Handle reuse ON for single-node SQLite.** litewire keeps it opt-in; ePHPm opts in deliberately — PHP's connect-per-request pattern is exactly the profile it serves. Without it, every PHP request pays a fresh `sqlite3_open` + WAL-index attach (~280 µs measured) and a cold statement cache. Idle cap 16, with the rationale in a comment at the construction site.

**2. `[db.sqlite.proxy] max_connections`** — new knob, default `0` (unlimited, matching `[db.mysql]` and `[server.limits]`). This closes the last gap from the listener-parity sweep: every listener ePHPm owns already had a cap; litewire's embedded frontends were the only accept loops without one, because they live inside the library. With the session-worker model each wire connection holds an OS thread, so the cap bounds threads too. Beyond the cap: refused at accept (MySQL clients get a real `ER_CON_COUNT_ERROR` 1040), never queued. Wired at **all three** LiteWire construction sites: single-node, clustered-sqld, and CDC-replicated Turso.

Knob follows the no-silent-no-op checklist end to end: doc comment with semantics/default/zero-meaning, enforcement in the same PR, reference-docs row, and tests covering both section-absent and explicit-value paths.

## Measured expectation (to be verified end-to-end)

litewire's backend-layer A/B for the config ePHPm now runs: connect+10-SELECT cycle **p50 −25–32%** (1 session), **−65%** (16 sessions), **throughput +185%**, **p99 −63–69%**. Working hypothesis (Luther's): this closes most of the 440 µs single-node gap between the SQLite and Turso engines in the published v0.6.0 benchmark. After merge, the release image gets rebuilt and the full 4-lane matrix re-run — the docs get whatever numbers actually come out.

## Verification on the new pin

- 89 ephpm-config tests (`--test-threads=1`), including the two new knob tests
- 260 ephpm-server lib tests
- All four CDC suites, including `two_node_cross_endpoint_cdc_replication_via_real_election` under `EPHPM_CLUSTER_INTEG=1`
- `cargo clippy --workspace --all-targets -- -D warnings` clean; nightly rustfmt check clean

## Known honest caveats

- litewire#15's reuse-**off** path (not what ePHPm runs) is a measured wash — p99/scaling wins, no median win. Documented in that PR.
- The +185% etc. are backend-layer numbers measured in a container; the end-to-end `db.php` effect will be smaller (HTTP+SAPI dominates the request) and gets measured before the tag.
