### PR TITLE
v0.6.1: sqld write admission control (write_permits), litewire pin bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2589,7 +2589,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "anyhow",
  "futures",
@@ -2607,10 +2607,11 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "litewire-translate",
  "parking_lot",
  "reqwest",
  "rusqlite",
@@ -2624,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2639,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2653,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "async-trait",
  "futures",
@@ -2668,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2681,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2693,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=d1c0b3413061#d1c0b34130616d2d14925c29a558eeb6e3bac8ae"
+source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3574,7 +3575,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3611,7 +3612,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,18 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ d1c0b341 — SQLite backend performance (litewire#15): a
+# litewire main @ 62636c4c — write admission control for the Hrana/sqld backend
+# (litewire#16): an opt-in write-permit semaphore (`HranaClient::write_permits`,
+# 0 = unlimited = default) that queues excess writers instead of letting sqld
+# collapse, wired to [db.sqlite.sqld] write_permits in the clustered path only.
+# Reads never take a permit; an explicit transaction holds its permit from its
+# first write until COMMIT. Fixes the clustered-SQLite write collapse (#217),
+# where c>=8 concurrent writers completed *zero* requests — a hang, not a 500,
+# so it was invisible to error-rate monitoring. Same PR closes a CI blind spot:
+# `backend-hrana-client` is not a default feature, so litewire CI had never
+# compiled hrana_client.rs at all and its unit tests had stopped compiling.
+#
+# On top of SQLite backend performance (litewire#15): a
 # per-session worker thread replaces per-statement spawn_blocking, an opt-in
 # handle-reuse pool (`RusqliteBuilder::handle_reuse`, enabled by ephpm's
 # single-node path — see spawn_single_node_litewire), and a `max_connections`
@@ -108,7 +119,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 # sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
 # DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
 # applies it at every extraction site.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "d1c0b3413061", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "62636c4c2ba8", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -901,11 +901,57 @@ pub struct SqldConfig {
     /// gRPC listen address for inter-node replication.
     #[serde(default = "default_sqld_grpc_listen")]
     pub grpc_listen: String,
+
+    /// Maximum **writes** litewire will have in flight against sqld at
+    /// once.
+    ///
+    /// Default `0` (off) in v0.6.x; planned default `1` in v0.7.0 — a
+    /// single permit already saturates sqld's single writer and prevents
+    /// the c>=8 write collapse (issue #217). `0` means unlimited, which is
+    /// the behavior of every prior release.
+    ///
+    /// SQLite has exactly one writer. Handing sqld more concurrent writes
+    /// than it can absorb makes it queue them so badly that requests stop
+    /// completing at all: past roughly four concurrent writers throughput
+    /// *collapses* rather than plateauing, and it does so by **hanging**,
+    /// not by erroring — the measured sweep produced zero HTTP 500s while
+    /// completing zero requests. Setting this admits `n` writes at a time
+    /// and parks the rest in a FIFO queue, so the excess waits locally
+    /// instead of thrashing inside sqld.
+    ///
+    /// Only the **clustered** SQLite path reads this — it configures
+    /// litewire's Hrana backend, which exists only when sqld is the store.
+    /// Single-node SQLite (in-process rusqlite) and the MySQL DB proxy are
+    /// unaffected, deliberately: they do not have sqld's queueing problem
+    /// and capping them would only lose throughput.
+    ///
+    /// Reads are never capped. Writes are never refused, only queued —
+    /// a queued write fails only if it waits longer than litewire's
+    /// 30-second acquire timeout, which surfaces as a retriable
+    /// `SQLITE_BUSY`.
+    ///
+    /// A workload dominated by multi-statement *explicit* transactions
+    /// wants `1` for a second, independent reason: a transaction holds its
+    /// permit from its first write to `COMMIT`, so anything above `1` lets
+    /// two transactions contend inside sqld again.
+    ///
+    /// Measured: `1` sustains ~598 RPS at c=16 where `0` completes *zero*
+    /// requests, and `8` sits above the cliff and reproduces the collapse.
+    /// One permit already saturates sqld's writer (~1.67 ms per serialized
+    /// write, the same per-write cost a single-client run shows), so higher
+    /// values cannot raise the ceiling. Full data and reasoning:
+    /// <https://ephpm.dev/benchmarking/findings/#from-zero-to-a-plateau-write-admission-for-sqld>
+    #[serde(default)]
+    pub write_permits: usize,
 }
 
 impl Default for SqldConfig {
     fn default() -> Self {
-        Self { http_listen: default_sqld_http_listen(), grpc_listen: default_sqld_grpc_listen() }
+        Self {
+            http_listen: default_sqld_http_listen(),
+            grpc_listen: default_sqld_grpc_listen(),
+            write_permits: 0,
+        }
     }
 }
 
@@ -3884,6 +3930,11 @@ path = "app.db"
         );
         assert_eq!(sqlite.sqld.http_listen, "127.0.0.1:8081");
         assert_eq!(sqlite.sqld.grpc_listen, "0.0.0.0:5001");
+        assert_eq!(
+            sqlite.sqld.write_permits, 0,
+            "write_permits must default to 0 (unlimited) when [db.sqlite.sqld] is absent — \
+             a surprise write cap would throttle every clustered deployment on upgrade"
+        );
         assert_eq!(sqlite.replication.role, "auto");
         assert!(sqlite.replication.primary_grpc_url.is_empty());
         assert_eq!(sqlite.engine, "sqlite", "engine must default to the genuine SQLite C engine");
@@ -3965,8 +4016,37 @@ primary_grpc_url = "http://10.0.1.2:5001"
         assert_eq!(sqlite.proxy.hrana_listen.as_deref(), Some("0.0.0.0:8080"));
         assert_eq!(sqlite.sqld.http_listen, "127.0.0.1:9081");
         assert_eq!(sqlite.sqld.grpc_listen, "0.0.0.0:6001");
+        assert_eq!(
+            sqlite.sqld.write_permits, 0,
+            "an explicit [db.sqlite.sqld] section that omits write_permits must still default \
+             to unlimited"
+        );
         assert_eq!(sqlite.replication.role, "replica");
         assert_eq!(sqlite.replication.primary_grpc_url, "http://10.0.1.2:5001");
+    }
+
+    #[test]
+    fn test_sqld_write_permits_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[db.sqlite]
+path = "/var/lib/ephpm/app.db"
+
+[db.sqlite.sqld]
+write_permits = 4
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let sqlite = config.db.sqlite.expect("sqlite should be present");
+        assert_eq!(sqlite.sqld.write_permits, 4);
+        // Setting one key in the section must not disturb the others.
+        assert_eq!(sqlite.sqld.http_listen, "127.0.0.1:8081");
+        assert_eq!(sqlite.sqld.grpc_listen, "0.0.0.0:5001");
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1690,7 +1690,20 @@ async fn start_clustered_sqlite(
     }
 
     // Create Hrana client backend pointing at local sqld, wrapped with stats tracking.
-    let backend = litewire::backend::HranaClient::new(&sqld_http_url);
+    //
+    // Write admission control is scoped to this backend on purpose. sqld is
+    // the only store here with a single write lock behind an HTTP round trip,
+    // and it is the only one that collapses under concurrent writes rather
+    // than plateauing. Applying the same cap to the in-process rusqlite
+    // backend or the MySQL proxy would cost throughput and buy nothing.
+    let mut backend = litewire::backend::HranaClient::new(&sqld_http_url);
+    if sqlite_config.sqld.write_permits > 0 {
+        backend = backend.write_permits(sqlite_config.sqld.write_permits);
+        tracing::info!(
+            write_permits = sqlite_config.sqld.write_permits,
+            "sqld write admission control enabled (reads uncapped; excess writes queue)"
+        );
+    }
     let tracked = tracked_backend::TrackedBackend::new(backend, query_stats.clone());
 
     // Start litewire with the tracked backend.

--- a/site/content/benchmarking/findings.md
+++ b/site/content/benchmarking/findings.md
@@ -164,6 +164,175 @@ reveals the ceiling above c=4 — and a read-only benchmark would never
 have found it at all, because on a primary a `SELECT` never touches
 replication.
 
+## From zero to a plateau: write admission for sqld
+
+The section above ends at a diagnosis. This one is what came of it, and
+the short version is that the fix was a semaphore in the right place —
+but finding the right place, and the right *size*, took the measurement
+apart in ways worth writing down. Shipped in v0.6.1 as
+`[db.sqlite.sqld] write_permits` ([ephpm#217](https://github.com/ephpm/ephpm/issues/217),
+litewire side at [litewire#16](https://github.com/ephpm/litewire/pull/16)).
+
+### The failure is a hang, and that is the whole problem
+
+Re-measured for v0.6.1 across a five-value permit sweep — twenty cells,
+two reps each, two independent cluster bring-ups — there were **zero
+HTTP 500s**. Not "few". None, anywhere in the matrix.
+
+Every cell that completed anything reported `Success rate: 100.00%`.
+Every cell that failed reported an *empty* status-code distribution,
+`NaN` percentiles, and all N clients "aborted due to deadline". The
+server never answers, so it never gets to answer wrongly.
+
+This is the observation that reframes the bug. An error-rate dashboard
+sees a clean 100% success rate while the database serves no one. A
+throughput dashboard sees `1.07 RPS` — a small number, not obviously a
+different *kind* of number from `600`. Only a completed-request count
+distinguishes "slow" from "dead", which is why every table in this
+section carries one.
+
+The earlier v0.6.0 pass caught the same behaviour at c=16 ("zero requests
+completed — all sixteen connections hung"). What the wider sweep shows is
+that this is the *normal* failure mode past the cliff, not the extreme
+tail of it.
+
+### Why the cap belongs at the Hrana backend and nowhere else
+
+The obvious temptation is a global write limiter in ePHPm. The data says
+that would be a mistake: **sqld is the only path with this problem, and
+every other path is actively rewarded by write concurrency.**
+
+| write path (write.php, RPS) | c=1 | c=16 | shape |
+|---|---|---|---|
+| Single-node SQLite (in-process rusqlite) | 648 | **1130** | scales up |
+| Turso engine, single-node | 666 | **1120** | scales up |
+| CDC-native cluster | 558 | **876** | scales up |
+| **Clustered sqld** | 458 | **collapse** | falls off a cliff |
+
+Three of the four *gain* 1.6–1.7× from c=1 to c=16. A cap sized to rescue
+the fourth would take that back from all of them for nothing — none of
+them has a single lock behind an HTTP round trip, which is the specific
+shape that makes sqld fragile.
+
+So the permit lives in litewire's **Hrana backend**, the one component
+that exists only when sqld is the store. Single-node SQLite, the Turso
+engine, CDC replication and the MySQL proxy never see it. That is not
+caution; it is the measurement telling you where the boundary is.
+
+### The sweep
+
+2 nodes, `--cpus 1` each, `write.php` (one autocommit INSERT per
+request), 15 s cells, 2 reps, 2 independent bring-ups, replication
+verified before every measurement. Ranges span all reps and runs.
+
+| `write_permits` | c=1 | c=4 | c=8 | c=16 |
+|---|---|---|---|---|
+| **0** (off — v0.6.0 behaviour) | 442–455 | 118–552 *erratic* | **0 completed** | **0 completed** |
+| **1** | 415–445 | 561–595 | 527–593 | **551–598** |
+| 2 | 443–445 | 497–532 | 520–573 | 565–574 |
+| 4 | 410–442 | 171–228 | 531–534 | 494–517 |
+| 8 | 444–451 | 232–266 | **0 completed** | **0 completed** |
+
+Reads (`db.php`, c=16) measured **229–240 RPS across every row**,
+baseline included. Reads never take a permit — WAL lets readers run
+alongside the writer, so admitting them would throttle traffic that was
+never the problem.
+
+A note on the `0` row versus the c=8 = 453 RPS in the table above: these
+are different sessions, and per [how to read these](/benchmarking/results/#how-to-read-these)
+absolute numbers do not transfer between them. The *shape* reproduced
+exactly — healthy at c=1, erratic at c=4, dead past it. The c=4 cell is
+worth calling out as an unstable knee rather than an operating point: the
+baseline measured 118 and 552 RPS on successive reps of the same cell. A
+single c=4 number from the unpatched path means nothing.
+
+### Why 1, and why 8 is as bad as off
+
+Two results in that table do the work.
+
+**The cliff sits between 4 and 8 concurrent writes reaching sqld.**
+`write_permits = 8` is *above* it, so it admits enough writers to
+reproduce the collapse exactly — same zero completions as no cap at all.
+A permit count only helps if it is below the threshold of the resource it
+protects, and here the useful range turns out to be narrow. The value is
+not a free dial where more is safer.
+
+**One permit already saturates the engine.** At c=16, `permits = 1`
+sustains ~598 writes/s, which is **~1.67 ms per serialized write**. The
+c=1 lane — a single client, no contention, nothing to queue behind —
+costs ~2.2 ms per request end to end, of which the write is the same
+~1.7 ms. The queue is *full*: sqld is doing back-to-back writes with no
+idle gap, and the semaphore is feeding it exactly as fast as it can
+swallow.
+
+That is why the ordering is monotone — **1 > 2 > 4 >> 8**. Additional
+permits cannot raise a ceiling set by a single writer; SQLite serializes
+regardless. All they can do is move contention from litewire's orderly
+FIFO queue into sqld's lock, which is the thing that degrades badly. The
+correct size for a semaphore in front of a single-writer engine is one.
+
+### What the permit has to know about transactions
+
+The subtle part is not the semaphore, it is deciding when to let go of
+it. An explicit transaction holds SQLite's write lock from its first
+write until `COMMIT`, so its permit must live exactly that long.
+
+Three cases were wrong in the dangerous direction before tests found
+them:
+
+- **`COMMIT` must never acquire.** If committing needed a permit, then
+  every permit being held by a transaction waiting to commit is a
+  deadlock. `COMMIT` only releases — and it carries the permit *across*
+  its own round trip rather than dropping it on entry, because sqld holds
+  the write lock until the commit lands.
+- **`END` is SQLite's synonym for `COMMIT`**, and litewire's statement
+  classifier had no entry for it. Treated as an ordinary statement, a
+  session that wrote inside `BEGIN … END` parked a permit and never gave
+  it back — a slow leak that ends with every write blocked forever. A
+  test caught it; review had not.
+- **`ROLLBACK TO savepoint` does not end a transaction.** It reads like a
+  rollback and classifies like one, but the transaction — and the write
+  lock — continue. Releasing there hands the permit to another writer
+  while the first still holds the lock.
+
+Acquisition is **lazy**, which falls out of the same reasoning: a plain
+`BEGIN` is deferred, and SQLite takes no write lock until the first
+write, so a read-only transaction takes no permit at all. That matters
+more than it sounds — wrapping reads in a transaction is something ORMs
+do constantly, and an eager implementation would have spent the whole
+permit budget on transactions that never write.
+
+### The honest bound
+
+This converts a collapse into a plateau. It does not make clustered sqld
+fast:
+
+| write path, c=16 | RPS |
+|---|---|
+| Single-node SQLite (rusqlite) | ~1130 |
+| Turso engine, single-node | ~1120 |
+| CDC-native cluster | ~876 |
+| **Clustered sqld, `write_permits = 1`** | **~598** |
+| Clustered sqld, default (`0`) | **0 completed** |
+
+Roughly half the single-node ceiling, and that gap is not tuning debt —
+it is one writer plus an HTTP round trip per statement. No permit count
+moves it, because the arithmetic above shows the writer is already
+saturated at one.
+
+The structural answer is a different replication design, not a better
+semaphore: [CDC-native clustering](/roadmap/turso-engine/) sustains ~876
+RPS at c=16 on the same fixture because it does not funnel writes through
+a single remote lock at all. Admission control makes the shipping
+clustered path **dependable**; v0.7 is where it gets fast.
+
+**Lesson:** when a system collapses instead of plateauing, the fix is
+usually to stop offering it work it cannot take, not to make the work
+cheaper — and the correct amount to offer is a property of the resource,
+which means it has to be measured rather than guessed. Sized by
+intuition, this knob would have been set to the CPU count and would have
+done nothing at all.
+
 ## Lazily-created tables make "absent" look like "broken"
 
 The same v0.6.0 pass found a cold-start defect in CDC replication worth

--- a/site/content/benchmarking/results.md
+++ b/site/content/benchmarking/results.md
@@ -228,6 +228,106 @@ a lane that failed it was discarded rather than reported.
   Tracked as a post-v0.6.0 follow-up — the backend-layer saving is real
   and measured, its delivery through the wire path is not yet.
 
+## v0.6.1 — the clustered-sqld write collapse, fixed
+
+v0.6.0's matrix found one outlier: **clustered SQLite via sqld collapsed
+under concurrent writes** while every other path scaled up. v0.6.1 adds
+`[db.sqlite.sqld] write_permits`, an opt-in cap on writes in flight
+against sqld. Full arc in
+[From zero to a plateau](/benchmarking/findings/#from-zero-to-a-plateau-write-admission-for-sqld);
+issue [ephpm#217](https://github.com/ephpm/ephpm/issues/217).
+
+**Provenance:** ePHPm `bab470e` (+ this change), litewire `62636c4c`. Lane C of
+the db matrix: 2 nodes, `--cpus 1` each, `write.php` (one autocommit
+INSERT per request), 15 s cells, 2 reps, 2 independent cluster bring-ups
+plus a same-binary confirmation run, replication verified before every
+measurement.
+
+### The failure was a hang, not an error
+
+Across the entire matrix there were **zero 5xx**. Completed cells were
+100% success; failed cells have an *empty* status-code distribution,
+`NaN` percentiles, and every client timing out. A dashboard watching RPS
+or error rate reads a total wedge as a small number — which is why the
+tables below report completed responses, not only throughput.
+
+### write.php throughput (RPS)
+
+| `write_permits` | c=1 | c=4 | c=8 | c=16 |
+|---|---|---|---|---|
+| **0** (default, = v0.6.0) | 442–455 | 118–552 *erratic* | **0 completed** | **0 completed** |
+| **1** (recommended) | 415–445 | 561–595 | 527–593 | **551–598** |
+| 2 | 443–445 | 497–532 | 520–573 | 565–574 |
+| 4 | 410–442 | 171–228 | 531–534 | 494–517 |
+| 8 | 444–451 | 232–266 | **0 completed** | **0 completed** |
+
+**Reads are unaffected:** `db.php` at c=16 measured 229–240 RPS across
+*every* setting including baseline. Reads never take a permit — WAL lets
+them run alongside the writer.
+
+### Config-only A/B: same binary, knob off vs on
+
+The sweep above changes the binary between the baseline row and the rest.
+This pass does not — one image, two config files — which isolates the
+knob from every other v0.6.1 change:
+
+| `write.php` c=16, one binary | RPS | completed in 15 s | 5xx | hangs |
+|---|---|---|---|---|
+| knob absent (default `0`) | 1.07 | **0** | 0 | all 16 |
+| `write_permits = 1` | **594–598** | **8,901–8,956** | 0 | none |
+
+p50 15.8 ms, p99 ~68 ms at `write_permits = 1`. With the knob absent the
+v0.6.1 binary reproduces the v0.6.0 collapse exactly — which is the
+evidence that the default of `0` is genuinely inert.
+
+### Why the recommended value is 1, not "as many as possible"
+
+- **The cliff sits between 4 and 8 concurrent writes reaching sqld.**
+  `write_permits = 8` is *above* it and reproduces the collapse exactly.
+  A permit count only helps if it is below the threshold of the resource
+  it protects.
+- **One permit already saturates the single writer.** 598 writes/s is
+  ~1.67 ms per serialized write — the same per-write cost the c=1 lane
+  shows. Higher values cannot raise the ceiling because SQLite
+  serializes regardless; they only move contention from litewire's FIFO
+  queue into sqld's lock. Monotone: 1 > 2 > 4 >> 8.
+
+### What this does not fix
+
+Admission control converts a **collapse into a plateau**. It does not
+make clustered sqld competitive:
+
+| Path (write.php, c=16) | RPS |
+|---|---|
+| Single-node SQLite (rusqlite) | ~1130 |
+| Turso engine, single-node | ~1120 |
+| CDC-native cluster | ~876 |
+| **Clustered sqld, `write_permits = 1`** | **~598** |
+| Clustered sqld, default (`0`) | **0 completed** |
+
+The remaining gap is single-writer physics plus an HTTP round trip per
+statement. Roughly half the single-node ceiling is the realistic target
+for this architecture, and no admission tuning moves it —
+[CDC-native clustering](/roadmap/turso-engine/) is the structural answer.
+
+### Caveats
+
+- **The default is `0` in v0.6.x**, so a *default* clustered deployment
+  still wedges at c≥8. Set `write_permits = 1` if you run clustered
+  SQLite under write load. The default is planned to become `1` in
+  v0.7.0.
+- **`c=4` is an unstable knee**, not a stable operating point. The
+  baseline measured 118 and 552 RPS on successive reps of the same cell.
+  Treat any single c=4 number from the unpatched path as meaningless.
+- **Autocommit workload.** One INSERT per request. A workload dominated
+  by multi-statement *explicit* transactions behaves differently: a
+  transaction holds its permit from first write to `COMMIT`, so values
+  above `1` let two transactions contend inside sqld again — `1` is
+  correct there for a second, independent reason.
+- Per methodology, `--cpus 1` and podman/WSL RTT ceilings mean the
+  absolute RPS does not transfer to a real cluster. The **deltas** —
+  "0 completed → ~598" and "8 is as bad as off" — are the durable claim.
+
 ## How to read these
 
 - **Absolute numbers are environment-specific.** The db.php p50 was

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -244,6 +244,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 |-----|------|---------|-------------|
 | `http_listen` | string | `"127.0.0.1:8081"` | sqld HTTP listener (litewire → sqld). |
 | `grpc_listen` | string | `"0.0.0.0:5001"` | sqld gRPC listener (inter-node replication). |
+| `write_permits` | integer | `0` (unlimited) | Maximum writes in flight against sqld at once. **Default 0 (off) in v0.6.x; planned default 1 in v0.7.0 — a single permit already saturates sqld's single writer and prevents the c>=8 write collapse ([issue #217](https://github.com/ephpm/ephpm/issues/217)).** SQLite has one writer; past ~4 concurrent writers sqld queues them so badly that requests stop completing altogether. Setting this admits `n` writes and queues the rest FIFO — never refused, only delayed (a queued write fails only after litewire's 30s acquire timeout, as a retriable `SQLITE_BUSY`). Reads are never capped. Clustered SQLite only: single-node SQLite and the MySQL proxy ignore it. Values above `1` do not raise throughput (SQLite serializes writes regardless) and `8` reproduces the collapse; `1` is also required for workloads dominated by multi-statement explicit transactions, since a transaction holds its permit until `COMMIT`. Full measurements and reasoning: [From zero to a plateau](/benchmarking/findings/#from-zero-to-a-plateau-write-admission-for-sqld) and the [v0.6.1 results](/benchmarking/results/#v061--the-clustered-sqld-write-collapse-fixed). |
 
 #### `[db.sqlite.replication]` (clustered mode only)
 


### PR DESCRIPTION
Fixes the clustered-SQLite write collapse (#217) with an opt-in write cap,
and bumps the litewire pin to pick up the mechanism.

Mechanism: ephpm/litewire#16 (merged as `62636c4c`; this PR pins it).

## The problem

SQLite allows one writer. litewire talks to sqld over HTTP, so every write is
a round trip contending for that single lock. Past roughly four concurrent
writers sqld queues them so badly that requests **stop completing at all**.

Every other database path scales *up* with write concurrency — single-node
rusqlite 648→1130 RPS (c=1→c=16), turso 666→1120, CDC cluster 558→876. sqld
was the outlier.

**The failure is a hang, not an error.** There were **zero 5xx** anywhere in
the matrix. Completed cells were `Success rate: 100.00%`; failed cells have an
empty status-code distribution and every client timing out. A dashboard
watching error rate sees nothing wrong while the database serves no one. This
is why the numbers below report completed-response counts, not just RPS.

## Measured

2 nodes, `--cpus 1` each, `write.php` (one autocommit INSERT per request),
15 s cells, 2 reps, **2 independent cluster bring-ups**, plus a same-binary
confirmation run. Replication verified before every measurement.

**write.php throughput (RPS):**

| `write_permits` | c=1 | c=4 | c=8 | c=16 |
|---|---|---|---|---|
| **0 (default — unchanged behaviour)** | 442–455 | 118–552 *erratic* | **0 completed** | **0 completed** |
| **1 (recommended)** | 415–445 | 561–595 | 527–593 | **551–598** |
| 2 | 443–445 | 497–532 | 520–573 | 565–574 |
| 4 | 410–442 | 171–228 | 531–534 | 494–517 |
| 8 | 444–451 | 232–266 | **0 completed** | **0 completed** |

**Reads (`db.php`, c=16):** 229–240 RPS across *every* setting including
baseline — unaffected. Reads never take a permit: WAL lets them run alongside
the writer, so throttling them would slow traffic that was never the problem.

Cleanest control — **same binary, config-only difference**: knob absent
collapses at c≥8 (0 completed); `write_permits = 1` sustains 594–598 RPS at
c=16 with 8,901–8,956 completed responses, zero 5xx, zero hangs.

### Why the recommended value is 1

**The cliff is between 4 and 8 concurrent writes**, so `permits = 8` sits
above it and reproduces the collapse exactly. A permit count only helps if it
is below the threshold of the thing it protects.

**`permits = 1` is the optimum, not a compromise.** 598 writes/s is ~1.7 ms
per serialized write — the same per-write cost the c=1 lane shows. A single
permit already saturates sqld's one writer. Higher values cannot raise the
ceiling because SQLite serializes regardless; they only add lock thrash below
it. Monotone: **1 > 2 > 4 >> 8**.

### The honest bound

This converts a collapse into a plateau at **roughly half** the throughput of
the other backends (~598 vs ~1130 single-node rusqlite). It does **not** make
clustered sqld competitive — the ceiling is single-writer physics plus an HTTP
round trip per statement. "Fixed" means "no longer falls over".

## Default policy

**The default stays `0` (off) in v0.6.x** so upgrading changes nothing, and is
**planned to become `1` in v0.7.0**. Both the config doc comment and the
reference table state that explicitly — a knob whose default is known to be
wrong should say so where an operator will actually read it.

Worth being clear about the implication: with the default at `0`, a *default*
clustered deployment still wedges at c≥8 in v0.6.x. Operators running
clustered SQLite under write load should set `1` now.

## Scope

Wired **only** into the clustered path, where litewire uses the Hrana backend.
Single-node SQLite (in-process rusqlite) and the MySQL proxy do not have
sqld's queueing problem, and capping them would cost throughput for nothing.

Startup logs `write_permits` at INFO when set. That line is load-bearing
beyond observability: `ephpm-config` has no `deny_unknown_fields`, so a binary
without the knob silently ignores it — the benchmark harness gates on this log
to prove a "patched" lane is not quietly a baseline lane.

## Tests

- Default-value assertion for **section absent** and for **section present but
  key omitted** (the serde section-default trap that bit `[server.security]`).
- Parse test for an explicit value that also asserts the sibling keys in the
  section are undisturbed.
- Config tests with `--test-threads=1`, server lib tests, CDC suites with
  `EPHPM_CLUSTER_INTEG=1`, clippy `-D warnings`, nightly fmt.

## Compatibility

Additive only. New optional key, default `0` = today's behaviour. No existing
key, default, or code path changes. Downgrade-safe: older binaries ignore the
key (no `deny_unknown_fields`).

Refs #217
