### PR TITLE
fix(db): proxy no longer requires its upstream at startup — readiness gates on first upstream connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "ephpm-query-stats",
  "hmac 0.12.1",
  "md5 0.8.0",
+ "metrics",
  "mysql_async",
  "parking_lot",
  "sha1",

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1119,6 +1119,29 @@ pub struct DbBackendConfig {
     pub replicas: Option<ReplicasConfig>,
 }
 
+/// Hand-written so a Rust-constructed `DbBackendConfig` lands on exactly
+/// the values an empty TOML table would produce. A derived `Default` would
+/// give `min_connections = 0` and empty duration strings — values no
+/// TOML-loaded config can ever hold, which is a trap for tests.
+impl Default for DbBackendConfig {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            listen: None,
+            socket: None,
+            min_connections: default_min_connections(),
+            max_connections: default_max_connections(),
+            idle_timeout: default_idle_timeout(),
+            max_lifetime: default_max_lifetime(),
+            pool_timeout: default_pool_timeout(),
+            health_check_interval: default_health_check_interval(),
+            inject_env: default_inject_env(),
+            reset_strategy: default_reset_strategy(),
+            replicas: None,
+        }
+    }
+}
+
 /// Read replica configuration for a database backend.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ReplicasConfig {

--- a/crates/ephpm-db/Cargo.toml
+++ b/crates/ephpm-db/Cargo.toml
@@ -12,6 +12,7 @@ ephpm-config = { workspace = true }
 ephpm-query-stats = { workspace = true }
 tokio = { workspace = true }
 bytes = { workspace = true }
+metrics = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/ephpm-db/src/health.rs
+++ b/crates/ephpm-db/src/health.rs
@@ -37,6 +37,68 @@ const LOG_INTERVAL_SECS: u64 = 60;
 /// the thousandth carries nothing new.
 const UNTHROTTLED_FAILURES: u64 = 3;
 
+/// How long a bound-but-not-yet-connected proxy lets clients sit in the
+/// kernel accept backlog before it starts closing them on arrival.
+///
+/// The backlog is what makes a late upstream invisible to PHP: a request
+/// that arrives while the proxy is still dialing waits a few hundred
+/// milliseconds and then succeeds, instead of getting `ECONNREFUSED`. But
+/// the backlog must not be the behavior for an upstream that is simply
+/// *down*: a client whose TCP connect succeeded then blocks reading a
+/// server greeting that never comes, and mysqlnd's read timeout is 24 hours
+/// by default. That converts fast 500s into requests that pin a PHP worker
+/// until the HTTP request deadline — a worse failure than the one this
+/// whole change exists to fix.
+///
+/// So the backlog window is bounded. After this long without an upstream,
+/// the proxy accepts and immediately closes, which PHP reports promptly
+/// ("Lost connection ... reading initial communication packet"). Five
+/// seconds comfortably covers both cases it needs to cover: a listener
+/// bound later in this same process (~250 ms) and a database container
+/// starting alongside ePHPm.
+pub const BACKLOG_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Accept and immediately close clients while the upstream is unreachable.
+///
+/// Spawned alongside the upstream-connect loop and aborted the moment the
+/// upstream answers. Sleeps [`BACKLOG_GRACE`] first so a proxy whose
+/// upstream appears promptly never drops a client at all.
+///
+/// One client can be dropped at the switchover instant — an `accept()` that
+/// completes in the same poll as the abort. PDO reports it and the next
+/// request succeeds; the alternative is machinery to close a millisecond-
+/// wide window.
+pub async fn drain_while_upstream_down(
+    listener: Arc<tokio::net::TcpListener>,
+    health: Arc<ProxyHealth>,
+) {
+    tokio::time::sleep(BACKLOG_GRACE).await;
+    tracing::warn!(
+        db = health.kind(),
+        upstream = %health.upstream(),
+        listen = %health.listen(),
+        grace_secs = BACKLOG_GRACE.as_secs(),
+        "database proxy upstream still unreachable after the backlog grace period; \
+         closing client connections on arrival so callers fail fast instead of \
+         blocking on a greeting that will not come"
+    );
+    loop {
+        match listener.accept().await {
+            // Dropping the stream sends FIN. The client sees a closed
+            // connection rather than an unbounded read.
+            Ok((client, peer)) => {
+                tracing::debug!(%peer, "closing client: proxy upstream is unreachable");
+                drop(client);
+            }
+            Err(e) => {
+                tracing::warn!("proxy accept error while upstream is down: {e}");
+                // Don't spin on a persistent accept error (EMFILE).
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    }
+}
+
 /// How long a proxy keeps trying to reach its upstream before giving up.
 ///
 /// The two variants exist because the two entry points have different

--- a/crates/ephpm-db/src/health.rs
+++ b/crates/ephpm-db/src/health.rs
@@ -1,0 +1,283 @@
+//! Upstream health state for the SQL proxies.
+//!
+//! A proxy is two independent things: a listener PHP connects to, and a
+//! pool of connections to some upstream database. Those two can be in
+//! different states — the listener can be up and serving while the
+//! upstream is unreachable — and the server needs to say so out loud
+//! rather than reporting a uniform "healthy".
+//!
+//! [`ProxyHealth`] is the shared handle that carries that distinction.
+//! One is created per configured proxy at startup and cloned into (a) the
+//! background upstream-connect loop, (b) the pool's connect closure, and
+//! (c) the HTTP readiness check. All state transitions also move
+//! Prometheus metrics, so a proxy that never reaches its upstream is
+//! visible without scraping logs:
+//!
+//! | Metric | Type | Meaning |
+//! |---|---|---|
+//! | `ephpm_db_proxy_upstream_ever_connected` | gauge | 1 once the proxy has completed one upstream handshake since boot. Stays 1. |
+//! | `ephpm_db_proxy_upstream_up` | gauge | 1 if the last upstream connect attempt succeeded, 0 if it failed. Flaps with the upstream. |
+//! | `ephpm_db_proxy_connect_failures_total` | counter | Upstream connect/handshake failures. |
+//!
+//! Labels: `db` (`mysql` / `postgres`) and `upstream` (the resolved
+//! `host:port` — never the URL, which carries credentials).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use metrics::{counter, gauge};
+use tracing::{error, warn};
+
+/// How often a still-failing upstream may log after the initial burst.
+const LOG_INTERVAL_SECS: u64 = 60;
+
+/// How many consecutive failures log unconditionally before rate limiting
+/// kicks in. The first few carry the diagnosis (refused vs. auth vs. TLS);
+/// the thousandth carries nothing new.
+const UNTHROTTLED_FAILURES: u64 = 3;
+
+/// How long a proxy keeps trying to reach its upstream before giving up.
+///
+/// The two variants exist because the two entry points have different
+/// callers. [`RetryBudget::Bounded`] backs the eager constructors
+/// (`MySqlProxy::new` / `PgProxy::new`), which return the error to a caller
+/// that can report it — an unbounded loop there would be an unkillable
+/// hang. [`RetryBudget::Unbounded`] backs the deferred startup path, where
+/// the listener is already bound and serving and there is nobody left to
+/// report to: giving up permanently would leave a live listener wired to a
+/// dead upstream for the lifetime of the process, recoverable only by a
+/// restart. Upstreams restart (RDS failover, a sidecar rollout, a local
+/// listener that binds a moment later) — the proxy should survive that.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RetryBudget {
+    /// Give up after this many attempts and return the last error.
+    Bounded(u32),
+    /// Retry forever, at [`RetryBudget::max_backoff_ms`] steady state.
+    Unbounded,
+}
+
+impl RetryBudget {
+    /// Is `attempt` (1-based) the last one this budget allows?
+    #[must_use]
+    pub fn is_final_attempt(self, attempt: u32) -> bool {
+        match self {
+            Self::Bounded(max) => attempt >= max,
+            Self::Unbounded => false,
+        }
+    }
+
+    /// Backoff ceiling in milliseconds.
+    ///
+    /// The bounded budget keeps the historical 8 s cap so its total stays
+    /// ~40 s across 10 attempts. The unbounded budget settles at 30 s: one
+    /// TCP connect every 30 s costs nothing, and it keeps a long outage
+    /// from turning into a reconnect storm the moment the upstream returns.
+    #[must_use]
+    pub fn max_backoff_ms(self) -> u64 {
+        match self {
+            Self::Bounded(_) => 8_000,
+            Self::Unbounded => 30_000,
+        }
+    }
+}
+
+/// Shared upstream-health state for one configured proxy.
+///
+/// Cheap to read (two relaxed atomic loads) — the readiness probe touches
+/// it on every scrape, and nothing else is on a hot path.
+#[derive(Debug)]
+pub struct ProxyHealth {
+    /// Short proxy kind, used as the `db` metric label: `mysql` or `postgres`.
+    kind: &'static str,
+    /// The address PHP connects to.
+    listen: String,
+    /// The upstream `host:port`. Never the full URL — that carries the password.
+    upstream: String,
+    /// Set once the proxy completes its first upstream handshake, and never
+    /// cleared. This is the readiness gate (see [`ProxyHealth::ever_connected`]).
+    ever_connected: AtomicBool,
+    /// Outcome of the most recent upstream connect attempt.
+    upstream_up: AtomicBool,
+    /// Consecutive failures since the last success — drives log throttling.
+    consecutive_failures: AtomicU64,
+    /// Unix seconds of the last emitted failure log.
+    last_log_unix: AtomicU64,
+}
+
+impl ProxyHealth {
+    /// Create health state for a proxy, in the "never connected" state.
+    ///
+    /// `upstream` must already be redacted to `host:port`.
+    #[must_use]
+    pub fn new(
+        kind: &'static str,
+        listen: impl Into<String>,
+        upstream: impl Into<String>,
+    ) -> Arc<Self> {
+        let this = Arc::new(Self {
+            kind,
+            listen: listen.into(),
+            upstream: upstream.into(),
+            ever_connected: AtomicBool::new(false),
+            upstream_up: AtomicBool::new(false),
+            consecutive_failures: AtomicU64::new(0),
+            last_log_unix: AtomicU64::new(0),
+        });
+        // Publish the initial (down) state so a proxy that never connects
+        // shows up as an explicit 0 rather than an absent series.
+        this.set_gauge("ephpm_db_proxy_upstream_ever_connected", 0.0);
+        this.set_gauge("ephpm_db_proxy_upstream_up", 0.0);
+        this
+    }
+
+    /// The `db` label / proxy kind (`mysql`, `postgres`).
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        self.kind
+    }
+
+    /// The address PHP connects to.
+    #[must_use]
+    pub fn listen(&self) -> &str {
+        &self.listen
+    }
+
+    /// The upstream `host:port`.
+    #[must_use]
+    pub fn upstream(&self) -> &str {
+        &self.upstream
+    }
+
+    /// Has this proxy ever completed an upstream handshake since boot?
+    ///
+    /// This — not [`ProxyHealth::is_up`] — is what readiness gates on. A
+    /// proxy that has never reached its upstream cannot serve a single
+    /// query and the process should stay out of load-balancer rotation; a
+    /// proxy that connected once and later lost its upstream is a database
+    /// outage, and dropping every replica out of rotation for that turns a
+    /// degraded service into a dead one.
+    #[must_use]
+    pub fn ever_connected(&self) -> bool {
+        self.ever_connected.load(Ordering::Relaxed)
+    }
+
+    /// Did the most recent upstream connect attempt succeed?
+    #[must_use]
+    pub fn is_up(&self) -> bool {
+        self.upstream_up.load(Ordering::Relaxed)
+    }
+
+    /// Record a successful upstream connect/handshake.
+    pub fn record_up(&self) {
+        self.consecutive_failures.store(0, Ordering::Relaxed);
+        if !self.ever_connected.swap(true, Ordering::Relaxed) {
+            self.set_gauge("ephpm_db_proxy_upstream_ever_connected", 1.0);
+        }
+        if !self.upstream_up.swap(true, Ordering::Relaxed) {
+            self.set_gauge("ephpm_db_proxy_upstream_up", 1.0);
+        }
+    }
+
+    /// Record a failed upstream connect/handshake.
+    ///
+    /// Logs the first [`UNTHROTTLED_FAILURES`] unconditionally, then at most
+    /// once per [`LOG_INTERVAL_SECS`] — an upstream that is down for an hour
+    /// must not turn into an hour of log volume, but it also must not go
+    /// completely silent.
+    pub fn record_down(&self, error: &dyn std::fmt::Display) {
+        let failures = self.consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
+        self.upstream_up.store(false, Ordering::Relaxed);
+        self.set_gauge("ephpm_db_proxy_upstream_up", 0.0);
+        counter!(
+            "ephpm_db_proxy_connect_failures_total",
+            "db" => self.kind,
+            "upstream" => self.upstream.clone(),
+        )
+        .increment(1);
+
+        if failures <= UNTHROTTLED_FAILURES {
+            warn!(
+                db = self.kind,
+                upstream = %self.upstream,
+                listen = %self.listen,
+                failures,
+                "database proxy upstream connect failed: {error}"
+            );
+        } else if self.should_log_now() {
+            error!(
+                db = self.kind,
+                upstream = %self.upstream,
+                listen = %self.listen,
+                failures,
+                ever_connected = self.ever_connected(),
+                "database proxy upstream still unreachable (throttled to one log \
+                 per {LOG_INTERVAL_SECS}s): {error}"
+            );
+        }
+    }
+
+    /// A short human-readable identity for probe payloads and logs.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        format!("{} proxy {} -> {}", self.kind, self.listen, self.upstream)
+    }
+
+    /// Claim the throttled log slot, if the interval has elapsed.
+    fn should_log_now(&self) -> bool {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
+        let last = self.last_log_unix.load(Ordering::Relaxed);
+        if now.saturating_sub(last) < LOG_INTERVAL_SECS {
+            return false;
+        }
+        // CAS so two threads failing at once emit one line, not two.
+        self.last_log_unix.compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed).is_ok()
+    }
+
+    fn set_gauge(&self, name: &'static str, value: f64) {
+        gauge!(name, "db" => self.kind, "upstream" => self.upstream.clone()).set(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_never_connected_and_down() {
+        let h = ProxyHealth::new("mysql", "127.0.0.1:3306", "127.0.0.1:3307");
+        assert!(!h.ever_connected());
+        assert!(!h.is_up());
+    }
+
+    #[test]
+    fn first_success_latches_ever_connected() {
+        let h = ProxyHealth::new("mysql", "127.0.0.1:3306", "127.0.0.1:3307");
+        h.record_up();
+        assert!(h.ever_connected());
+        assert!(h.is_up());
+
+        // A later outage clears `is_up` but must NOT clear `ever_connected`:
+        // readiness is a boot-time gate, not a live database probe.
+        h.record_down(&"connection refused");
+        assert!(h.ever_connected(), "ever_connected must latch");
+        assert!(!h.is_up());
+    }
+
+    #[test]
+    fn throttle_allows_first_burst_then_closes() {
+        let h = ProxyHealth::new("mysql", "127.0.0.1:3306", "127.0.0.1:3307");
+        // The first call after construction may log (last_log_unix == 0).
+        assert!(h.should_log_now());
+        // The immediate next one must not — the interval has not elapsed.
+        assert!(!h.should_log_now());
+    }
+
+    #[test]
+    fn describe_never_contains_credentials() {
+        let h = ProxyHealth::new("postgres", "127.0.0.1:5432", "db.internal:5432");
+        let d = h.describe();
+        assert!(d.contains("db.internal:5432"));
+        assert!(!d.contains('@'), "upstream label must be host:port, never a URL");
+    }
+}

--- a/crates/ephpm-db/src/lib.rs
+++ b/crates/ephpm-db/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod duration;
 pub mod error;
+pub mod health;
 pub mod mysql;
 pub mod pool;
 pub mod postgres;

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -44,6 +44,7 @@ use tracing::{debug, info, warn};
 
 use crate::ResetStrategy;
 use crate::error::DbError;
+use crate::health::{ProxyHealth, RetryBudget};
 use crate::pool::{Checkout, Pool, PoolConfig};
 use crate::stats::{PendingStatement, ResponseOutcome, SpliceWatch};
 use crate::url::DbUrl;
@@ -147,6 +148,11 @@ impl MySqlProxy {
     /// Create a new proxy by connecting to the backend, authenticating, and
     /// building the pool.
     ///
+    /// Connects eagerly with a **bounded** retry budget (~40 s) and returns
+    /// the error to the caller if the backend never answers. Production
+    /// startup uses [`spawn_deferred`] instead, which binds the listener
+    /// first and retries the upstream forever in the background.
+    ///
     /// # Errors
     ///
     /// Returns an error if the initial backend connection or handshake fails.
@@ -161,25 +167,69 @@ impl MySqlProxy {
         stats: QueryStats,
     ) -> Result<Self, DbError> {
         let db_url = Arc::new(DbUrl::parse(url)?);
+        let health = ProxyHealth::new("mysql", listen, db_url.addr());
+        Self::connect(
+            db_url,
+            listen,
+            socket,
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+            stats,
+            health,
+            RetryBudget::Bounded(10),
+        )
+        .await
+    }
 
+    /// Connect to the upstream and build the pools.
+    ///
+    /// Shared by the eager constructor and the deferred startup path; the
+    /// only difference between them is the [`RetryBudget`].
+    async fn connect(
+        db_url: Arc<DbUrl>,
+        listen: &str,
+        socket: Option<std::path::PathBuf>,
+        pool_config: PoolConfig,
+        reset_strategy: ResetStrategy,
+        replica_urls: Vec<String>,
+        rw_split: RwSplitParams,
+        stats: QueryStats,
+        health: Arc<ProxyHealth>,
+        retry: RetryBudget,
+    ) -> Result<Self, DbError> {
         // Establish a single connection to capture server metadata.
         //
         // Under k8s/systemd startup ordering the backend may not be reachable
         // yet — the proxy used to bail immediately and stay dead for the
         // process lifetime, requiring a manual restart after the DB came up.
-        // Bounded exponential backoff (250ms doubling to 8s, ~10 tries,
-        // ~30s total) makes the proxy resilient to a slow-to-start backend
-        // without wedging on a genuine misconfiguration.
-        let (probe_stream, meta) = connect_with_retry(&db_url, "MySQL").await?;
+        // Exponential backoff (250ms doubling to the budget's ceiling) makes
+        // the proxy resilient to a slow-to-start backend.
+        let (probe_stream, meta) = connect_with_retry(&db_url, "MySQL", &health, retry).await?;
         let meta = Arc::new(meta);
 
         // Build the primary pool using clones of the URL and meta for closures.
+        // The pool's connect closure is also the live upstream-health signal:
+        // every physical backend connection the pool opens (never once per
+        // request) moves `ephpm_db_proxy_upstream_up`, so an upstream that
+        // dies after startup is visible without a dedicated prober.
         let db_url_c = Arc::clone(&db_url);
+        let health_c = Arc::clone(&health);
         let connect = move || -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
             let u = Arc::clone(&db_url_c);
+            let h = Arc::clone(&health_c);
             Box::pin(async move {
-                let (stream, _) = connect_and_handshake(&u).await?;
-                Ok(stream)
+                match connect_and_handshake(&u).await {
+                    Ok((stream, _)) => {
+                        h.record_up();
+                        Ok(stream)
+                    }
+                    Err(e) => {
+                        h.record_down(&e);
+                        Err(e)
+                    }
+                }
             })
         };
 
@@ -275,7 +325,23 @@ impl MySqlProxy {
     pub async fn run(self) -> Result<(), DbError> {
         let listener = TcpListener::bind(&self.listen).await?;
         info!(listen = %self.listen, "MySQL proxy listening");
+        self.run_on(listener).await
+    }
 
+    /// Accept client connections on an already-bound listener.
+    ///
+    /// Split out from [`MySqlProxy::run`] so startup can bind the listen
+    /// socket before the upstream is reachable: clients that arrive during
+    /// the upstream-connect window queue in the kernel accept backlog and
+    /// are served as soon as the loop starts, instead of getting
+    /// `ECONNREFUSED`.
+    ///
+    /// # Errors
+    ///
+    /// Currently never returns `Err` — accept errors are logged and the
+    /// loop continues. The signature is fallible for symmetry with
+    /// [`MySqlProxy::run`].
+    pub async fn run_on(self, listener: TcpListener) -> Result<(), DbError> {
         let proxy = Arc::new(self);
         loop {
             let (client, peer) = match listener.accept().await {
@@ -370,31 +436,34 @@ impl MySqlProxy {
 
 // ── Backend connection & auth ─────────────────────────────────────────────────
 
-/// Bounded exponential backoff wrapper around [`connect_and_handshake`].
+/// Exponential-backoff wrapper around [`connect_and_handshake`].
 ///
 /// Attempts the initial connect + handshake with increasing delays between
-/// tries so a slow-to-start backend (k8s/systemd ordering) doesn't kill the
-/// proxy on process startup. Retries approximately: 250ms, 500ms, 1s, 2s,
-/// 4s, 8s, 8s, 8s, 8s (10 attempts, ~40s total).
+/// tries so a slow-to-start backend (k8s/systemd ordering, or a listener
+/// this same process is about to bind) doesn't kill the proxy on startup.
+/// Delays run 250 ms doubling to the [`RetryBudget`]'s ceiling.
 ///
-/// Constants chosen to keep the total bounded without introducing a new
-/// config knob (this is a reliability paper cut, not an operator dial).
-/// Errors are logged at INFO for the first few attempts, WARN thereafter.
+/// Every attempt moves [`ProxyHealth`], which owns log throttling and the
+/// failure metrics — so an unbounded retry against a long-dead upstream
+/// stays visible without becoming log volume.
 ///
 /// `db_kind` is a short label ("MySQL", "PostgreSQL") used only for logs.
 async fn connect_with_retry(
     url: &DbUrl,
     db_kind: &str,
+    health: &ProxyHealth,
+    retry: RetryBudget,
 ) -> Result<(TcpStream, ServerMeta), DbError> {
-    const MAX_ATTEMPTS: u32 = 10;
     const INITIAL_BACKOFF_MS: u64 = 250;
-    const MAX_BACKOFF_MS: u64 = 8_000;
 
+    let max_backoff_ms = retry.max_backoff_ms();
     let mut backoff_ms = INITIAL_BACKOFF_MS;
-    let mut last_err: Option<DbError> = None;
-    for attempt in 1..=MAX_ATTEMPTS {
+    let mut attempt: u32 = 0;
+    loop {
+        attempt = attempt.saturating_add(1);
         match connect_and_handshake(url).await {
             Ok(ok) => {
+                health.record_up();
                 if attempt > 1 {
                     info!(
                         db = db_kind,
@@ -406,7 +475,8 @@ async fn connect_with_retry(
                 return Ok(ok);
             }
             Err(e) => {
-                let is_last = attempt == MAX_ATTEMPTS;
+                health.record_down(&e);
+                let is_last = retry.is_final_attempt(attempt);
                 if is_last {
                     warn!(
                         db = db_kind,
@@ -415,34 +485,13 @@ async fn connect_with_retry(
                         error = %e,
                         "backend still unreachable after max retries; giving up"
                     );
-                } else if attempt >= 3 {
-                    warn!(
-                        db = db_kind,
-                        attempt,
-                        addr = %url.addr(),
-                        error = %e,
-                        backoff_ms,
-                        "backend connect failed; retrying"
-                    );
-                } else {
-                    info!(
-                        db = db_kind,
-                        attempt,
-                        addr = %url.addr(),
-                        error = %e,
-                        backoff_ms,
-                        "backend not yet reachable; retrying"
-                    );
+                    return Err(e);
                 }
-                last_err = Some(e);
-                if !is_last {
-                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = (backoff_ms.saturating_mul(2)).min(MAX_BACKOFF_MS);
-                }
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                backoff_ms = (backoff_ms.saturating_mul(2)).min(max_backoff_ms);
             }
         }
     }
-    Err(last_err.unwrap_or(DbError::Auth("connect_with_retry: no attempt recorded".into())))
 }
 
 /// Connect to the `MySQL` backend and complete the authentication handshake.
@@ -1905,6 +1954,92 @@ pub async fn build_proxy(
 ) -> Result<MySqlProxy, DbError> {
     MySqlProxy::new(url, listen, socket, pool_config, reset_strategy, replica_urls, rw_split, stats)
         .await
+}
+
+/// Bind the proxy listener now; reach the upstream in the background.
+///
+/// This is the startup path. It inverts the old ordering, which connected
+/// to the upstream first and only bound the listener afterwards — so a
+/// proxy whose upstream was not yet up spent its whole retry budget with
+/// **no socket bound**, then gave up permanently. Two things fell out of
+/// that: an upstream started later in the same process (`[db.mysql]`
+/// pointed at `[db.sqlite]`'s own litewire listener) could never be
+/// reached, and any deployment whose database was down at boot came up
+/// with a dead proxy that only a restart could fix.
+///
+/// What this does instead:
+///
+/// 1. Parse the URL and bind the listen socket **synchronously**. Both are
+///    configuration errors, so both are fatal to startup — a proxy that
+///    cannot bind its port must not be a logged warning and a silently
+///    dead listener.
+/// 2. Return immediately, so the rest of startup (including the embedded
+///    SQLite listener this proxy may be pointed at) proceeds.
+/// 3. Reach the upstream from a background task with an unbounded,
+///    capped-backoff retry, then serve on the already-bound listener.
+///
+/// Clients that connect during step 3 do not get `ECONNREFUSED`: the socket
+/// is bound, so their connections sit in the kernel accept backlog and are
+/// served as soon as the upstream answers.
+///
+/// `health` is moved into the connect loop and the pool; the caller keeps a
+/// clone to drive the readiness probe.
+///
+/// # Errors
+///
+/// Returns an error if the URL is malformed or the listen address cannot be
+/// bound. Upstream unreachability is *not* an error here — that is what the
+/// background retry and [`ProxyHealth`] are for.
+pub async fn spawn_deferred(
+    url: &str,
+    listen: &str,
+    socket: Option<std::path::PathBuf>,
+    pool_config: PoolConfig,
+    reset_strategy: ResetStrategy,
+    replica_urls: Vec<String>,
+    rw_split: RwSplitParams,
+    stats: QueryStats,
+    health: Arc<ProxyHealth>,
+) -> Result<tokio::task::JoinHandle<()>, DbError> {
+    let db_url = Arc::new(DbUrl::parse(url)?);
+    let listener = TcpListener::bind(listen).await?;
+    info!(
+        listen = %listen,
+        upstream = %db_url.addr(),
+        "MySQL proxy listening (upstream connect continues in the background)"
+    );
+
+    let listen_owned = listen.to_string();
+    Ok(tokio::spawn(async move {
+        let proxy = match MySqlProxy::connect(
+            db_url,
+            &listen_owned,
+            socket,
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+            stats,
+            health,
+            RetryBudget::Unbounded,
+        )
+        .await
+        {
+            Ok(proxy) => proxy,
+            Err(e) => {
+                // Unreachable in practice: the unbounded budget never gives
+                // up, so only a pool-seed failure lands here.
+                tracing::error!("MySQL proxy failed to start: {e:#}");
+                return;
+            }
+        };
+        // Detach pool maintenance — it runs for the proxy's lifetime.
+        drop(proxy.start_maintenance());
+        match proxy.run_on(listener).await {
+            Ok(()) => info!("MySQL proxy stopped"),
+            Err(e) => tracing::error!("MySQL proxy error: {e:#}"),
+        }
+    }))
 }
 
 #[cfg(test)]

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -325,7 +325,7 @@ impl MySqlProxy {
     pub async fn run(self) -> Result<(), DbError> {
         let listener = TcpListener::bind(&self.listen).await?;
         info!(listen = %self.listen, "MySQL proxy listening");
-        self.run_on(listener).await
+        self.run_on(Arc::new(listener)).await
     }
 
     /// Accept client connections on an already-bound listener.
@@ -341,7 +341,7 @@ impl MySqlProxy {
     /// Currently never returns `Err` — accept errors are logged and the
     /// loop continues. The signature is fallible for symmetry with
     /// [`MySqlProxy::run`].
-    pub async fn run_on(self, listener: TcpListener) -> Result<(), DbError> {
+    pub async fn run_on(self, listener: Arc<TcpListener>) -> Result<(), DbError> {
         let proxy = Arc::new(self);
         loop {
             let (client, peer) = match listener.accept().await {
@@ -1980,7 +1980,9 @@ pub async fn build_proxy(
 ///
 /// Clients that connect during step 3 do not get `ECONNREFUSED`: the socket
 /// is bound, so their connections sit in the kernel accept backlog and are
-/// served as soon as the upstream answers.
+/// served as soon as the upstream answers. That window is bounded by
+/// [`BACKLOG_GRACE`] — past it, clients are accepted and closed so they fail
+/// fast rather than blocking on a greeting that will not come.
 ///
 /// `health` is moved into the connect loop and the pool; the caller keeps a
 /// clone to drive the readiness probe.
@@ -2010,7 +2012,16 @@ pub async fn spawn_deferred(
     );
 
     let listen_owned = listen.to_string();
+    let listener = Arc::new(listener);
     Ok(tokio::spawn(async move {
+        // Fail-fast guard for a long outage; aborted the moment the upstream
+        // answers, and a no-op entirely when that happens inside the grace
+        // period (the common case).
+        let drain = tokio::spawn(crate::health::drain_while_upstream_down(
+            Arc::clone(&listener),
+            Arc::clone(&health),
+        ));
+
         let proxy = match MySqlProxy::connect(
             db_url,
             &listen_owned,
@@ -2028,11 +2039,13 @@ pub async fn spawn_deferred(
             Ok(proxy) => proxy,
             Err(e) => {
                 // Unreachable in practice: the unbounded budget never gives
-                // up, so only a pool-seed failure lands here.
+                // up, so only a pool-seed failure lands here. Leave the drain
+                // running so clients keep failing fast rather than hanging.
                 tracing::error!("MySQL proxy failed to start: {e:#}");
                 return;
             }
         };
+        drain.abort();
         // Detach pool maintenance — it runs for the proxy's lifetime.
         drop(proxy.start_maintenance());
         match proxy.run_on(listener).await {

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -35,6 +35,7 @@ use tracing::{debug, info, warn};
 
 use crate::ResetStrategy;
 use crate::error::DbError;
+use crate::health::{ProxyHealth, RetryBudget};
 use crate::pool::{Checkout, Pool, PoolConfig};
 use crate::stats::ResponseOutcome;
 use crate::url::DbUrl;
@@ -134,6 +135,11 @@ impl PgProxy {
     /// Create a new proxy by connecting to the backend, authenticating, and
     /// building the pool.
     ///
+    /// Connects eagerly with a **bounded** retry budget (~40 s) and returns
+    /// the error to the caller. Production startup uses [`spawn_deferred`]
+    /// instead, which binds the listener first and retries the upstream
+    /// forever in the background.
+    ///
     /// # Errors
     ///
     /// Returns an error if the initial backend connection or handshake fails.
@@ -147,23 +153,63 @@ impl PgProxy {
         stats: QueryStats,
     ) -> Result<Self, DbError> {
         let db_url = Arc::new(DbUrl::parse(url)?);
+        let health = ProxyHealth::new("postgres", listen, db_url.addr());
+        Self::connect(
+            db_url,
+            listen,
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+            stats,
+            health,
+            RetryBudget::Bounded(10),
+        )
+        .await
+    }
 
+    /// Connect to the upstream and build the pools.
+    ///
+    /// Shared by the eager constructor and the deferred startup path; the
+    /// only difference between them is the [`RetryBudget`].
+    async fn connect(
+        db_url: Arc<DbUrl>,
+        listen: &str,
+        pool_config: PoolConfig,
+        reset_strategy: ResetStrategy,
+        replica_urls: Vec<String>,
+        rw_split: PgRwSplitParams,
+        stats: QueryStats,
+        health: Arc<ProxyHealth>,
+        retry: RetryBudget,
+    ) -> Result<Self, DbError> {
         // Establish a probe connection to capture server metadata.
         //
-        // Bounded exponential backoff (250ms doubling to 8s, ~10 tries) so
+        // Exponential backoff (250ms doubling to the budget's ceiling) so
         // startup ordering under k8s/systemd doesn't leave the proxy dead
         // when the DB comes up a few seconds later. See
         // `pg_connect_with_retry` for the schedule.
-        let (probe_stream, meta) = pg_connect_with_retry(&db_url).await?;
+        let (probe_stream, meta) = pg_connect_with_retry(&db_url, &health, retry).await?;
         let meta = Arc::new(meta);
 
-        // Build the primary pool.
+        // Build the primary pool. The connect closure doubles as the live
+        // upstream-health signal (see the MySQL proxy for the rationale).
         let db_url_c = Arc::clone(&db_url);
+        let health_c = Arc::clone(&health);
         let connect = move || -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
             let u = Arc::clone(&db_url_c);
+            let h = Arc::clone(&health_c);
             Box::pin(async move {
-                let (stream, _) = pg_connect_and_handshake(&u).await?;
-                Ok(stream)
+                match pg_connect_and_handshake(&u).await {
+                    Ok((stream, _)) => {
+                        h.record_up();
+                        Ok(stream)
+                    }
+                    Err(e) => {
+                        h.record_down(&e);
+                        Err(e)
+                    }
+                }
             })
         };
 
@@ -256,7 +302,21 @@ impl PgProxy {
     pub async fn run(self) -> Result<(), DbError> {
         let listener = TcpListener::bind(&self.listen).await?;
         info!(listen = %self.listen, "PostgreSQL proxy listening");
+        self.run_on(listener).await
+    }
 
+    /// Accept client connections on an already-bound listener.
+    ///
+    /// See [`MySqlProxy::run_on`](crate::mysql::MySqlProxy::run_on) — same
+    /// contract: the listen socket is bound before the upstream is known
+    /// reachable, so early clients queue in the accept backlog rather than
+    /// getting `ECONNREFUSED`.
+    ///
+    /// # Errors
+    ///
+    /// Currently never returns `Err`; accept errors are logged and the loop
+    /// continues.
+    pub async fn run_on(self, listener: TcpListener) -> Result<(), DbError> {
         let proxy = Arc::new(self);
         loop {
             let (client, peer) = match listener.accept().await {
@@ -359,22 +419,28 @@ impl PgProxy {
 /// messages on the right code path — see `handle_backend_auth`).
 /// Integration coverage in `tests/pg_proxy_integration.rs` pins this
 /// against real PG 13 (`md5`) and PG 17 (`scram-sha-256`).
-/// Bounded exponential backoff wrapper around [`pg_connect_and_handshake`].
+/// Exponential-backoff wrapper around [`pg_connect_and_handshake`].
 ///
-/// Retries on the same schedule as the MySQL proxy: ~250ms, 500ms, 1s, 2s,
-/// 4s, 8s, ..., 10 attempts, ~40s total. Prevents startup ordering (k8s,
-/// systemd) from wedging the proxy when the backend comes up seconds
-/// later.
-async fn pg_connect_with_retry(url: &DbUrl) -> Result<(TcpStream, PgServerMeta), DbError> {
-    const MAX_ATTEMPTS: u32 = 10;
+/// Same schedule as the MySQL proxy: 250 ms doubling to the
+/// [`RetryBudget`]'s ceiling. Prevents startup ordering (k8s, systemd, or a
+/// listener this process binds moments later) from wedging the proxy when
+/// the backend comes up seconds later. [`ProxyHealth`] owns the failure
+/// logging and metrics.
+async fn pg_connect_with_retry(
+    url: &DbUrl,
+    health: &ProxyHealth,
+    retry: RetryBudget,
+) -> Result<(TcpStream, PgServerMeta), DbError> {
     const INITIAL_BACKOFF_MS: u64 = 250;
-    const MAX_BACKOFF_MS: u64 = 8_000;
 
+    let max_backoff_ms = retry.max_backoff_ms();
     let mut backoff_ms = INITIAL_BACKOFF_MS;
-    let mut last_err: Option<DbError> = None;
-    for attempt in 1..=MAX_ATTEMPTS {
+    let mut attempt: u32 = 0;
+    loop {
+        attempt = attempt.saturating_add(1);
         match pg_connect_and_handshake(url).await {
             Ok(ok) => {
+                health.record_up();
                 if attempt > 1 {
                     info!(
                         attempt,
@@ -385,40 +451,21 @@ async fn pg_connect_with_retry(url: &DbUrl) -> Result<(TcpStream, PgServerMeta),
                 return Ok(ok);
             }
             Err(e) => {
-                let is_last = attempt == MAX_ATTEMPTS;
-                if is_last {
+                health.record_down(&e);
+                if retry.is_final_attempt(attempt) {
                     warn!(
                         attempt,
                         addr = %url.addr(),
                         error = %e,
                         "PostgreSQL backend still unreachable after max retries; giving up"
                     );
-                } else if attempt >= 3 {
-                    warn!(
-                        attempt,
-                        addr = %url.addr(),
-                        error = %e,
-                        backoff_ms,
-                        "PostgreSQL backend connect failed; retrying"
-                    );
-                } else {
-                    info!(
-                        attempt,
-                        addr = %url.addr(),
-                        error = %e,
-                        backoff_ms,
-                        "PostgreSQL backend not yet reachable; retrying"
-                    );
+                    return Err(e);
                 }
-                last_err = Some(e);
-                if !is_last {
-                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
-                    backoff_ms = (backoff_ms.saturating_mul(2)).min(MAX_BACKOFF_MS);
-                }
+                tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                backoff_ms = (backoff_ms.saturating_mul(2)).min(max_backoff_ms);
             }
         }
     }
-    Err(last_err.unwrap_or(DbError::Auth("pg_connect_with_retry: no attempt recorded".into())))
 }
 
 async fn pg_connect_and_handshake(url: &DbUrl) -> Result<(TcpStream, PgServerMeta), DbError> {
@@ -1340,6 +1387,65 @@ pub async fn build_proxy(
     stats: QueryStats,
 ) -> Result<PgProxy, DbError> {
     PgProxy::new(url, listen, pool_config, reset_strategy, replica_urls, rw_split, stats).await
+}
+
+/// Bind the proxy listener now; reach the upstream in the background.
+///
+/// The `PostgreSQL` twin of
+/// [`mysql::spawn_deferred`](crate::mysql::spawn_deferred) — see that
+/// function for the full rationale. In short: bind (fatal on failure),
+/// return, then connect upstream with unbounded capped-backoff retry and
+/// serve on the already-bound listener.
+///
+/// # Errors
+///
+/// Returns an error if the URL is malformed or the listen address cannot be
+/// bound. Upstream unreachability is not an error here.
+pub async fn spawn_deferred(
+    url: &str,
+    listen: &str,
+    pool_config: PoolConfig,
+    reset_strategy: ResetStrategy,
+    replica_urls: Vec<String>,
+    rw_split: PgRwSplitParams,
+    stats: QueryStats,
+    health: Arc<ProxyHealth>,
+) -> Result<tokio::task::JoinHandle<()>, DbError> {
+    let db_url = Arc::new(DbUrl::parse(url)?);
+    let listener = TcpListener::bind(listen).await?;
+    info!(
+        listen = %listen,
+        upstream = %db_url.addr(),
+        "PostgreSQL proxy listening (upstream connect continues in the background)"
+    );
+
+    let listen_owned = listen.to_string();
+    Ok(tokio::spawn(async move {
+        let proxy = match PgProxy::connect(
+            db_url,
+            &listen_owned,
+            pool_config,
+            reset_strategy,
+            replica_urls,
+            rw_split,
+            stats,
+            health,
+            RetryBudget::Unbounded,
+        )
+        .await
+        {
+            Ok(proxy) => proxy,
+            Err(e) => {
+                tracing::error!("PostgreSQL proxy failed to start: {e:#}");
+                return;
+            }
+        };
+        drop(proxy.start_maintenance());
+        match proxy.run_on(listener).await {
+            Ok(()) => info!("PostgreSQL proxy stopped"),
+            Err(e) => tracing::error!("PostgreSQL proxy error: {e:#}"),
+        }
+    }))
 }
 
 #[cfg(test)]

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -302,7 +302,7 @@ impl PgProxy {
     pub async fn run(self) -> Result<(), DbError> {
         let listener = TcpListener::bind(&self.listen).await?;
         info!(listen = %self.listen, "PostgreSQL proxy listening");
-        self.run_on(listener).await
+        self.run_on(Arc::new(listener)).await
     }
 
     /// Accept client connections on an already-bound listener.
@@ -316,7 +316,7 @@ impl PgProxy {
     ///
     /// Currently never returns `Err`; accept errors are logged and the loop
     /// continues.
-    pub async fn run_on(self, listener: TcpListener) -> Result<(), DbError> {
+    pub async fn run_on(self, listener: Arc<TcpListener>) -> Result<(), DbError> {
         let proxy = Arc::new(self);
         loop {
             let (client, peer) = match listener.accept().await {
@@ -1395,7 +1395,10 @@ pub async fn build_proxy(
 /// [`mysql::spawn_deferred`](crate::mysql::spawn_deferred) — see that
 /// function for the full rationale. In short: bind (fatal on failure),
 /// return, then connect upstream with unbounded capped-backoff retry and
-/// serve on the already-bound listener.
+/// serve on the already-bound listener. Clients arriving before the upstream
+/// answers queue in the accept backlog for up to
+/// [`BACKLOG_GRACE`](crate::health::BACKLOG_GRACE), then are closed on
+/// arrival so they fail fast.
 ///
 /// # Errors
 ///
@@ -1420,7 +1423,14 @@ pub async fn spawn_deferred(
     );
 
     let listen_owned = listen.to_string();
+    let listener = Arc::new(listener);
     Ok(tokio::spawn(async move {
+        // See the MySQL twin: bounded backlog window, then fail fast.
+        let drain = tokio::spawn(crate::health::drain_while_upstream_down(
+            Arc::clone(&listener),
+            Arc::clone(&health),
+        ));
+
         let proxy = match PgProxy::connect(
             db_url,
             &listen_owned,
@@ -1440,6 +1450,7 @@ pub async fn spawn_deferred(
                 return;
             }
         };
+        drain.abort();
         drop(proxy.start_maintenance());
         match proxy.run_on(listener).await {
             Ok(()) => info!("PostgreSQL proxy stopped"),

--- a/crates/ephpm-db/tests/deferred_startup.rs
+++ b/crates/ephpm-db/tests/deferred_startup.rs
@@ -1,0 +1,329 @@
+//! Regression tests for issue #226: the proxy must not require its upstream
+//! to exist at startup.
+//!
+//! The bug: `MySqlProxy::new()` connected to the upstream *first* and bound
+//! the listen socket only afterwards, with a bounded ~40 s retry budget.
+//! Chaining `[db.mysql]` in front of ePHPm's own `[db.sqlite]` litewire
+//! listener — which the same startup function binds a few statements later —
+//! was therefore impossible: the proxy spent its whole budget against a
+//! listener that did not exist yet, gave up permanently, and left PHP with
+//! `[2002] Connection refused` for the life of the process. The general form
+//! of the same bug is any deployment whose database is slower to start than
+//! ePHPm.
+//!
+//! Everything here runs against an in-process mock `MySQL` server, so the
+//! tests need no container and run in ordinary CI. The mock is deliberately
+//! started *late* — that is the whole point.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use ephpm_db::ResetStrategy;
+use ephpm_db::health::{ProxyHealth, RetryBudget};
+use ephpm_db::mysql::RwSplitParams;
+use ephpm_db::pool::PoolConfig;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+// ── MySQL packet framing (test-local, deliberately independent of the crate) ──
+
+const CLIENT_PROTOCOL_41: u32 = 0x0000_0200;
+const CLIENT_SECURE_CONNECTION: u32 = 0x0000_8000;
+const CLIENT_PLUGIN_AUTH: u32 = 0x0008_0000;
+
+async fn read_packet(stream: &mut TcpStream) -> std::io::Result<(u8, Vec<u8>)> {
+    let mut header = [0u8; 4];
+    stream.read_exact(&mut header).await?;
+    let len = u32::from_le_bytes([header[0], header[1], header[2], 0]) as usize;
+    let mut payload = vec![0u8; len];
+    stream.read_exact(&mut payload).await?;
+    Ok((header[3], payload))
+}
+
+async fn write_packet(stream: &mut TcpStream, seq: u8, payload: &[u8]) -> std::io::Result<()> {
+    let len = u32::try_from(payload.len()).expect("test packet fits in 24 bits");
+    let bytes = len.to_le_bytes();
+    stream.write_all(&[bytes[0], bytes[1], bytes[2], seq]).await?;
+    stream.write_all(payload).await
+}
+
+fn ok_packet() -> Vec<u8> {
+    vec![0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]
+}
+
+/// A `HandshakeV10` greeting the proxy's `parse_server_greeting` accepts.
+fn greeting() -> Vec<u8> {
+    let caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH;
+    let mut p = Vec::with_capacity(80);
+    p.push(10); // protocol version
+    p.extend_from_slice(b"8.0.0-mock\0");
+    p.extend_from_slice(&1_u32.to_le_bytes()); // connection id
+    p.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]); // auth-plugin-data part 1
+    p.push(0); // filler
+    p.extend_from_slice(&caps.to_le_bytes()[..2]);
+    p.push(33); // charset
+    p.extend_from_slice(&0x0002_u16.to_le_bytes()); // status: AUTOCOMMIT
+    p.extend_from_slice(&caps.to_le_bytes()[2..]);
+    p.push(21); // auth-plugin-data length (8 + 12 + null)
+    p.extend_from_slice(&[0u8; 10]); // reserved
+    p.extend_from_slice(&[9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    p.push(0); // null-terminate part 2
+    p.extend_from_slice(b"mysql_native_password\0");
+    p
+}
+
+fn handshake_response() -> Vec<u8> {
+    let caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH;
+    let mut b = Vec::with_capacity(64);
+    b.extend_from_slice(&caps.to_le_bytes());
+    b.extend_from_slice(&16_777_215_u32.to_le_bytes());
+    b.push(33);
+    b.extend_from_slice(&[0u8; 23]);
+    b.extend_from_slice(b"root\0");
+    b.push(0); // lenenc-encoded empty auth response
+    b.extend_from_slice(b"mysql_native_password\0");
+    b
+}
+
+// ── A mock MySQL backend that can be started whenever the test wants ─────────
+
+/// Reserve a loopback port and release it, so a backend can be bound there
+/// later. Between the release and the late `start_mock_backend_on`, the
+/// address is exactly what the bug needs: routable but refusing connections.
+async fn reserve_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("reserve port");
+    let addr = listener.local_addr().expect("reserved addr");
+    drop(listener);
+    addr
+}
+
+/// Bind a mock `MySQL` server on `addr`. Returns the count of accepted
+/// backend connections.
+async fn start_mock_backend_on(addr: SocketAddr) -> Arc<AtomicUsize> {
+    let listener = TcpListener::bind(addr).await.expect("bind mock backend");
+    let connects = Arc::new(AtomicUsize::new(0));
+    let connects_task = Arc::clone(&connects);
+    tokio::spawn(async move {
+        loop {
+            let Ok((sock, _)) = listener.accept().await else { break };
+            connects_task.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(mock_session(sock));
+        }
+    });
+    connects
+}
+
+/// Greet, accept any auth, then answer everything with `OK`.
+async fn mock_session(mut sock: TcpStream) {
+    let _ = sock.set_nodelay(true);
+    if write_packet(&mut sock, 0, &greeting()).await.is_err() {
+        return;
+    }
+    if read_packet(&mut sock).await.is_err() {
+        return;
+    }
+    if write_packet(&mut sock, 2, &ok_packet()).await.is_err() {
+        return;
+    }
+    loop {
+        if read_packet(&mut sock).await.is_err() {
+            return;
+        }
+        if write_packet(&mut sock, 1, &ok_packet()).await.is_err() {
+            return;
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn test_pool_config() -> PoolConfig {
+    PoolConfig {
+        min_connections: 1,
+        max_connections: 5,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        health_check_interval: Duration::from_secs(30),
+    }
+}
+
+/// Start a proxy on a free port with the deferred (production) startup path.
+async fn spawn_proxy(upstream: SocketAddr) -> (String, Arc<ProxyHealth>) {
+    let listen = reserve_addr().await.to_string();
+    let health = ProxyHealth::new("mysql", listen.clone(), upstream.to_string());
+    ephpm_db::mysql::spawn_deferred(
+        &format!("mysql://root@{upstream}/test"),
+        &listen,
+        None,
+        test_pool_config(),
+        ResetStrategy::Smart,
+        vec![],
+        RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
+        Arc::clone(&health),
+    )
+    .await
+    .expect("spawn_deferred must succeed without a reachable upstream");
+    (listen, health)
+}
+
+/// Poll until `health` reports its first upstream handshake, or time out.
+async fn await_first_connect(health: &ProxyHealth, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if health.ever_connected() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+/// Complete one client handshake through the proxy.
+async fn client_handshake(sock: &mut TcpStream) -> Result<(), String> {
+    let (_, payload) = read_packet(sock).await.map_err(|e| format!("read greeting: {e}"))?;
+    if payload.first() != Some(&10) {
+        return Err(format!("not a HandshakeV10: {:?}", payload.first()));
+    }
+    write_packet(sock, 1, &handshake_response())
+        .await
+        .map_err(|e| format!("write handshake response: {e}"))?;
+    let (_, ok) = read_packet(sock).await.map_err(|e| format!("read auth result: {e}"))?;
+    if ok.first() == Some(&0x00) { Ok(()) } else { Err(format!("auth not OK: {:?}", ok.first())) }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// The core of #226. Before the fix this call could not even be made: startup
+/// connected first and bound second, so with nothing listening upstream there
+/// was no proxy and no socket. Now the socket exists immediately.
+#[tokio::test]
+async fn listener_is_bound_before_the_upstream_exists() {
+    let upstream = reserve_addr().await; // nothing is listening there
+    let (listen, health) = spawn_proxy(upstream).await;
+
+    let client = tokio::time::timeout(Duration::from_secs(2), TcpStream::connect(&listen))
+        .await
+        .expect("connect to the proxy must not hang");
+    assert!(client.is_ok(), "the proxy listen socket must be bound with no upstream: {client:?}");
+
+    assert!(!health.ever_connected(), "no upstream exists, so no handshake can have happened");
+    assert!(!health.is_up(), "the live gauge must report the upstream down");
+}
+
+/// An upstream that appears after ePHPm has started — the local litewire
+/// listener in the chained config, or any database slower to boot than the
+/// server — must be picked up by the retry loop.
+#[tokio::test]
+async fn upstream_that_appears_late_is_picked_up() {
+    let upstream = reserve_addr().await;
+    let (listen, health) = spawn_proxy(upstream).await;
+
+    // The proxy is now burning connect attempts against a dead address.
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    assert!(!health.ever_connected(), "sanity: nothing to connect to yet");
+
+    let backend_connects = start_mock_backend_on(upstream).await;
+
+    assert!(
+        await_first_connect(&health, Duration::from_secs(15)).await,
+        "the proxy must reach an upstream that appeared after startup"
+    );
+    assert!(health.is_up());
+    assert!(backend_connects.load(Ordering::SeqCst) >= 1, "the backend must have been dialed");
+
+    // And it must actually serve: full client handshake through the proxy.
+    let mut client = TcpStream::connect(&listen).await.expect("connect to proxy");
+    client_handshake(&mut client).await.expect("proxy must serve clients once upstream is up");
+}
+
+/// A client that connects during the upstream-connect window must not get
+/// `ECONNREFUSED`. The socket is bound, so it queues in the kernel accept
+/// backlog and is served once the proxy starts accepting — which is what
+/// makes PHP's first request survive a cold start rather than 500.
+#[tokio::test]
+async fn client_connected_before_the_upstream_is_served_from_the_backlog() {
+    let upstream = reserve_addr().await;
+    let (listen, health) = spawn_proxy(upstream).await;
+
+    // Connect while the upstream is still dead and hold the socket.
+    let mut early_client =
+        TcpStream::connect(&listen).await.expect("connect must succeed into the backlog");
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    start_mock_backend_on(upstream).await;
+    assert!(await_first_connect(&health, Duration::from_secs(15)).await);
+
+    // The connection made before any upstream existed now gets its greeting.
+    tokio::time::timeout(Duration::from_secs(10), client_handshake(&mut early_client))
+        .await
+        .expect("the queued client must be served, not time out")
+        .expect("the queued client must complete its handshake");
+}
+
+/// Retry is unbounded on the deferred path: an upstream down for longer than
+/// the old ~40 s budget must still be picked up. Before the fix the proxy
+/// gave up permanently and only a process restart could recover it.
+#[tokio::test]
+async fn retry_survives_longer_than_the_old_bounded_budget() {
+    // The schedule itself is what makes this true; asserting it directly is
+    // faster and more honest than sleeping for 40 s in CI.
+    assert!(!RetryBudget::Unbounded.is_final_attempt(10), "the old budget stopped at 10 attempts");
+    assert!(!RetryBudget::Unbounded.is_final_attempt(u32::MAX));
+    assert!(RetryBudget::Bounded(10).is_final_attempt(10));
+    assert!(!RetryBudget::Bounded(10).is_final_attempt(9));
+
+    // 250ms doubling caps at 30 s, so steady state is one connect attempt per
+    // 30 s — cheap enough to run forever, frequent enough to recover fast.
+    assert_eq!(RetryBudget::Unbounded.max_backoff_ms(), 30_000);
+    assert_eq!(RetryBudget::Bounded(10).max_backoff_ms(), 8_000);
+}
+
+/// A listen address that cannot be bound is a configuration error and must
+/// fail startup — not log and leave a dead port, which is the failure shape
+/// #226 is about.
+#[tokio::test]
+async fn bind_failure_is_an_error_not_a_warning() {
+    let occupied = TcpListener::bind("127.0.0.1:0").await.expect("occupy a port");
+    let addr = occupied.local_addr().unwrap().to_string();
+    let health = ProxyHealth::new("mysql", addr.clone(), "127.0.0.1:1".to_string());
+
+    let result = ephpm_db::mysql::spawn_deferred(
+        "mysql://root@127.0.0.1:1/test",
+        &addr,
+        None,
+        test_pool_config(),
+        ResetStrategy::Smart,
+        vec![],
+        RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
+        health,
+    )
+    .await;
+
+    assert!(result.is_err(), "binding an occupied port must return an error");
+}
+
+/// A malformed URL is likewise fatal at startup, before anything is bound.
+#[tokio::test]
+async fn malformed_url_is_an_error() {
+    let listen = reserve_addr().await.to_string();
+    let health = ProxyHealth::new("mysql", listen.clone(), "unparsed".to_string());
+    let result = ephpm_db::mysql::spawn_deferred(
+        "not-a-database-url",
+        &listen,
+        None,
+        test_pool_config(),
+        ResetStrategy::Smart,
+        vec![],
+        RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
+        health,
+    )
+    .await;
+
+    assert!(result.is_err(), "a malformed [db.mysql] url must fail startup");
+}

--- a/crates/ephpm-db/tests/deferred_startup.rs
+++ b/crates/ephpm-db/tests/deferred_startup.rs
@@ -264,6 +264,29 @@ async fn client_connected_before_the_upstream_is_served_from_the_backlog() {
         .expect("the queued client must complete its handshake");
 }
 
+/// The backlog window is bounded. An upstream that is simply *down* must not
+/// leave clients blocked reading a greeting that never comes — mysqlnd's read
+/// timeout is 24 hours, so that would pin a PHP worker until the HTTP request
+/// deadline. Past the grace period the proxy closes clients on arrival.
+///
+/// This was found by the podman reproduction of #226, not by review: the
+/// first cut of the fix traded a fast 500 for a 300 s hang.
+#[tokio::test]
+async fn a_long_dead_upstream_closes_clients_instead_of_hanging_them() {
+    let upstream = reserve_addr().await; // never comes up
+    let (listen, health) = spawn_proxy(upstream).await;
+
+    tokio::time::sleep(ephpm_db::health::BACKLOG_GRACE + Duration::from_millis(750)).await;
+    assert!(!health.ever_connected(), "sanity: the upstream never appeared");
+
+    let mut client = TcpStream::connect(&listen).await.expect("connect still succeeds");
+    let mut buf = [0u8; 4];
+    let read = tokio::time::timeout(Duration::from_secs(5), client.read(&mut buf))
+        .await
+        .expect("the client must be closed promptly, not left blocked on a read");
+    assert_eq!(read.ok(), Some(0), "the proxy must close the connection (EOF), not answer it");
+}
+
 /// Retry is unbounded on the deferred path: an upstream down for longer than
 /// the old ~40 s budget must still be picked up. Before the fix the proxy
 /// gave up permanently and only a process restart could recover it.

--- a/crates/ephpm-server/src/db_health.rs
+++ b/crates/ephpm-server/src/db_health.rs
@@ -1,0 +1,211 @@
+//! Database-proxy health as seen by the HTTP readiness probe.
+//!
+//! # Why readiness gates on the *first* upstream connect and nothing after
+//!
+//! A proxy that has never reached its upstream since boot cannot serve a
+//! single query. Before this existed, that state was invisible: the proxy
+//! logged, gave up, and the process went on passing both `/_ephpm/health`
+//! and `/_ephpm/ready` while every DB-backed page returned 500. A
+//! health-checked deployment reported healthy and served errors, and a bad
+//! rollout replaced healthy pods with pods that could never work.
+//!
+//! So: **readiness fails until every configured proxy has completed one
+//! upstream handshake.** A rollout containing a pod that cannot reach the
+//! database now stalls instead of completing.
+//!
+//! The deliberate other half — **after that first success, readiness never
+//! flaps on upstream state**:
+//!
+//! - Gating readiness on *live* database reachability makes every replica
+//!   sharing one database fail its probe at the same instant. Kubernetes
+//!   then empties the Service, and a database that was merely degraded
+//!   becomes a total outage — including for the static assets, cached
+//!   pages, and non-DB routes the pods could still serve.
+//!   Correlated dependencies do not belong in a per-pod readiness gate.
+//! - It also breaks recovery: with no endpoints there is no traffic, so
+//!   nothing reopens pooled connections, and external monitoring sees a
+//!   black hole rather than 500s that name the failing database.
+//!
+//! Liveness (`/_ephpm/health`) stays green in both cases. Restarting the
+//! process does not make a remote database come back; it only discards warm
+//! pools and OPcache and adds a crash-loop to the incident.
+//!
+//! A post-startup outage is therefore reported, not routed around:
+//! `ephpm_db_proxy_upstream_up` drops to 0,
+//! `ephpm_db_proxy_connect_failures_total` climbs, and
+//! [`ProxyHealth`](ephpm_db::health::ProxyHealth) logs it at ERROR
+//! (throttled to one line per minute). Alert on the gauge.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use ephpm_config::Config;
+use ephpm_db::health::ProxyHealth;
+use ephpm_db::url::DbUrl;
+
+/// Upstream health for every SQL proxy this process was configured to run.
+///
+/// Built from config *before* the HTTP listeners are bound and shared with
+/// both the router (readiness) and proxy startup (state transitions), so
+/// there is no window where a proxy exists but has not yet registered and
+/// the probe would report a premature "ready".
+#[derive(Debug, Default)]
+pub struct DbProxyHealth {
+    /// Health of the `[db.mysql]` proxy, if configured.
+    mysql: Option<Arc<ProxyHealth>>,
+    /// Health of the `[db.postgres]` proxy, if configured.
+    postgres: Option<Arc<ProxyHealth>>,
+}
+
+impl DbProxyHealth {
+    /// Pre-register health state for each configured proxy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a configured proxy URL cannot be parsed — the
+    /// same failure `spawn_deferred` would hit, surfaced at startup where
+    /// it is actionable.
+    pub fn from_config(config: &Config) -> anyhow::Result<Arc<Self>> {
+        let mysql = config
+            .db
+            .mysql
+            .as_ref()
+            .map(|c| {
+                let listen = c.listen.clone().unwrap_or_else(|| "127.0.0.1:3306".to_string());
+                let upstream =
+                    DbUrl::parse(&c.url).context("invalid [db.mysql] url").map(|u| u.addr())?;
+                anyhow::Ok(ProxyHealth::new("mysql", listen, upstream))
+            })
+            .transpose()?;
+
+        let postgres = config
+            .db
+            .postgres
+            .as_ref()
+            .map(|c| {
+                let listen = c.listen.clone().unwrap_or_else(|| "127.0.0.1:5432".to_string());
+                let upstream =
+                    DbUrl::parse(&c.url).context("invalid [db.postgres] url").map(|u| u.addr())?;
+                anyhow::Ok(ProxyHealth::new("postgres", listen, upstream))
+            })
+            .transpose()?;
+
+        Ok(Arc::new(Self { mysql, postgres }))
+    }
+
+    /// The `[db.mysql]` proxy's health handle.
+    #[must_use]
+    pub fn mysql(&self) -> Option<&Arc<ProxyHealth>> {
+        self.mysql.as_ref()
+    }
+
+    /// The `[db.postgres]` proxy's health handle.
+    #[must_use]
+    pub fn postgres(&self) -> Option<&Arc<ProxyHealth>> {
+        self.postgres.as_ref()
+    }
+
+    /// Every configured proxy's health handle.
+    pub fn iter(&self) -> impl Iterator<Item = &Arc<ProxyHealth>> {
+        self.mysql.iter().chain(self.postgres.iter())
+    }
+
+    /// The first proxy that has never reached its upstream since boot, if
+    /// any. `Some` means the process must report **not ready**.
+    ///
+    /// Deliberately reads `ever_connected`, not the live `is_up` — see the
+    /// module docs for why a database outage must not evict every pod from
+    /// the load balancer.
+    #[must_use]
+    pub fn first_never_connected(&self) -> Option<&Arc<ProxyHealth>> {
+        self.iter().find(|h| !h.ever_connected())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with(mysql: Option<&str>, postgres: Option<&str>) -> Config {
+        let mut config = Config::default();
+        config.db.mysql = mysql.map(|url| ephpm_config::DbBackendConfig {
+            url: url.to_string(),
+            ..Default::default()
+        });
+        config.db.postgres = postgres.map(|url| ephpm_config::DbBackendConfig {
+            url: url.to_string(),
+            ..Default::default()
+        });
+        config
+    }
+
+    #[test]
+    fn no_proxies_configured_is_always_ready() {
+        let health = DbProxyHealth::from_config(&Config::default()).unwrap();
+        assert!(health.first_never_connected().is_none());
+        assert_eq!(health.iter().count(), 0);
+    }
+
+    /// The exact hole issue #226 reported: a configured proxy that has not
+    /// reached its upstream must hold readiness down.
+    #[test]
+    fn configured_proxy_holds_readiness_until_first_connect() {
+        let health = DbProxyHealth::from_config(&config_with(
+            Some("mysql://root@127.0.0.1:3307/main"),
+            None,
+        ))
+        .unwrap();
+        assert!(
+            health.first_never_connected().is_some(),
+            "a proxy that has never reached its upstream must fail readiness"
+        );
+
+        health.mysql().unwrap().record_up();
+        assert!(health.first_never_connected().is_none(), "one handshake must clear the gate");
+    }
+
+    /// The deliberate half of the design: a *later* outage must not evict
+    /// the pod. If this ever starts failing, someone changed
+    /// `first_never_connected` to read live state — read the module docs
+    /// before "fixing" it.
+    #[test]
+    fn later_outage_does_not_flap_readiness() {
+        let health = DbProxyHealth::from_config(&config_with(
+            Some("mysql://root@127.0.0.1:3307/main"),
+            None,
+        ))
+        .unwrap();
+        let mysql = health.mysql().unwrap();
+        mysql.record_up();
+        mysql.record_down(&"connection refused");
+
+        assert!(!mysql.is_up(), "the live gauge must reflect the outage");
+        assert!(
+            health.first_never_connected().is_none(),
+            "readiness must not flap on a post-startup database outage"
+        );
+    }
+
+    #[test]
+    fn every_configured_proxy_gates_readiness() {
+        let health = DbProxyHealth::from_config(&config_with(
+            Some("mysql://root@127.0.0.1:3307/main"),
+            Some("postgres://postgres@127.0.0.1:15432/main"),
+        ))
+        .unwrap();
+        assert_eq!(health.iter().count(), 2);
+
+        health.mysql().unwrap().record_up();
+        let pending = health.first_never_connected().expect("postgres still pending");
+        assert_eq!(pending.kind(), "postgres");
+
+        health.postgres().unwrap().record_up();
+        assert!(health.first_never_connected().is_none());
+    }
+
+    #[test]
+    fn malformed_url_fails_startup() {
+        let err = DbProxyHealth::from_config(&config_with(Some("not-a-url"), None)).unwrap_err();
+        assert!(format!("{err:#}").contains("[db.mysql] url"));
+    }
+}

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod acme;
 pub mod body;
+pub mod db_health;
 pub mod file_cache;
 mod idle;
 pub mod metrics;
@@ -240,6 +241,12 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         metric_label_series_max: config.db.analysis.metric_label_series_max,
     });
 
+    // Upstream health for every configured SQL proxy, built BEFORE the HTTP
+    // listeners so `/_ephpm/ready` can never report ready in the window
+    // between the router existing and the proxies starting. Fails startup on
+    // a malformed proxy URL.
+    let db_health = db_health::DbProxyHealth::from_config(&config)?;
+
     // Bind the HTTP listeners BEFORE constructing DB proxies: proxy startup
     // now retries a down backend with backoff (up to ~40s per proxy), and if
     // that ran first the listen sockets wouldn't exist yet — long enough for
@@ -258,12 +265,18 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         metrics_handle,
         middleware_chain,
         effective_node_id,
+        Arc::clone(&db_health),
     )
     .await?;
 
-    let _db_handles =
-        start_db_proxies(&config, cluster_handle.as_ref(), channel_handle.as_ref(), &query_stats)
-            .await?;
+    let _db_handles = start_db_proxies(
+        &config,
+        cluster_handle.as_ref(),
+        channel_handle.as_ref(),
+        &query_stats,
+        &db_health,
+    )
+    .await?;
 
     accept_loop(listeners).await
 }
@@ -338,6 +351,9 @@ async fn bind_listeners(
     // PHP `$_SERVER` as `EPHPM_NODE_ID`. `None` in single-node mode, where the
     // Router falls back to `[cluster] node_id` from config.
     node_id: Option<String>,
+    // Upstream health of the configured SQL proxies, so the readiness probe
+    // reports 503 until each one has reached its upstream at least once.
+    db_health: Arc<db_health::DbProxyHealth>,
 ) -> anyhow::Result<Listeners> {
     let addr: SocketAddr = config.server.listen.parse().context("invalid listen address")?;
 
@@ -495,7 +511,8 @@ async fn bind_listeners(
         // when `[cluster] node_id` is left empty (auto-derived per pod in
         // Kind). In single-node mode this is None, so Router keeps whatever it
         // derived from `[cluster] node_id`.
-        .with_node_id(node_id),
+        .with_node_id(node_id)
+        .with_db_health(db_health),
     );
 
     let has_tls = !matches!(tls_mode, TlsMode::None);
@@ -1272,11 +1289,29 @@ fn db_listen_exposure(addr: &str) -> Option<&'static str> {
 }
 
 /// Start database proxies (`MySQL`, `PostgreSQL`, `TDS`, embedded `SQLite`).
+///
+/// # Startup ordering
+///
+/// The SQL proxies bind their listen sockets here and reach their upstreams
+/// from background tasks, so nothing in this function blocks on a database
+/// being reachable. That is load-bearing, not tidiness: the embedded-SQLite
+/// branch below runs *after* the proxy branches, and a `[db.mysql]` proxy
+/// pointed at `[db.sqlite]`'s own litewire listener used to exhaust its
+/// entire connect budget against a listener this function had not bound yet,
+/// then give up permanently (issue #226). The same inversion fixes every
+/// deployment whose database is simply slower to start than ePHPm.
+///
+/// Errors from proxy startup — a malformed URL, a listen address that cannot
+/// be bound — are now fatal rather than logged. A proxy that cannot bind its
+/// port is a configuration error, and the previous behavior (log, continue,
+/// leave the port dead) is precisely the failure mode this function is being
+/// fixed for.
 async fn start_db_proxies(
     config: &Config,
     cluster: Option<&Arc<ephpm_cluster::ClusterHandle>>,
     channel_handle: Option<&ephpm_cluster::ChannelHandle>,
     query_stats: &ephpm_query_stats::QueryStats,
+    db_health: &db_health::DbProxyHealth,
 ) -> anyhow::Result<Vec<tokio::task::JoinHandle<()>>> {
     let mut handles = vec![];
 
@@ -1315,36 +1350,28 @@ async fn start_db_proxies(
             sticky_duration: parse_duration(&config.db.read_write_split.sticky_duration)?,
         };
 
-        match ephpm_db::mysql::build_proxy(
-            &url,
-            &listen,
-            mysql_config.socket.clone(),
-            pool_config,
-            reset_strategy,
-            replica_urls,
-            rw_split,
-            // Same collector the litewire paths hand to `TrackedBackend`, so
-            // proxied and embedded queries land on one metrics surface.
-            query_stats.clone(),
-        )
-        .await
-        {
-            Ok(proxy) => {
-                let maintenance_handle = proxy.start_maintenance();
-                let proxy_handle = tokio::spawn(async move {
-                    match proxy.run().await {
-                        Ok(()) => tracing::info!("MySQL proxy stopped"),
-                        Err(e) => tracing::error!("MySQL proxy error: {e:#}"),
-                    }
-                });
-                handles.push(proxy_handle);
-                // Drop the handle to detach the maintenance task — it runs independently.
-                drop(maintenance_handle);
-            }
-            Err(e) => {
-                tracing::error!("failed to start MySQL proxy: {e:#}");
-            }
-        }
+        let health = db_health
+            .mysql()
+            .cloned()
+            .context("[db.mysql] is configured but no health handle was registered")?;
+
+        handles.push(
+            ephpm_db::mysql::spawn_deferred(
+                &url,
+                &listen,
+                mysql_config.socket.clone(),
+                pool_config,
+                reset_strategy,
+                replica_urls,
+                rw_split,
+                // Same collector the litewire paths hand to `TrackedBackend`, so
+                // proxied and embedded queries land on one metrics surface.
+                query_stats.clone(),
+                health,
+            )
+            .await
+            .context("failed to start MySQL proxy")?,
+        );
     }
 
     // PostgreSQL proxy
@@ -1379,32 +1406,25 @@ async fn start_db_proxies(
             sticky_duration: parse_duration(&config.db.read_write_split.sticky_duration)?,
         };
 
-        match ephpm_db::postgres::build_proxy(
-            &url,
-            &listen,
-            pool_config,
-            reset_strategy,
-            replica_urls,
-            rw_split,
-            query_stats.clone(),
-        )
-        .await
-        {
-            Ok(proxy) => {
-                let maintenance_handle = proxy.start_maintenance();
-                let proxy_handle = tokio::spawn(async move {
-                    match proxy.run().await {
-                        Ok(()) => tracing::info!("PostgreSQL proxy stopped"),
-                        Err(e) => tracing::error!("PostgreSQL proxy error: {e:#}"),
-                    }
-                });
-                handles.push(proxy_handle);
-                drop(maintenance_handle);
-            }
-            Err(e) => {
-                tracing::error!("failed to start PostgreSQL proxy: {e:#}");
-            }
-        }
+        let health = db_health
+            .postgres()
+            .cloned()
+            .context("[db.postgres] is configured but no health handle was registered")?;
+
+        handles.push(
+            ephpm_db::postgres::spawn_deferred(
+                &url,
+                &listen,
+                pool_config,
+                reset_strategy,
+                replica_urls,
+                rw_split,
+                query_stats.clone(),
+                health,
+            )
+            .await
+            .context("failed to start PostgreSQL proxy")?,
+        );
     }
 
     // TDS (SQL Server) proxy — not yet implemented.

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -324,6 +324,10 @@ pub struct Router {
     /// construction from `[[middleware]]` config (see
     /// [`ingest_strip_headers`]).
     ingest_strip_headers: Vec<String>,
+    /// Upstream health of the configured SQL proxies, consulted by
+    /// [`Router::readiness_check`]. `None` when the router was built without
+    /// one (tests); readiness then ignores the database entirely.
+    db_health: Option<Arc<crate::db_health::DbProxyHealth>>,
 }
 
 /// Header names always stripped from inbound requests at ingest, in addition
@@ -647,6 +651,7 @@ impl Router {
             canonical_scripts: dashmap::DashMap::new(),
             canonical_scripts_swept: std::sync::Mutex::new(Instant::now()),
             ingest_strip_headers: build_ingest_strip_headers(&config.middleware),
+            db_health: None,
         }
     }
 
@@ -802,6 +807,18 @@ impl Router {
                 self.node_id = Some(id.to_string());
             }
         }
+        self
+    }
+
+    /// Attach the SQL proxies' upstream health to the readiness probe.
+    ///
+    /// `serve()` builds one [`DbProxyHealth`](crate::db_health::DbProxyHealth)
+    /// from config before the listeners are bound and hands the same handle
+    /// to proxy startup, so `/_ephpm/ready` reports 503 until every
+    /// configured proxy has reached its upstream once.
+    #[must_use]
+    pub fn with_db_health(mut self, db_health: Arc<crate::db_health::DbProxyHealth>) -> Self {
+        self.db_health = Some(db_health);
         self
     }
 
@@ -1939,7 +1956,32 @@ impl Router {
                 );
             }
         }
+        // A configured SQL proxy that has never reached its upstream cannot
+        // serve a single query — the process must stay out of rotation and a
+        // rollout containing it must stall. Deliberately a *first-connect*
+        // gate, not a live database probe: see `crate::db_health` for why a
+        // post-startup outage must not evict every replica at once.
+        if let Some(resp) = Self::db_not_ready(self.db_health.as_ref()) {
+            return resp;
+        }
         json_response(StatusCode::OK, r#"{"status":"ready"}"#)
+    }
+
+    /// The database half of [`Router::readiness_check`]: `Some(503)` when a
+    /// configured SQL proxy has never reached its upstream, `None` otherwise.
+    ///
+    /// Split out so the behavior can be tested without a live PHP runtime.
+    fn db_not_ready(
+        db_health: Option<&Arc<crate::db_health::DbProxyHealth>>,
+    ) -> Option<Response<ServerBody>> {
+        let pending = db_health?.first_never_connected()?;
+        Some(json_response_owned(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                r#"{{"status":"not_ready","reason":"database proxy has not reached its upstream: {}"}}"#,
+                json_escape(&pending.describe())
+            ),
+        ))
     }
 
     /// Apply custom response headers from config.
@@ -2230,6 +2272,45 @@ fn json_response(status: StatusCode, body: &'static str) -> Response<ServerBody>
         .header("content-type", "application/json")
         .body(body::buffered(Full::new(Bytes::from_static(body.as_bytes()))))
         .expect("static json response")
+}
+
+/// A JSON response whose body is built at runtime.
+///
+/// Only used off the hot path (the readiness probe, which needs to name the
+/// proxy that is holding the pod down).
+fn json_response_owned(status: StatusCode, body: String) -> Response<ServerBody> {
+    Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(body::buffered(Full::new(Bytes::from(body))))
+        .expect("owned json response")
+}
+
+/// Escape a string for embedding in a JSON string literal.
+///
+/// The readiness reason interpolates config-derived text (a listen address
+/// and an upstream `host:port`). Those are operator-controlled rather than
+/// attacker-controlled, but a stray quote would still emit a body that no
+/// probe could parse, so escape rather than trust.
+fn json_escape(s: &str) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                // Writing to a String is infallible.
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Build database environment variables from config for PHP injection.
@@ -4636,5 +4717,107 @@ data: two
         config.server.timeouts.request = 30;
         let router = Router::new(&config, test_store(), None, None, None, None, None);
         assert_eq!(router.request_timeout, Duration::from_secs(30));
+    }
+
+    // ── Readiness: database proxy upstream (issue #226) ───────────────────
+
+    /// A `DbProxyHealth` with one MySQL proxy configured.
+    fn health_with_mysql() -> Arc<crate::db_health::DbProxyHealth> {
+        let mut config = Config::default();
+        config.db.mysql = Some(ephpm_config::DbBackendConfig {
+            url: "mysql://root@127.0.0.1:3307/main".to_string(),
+            listen: Some("127.0.0.1:3306".to_string()),
+            ..Default::default()
+        });
+        crate::db_health::DbProxyHealth::from_config(&config).expect("valid db config")
+    }
+
+    /// No `[db.mysql]` / `[db.postgres]` at all: readiness must not mention
+    /// databases. That is the overwhelming majority of deployments (embedded
+    /// SQLite, or no database) and must behave exactly as before.
+    #[test]
+    fn readiness_ignores_databases_when_no_proxy_is_configured() {
+        let health = crate::db_health::DbProxyHealth::from_config(&Config::default()).unwrap();
+        assert!(Router::db_not_ready(Some(&health)).is_none());
+        assert!(Router::db_not_ready(None).is_none());
+    }
+
+    /// The reported hole: the proxy never reached its upstream, yet the
+    /// server reported ready and served 500s.
+    #[test]
+    fn readiness_fails_while_a_proxy_has_never_reached_its_upstream() {
+        let health = health_with_mysql();
+        let resp = Router::db_not_ready(Some(&health)).expect("must report not ready");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        health.mysql().unwrap().record_up();
+        assert!(
+            Router::db_not_ready(Some(&health)).is_none(),
+            "one upstream handshake must clear the readiness gate"
+        );
+    }
+
+    /// The 503 body must be parseable JSON that names the proxy — an operator
+    /// reading `kubectl describe` should not have to open the logs to learn
+    /// which upstream is unreachable.
+    #[tokio::test]
+    async fn readiness_body_names_the_pending_proxy() {
+        let health = health_with_mysql();
+        let resp = Router::db_not_ready(Some(&health)).expect("not ready");
+        let bytes = http_body_util::BodyExt::collect(resp.into_body())
+            .await
+            .expect("collect body")
+            .to_bytes();
+        let body = String::from_utf8(bytes.to_vec()).expect("utf-8 body");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("probe body is JSON");
+        assert_eq!(parsed["status"], "not_ready");
+        let reason = parsed["reason"].as_str().expect("reason string");
+        assert!(reason.contains("mysql"), "reason names the proxy kind: {reason}");
+        assert!(reason.contains("127.0.0.1:3307"), "reason names the upstream: {reason}");
+    }
+
+    /// A post-startup outage must NOT flap readiness. If this test starts
+    /// failing, someone changed the gate to read live upstream state — read
+    /// the `crate::db_health` module docs before calling that a fix.
+    #[test]
+    fn readiness_does_not_flap_on_a_post_startup_outage() {
+        let health = health_with_mysql();
+        let mysql = health.mysql().unwrap();
+        mysql.record_up();
+        mysql.record_down(&"connection refused");
+        assert!(!mysql.is_up(), "the live gauge must reflect the outage");
+        assert!(
+            Router::db_not_ready(Some(&health)).is_none(),
+            "a database outage must not evict the pod from rotation"
+        );
+    }
+
+    /// The whole probe path, including ordering against the PHP and
+    /// worker-pool gates. Stub builds only: marking the PHP runtime ready is
+    /// a flag flip there, rather than a real SAPI boot.
+    #[cfg(not(php_linked))]
+    #[test]
+    fn ready_endpoint_reports_503_until_the_proxy_reaches_its_upstream() {
+        let dir = tempfile::tempdir().unwrap();
+        ephpm_php::PhpRuntime::init_with_ini_file(None).expect("stub init");
+
+        let health = health_with_mysql();
+        let router = test_router(dir.path()).with_db_health(Arc::clone(&health));
+        assert_eq!(
+            router.readiness_check().status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "/_ephpm/ready must be 503 while the proxy has never reached its upstream"
+        );
+
+        health.mysql().unwrap().record_up();
+        assert_eq!(router.readiness_check().status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn json_escape_neutralizes_quotes_and_controls() {
+        assert_eq!(json_escape("a\"b"), "a\\\"b");
+        assert_eq!(json_escape("a\nb"), "a\\nb");
+        assert_eq!(json_escape("a\\b"), "a\\\\b");
+        assert_eq!(json_escape("plain"), "plain");
     }
 }

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -224,9 +224,16 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 The proxy binds `listen` at startup and reaches `url` from a background task,
 retrying forever with exponential backoff (250 ms doubling to a 30 s ceiling).
 A database that is slower to start than ePHPm — or that restarts later — is
-picked up when it appears; no ePHPm restart is needed. Clients that connect
-during the window queue in the kernel accept backlog rather than getting
-`ECONNREFUSED`, so PHP's first request waits instead of erroring.
+picked up when it appears; no ePHPm restart is needed.
+
+Clients that connect during the first **5 seconds** of that window queue in the
+kernel accept backlog rather than getting `ECONNREFUSED`, so PHP's first
+request waits a moment and then succeeds. Past 5 seconds the proxy accepts and
+immediately closes each client, so callers fail fast: a client whose TCP
+connect succeeded would otherwise block reading a server greeting that never
+comes, and mysqlnd's read timeout is 24 hours by default — that would pin a PHP
+worker until the HTTP request deadline. PHP reports the close promptly
+(`Lost connection to MySQL server at 'reading initial communication packet'`).
 
 Two things *are* fatal at startup, because both are configuration errors: a
 `url` that cannot be parsed, and a `listen` address that cannot be bound.

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -219,6 +219,39 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 >
 > Binding `listen` to a non-loopback address therefore gives full read/write access to your database to any host that can reach the port. ePHPm logs a startup warning when `listen` is a non-loopback IP literal (`0.0.0.0:3306`, `10.0.0.5:3306`, …), but does **not** refuse to start — binding `0.0.0.0` inside a container that is firewalled by a network policy is a legitimate deployment. Addresses given as hostnames (`localhost:3306`, `db.internal:3306`) are not classified, because that would require a DNS lookup at startup; no warning is logged for them either way.
 
+#### Startup: the upstream does not have to be reachable
+
+The proxy binds `listen` at startup and reaches `url` from a background task,
+retrying forever with exponential backoff (250 ms doubling to a 30 s ceiling).
+A database that is slower to start than ePHPm — or that restarts later — is
+picked up when it appears; no ePHPm restart is needed. Clients that connect
+during the window queue in the kernel accept backlog rather than getting
+`ECONNREFUSED`, so PHP's first request waits instead of erroring.
+
+Two things *are* fatal at startup, because both are configuration errors: a
+`url` that cannot be parsed, and a `listen` address that cannot be bound.
+
+#### Readiness and the database proxy
+
+`/_ephpm/ready` reports **503 until every configured proxy has reached its
+upstream once**. A process whose proxy has never connected cannot serve a
+single query, so it must stay out of load-balancer rotation, and a rollout
+containing such a pod should stall rather than replace healthy pods.
+
+After that first success, readiness never flaps on upstream state again. This
+is deliberate: gating readiness on live database reachability would fail every
+replica's probe at the same instant during a shared-database outage, empty the
+Service, and turn a degraded database into a total outage — including for the
+static assets and non-DB routes those pods could still serve. Liveness
+(`/_ephpm/health`) stays green throughout; restarting the process does not
+bring a remote database back.
+
+A post-startup outage is reported instead of routed around:
+`ephpm_db_proxy_upstream_up` drops to `0`,
+`ephpm_db_proxy_connect_failures_total` climbs, and the proxy logs at ERROR
+(throttled to one line per minute). See
+[Metrics → Database (proxy upstream health)](/reference/metrics/#database-proxy-upstream-health).
+
 ### `[db.sqlite]`
 
 | Key | Type | Default | Description |

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -76,6 +76,31 @@ These appear when a cluster-wide OPcache invalidation actually fires. When
 |--------|------|--------|-------------|
 | `ephpm_opcache_invalidations_total` | counter | `vhost`, `trigger` | Cluster-wide OPcache invalidations run for a vhost. `trigger` is always `kv` today — both `ephpm deploy` and `ephpm cache reset` arrive via the KV version key. The planned file watcher (roadmap Phase 3) will add a second value. |
 
+## Database (proxy upstream health)
+
+These appear when `[db.mysql]` or `[db.postgres]` is configured. Labels: `db`
+(`mysql` / `postgres`) and `upstream` (the resolved `host:port` — never the
+URL, which carries credentials).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ephpm_db_proxy_upstream_ever_connected` | gauge | `db`, `upstream` | `1` once the proxy has completed one upstream handshake since boot. Latches — it never returns to `0`. While it is `0`, `/_ephpm/ready` reports 503. |
+| `ephpm_db_proxy_upstream_up` | gauge | `db`, `upstream` | `1` if the most recent upstream connect attempt succeeded, `0` if it failed. Flaps with the database. |
+| `ephpm_db_proxy_connect_failures_total` | counter | `db`, `upstream` | Upstream connect/handshake failures. |
+
+`ephpm_db_proxy_upstream_up` is the metric to alert on. Readiness deliberately
+does **not** flap with it — a shared database going down would otherwise fail
+every replica's probe at the same instant and empty the Service. See
+[Readiness and the database proxy](/reference/config/#readiness-and-the-database-proxy).
+
+```promql
+# A proxy that never came up: the pod is not in rotation and never will be.
+ephpm_db_proxy_upstream_ever_connected == 0
+
+# A database outage on a pod that IS still in rotation, serving 500s.
+ephpm_db_proxy_upstream_up == 0 and ephpm_db_proxy_upstream_ever_connected == 1
+```
+
 ## Database (query stats)
 
 These appear when `[db.analysis] query_stats = true` (the default).

--- a/site/content/roadmap/kubernetes.md
+++ b/site/content/roadmap/kubernetes.md
@@ -30,7 +30,12 @@ ePHPm exposes two built-in probe endpoints on the main HTTP port:
 | Endpoint | Purpose | Response |
 |----------|---------|----------|
 | `/_ephpm/health` | Liveness probe | `200 {"status":"ok"}` — always succeeds if the process is running |
-| `/_ephpm/ready` | Readiness probe | `200 {"status":"ready"}` when PHP runtime is initialized; `503 {"status":"not_ready","reason":"PHP runtime not initialized"}` otherwise |
+| `/_ephpm/ready` | Readiness probe | `200 {"status":"ready"}` once the PHP runtime is initialized, a worker has finished booting (worker mode only), and every configured SQL proxy has reached its upstream at least once. Otherwise `503 {"status":"not_ready","reason":"..."}` naming which of those is outstanding. |
+
+Readiness gates on the SQL proxy's **first** upstream connect, not on live
+database reachability — a shared-database outage must not fail every replica's
+probe at once and empty the Service. See
+[Readiness and the database proxy](/reference/config/#readiness-and-the-database-proxy).
 
 ### Pod spec example
 


### PR DESCRIPTION
Closes #226.

## The bug, both halves

**A — the reported symptom.** `start_db_proxies()` awaited `build_proxy()` inline, and `build_proxy` connected to the upstream *before* binding the listen socket, on a bounded ~10-attempt / ~40 s budget. The embedded-SQLite (litewire) branch runs *after* the proxy branches in the same function, so a `[db.mysql]` proxy pointed at `[db.sqlite]`'s own `mysql_listen` burned its entire budget against a listener the same function had not bound yet, gave up **non-fatally**, and PHP got `[2002] Connection refused` for the life of the process.

**B — the general half.** After the proxy gave up, the server still passed **both** liveness and readiness while every DB-backed page returned 500. A health-checked deployment reported healthy and served errors, and a rollout containing such a pod completed and replaced healthy pods. That applies to every proxy deployment whose upstream is down at boot, not just the chained one.

## What changed

### Startup ordering — bind first, connect later

`mysql::spawn_deferred` / `postgres::spawn_deferred` replace the `build_proxy` + `run()` pair on the startup path:

1. Parse the URL and **bind the listen socket synchronously**. Both are configuration errors and both are now **fatal to startup** — previously a proxy that could not bind logged an error and left the port dead, which is precisely the failure shape this issue is about.
2. Return immediately, so the rest of `start_db_proxies()` (including the litewire listener this proxy may be pointed at) proceeds.
3. Reach the upstream from a background task, then serve on the already-bound listener.

Clients that connect during step 3 do **not** get `ECONNREFUSED` — the socket is bound, so they queue in the kernel accept backlog and are served the moment the upstream answers. PHP's first request waits instead of erroring.

That backlog window is bounded at 5 s (`health::BACKLOG_GRACE`); see the second commit below for why.

Nothing about the ordering inside `start_db_proxies()` is load-bearing any more, but the doc comment now says why it once was, so a future reorder cannot silently reintroduce the bug.

### The backlog is bounded — a dead upstream must fail fast

The podman reproduction caught a problem the first cut of this fix introduced. Queuing early clients in the accept backlog is right for an upstream that appears a moment later and **wrong** for one that is simply down: the client's TCP connect succeeds and it then blocks reading a server greeting that never comes. mysqlnd's read timeout is 24 hours by default, so `seed.php` against a permanently dead upstream returned nothing for **>150 s** (the 300 s `[server.timeouts] request` deadline is the only backstop). That trades a fast, visible 500 for a request that pins a PHP worker — worse than the bug being fixed.

So a drain task now runs alongside the connect loop: it sleeps 5 s, then accepts and immediately closes each client until the upstream answers, at which point it is aborted. PHP reports the close promptly. Measured after the fix: **3.6 ms**, `[2006] MySQL server has gone away`. Five seconds covers both cases that need the backlog — a listener bound later in this same process (~250 ms in the chained config) and a database container starting alongside ePHPm.

### Retry semantics — unbounded with a capped backoff

The deferred path retries forever, 250 ms doubling to a **30 s** ceiling. The old behavior (10 attempts, 8 s ceiling, then permanent surrender) is wrong for a proxy whose listener is already live: there is no caller left to report the failure to, and giving up leaves a live listener wired to a dead upstream, recoverable only by a process restart. Upstreams restart — RDS failover, a sidecar rollout, a local listener that binds a moment later. One TCP connect per 30 s costs nothing, and the ceiling keeps a long outage from becoming a reconnect storm the instant the upstream returns.

The eager constructors (`MySqlProxy::new` / `PgProxy::new`) keep the bounded budget unchanged — they *do* have a caller that can report, and an unbounded loop there would be an unkillable hang. The split is expressed as `RetryBudget::{Bounded, Unbounded}` rather than two copies of the loop.

### Readiness — the design decision

**`/_ephpm/ready` now reports 503 until every configured SQL proxy has completed one upstream handshake. After that first success, readiness never flaps on upstream state again.**

Why gate at all: a proxy that has never reached its upstream cannot serve a single query. That process must stay out of load-balancer rotation, and a rollout containing it must stall rather than replace healthy pods. That is exactly the hole in the issue.

Why *only* the first connect, and not live reachability — I considered the fully-live gate and rejected it:

- **Correlated failure.** Every replica shares one database. A live gate fails every replica's probe at the same instant, Kubernetes empties the Service, and a database that was merely degraded becomes a total outage — including for the static assets, cached pages, and non-DB routes those pods could still serve. A dependency shared by every replica does not belong in a per-pod readiness gate.
- **It breaks recovery.** With no endpoints there is no traffic, so nothing reopens pooled connections, and external monitoring sees a black hole instead of 500s that name the failing database.

Liveness (`/_ephpm/health`) stays green in both cases, deliberately: restarting the process does not make a remote database come back, it only discards warm pools and OPcache and adds a crash-loop to the incident.

So a post-startup outage is **reported, not routed around** — the loud-surfacing option from the issue, applied to the half where readiness must not act:

| Metric | Type | Meaning |
|---|---|---|
| `ephpm_db_proxy_upstream_ever_connected` | gauge | 1 once the proxy has handshaken since boot. Latches. While 0, readiness is 503. |
| `ephpm_db_proxy_upstream_up` | gauge | 1/0 on the most recent connect attempt. Flaps with the database. **Alert on this.** |
| `ephpm_db_proxy_connect_failures_total` | counter | Upstream connect/handshake failures. |

Plus a rate-limited log: the first 3 consecutive failures at WARN (they carry the diagnosis — refused vs. auth vs. TLS), then at most one ERROR per 60 s. Labels are `db` and `upstream`, where `upstream` is the resolved `host:port` — never the URL, which carries the password.

The live gauge costs nothing extra: the pool's connect closure *is* the probe, so it moves on every physical backend connection (not per request) and there is no dedicated prober.

The full rationale lives in the `crates/ephpm-server/src/db_health.rs` module docs, so the next person to consider "shouldn't readiness track the database?" finds the argument before the code.

## Tests

**New — `crates/ephpm-db/tests/deferred_startup.rs` (7), against an in-process mock MySQL server, no container:**

- `listener_is_bound_before_the_upstream_exists` — the socket answers with nothing listening upstream.
- `upstream_that_appears_late_is_picked_up` — mock backend started 600 ms *after* the proxy; proxy connects and then serves a full client handshake.
- `client_connected_before_the_upstream_is_served_from_the_backlog` — a client connected while the upstream was dead completes its handshake once the upstream appears. This is the PHP-cold-start case.
- `a_long_dead_upstream_closes_clients_instead_of_hanging_them` — past the grace period the client gets EOF, not an unbounded read.
- `retry_survives_longer_than_the_old_bounded_budget` — asserts the `RetryBudget` schedule directly rather than sleeping 40 s in CI.
- `bind_failure_is_an_error_not_a_warning`, `malformed_url_is_an_error` — the two fatal startup errors.

**New — readiness (9):** 5 in `ephpm-server/src/db_health.rs` (no proxy configured is always ready; a configured proxy holds readiness down; one handshake clears it; every configured proxy gates; malformed URL fails startup) and 4 in `router.rs` (`db_not_ready` for the no-proxy/pending/cleared cases, the 503 JSON body names the proxy and upstream, the full `/_ephpm/ready` path, and `json_escape`).

**New — `ephpm-db/src/health.rs` (4):** initial state, `ever_connected` latching across a later outage, log throttling, and that `describe()` can never carry credentials.

Two of these are explicitly *anti*-regression tests for the design decision — `later_outage_does_not_flap_readiness` and `readiness_does_not_flap_on_a_post_startup_outage` — and both say in their doc comment to read the module docs before "fixing" them.

**Suites:** ephpm-db 93 unit + 48 integration, ephpm-server 271 lib + 4 integration, ephpm-config 90 (`--test-threads=1`). All green. `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo +nightly fmt --all -- --check` clean.

**Negative controls** (both broken deliberately, observed failing, then restored):

1. Made `Router::db_not_ready` return `None` unconditionally (pre-fix readiness). `readiness_fails_while_a_proxy_has_never_reached_its_upstream`, `readiness_body_names_the_pending_proxy`, and `ready_endpoint_reports_503_until_the_proxy_reaches_its_upstream` all FAILED.
2. Restored the pre-fix ordering in `spawn_deferred` — connect upstream first (budget shortened to 2 attempts so it fails fast), bind afterwards. `listener_is_bound_before_the_upstream_exists`, `upstream_that_appears_late_is_picked_up`, and `client_connected_before_the_upstream_is_served_from_the_backlog` all FAILED with `ConnectionRefused` at the `spawn_deferred` call itself — i.e. the tests detect the exact old ordering, not just some adjacent symptom.

## End-to-end reproduction

Podman, against a `docker/Dockerfile` image built from this branch (real `libphp`, not a stub), using the issue's config verbatim. `localhost/ephpm:v061-rc` — built from `main` — is the before.

### Lane 1 — the issue's chained config

`[db.mysql] url = mysql://root@127.0.0.1:3307/main` in front of `[db.sqlite] proxy.mysql_listen = 127.0.0.1:3307`.

*Before (main):* ~40 s of `backend connect failed; retrying`, then

```
WARN  backend still unreachable after max retries; giving up  attempt=10 addr=127.0.0.1:3307
ERROR failed to start MySQL proxy: I/O error: Connection refused (os error 111)
INFO  SQLite MySQL wire protocol enabled  listen=127.0.0.1:3307      <- bound only NOW
```

`/_ephpm/health` 200 · `/_ephpm/ready` **200** · `seed.php` **500** `SQLSTATE[HY000] [2002] Connection refused`. Both halves of the bug, exactly as reported.

*After (this branch):*

```
INFO MySQL proxy listening (upstream connect continues in the background) listen=127.0.0.1:3306 upstream=127.0.0.1:3307
WARN database proxy upstream connect failed: Connection refused  failures=1
INFO SQLite MySQL wire protocol enabled  listen=127.0.0.1:3307
INFO backend connection established after retry  attempt=2 addr=127.0.0.1:3307     <- 250 ms later
```

`/_ephpm/ready` **200** · `seed.php` **200** `{"count":10,"sum":55}` · `db.php` **200** `{"sum":55}` in 4–7 ms.

### Lane 2 — a database that starts long after ePHPm

`[db.mysql]` → `127.0.0.1:3399`, with `mysql:8` started ~90 s later — well past the old 40 s budget.

Before the database exists: `/_ephpm/ready` **503** `{"reason":"database proxy has not reached its upstream: mysql proxy 127.0.0.1:3306 -> 127.0.0.1:3399"}`, `/_ephpm/health` **200**, and the scrape carries

```
ephpm_db_proxy_upstream_ever_connected{db="mysql",upstream="127.0.0.1:3399"} 0
ephpm_db_proxy_upstream_up{db="mysql",upstream="127.0.0.1:3399"} 0
ephpm_db_proxy_connect_failures_total{db="mysql",upstream="127.0.0.1:3399"} 6
```

After MySQL comes up: `backend connection established after retry attempt=8`, readiness flips to **200**, both gauges flip to `1`, and PHP serves real MySQL — `SELECT @@port` *through the proxy* returns `3399`, proving the traffic reached the actual server, and `db.php` returns the canonical `{"sum":55}` in 6 ms. On `main` this recovery is impossible without a process restart.

### Lane 3 — a permanently dead upstream

`/_ephpm/health` **200** · `/_ephpm/ready` **503** naming the proxy · `seed.php` **500** in **3.6 ms** (`[2006] MySQL server has gone away`). Logs carry the throttled ERROR plus the one-time grace-period warning.

This is the lane that caught the backlog problem described above: the first cut of the fix returned nothing at all here for >150 s.

## Also in this PR

- `DbBackendConfig` gets a hand-written `Default` whose values match what an empty TOML table produces. A derived `Default` would give `min_connections = 0` and empty duration strings — values no loaded config can hold, which is a trap for tests.
- Docs updated in the same PR: `reference/config.md` (startup behavior, the bounded backlog window, and a "Readiness and the database proxy" section), `reference/metrics.md` (the three new metrics with alerting PromQL), `roadmap/kubernetes.md` (the `/_ephpm/ready` row was still describing PHP-only readiness).
