### PR TITLE
feat(db): record query stats from the MySQL and PostgreSQL proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "base64ct",
  "bytes",
  "ephpm-config",
+ "ephpm-query-stats",
  "hmac 0.12.1",
  "md5 0.8.0",
  "mysql_async",

--- a/crates/ephpm-db/Cargo.toml
+++ b/crates/ephpm-db/Cargo.toml
@@ -9,6 +9,7 @@ description = "SQL proxy and connection pooling for ePHPm"
 
 [dependencies]
 ephpm-config = { workspace = true }
+ephpm-query-stats = { workspace = true }
 tokio = { workspace = true }
 bytes = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ephpm-db/src/lib.rs
+++ b/crates/ephpm-db/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod mysql;
 pub mod pool;
 pub mod postgres;
+mod stats;
 pub mod url;
 
 /// Strategy for resetting backend connections when returning to the pool.

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
+use ephpm_query_stats::QueryStats;
 use sha1::{Digest as _, Sha1};
 use sha2::Sha256;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -44,6 +45,7 @@ use tracing::{debug, info, warn};
 use crate::ResetStrategy;
 use crate::error::DbError;
 use crate::pool::{Checkout, Pool, PoolConfig};
+use crate::stats::{PendingStatement, ResponseOutcome, SpliceWatch};
 use crate::url::DbUrl;
 
 // ── Capability flags ──────────────────────────────────────────────────────────
@@ -81,6 +83,17 @@ enum PoolTarget {
     Primary,
     /// Index into the replica pool slice, assigned by round-robin.
     Replica(usize),
+}
+
+/// Per-connection record of a statement the client prepared.
+#[derive(Clone, Debug)]
+struct PreparedStmt {
+    /// Pool the statement was compiled on; execute/close must follow it.
+    target: PoolTarget,
+    /// SQL text seen in `COM_STMT_PREPARE`, retained only when query stats
+    /// are enabled so `COM_STMT_EXECUTE` can be attributed to a digest.
+    /// `None` means "not tracking" — never "unknown statement".
+    sql: Option<String>,
 }
 
 // ── Read-write split & sticky routing ─────────────────────────────────────────
@@ -124,6 +137,10 @@ pub struct MySqlProxy {
     _socket: Option<std::path::PathBuf>,
     reset_strategy: ResetStrategy,
     rw_split: RwSplitParams,
+    /// Shared per-process query stats. Recording is gated on
+    /// [`QueryStats::is_enabled`] so `[db.analysis] query_stats = false`
+    /// leaves the forwarding paths byte-for-byte as they were.
+    stats: QueryStats,
 }
 
 impl MySqlProxy {
@@ -141,6 +158,7 @@ impl MySqlProxy {
         reset_strategy: ResetStrategy,
         replica_urls: Vec<String>,
         rw_split: RwSplitParams,
+        stats: QueryStats,
     ) -> Result<Self, DbError> {
         let db_url = Arc::new(DbUrl::parse(url)?);
 
@@ -228,7 +246,17 @@ impl MySqlProxy {
             _socket: socket,
             reset_strategy,
             rw_split,
+            stats,
         })
+    }
+
+    /// The stats handle, or `None` when recording is switched off.
+    ///
+    /// Every tap point takes this shape so that a disabled collector skips
+    /// clock reads and SQL copies entirely rather than relying on
+    /// `QueryStats::record` to discard them.
+    fn stats(&self) -> Option<&QueryStats> {
+        self.stats.is_enabled().then_some(&self.stats)
     }
 
     /// Start the background pool maintenance task.
@@ -302,6 +330,7 @@ impl MySqlProxy {
                 &self.replica_rr,
                 &self.rw_split,
                 self.reset_strategy,
+                self.stats(),
             )
             .await;
         }
@@ -313,7 +342,10 @@ impl MySqlProxy {
         let mut checkout = self.pool.acquire().await?;
         let backend = checkout.take_stream();
 
-        let outcome = proxy_bidirectional_sniff(client, backend).await;
+        // Because every strategy now takes the packet-aware relay, query
+        // stats see this path regardless of `reset_strategy` — there is no
+        // longer an opaque byte-copy variant that hides statements.
+        let outcome = proxy_bidirectional_sniff(client, backend, self.stats()).await;
 
         match outcome.backend {
             Some(backend) => match self.reset_strategy {
@@ -1030,9 +1062,27 @@ struct SessionOutcome {
 /// on to catch a desynchronised connection either — the ping is skipped inside
 /// the validation window, and a leftover `OK` packet is indistinguishable from
 /// a `COM_PING` reply.
+///
+/// ## Query stats
+///
+/// When `stats` is `Some`, each forwarded `COM_QUERY` is remembered and
+/// recorded once its response has completed. Completion is inferred from the
+/// arrival of the *next* client command, which the MySQL protocol guarantees
+/// cannot happen until the previous response has been fully received — see
+/// [`SpliceWatch`] for the full argument and for why prepared-statement
+/// executes are out of reach here.
+///
+/// Every session-ending path settles the trailing statement before returning:
+/// an intercepted `COM_QUIT` is itself "the next command" and so carries the
+/// same completion proof, and a client that just closes its socket is caught
+/// by the read-failure exits. All four settle points go through
+/// [`flush_pending`] — missing one silently drops the last statement of a
+/// connection, which for short-lived PHP sessions is a large share of all
+/// traffic. When `stats` is `None` the only cost is a `None` check per read.
 async fn proxy_bidirectional_sniff(
     mut client: TcpStream,
     mut backend: TcpStream,
+    stats: Option<&QueryStats>,
 ) -> SessionOutcome {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1040,24 +1090,40 @@ async fn proxy_bidirectional_sniff(
     let dirty = Arc::new(AtomicBool::new(false));
     let dirty_w = Arc::clone(&dirty);
 
+    let recorder = stats.map(|s| (s, Arc::new(SpliceWatch::new())));
+    let watch_r = recorder.as_ref().map(|(_, w)| Arc::clone(w));
+
     let end = {
         let (mut cr, mut cw) = client.split();
         let (mut br, mut bw) = backend.split();
 
         let client_to_backend = async {
+            let mut pending: Option<PendingStatement> = None;
             loop {
                 let mut header = [0u8; 4];
                 // Any read failure here is a client-side event: EOF, reset, or
                 // a half-written packet. None of them say anything about the
-                // backend.
+                // backend. The session is over, so settle the trailing
+                // statement rather than dropping it — a client that closes
+                // without COM_QUIT still had its last response forwarded.
                 if cr.read_exact(&mut header).await.is_err() {
+                    flush_pending(recorder.as_ref(), &mut pending);
                     return SessionEnd::Client;
                 }
                 let len = u32::from_le_bytes([header[0], header[1], header[2], 0]) as usize;
                 let mut payload = vec![0u8; len];
                 if cr.read_exact(&mut payload).await.is_err() {
+                    flush_pending(recorder.as_ref(), &mut pending);
                     return SessionEnd::Client;
                 }
+
+                // A new command proves the previous response completed. This
+                // must stay ahead of the COM_QUIT interception below: QUIT is
+                // itself "the next command", so it carries the same proof and
+                // is what settles the last statement of an orderly PHP
+                // session — the common clean end, and therefore the one that
+                // matters most for stats completeness.
+                flush_pending(recorder.as_ref(), &mut pending);
 
                 if let Some(&cmd) = payload.first() {
                     // Session termination: swallow it. Forwarding this is the
@@ -1079,9 +1145,20 @@ async fn proxy_bidirectional_sniff(
                     }
                 }
 
+                // Arm before the command hits the wire: the response cannot
+                // arrive before the write, so the reader half can never see
+                // a chunk for a statement that has not been armed yet.
+                let armed = recorder.as_ref().and_then(|(_, w)| {
+                    recordable_sql(&payload).map(|sql| {
+                        w.arm();
+                        PendingStatement { sql: sql.to_string(), sent_ns: w.now_ns() }
+                    })
+                });
+
                 if bw.write_all(&header).await.is_err() || bw.write_all(&payload).await.is_err() {
                     return SessionEnd::Backend;
                 }
+                pending = armed;
             }
         };
 
@@ -1090,6 +1167,13 @@ async fn proxy_bidirectional_sniff(
             loop {
                 match br.read(&mut buf).await {
                     Ok(n) if n > 0 => {
+                        // Date the response bytes so the client half can
+                        // settle the statement they belong to. One clock read
+                        // per read syscall — per buffer, not per packet or
+                        // row — and only when stats are on.
+                        if let Some(watch) = watch_r.as_deref() {
+                            watch.note_backend_chunk(&buf[..n]);
+                        }
                         if cw.write_all(&buf[..n]).await.is_err() {
                             return SessionEnd::Client;
                         }
@@ -1126,6 +1210,42 @@ async fn proxy_bidirectional_sniff(
     SessionOutcome {
         backend: reusable.then_some(backend),
         dirty: dirty.load(std::sync::atomic::Ordering::Relaxed),
+    }
+}
+
+/// The SQL text a forwarded command should be attributed to, if any.
+///
+/// Only `COM_QUERY` qualifies. Two deliberate exclusions:
+///
+/// - `COM_STMT_PREPARE` carries SQL, but preparing is a metadata round trip
+///   rather than an execution. Recording it under the statement's digest
+///   would publish parse latency as query latency. `TrackedBackend` makes
+///   the same call for litewire's `describe_columns`.
+/// - `COM_STMT_EXECUTE` is an execution, but carries only a statement ID.
+///   Mapping it back to SQL requires having parsed the *prepare response*,
+///   which only the R/W-split routing loop does; the splice path never
+///   reads the backend→client direction. See [`crate::stats`].
+fn recordable_sql(payload: &[u8]) -> Option<&str> {
+    if payload.first() != Some(&COM_QUERY) {
+        return None;
+    }
+    std::str::from_utf8(&payload[1..]).ok().filter(|sql| !sql.trim().is_empty())
+}
+
+/// Settle a pending statement, if there is one and stats are on.
+///
+/// Called at every point that constitutes proof the previous response
+/// completed: the arrival of the next client command — which includes the
+/// intercepted `COM_QUIT` that ends a normal PHP session — and both
+/// client-side read failures that end a session without one. Missing any of
+/// them silently drops the last statement of a connection, which for
+/// short-lived PHP sessions is a large share of all traffic.
+fn flush_pending(
+    recorder: Option<&(&QueryStats, Arc<SpliceWatch>)>,
+    pending: &mut Option<PendingStatement>,
+) {
+    if let (Some((stats, watch)), Some(statement)) = (recorder, pending.take()) {
+        watch.flush(stats, &statement);
     }
 }
 
@@ -1306,17 +1426,27 @@ fn decode_lenenc_int(buf: &[u8]) -> Option<(u64, usize)> {
 /// not set `CLIENT_DEPRECATE_EOF` (0x0100_0000), every result set we see
 /// from real MySQL servers uses the two-EOF layout — we don't have to handle
 /// the deprecated-EOF row terminator.
+///
+/// The returned [`ResponseOutcome`] is assembled purely from bytes this
+/// function already had to look at: the `OK_Packet`'s length-encoded
+/// affected-row count, the presence of an `ERR_Packet`, or the number of
+/// row packets in a result set. Nothing is estimated.
 async fn forward_mysql_response(
     backend: &mut TcpStream,
     client: &mut TcpStream,
-) -> Result<(), DbError> {
+) -> Result<ResponseOutcome, DbError> {
     let (seq, payload) = read_packet(backend).await?;
     write_packet(client, seq, &payload).await?;
 
     // Single-packet responses.
     match payload.first().copied() {
-        Some(0x00 | 0xFF) => return Ok(()),
-        Some(0xFE) if payload.len() < 9 => return Ok(()),
+        Some(0x00) => {
+            // OK_Packet: [0x00][affected_rows: lenenc][last_insert_id: lenenc]…
+            let affected = decode_lenenc_int(&payload[1..]).map_or(0, |(v, _)| v);
+            return Ok(ResponseOutcome { ok: true, rows: affected });
+        }
+        Some(0xFF) => return Ok(ResponseOutcome { ok: false, rows: 0 }),
+        Some(0xFE) if payload.len() < 9 => return Ok(ResponseOutcome::ok_unknown_rows()),
         Some(0xFB) => {
             return Err(DbError::Protocol(
                 "LOCAL INFILE response not supported by smart-reset proxy path".into(),
@@ -1339,7 +1469,7 @@ async fn forward_mysql_response(
     write_packet(client, s, &p).await?;
     if p.first() == Some(&0xFF) {
         // ERR_Packet here (e.g. cursor open failed) — no rows follow.
-        return Ok(());
+        return Ok(ResponseOutcome { ok: false, rows: 0 });
     }
     if !(p.first() == Some(&0xFE) && p.len() < 9) {
         return Err(DbError::Protocol(
@@ -1348,13 +1478,17 @@ async fn forward_mysql_response(
     }
 
     // Row packets until the terminating EOF or ERR.
+    let mut rows = 0u64;
     loop {
         let (s, p) = read_packet(backend).await?;
         write_packet(client, s, &p).await?;
         match p.first().copied() {
-            Some(0xFE) if p.len() < 9 => return Ok(()), // terminating EOF
-            Some(0xFF) => return Ok(()),                // ERR mid-stream
-            _ => {}                                     // another row
+            // Terminating EOF.
+            Some(0xFE) if p.len() < 9 => return Ok(ResponseOutcome { ok: true, rows }),
+            // ERR mid-stream: the rows already forwarded are real, but the
+            // statement did not complete successfully.
+            Some(0xFF) => return Ok(ResponseOutcome { ok: false, rows }),
+            _ => rows += 1,
         }
     }
 }
@@ -1487,7 +1621,7 @@ fn route_command<'a>(
     replica_pools: &'a [Pool],
     state: &ClientState,
     rw_split: &RwSplitParams,
-    stmt_pool_map: &HashMap<u32, PoolTarget>,
+    stmt_pool_map: &HashMap<u32, PreparedStmt>,
     replica_rr: &AtomicUsize,
 ) -> (&'a Pool, QueryKind) {
     if !rw_split.enabled || replica_pools.is_empty() {
@@ -1503,18 +1637,37 @@ fn route_command<'a>(
         }
         COM_STMT_EXECUTE | COM_STMT_SEND_LONG_DATA | COM_STMT_FETCH => {
             let target = parse_stmt_id(payload)
-                .and_then(|id| stmt_pool_map.get(&id).copied())
+                .and_then(|id| stmt_pool_map.get(&id).map(|s| s.target))
                 .map_or(pool, |pt| resolve_pool_target(pt, pool, replica_pools));
             let kind = if std::ptr::eq(target, pool) { QueryKind::Write } else { QueryKind::Read };
             (target, kind)
         }
         COM_STMT_CLOSE | COM_STMT_RESET => {
             let target = parse_stmt_id(payload)
-                .and_then(|id| stmt_pool_map.get(&id).copied())
+                .and_then(|id| stmt_pool_map.get(&id).map(|s| s.target))
                 .map_or(pool, |pt| resolve_pool_target(pt, pool, replica_pools));
             (target, QueryKind::Read)
         }
         _ => (pool, QueryKind::Write),
+    }
+}
+
+/// SQL to attribute a routing-loop command to, if any.
+///
+/// Extends [`recordable_sql`] with `COM_STMT_EXECUTE`: this path parsed the
+/// prepare response, so it holds the statement ID → SQL mapping the splice
+/// path lacks. `COM_STMT_PREPARE` is still excluded on purpose — see
+/// [`recordable_sql`] for why.
+fn routing_recordable_sql<'a>(
+    payload: &'a [u8],
+    stmt_pool_map: &'a HashMap<u32, PreparedStmt>,
+) -> Option<&'a str> {
+    match payload.first().copied() {
+        Some(COM_QUERY) => recordable_sql(payload),
+        Some(COM_STMT_EXECUTE) => parse_stmt_id(payload)
+            .and_then(|id| stmt_pool_map.get(&id))
+            .and_then(|stmt| stmt.sql.as_deref()),
+        _ => None,
     }
 }
 
@@ -1546,10 +1699,17 @@ fn track_dirty(state: &mut ClientState, payload: &[u8], query_kind: QueryKind) {
     }
 }
 
+/// What relaying one client command produced.
+struct RelayResult {
+    /// The prepared-statement id, when the command was a `COM_STMT_PREPARE`
+    /// the backend accepted.
+    prepared: Option<u32>,
+    /// What the response said, when the command had one the proxy framed.
+    /// `None` for prepare and close — neither is a recordable execution.
+    response: Option<ResponseOutcome>,
+}
+
 /// Forward one client command to `backend` and relay the response.
-///
-/// Returns the prepared-statement id when `payload` was a `COM_STMT_PREPARE`
-/// the backend accepted, `None` otherwise.
 ///
 /// # Errors
 ///
@@ -1562,13 +1722,19 @@ async fn relay_one_command(
     client: &mut TcpStream,
     seq: u8,
     payload: &[u8],
-) -> Result<Option<u32>, DbError> {
+) -> Result<RelayResult, DbError> {
     write_packet(backend, seq, payload).await?;
     match payload[0] {
-        COM_STMT_PREPARE => forward_prepare_response(backend, client).await,
+        COM_STMT_PREPARE => Ok(RelayResult {
+            prepared: forward_prepare_response(backend, client).await?,
+            response: None,
+        }),
         // COM_STMT_CLOSE is fire-and-forget — the server sends no response.
-        COM_STMT_CLOSE => Ok(None),
-        _ => forward_mysql_response(backend, client).await.map(|()| None),
+        COM_STMT_CLOSE => Ok(RelayResult { prepared: None, response: None }),
+        _ => Ok(RelayResult {
+            prepared: None,
+            response: Some(forward_mysql_response(backend, client).await?),
+        }),
     }
 }
 
@@ -1579,6 +1745,17 @@ async fn relay_one_command(
 /// read/write-aware routing. Statement IDs are tracked per-connection so that
 /// execute/close/reset/fetch commands are routed to the same pool that
 /// compiled the statement.
+///
+/// # Query stats
+///
+/// This path frames both directions, so recording is exact: the clock runs
+/// from just before the command is written to the backend until
+/// [`forward_mysql_response`] has consumed the last packet of its response,
+/// and success plus row counts come out of that response. Because the
+/// prepare response is parsed here, the SQL captured at
+/// `COM_STMT_PREPARE` time is retained per connection and used to attribute
+/// each `COM_STMT_EXECUTE` — coverage the single-backend splice path cannot
+/// match.
 async fn proxy_routing_loop(
     mut client: TcpStream,
     pool: &Pool,
@@ -1586,11 +1763,13 @@ async fn proxy_routing_loop(
     replica_rr: &AtomicUsize,
     rw_split: &RwSplitParams,
     reset_strategy: crate::ResetStrategy,
+    recorder: Option<&QueryStats>,
 ) -> Result<(), DbError> {
     let mut state = ClientState::default();
-    // Maps statement IDs to the pool type they were prepared on, so that
-    // COM_STMT_EXECUTE and friends route to the correct backend.
-    let mut stmt_pool_map: HashMap<u32, PoolTarget> = HashMap::new();
+    // Maps statement IDs to the pool they were prepared on (so that
+    // COM_STMT_EXECUTE and friends route to the correct backend) and, when
+    // stats are on, to the SQL they were compiled from.
+    let mut stmt_pool_map: HashMap<u32, PreparedStmt> = HashMap::new();
 
     loop {
         let Ok((seq, payload)) = read_packet(&mut client).await else {
@@ -1627,8 +1806,9 @@ async fn proxy_routing_loop(
         // A relay failure means this backend is no longer in a known protocol
         // state. Discard it explicitly — never let it fall through to a
         // `return_to_pool` below.
-        let prepared = match relay_one_command(&mut backend, &mut client, seq, &payload).await {
-            Ok(prepared) => prepared,
+        let started = recorder.map(|_| std::time::Instant::now());
+        let relayed = match relay_one_command(&mut backend, &mut client, seq, &payload).await {
+            Ok(relayed) => relayed,
             Err(e) => {
                 debug!("backend relay failed, discarding connection: {e}");
                 checkout.retire();
@@ -1645,8 +1825,13 @@ async fn proxy_routing_loop(
                     replica_pools.iter().position(|r| std::ptr::eq(target_pool, r)).unwrap_or(0);
                 PoolTarget::Replica(idx)
             };
-            if let Some(stmt_id) = prepared {
-                stmt_pool_map.insert(stmt_id, pool_target);
+            // Retain the prepared SQL only when it will be used: it is what
+            // lets a later COM_STMT_EXECUTE be attributed to a digest.
+            let sql = recorder
+                .and_then(|_| std::str::from_utf8(payload.get(1..).unwrap_or_default()).ok())
+                .map(ToString::to_string);
+            if let Some(stmt_id) = relayed.prepared {
+                stmt_pool_map.insert(stmt_id, PreparedStmt { target: pool_target, sql });
                 debug!(stmt_id, ?pool_target, "prepared statement registered");
             }
         } else if cmd == COM_STMT_CLOSE {
@@ -1654,6 +1839,18 @@ async fn proxy_routing_loop(
                 if let Some(removed) = stmt_pool_map.remove(&stmt_id) {
                     debug!(stmt_id, ?removed, "prepared statement closed");
                 }
+            }
+        }
+
+        // Record after the statement-id map is up to date, so a
+        // COM_STMT_EXECUTE resolves against the SQL its prepare registered.
+        // `relayed.response` is `None` for prepare and close, neither of
+        // which is a recordable execution.
+        if let (Some(collector), Some(started), Some(outcome)) =
+            (recorder, started, relayed.response)
+        {
+            if let Some(sql) = routing_recordable_sql(&payload, &stmt_pool_map) {
+                collector.record(sql, started.elapsed(), outcome.ok, outcome.rows);
             }
         }
 
@@ -1687,7 +1884,10 @@ async fn proxy_routing_loop(
 
 /// Build a [`Pool`] for `MySQL`.
 ///
-/// Exported so `lib.rs` can construct `MySqlProxy` from config.
+/// Exported so `lib.rs` can construct `MySqlProxy` from config. `stats` is
+/// the process-wide collector shared with the litewire paths; pass one built
+/// with `enabled: false` (i.e. `[db.analysis] query_stats = false`) to leave
+/// the forwarding paths uninstrumented.
 ///
 /// # Errors
 ///
@@ -1701,8 +1901,10 @@ pub async fn build_proxy(
     reset_strategy: ResetStrategy,
     replica_urls: Vec<String>,
     rw_split: RwSplitParams,
+    stats: QueryStats,
 ) -> Result<MySqlProxy, DbError> {
-    MySqlProxy::new(url, listen, socket, pool_config, reset_strategy, replica_urls, rw_split).await
+    MySqlProxy::new(url, listen, socket, pool_config, reset_strategy, replica_urls, rw_split, stats)
+        .await
 }
 
 #[cfg(test)]
@@ -1912,21 +2114,21 @@ mod tests {
 
     #[test]
     fn stmt_pool_map_tracks_prepare_to_execute() {
-        let mut map: HashMap<u32, PoolTarget> = HashMap::new();
+        let mut map: HashMap<u32, PreparedStmt> = HashMap::new();
 
         // Simulate: SELECT prepared on replica 0.
-        map.insert(1, PoolTarget::Replica(0));
+        map.insert(1, PreparedStmt { target: PoolTarget::Replica(0), sql: None });
         // Simulate: INSERT prepared on primary.
-        map.insert(2, PoolTarget::Primary);
+        map.insert(2, PreparedStmt { target: PoolTarget::Primary, sql: None });
 
-        assert_eq!(map.get(&1).copied(), Some(PoolTarget::Replica(0)));
-        assert_eq!(map.get(&2).copied(), Some(PoolTarget::Primary));
+        assert_eq!(map.get(&1).map(|s| s.target), Some(PoolTarget::Replica(0)));
+        assert_eq!(map.get(&2).map(|s| s.target), Some(PoolTarget::Primary));
 
         // Close statement 1.
         map.remove(&1);
-        assert_eq!(map.get(&1), None);
+        assert!(!map.contains_key(&1));
         // Statement 2 still tracked.
-        assert_eq!(map.get(&2).copied(), Some(PoolTarget::Primary));
+        assert_eq!(map.get(&2).map(|s| s.target), Some(PoolTarget::Primary));
     }
 
     // ── forward_prepare_response (via mock TCP pair) ─────────────────
@@ -2002,7 +2204,7 @@ mod tests {
         write_packet(&mut backend_write, 6, &[0xFE, 0, 0, 0x02, 0]).await.unwrap();
         drop(backend_write);
 
-        forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
         drop(client_write);
 
         let mut seqs = Vec::new();
@@ -2010,6 +2212,8 @@ mod tests {
             seqs.push(s);
         }
         assert_eq!(seqs, vec![1, 2, 3, 4, 5, 6], "all 6 packets must reach the client");
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 1, "one row packet between the two EOFs");
     }
 
     #[tokio::test]
@@ -2021,12 +2225,46 @@ mod tests {
         write_packet(&mut backend_write, 1, &[0x00, 0, 0, 0x02, 0, 0, 0]).await.unwrap();
         drop(backend_write);
 
-        forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
         drop(client_write);
 
         let (_, p) = read_packet(&mut client_read).await.unwrap();
         assert_eq!(p[0], 0x00, "OK packet forwarded once");
         assert!(read_packet(&mut client_read).await.is_err(), "no further packets");
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 0);
+    }
+
+    #[tokio::test]
+    async fn forward_mysql_response_ok_packet_reports_affected_rows() {
+        let (mut backend_write, mut backend_read) = make_tcp_pair().await;
+        let (mut client_write, _client_read) = make_tcp_pair().await;
+
+        // [0x00][affected_rows=5][last_insert_id=0][status][warnings]
+        write_packet(&mut backend_write, 1, &[0x00, 5, 0, 0x02, 0, 0, 0]).await.unwrap();
+        drop(backend_write);
+
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 5, "affected rows come out of the OK packet, not a guess");
+    }
+
+    #[tokio::test]
+    async fn forward_mysql_response_err_packet_marks_failure() {
+        let (mut backend_write, mut backend_read) = make_tcp_pair().await;
+        let (mut client_write, _client_read) = make_tcp_pair().await;
+
+        let mut err = vec![0xFF];
+        err.extend_from_slice(&1146_u16.to_le_bytes());
+        err.push(b'#');
+        err.extend_from_slice(b"42S02");
+        err.extend_from_slice(b"Table 'x' doesn't exist");
+        write_packet(&mut backend_write, 1, &err).await.unwrap();
+        drop(backend_write);
+
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        assert!(!outcome.ok);
+        assert_eq!(outcome.rows, 0);
     }
 
     #[tokio::test]
@@ -2041,7 +2279,7 @@ mod tests {
         write_packet(&mut backend_write, 4, &[0xFE, 0, 0, 0x02, 0]).await.unwrap();
         drop(backend_write);
 
-        forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
         drop(client_write);
 
         let mut seqs = Vec::new();
@@ -2049,6 +2287,232 @@ mod tests {
             seqs.push(s);
         }
         assert_eq!(seqs, vec![1, 2, 3, 4]);
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 0, "an empty result set must report zero rows");
+    }
+
+    // ── query stats: what a command is attributed to ─────────────────
+
+    /// Build a `COM_QUERY` payload.
+    fn com_query(sql: &str) -> Vec<u8> {
+        let mut p = vec![COM_QUERY];
+        p.extend_from_slice(sql.as_bytes());
+        p
+    }
+
+    /// Build a `COM_STMT_EXECUTE` payload for `stmt_id`.
+    fn com_stmt_execute(stmt_id: u32) -> Vec<u8> {
+        let mut p = vec![COM_STMT_EXECUTE];
+        p.extend_from_slice(&stmt_id.to_le_bytes());
+        p.push(0x00); // flags
+        p.extend_from_slice(&1_u32.to_le_bytes()); // iteration count
+        p
+    }
+
+    #[test]
+    fn recordable_sql_takes_com_query() {
+        let payload = com_query("SELECT * FROM users WHERE id = 1");
+        assert_eq!(recordable_sql(&payload), Some("SELECT * FROM users WHERE id = 1"));
+    }
+
+    #[test]
+    fn recordable_sql_skips_prepare_and_execute() {
+        // COM_STMT_PREPARE carries SQL but is a metadata round trip, not an
+        // execution — recording it would publish parse latency as query
+        // latency. COM_STMT_EXECUTE is an execution but carries no SQL.
+        let mut prepare = vec![COM_STMT_PREPARE];
+        prepare.extend_from_slice(b"SELECT * FROM users WHERE id = ?");
+        assert_eq!(recordable_sql(&prepare), None, "prepare must not be recorded as a query");
+        assert_eq!(recordable_sql(&com_stmt_execute(1)), None);
+    }
+
+    #[test]
+    fn recordable_sql_skips_empty_and_non_utf8() {
+        assert_eq!(recordable_sql(&com_query("   ")), None);
+        assert_eq!(recordable_sql(&[COM_QUERY, 0xFF, 0xFE]), None);
+        assert_eq!(recordable_sql(&[]), None);
+    }
+
+    #[test]
+    fn routing_loop_attributes_execute_to_the_prepared_sql() {
+        // The routing loop parses the prepare *response*, so it holds the
+        // statement ID → SQL mapping and can attribute an execute.
+        let mut map: HashMap<u32, PreparedStmt> = HashMap::new();
+        map.insert(
+            7,
+            PreparedStmt {
+                target: PoolTarget::Primary,
+                sql: Some("SELECT * FROM users WHERE id = ?".to_string()),
+            },
+        );
+
+        assert_eq!(
+            routing_recordable_sql(&com_stmt_execute(7), &map),
+            Some("SELECT * FROM users WHERE id = ?")
+        );
+        // An execute for a statement we never saw prepared stays unrecorded
+        // rather than being attributed to a made-up digest.
+        assert_eq!(routing_recordable_sql(&com_stmt_execute(8), &map), None);
+        // And with stats off no SQL was retained, so nothing is recordable.
+        map.insert(9, PreparedStmt { target: PoolTarget::Primary, sql: None });
+        assert_eq!(routing_recordable_sql(&com_stmt_execute(9), &map), None);
+    }
+
+    // ── query stats: the splice tap point ────────────────────────────
+
+    /// Write a `COM_QUERY` from the client side of the proxy.
+    async fn send_query(client: &mut TcpStream, sql: &str) {
+        write_packet(client, 0, &com_query(sql)).await.unwrap();
+    }
+
+    /// Answer one command on the fake backend with a minimal OK packet, and
+    /// wait for the client to read it back so the proxy has demonstrably
+    /// stamped the response.
+    async fn answer_ok(backend: &mut TcpStream, client: &mut TcpStream) {
+        let (_, _cmd) = read_packet(backend).await.unwrap();
+        write_packet(backend, 1, &[0x00, 0, 0, 0x02, 0, 0, 0]).await.unwrap();
+        let (_, resp) = read_packet(client).await.unwrap();
+        assert_eq!(resp[0], 0x00);
+    }
+
+    /// Drive two queries plus a disconnect through the sniffing splice path
+    /// and return the stats collector it recorded into.
+    async fn drive_sniff_session(stats: Option<QueryStats>) -> Option<QueryStats> {
+        let (mut driver, proxy_client) = make_tcp_pair().await;
+        let (proxy_backend, mut fake_backend) = make_tcp_pair().await;
+
+        let handed = stats.clone();
+        let proxy = tokio::spawn(async move {
+            proxy_bidirectional_sniff(proxy_client, proxy_backend, handed.as_ref()).await
+        });
+
+        send_query(&mut driver, "SELECT * FROM users WHERE id = 1").await;
+        answer_ok(&mut fake_backend, &mut driver).await;
+
+        // The second command is what proves the first response completed.
+        send_query(&mut driver, "SELECT * FROM users WHERE id = 2").await;
+        answer_ok(&mut fake_backend, &mut driver).await;
+
+        // Disconnect: the last statement is settled on the way out.
+        drop(driver);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy).await;
+        stats
+    }
+
+    #[tokio::test]
+    async fn splice_path_records_forwarded_queries() {
+        let stats =
+            drive_sniff_session(Some(QueryStats::new(ephpm_query_stats::StatsConfig::default())))
+                .await
+                .unwrap();
+
+        assert_eq!(stats.digest_count(), 1, "both queries share one digest after normalization");
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 2, "the trailing statement must be settled on disconnect");
+        assert_eq!(top[0].error_count, 0);
+        assert_eq!(top[0].total_rows, 0, "the splice path cannot count rows and must not guess");
+        assert!(top[0].total_time > std::time::Duration::ZERO);
+    }
+
+    /// Negative control for the `[db.analysis] query_stats = false` path: the
+    /// exact same session with no collector attached must record nothing and
+    /// still forward every byte.
+    #[tokio::test]
+    async fn splice_path_records_nothing_when_stats_are_off() {
+        // `None` is what `MySqlProxy::stats()` yields when the toggle is off.
+        assert!(drive_sniff_session(None).await.is_none());
+
+        // And a collector that is present but disabled must also stay empty —
+        // proving the toggle holds at both layers.
+        let disabled = QueryStats::new(ephpm_query_stats::StatsConfig {
+            enabled: false,
+            ..Default::default()
+        });
+        let stats = drive_sniff_session(Some(disabled)).await.unwrap();
+        assert_eq!(stats.digest_count(), 0);
+    }
+
+    /// The trailing statement of a session must still be timed when the
+    /// client ends with `COM_QUIT`, which is intercepted and never forwarded
+    /// to the pooled backend. QUIT is itself "the next command", so it
+    /// carries the same proof that the previous response completed — and it
+    /// is the *common* clean end for a PHP client, so this is the settle
+    /// point that matters most for stats completeness.
+    #[tokio::test]
+    async fn splice_path_settles_trailing_statement_on_intercepted_quit() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        let (mut driver, proxy_client) = make_tcp_pair().await;
+        let (proxy_backend, mut fake_backend) = make_tcp_pair().await;
+
+        let handed = stats.clone();
+        let proxy = tokio::spawn(async move {
+            proxy_bidirectional_sniff(proxy_client, proxy_backend, Some(&handed)).await
+        });
+
+        send_query(&mut driver, "SELECT * FROM users WHERE id = 1").await;
+        answer_ok(&mut fake_backend, &mut driver).await;
+
+        // Orderly close, exactly as mysqlnd does when PDO drops its handle.
+        write_packet(&mut driver, 0, &[COM_QUIT]).await.unwrap();
+
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), proxy)
+            .await
+            .expect("the session must end when the client sends COM_QUIT")
+            .expect("proxy task must not panic");
+        assert!(
+            outcome.backend.is_some(),
+            "an intercepted COM_QUIT must leave the pooled backend recyclable"
+        );
+
+        assert_eq!(
+            stats.digest_count(),
+            1,
+            "the statement preceding COM_QUIT must still be recorded"
+        );
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert!(top[0].total_time > std::time::Duration::ZERO);
+
+        // The backend must never have been handed the QUIT byte: nothing
+        // more arrives on it, so this read can only time out.
+        let leaked = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            read_packet(&mut fake_backend),
+        )
+        .await;
+        assert!(leaked.is_err(), "COM_QUIT must not reach the pooled backend");
+    }
+
+    /// The documented prepared-statement limitation, pinned: on the splice
+    /// path a prepare/execute pair produces no digest at all, because the
+    /// prepare is metadata and the execute cannot be mapped back to SQL.
+    #[tokio::test]
+    async fn splice_path_does_not_record_prepared_statements() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        let (mut driver, proxy_client) = make_tcp_pair().await;
+        let (proxy_backend, mut fake_backend) = make_tcp_pair().await;
+
+        let handed = stats.clone();
+        let proxy = tokio::spawn(async move {
+            proxy_bidirectional_sniff(proxy_client, proxy_backend, Some(&handed)).await
+        });
+
+        let mut prepare = vec![COM_STMT_PREPARE];
+        prepare.extend_from_slice(b"SELECT * FROM users WHERE id = ?");
+        write_packet(&mut driver, 0, &prepare).await.unwrap();
+        answer_ok(&mut fake_backend, &mut driver).await;
+
+        write_packet(&mut driver, 0, &com_stmt_execute(1)).await.unwrap();
+        answer_ok(&mut fake_backend, &mut driver).await;
+
+        drop(driver);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy).await;
+
+        assert_eq!(
+            stats.digest_count(),
+            0,
+            "prepare is metadata and execute has no SQL — neither may be recorded here"
+        );
     }
 
     // ── decode_lenenc_int ────────────────────────────────────────────

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use base64ct::Encoding;
+use ephpm_query_stats::QueryStats;
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -35,6 +36,7 @@ use tracing::{debug, info, warn};
 use crate::ResetStrategy;
 use crate::error::DbError;
 use crate::pool::{Checkout, Pool, PoolConfig};
+use crate::stats::ResponseOutcome;
 use crate::url::DbUrl;
 
 // ── PG message tags ──────────────────────────────────────────────────────────
@@ -53,6 +55,8 @@ const MSG_BACKEND_KEY_DATA: u8 = b'K';
 const MSG_READY_FOR_QUERY: u8 = b'Z';
 /// `ErrorResponse` — backend error.
 const MSG_ERROR_RESPONSE: u8 = b'E';
+/// `DataRow` — one row of a result set. Counted for query stats.
+const MSG_DATA_ROW: u8 = b'D';
 /// `Query` — frontend simple query.
 const MSG_QUERY: u8 = b'Q';
 /// `Terminate` — frontend connection close.
@@ -120,6 +124,10 @@ pub struct PgProxy {
     listen: String,
     reset_strategy: ResetStrategy,
     rw_split: PgRwSplitParams,
+    /// Shared per-process query stats. Recording is gated on
+    /// [`QueryStats::is_enabled`] so `[db.analysis] query_stats = false`
+    /// leaves the forwarding paths byte-for-byte as they were.
+    stats: QueryStats,
 }
 
 impl PgProxy {
@@ -136,6 +144,7 @@ impl PgProxy {
         reset_strategy: ResetStrategy,
         replica_urls: Vec<String>,
         rw_split: PgRwSplitParams,
+        stats: QueryStats,
     ) -> Result<Self, DbError> {
         let db_url = Arc::new(DbUrl::parse(url)?);
 
@@ -219,7 +228,16 @@ impl PgProxy {
             listen: listen.to_string(),
             reset_strategy,
             rw_split,
+            stats,
         })
+    }
+
+    /// The stats handle, or `None` when recording is switched off.
+    ///
+    /// Mirrors `MySqlProxy::stats`: a disabled collector means the routing
+    /// loop never reads the clock or copies SQL out of the wire buffer.
+    fn stats(&self) -> Option<&QueryStats> {
+        self.stats.is_enabled().then_some(&self.stats)
     }
 
     /// Start the background pool maintenance task.
@@ -291,10 +309,14 @@ impl PgProxy {
                 &self.replica_rr,
                 &self.rw_split,
                 self.reset_strategy,
+                self.stats(),
             )
             .await
         } else {
-            // Fast path: simple bidirectional copy.
+            // Fast path: simple bidirectional copy. No message framing in
+            // either direction, so no statement is ever visible here and
+            // query stats record nothing — see `stats.rs`. Only reachable
+            // with `reset_strategy = "never"`/`"always"` and no replicas.
             let mut checkout = self.pool.acquire().await?;
             let backend = checkout.take_stream();
 
@@ -1109,6 +1131,22 @@ fn pg_select_pool<'a>(
 /// In both cases the session is pinned to one backend connection and spliced
 /// straight through for the rest of its lifetime — see
 /// [`pg_relay_pinned_session`].
+///
+/// # Query stats
+///
+/// Simple `Query` messages are recorded: the clock runs from just before the
+/// message is written to the backend until the terminating `ReadyForQuery`
+/// is forwarded, `ErrorResponse` anywhere in that stream marks the statement
+/// failed, and `DataRow` messages are counted. Statements that reach the
+/// pinned-splice paths above are *not* recorded, because after the switch
+/// the proxy no longer reads message boundaries — see [`crate::stats`].
+///
+/// The row count is rows *returned*. Rows *affected* by a mutation live in
+/// the `CommandComplete` payload (`"UPDATE 3"`), which
+/// [`forward_pg_message`] streams through without buffering, so a mutation
+/// records zero rows rather than a guessed number. This is the one place
+/// the proxy's numbers are narrower than `TrackedBackend`'s, which gets
+/// `affected_rows` directly from litewire.
 async fn pg_proxy_routing_loop(
     mut client: TcpStream,
     pool: &Pool,
@@ -1116,6 +1154,7 @@ async fn pg_proxy_routing_loop(
     replica_rr: &AtomicUsize,
     rw_split: &PgRwSplitParams,
     reset_strategy: ResetStrategy,
+    recorder: Option<&QueryStats>,
 ) -> Result<(), DbError> {
     let mut state = PgClientState::default();
 
@@ -1151,11 +1190,12 @@ async fn pg_proxy_routing_loop(
             return pg_relay_pinned_session(client, backend, checkout, reset_strategy).await;
         }
 
-        // Query payload is null-terminated SQL.
-        let query_kind = {
-            let sql = String::from_utf8_lossy(&payload);
-            classify_pg_query(sql.trim_end_matches('\0'))
-        };
+        // Query payload is null-terminated SQL. Borrowed, not copied: the
+        // payload outlives the recording call at the bottom of this
+        // iteration, so instrumentation costs no allocation.
+        let sql_cow = String::from_utf8_lossy(&payload);
+        let sql = sql_cow.trim_end_matches('\0');
+        let query_kind = classify_pg_query(sql);
 
         // Update state tracking.
         match query_kind {
@@ -1174,10 +1214,13 @@ async fn pg_proxy_routing_loop(
         let mut checkout = target_pool.acquire().await?;
         let mut backend = checkout.take_stream();
 
+        let started = recorder.map(|_| std::time::Instant::now());
+
         // Any failure below leaves the backend mid-message or mid-result-set.
         // Discard it explicitly rather than letting control flow reach a
         // `return_to_pool`.
         let mut copy_mode = false;
+        let mut outcome = ResponseOutcome::ok_unknown_rows();
         let relay: Result<(), DbError> = async {
             write_pg_message(&mut backend, tag, &payload).await?;
 
@@ -1186,6 +1229,11 @@ async fn pg_proxy_routing_loop(
             // sub-protocol, in which case no further backend output is coming.
             loop {
                 let resp_tag = forward_pg_message(&mut backend, &mut client).await?;
+                match resp_tag {
+                    MSG_DATA_ROW => outcome.rows += 1,
+                    MSG_ERROR_RESPONSE => outcome.ok = false,
+                    _ => {}
+                }
                 if resp_tag == MSG_READY_FOR_QUERY {
                     return Ok(());
                 }
@@ -1203,7 +1251,14 @@ async fn pg_proxy_routing_loop(
         }
 
         if copy_mode {
+            // The statement is still in flight — its outcome belongs to the
+            // copy stream we are about to splice, so recording it now would
+            // publish a truncated duration. Left out deliberately.
             return pg_relay_pinned_session(client, backend, checkout, reset_strategy).await;
+        }
+
+        if let (Some(collector), Some(started)) = (recorder, started) {
+            collector.record(sql, started.elapsed(), outcome.ok, outcome.rows);
         }
 
         // Return backend to pool.
@@ -1267,6 +1322,10 @@ async fn pg_relay_pinned_session(
 
 /// Build a [`PgProxy`] from configuration parameters.
 ///
+/// `stats` is the process-wide collector shared with the litewire paths;
+/// pass one built with `enabled: false` (i.e. `[db.analysis] query_stats =
+/// false`) to leave the forwarding paths uninstrumented.
+///
 /// # Errors
 ///
 /// Propagates any error from [`PgProxy::new`] (backend connection or
@@ -1278,8 +1337,9 @@ pub async fn build_proxy(
     reset_strategy: ResetStrategy,
     replica_urls: Vec<String>,
     rw_split: PgRwSplitParams,
+    stats: QueryStats,
 ) -> Result<PgProxy, DbError> {
-    PgProxy::new(url, listen, pool_config, reset_strategy, replica_urls, rw_split).await
+    PgProxy::new(url, listen, pool_config, reset_strategy, replica_urls, rw_split, stats).await
 }
 
 #[cfg(test)]
@@ -1604,8 +1664,16 @@ mod tests {
         let proxy_task = tokio::spawn(async move {
             let pool = pool_dialing(backend_addr);
             let rr = AtomicUsize::new(0);
-            pg_proxy_routing_loop(proxy_side, &pool, &[], &rr, &rw_split, ResetStrategy::Smart)
-                .await
+            pg_proxy_routing_loop(
+                proxy_side,
+                &pool,
+                &[],
+                &rr,
+                &rw_split,
+                ResetStrategy::Smart,
+                None,
+            )
+            .await
         });
 
         // Parse / Bind / Describe / Execute / Sync — what PDO_pgsql sends for
@@ -1634,6 +1702,125 @@ mod tests {
         drop(client);
         proxy_task.abort();
         backend_task.abort();
+    }
+
+    // ── query stats ─────────────────────────────────────────────────
+
+    /// Fake PG backend that answers one simple `Query` with `row_count`
+    /// data rows, optionally followed by an `ErrorResponse`.
+    fn spawn_query_backend(
+        listener: tokio::net::TcpListener,
+        row_count: usize,
+        fail: bool,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            while let Ok((tag, _payload)) = read_pg_message(&mut sock).await {
+                if tag != MSG_QUERY {
+                    continue;
+                }
+                write_pg_message(&mut sock, b'T', b"\0\0").await.unwrap();
+                for _ in 0..row_count {
+                    write_pg_message(&mut sock, MSG_DATA_ROW, b"\0\0").await.unwrap();
+                }
+                if fail {
+                    let mut err = Vec::new();
+                    err.push(b'M');
+                    err.extend_from_slice(b"boom\0");
+                    err.push(0);
+                    write_pg_message(&mut sock, MSG_ERROR_RESPONSE, &err).await.unwrap();
+                } else {
+                    write_pg_message(&mut sock, b'C', b"SELECT 2\0").await.unwrap();
+                }
+                send_ready_for_query(&mut sock, b'I').await.unwrap();
+            }
+        })
+    }
+
+    /// Drive one simple `Query` through the routing loop against a fake
+    /// backend and return once `ReadyForQuery` has reached the client.
+    async fn drive_pg_query(stats: Option<QueryStats>, row_count: usize, fail: bool) {
+        let backend_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+        let backend_task = spawn_query_backend(backend_listener, row_count, fail);
+
+        let (mut client, proxy_side) = make_tcp_pair().await;
+        let rw_split =
+            PgRwSplitParams { enabled: false, sticky_duration: std::time::Duration::from_secs(1) };
+        let proxy_task = tokio::spawn(async move {
+            let pool = pool_dialing(backend_addr);
+            let rr = AtomicUsize::new(0);
+            pg_proxy_routing_loop(
+                proxy_side,
+                &pool,
+                &[],
+                &rr,
+                &rw_split,
+                // `Never` keeps the fake backend out of the DISCARD ALL path.
+                ResetStrategy::Never,
+                stats.as_ref(),
+            )
+            .await
+        });
+
+        write_pg_message(&mut client, MSG_QUERY, b"SELECT * FROM users WHERE id = 1\0")
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                let (tag, _) = read_pg_message(&mut client).await.unwrap();
+                if tag == MSG_READY_FOR_QUERY {
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("the query must complete");
+
+        drop(client);
+        proxy_task.abort();
+        backend_task.abort();
+    }
+
+    #[tokio::test]
+    async fn pg_routing_loop_records_simple_queries() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        drive_pg_query(Some(stats.clone()), 2, false).await;
+
+        assert_eq!(stats.digest_count(), 1);
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert_eq!(top[0].error_count, 0);
+        assert_eq!(top[0].total_rows, 2, "DataRow messages are counted, not estimated");
+        assert!(top[0].digest_text.contains('?'), "literals must be normalized away");
+        assert!(top[0].total_time > std::time::Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn pg_routing_loop_records_errors() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        drive_pg_query(Some(stats.clone()), 1, true).await;
+
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert_eq!(top[0].error_count, 1, "ErrorResponse in the stream marks the statement failed");
+        assert_eq!(top[0].total_rows, 1, "rows already forwarded before the error are real");
+    }
+
+    /// Negative control for `[db.analysis] query_stats = false`.
+    #[tokio::test]
+    async fn pg_routing_loop_records_nothing_when_stats_are_off() {
+        // No collector at all — what `PgProxy::stats()` yields when off.
+        drive_pg_query(None, 2, false).await;
+
+        // A present-but-disabled collector must also stay empty.
+        let disabled = QueryStats::new(ephpm_query_stats::StatsConfig {
+            enabled: false,
+            ..Default::default()
+        });
+        drive_pg_query(Some(disabled.clone()), 2, false).await;
+        assert_eq!(disabled.digest_count(), 0);
     }
 
     // ── Test helpers ─────────────────────────────────────────────────

--- a/crates/ephpm-db/src/stats.rs
+++ b/crates/ephpm-db/src/stats.rs
@@ -1,0 +1,284 @@
+//! Query-stats recording for the wire proxies.
+//!
+//! The DB proxy forwards raw wire-protocol bytes between PHP and a real
+//! MySQL/PostgreSQL server. It never materialises a `litewire` backend, so
+//! it cannot reuse `ephpm-server`'s `TrackedBackend` decorator — the only
+//! place a statement is visible is the point where the proxy already parses
+//! the client's command in order to classify it for read/write splitting.
+//! This module holds the small amount of shared machinery those tap points
+//! need, and documents how the numbers they produce differ from the ones
+//! `TrackedBackend` produces.
+//!
+//! # Timing semantics vs `TrackedBackend`
+//!
+//! `TrackedBackend` wraps an **in-process** litewire backend: the duration it
+//! records is the time spent inside SQLite (plus litewire's translation),
+//! with no network in the measurement at all.
+//!
+//! The proxy records a **wire round trip**: from the moment the client's
+//! command has been written to the pooled backend socket, to the moment the
+//! last byte of that command's response has been read back from it. That
+//! includes the network path to the database server, the server's own
+//! execution time, and result-set transfer — but *not* time the client spends
+//! thinking between statements, and *not* the time the proxy spends waiting
+//! for a pooled connection (the checkout happens before the clock starts).
+//!
+//! Both feed the same [`QueryStats`] instance and therefore the same
+//! Prometheus series. A deployment that runs the proxy and the embedded
+//! SQLite path simultaneously will see the two mixed under one metric name;
+//! that is deliberate (one metrics surface, no new label dimension), and is
+//! called out in the metrics reference.
+//!
+//! # What is *not* recorded
+//!
+//! Recording only happens on code paths where the proxy already frames the
+//! protocol. Anything it forwards as an opaque byte splice is invisible to
+//! it, and is left out rather than estimated:
+//!
+//! - MySQL `COM_STMT_EXECUTE` on the single-backend (non R/W-split) path.
+//!   That path never parses the backend→client direction, so it never sees
+//!   the statement ID that `COM_STMT_PREPARE` returned and cannot map an
+//!   execute back to SQL text.
+//! - MySQL `COM_STMT_PREPARE` itself, on every path. Preparing is a metadata
+//!   operation, not an execution; recording its round trip under the same
+//!   digest as the statement would report parse latency as query latency.
+//!   This matches `TrackedBackend`, which deliberately passes
+//!   `describe_columns` through unrecorded for the same reason.
+//! - PostgreSQL extended-query-protocol traffic (`Parse`/`Bind`/`Execute`)
+//!   and both copy sub-protocols. Those pin the session to one backend and
+//!   splice it verbatim, because message boundaries stop lining up with turn
+//!   boundaries.
+//! - Every statement on a session using `reset_strategy = "never"` or
+//!   `"always"` *without* R/W splitting, which is spliced end to end.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use ephpm_query_stats::QueryStats;
+
+/// What the proxy managed to observe about one statement's response.
+///
+/// Fields are only ever populated from bytes the proxy actually parsed; a
+/// field the wire path cannot attribute stays at its neutral value rather
+/// than being guessed.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ResponseOutcome {
+    /// `false` when the response carried a protocol-level error packet.
+    pub ok: bool,
+    /// Rows returned, or rows affected for a mutation. `0` when the path
+    /// cannot count them.
+    pub rows: u64,
+}
+
+impl ResponseOutcome {
+    /// A successful response whose row count could not be attributed.
+    pub(crate) const fn ok_unknown_rows() -> Self {
+        Self { ok: true, rows: 0 }
+    }
+}
+
+/// Cross-task observation point for the MySQL single-backend splice path.
+///
+/// That path runs two concurrent halves: a packet-framed client→backend
+/// loop (which knows the SQL and when it was forwarded) and a bulk
+/// backend→client copy (which knows when response bytes arrived, but not
+/// what they mean). This type is the only thing they share.
+///
+/// The completion rule exploits the MySQL client/server protocol being
+/// strictly synchronous: a client may not send command *N+1* until it has
+/// received the whole response to command *N*. So the arrival of the next
+/// client command proves the previous response is complete, and the most
+/// recent backend read timestamp at that moment is the timestamp of its
+/// last byte. Statements are therefore recorded one command late, and the
+/// final statement of a session is recorded when the client disconnects.
+///
+/// A client that pipelines commands (nothing in the PHP ecosystem does —
+/// neither `mysqlnd` nor `libmysqlclient` will) would have its timings
+/// mis-attributed by this rule; it cannot desynchronise the proxy itself,
+/// since no forwarding decision depends on any of this state.
+pub(crate) struct SpliceWatch {
+    /// Reference point for the nanosecond stamps below.
+    epoch: Instant,
+    /// Nanoseconds-since-`epoch` of the most recent non-empty backend read.
+    last_backend_ns: AtomicU64,
+    /// Set when a statement has been forwarded and its first response chunk
+    /// has not been inspected yet.
+    awaiting_first_chunk: AtomicBool,
+    /// Set when the first response chunk began with a MySQL `ERR_Packet`.
+    response_error: AtomicBool,
+}
+
+/// A statement forwarded to the backend whose response has not been
+/// attributed yet.
+pub(crate) struct PendingStatement {
+    /// The SQL text as sent by the client.
+    pub sql: String,
+    /// Nanoseconds-since-epoch at which the command finished being written
+    /// to the backend socket.
+    pub sent_ns: u64,
+}
+
+impl SpliceWatch {
+    /// Create a watch anchored at the current instant.
+    pub(crate) fn new() -> Self {
+        Self {
+            epoch: Instant::now(),
+            last_backend_ns: AtomicU64::new(0),
+            awaiting_first_chunk: AtomicBool::new(false),
+            response_error: AtomicBool::new(false),
+        }
+    }
+
+    /// Nanoseconds elapsed since this watch was created.
+    pub(crate) fn now_ns(&self) -> u64 {
+        u64::try_from(self.epoch.elapsed().as_nanos()).unwrap_or(u64::MAX)
+    }
+
+    /// Arm the watch for the response to a statement just forwarded.
+    pub(crate) fn arm(&self) {
+        self.response_error.store(false, Ordering::Relaxed);
+        self.awaiting_first_chunk.store(true, Ordering::Relaxed);
+    }
+
+    /// Record that `chunk` bytes just arrived from the backend.
+    ///
+    /// The first chunk after [`Self::arm`] starts at a packet boundary (the
+    /// previous response ended on one), so byte 4 is the first payload byte
+    /// of the response's first packet — `0xFF` marks a MySQL `ERR_Packet`.
+    /// A first chunk shorter than five bytes leaves the status at "ok"; a
+    /// real server writes the whole packet in one `write`, so this is a
+    /// theoretical rather than an observed case.
+    pub(crate) fn note_backend_chunk(&self, chunk: &[u8]) {
+        self.last_backend_ns.store(self.now_ns(), Ordering::Relaxed);
+        if self.awaiting_first_chunk.swap(false, Ordering::Relaxed)
+            && chunk.len() >= 5
+            && chunk[4] == 0xFF
+        {
+            self.response_error.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Resolve a pending statement against the bytes seen since it was sent.
+    ///
+    /// Returns `None` when no backend bytes have arrived since the statement
+    /// was forwarded — the response cannot be attributed, so nothing is
+    /// recorded rather than recording a fabricated duration.
+    pub(crate) fn settle(&self, pending: &PendingStatement) -> Option<(Duration, bool)> {
+        let last = self.last_backend_ns.load(Ordering::Relaxed);
+        if last <= pending.sent_ns {
+            return None;
+        }
+        let elapsed = Duration::from_nanos(last - pending.sent_ns);
+        Some((elapsed, !self.response_error.load(Ordering::Relaxed)))
+    }
+
+    /// Settle `pending` and record it into `stats` if it can be attributed.
+    pub(crate) fn flush(&self, stats: &QueryStats, pending: &PendingStatement) {
+        if let Some((elapsed, ok)) = self.settle(pending) {
+            // Row counts are unavailable on this path — see the module docs.
+            stats.record(&pending.sql, elapsed, ok, 0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ephpm_query_stats::StatsConfig;
+
+    use super::*;
+
+    fn stats() -> QueryStats {
+        QueryStats::new(StatsConfig::default())
+    }
+
+    #[test]
+    fn settle_returns_none_without_backend_bytes() {
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending = PendingStatement { sql: "SELECT 1".into(), sent_ns: watch.now_ns() };
+        assert!(
+            watch.settle(&pending).is_none(),
+            "a statement with no observed response must not be recorded"
+        );
+    }
+
+    #[test]
+    fn settle_measures_from_send_to_last_backend_byte() {
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending = PendingStatement { sql: "SELECT 1".into(), sent_ns: 0 };
+        watch.note_backend_chunk(&[0, 0, 0, 1, 0x00]);
+        let (elapsed, ok) = watch.settle(&pending).expect("response observed");
+        assert!(ok, "an OK first packet must not be counted as an error");
+        assert!(elapsed > Duration::ZERO);
+    }
+
+    #[test]
+    fn err_packet_in_first_chunk_marks_failure() {
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending = PendingStatement { sql: "SELECT bad".into(), sent_ns: 0 };
+        // [len:3][seq:1][0xFF ...] — a MySQL ERR_Packet.
+        watch.note_backend_chunk(&[0x10, 0, 0, 1, 0xFF, 0x48, 0x04]);
+        let (_, ok) = watch.settle(&pending).expect("response observed");
+        assert!(!ok, "an ERR_Packet must be recorded as an error");
+    }
+
+    #[test]
+    fn only_the_first_chunk_is_inspected_for_errors() {
+        // A row packet whose payload happens to start with 0xFF must not be
+        // mistaken for an error once the first chunk has been consumed.
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending = PendingStatement { sql: "SELECT 1".into(), sent_ns: 0 };
+        watch.note_backend_chunk(&[0x01, 0, 0, 1, 0x01]);
+        watch.note_backend_chunk(&[0x02, 0, 0, 2, 0xFF, 0xFF]);
+        let (_, ok) = watch.settle(&pending).expect("response observed");
+        assert!(ok, "later chunks must not flip the status");
+    }
+
+    #[test]
+    fn flush_records_into_stats() {
+        let stats = stats();
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending =
+            PendingStatement { sql: "SELECT * FROM users WHERE id = 7".into(), sent_ns: 0 };
+        watch.note_backend_chunk(&[0x01, 0, 0, 1, 0x01]);
+        watch.flush(&stats, &pending);
+
+        assert_eq!(stats.digest_count(), 1);
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert!(top[0].digest_text.contains('?'), "literals must be normalized away");
+        assert_eq!(top[0].total_rows, 0, "the splice path must not invent a row count");
+    }
+
+    #[test]
+    fn flush_is_a_no_op_when_the_response_was_never_seen() {
+        let stats = stats();
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending = PendingStatement { sql: "SELECT 1".into(), sent_ns: watch.now_ns() };
+        watch.flush(&stats, &pending);
+        assert_eq!(stats.digest_count(), 0);
+    }
+
+    #[test]
+    fn disabled_stats_record_nothing_through_flush() {
+        let stats = QueryStats::new(StatsConfig { enabled: false, ..Default::default() });
+        let watch = SpliceWatch::new();
+        watch.arm();
+        let pending = PendingStatement { sql: "SELECT 1".into(), sent_ns: 0 };
+        watch.note_backend_chunk(&[0x01, 0, 0, 1, 0x01]);
+        watch.flush(&stats, &pending);
+        assert_eq!(stats.digest_count(), 0, "the toggle must reach the proxy tap point");
+    }
+
+    #[test]
+    fn ok_unknown_rows_is_neutral() {
+        let outcome = ResponseOutcome::ok_unknown_rows();
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 0);
+    }
+}

--- a/crates/ephpm-db/tests/pg_proxy_integration.rs
+++ b/crates/ephpm-db/tests/pg_proxy_integration.rs
@@ -70,6 +70,9 @@ async fn start_proxy(
         reset_strategy,
         vec![],
         PgRwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        // Instrumented like production: these tests exercise the recording
+        // tap point as a side effect of every forwarded statement.
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
     )
     .await
     .expect("failed to create PgProxy — backend handshake failed");

--- a/crates/ephpm-db/tests/pg_terminate_poisoning.rs
+++ b/crates/ephpm-db/tests/pg_terminate_poisoning.rs
@@ -332,6 +332,9 @@ async fn start_proxy(backend: &MockPgBackend, reset_strategy: ResetStrategy) -> 
         reset_strategy,
         vec![],
         PgRwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        // Instrumented like production, so these pool-lifecycle tests also
+        // exercise the query-stats tap point on every relayed statement.
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
     )
     .await
     .expect("build PgProxy against mock backend");

--- a/crates/ephpm-db/tests/pool_quit_poisoning.rs
+++ b/crates/ephpm-db/tests/pool_quit_poisoning.rs
@@ -330,6 +330,9 @@ async fn start_proxy(backend: &MockBackend, reset_strategy: ResetStrategy) -> St
         reset_strategy,
         vec![],
         RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        // Instrumented like production, so these pool-lifecycle tests also
+        // exercise the query-stats tap point on every relayed command.
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
     )
     .await
     .expect("build MySqlProxy against mock backend");

--- a/crates/ephpm-db/tests/proxy_integration.rs
+++ b/crates/ephpm-db/tests/proxy_integration.rs
@@ -50,6 +50,9 @@ async fn start_proxy(
         reset_strategy,
         vec![],
         RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        // Instrumented like production: these tests exercise the recording
+        // tap points as a side effect of every forwarded statement.
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
     )
     .await
     .expect("failed to create MySqlProxy");

--- a/crates/ephpm-query-stats/src/lib.rs
+++ b/crates/ephpm-query-stats/src/lib.rs
@@ -152,6 +152,19 @@ impl QueryStats {
         }
     }
 
+    /// Whether recording is switched on (`[db.analysis] query_stats`).
+    ///
+    /// Every `record*` method already short-circuits when this is `false`,
+    /// so callers that only need the toggle honoured can ignore it. It
+    /// exists for callers that must skip *producing* the arguments as well:
+    /// the DB proxy would otherwise clone SQL text out of wire buffers and
+    /// read the clock on every forwarded command just to throw the values
+    /// away inside `record`.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
     /// Record a completed query (SELECT, SHOW, etc.).
     pub fn record_query(&self, sql: &str, duration: Duration, success: bool, rows: u64) {
         self.record_internal(sql, duration, success, rows, QueryKind::Query);
@@ -584,6 +597,15 @@ mod tests {
         stats.record("SELECT 1", Duration::from_millis(1), true, 1);
         stats.record("INSERT INTO t VALUES (1)", Duration::from_millis(1), true, 1);
         assert_eq!(stats.digest_count(), 2);
+    }
+
+    #[test]
+    fn is_enabled_reflects_config() {
+        assert!(QueryStats::new(StatsConfig::default()).is_enabled());
+        assert!(
+            !QueryStats::new(StatsConfig { enabled: false, ..Default::default() }).is_enabled(),
+            "callers gate argument construction on this — it must track the config flag"
+        );
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1323,6 +1323,9 @@ async fn start_db_proxies(
             reset_strategy,
             replica_urls,
             rw_split,
+            // Same collector the litewire paths hand to `TrackedBackend`, so
+            // proxied and embedded queries land on one metrics surface.
+            query_stats.clone(),
         )
         .await
         {
@@ -1383,6 +1386,7 @@ async fn start_db_proxies(
             reset_strategy,
             replica_urls,
             rw_split,
+            query_stats.clone(),
         )
         .await
         {

--- a/site/content/architecture/database/db-proxy.md
+++ b/site/content/architecture/database/db-proxy.md
@@ -16,7 +16,7 @@ This document covers the SQL connection pooling proxy, wire protocol implementat
 - Read/write splitting based on first-keyword query classification, with sticky-after-write routing and replica round-robin
 - Replication support (primary + replica pools via `[db.mysql.replicas]`)
 - Slow query detection and logging (`ephpm-query-stats`, `[db.analysis].slow_query_threshold`)
-- Query digest / statistics collection with Prometheus export
+- Query digest / statistics collection with Prometheus export, recorded into the same collector the embedded-SQLite paths use. The proxy can only observe statements where it already parses the wire protocol, so coverage is narrower than the embedded path — the [`[db.analysis]` coverage table](/reference/config/#dbanalysis) lists exactly what each path records, and what it deliberately does not (prepared-statement executes on the default MySQL path, PostgreSQL extended-protocol traffic, and PostgreSQL sessions using `reset_strategy = "never"`/`"always"` without replicas)
 
 **Planned / Not Yet Implemented:**
 - TDS proxying to a real SQL Server — the `[db.tds]` config is accepted, but startup logs a warning and no proxy is started (litewire's TDS frontend for embedded SQLite is separate and does work)

--- a/site/content/architecture/metrics.md
+++ b/site/content/architecture/metrics.md
@@ -54,7 +54,12 @@ EPHPM_SERVER__METRICS__PATH="/metrics"
 ### Query Stats Metrics (from `ephpm-query-stats`)
 
 Enabled when `[db.analysis] query_stats = true` (default). These metrics track
-SQL queries flowing through the DB proxy or litewire.
+SQL queries flowing through the DB proxy or litewire, sharing one collector and
+one set of label dimensions — there is no label identifying which path a sample
+came from. Note that proxy durations are wire round trips (they include network
+latency to the database server) while litewire durations are in-process, and
+that the proxy records a narrower set of statements. See the
+[`[db.analysis]` coverage table](/reference/config/#dbanalysis).
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|

--- a/site/content/architecture/query-stats.md
+++ b/site/content/architecture/query-stats.md
@@ -9,7 +9,9 @@ ePHPm has two SQL strategies (see [sql.md](sql.md)):
 - **DB Proxy** (`ephpm-db`) -- forwards MySQL wire traffic to a real MySQL server
 - **LiteWire** (`litewire`) -- translates MySQL wire traffic to SQLite
 
-Both see every query PHP executes. Neither currently records query-level metrics. Without this, operators have no visibility into slow queries, hot tables, error patterns, or query mix. They have to bolt on external tools (slow query log on MySQL, APM agents in PHP) that don't exist in the LiteWire/SQLite path at all.
+Both see every query PHP executes. Before this design landed, neither recorded query-level metrics, so operators had no visibility into slow queries, hot tables, error patterns, or query mix — they had to bolt on external tools (slow query log on MySQL, APM agents in PHP) that don't exist in the LiteWire/SQLite path at all.
+
+> **Status:** both paths now record. The LiteWire side is complete (`TrackedBackend`); the DB Proxy side records only where the proxy already parses the wire protocol, which is narrower — see the [`[db.analysis]` coverage table](/reference/config/#dbanalysis) for exactly what each path captures.
 
 ## Solution
 

--- a/site/content/guides/query-stats-prometheus.md
+++ b/site/content/guides/query-stats-prometheus.md
@@ -3,7 +3,9 @@ title = "Query Stats with Prometheus"
 weight = 7
 +++
 
-ePHPm tracks every SQL query that flows through it — to a real MySQL/Postgres backend or to embedded SQLite — and exposes per-digest timing, throughput, and error-rate as Prometheus metrics. No APM agent, no database plugin.
+ePHPm tracks the SQL that flows through it — to a real MySQL/Postgres backend or to embedded SQLite — and exposes per-digest timing, throughput, and error-rate as Prometheus metrics. No APM agent, no database plugin.
+
+Coverage is complete on the embedded-SQLite paths. On the MySQL/Postgres proxy it is limited to the statements the proxy actually parses, and the durations are wire round trips rather than in-process execution time; the [`[db.analysis]` coverage table](/reference/config/#dbanalysis) spells out exactly what each path records.
 
 ## Turn it on
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -211,7 +211,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `pool_timeout` | duration string | `"5s"` | Time to wait for a connection before failing. |
 | `health_check_interval` | duration string | `"30s"` | Frequency of backend health checks. |
 | `inject_env` | bool | `true` | Inject `DB_CONNECTION`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DATABASE_URL` into PHP. |
-| `reset_strategy` | string | `"smart"` | `"smart"` (reset after non-SELECT), `"always"`, `"never"`. |
+| `reset_strategy` | string | `"smart"` | `"smart"` (reset after non-SELECT), `"always"`, `"never"`. On PostgreSQL it also decides whether [query stats](#dbanalysis) see proxied statements — `"always"`/`"never"` without replicas take an opaque splice and record nothing. The MySQL proxy frames every session regardless, so its stats coverage does not depend on this knob. |
 | `replicas.urls` | array of strings | `[]` | Read replica URLs. Reads distributed across; writes go to primary. |
 
 > **The proxy listener is unauthenticated — keep it on loopback.**
@@ -267,12 +267,32 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `query_stats` | bool | `true` | Track per-digest timing/throughput metrics. |
+| `query_stats` | bool | `true` | Track per-digest timing/throughput metrics. Applies to the embedded SQLite paths **and** the MySQL/PostgreSQL proxies — see the coverage table below. |
 | `slow_query_threshold` | duration string | `"1s"` | Queries exceeding this are logged at WARN. |
 | `auto_explain` | bool | `false` | **Not yet implemented** — parsed but unused. |
 | `auto_explain_target` | string | `"stderr"` | **Not yet implemented**. |
 | `digest_store_max_entries` | usize | `100_000` | Max in-memory query digests; oldest evicted on overflow. |
 | `metric_label_series_max` | usize | `1000` | Max distinct `digest` label values emitted to Prometheus; overflow folds into `digest="__other__"`. `0` = unlimited. |
+
+#### What query stats cover
+
+One collector serves every database path, so proxied and embedded queries land on the same metric names with no extra label to distinguish them. What each path can *see* differs, because the proxy only observes statements at the points where it already parses the wire protocol:
+
+| Path | Statements recorded | Duration measured | Row counts |
+|------|--------------------|-------------------|------------|
+| Embedded SQLite (`[db.sqlite]`, any engine or replication mode) | All queries and mutations | In-process execution time | Rows returned / rows affected |
+| MySQL proxy, single-backend path (any reset strategy) | `COM_QUERY` only | Wire round trip: command written to the backend → last response byte read back | Not available |
+| MySQL proxy, R/W splitting enabled with replicas | `COM_QUERY` and `COM_STMT_EXECUTE` | Same wire round trip | Rows returned, or affected rows from the `OK` packet |
+| PostgreSQL proxy, `reset_strategy = "smart"` (default) or R/W splitting | Simple `Query` messages | Wire round trip: message written → `ReadyForQuery` | Rows returned (`DataRow` count); mutations record `0` |
+| PostgreSQL proxy, `reset_strategy = "never"`/`"always"` without replicas | None | — | — |
+
+Notable gaps, all deliberate:
+
+- **Proxy durations include the network.** The embedded-SQLite numbers are in-process execution time; the proxy numbers are a round trip to your database server. Comparing them directly is comparing two different things.
+- **`COM_STMT_PREPARE` is never recorded.** Preparing is a metadata round trip, not an execution — recording it under the statement's digest would publish parse latency as query latency.
+- **`COM_STMT_EXECUTE` is invisible on the default MySQL path.** Attributing an execute to its SQL requires having parsed the *prepare response*, which only the R/W-split routing loop does. Applications that turn off PDO's emulated prepares (`PDO::ATTR_EMULATE_PREPARES = false`) will therefore see little or no proxy query-stat traffic unless R/W splitting is on.
+- **PostgreSQL extended-protocol traffic is invisible.** `Parse`/`Bind`/`Execute` pin the session to one backend and splice it verbatim, because message boundaries stop lining up with turn boundaries. Same for `COPY`, and for PostgreSQL sessions using `reset_strategy = "never"`/`"always"` without replicas.
+- **Rows the proxy cannot count are reported as `0`, never estimated.**
 
 ## `[kv]`
 

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -90,6 +90,10 @@ These appear when `[db.analysis] query_stats = true` (the default).
 
 `digest` is the **normalized SQL** (literals replaced with `?`), truncated to 64 characters for label safety. Cardinality scales with distinct query *shapes*, not executions.
 
+These series are emitted by both the embedded SQLite paths and the MySQL/PostgreSQL proxies, with **no label distinguishing them** — one collector, one metrics surface. That is worth knowing when reading `ephpm_query_duration_seconds`: the embedded paths time in-process execution, while the proxies time a wire round trip to your database server (command written to the backend socket → last response byte read back), which includes network latency. If a deployment runs a proxy and the embedded engine at the same time, the two are mixed under one metric name.
+
+`ephpm_query_rows_total` is likewise narrower on the proxy paths, which report `0` where they cannot count rows rather than estimating: the default MySQL path has no row visibility at all, and the PostgreSQL path counts rows *returned* but not rows *affected* by a mutation. Statement coverage per path — including what the proxies deliberately do not record, such as prepared-statement executes and PostgreSQL extended-protocol traffic — is tabulated under [`[db.analysis]`](/reference/config/#dbanalysis) in the config reference.
+
 ## Cardinality notes
 
 The per-metric `digest` label series is **capped** — by default at 1,000 distinct label values per process (`StatsConfig::metric_label_series_max`). Every additional distinct digest observed after the cap is exhausted has its Prometheus emissions folded into a single shared `digest="__other__"` bucket. Internal tracking (`top_queries()`, the digest table, the slow-query log) is **not** affected by this cap and still exposes the real normalized SQL — only the Prometheus label surface is bounded.


### PR DESCRIPTION
# Query stats for the MySQL and PostgreSQL proxies

## Why

`ephpm-query-stats` has been wired into every litewire path since it landed — `TrackedBackend` wraps the backend at all three spawn sites in `ephpm-server` (single-node, clustered sqld, and Turso CDC). The wire proxies in `ephpm-db` were never wired in at all. A deployment running `[db.mysql]` or `[db.postgres]` got an empty `ephpm_query_*` surface, while `site/content/guides/query-stats-prometheus.md` opened with "ePHPm tracks every SQL query that flows through it — to a real MySQL/Postgres backend or to embedded SQLite".

This closes the gap, and corrects the docs that overclaimed it.

## Where the tap point is

Both proxies already extract SQL to classify statements for read/write splitting. That is where the recording goes — no new parsing was introduced on any forwarding path.

| Path | Tap point | Duration | Rows |
|---|---|---|---|
| MySQL, `reset_strategy = "smart"` (default) | `proxy_bidirectional_sniff`, which already frames client→backend | request forwarded → last response byte read back | not available |
| MySQL, R/W split enabled with replicas | `proxy_routing_loop`, framed in both directions | request written → response fully consumed | `OK` packet affected rows, or row-packet count |
| PostgreSQL, `reset_strategy = "smart"` (default) or R/W split | `pg_proxy_routing_loop` | `Query` written → `ReadyForQuery` | `DataRow` count |
| Either proxy, `never`/`always` without replicas | none — opaque splice | — | — |

### The MySQL default path needed a trick

Unlike PostgreSQL, MySQL's default path is a splice: the client→backend direction is packet-framed (for dirty-bit sniffing) but backend→client is a bulk `tokio::io::copy`. There is no point in that code where a response is known to have ended.

Converting it to a framed request/response loop was considered and rejected. `forward_mysql_response` — the framing the routing loop uses — has a documented history of hanging WordPress, does not handle `LOCAL INFILE`, and (a latent bug, see below) does not handle multi-result-set responses even though the proxy advertises `CLIENT_MULTI_RESULTS`. Adding it to the path every default deployment uses, for observability, is not a trade worth making.

Instead, `SpliceWatch` (new `crates/ephpm-db/src/stats.rs`) exploits the MySQL protocol being strictly synchronous: **a client may not send command *N+1* until it has fully received the response to command *N***. So the arrival of the next command proves the previous response is complete, and the most recent backend-read timestamp at that moment is the timestamp of its last byte. The response direction keeps its bulk copy and only takes a timestamp per read syscall. The trailing statement of a session is settled on disconnect.

The first chunk after a command starts on a packet boundary, so byte 4 is the response's first payload byte — `0xFF` gives a real error status without parsing anything else.

## The prepared-statement decision

- **`COM_STMT_PREPARE` is never recorded**, on either path. Preparing is a metadata round trip; recording it under the statement's digest would publish parse latency as query latency. This matches `TrackedBackend`, which deliberately passes litewire's `describe_columns` through unrecorded for exactly that reason.
- **`COM_STMT_EXECUTE` is recorded on the routing loop only.** That path parses the prepare *response*, so it holds the statement ID and can retain the SQL to attribute against (`PreparedStmt.sql`, populated only when stats are on). The splice path never reads backend→client and therefore never learns the statement ID.

Consequence, documented in the config reference: an app that disables PDO's emulated prepares will see little proxy query-stat traffic unless R/W splitting is on. WordPress and default-configured PDO/mysqli send `COM_QUERY` and are fully covered.

## Semantics that differ from `TrackedBackend`

Both feed the same `QueryStats` and therefore the same Prometheus series, with **no label distinguishing them**. That is deliberate — one metrics surface, and adding a `backend=` label would double cardinality and break existing dashboards — but it means the difference has to be documented rather than encoded:

- **`TrackedBackend` times in-process execution. The proxy times a wire round trip**, including network latency to the database server. Called out in `stats.rs`, `site/content/reference/metrics.md`, `site/content/architecture/metrics.md`, and the guide.
- **Rows the wire path cannot attribute are `0`, never estimated.** The MySQL splice path has no row visibility. PostgreSQL counts rows *returned*; rows *affected* live in the `CommandComplete` payload, which `forward_pg_message` streams without buffering, so a mutation records `0`.
- Pool checkout happens before the clock starts, so pool-wait time is not folded into query duration.

## Toggle

`[db.analysis] query_stats = false` reaches the proxies through the same `StatsConfig.enabled` flag `TrackedBackend` honours, surfaced by a new `QueryStats::is_enabled()`. `MySqlProxy::stats()` / `PgProxy::stats()` return `Option<&QueryStats>`, so with stats off the proxies take no clock reads, allocate no SQL copies, and the MySQL response direction falls back to plain `tokio::io::copy`. Both proxies have a negative-control test for this.

## Turso CDC: no gap found

The suspected gap in `crates/ephpm-server/src/turso_cdc.rs` does not exist. Verified by inspection:

- `turso_cdc.rs:503` — `let tracked = tracked_backend::TrackedBackend::new(wire_factory, query_stats.clone());`
- `turso_cdc.rs:504` — `spawn_litewire_serve(sqlite_config, tracked, handles);`
- `spawn_litewire_serve` (`turso_cdc.rs:1634`) is generic over `B: litewire::backend::Backend` and has exactly one caller, line 504.
- `query_stats` reaches `start_clustered_turso_cdc` from `lib.rs:1429`.
- All three `LiteWire::new` sites in the crate (`lib.rs:1565`, `lib.rs:1701`, `turso_cdc.rs:1639`) receive an already-wrapped backend.

The CDC `mgmt_factory` is intentionally *not* wrapped: it is used by the tailer and apply loop for replication bookkeeping, not for user queries, and wrapping it would pollute the digest table with CDC internals.

**No change was made to `turso_cdc.rs`.**

## Latent bug noticed, not fixed here

`forward_mysql_response` returns after the first result set's terminating EOF, but the proxy's synthetic greeting advertises `CLIENT_MULTI_STATEMENTS` and `CLIENT_MULTI_RESULTS`. A multi-result response on the R/W-split routing loop would leave the follow-on result sets buffered and desync the connection. Pre-existing, unrelated to this PR, and worth its own issue.

## Tests

- `crates/ephpm-db/src/stats.rs` — 8 unit tests on `SpliceWatch` settle/arm/error-detection semantics, including "no response observed → record nothing" and the disabled-collector control.
- `crates/ephpm-db/src/mysql.rs` — attribution unit tests (`recordable_sql`, `routing_recordable_sql`), three end-to-end splice-path tests over real TCP pairs (records two queries under one digest; **negative control**: records nothing with no collector *and* with a disabled collector; prepare+execute records nothing), plus `ResponseOutcome` assertions on the existing `forward_mysql_response` framing tests and two new ones (affected rows, `ERR` packet).
- `crates/ephpm-db/src/postgres.rs` — three routing-loop tests against a fake PG backend: rows counted, `ErrorResponse` counted as an error, and a **negative control** for the toggle.

`cargo test -p ephpm-db` 85 lib tests green (3 consecutive runs, no flake); `ephpm-server` 260; `ephpm-query-stats` 56; `ephpm-config` 89 (`--test-threads=1`). `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo +nightly fmt --all -- --check` clean.

## Docs

- `site/content/reference/config.md` — per-path coverage table under `[db.analysis]`, plus the stats implication of `reset_strategy`.
- `site/content/reference/metrics.md` — no path label; proxy vs in-process duration semantics; narrower `ephpm_query_rows_total`.
- `site/content/architecture/metrics.md`, `site/content/architecture/database/db-proxy.md`, `site/content/guides/query-stats-prometheus.md` — corrected coverage claims that were aspirational before this PR.

## Rebased onto #221

This landed on top of `f25e4d9` (#221, `COM_QUIT` interception). Two consequences worth reviewing:

**A documented gap closed itself.** #221 deletes `proxy_bidirectional`, so every MySQL single-backend session is framed regardless of `reset_strategy`. The "`never`/`always` records nothing" limitation this PR originally documented is gone **for MySQL**. PostgreSQL keeps it — its fast path is still an opaque splice. The coverage table and three doc sites were updated accordingly.

**The QUIT/settle interaction needed care, and is pinned by a test.** #221 makes an intercepted `COM_QUIT` the *common* clean end of a PHP session, which makes it the settle point that matters most for stats completeness. Two properties had to hold:

1. The settle hook runs **before** the QUIT check. `COM_QUIT` is itself "the next command", so it carries exactly the completion proof `SpliceWatch` relies on. An orderly mysqlnd disconnect now settles the trailing statement *earlier* and more reliably than the old EOF path did.
2. The two client-read failures that end a session **without** a QUIT also settle. #221 replaced the flushing match arm with bare early returns; one of those is reached by an auto-merge git does **not** flag as a conflict, which is exactly how this gets lost in a hurried rebase.

All four settle points now go through a single `flush_pending` helper so the invariant is stated once. `splice_path_settles_trailing_statement_on_intercepted_quit` asserts three things at once: the pre-QUIT statement is recorded with non-zero duration, `outcome.backend.is_some()` (interception still leaves the backend recyclable), and a read on the fake backend times out — proving the QUIT byte never reached it.

Mechanical parts of the rebase: `proxy_bidirectional_sniff` returns `SessionOutcome`; `stamping_copy` was deleted and merged into #221's hand-rolled `backend_to_client` loop (convergent — both replaced `tokio::io::copy`, theirs for error attribution, mine for timestamping) preserving `Ok(0) | Err => SessionEnd::Backend`; `relay_one_command` widened from `Option<u32>` to a `RelayResult { prepared, response }` struct to thread `ResponseOutcome` out; and #221's two new test files gained the `QueryStats` constructor argument so their suites exercise the tap point too.

Post-rebase counts: `ephpm-db` **89 lib tests + 10 binaries green** (including #221's `pool_quit_poisoning`, `pg_terminate_poisoning`, `pool_lifecycle`), `ephpm-server` 260, `ephpm-query-stats` 56, `ephpm-config` 90. Clippy `--workspace --all-targets -D warnings` clean, nightly fmt clean.
