### PR TITLE
perf(build): thin LTO for Windows releases; drop the php8embed.dll fiction

### DIFF
--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -298,7 +298,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       # Release CI does NOT build PHP in-repo. `cargo xtask release` downloads a
-      # prebuilt PHP SDK tarball (static libphp.a / php8embed.dll + headers) from
+      # prebuilt PHP SDK tarball (static libphp.a / php8embed.lib + headers) from
       # github.com/ephpm/php-sdk releases, caches it under php-sdk/, exports
       # PHP_SDK_PATH, and builds the release binary against it.
       - name: Build release binary (downloads prebuilt PHP SDK)

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -112,7 +112,7 @@ Windows builds run natively (no cross-compile, no `cargo-xwin`) — you just nee
 cargo xtask release --target windows   # → target\x86_64-pc-windows-msvc\release\ephpm.exe
 ```
 
-The SDK download is the same php-sdk release, with prebuilt `php8embed.dll`/`.lib` for Windows.
+The SDK download is the same php-sdk release, with a prebuilt static `php8embed.lib` for Windows. It links statically, so `ephpm.exe` is a single self-contained binary — there is no DLL to deploy alongside it.
 
 A binary built from source can also self-install:
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -259,13 +259,14 @@ fn require_macos_arm64() -> Result<(), ExitCode> {
 /// import) before invoking xtask.
 ///
 /// The Windows SDK is the same `php-sdk` GitHub release used for Linux/macOS,
-/// just the `windows-x86_64` artifact: it contains `php8embed.dll`,
-/// `php8embed.lib`, and the headers under `include/php/`. The build links
-/// against `php8embed.lib` (import lib for the DLL).
+/// just the `windows-x86_64` artifact: it contains a *static* `php8embed.lib`
+/// (static-php-cli `--build-embed` emits a fat lib of PHP's objects, not a
+/// DLL plus import lib), its static dependency archives, and the headers under
+/// `include/php/`. `crates/ephpm-php/build.rs` links it with
+/// `rustc-link-lib=static=php8embed`.
 ///
-/// The resulting binary requires `php8embed.dll` at runtime, which is also
-/// embedded into the binary via `include_bytes!()` in `windows_dll.rs` and
-/// extracted at startup.
+/// The resulting `ephpm.exe` is a single self-contained binary, same as on
+/// Linux/macOS — there is no DLL to ship, extract, or delay-load.
 ///
 /// History: this used to cross-compile from Linux via `cargo-xwin`. That path
 /// was removed because every Windows SDK case-sensitivity / transitive-include
@@ -313,9 +314,22 @@ fn release_windows(args: &[String]) -> ExitCode {
     }
 
     eprintln!("==> Building ephpm.exe (release, target: {target})...");
+    // Override the workspace's `lto = "fat"` / `codegen-units = 1` for Windows
+    // only. Fat LTO deserializes every crate's LLVM IR into a single module in
+    // a single process; that process is the peak-RSS of the whole build, and
+    // on the self-hosted Windows runner each job gets a fixed-size Hyper-V
+    // container, so the peak sets how many jobs can run concurrently.
+    //
+    // Thin LTO keeps per-module summaries and parallelizes instead, cutting
+    // peak memory substantially while retaining most of the optimization. The
+    // fat-LTO profile exists for the v0.4.2 perf work on proxy dispatch / KV
+    // RESP framing / query-stats — hot paths of the *Linux* deployment. Linux
+    // release artifacts are unaffected: this is set here, not in Cargo.toml.
     let status = Command::new("cargo")
         .args(["build", "--release", "--package", "ephpm", "--target", target])
         .env("PHP_SDK_PATH", &sdk_dir)
+        .env("CARGO_PROFILE_RELEASE_LTO", "thin")
+        .env("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", "16")
         .status();
 
     if !ran_ok(&status) {
@@ -323,24 +337,18 @@ fn release_windows(args: &[String]) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    // Copy php8embed.dll next to the .exe so the binary is runnable as a pair
-    // (the DLL is also embedded via include_bytes!() and extracted at runtime,
-    // but shipping it side-by-side keeps things obvious).
+    // No DLL to ship. The php-sdk Windows tarball ships a *static*
+    // php8embed.lib (static-php-cli `--build-embed` is a static build — a fat
+    // lib of PHP's objects), which crates/ephpm-php/build.rs links with
+    // `rustc-link-lib=static=php8embed`. ephpm.exe is a single self-contained
+    // binary on Windows, same as on Linux/macOS.
     let exe_dir = workspace_root().join("target").join(target).join("release");
-    let dll_dest = exe_dir.join("php8embed.dll");
-    let dll_src = sdk_dir.join("lib").join("php8embed.dll");
-    if dll_src.exists() {
-        if let Err(e) = fs::copy(&dll_src, &dll_dest) {
-            eprintln!("warning: failed to copy php8embed.dll: {e}");
-        }
-    }
 
     eprintln!();
     eprintln!("==> Windows binary ready:");
     eprintln!("    {}", exe_dir.join("ephpm.exe").display());
-    eprintln!("    {}", dll_dest.display());
     eprintln!();
-    eprintln!("    Deploy both files together. php8embed.dll must be next to ephpm.exe.");
+    eprintln!("    Single static binary — no DLL to deploy alongside it.");
     ExitCode::SUCCESS
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -314,23 +314,30 @@ fn release_windows(args: &[String]) -> ExitCode {
     }
 
     eprintln!("==> Building ephpm.exe (release, target: {target})...");
-    // Override the workspace's `lto = "fat"` / `codegen-units = 1` for Windows
-    // only. Fat LTO deserializes every crate's LLVM IR into a single module in
-    // a single process; that process is the peak-RSS of the whole build, and
-    // on the self-hosted Windows runner each job gets a fixed-size Hyper-V
-    // container, so the peak sets how many jobs can run concurrently.
+    // Default the workspace's `lto = "fat"` / `codegen-units = 1` down for
+    // Windows only. Fat LTO deserializes every crate's LLVM IR into a single
+    // module in a single process; that process is the peak-RSS of the whole
+    // build, and on the self-hosted Windows runner each job gets a fixed-size
+    // Hyper-V container, so the peak sets how many jobs can run concurrently.
     //
-    // Thin LTO keeps per-module summaries and parallelizes instead, cutting
-    // peak memory substantially while retaining most of the optimization. The
-    // fat-LTO profile exists for the v0.4.2 perf work on proxy dispatch / KV
-    // RESP framing / query-stats — hot paths of the *Linux* deployment. Linux
-    // release artifacts are unaffected: this is set here, not in Cargo.toml.
-    let status = Command::new("cargo")
-        .args(["build", "--release", "--package", "ephpm", "--target", target])
-        .env("PHP_SDK_PATH", &sdk_dir)
-        .env("CARGO_PROFILE_RELEASE_LTO", "thin")
-        .env("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", "16")
-        .status();
+    // DEFAULTS, not overrides: release.yml's build-windows job exports
+    // CARGO_PROFILE_RELEASE_LTO="off" because the v0.5.1 arc proved even thin
+    // LTO OOMs the Windows final link once turso is in (#183, #193) — fat
+    // OOM'd, thin OOM'd, off ships. Stomping a caller's value here would
+    // silently re-break release CI, so an existing env var always wins. The
+    // thin default is for everyone NOT setting it (local builds, ad-hoc CI),
+    // who previously inherited fat from Cargo.toml. Linux/macOS release
+    // artifacts are unaffected: this is set here, not in Cargo.toml.
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--release", "--package", "ephpm", "--target", target])
+        .env("PHP_SDK_PATH", &sdk_dir);
+    if env::var_os("CARGO_PROFILE_RELEASE_LTO").is_none() {
+        cmd.env("CARGO_PROFILE_RELEASE_LTO", "thin");
+    }
+    if env::var_os("CARGO_PROFILE_RELEASE_CODEGEN_UNITS").is_none() {
+        cmd.env("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", "16");
+    }
+    let status = cmd.status();
 
     if !ran_ok(&status) {
         eprintln!("error: cargo build failed");


### PR DESCRIPTION
Two changes to `release_windows()`, both from nobody revisiting it since the php-sdk went fully static.

## 1. Thin LTO for Windows only

`Cargo.toml` sets this for **every** target:

```toml
[profile.release]
lto = "fat"
codegen-units = 1
```

Fat LTO deserializes every crate's LLVM IR into a single module in a single process. That process is the peak-RSS of the whole build. On the self-hosted Windows runner each job gets a fixed-size Hyper-V container, so that peak is what caps Windows concurrency — the pool is currently pinned at `max_concurrent = 1` because the container is sized 16 GiB against a 24 GiB VM and two won't fit.

The fat-LTO profile was added for the v0.4.2 perf release, targeting proxy dispatch / KV RESP framing / query-stats — hot paths of the **Linux** deployment. Windows is a compat target paying a memory cost for optimization it doesn't benefit from.

Set through `CARGO_PROFILE_RELEASE_{LTO,CODEGEN_UNITS}` in `release_windows()` rather than in `Cargo.toml`, so **Linux and macOS release artifacts are unchanged**.

## 2. Remove the `php8embed.dll` handling — it never ran

`crates/ephpm-php/build.rs:69` links `rustc-link-lib=static=php8embed`. The php-sdk Windows tarball ships a *static* fat lib (static-php-cli `--build-embed`), not a DLL plus import lib. Its own comment says so: *"no DLL to embed, extract, or delay-load."*

So `dll_src.exists()` was always false and the copy silently no-opped. But the success banner printed anyway:

```
==> Windows binary ready:
    ...\ephpm.exe
    ...\php8embed.dll          <- never created
    Deploy both files together. php8embed.dll must be next to ephpm.exe.
```

That's not a stale comment, it's a wrong instruction — it sends someone hunting for a file that doesn't exist and can't exist. The doc comment was equally wrong, describing `include_bytes!()` extraction from a `windows_dll.rs` that is **not present anywhere in the tree**.

Same claim had spread into `site/content/getting-started/install.md` and `site/content/developer/architecture-overview.md`; both corrected.

## Verification

- `cargo check -p xtask` and `cargo clippy -p xtask` clean.
- Swept the tree for `php8embed.dll` — no remaining references outside `.claude/worktrees/` copies.
- `windows_dll.rs` confirmed absent.

## Not included

ICU. The Windows link also pulls `php8embed.lib`'s static dependency archives — libcrypto, libssl, libxml2, **icu\***, libsqlite3, libsodium (`build.rs:107`). ICU is tens of MB of static archives and likely a second, independent memory peak in `link.exe` that thin LTO does **not** touch. Trimming it means rebuilding the Windows SDK without intl, which lives in `ephpm/php-sdk` and changes PHP's feature set. Deliberately out of scope.

Which of the two peaks actually dominates is unmeasured. Sampling the runner's `vmmem` working set across a full build will separate them — if the ceiling turns out to be the linker, this PR helps wall-clock more than memory.
