### PR TITLE
docs(ci): nightly E2E comment no longer claims a Kind cluster

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -390,8 +390,11 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     # Run inside the CI image so cargo has a C linker available
     # (xtask needs `cc` to compile; bare runners only ship rustup).
-    # Same image as build-linux; ephemerd's host docker socket is
-    # reachable from inside so the kind cluster inside xtask works.
+    # Same image as build-linux. `cargo xtask e2e` dispatches to
+    # xtask/src/e2e_bare.rs, which spawns ephpm processes directly on
+    # 127.0.0.1 -- no Kind, no Tilt, no docker socket, no privileged
+    # DinD. The Kind path lives behind `cargo xtask k8s-e2e` and is
+    # only reachable from k8s-e2e.yml (workflow_dispatch only).
     container: ephpm/ephpm-ci:latest
     # Auxiliary -- does not gate the release path.
     continue-on-error: true


### PR DESCRIPTION
Comment-only fix to `.github/workflows/nightly.yml`.

## The stale claim

The nightly `e2e` job carried this above `container: ephpm/ephpm-ci:latest`:

> Same image as build-linux; ephemerd's host docker socket is reachable from inside so the kind cluster inside xtask works.

That hasn't been true since the default E2E harness moved to bare-process. `xtask/src/main.rs` dispatches:

```rust
Some("e2e")     => e2e_bare::run(&args[1..]),
Some("k8s-e2e") => e2e(&args[1..]),
```

and `xtask/src/e2e_bare.rs` opens with *"Spawns ephpm binaries on 127.0.0.1 ... No Kind, no Tilt, no privileged DinD."* The nightly runs `cargo xtask e2e`, so it takes the bare path — no Kind cluster, no docker socket. Kind now lives only behind `k8s-e2e`, reachable from `k8s-e2e.yml`, which is `workflow_dispatch`-only.

The step itself was already renamed to "Run bare-process E2E tests" when the harness changed; only the job-level comment was left behind.

## Why bother

The comment reads as a live dependency on the host docker socket and privileged DinD. That is exactly the sort of thing that stops someone from turning `dind.allow_privileged` off on the runner fleet — the flag was just disabled fleet-wide, and this comment was the one piece of evidence suggesting a scheduled workflow still needed it.

The container image is still required for an unrelated reason (`cc` for xtask), so the `container:` line stays; only the justification changed.

## Verification

- `cargo xtask e2e` → `e2e_bare::run` confirmed at `xtask/src/main.rs:36`.
- Swept the rest of the repo: `AGENTS.md`, `CLAUDE.md`, `crates/ephpm-e2e/src/lib.rs`, and the `triage-ci` / `e2e-local` skills already describe the bare-vs-Kind split correctly. This was the only stale spot.
- No YAML structure change — the diff is 4 comment lines.
