### PR TITLE
fix(db): pooled proxy no longer forwards COM_QUIT — intercept, validate on checkout, discard broken

### DIFF
--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -15,10 +15,13 @@
 //!    d. Starts bidirectional byte forwarding between the client and a
 //!    checked-out backend connection.
 //!
-//! 3. When the client closes its connection, the proxy sends
-//!    `COM_RESET_CONNECTION` to the backend (resets session variables,
-//!    temporary tables, prepared statements, etc.) and returns the
-//!    connection to the pool.
+//! 3. When the client ends its session — `COM_QUIT` or a plain socket close —
+//!    the proxy closes only the client-facing socket. `COM_QUIT` is
+//!    **intercepted, never forwarded**: the backend is shared across sessions
+//!    and closing it would poison the pool. Depending on `reset_strategy` the
+//!    proxy then sends `COM_RESET_CONNECTION` to the backend (resetting
+//!    session variables, temporary tables, prepared statements, etc.) and
+//!    returns the still-open connection to the pool.
 //!
 //! ## Auth plugin support
 //!
@@ -303,31 +306,29 @@ impl MySqlProxy {
             .await;
         }
 
-        // Single-backend bidirectional path. Use a dirty-sniffing copier for
-        // the client→backend direction so `Smart` can skip the reset for
-        // read-only sessions; raw byte copy in the other direction.
+        // Single-backend path. Every strategy goes through the packet-aware
+        // relay: intercepting `COM_QUIT` requires seeing packet boundaries, so
+        // there is no correct byte-copy variant for a *pooled* backend. The
+        // `dirty` bit it produces is only consulted by `Smart`.
         let mut checkout = self.pool.acquire().await?;
         let backend = checkout.take_stream();
 
-        let result = match self.reset_strategy {
-            ResetStrategy::Smart => proxy_bidirectional_sniff(client, backend).await,
-            _ => proxy_bidirectional(client, backend).await.map(|b| (b, true)),
-        };
+        let outcome = proxy_bidirectional_sniff(client, backend).await;
 
-        match result {
-            Ok((backend, dirty)) => match self.reset_strategy {
+        match outcome.backend {
+            Some(backend) => match self.reset_strategy {
                 ResetStrategy::Never => checkout.return_to_pool(backend),
                 ResetStrategy::Always => checkout.return_with_reset(backend).await,
                 ResetStrategy::Smart => {
-                    if dirty {
+                    if outcome.dirty {
                         checkout.return_with_reset(backend).await;
                     } else {
                         checkout.return_to_pool(backend);
                     }
                 }
             },
-            Err(e) => {
-                debug!("proxy session error, discarding backend connection: {e}");
+            None => {
+                debug!("backend connection failed during session; discarding, not recycling");
                 checkout.retire();
             }
         }
@@ -950,92 +951,114 @@ async fn ping_connection(mut stream: TcpStream) -> Result<(TcpStream, bool), DbE
 
 // ── Bidirectional proxy ───────────────────────────────────────────────────────
 
-/// Splice `client` ↔ `backend` until one side closes.
+/// Which side of the proxy ended a session.
 ///
-/// Returns the backend stream on clean close so it can be reset and recycled.
-/// Returns `Err` if an I/O error occurs (backend is discarded).
-async fn proxy_bidirectional(
-    mut client: TcpStream,
-    mut backend: TcpStream,
-) -> Result<TcpStream, DbError> {
-    // Scope the split halves so the borrows end before we move `backend`.
-    let result = {
-        let (mut cr, mut cw) = client.split();
-        let (mut br, mut bw) = backend.split();
-
-        let client_to_backend = tokio::io::copy(&mut cr, &mut bw);
-        let backend_to_client = tokio::io::copy(&mut br, &mut cw);
-
-        // Run both directions concurrently. When one direction closes, shut down
-        // the other. `copy` returns 0 bytes on clean EOF.
-        tokio::select! {
-            r = client_to_backend => r,
-            r = backend_to_client => r,
-        }
-    };
-
-    match result {
-        Ok(_) => Ok(backend),
-        Err(e)
-            if e.kind() == std::io::ErrorKind::ConnectionReset
-                || e.kind() == std::io::ErrorKind::BrokenPipe =>
-        {
-            Ok(backend)
-        }
-        Err(e) => Err(DbError::Io(e)),
-    }
+/// The distinction decides whether the pooled backend may be recycled. Both
+/// sides report the same `io::ErrorKind` values (`BrokenPipe`,
+/// `ConnectionReset`), so the kind alone cannot be used: a client that
+/// disappears mid-response and a backend that has closed are
+/// indistinguishable by error kind, and treating the latter as a clean end
+/// re-parks a dead socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionEnd {
+    /// The client finished — orderly `COM_QUIT`, EOF, or a failure on the
+    /// client socket. The backend was never told the session ended, so it is
+    /// still usable.
+    Client,
+    /// The backend connection failed or closed. It must be discarded.
+    Backend,
 }
 
-/// Packet-aware bidirectional proxy that records whether the client ever
-/// issued anything other than a read-only command. Returns
-/// `(backend, dirty)` where `dirty == true` means the session must be reset
-/// before the backend returns to the pool (`SET`, `INSERT`, `BEGIN`,
-/// prepared statements, `USE`, etc.). A pure-`SELECT` session reports
-/// `dirty == false`, allowing the Smart strategy to skip the
-/// `COM_RESET_CONNECTION` round-trip.
+/// Result of proxying one client session over a pooled backend.
+struct SessionOutcome {
+    /// The backend stream, or `None` when the backend must be discarded.
+    ///
+    /// Deliberately not a `Result`: the previous signature returned
+    /// `Ok((backend, dirty))` for `BrokenPipe`/`ConnectionReset`, which is how
+    /// a dead backend got recycled as if the session had ended cleanly. Making
+    /// "backend still usable" the payload rather than the error discriminant
+    /// removes that failure mode by construction.
+    backend: Option<TcpStream>,
+    /// Whether the client issued anything that requires a session reset.
+    dirty: bool,
+}
+
+/// Packet-aware bidirectional proxy for one client session.
 ///
-/// The client→backend stream is parsed packet-by-packet so we can inspect
-/// the command byte and (for `COM_QUERY`) the SQL keyword. The
-/// backend→client stream is byte-copied with `tokio::io::copy` since we
-/// don't need to understand it — we just flush it back to the client.
+/// Records whether the client ever issued anything other than a read-only
+/// command: `dirty == true` means the session must be reset before the
+/// backend returns to the pool (`SET`, `INSERT`, `BEGIN`, prepared
+/// statements, `USE`, etc.). A pure-`SELECT` session reports `dirty ==
+/// false`, allowing the Smart strategy to skip the `COM_RESET_CONNECTION`
+/// round trip.
+///
+/// ## `COM_QUIT` is intercepted, never forwarded
+///
+/// PHP has no idea the proxy pools anything. When a request ends, PDO
+/// destroys its handle and mysqlnd sends `COM_QUIT` — a request to *close the
+/// connection*, which is correct for the client-facing socket and catastrophic
+/// for the pooled one. Relaying it makes the backend close, and every
+/// subsequent checkout of that slot draws a corpse. `COM_QUIT` therefore
+/// terminates the relay loop here and is dropped on the floor; the backend
+/// never learns the client went away and is recycled alive.
+///
+/// The same reasoning applies to a client that simply closes its socket: EOF
+/// on the client side is a client-side event and must not be relayed as a
+/// backend shutdown.
+///
+/// ## Framing
+///
+/// Both directions are framed rather than byte-copied. The client→backend
+/// direction has to be, in order to see command bytes at all; the
+/// backend→client direction is hand-copied so that an error can be
+/// attributed to the side that produced it (see [`SessionEnd`]).
+///
+/// ## Known limitation
+///
+/// A client that pipelines — writes `COM_QUIT` without having read the
+/// response to its previous command — can leave unread bytes on the backend
+/// socket, which would desynchronise the next session on that connection.
+/// `mysqlnd` is strictly synchronous so this does not arise in practice, and
+/// the checkout-time validation in [`crate::pool::Pool::acquire`] rejects a
+/// connection left in that state rather than handing it out.
 async fn proxy_bidirectional_sniff(
     mut client: TcpStream,
     mut backend: TcpStream,
-) -> Result<(TcpStream, bool), DbError> {
+) -> SessionOutcome {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     let dirty = Arc::new(AtomicBool::new(false));
     let dirty_w = Arc::clone(&dirty);
 
-    let result = {
+    let end = {
         let (mut cr, mut cw) = client.split();
         let (mut br, mut bw) = backend.split();
 
         let client_to_backend = async {
             loop {
                 let mut header = [0u8; 4];
-                match cr.read_exact(&mut header).await {
-                    Ok(_) => {}
-                    Err(e)
-                        if matches!(
-                            e.kind(),
-                            std::io::ErrorKind::UnexpectedEof
-                                | std::io::ErrorKind::ConnectionReset
-                                | std::io::ErrorKind::BrokenPipe
-                        ) =>
-                    {
-                        return Ok::<(), std::io::Error>(());
-                    }
-                    Err(e) => return Err(e),
+                // Any read failure here is a client-side event: EOF, reset, or
+                // a half-written packet. None of them say anything about the
+                // backend.
+                if cr.read_exact(&mut header).await.is_err() {
+                    return SessionEnd::Client;
                 }
                 let len = u32::from_le_bytes([header[0], header[1], header[2], 0]) as usize;
                 let mut payload = vec![0u8; len];
-                cr.read_exact(&mut payload).await?;
+                if cr.read_exact(&mut payload).await.is_err() {
+                    return SessionEnd::Client;
+                }
 
                 if let Some(&cmd) = payload.first() {
+                    // Session termination: swallow it. Forwarding this is the
+                    // pool-poisoning bug — see the function docs.
+                    if cmd == COM_QUIT {
+                        debug!("client sent COM_QUIT; not forwarding to pooled backend");
+                        return SessionEnd::Client;
+                    }
                     let writeish = match cmd {
-                        COM_QUIT | 0x0E /* COM_PING */ => false,
+                        0x0E /* COM_PING */ => false,
                         COM_QUERY => {
                             let sql = std::str::from_utf8(&payload[1..]).unwrap_or("");
                             !matches!(classify_mysql_query(sql), QueryKind::Read)
@@ -1047,30 +1070,45 @@ async fn proxy_bidirectional_sniff(
                     }
                 }
 
-                bw.write_all(&header).await?;
-                bw.write_all(&payload).await?;
+                if bw.write_all(&header).await.is_err() || bw.write_all(&payload).await.is_err() {
+                    return SessionEnd::Backend;
+                }
             }
         };
 
-        let backend_to_client = tokio::io::copy(&mut br, &mut cw);
+        let backend_to_client = async {
+            let mut buf = vec![0u8; 16 * 1024];
+            loop {
+                match br.read(&mut buf).await {
+                    Ok(n) if n > 0 => {
+                        if cw.write_all(&buf[..n]).await.is_err() {
+                            return SessionEnd::Client;
+                        }
+                    }
+                    // `Ok(0)` is backend EOF; `Err` is a backend read failure.
+                    // Once COM_QUIT is no longer forwarded, EOF means the
+                    // server really did drop the connection — either way the
+                    // stream is not reusable.
+                    Ok(_) | Err(_) => return SessionEnd::Backend,
+                }
+            }
+        };
 
+        // Both branches are cancel-safe at the point the other completes:
+        // `read` consumes nothing when dropped, and a cancelled write targets
+        // the side that has already gone away.
         tokio::select! {
-            r = client_to_backend => r.map(|()| 0u64),
-            r = backend_to_client => r,
+            e = client_to_backend => e,
+            e = backend_to_client => e,
         }
     };
 
-    match result {
-        Ok(_) => Ok((backend, dirty.load(std::sync::atomic::Ordering::Relaxed))),
-        Err(e)
-            if matches!(
-                e.kind(),
-                std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::BrokenPipe
-            ) =>
-        {
-            Ok((backend, dirty.load(std::sync::atomic::Ordering::Relaxed)))
-        }
-        Err(e) => Err(DbError::Io(e)),
+    SessionOutcome {
+        backend: match end {
+            SessionEnd::Client => Some(backend),
+            SessionEnd::Backend => None,
+        },
+        dirty: dirty.load(std::sync::atomic::Ordering::Relaxed),
     }
 }
 
@@ -1491,6 +1529,32 @@ fn track_dirty(state: &mut ClientState, payload: &[u8], query_kind: QueryKind) {
     }
 }
 
+/// Forward one client command to `backend` and relay the response.
+///
+/// Returns the prepared-statement id when `payload` was a `COM_STMT_PREPARE`
+/// the backend accepted, `None` otherwise.
+///
+/// # Errors
+///
+/// Any error leaves the backend connection in an unknown protocol state — a
+/// partially written command, a partially drained result set. The caller must
+/// discard the connection; returning it to the pool would desynchronise
+/// whichever session picks it up next.
+async fn relay_one_command(
+    backend: &mut TcpStream,
+    client: &mut TcpStream,
+    seq: u8,
+    payload: &[u8],
+) -> Result<Option<u32>, DbError> {
+    write_packet(backend, seq, payload).await?;
+    match payload[0] {
+        COM_STMT_PREPARE => forward_prepare_response(backend, client).await,
+        // COM_STMT_CLOSE is fire-and-forget — the server sends no response.
+        COM_STMT_CLOSE => Ok(None),
+        _ => forward_mysql_response(backend, client).await.map(|()| None),
+    }
+}
+
 /// Proxy loop with per-query routing and dirty-bit tracking.
 ///
 /// Handles `COM_QUERY` and the full prepared statement protocol
@@ -1521,6 +1585,10 @@ async fn proxy_routing_loop(
 
         let cmd = payload[0];
         if cmd == COM_QUIT {
+            // Session termination belongs to the client-facing socket only.
+            // The pooled backends are shared across sessions and must never
+            // see it — see `proxy_bidirectional_sniff` for the full rationale.
+            debug!("client sent COM_QUIT; ending session without touching pooled backends");
             break;
         }
 
@@ -1539,8 +1607,19 @@ async fn proxy_routing_loop(
         let mut checkout = target_pool.acquire().await?;
         let mut backend = checkout.take_stream();
 
+        // A relay failure means this backend is no longer in a known protocol
+        // state. Discard it explicitly — never let it fall through to a
+        // `return_to_pool` below.
+        let prepared = match relay_one_command(&mut backend, &mut client, seq, &payload).await {
+            Ok(prepared) => prepared,
+            Err(e) => {
+                debug!("backend relay failed, discarding connection: {e}");
+                checkout.retire();
+                return Err(e);
+            }
+        };
+
         if cmd == COM_STMT_PREPARE {
-            write_packet(&mut backend, seq, &payload).await?;
             let pool_target = if std::ptr::eq(target_pool, pool) {
                 PoolTarget::Primary
             } else {
@@ -1549,20 +1628,16 @@ async fn proxy_routing_loop(
                     replica_pools.iter().position(|r| std::ptr::eq(target_pool, r)).unwrap_or(0);
                 PoolTarget::Replica(idx)
             };
-            if let Some(stmt_id) = forward_prepare_response(&mut backend, &mut client).await? {
+            if let Some(stmt_id) = prepared {
                 stmt_pool_map.insert(stmt_id, pool_target);
                 debug!(stmt_id, ?pool_target, "prepared statement registered");
             }
         } else if cmd == COM_STMT_CLOSE {
-            write_packet(&mut backend, seq, &payload).await?;
             if let Some(stmt_id) = parse_stmt_id(&payload) {
                 if let Some(removed) = stmt_pool_map.remove(&stmt_id) {
                     debug!(stmt_id, ?removed, "prepared statement closed");
                 }
             }
-        } else {
-            write_packet(&mut backend, seq, &payload).await?;
-            forward_mysql_response(&mut backend, &mut client).await?;
         }
 
         // Return backend to pool.

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -1013,14 +1013,23 @@ struct SessionOutcome {
 /// backend→client direction is hand-copied so that an error can be
 /// attributed to the side that produced it (see [`SessionEnd`]).
 ///
-/// ## Known limitation
+/// ## Session hygiene
 ///
-/// A client that pipelines — writes `COM_QUIT` without having read the
-/// response to its previous command — can leave unread bytes on the backend
-/// socket, which would desynchronise the next session on that connection.
-/// `mysqlnd` is strictly synchronous so this does not arise in practice, and
-/// the checkout-time validation in [`crate::pool::Pool::acquire`] rejects a
-/// connection left in that state rather than handing it out.
+/// A backend is recycled only when the client ended the session *and*
+/// [`crate::pool::has_unread_bytes`] finds nothing left on the backend socket. The second
+/// condition covers a client that ends its session mid-conversation — one that
+/// writes `COM_QUIT`, or just closes, without having read the response to its
+/// previous command. That leaves a partly drained response behind, and
+/// recycling it would desynchronise whichever session picks the connection up
+/// next.
+///
+/// `mysqlnd` is strictly synchronous, so this guards against clients ePHPm
+/// does not ship rather than a case seen in practice. It is deliberately not
+/// load-bearing: the check is best-effort (see [`crate::pool::has_unread_bytes`]), and
+/// checkout-time validation in [`crate::pool::Pool::acquire`] cannot be relied
+/// on to catch a desynchronised connection either — the ping is skipped inside
+/// the validation window, and a leftover `OK` packet is indistinguishable from
+/// a `COM_PING` reply.
 async fn proxy_bidirectional_sniff(
     mut client: TcpStream,
     mut backend: TcpStream,
@@ -1103,11 +1112,19 @@ async fn proxy_bidirectional_sniff(
         }
     };
 
+    let reusable = match end {
+        // The client left a partly drained response behind — alive, but not
+        // safe to hand to the next session.
+        SessionEnd::Client if crate::pool::has_unread_bytes(&backend) => {
+            debug!("client ended mid-response, leaving unread backend bytes; discarding");
+            false
+        }
+        SessionEnd::Client => true,
+        SessionEnd::Backend => false,
+    };
+
     SessionOutcome {
-        backend: match end {
-            SessionEnd::Client => Some(backend),
-            SessionEnd::Backend => None,
-        },
+        backend: reusable.then_some(backend),
         dirty: dirty.load(std::sync::atomic::Ordering::Relaxed),
     }
 }

--- a/crates/ephpm-db/src/pool.rs
+++ b/crates/ephpm-db/src/pool.rs
@@ -22,6 +22,25 @@ use crate::error::DbError;
 /// A boxed, send future. Used as the return type for closures stored in the pool.
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 
+/// Ping an idle connection at checkout when it has been parked at least this
+/// long.
+///
+/// A pooled backend can die while it sits in the idle queue — the server
+/// restarts, an idle timeout fires, a firewall reaps the flow — and nothing
+/// in the pool notices until the next caller writes to it and gets
+/// `BrokenPipe`. The background health check only samples every
+/// `health_check_interval` (30s by default), which leaves a window in which
+/// every checkout hands out a corpse.
+///
+/// Validating on *every* checkout would be correct but costs a full backend
+/// round trip (`COM_PING` / `SELECT 1`, roughly 50–100µs on loopback) on the
+/// hot path, which is the same order as the query it precedes. A connection
+/// handed back and immediately re-acquired cannot have died in the interim
+/// for any reason the ping would detect, so the check is skipped below this
+/// threshold: under sustained load the pool never pays for it, and a quiet
+/// site — the exact shape that exposes dead idle connections — always does.
+const VALIDATE_AFTER_IDLE: Duration = Duration::from_millis(500);
+
 /// Configuration parameters for the pool.
 #[derive(Clone, Debug)]
 pub struct PoolConfig {
@@ -128,10 +147,26 @@ impl Pool {
         })
     }
 
+    /// Number of connections currently parked in the idle queue.
+    ///
+    /// Does not count connections that are checked out. Intended for tests and
+    /// diagnostics — the value is a snapshot and may be stale the moment it is
+    /// returned.
+    #[must_use]
+    pub fn idle_len(&self) -> usize {
+        self.state.idle.lock().len()
+    }
+
     /// Acquire a connection from the pool, waiting up to `pool_timeout`.
     ///
     /// Tries the idle queue first; creates a new connection if the queue is empty
     /// (within `max_connections` limit).
+    ///
+    /// Idle connections that have been parked longer than
+    /// [`VALIDATE_AFTER_IDLE`] are pinged before being handed out; one that
+    /// fails is discarded and the next candidate (or a fresh dial) is used
+    /// instead. A caller therefore never receives a connection the pool has
+    /// already observed to be dead.
     ///
     /// # Errors
     ///
@@ -171,8 +206,29 @@ impl Pool {
             if age_ok && idle_ok {
                 // Discard the parked permit (we now hold `permit` from above).
                 drop(slot.permit);
+
+                // Validate before handing out. A connection that has been
+                // parked for a while may have been closed by the server with
+                // no local indication; writing to it is how the caller finds
+                // out, and by then the request has already failed.
+                let stream = if slot.last_used.elapsed() >= VALIDATE_AFTER_IDLE {
+                    match (self.ping)(slot.stream).await {
+                        Ok((stream, true)) => stream,
+                        Ok((_, false)) => {
+                            debug!("idle connection failed checkout validation, discarding");
+                            continue;
+                        }
+                        Err(e) => {
+                            debug!("idle connection validation I/O error, discarding: {e}");
+                            continue;
+                        }
+                    }
+                } else {
+                    slot.stream
+                };
+
                 return Ok(Checkout {
-                    stream: Some(slot.stream),
+                    stream: Some(stream),
                     permit: Some(permit),
                     created_at: slot.created_at,
                     pool: self.clone(),
@@ -197,6 +253,13 @@ impl Pool {
     ///
     /// The caller must run the protocol-level reset (`COM_RESET_CONNECTION` /
     /// `DISCARD ALL`) before calling this. Pass the post-reset stream.
+    ///
+    /// The caller must also have established that the connection is still
+    /// live. Re-parking a connection the backend has already closed poisons
+    /// the idle queue: the next caller draws the corpse, fails, and — if its
+    /// failure path also recycles — puts it straight back. See
+    /// [`crate::mysql`] for the session-termination interception that keeps
+    /// this invariant on the proxy paths.
     pub(crate) fn recycle(
         &self,
         stream: TcpStream,

--- a/crates/ephpm-db/src/pool.rs
+++ b/crates/ephpm-db/src/pool.rs
@@ -41,6 +41,36 @@ pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 /// site — the exact shape that exposes dead idle connections — always does.
 const VALIDATE_AFTER_IDLE: Duration = Duration::from_millis(500);
 
+/// Whether a pooled backend still has unread bytes waiting on it.
+///
+/// A client that ends its session without draining the response to its last
+/// command leaves the backend mid-conversation. The connection is perfectly
+/// alive, so nothing on the liveness path notices, but the leftover bytes
+/// would be read as the *next* session's response. Neither a `MySQL` server
+/// nor a pooled `PostgreSQL` connection sends unsolicited traffic in normal
+/// operation, so anything readable at end-of-session is leftover data and the
+/// connection must be discarded rather than recycled.
+///
+/// Non-blocking: a single `try_read`. It consumes a byte when data is present,
+/// which is harmless precisely because the caller discards the connection in
+/// that case.
+///
+/// Best-effort, and callers must treat it as such: `try_read` consults tokio's
+/// readiness cache and can report `WouldBlock` for data that has arrived but
+/// whose readiness event was lost when the reader half was cancelled. It may
+/// therefore miss a desynchronised connection; it will never falsely condemn a
+/// clean one.
+pub(crate) fn has_unread_bytes(stream: &TcpStream) -> bool {
+    let mut probe = [0u8; 1];
+    match stream.try_read(&mut probe) {
+        // Nothing waiting — the only case in which the connection is reusable.
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => false,
+        // `Ok(n > 0)` is leftover data, `Ok(0)` is EOF, and any other error
+        // means the socket is unhealthy. None of them are reusable.
+        Ok(_) | Err(_) => true,
+    }
+}
+
 /// Configuration parameters for the pool.
 #[derive(Clone, Debug)]
 pub struct PoolConfig {
@@ -436,5 +466,49 @@ impl Drop for Checkout {
     fn drop(&mut self) {
         // If the stream was not taken, it is dropped here (connection closed).
         // The permit is also dropped, freeing the pool slot.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    /// Connect a client/server socket pair over loopback.
+    async fn socket_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let client = TcpStream::connect(addr).await.expect("connect");
+        let (server, _) = listener.accept().await.expect("accept");
+        (client, server)
+    }
+
+    /// A connection whose peer has sent nothing is clean and must be reusable.
+    /// A false positive here would discard every healthy pooled connection.
+    #[tokio::test]
+    async fn quiet_connection_has_no_unread_bytes() {
+        let (client, _server) = socket_pair().await;
+        assert!(!has_unread_bytes(&client), "an idle connection must not be condemned");
+    }
+
+    /// Leftover response data must condemn the connection — that is the whole
+    /// point: those bytes would be read as the next session's reply.
+    #[tokio::test]
+    async fn pending_data_is_detected() {
+        let (client, mut server) = socket_pair().await;
+        server.write_all(b"leftover").await.expect("write");
+        client.readable().await.expect("readable");
+        assert!(has_unread_bytes(&client), "buffered peer data must condemn the connection");
+    }
+
+    /// A closed peer reads as EOF, which is likewise not reusable.
+    #[tokio::test]
+    async fn closed_peer_is_detected() {
+        let (client, server) = socket_pair().await;
+        drop(server);
+        client.readable().await.expect("readable");
+        assert!(has_unread_bytes(&client), "a peer that closed must condemn the connection");
     }
 }

--- a/crates/ephpm-db/src/pool.rs
+++ b/crates/ephpm-db/src/pool.rs
@@ -76,7 +76,11 @@ pub(crate) fn has_unread_bytes(stream: &TcpStream) -> bool {
 pub struct PoolConfig {
     /// Keep at least this many connections open at all times.
     pub min_connections: u32,
-    /// Never exceed this many connections (in-use + idle).
+    /// Never exceed this many concurrent checkouts.
+    ///
+    /// This also bounds live backend connections: a connection is only ever
+    /// dialled while its caller holds a permit, so the number in existence
+    /// cannot outgrow the peak number of simultaneous checkouts.
     pub max_connections: u32,
     /// Close idle connections that have been idle longer than this.
     pub idle_timeout: Duration,
@@ -89,14 +93,16 @@ pub struct PoolConfig {
 }
 
 /// An idle slot in the pool.
+///
+/// Deliberately holds no semaphore permit. A permit represents *a checkout in
+/// progress*, not *a connection that exists* — see [`Pool::acquire`] for why
+/// the distinction is load-bearing.
 struct Slot {
     stream: TcpStream,
     /// Time the backend connection was first established.
     created_at: Instant,
     /// Time the connection was last returned to the pool.
     last_used: Instant,
-    /// The semaphore permit "parked" with this idle connection.
-    permit: OwnedSemaphorePermit,
 }
 
 struct PoolState {
@@ -198,6 +204,18 @@ impl Pool {
     /// instead. A caller therefore never receives a connection the pool has
     /// already observed to be dead.
     ///
+    /// # Permit accounting
+    ///
+    /// A permit means "a checkout is in progress", not "a connection exists".
+    /// Idle connections hold none. This matters: permits were once parked with
+    /// idle slots, which made returning a connection *consume* a permit rather
+    /// than release one. Once `in-use + idle` reached `max_connections`,
+    /// nothing on the healthy path could free a permit again and every later
+    /// acquire blocked until `pool_timeout` — a pool full of perfectly good
+    /// connections that it could not hand out. That deadlock was masked for as
+    /// long as the proxy was killing connections on every request, because the
+    /// resulting discards released permits continuously.
+    ///
     /// # Errors
     ///
     /// - [`DbError::PoolClosed`] if the pool has been shut down.
@@ -234,9 +252,6 @@ impl Pool {
             let idle_ok = slot.last_used.elapsed() < self.config.idle_timeout;
 
             if age_ok && idle_ok {
-                // Discard the parked permit (we now hold `permit` from above).
-                drop(slot.permit);
-
                 // Validate before handing out. A connection that has been
                 // parked for a while may have been closed by the server with
                 // no local indication; writing to it is how the caller finds
@@ -264,9 +279,8 @@ impl Pool {
                     pool: self.clone(),
                 });
             }
-            // Expired: discard both the stream and its parked permit.
+            // Expired: discard the stream and try the next candidate.
             debug!("discarding expired idle connection");
-            drop(slot.permit);
         }
 
         // No suitable idle connection — open a new one.
@@ -296,8 +310,13 @@ impl Pool {
         created_at: Instant,
         permit: OwnedSemaphorePermit,
     ) {
-        let slot = Slot { stream, created_at, last_used: Instant::now(), permit };
+        let slot = Slot { stream, created_at, last_used: Instant::now() };
         self.state.idle.lock().push_back(slot);
+        // Release the permit *after* the connection is visible in the idle
+        // queue, so a caller woken by this release is guaranteed to find it.
+        // Dropping it is the point: returning a connection has to hand a
+        // permit back to whoever is waiting, not consume one.
+        drop(permit);
     }
 
     /// Reset a connection using the pool's reset closure and return it to idle.
@@ -351,27 +370,28 @@ impl Pool {
         if current_idle >= self.config.min_connections {
             return;
         }
-        let needed = self.config.min_connections - current_idle;
+        // Warm-up connections are parked directly rather than checked out, so
+        // they are not covered by a permit. Bound them by the semaphore's free
+        // capacity so warming can never push the live connection count past
+        // `max_connections` while checkouts are in flight.
+        let headroom = self.semaphore.available_permits().saturating_sub(current_idle as usize);
+        let needed = usize::try_from(self.config.min_connections - current_idle)
+            .unwrap_or(usize::MAX)
+            .min(headroom);
         for _ in 0..needed {
             if self.state.closed.load(Ordering::Acquire) {
                 break;
             }
-            // Try to grab a permit without blocking.
-            let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() else {
-                break; // at max_connections
-            };
             match (self.connect)().await {
                 Ok(stream) => {
                     self.state.idle.lock().push_back(Slot {
                         stream,
                         created_at: Instant::now(),
                         last_used: Instant::now(),
-                        permit,
                     });
                 }
                 Err(e) => {
                     warn!("pool warm-up connection failed: {e}");
-                    // permit is dropped, freeing the slot
                 }
             }
         }
@@ -390,16 +410,13 @@ impl Pool {
                         stream,
                         created_at: slot.created_at,
                         last_used: slot.last_used,
-                        permit: slot.permit,
                     });
                 }
                 Ok((_, false)) => {
                     debug!("health check failed: dropping connection");
-                    // permit dropped here
                 }
                 Err(e) => {
                     debug!("health check I/O error: {e}");
-                    // permit dropped here
                 }
             }
         }

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -11,8 +11,12 @@
 //!    credential validation — loopback only), sends synthetic metadata,
 //!    and starts bidirectional byte forwarding.
 //!
-//! 3. When the client closes or sends `Terminate`, the proxy sends
-//!    `DISCARD ALL` to the backend and returns the connection to the pool.
+//! 3. When the client closes or sends `Terminate`, the proxy closes only the
+//!    client-facing socket. `Terminate` is **intercepted, never forwarded** —
+//!    the backend is shared across sessions and closing it would poison the
+//!    pool. The proxy then sends `DISCARD ALL` to the backend (unless
+//!    `reset_strategy = "never"`) and returns the still-open connection to the
+//!    pool.
 //!
 //! ## Auth support
 //!
@@ -294,10 +298,8 @@ impl PgProxy {
             let mut checkout = self.pool.acquire().await?;
             let backend = checkout.take_stream();
 
-            let result = pg_proxy_bidirectional(client, backend).await;
-
-            match result {
-                Ok(backend) => match self.reset_strategy {
+            match pg_proxy_bidirectional(client, backend).await {
+                Some(backend) => match self.reset_strategy {
                     ResetStrategy::Never => {
                         checkout.return_to_pool(backend);
                     }
@@ -308,8 +310,8 @@ impl PgProxy {
                         unreachable!()
                     }
                 },
-                Err(e) => {
-                    debug!("proxy session error, discarding backend connection: {e}");
+                None => {
+                    debug!("backend connection failed during session; discarding, not recycling");
                     checkout.retire();
                 }
             }
@@ -905,35 +907,103 @@ async fn pg_ping_connection(mut stream: TcpStream) -> Result<(TcpStream, bool), 
 
 // ── Bidirectional proxy ─────────────────────────────────────────────────────
 
-/// Splice `client` ↔ `backend` until one side closes.
+/// Which side of the proxy ended a session.
 ///
-/// Returns the backend stream on clean close so it can be reset and recycled.
+/// See the MySQL counterpart in [`crate::mysql`] — the same reasoning applies:
+/// both sides report identical `io::ErrorKind` values, so error kind alone
+/// cannot decide whether a pooled backend is still usable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PgSessionEnd {
+    /// The client finished — `Terminate`, EOF, or a failure on the client
+    /// socket. The backend never learned the session ended.
+    Client,
+    /// The backend connection failed or closed. It must be discarded.
+    Backend,
+}
+
+/// Relay `client` ↔ `backend` until the session ends.
+///
+/// Returns the backend stream when the *client* ended the session, and `None`
+/// when the backend failed and must be discarded rather than recycled.
+///
+/// ## `Terminate` is intercepted, never forwarded
+///
+/// `Terminate` (`'X'`) is the PG frontend's "close this connection" message —
+/// PDO sends it when the request ends. Relaying it to a *pooled* backend makes
+/// the server close the connection, and the pool then hands that dead socket
+/// to the next request. It is swallowed here, exactly as `COM_QUIT` is on the
+/// MySQL side.
+///
+/// ## Framing
+///
+/// Post-startup PG frontend messages are uniformly `[tag: 1][len: 4BE][payload]`,
+/// so the client→backend direction can be framed without understanding any
+/// individual message — enough to spot `Terminate`. The backend→client
+/// direction is copied in bulk but hand-rolled so an I/O error can be
+/// attributed to the side that produced it.
 async fn pg_proxy_bidirectional(
     mut client: TcpStream,
     mut backend: TcpStream,
-) -> Result<TcpStream, DbError> {
-    let result = {
+) -> Option<TcpStream> {
+    let end = {
         let (mut cr, mut cw) = client.split();
         let (mut br, mut bw) = backend.split();
 
-        let client_to_backend = tokio::io::copy(&mut cr, &mut bw);
-        let backend_to_client = tokio::io::copy(&mut br, &mut cw);
+        let client_to_backend = async {
+            let mut header = [0u8; 5];
+            loop {
+                // Any read failure is a client-side event and says nothing
+                // about the health of the backend.
+                if cr.read_exact(&mut header).await.is_err() {
+                    return PgSessionEnd::Client;
+                }
+                if header[0] == MSG_TERMINATE {
+                    debug!("client sent Terminate; not forwarding to pooled backend");
+                    return PgSessionEnd::Client;
+                }
+                let len = i32::from_be_bytes([header[1], header[2], header[3], header[4]]);
+                if !(4..=MAX_PG_MESSAGE_LEN).contains(&len) {
+                    debug!(len, "client sent an out-of-range PG message length; ending session");
+                    return PgSessionEnd::Client;
+                }
+                let payload_len = usize::try_from(len - 4).unwrap_or(0);
+                let mut payload = vec![0u8; payload_len];
+                if payload_len > 0 && cr.read_exact(&mut payload).await.is_err() {
+                    return PgSessionEnd::Client;
+                }
+
+                if bw.write_all(&header).await.is_err() || bw.write_all(&payload).await.is_err() {
+                    return PgSessionEnd::Backend;
+                }
+            }
+        };
+
+        let backend_to_client = async {
+            let mut buf = vec![0u8; 16 * 1024];
+            loop {
+                match br.read(&mut buf).await {
+                    Ok(n) if n > 0 => {
+                        if cw.write_all(&buf[..n]).await.is_err() {
+                            return PgSessionEnd::Client;
+                        }
+                    }
+                    // `Ok(0)` is backend EOF; `Err` is a backend read failure.
+                    // With `Terminate` no longer forwarded, EOF means the
+                    // server genuinely closed the connection.
+                    Ok(_) | Err(_) => return PgSessionEnd::Backend,
+                }
+            }
+        };
 
         tokio::select! {
-            r = client_to_backend => r,
-            r = backend_to_client => r,
+            e = client_to_backend => e,
+            e = backend_to_client => e,
         }
     };
 
-    match result {
-        Ok(_) => Ok(backend),
-        Err(e)
-            if e.kind() == std::io::ErrorKind::ConnectionReset
-                || e.kind() == std::io::ErrorKind::BrokenPipe =>
-        {
-            Ok(backend)
-        }
-        Err(e) => Err(DbError::Io(e)),
+    match end {
+        PgSessionEnd::Client => Some(backend),
+        PgSessionEnd::Backend => None,
     }
 }
 
@@ -1046,6 +1116,10 @@ async fn pg_proxy_routing_loop(
         };
 
         if tag == MSG_TERMINATE {
+            // Session termination belongs to the client-facing socket only.
+            // Pooled backends are shared across sessions and must never see
+            // it — see `pg_proxy_bidirectional` for the full rationale.
+            debug!("client sent Terminate; ending session without touching pooled backends");
             break;
         }
 
@@ -1090,21 +1164,32 @@ async fn pg_proxy_routing_loop(
         let mut checkout = target_pool.acquire().await?;
         let mut backend = checkout.take_stream();
 
-        write_pg_message(&mut backend, tag, &payload).await?;
-
-        // Forward response(s) until ReadyForQuery — or until the backend hands
-        // the conversation back to the client via a copy sub-protocol, in
-        // which case no further backend output is coming.
+        // Any failure below leaves the backend mid-message or mid-result-set.
+        // Discard it explicitly rather than letting control flow reach a
+        // `return_to_pool`.
         let mut copy_mode = false;
-        loop {
-            let resp_tag = forward_pg_message(&mut backend, &mut client).await?;
-            if resp_tag == MSG_READY_FOR_QUERY {
-                break;
+        let relay: Result<(), DbError> = async {
+            write_pg_message(&mut backend, tag, &payload).await?;
+
+            // Forward response(s) until ReadyForQuery — or until the backend
+            // hands the conversation back to the client via a copy
+            // sub-protocol, in which case no further backend output is coming.
+            loop {
+                let resp_tag = forward_pg_message(&mut backend, &mut client).await?;
+                if resp_tag == MSG_READY_FOR_QUERY {
+                    return Ok(());
+                }
+                if resp_tag == MSG_COPY_IN_RESPONSE || resp_tag == MSG_COPY_BOTH_RESPONSE {
+                    copy_mode = true;
+                    return Ok(());
+                }
             }
-            if resp_tag == MSG_COPY_IN_RESPONSE || resp_tag == MSG_COPY_BOTH_RESPONSE {
-                copy_mode = true;
-                break;
-            }
+        }
+        .await;
+        if let Err(e) = relay {
+            debug!("backend relay failed, discarding connection: {e}");
+            checkout.retire();
+            return Err(e);
         }
 
         if copy_mode {
@@ -1153,15 +1238,15 @@ async fn pg_relay_pinned_session(
     reset_strategy: ResetStrategy,
 ) -> Result<(), DbError> {
     match pg_proxy_bidirectional(client, backend).await {
-        Ok(backend) => {
+        Some(backend) => {
             if matches!(reset_strategy, ResetStrategy::Never) {
                 checkout.return_to_pool(backend);
             } else {
                 checkout.return_with_reset(backend).await;
             }
         }
-        Err(e) => {
-            debug!("pinned session error, discarding backend connection: {e}");
+        None => {
+            debug!("pinned session backend failed; discarding, not recycling");
             checkout.retire();
         }
     }

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -1001,10 +1001,20 @@ async fn pg_proxy_bidirectional(
         }
     };
 
-    match end {
-        PgSessionEnd::Client => Some(backend),
-        PgSessionEnd::Backend => None,
-    }
+    let reusable = match end {
+        // The client left a partly drained response behind — alive, but not
+        // safe to hand to the next session. On PG this also condemns a
+        // connection carrying an unconsumed asynchronous `NoticeResponse` or
+        // `NotificationResponse`, which is the right call: the next session's
+        // `DISCARD ALL` would read it as its own reply.
+        PgSessionEnd::Client if crate::pool::has_unread_bytes(&backend) => {
+            debug!("client ended mid-response, leaving unread backend bytes; discarding");
+            false
+        }
+        PgSessionEnd::Client => true,
+        PgSessionEnd::Backend => false,
+    };
+    reusable.then_some(backend)
 }
 
 // ── Routing & smart reset ────────────────────────────────────────────────────

--- a/crates/ephpm-db/tests/pg_terminate_poisoning.rs
+++ b/crates/ephpm-db/tests/pg_terminate_poisoning.rs
@@ -1,0 +1,470 @@
+//! Regression tests for pooled-backend poisoning on the `PostgreSQL` proxy path.
+//!
+//! The `PostgreSQL` equivalent of the `COM_QUIT` bug: PDO sends `Terminate`
+//! (`'X'`) when it tears down a handle, and the proxy relayed it to the pooled
+//! backend. Two code paths carried it — the simple bidirectional relay used
+//! when `reset_strategy = "never"`, and the *pinned* session that every
+//! extended-query client (which is to say, every real `PDO_pgsql` client) ends
+//! up on after its first `Parse`.
+//!
+//! `Smart` masked the damage: `DISCARD ALL` failed against the just-closed
+//! socket, so the connection was discarded rather than re-parked and the pool
+//! self-healed by burning a connection per request. `Never` had no such luck —
+//! it recycled the corpse.
+//!
+//! Everything runs against an in-process mock `PostgreSQL` server.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use ephpm_db::ResetStrategy;
+use ephpm_db::pool::PoolConfig;
+use ephpm_db::postgres::{PgProxy, PgRwSplitParams};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
+
+// ── PG message framing (test-local) ──────────────────────────────────────────
+
+const MSG_QUERY: u8 = b'Q';
+const MSG_TERMINATE: u8 = b'X';
+const MSG_SYNC: u8 = b'S';
+const MSG_PARSE: u8 = b'P';
+const MSG_BIND: u8 = b'B';
+const MSG_EXECUTE: u8 = b'E';
+const MSG_ROW_DESCRIPTION: u8 = b'T';
+const MSG_DATA_ROW: u8 = b'D';
+const MSG_COMMAND_COMPLETE: u8 = b'C';
+const MSG_READY_FOR_QUERY: u8 = b'Z';
+const MSG_AUTH: u8 = b'R';
+const MSG_PARAMETER_STATUS: u8 = b'S';
+const MSG_BACKEND_KEY_DATA: u8 = b'K';
+
+async fn read_message(stream: &mut TcpStream) -> std::io::Result<(u8, Vec<u8>)> {
+    let mut header = [0u8; 5];
+    stream.read_exact(&mut header).await?;
+    let len = i32::from_be_bytes([header[1], header[2], header[3], header[4]]);
+    let payload_len = usize::try_from(len - 4).unwrap_or(0);
+    let mut payload = vec![0u8; payload_len];
+    if payload_len > 0 {
+        stream.read_exact(&mut payload).await?;
+    }
+    Ok((header[0], payload))
+}
+
+async fn write_message(stream: &mut TcpStream, tag: u8, payload: &[u8]) -> std::io::Result<()> {
+    let len = i32::try_from(payload.len() + 4).expect("test message fits in i32");
+    stream.write_all(&[tag]).await?;
+    stream.write_all(&len.to_be_bytes()).await?;
+    stream.write_all(payload).await
+}
+
+// ── Mock PostgreSQL backend ──────────────────────────────────────────────────
+
+struct MockPgBackend {
+    addr: SocketAddr,
+    /// Backend TCP connections accepted — how many times the pool had to dial.
+    connects: Arc<AtomicUsize>,
+    /// `Terminate` messages that reached the backend. Must stay at zero.
+    terminates: Arc<AtomicUsize>,
+    kill: broadcast::Sender<()>,
+}
+
+impl MockPgBackend {
+    fn url(&self) -> String {
+        format!("postgres://postgres@{}/test", self.addr)
+    }
+
+    fn kill_live_connections(&self) {
+        let _ = self.kill.send(());
+    }
+}
+
+async fn start_mock_backend() -> MockPgBackend {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock PG backend");
+    let addr = listener.local_addr().expect("mock PG addr");
+    let connects = Arc::new(AtomicUsize::new(0));
+    let terminates = Arc::new(AtomicUsize::new(0));
+    let (kill, _) = broadcast::channel(16);
+
+    let connects_task = Arc::clone(&connects);
+    let terminates_task = Arc::clone(&terminates);
+    let kill_task = kill.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((sock, _)) = listener.accept().await else { break };
+            let id = connects_task.fetch_add(1, Ordering::SeqCst) + 1;
+            let terminates = Arc::clone(&terminates_task);
+            let mut killed = kill_task.subscribe();
+            tokio::spawn(async move {
+                tokio::select! {
+                    () = mock_session(sock, id, terminates) => {}
+                    _ = killed.recv() => { /* drop the socket */ }
+                }
+            });
+        }
+    });
+
+    MockPgBackend { addr, connects, terminates, kill }
+}
+
+/// One backend connection: startup, then answer queries and **close on
+/// `Terminate`**, exactly as a real server does.
+async fn mock_session(mut sock: TcpStream, id: usize, terminates: Arc<AtomicUsize>) {
+    let _ = sock.set_nodelay(true);
+
+    // StartupMessage has no tag byte: [len: 4BE][payload].
+    let Ok(len) = sock.read_i32().await else { return };
+    let payload_len = usize::try_from(len - 4).unwrap_or(0);
+    let mut payload = vec![0u8; payload_len];
+    if sock.read_exact(&mut payload).await.is_err() {
+        return;
+    }
+
+    if write_message(&mut sock, MSG_AUTH, &0_i32.to_be_bytes()).await.is_err() {
+        return;
+    }
+    if write_message(&mut sock, MSG_PARAMETER_STATUS, b"server_version\0mock\0").await.is_err() {
+        return;
+    }
+    if write_message(&mut sock, MSG_BACKEND_KEY_DATA, &[0u8; 8]).await.is_err() {
+        return;
+    }
+    if write_message(&mut sock, MSG_READY_FOR_QUERY, b"I").await.is_err() {
+        return;
+    }
+
+    loop {
+        let Ok((tag, _)) = read_message(&mut sock).await else { return };
+        let ok = match tag {
+            MSG_TERMINATE => {
+                terminates.fetch_add(1, Ordering::SeqCst);
+                return; // a real server closes the socket here
+            }
+            // A simple Query, or the Sync that flushes an extended-protocol
+            // batch, both produce one complete response ending in ReadyForQuery.
+            MSG_QUERY | MSG_SYNC => write_row_set(&mut sock, id).await.is_ok(),
+            // Parse / Bind / Describe / Execute produce no output until Sync.
+            _ => true,
+        };
+        if !ok {
+            return;
+        }
+    }
+}
+
+/// A one-column, one-row result carrying this backend connection's id.
+async fn write_row_set(sock: &mut TcpStream, id: usize) -> std::io::Result<()> {
+    let mut desc = Vec::with_capacity(32);
+    desc.extend_from_slice(&1_i16.to_be_bytes()); // field count
+    desc.extend_from_slice(b"backend_id\0");
+    desc.extend_from_slice(&0_i32.to_be_bytes()); // table oid
+    desc.extend_from_slice(&0_i16.to_be_bytes()); // column attnum
+    desc.extend_from_slice(&25_i32.to_be_bytes()); // type oid: text
+    desc.extend_from_slice(&(-1_i16).to_be_bytes()); // type length
+    desc.extend_from_slice(&(-1_i32).to_be_bytes()); // type modifier
+    desc.extend_from_slice(&0_i16.to_be_bytes()); // format: text
+    write_message(sock, MSG_ROW_DESCRIPTION, &desc).await?;
+
+    let value = id.to_string();
+    let mut row = Vec::with_capacity(value.len() + 6);
+    row.extend_from_slice(&1_i16.to_be_bytes()); // field count
+    row.extend_from_slice(&i32::try_from(value.len()).expect("short value").to_be_bytes());
+    row.extend_from_slice(value.as_bytes());
+    write_message(sock, MSG_DATA_ROW, &row).await?;
+
+    write_message(sock, MSG_COMMAND_COMPLETE, b"SELECT 1\0").await?;
+    write_message(sock, MSG_READY_FOR_QUERY, b"I").await
+}
+
+// ── Client: one PHP-shaped request ───────────────────────────────────────────
+
+/// Whether the client speaks the simple or the extended query protocol.
+///
+/// `PDO_pgsql` uses the extended protocol, which pins the session to one
+/// backend for its whole lifetime — a different code path in the proxy, and
+/// the one that mattered in production.
+#[derive(Clone, Copy)]
+enum Protocol {
+    Simple,
+    Extended,
+}
+
+/// Gap between sequential sessions.
+///
+/// The client returns as soon as it has written `Terminate`, while the proxy
+/// still has to finish its relay and park the backend. Without a gap the next
+/// session can win that race and dial fresh, never touching the connection the
+/// previous session left behind — which would hide the defect under test. Far
+/// below the pool's 500ms checkout-validation threshold, so the ping never
+/// runs and cannot mask anything either.
+const REQUEST_PACING: Duration = Duration::from_millis(20);
+
+async fn client_session(proxy: &str, protocol: Protocol) -> Result<usize, String> {
+    let result =
+        match tokio::time::timeout(Duration::from_secs(5), client_session_inner(proxy, protocol))
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => Err("session timed out".to_string()),
+        };
+    tokio::time::sleep(REQUEST_PACING).await;
+    result
+}
+
+async fn client_session_inner(proxy: &str, protocol: Protocol) -> Result<usize, String> {
+    let mut s = TcpStream::connect(proxy).await.map_err(|e| format!("connect: {e}"))?;
+    let _ = s.set_nodelay(true);
+
+    // StartupMessage.
+    let mut startup = Vec::with_capacity(64);
+    startup.extend_from_slice(&0x0003_0000_i32.to_be_bytes());
+    startup.extend_from_slice(b"user\0postgres\0");
+    startup.extend_from_slice(b"database\0test\0");
+    startup.push(0);
+    let total = i32::try_from(startup.len() + 4).expect("startup fits in i32");
+    s.write_all(&total.to_be_bytes()).await.map_err(|e| format!("startup len: {e}"))?;
+    s.write_all(&startup).await.map_err(|e| format!("startup: {e}"))?;
+
+    // Drain the handshake up to ReadyForQuery.
+    loop {
+        let (tag, _) = read_message(&mut s).await.map_err(|e| format!("handshake: {e}"))?;
+        if tag == MSG_READY_FOR_QUERY {
+            break;
+        }
+    }
+
+    match protocol {
+        Protocol::Simple => {
+            write_message(&mut s, MSG_QUERY, b"SELECT backend_id\0")
+                .await
+                .map_err(|e| format!("query: {e}"))?;
+        }
+        Protocol::Extended => {
+            let mut parse = Vec::with_capacity(32);
+            parse.push(0); // unnamed statement
+            parse.extend_from_slice(b"SELECT backend_id\0");
+            parse.extend_from_slice(&0_i16.to_be_bytes()); // no parameter types
+            write_message(&mut s, MSG_PARSE, &parse).await.map_err(|e| format!("parse: {e}"))?;
+
+            let mut bind = Vec::with_capacity(16);
+            bind.push(0); // unnamed portal
+            bind.push(0); // unnamed statement
+            bind.extend_from_slice(&0_i16.to_be_bytes()); // format codes
+            bind.extend_from_slice(&0_i16.to_be_bytes()); // parameter values
+            bind.extend_from_slice(&0_i16.to_be_bytes()); // result format codes
+            write_message(&mut s, MSG_BIND, &bind).await.map_err(|e| format!("bind: {e}"))?;
+
+            let mut execute = Vec::with_capacity(8);
+            execute.push(0); // unnamed portal
+            execute.extend_from_slice(&0_i32.to_be_bytes()); // no row limit
+            write_message(&mut s, MSG_EXECUTE, &execute)
+                .await
+                .map_err(|e| format!("execute: {e}"))?;
+
+            write_message(&mut s, MSG_SYNC, b"").await.map_err(|e| format!("sync: {e}"))?;
+        }
+    }
+
+    let id = read_row_set(&mut s).await?;
+
+    // PDO sends this when it destroys the handle at request end.
+    write_message(&mut s, MSG_TERMINATE, b"").await.map_err(|e| format!("terminate: {e}"))?;
+    drop(s);
+    Ok(id)
+}
+
+async fn read_row_set(s: &mut TcpStream) -> Result<usize, String> {
+    let mut value: Option<usize> = None;
+    loop {
+        let (tag, payload) = read_message(s).await.map_err(|e| format!("response: {e}"))?;
+        match tag {
+            MSG_DATA_ROW => {
+                // [field count: 2BE][len: 4BE][bytes]
+                let len = usize::try_from(i32::from_be_bytes([
+                    *payload.get(2).ok_or("short DataRow")?,
+                    *payload.get(3).ok_or("short DataRow")?,
+                    *payload.get(4).ok_or("short DataRow")?,
+                    *payload.get(5).ok_or("short DataRow")?,
+                ]))
+                .map_err(|e| format!("negative DataRow field length: {e}"))?;
+                let bytes = payload.get(6..6 + len).ok_or("truncated DataRow")?;
+                let text =
+                    std::str::from_utf8(bytes).map_err(|e| format!("DataRow not utf8: {e}"))?;
+                value = Some(text.parse().map_err(|e| format!("DataRow value {text:?}: {e}"))?);
+            }
+            b'E' => return Err("backend returned ErrorResponse".to_string()),
+            MSG_READY_FOR_QUERY => {
+                return value.ok_or_else(|| "no DataRow in response".to_string());
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── Proxy harness ────────────────────────────────────────────────────────────
+
+fn test_pool_config() -> PoolConfig {
+    PoolConfig {
+        min_connections: 1,
+        max_connections: 4,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        // Long enough that the background health check never runs.
+        health_check_interval: Duration::from_secs(3600),
+    }
+}
+
+/// Start a proxy in front of `backend`; no background maintenance task, so
+/// every recovery is attributable to the request path itself.
+async fn start_proxy(backend: &MockPgBackend, reset_strategy: ResetStrategy) -> String {
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("bind for port discovery");
+    let listen = probe.local_addr().expect("probe addr").to_string();
+    drop(probe);
+
+    let proxy = PgProxy::new(
+        &backend.url(),
+        &listen,
+        test_pool_config(),
+        reset_strategy,
+        vec![],
+        PgRwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+    )
+    .await
+    .expect("build PgProxy against mock backend");
+
+    tokio::spawn(async move {
+        if let Err(e) = proxy.run().await {
+            eprintln!("mock PG proxy stopped: {e}");
+        }
+    });
+
+    for _ in 0..100 {
+        if TcpStream::connect(&listen).await.is_ok() {
+            return listen;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("PG proxy never became ready at {listen}");
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// The MySQL probe, ported to `PostgreSQL`: 20 sequential connect / query /
+/// disconnect cycles over the simple bidirectional relay.
+#[tokio::test(flavor = "multi_thread")]
+async fn twenty_sequential_sessions_all_succeed() {
+    for strategy in [ResetStrategy::Never, ResetStrategy::Always, ResetStrategy::Smart] {
+        let backend = start_mock_backend().await;
+        let proxy = start_proxy(&backend, strategy).await;
+
+        let mut ok = 0usize;
+        let mut failures = Vec::new();
+        for i in 1..=20 {
+            match client_session(&proxy, Protocol::Simple).await {
+                Ok(_) => ok += 1,
+                Err(e) => failures.push(format!("#{i}: {e}")),
+            }
+        }
+        assert_eq!(ok, 20, "expected 20/20 under {strategy:?}; failures: {failures:?}");
+        assert_eq!(
+            backend.terminates.load(Ordering::SeqCst),
+            0,
+            "Terminate reached a pooled backend under {strategy:?}"
+        );
+    }
+}
+
+/// `reset_strategy = "never"` takes the plain bidirectional relay, which had no
+/// reset on the return path to accidentally notice the socket was dead. This
+/// is the configuration that poisoned permanently.
+#[tokio::test(flavor = "multi_thread")]
+async fn terminate_is_not_forwarded_and_the_backend_is_reused() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Never).await;
+
+    let first = client_session(&proxy, Protocol::Simple).await.expect("first session");
+    let mut served_by = vec![first];
+    for _ in 0..19 {
+        served_by.push(client_session(&proxy, Protocol::Simple).await.expect("subsequent session"));
+    }
+
+    assert!(
+        served_by.iter().all(|id| *id == first),
+        "every session should reuse one pooled backend, got ids {served_by:?}"
+    );
+    assert_eq!(
+        backend.connects.load(Ordering::SeqCst),
+        1,
+        "the pool should have dialled the backend exactly once for 20 client sessions"
+    );
+    assert_eq!(backend.terminates.load(Ordering::SeqCst), 0, "Terminate was relayed");
+}
+
+/// The `PDO_pgsql` shape. The first extended-protocol message pins the session
+/// to one backend and splices the rest of it verbatim — which is how
+/// `Terminate` reached the backend even under the default `Smart` strategy.
+/// `Smart` hid it by burning a connection per request instead of poisoning
+/// one, so the symptom was cost rather than failure.
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_protocol_session_does_not_forward_terminate() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Smart).await;
+
+    for i in 1..=20 {
+        let result = client_session(&proxy, Protocol::Extended).await;
+        assert!(result.is_ok(), "extended-protocol session #{i} failed: {result:?}");
+    }
+
+    assert_eq!(
+        backend.terminates.load(Ordering::SeqCst),
+        0,
+        "Terminate must not be relayed on the pinned session path"
+    );
+    assert_eq!(
+        backend.connects.load(Ordering::SeqCst),
+        1,
+        "the pinned session path should reuse one backend, not burn one per request"
+    );
+}
+
+/// A backend that dies while idle must be caught at checkout.
+#[tokio::test(flavor = "multi_thread")]
+async fn dead_idle_connection_is_replaced_at_checkout() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Never).await;
+
+    let first = client_session(&proxy, Protocol::Simple).await.expect("first session");
+    backend.kill_live_connections();
+    // Longer than the pool's 500ms checkout-validation threshold.
+    tokio::time::sleep(Duration::from_millis(750)).await;
+
+    let second = client_session(&proxy, Protocol::Simple)
+        .await
+        .expect("session after the backend died must succeed on a fresh dial");
+    assert_ne!(first, second, "expected a freshly dialled backend connection");
+    assert!(backend.connects.load(Ordering::SeqCst) >= 2, "the pool never re-dialled");
+}
+
+/// A backend that dies inside the validation window has to be caught by the
+/// relay. What must never happen is the corpse going back into the pool.
+#[tokio::test(flavor = "multi_thread")]
+async fn broken_backend_is_discarded_not_reparked() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Never).await;
+
+    client_session(&proxy, Protocol::Simple).await.expect("first session");
+    backend.kill_live_connections();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Draws the dead socket; nothing can be promised about this one.
+    let _ = client_session(&proxy, Protocol::Simple).await;
+
+    for i in 1..=5 {
+        let result = client_session(&proxy, Protocol::Simple).await;
+        assert!(result.is_ok(), "recovery session #{i} failed: {result:?} — corpse was re-parked");
+    }
+}

--- a/crates/ephpm-db/tests/pool_lifecycle.rs
+++ b/crates/ephpm-db/tests/pool_lifecycle.rs
@@ -4,6 +4,8 @@
 //! requiring a real database server. Uses `tokio::net::TcpListener` to
 //! simulate a backend.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use ephpm_db::error::DbError;
@@ -132,4 +134,131 @@ async fn close_rejects_new_acquires() {
     assert!(result.is_err(), "acquire after close should fail");
     let err = result.err().unwrap();
     assert!(matches!(err, DbError::PoolClosed), "error should be PoolClosed, got: {err}");
+}
+
+// ── Checkout-time validation ─────────────────────────────────────────────────
+
+/// Build a pool whose `ping` verdict and dial count are observable.
+///
+/// `alive` decides what the ping closure reports; `pings` and `connects` count
+/// how often each closure ran.
+fn instrumented_pool(
+    addr: std::net::SocketAddr,
+    alive: bool,
+) -> (Pool, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+    let connects = Arc::new(AtomicUsize::new(0));
+    let pings = Arc::new(AtomicUsize::new(0));
+
+    let connects_c = Arc::clone(&connects);
+    let connect = move || -> ephpm_db::pool::BoxFuture<Result<TcpStream, DbError>> {
+        let counter = Arc::clone(&connects_c);
+        Box::pin(async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(TcpStream::connect(addr).await?)
+        })
+    };
+    let reset = |s: TcpStream| -> ephpm_db::pool::BoxFuture<Result<TcpStream, DbError>> {
+        Box::pin(async { Ok(s) })
+    };
+    let pings_c = Arc::clone(&pings);
+    let ping =
+        move |s: TcpStream| -> ephpm_db::pool::BoxFuture<Result<(TcpStream, bool), DbError>> {
+            let counter = Arc::clone(&pings_c);
+            Box::pin(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok((s, alive))
+            })
+        };
+
+    (Pool::new(test_config(4), connect, reset, ping), connects, pings)
+}
+
+/// A connection returned and immediately re-acquired cannot have died in the
+/// interim for any reason a ping would catch, so the checkout must not pay for
+/// one. This is what keeps validation off the hot path under load.
+#[tokio::test]
+async fn acquire_skips_validation_for_a_freshly_returned_connection() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accept = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((s, _)) = listener.accept().await {
+            held.push(s);
+        }
+    });
+
+    let (pool, connects, pings) = instrumented_pool(addr, true);
+
+    let mut checkout = pool.acquire().await.unwrap();
+    let stream = checkout.take_stream();
+    checkout.return_to_pool(stream);
+
+    let second = pool.acquire().await;
+    assert!(second.is_ok(), "re-acquire should succeed");
+    assert_eq!(pings.load(Ordering::SeqCst), 0, "no ping should run inside the validation window");
+    assert_eq!(connects.load(Ordering::SeqCst), 1, "the idle connection should have been reused");
+
+    accept.abort();
+}
+
+/// Past the idle threshold the connection is pinged, and a ping that reports
+/// "dead" must cause the pool to discard the slot and dial fresh rather than
+/// hand out a socket it already knows is gone.
+#[tokio::test]
+async fn acquire_discards_an_idle_connection_that_fails_validation() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accept = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((s, _)) = listener.accept().await {
+            held.push(s);
+        }
+    });
+
+    let (pool, connects, pings) = instrumented_pool(addr, false);
+
+    let mut checkout = pool.acquire().await.unwrap();
+    let stream = checkout.take_stream();
+    checkout.return_to_pool(stream);
+    assert_eq!(pool.idle_len(), 1, "connection should be parked");
+
+    // Wait past the pool's 500ms checkout-validation threshold.
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let second = pool.acquire().await;
+    assert!(second.is_ok(), "acquire should recover by dialling a fresh connection");
+    assert_eq!(pings.load(Ordering::SeqCst), 1, "the idle connection should have been pinged");
+    assert_eq!(connects.load(Ordering::SeqCst), 2, "a fresh connection should have been dialled");
+    assert_eq!(pool.idle_len(), 0, "the failed connection must not be left in the idle queue");
+
+    accept.abort();
+}
+
+/// A live connection that has been idle a while is pinged and then handed out
+/// — validation must not throw away healthy connections.
+#[tokio::test]
+async fn acquire_keeps_an_idle_connection_that_passes_validation() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accept = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((s, _)) = listener.accept().await {
+            held.push(s);
+        }
+    });
+
+    let (pool, connects, pings) = instrumented_pool(addr, true);
+
+    let mut checkout = pool.acquire().await.unwrap();
+    let stream = checkout.take_stream();
+    checkout.return_to_pool(stream);
+
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let second = pool.acquire().await;
+    assert!(second.is_ok(), "acquire should succeed");
+    assert_eq!(pings.load(Ordering::SeqCst), 1, "the idle connection should have been pinged");
+    assert_eq!(connects.load(Ordering::SeqCst), 1, "no redial should have been needed");
+
+    accept.abort();
 }

--- a/crates/ephpm-db/tests/pool_lifecycle.rs
+++ b/crates/ephpm-db/tests/pool_lifecycle.rs
@@ -262,3 +262,47 @@ async fn acquire_keeps_an_idle_connection_that_passes_validation() {
 
     accept.abort();
 }
+
+/// Every idle connection parks a semaphore permit. If `acquire` demands a
+/// *fresh* permit before consulting the idle queue, a pool that has grown to
+/// `max_connections` can never hand out the connections it already holds:
+/// returning a connection parks a permit rather than releasing one, so nothing
+/// on the healthy path ever frees one again and every later acquire blocks
+/// until `pool_timeout`.
+///
+/// This is a pool-accounting bug, not a protocol bug — it needs enough
+/// concurrency to grow the pool to its ceiling, which a sequential probe
+/// structurally cannot do.
+#[tokio::test]
+async fn acquire_reuses_idle_connections_when_the_pool_is_at_capacity() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let accept = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((s, _)) = listener.accept().await {
+            held.push(s);
+        }
+    });
+
+    let (pool, connects, _pings) = instrumented_pool(addr, true);
+
+    // Grow the pool to max_connections (4) concurrently, then return them all.
+    let mut checkouts = Vec::new();
+    for _ in 0..4 {
+        checkouts.push(pool.acquire().await.expect("initial acquire"));
+    }
+    for mut checkout in checkouts {
+        let stream = checkout.take_stream();
+        checkout.return_to_pool(stream);
+    }
+    assert_eq!(pool.idle_len(), 4, "pool should now be full of idle connections");
+    assert_eq!(connects.load(Ordering::SeqCst), 4, "should have dialled exactly max_connections");
+
+    // The pool holds four perfectly good connections. Handing one out must not
+    // require a permit that only a discard could ever produce.
+    let checkout = pool.acquire().await;
+    assert!(checkout.is_ok(), "acquire must reuse an idle connection; it timed out instead");
+    assert_eq!(connects.load(Ordering::SeqCst), 4, "should have reused, not redialled");
+
+    accept.abort();
+}

--- a/crates/ephpm-db/tests/pool_quit_poisoning.rs
+++ b/crates/ephpm-db/tests/pool_quit_poisoning.rs
@@ -226,16 +226,27 @@ const REQUEST_PACING: Duration = Duration::from_millis(20);
 ///
 /// Returns the id of the backend connection that served the query.
 async fn client_session(proxy: &str) -> Result<usize, String> {
-    let result =
-        match tokio::time::timeout(Duration::from_secs(5), client_session_inner(proxy)).await {
-            Ok(result) => result,
-            Err(_) => Err("session timed out".to_string()),
-        };
+    client_session_sql(proxy, "SELECT backend_id").await
+}
+
+/// As `client_session`, but with a caller-chosen statement. A write marks the
+/// session dirty, which routes the return through `COM_RESET_CONNECTION` — a
+/// longer checkout window, and the shape the pooled write lanes exercise.
+async fn client_session_sql(proxy: &str, sql: &str) -> Result<usize, String> {
+    let result = match tokio::time::timeout(
+        Duration::from_secs(5),
+        client_session_inner(proxy, sql),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err("session timed out".to_string()),
+    };
     tokio::time::sleep(REQUEST_PACING).await;
     result
 }
 
-async fn client_session_inner(proxy: &str) -> Result<usize, String> {
+async fn client_session_inner(proxy: &str, sql: &str) -> Result<usize, String> {
     let mut s = TcpStream::connect(proxy).await.map_err(|e| format!("connect: {e}"))?;
     let _ = s.set_nodelay(true);
     read_packet(&mut s).await.map_err(|e| format!("greeting: {e}"))?;
@@ -248,7 +259,7 @@ async fn client_session_inner(proxy: &str) -> Result<usize, String> {
     }
 
     let mut query = vec![COM_QUERY];
-    query.extend_from_slice(b"SELECT backend_id");
+    query.extend_from_slice(sql.as_bytes());
     write_packet(&mut s, 0, &query).await.map_err(|e| format!("query: {e}"))?;
     let id = read_result_set(&mut s).await?;
 
@@ -458,5 +469,67 @@ async fn broken_backend_is_discarded_not_reparked() {
     for i in 1..=5 {
         let result = client_session(&proxy).await;
         assert!(result.is_ok(), "recovery session #{i} failed: {result:?} — corpse was re-parked");
+    }
+}
+
+/// Concurrent write sessions, sustained across several rounds.
+///
+/// A sequential probe structurally cannot catch pool-accounting bugs: it never
+/// has more than one connection in flight, so the pool never grows to
+/// `max_connections` and the semaphore is never fully subscribed. This drives
+/// four times `max_connections` concurrently and repeats, so the pool reaches
+/// its ceiling and then has to keep recycling through it.
+///
+/// Writes specifically: `dirty` routes the return through
+/// `COM_RESET_CONNECTION`, which widens the window in which every connection is
+/// simultaneously checked out.
+///
+/// The failure this pins is a wedge, not a blip — once the pool stops being
+/// able to hand out the connections it holds, every later request fails with
+/// `PoolTimeout` and it never recovers. So the later rounds matter more than
+/// the first.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_write_sessions_do_not_wedge_the_pool() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Smart).await;
+
+    for round in 1..=5 {
+        let mut handles = Vec::with_capacity(16);
+        for _ in 0..16 {
+            let proxy = proxy.clone();
+            handles.push(tokio::spawn(async move {
+                client_session_sql(&proxy, "INSERT INTO t VALUES (1)").await
+            }));
+        }
+        for (i, handle) in handles.into_iter().enumerate() {
+            let result = handle.await.expect("session task panicked");
+            assert!(result.is_ok(), "round {round}, session {i} failed: {result:?}");
+        }
+    }
+
+    assert_eq!(
+        backend.quits.load(Ordering::SeqCst),
+        0,
+        "COM_QUIT must never be relayed, concurrency or not"
+    );
+}
+
+/// The same shape with reads, which return without a reset and so cycle through
+/// the pool faster.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_read_sessions_do_not_wedge_the_pool() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Smart).await;
+
+    for round in 1..=5 {
+        let mut handles = Vec::with_capacity(16);
+        for _ in 0..16 {
+            let proxy = proxy.clone();
+            handles.push(tokio::spawn(async move { client_session(&proxy).await }));
+        }
+        for (i, handle) in handles.into_iter().enumerate() {
+            let result = handle.await.expect("session task panicked");
+            assert!(result.is_ok(), "round {round}, session {i} failed: {result:?}");
+        }
     }
 }

--- a/crates/ephpm-db/tests/pool_quit_poisoning.rs
+++ b/crates/ephpm-db/tests/pool_quit_poisoning.rs
@@ -1,0 +1,462 @@
+//! Regression tests for pooled-backend poisoning on the `MySQL` proxy path.
+//!
+//! The bug these pin: PHP has no idea the proxy pools anything. At the end of
+//! every request PDO tears down its handle and mysqlnd sends `COM_QUIT`. The
+//! proxy relayed that to the *pooled* backend, the backend closed, the dead
+//! socket was parked as a healthy idle slot, and every later checkout drew a
+//! corpse. Field probe on v0.6.0, 20 sequential reads at ordinary pacing:
+//! `ok=2 failed=18`, first failure at request #3, permanent.
+//!
+//! Everything here runs against an in-process mock `MySQL` server, so the
+//! tests need no container and run in ordinary CI. The mock closes its socket
+//! on `COM_QUIT` exactly as a real server does — that is the whole mechanism.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use ephpm_db::ResetStrategy;
+use ephpm_db::mysql::{MySqlProxy, RwSplitParams};
+use ephpm_db::pool::PoolConfig;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
+
+// ── MySQL packet framing (test-local, deliberately independent of the crate) ──
+
+const COM_QUIT: u8 = 0x01;
+const COM_QUERY: u8 = 0x03;
+
+const CLIENT_PROTOCOL_41: u32 = 0x0000_0200;
+const CLIENT_SECURE_CONNECTION: u32 = 0x0000_8000;
+const CLIENT_PLUGIN_AUTH: u32 = 0x0008_0000;
+
+async fn read_packet(stream: &mut TcpStream) -> std::io::Result<(u8, Vec<u8>)> {
+    let mut header = [0u8; 4];
+    stream.read_exact(&mut header).await?;
+    let len = u32::from_le_bytes([header[0], header[1], header[2], 0]) as usize;
+    let mut payload = vec![0u8; len];
+    stream.read_exact(&mut payload).await?;
+    Ok((header[3], payload))
+}
+
+async fn write_packet(stream: &mut TcpStream, seq: u8, payload: &[u8]) -> std::io::Result<()> {
+    let len = u32::try_from(payload.len()).expect("test packet fits in 24 bits");
+    let bytes = len.to_le_bytes();
+    stream.write_all(&[bytes[0], bytes[1], bytes[2], seq]).await?;
+    stream.write_all(payload).await
+}
+
+fn ok_packet() -> Vec<u8> {
+    vec![0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
+}
+
+fn eof_packet() -> Vec<u8> {
+    vec![0xFE, 0x00, 0x00, 0x02, 0x00]
+}
+
+/// A `HandshakeV10` greeting the proxy's `parse_server_greeting` accepts.
+fn greeting() -> Vec<u8> {
+    let caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH;
+    let mut p = Vec::with_capacity(80);
+    p.push(10); // protocol version
+    p.extend_from_slice(b"8.0.0-mock\0");
+    p.extend_from_slice(&1_u32.to_le_bytes()); // connection id
+    p.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]); // auth-plugin-data part 1
+    p.push(0); // filler
+    p.extend_from_slice(&caps.to_le_bytes()[..2]);
+    p.push(33); // charset
+    p.extend_from_slice(&0x0002_u16.to_le_bytes()); // status: AUTOCOMMIT
+    p.extend_from_slice(&caps.to_le_bytes()[2..]);
+    p.push(21); // auth-plugin-data length (8 + 12 + null)
+    p.extend_from_slice(&[0u8; 10]); // reserved
+    p.extend_from_slice(&[9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    p.push(0); // null-terminate part 2
+    p.extend_from_slice(b"mysql_native_password\0");
+    p
+}
+
+/// A protocol-41 column definition packet.
+fn column_def(name: &str) -> Vec<u8> {
+    let mut d = Vec::with_capacity(64);
+    for field in [b"def".as_slice(), b"", b"", b"", name.as_bytes(), name.as_bytes()] {
+        d.push(u8::try_from(field.len()).expect("short field"));
+        d.extend_from_slice(field);
+    }
+    d.push(0x0c); // length of the fixed-field block
+    d.extend_from_slice(&33_u16.to_le_bytes()); // charset
+    d.extend_from_slice(&255_u32.to_le_bytes()); // column length
+    d.push(0xFD); // MYSQL_TYPE_VAR_STRING
+    d.extend_from_slice(&0_u16.to_le_bytes()); // flags
+    d.push(0); // decimals
+    d.extend_from_slice(&[0, 0]); // filler
+    d
+}
+
+// ── Mock MySQL backend ───────────────────────────────────────────────────────
+
+/// Counters and controls for the in-process mock `MySQL` backend.
+struct MockBackend {
+    addr: SocketAddr,
+    /// Backend TCP connections accepted — how many times the pool had to dial.
+    connects: Arc<AtomicUsize>,
+    /// `COM_QUIT` packets that reached the backend. Must stay at zero: session
+    /// termination belongs to the client-facing socket, never to a pooled one.
+    quits: Arc<AtomicUsize>,
+    /// Drops every live backend connection, simulating a server that closes
+    /// connections while they sit idle in the pool.
+    kill: broadcast::Sender<()>,
+}
+
+impl MockBackend {
+    fn url(&self) -> String {
+        format!("mysql://root@{}/test", self.addr)
+    }
+
+    fn kill_live_connections(&self) {
+        let _ = self.kill.send(());
+    }
+}
+
+async fn start_mock_backend() -> MockBackend {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock backend");
+    let addr = listener.local_addr().expect("mock backend addr");
+    let connects = Arc::new(AtomicUsize::new(0));
+    let quits = Arc::new(AtomicUsize::new(0));
+    let (kill, _) = broadcast::channel(16);
+
+    let connects_task = Arc::clone(&connects);
+    let quits_task = Arc::clone(&quits);
+    let kill_task = kill.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((sock, _)) = listener.accept().await else { break };
+            let id = connects_task.fetch_add(1, Ordering::SeqCst) + 1;
+            let quits = Arc::clone(&quits_task);
+            let mut killed = kill_task.subscribe();
+            tokio::spawn(async move {
+                tokio::select! {
+                    () = mock_session(sock, id, quits) => {}
+                    _ = killed.recv() => { /* drop the socket */ }
+                }
+            });
+        }
+    });
+
+    MockBackend { addr, connects, quits, kill }
+}
+
+/// One backend connection, behaving like a real `MySQL` server: greet,
+/// authenticate, answer commands, and **close on `COM_QUIT`**.
+async fn mock_session(mut sock: TcpStream, id: usize, quits: Arc<AtomicUsize>) {
+    let _ = sock.set_nodelay(true);
+    if write_packet(&mut sock, 0, &greeting()).await.is_err() {
+        return;
+    }
+    if read_packet(&mut sock).await.is_err() {
+        return;
+    }
+    if write_packet(&mut sock, 2, &ok_packet()).await.is_err() {
+        return;
+    }
+
+    loop {
+        let Ok((_, payload)) = read_packet(&mut sock).await else { return };
+        let ok = match payload.first().copied() {
+            Some(COM_QUIT) => {
+                quits.fetch_add(1, Ordering::SeqCst);
+                return; // a real server closes the socket here
+            }
+            Some(COM_QUERY) => write_result_set(&mut sock, id).await.is_ok(),
+            // COM_PING, COM_RESET_CONNECTION and anything else: plain OK.
+            _ => write_packet(&mut sock, 1, &ok_packet()).await.is_ok(),
+        };
+        if !ok {
+            return;
+        }
+    }
+}
+
+/// A one-column, one-row result set carrying this backend connection's id, so
+/// the client can tell which pooled connection served it.
+async fn write_result_set(sock: &mut TcpStream, id: usize) -> std::io::Result<()> {
+    write_packet(sock, 1, &[0x01]).await?; // column count
+    write_packet(sock, 2, &column_def("backend_id")).await?;
+    write_packet(sock, 3, &eof_packet()).await?;
+    let value = id.to_string();
+    let mut row = Vec::with_capacity(value.len() + 1);
+    row.push(u8::try_from(value.len()).expect("short value"));
+    row.extend_from_slice(value.as_bytes());
+    write_packet(sock, 4, &row).await?;
+    write_packet(sock, 5, &eof_packet()).await
+}
+
+// ── Client: one PHP-shaped request ───────────────────────────────────────────
+
+fn handshake_response() -> Vec<u8> {
+    let caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH;
+    let mut b = Vec::with_capacity(64);
+    b.extend_from_slice(&caps.to_le_bytes());
+    b.extend_from_slice(&16_777_215_u32.to_le_bytes());
+    b.push(33);
+    b.extend_from_slice(&[0u8; 23]);
+    b.extend_from_slice(b"root\0");
+    b.push(0); // lenenc-encoded empty auth response
+    b.extend_from_slice(b"mysql_native_password\0");
+    b
+}
+
+/// Gap between sequential sessions.
+///
+/// The field probe ran "at ordinary pacing" — a real site's requests do not
+/// arrive back-to-back within microseconds of each other. It matters here for
+/// a mechanical reason too: the client returns as soon as it has written
+/// `COM_QUIT`, while the proxy still has to finish its relay and park the
+/// backend. Without a gap the next session can win that race, dial a fresh
+/// connection, and never touch the connection the previous session left
+/// behind — which would hide exactly the defect under test.
+///
+/// Far below the pool's 500ms checkout-validation threshold, so the ping never
+/// runs and cannot mask anything either.
+const REQUEST_PACING: Duration = Duration::from_millis(20);
+
+/// Connect, run one `SELECT`, send `COM_QUIT`, disconnect — the exact shape of
+/// a PHP request that opens a PDO handle and lets it fall out of scope.
+///
+/// Returns the id of the backend connection that served the query.
+async fn client_session(proxy: &str) -> Result<usize, String> {
+    let result =
+        match tokio::time::timeout(Duration::from_secs(5), client_session_inner(proxy)).await {
+            Ok(result) => result,
+            Err(_) => Err("session timed out".to_string()),
+        };
+    tokio::time::sleep(REQUEST_PACING).await;
+    result
+}
+
+async fn client_session_inner(proxy: &str) -> Result<usize, String> {
+    let mut s = TcpStream::connect(proxy).await.map_err(|e| format!("connect: {e}"))?;
+    let _ = s.set_nodelay(true);
+    read_packet(&mut s).await.map_err(|e| format!("greeting: {e}"))?;
+    write_packet(&mut s, 1, &handshake_response())
+        .await
+        .map_err(|e| format!("handshake response: {e}"))?;
+    let (_, ok) = read_packet(&mut s).await.map_err(|e| format!("auth ok: {e}"))?;
+    if ok.first() != Some(&0x00) {
+        return Err("proxy did not accept the handshake".to_string());
+    }
+
+    let mut query = vec![COM_QUERY];
+    query.extend_from_slice(b"SELECT backend_id");
+    write_packet(&mut s, 0, &query).await.map_err(|e| format!("query: {e}"))?;
+    let id = read_result_set(&mut s).await?;
+
+    // mysqlnd sends this when PDO destroys the handle at request end.
+    write_packet(&mut s, 0, &[COM_QUIT]).await.map_err(|e| format!("quit: {e}"))?;
+    drop(s);
+    Ok(id)
+}
+
+async fn read_result_set(s: &mut TcpStream) -> Result<usize, String> {
+    let (_, header) = read_packet(s).await.map_err(|e| format!("result header: {e}"))?;
+    match header.first().copied() {
+        Some(0xFF) => return Err("backend returned ERR".to_string()),
+        Some(0x00) => return Err("expected a result set, got OK".to_string()),
+        None => return Err("empty result header".to_string()),
+        Some(_) => {}
+    }
+    let columns = usize::from(header[0]);
+    for _ in 0..columns {
+        read_packet(s).await.map_err(|e| format!("column definition: {e}"))?;
+    }
+    read_packet(s).await.map_err(|e| format!("column EOF: {e}"))?;
+
+    let (_, row) = read_packet(s).await.map_err(|e| format!("row: {e}"))?;
+    if row.first() == Some(&0xFE) {
+        return Err("result set had no rows".to_string());
+    }
+    let len = usize::from(row[0]);
+    let value = std::str::from_utf8(row.get(1..1 + len).ok_or("short row")?)
+        .map_err(|e| format!("row is not utf8: {e}"))?;
+    let id = value.parse::<usize>().map_err(|e| format!("row value {value:?}: {e}"))?;
+    read_packet(s).await.map_err(|e| format!("terminating EOF: {e}"))?;
+    Ok(id)
+}
+
+// ── Proxy harness ────────────────────────────────────────────────────────────
+
+fn test_pool_config() -> PoolConfig {
+    PoolConfig {
+        min_connections: 1,
+        max_connections: 4,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        // Long enough that the background health check never runs. The bug
+        // must be fixed at checkout time, not papered over by a 30s reaper —
+        // that is the difference between "broken for one request" and "broken
+        // for thirty seconds".
+        health_check_interval: Duration::from_secs(3600),
+    }
+}
+
+/// Start a proxy in front of `backend` and return its listen address.
+///
+/// Deliberately does **not** start the pool maintenance task: no background
+/// warmer, no background health check. Every recovery observed in these tests
+/// is therefore attributable to the request path itself.
+async fn start_proxy(backend: &MockBackend, reset_strategy: ResetStrategy) -> String {
+    let probe = TcpListener::bind("127.0.0.1:0").await.expect("bind for port discovery");
+    let listen = probe.local_addr().expect("probe addr").to_string();
+    drop(probe);
+
+    let proxy = MySqlProxy::new(
+        &backend.url(),
+        &listen,
+        None,
+        test_pool_config(),
+        reset_strategy,
+        vec![],
+        RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+    )
+    .await
+    .expect("build MySqlProxy against mock backend");
+
+    tokio::spawn(async move {
+        if let Err(e) = proxy.run().await {
+            eprintln!("mock proxy stopped: {e}");
+        }
+    });
+
+    for _ in 0..100 {
+        if TcpStream::connect(&listen).await.is_ok() {
+            return listen;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("proxy never became ready at {listen}");
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// The field probe, ported verbatim: 20 sequential connect / query /
+/// disconnect cycles at ordinary pacing. v0.6.0 scored `ok=2 failed=18` with
+/// the first failure at request #3 and no recovery.
+#[tokio::test(flavor = "multi_thread")]
+async fn twenty_sequential_sessions_all_succeed() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Smart).await;
+
+    let mut ok = 0usize;
+    let mut failures = Vec::new();
+    for i in 1..=20 {
+        match client_session(&proxy).await {
+            Ok(_) => ok += 1,
+            Err(e) => failures.push(format!("#{i}: {e}")),
+        }
+    }
+
+    assert_eq!(ok, 20, "expected 20/20 sessions to succeed; failures: {failures:?}");
+    assert_eq!(
+        backend.quits.load(Ordering::SeqCst),
+        0,
+        "COM_QUIT must never be relayed to a pooled backend"
+    );
+}
+
+/// Same probe under the other two reset strategies. `Never` is the one that
+/// poisons permanently — it recycles without a reset, so nothing on the return
+/// path ever notices the socket is dead.
+#[tokio::test(flavor = "multi_thread")]
+async fn twenty_sequential_sessions_all_succeed_for_every_reset_strategy() {
+    for strategy in [ResetStrategy::Never, ResetStrategy::Always] {
+        let backend = start_mock_backend().await;
+        let proxy = start_proxy(&backend, strategy).await;
+
+        for i in 1..=20 {
+            let result = client_session(&proxy).await;
+            assert!(result.is_ok(), "session #{i} failed under {strategy:?}: {result:?}");
+        }
+        assert_eq!(
+            backend.quits.load(Ordering::SeqCst),
+            0,
+            "COM_QUIT reached the backend under {strategy:?}"
+        );
+    }
+}
+
+/// The backend connection must survive the client's disconnect and be handed
+/// to the next request. Proven two ways: the backend accepted exactly one TCP
+/// connection, and every session was served by the same connection id.
+#[tokio::test(flavor = "multi_thread")]
+async fn com_quit_is_not_forwarded_and_the_backend_is_reused() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Smart).await;
+
+    let first = client_session(&proxy).await.expect("first session");
+    let mut served_by = vec![first];
+    for _ in 0..19 {
+        served_by.push(client_session(&proxy).await.expect("subsequent session"));
+    }
+
+    assert!(
+        served_by.iter().all(|id| *id == first),
+        "every session should reuse one pooled backend, got ids {served_by:?}"
+    );
+    assert_eq!(
+        backend.connects.load(Ordering::SeqCst),
+        1,
+        "the pool should have dialled the backend exactly once for 20 client sessions"
+    );
+    assert_eq!(backend.quits.load(Ordering::SeqCst), 0, "COM_QUIT was relayed to the backend");
+}
+
+/// A backend that dies while its connection sits idle must be detected at
+/// checkout, not handed to the caller. The idle gap here exceeds the pool's
+/// validation threshold, so the ping runs and the pool dials fresh.
+#[tokio::test(flavor = "multi_thread")]
+async fn dead_idle_connection_is_replaced_at_checkout() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Smart).await;
+
+    let first = client_session(&proxy).await.expect("first session");
+    backend.kill_live_connections();
+    // Longer than the pool's checkout-validation threshold (500ms) and far
+    // shorter than health_check_interval, so only the checkout ping can save
+    // this request.
+    tokio::time::sleep(Duration::from_millis(750)).await;
+
+    let second = client_session(&proxy)
+        .await
+        .expect("session after the backend died must succeed on a fresh dial");
+    assert_ne!(first, second, "expected a freshly dialled backend connection");
+    assert!(backend.connects.load(Ordering::SeqCst) >= 2, "the pool never re-dialled");
+}
+
+/// A backend that dies inside the validation window cannot be caught by the
+/// ping — the relay itself has to notice. What must never happen is the dead
+/// socket going *back* into the pool, which is what made the original failure
+/// permanent rather than transient.
+#[tokio::test(flavor = "multi_thread")]
+async fn broken_backend_is_discarded_not_reparked() {
+    let backend = start_mock_backend().await;
+    let proxy = start_proxy(&backend, ResetStrategy::Never).await;
+
+    client_session(&proxy).await.expect("first session");
+    backend.kill_live_connections();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // This request draws the dead socket. Whether it succeeds is not the
+    // point — nothing can be promised about a connection the peer closed a
+    // moment ago.
+    let _ = client_session(&proxy).await;
+
+    // Recovery must be immediate and permanent. Under the original code the
+    // corpse was recycled on the error path, so every request from here on
+    // failed until the 30s background reaper ran.
+    for i in 1..=5 {
+        let result = client_session(&proxy).await;
+        assert!(result.is_ok(), "recovery session #{i} failed: {result:?} — corpse was re-parked");
+    }
+}


### PR DESCRIPTION
## The finding

With `[db.mysql]` in its shipped default shape (`reset_strategy = "smart"`, pooling on), the MySQL proxy serves a handful of requests and then every subsequent PHP request fails with `SQLSTATE[HY000] [2006] MySQL server has gone away`, permanently. Decisive field probe on v0.6.0 (`min_connections = 4`, sequential requests at ordinary pacing):

```
20 READS  (clean sessions)   ok=2   failed=18   first failure at request #3
20 WRITES (dirty sessions)   ok=0   failed=20   first failure at request #1
20 READS  again              ok=0   failed=20   first failure at request #1
```

Two successes, then permanent failure. The number of successes tracked `min_connections` — the pool's warm connections were consumed, and everything after that drew a corpse. Reproduced against **both** an in-process-style litewire backend and a real `mysql:8`, so it is a property of `ephpm-db`, not of any one backend.

**PHP does not know the proxy pools anything.** That is the whole bug in one sentence. At the end of every request PDO destroys its handle and mysqlnd sends `COM_QUIT` — a request to close *this connection*, which is exactly right for the client-facing socket and catastrophic for a backend shared across sessions.

## Three links

1. **`proxy_bidirectional_sniff` relayed `COM_QUIT` to the backend.** The command byte was excluded from the *dirty* classification only (`COM_QUIT | 0x0E => false`); the packet was still written through to `bw`. The backend closed.

2. **The dead socket was parked as healthy.** A clean (SELECT-only) session took `checkout.return_to_pool(backend)` — no reset, no liveness check. `Pool::acquire` checked `max_lifetime` and `idle_timeout` but never pinged; liveness was only tested by the background `health_check` timer (30s by default). The next request was handed the corpse.

3. **The error path re-parked it.** The relay then failed with `BrokenPipe`/`ConnectionReset`, which the sniffer mapped to `Ok((backend, dirty))` — a success. So the dead socket went back into the pool. `checkout.retire()` was never reached and the poison sustained itself.

Corroborating detail from the field logs: `pool reset failed, discarding connection: I/O error: early eof` appeared for *dirty* sessions (`COM_RESET_CONNECTION` against an already-closed socket), which is why writes partially self-healed while clean reads did not. `proxy session error` never appeared at all, confirming the `Ok(..)` arm rather than the retire path. The failing request produced no log output at any level, including DEBUG.

## Why nobody noticed: the quiet-site inversion

The failure disappears under saturating load and appears at ordinary pacing. A connection returned and immediately re-acquired has no time to be observed as closed; a connection that sits idle for a moment does. So a busy site looks healthy, a quiet site is broken, and a load test is the least likely thing to catch it.

It also nearly became a published performance headline. The proxy benchmark matrix reported `D-mysql-proxy-pool  db  c=1  876 RPS` — which would have read as "connection pooling is 2.9x faster than no proxy at all". Response accounting says otherwise: `876.6 RPS  0x200  13150x[500]`. Every one of those responses was an HTTP 500. Serving an error is cheap. `oha` itself reported `Success rate: 100.00%` for those cells, because it counts transport success, not HTTP status.

## The fix, all three layers

**1. Session termination is intercepted, never forwarded.** `COM_QUIT` ends the relay loop and is dropped on the floor; the backend never learns the client went away and is recycled alive under the configured `reset_strategy`. All three strategies now use the packet-framed relay — seeing `COM_QUIT` requires packet boundaries, so there is no correct byte-copy variant for a *pooled* backend. (`Never` and `Always` previously used a raw `tokio::io::copy` splice, which is why they were affected too.)

**2. `Pool::acquire` validates before handing out.** An idle connection parked longer than `VALIDATE_AFTER_IDLE` (500ms) is pinged — `COM_PING` on MySQL, `SELECT 1` on PG, via the pool's existing `ping` closure — and discarded if it fails, falling through to the next candidate or a fresh dial. Under sustained load nothing crosses the threshold, so the hot path is unchanged; a quiet site — the exact shape that exposes dead idle connections — always pays the ~50–100µs. No new config knob; the threshold is a documented constant.

**3. Backend failures discard, never re-park.** The relay now reports which *side* ended the session rather than returning a `Result` whose error kinds were ambiguous — both a vanished client and a closed backend produce `BrokenPipe`, so the kind alone could never have decided this. Backend EOF and backend I/O errors yield `backend: None`, so the re-park path is gone *by construction* rather than by convention. Both routing loops now discard explicitly on relay failure instead of relying on `Drop`, and every `return_to_pool` / `Ok((backend, ..))` site was audited.

## PostgreSQL audit verdict: same bug, partly masked

The original finding noted the PG proxy "takes a different path entirely" and was unaffected. That is true of the default `Smart` simple-query path, and not true in general. `Terminate` (`'X'`) reached the backend on two paths:

- **`reset_strategy = "never"` fast path** — plain bidirectional relay, no reset on the return path to accidentally notice the socket was dead. This poisoned permanently, identically to MySQL.
- **The pinned session** — `pg_relay_pinned_session`, which every extended-query client lands on after its first `Parse`. That is **every real `PDO_pgsql` client**. Under `Smart` this was masked rather than absent: `DISCARD ALL` failed against the just-closed socket, so the connection was discarded and the pool self-healed by burning a connection per request. The symptom was cost, not failure — which is why it never surfaced as an outage.

Both are fixed the same way, and the PG regression tests cover both paths.

## Tests

New: `crates/ephpm-db/tests/pool_quit_poisoning.rs` (5), `crates/ephpm-db/tests/pg_terminate_poisoning.rs` (5), plus 3 pool-level tests in `pool_lifecycle.rs`. All run against in-process mock MySQL/PG servers that close on `COM_QUIT` / `Terminate` exactly as real ones do — no container, ordinary CI.

- The field probe ported verbatim: 20 sequential connect/query/disconnect cycles, asserting 20/20, for MySQL and PG and all three reset strategies.
- `COM_QUIT` / `Terminate` not forwarded: asserted two ways — the backend accepted exactly **1** TCP connection for 20 client sessions, and every session reported the same backend connection id.
- Checkout validation: kill the backend, wait past the 500ms threshold, next request succeeds on a fresh dial with a different connection id.
- Error path: kill the backend *inside* the validation window so only the relay can catch it, then assert the next five sessions all succeed — under the old code the corpse was recycled and every request failed until the 30s reaper ran.
- PG extended-protocol (`Parse`/`Bind`/`Execute`/`Sync`) session, the `PDO_pgsql` shape, asserting one reused backend across 20 requests.

**Negative control.** Reverting the fix reproduces the field failure. With all three layers reverted to v0.6.0 semantics (forward `COM_QUIT`, exclude it from the dirty flag, map backend EOF back to "reusable", disable checkout validation):

```
expected 20/20 sessions to succeed; failures: ["#2: query: Broken pipe", ... "#20: query: Broken pipe"]
  left: 1
 right: 20
```

**ok=1, failed=19, first failure at request #2, permanent** — the field shape exactly. (The field probe scored ok=2 because it ran with 4 warm connections; this harness seeds 1.) Restoring the fix returns all 10 protocol tests to green. Reverting only the `COM_QUIT`/`Terminate` interception, leaving the other two layers in, fails 8 of the 10 — so each layer is load-bearing and none is redundant.

One thing the negative control caught that is worth recording: reverting *only* the dirty-flag exclusion made the probe pass, because a `COM_QUIT`-marked-dirty session runs `COM_RESET_CONNECTION`, fails, and discards. That is the same accident that made writes self-heal in the field while clean reads did not.

## Verification

`cargo test -p ephpm-db` (103 run, 14 ignored — the pre-existing `MYSQL_TEST_URL` / `PG_TEST_URL` integration tests) and `cargo test -p ephpm-server` (264) both green, run twice with identical results. `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo +nightly fmt --all -- --check` clean.

## Docs

No doc changes needed — `site/content/architecture/database/db-proxy.md` already described the intended behaviour (`COM_QUIT` → "Close frontend connection, return backend to pool", and "the frontend connection and backend connection have independent lifecycles"). The code had diverged from the docs, not the other way round.
