### PR TITLE
feat(cdc): Prometheus instrumentation for CDC-native Turso replication

### DIFF
--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod stream_compress;
 pub mod tls;
 pub mod tracked_backend;
 pub mod turso_cdc;
+pub mod turso_cdc_metrics;
 pub mod worker_pool;
 
 use std::net::SocketAddr;

--- a/crates/ephpm-server/src/metrics.rs
+++ b/crates/ephpm-server/src/metrics.rs
@@ -42,6 +42,18 @@ const COMPRESSION_RATIO_BUCKETS: &[f64] =
 /// frameworks (Laravel, WordPress) can take seconds to bootstrap once.
 const WORKER_BOOT_BUCKETS: &[f64] = &[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0];
 
+/// CDC batch-apply duration buckets (seconds): 100 µs up to 5 s. A batch
+/// is one replicated transaction, so the healthy range is sub-millisecond
+/// and the tail matters more than the median.
+const CDC_APPLY_BUCKETS: &[f64] =
+    &[0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0];
+
+/// Snapshot bootstrap transfer buckets (seconds): 10 ms up to 5 min. A
+/// logical dump of a large database is minutes, not milliseconds, and it
+/// blocks a cold replica's startup — the wide top end is the point.
+const CDC_SNAPSHOT_BUCKETS: &[f64] =
+    &[0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0];
+
 /// Install the Prometheus recorder and return a scrape handle.
 ///
 /// Must be called once at process startup, before any `metrics::counter!` /
@@ -94,6 +106,16 @@ pub fn init() -> anyhow::Result<PrometheusHandle> {
             PHP_DURATION_BUCKETS,
         )
         .context("failed to configure worker_request_wait buckets")?
+        .set_buckets_for_metric(
+            Matcher::Full(crate::turso_cdc_metrics::METRIC_APPLY_DURATION.to_string()),
+            CDC_APPLY_BUCKETS,
+        )
+        .context("failed to configure cdc_apply_duration buckets")?
+        .set_buckets_for_metric(
+            Matcher::Full(crate::turso_cdc_metrics::METRIC_SNAPSHOT_DURATION.to_string()),
+            CDC_SNAPSHOT_BUCKETS,
+        )
+        .context("failed to configure cdc_snapshot_duration buckets")?
         .install_recorder()
         .context("failed to install Prometheus recorder")?;
 

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -190,7 +190,7 @@ use litewire::litewire_turso::cdc::{CdcRow, CdcTailer, TxnBatch, apply_batch, re
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use crate::tracked_backend;
+use crate::{tracked_backend, turso_cdc_metrics as cdc_metrics};
 
 /// Full stream-type string this build uses for the default vhost.
 ///
@@ -243,6 +243,17 @@ const POLL_INTERVAL: Duration = Duration::from_millis(25);
 /// How long a replica waits between connect retries when the primary
 /// is unreachable.
 const REPLICA_RECONNECT_DELAY: Duration = Duration::from_secs(2);
+
+/// How often the primary samples `MAX(turso_cdc.change_id)` to publish
+/// [`cdc_metrics::METRIC_HEAD_CHANGE_ID`].
+///
+/// One indexed `MAX()` on an INTEGER PRIMARY KEY per second, and only
+/// while this node is the elected primary. That is what makes the lag
+/// gauge honest when no subscriber is attached: without it the head
+/// would only ever advance as a side effect of shipping, so a primary
+/// whose replica just died would report a frozen lag instead of a
+/// growing one.
+const HEAD_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Heartbeat interval on primary-side subscribers.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -454,6 +465,17 @@ pub async fn start_clustered_turso_cdc(
 
     let max_snapshot_bytes = sqlite_config.replication.max_snapshot_bytes;
 
+    // Seed the zero-valued CDC series before anything can record. An
+    // operator scraping a freshly booted node must be able to tell
+    // "replication is on and idle" from "this build has no CDC
+    // instrumentation", and an absent counter cannot say which.
+    cdc_metrics::init();
+
+    // Publish MAX(change_id) on a timer while primary. See
+    // HEAD_SAMPLE_INTERVAL for why this cannot be folded into the
+    // shipping path.
+    spawn_head_sampler(Arc::clone(&mgmt_factory), Arc::clone(&is_primary), handles);
+
     // Register the primary-side snapshot handler NOW, before anything
     // dials, so a peer that comes up as a cold replica can reach us as
     // soon as we win an election. Serving is gated on actually being
@@ -472,6 +494,7 @@ pub async fn start_clustered_turso_cdc(
         while let Some(incoming) = cdc_streams.recv().await {
             let IncomingStream { stream, peer, .. } = incoming;
             if !subs_is_primary.load(Ordering::Relaxed) {
+                cdc_metrics::record_stream_refused("cdc");
                 tracing::warn!(
                     peer = %peer,
                     "CDC: refusing to serve a replication stream — this node is not the \
@@ -670,6 +693,45 @@ async fn start_role(role: Role, mgmt: Arc<Turso>, channel: ephpm_cluster::Channe
     }
 }
 
+/// Spawn the primary-side head sampler: publish
+/// `MAX(turso_cdc.change_id)` every [`HEAD_SAMPLE_INTERVAL`] while this
+/// node is the elected primary.
+///
+/// The connection is opened once and reused; a per-tick connection would
+/// cost more than the query. A read failure is logged at debug and the
+/// loop continues — `current_max_change_id` already answers `0` for the
+/// cold case where `turso_cdc` does not exist yet, and the head gauge is
+/// monotonic, so a transient failure cannot walk it backwards.
+fn spawn_head_sampler(
+    mgmt: Arc<Turso>,
+    is_primary: Arc<AtomicBool>,
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+) {
+    handles.push(tokio::spawn(async move {
+        let conn = match mgmt.raw_connection() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("CDC head sampler: cannot open mgmt connection: {e:#}");
+                return;
+            }
+        };
+        let mut ticker = tokio::time::interval(HEAD_SAMPLE_INTERVAL);
+        loop {
+            ticker.tick().await;
+            // Only the primary has a meaningful head: a replica's local
+            // turso_cdc holds whatever its own wire frontend captured,
+            // which is not the replication stream's position.
+            if !is_primary.load(Ordering::Relaxed) {
+                continue;
+            }
+            match current_max_change_id(&conn).await {
+                Ok(head) => cdc_metrics::observe_head(head),
+                Err(e) => tracing::debug!("CDC head sampler: MAX(change_id) failed: {e:#}"),
+            }
+        }
+    }));
+}
+
 // ---------------------------------------------------------------------------
 // Primary: one tailer per subscriber. (Subscriber-side accept is
 // registered up in `start_clustered_turso_cdc` so it exists across role
@@ -700,7 +762,16 @@ async fn start_role(role: Role, mgmt: Arc<Turso>, channel: ephpm_cluster::Channe
 /// [`ChannelStream`]; before this was generic the only coverage of this
 /// function was a hand-rolled copy inside the e2e tests, which is how the
 /// cold-start reconnect loop went unnoticed.
-async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
+///
+/// Public for the same reason [`serve_snapshot`] is: the two-node e2e
+/// suites drive this exact function rather than a twin, so the metrics it
+/// records are the ones a real primary records. Not part of a stable API.
+///
+/// # Errors
+///
+/// Returns an error if the first frame is not a valid `Subscribe`, if a
+/// `turso_cdc` poll fails, or if the stream breaks.
+pub async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
     mut stream: S,
     mgmt: &Turso,
 ) -> anyhow::Result<()> {
@@ -710,6 +781,12 @@ async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
     };
     anyhow::ensure!(from >= 0, "subscriber sent a negative watermark: {from}");
     tracing::info!(from_change_id = from, "CDC: subscriber attached");
+
+    // RAII: every exit path below is a `?` or a `bail!`, so the
+    // subscriber gauge and this cursor's contribution to the lag gauge
+    // are unwound by the guard's Drop rather than by a detach call this
+    // function has no single place to make.
+    let subscriber = cdc_metrics::attach_subscriber(from);
 
     let mut tailer = CdcTailer::new(mgmt, from);
     let mut idle_since = tokio::time::Instant::now();
@@ -726,18 +803,42 @@ async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
                 // Drop the stream rather than skip past the failure —
                 // the replica reconnects with the same watermark and we
                 // retry from the identical cursor.
+                cdc_metrics::record_tail_poll_error();
                 anyhow::bail!("CDC tail poll error: {e:#}");
             }
         };
 
-        match batch {
-            Some(batch) => {
+        // A rowless batch has no commit `change_id` to advance a cursor
+        // with (litewire#17 made `commit_change_id` return `Option`), and
+        // shipping `{"rows":[]}` would trip the subscriber's own
+        // empty-frame guard and tear the stream down. Fold it into the
+        // idle arm below: nothing to send, nothing to record.
+        let shippable = batch.and_then(|b| {
+            let id = b.commit_change_id()?;
+            Some((b, id))
+        });
+
+        match shippable {
+            Some((batch, commit_change_id)) => {
+                let rows = batch.rows.len();
                 let frame =
                     Frame::Batch { rows: batch.rows.iter().map(WireCdcRow::from).collect() };
                 write_frame(&mut stream, &frame).await?;
+                // Recorded only after the frame is on the wire: counting
+                // a batch we then failed to write would overstate how far
+                // this subscriber has actually got.
+                subscriber.record_batch_shipped(commit_change_id, rows);
                 idle_since = tokio::time::Instant::now();
             }
             None => {
+                // No *complete* transaction beyond the cursor, so the
+                // cursor is a lower bound on the head — free, with no
+                // extra query. A lower bound is safe because the head
+                // gauge only ever moves via `fetch_max`; the sampler
+                // supplies the exact MAX, and an in-flight uncommitted
+                // transaction (whose rows are already in the log but not
+                // yet yielded) is the gap between the two.
+                cdc_metrics::observe_head(tailer.cursor());
                 // Keep the stream warm so a replica can tell "idle
                 // primary" from "dead primary".
                 if idle_since.elapsed() >= HEARTBEAT_INTERVAL {
@@ -754,7 +855,19 @@ async fn serve_subscriber<S: AsyncReadExt + AsyncWriteExt + Unpin>(
 // Replica: dial the cluster channel + read + apply.
 // ---------------------------------------------------------------------------
 
-async fn run_replica(
+/// The replica driver: dial the primary's `cdc/default` stream, announce
+/// the local watermark, apply what arrives, and retry forever.
+///
+/// Public so the two-node e2e suites run this exact loop instead of a
+/// twin — it is where the reconnect and connect-outcome metrics are
+/// recorded, and a copied loop would record none of them. Only returns on
+/// a fatal setup error; normal stream failures are retried internally.
+/// Not part of a stable API.
+///
+/// # Errors
+///
+/// Returns an error only if the local apply connection cannot be opened.
+pub async fn run_replica(
     mgmt: Arc<Turso>,
     primary_addr: SocketAddr,
     channel: ephpm_cluster::ChannelHandle,
@@ -782,6 +895,7 @@ async fn run_replica(
                 let watermark = match read_watermark(&apply_conn).await {
                     Ok(w) => w,
                     Err(e) => {
+                        cdc_metrics::record_connect_outcome("watermark_error");
                         tracing::warn!("CDC replica: cannot read local watermark: {e}");
                         tokio::time::sleep(REPLICA_RECONNECT_DELAY).await;
                         continue;
@@ -789,14 +903,17 @@ async fn run_replica(
                 };
                 match subscribe_and_consume(&mut stream, &apply_conn, watermark).await {
                     Ok(()) => {
+                        cdc_metrics::record_connect_outcome("closed");
                         tracing::info!("CDC replica: primary closed stream cleanly");
                     }
                     Err(e) => {
+                        cdc_metrics::record_connect_outcome("stream_error");
                         tracing::warn!("CDC replica stream error: {e:#}");
                     }
                 }
             }
             Err(e) => {
+                cdc_metrics::record_connect_outcome("dial_error");
                 tracing::debug!(primary = %primary_addr, "CDC replica dial failed: {e:#}");
             }
         }
@@ -805,20 +922,34 @@ async fn run_replica(
 }
 
 /// Announce our watermark, then apply everything the primary sends.
-async fn subscribe_and_consume(
-    stream: &mut ChannelStream,
+///
+/// Generic over the stream, and public, for the same reason
+/// [`serve_subscriber`] is: the two-node e2e suites drive this exact
+/// function so the replica-side metrics under test are the production
+/// ones. Not part of a stable API.
+///
+/// # Errors
+///
+/// Returns an error if the subscribe frame cannot be sent, if the primary
+/// sends a malformed or wrong-direction frame, or if `apply_batch` fails.
+pub async fn subscribe_and_consume<S: AsyncReadExt + AsyncWriteExt + Unpin>(
+    stream: &mut S,
     apply_conn: &litewire::litewire_turso::TursoConnection,
     watermark: i64,
 ) -> anyhow::Result<()> {
     write_frame(stream, &Frame::Subscribe { from_change_id: watermark })
         .await
         .context("send subscribe frame")?;
+    // Publish what we are resuming from before a single batch lands, so
+    // the watermark gauge reflects durable local state rather than only
+    // what this process has applied since it started.
+    cdc_metrics::record_applied_watermark(watermark);
     tracing::info!(from_change_id = watermark, "CDC replica: subscribed");
     consume_frames(stream, apply_conn).await
 }
 
-async fn consume_frames(
-    stream: &mut ChannelStream,
+async fn consume_frames<S: AsyncReadExt + AsyncWriteExt + Unpin>(
+    stream: &mut S,
     apply_conn: &litewire::litewire_turso::TursoConnection,
 ) -> anyhow::Result<()> {
     loop {
@@ -839,14 +970,33 @@ async fn consume_frames(
                 let Some(change_id) = batch.commit_change_id() else {
                     anyhow::bail!("peer sent an empty CDC batch frame");
                 };
+                // Read after the guard: an empty batch never reaches the
+                // recording site below, so `rows_applied` can never be
+                // incremented by zero for a frame we rejected.
+                let row_count = batch.rows.len();
                 // A failed apply must NOT be skipped: continuing to the
                 // next batch would let the watermark advance past the
                 // failure and make the divergence permanent and silent.
                 // Fail the stream; the replica reconnects and resumes
                 // from the watermark, which has not moved.
-                apply_batch(apply_conn, &batch)
-                    .await
-                    .with_context(|| format!("CDC apply_batch failed at change_id {change_id}"))?;
+                let started = std::time::Instant::now();
+                match apply_batch(apply_conn, &batch).await {
+                    Ok(()) => {
+                        // Advances the watermark gauge to `change_id`,
+                        // which is exactly what the local watermark table
+                        // now holds.
+                        cdc_metrics::record_batch_applied(change_id, row_count, started.elapsed());
+                    }
+                    Err(e) => {
+                        // Deliberately does NOT touch the watermark
+                        // gauge: the watermark did not move, and a gauge
+                        // that advanced past a failed apply would report
+                        // convergence that has not happened.
+                        cdc_metrics::record_apply_error();
+                        return Err(anyhow::Error::new(e)
+                            .context(format!("CDC apply_batch failed at change_id {change_id}")));
+                    }
+                }
             }
             Frame::Ping => {}
             Frame::Subscribe { .. } => {
@@ -905,6 +1055,7 @@ fn spawn_snapshot_server(
         while let Some(incoming) = snapshot_streams.recv().await {
             let IncomingStream { stream, peer, .. } = incoming;
             if !is_primary.load(Ordering::Relaxed) {
+                cdc_metrics::record_stream_refused("snapshot");
                 tracing::warn!(
                     peer = %peer,
                     "snapshot bootstrap: refusing to serve a database dump — this node is \
@@ -941,19 +1092,41 @@ fn spawn_snapshot_server(
 /// Returns an error if the dump cannot be produced or the stream write
 /// fails.
 pub async fn serve_snapshot(mut stream: ChannelStream, mgmt: &Turso) -> anyhow::Result<i64> {
+    // Recorded here rather than at the call site so a test that drives
+    // `serve_snapshot` directly still exercises the instrumentation, and
+    // so both outcomes are counted in one place.
+    let started = std::time::Instant::now();
+    match serve_snapshot_inner(&mut stream, mgmt).await {
+        Ok((watermark, bytes)) => {
+            cdc_metrics::record_snapshot_served("ok", bytes, started.elapsed());
+            Ok(watermark)
+        }
+        Err(e) => {
+            cdc_metrics::record_snapshot_served("error", 0, started.elapsed());
+            Err(e)
+        }
+    }
+}
+
+/// Body of [`serve_snapshot`]. Returns the watermark and the dump size in
+/// bytes so the caller can record both without measuring twice.
+async fn serve_snapshot_inner(
+    stream: &mut ChannelStream,
+    mgmt: &Turso,
+) -> anyhow::Result<(i64, u64)> {
     let conn = mgmt.raw_connection().context("snapshot: open mgmt connection")?;
     let (watermark, dump) = produce_snapshot(&conn).await.context("snapshot: produce dump")?;
 
     let header = SnapshotHeader { watermark, total_len: dump.len() as u64 };
-    write_snapshot_header(&mut stream, &header).await?;
+    write_snapshot_header(stream, &header).await?;
 
     for chunk in dump.as_bytes().chunks(SNAPSHOT_CHUNK_TARGET) {
-        write_snapshot_chunk(&mut stream, chunk).await?;
+        write_snapshot_chunk(stream, chunk).await?;
     }
     // Zero-length end marker: signals a clean end of body.
-    write_snapshot_chunk(&mut stream, &[]).await?;
+    write_snapshot_chunk(stream, &[]).await?;
     stream.flush().await?;
-    Ok(watermark)
+    Ok((watermark, dump.len() as u64))
 }
 
 /// Produce a logical dump of the current DB state plus the aligned
@@ -1343,6 +1516,13 @@ async fn maybe_bootstrap_cold_replica(
     let conn = mgmt.raw_connection().context("snapshot bootstrap: open local connection")?;
 
     if !local_db_is_cold(&conn).await.context("snapshot bootstrap: cold-start check")? {
+        cdc_metrics::record_bootstrap("skipped");
+        // A warm replica already has a watermark; publish it so the gauge
+        // is populated before the first batch rather than reading 0 until
+        // one arrives.
+        if let Ok(wm) = read_watermark(&conn).await {
+            cdc_metrics::record_applied_watermark(wm);
+        }
         tracing::info!("snapshot bootstrap: local DB already populated; skipping");
         return Ok(());
     }
@@ -1359,6 +1539,7 @@ async fn maybe_bootstrap_cold_replica(
     for attempt in 1..=MAX_ATTEMPTS {
         match fetch_and_apply_snapshot(&conn, primary_addr, channel, max_snapshot_bytes).await {
             Ok(n) => {
+                cdc_metrics::record_bootstrap("ok");
                 tracing::info!(
                     primary = %primary_addr,
                     watermark = n,
@@ -1378,6 +1559,7 @@ async fn maybe_bootstrap_cold_replica(
         }
     }
 
+    cdc_metrics::record_bootstrap("failed");
     let cause = last_error.unwrap_or_else(|| anyhow::anyhow!("no attempt recorded an error"));
     Err(cause.context(format!(
         "snapshot bootstrap from {primary_addr} failed after {MAX_ATTEMPTS} attempts. \
@@ -1439,6 +1621,7 @@ pub async fn fetch_and_apply_snapshot(
     channel: &ephpm_cluster::ChannelHandle,
     max_snapshot_bytes: u64,
 ) -> anyhow::Result<i64> {
+    let started = std::time::Instant::now();
     let mut stream = channel
         .dial(primary_addr, SNAPSHOT_STREAM_TYPE)
         .await
@@ -1475,6 +1658,12 @@ pub async fn fetch_and_apply_snapshot(
     }
     let dump = String::from_utf8(body).context("snapshot: dump body is not valid utf-8")?;
     apply_snapshot(conn, header.watermark, &dump).await?;
+    // Only counted once the dump is durably applied: bytes received into
+    // a buffer that then failed validation are not a bootstrap.
+    cdc_metrics::record_snapshot_received(received, started.elapsed());
+    // The local watermark table now holds exactly this value, so the
+    // replica's watermark gauge is correct before the CDC tail starts.
+    cdc_metrics::record_applied_watermark(header.watermark);
     Ok(header.watermark)
 }
 

--- a/crates/ephpm-server/src/turso_cdc_metrics.rs
+++ b/crates/ephpm-server/src/turso_cdc_metrics.rs
@@ -1,0 +1,476 @@
+//! Prometheus instrumentation for the experimental CDC-native Turso
+//! replication path ([`crate::turso_cdc`]).
+//!
+//! Every series here is emitted **only** when
+//! `[db.sqlite.replication] cdc_experimental = true` actually starts the
+//! CDC path — [`init`] is called from `start_clustered_turso_cdc` and
+//! nothing else registers these names. A deployment on sqld or
+//! single-node SQLite has no `ephpm_cdc_*` series at all.
+//!
+//! # The lag metric, precisely
+//!
+//! [`METRIC_LAG_CHANGES`] is the headline number and it is a **row
+//! count, not a duration**. It counts `turso_cdc` change-log rows on the
+//! primary that have not yet been shipped to the slowest attached
+//! subscriber:
+//!
+//! ```text
+//! ephpm_cdc_replication_lag_changes
+//!   = ephpm_cdc_primary_head_change_id   (MAX(turso_cdc.change_id) here)
+//!   - ephpm_cdc_shipped_change_id        (min cursor over subscribers)
+//! ```
+//!
+//! Both inputs are `change_id` values, which turso allocates one per
+//! captured row change. So "lag = 500" means *five hundred row changes*
+//! behind, and says nothing about seconds — 500 changes is
+//! sub-millisecond on an idle cluster and minutes behind a bulk import.
+//! Do not graph it with a seconds unit.
+//!
+//! ## Why there is no time-based lag
+//!
+//! A seconds-valued lag needs a commit timestamp travelling with the
+//! change so the consumer can subtract it from its own clock. The
+//! `turso_cdc` table does carry one (`change_time`, column 2 of the v2
+//! schema), but litewire's `CdcRow` does not expose it — the struct is
+//! `(change_id, change_txn_id, change_type, table_name, id, before,
+//! after, updates)`. Surfacing a time-based lag therefore needs **two**
+//! upstream changes, not an ephpm-side calculation:
+//!
+//! 1. a litewire change adding `change_time` to `CdcRow` (plus a pin
+//!    bump here), and
+//! 2. a wire change adding the field to `turso_cdc`'s `WireCdcRow`.
+//!
+//! Until both land, any "seconds behind" figure this crate published
+//! would be invented. The row-count lag above is what the data actually
+//! supports, so it is what ships.
+//!
+//! ## What the lag does and does not cover
+//!
+//! It is measured at the **ship** boundary — the moment a batch is
+//! written into the subscriber's yamux stream — not at the apply
+//! boundary on the replica. It therefore excludes network flight time
+//! and the replica's `apply_batch` cost. For true end-to-end lag,
+//! subtract across nodes in PromQL:
+//!
+//! ```promql
+//! max(ephpm_cdc_primary_head_change_id) - min(ephpm_cdc_applied_change_id)
+//! ```
+//!
+//! ## Behaviour with no subscribers
+//!
+//! [`METRIC_SUBSCRIBERS`] going to `0` is the unambiguous "replication
+//! is not happening" signal and is what to alert on. The lag gauge stays
+//! *live* in that state rather than freezing: the shipped cursor retains
+//! the last position any subscriber reached, so a primary that keeps
+//! taking writes after its replica dies shows a genuinely growing lag.
+//! Before the first subscriber ever attaches there is no cursor to
+//! subtract from, and the lag and shipped gauges are simply not emitted.
+
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
+
+use dashmap::DashMap;
+use metrics::{counter, gauge, histogram};
+
+// ---------------------------------------------------------------------------
+// Metric names. Exported so integration tests assert against the same
+// strings the recorder emits, and so `site/content/reference/metrics.md`
+// has one authoritative source to be checked against.
+// ---------------------------------------------------------------------------
+
+/// Gauge: CDC subscriber streams currently attached to this node.
+pub const METRIC_SUBSCRIBERS: &str = "ephpm_cdc_subscribers";
+/// Counter: committed transaction batches written to subscriber streams.
+pub const METRIC_BATCHES_SHIPPED: &str = "ephpm_cdc_batches_shipped_total";
+/// Counter: CDC rows contained in those shipped batches.
+pub const METRIC_ROWS_SHIPPED: &str = "ephpm_cdc_rows_shipped_total";
+/// Gauge: lowest `change_id` shipped across all attached subscribers.
+pub const METRIC_SHIPPED_CHANGE_ID: &str = "ephpm_cdc_shipped_change_id";
+/// Gauge: `MAX(turso_cdc.change_id)` observed on this node.
+pub const METRIC_HEAD_CHANGE_ID: &str = "ephpm_cdc_primary_head_change_id";
+/// Gauge: head minus shipped cursor, in change-log rows. See the module
+/// docs — this is **not** seconds.
+pub const METRIC_LAG_CHANGES: &str = "ephpm_cdc_replication_lag_changes";
+/// Counter: `turso_cdc` tail-poll failures on the primary.
+pub const METRIC_TAIL_POLL_ERRORS: &str = "ephpm_cdc_tail_poll_errors_total";
+/// Counter: inbound streams refused because this node is not the primary.
+/// Label: `stream` (`cdc` / `snapshot`).
+pub const METRIC_STREAMS_REFUSED: &str = "ephpm_cdc_streams_refused_total";
+/// Counter: snapshot bootstraps served. Label: `status` (`ok` / `error`).
+pub const METRIC_SNAPSHOTS_SERVED: &str = "ephpm_cdc_snapshots_served_total";
+/// Counter: snapshot dump bytes written to dialing replicas.
+pub const METRIC_SNAPSHOT_BYTES_SERVED: &str = "ephpm_cdc_snapshot_bytes_served_total";
+/// Histogram: snapshot transfer duration. Label: `role` (`serve` / `fetch`).
+pub const METRIC_SNAPSHOT_DURATION: &str = "ephpm_cdc_snapshot_duration_seconds";
+
+/// Counter: CDC batches applied to the local database.
+pub const METRIC_BATCHES_APPLIED: &str = "ephpm_cdc_batches_applied_total";
+/// Counter: CDC rows applied to the local database.
+pub const METRIC_ROWS_APPLIED: &str = "ephpm_cdc_rows_applied_total";
+/// Gauge: this replica's applied watermark (`change_id`).
+pub const METRIC_APPLIED_CHANGE_ID: &str = "ephpm_cdc_applied_change_id";
+/// Counter: `apply_batch` failures on the replica.
+pub const METRIC_APPLY_ERRORS: &str = "ephpm_cdc_apply_errors_total";
+/// Histogram: per-batch `apply_batch` duration on the replica.
+pub const METRIC_APPLY_DURATION: &str = "ephpm_cdc_apply_duration_seconds";
+/// Counter: replica subscribe attempts by terminal outcome. Label:
+/// `outcome` (`closed` / `dial_error` / `stream_error` / `watermark_error`).
+pub const METRIC_REPLICA_CONNECTS: &str = "ephpm_cdc_replica_connects_total";
+/// Counter: cold-start snapshot bootstrap outcomes. Label: `outcome`
+/// (`ok` / `skipped` / `failed`).
+pub const METRIC_BOOTSTRAP: &str = "ephpm_cdc_bootstrap_total";
+/// Counter: snapshot dump bytes received during bootstrap.
+pub const METRIC_SNAPSHOT_BYTES_RECEIVED: &str = "ephpm_cdc_snapshot_bytes_received_total";
+
+// ---------------------------------------------------------------------------
+// Process-global subscriber registry.
+//
+// A process runs at most one CDC role at a time, and every gauge above is
+// unlabelled and process-wide, so the bookkeeping behind them is global
+// too. Making it global keeps `serve_subscriber`'s signature free of a
+// registry parameter that only exists to be threaded through.
+// ---------------------------------------------------------------------------
+
+static REGISTRY: LazyLock<Arc<SubscriberRegistry>> =
+    LazyLock::new(|| Arc::new(SubscriberRegistry::new()));
+
+/// Primary-side bookkeeping behind the shipped/head/lag gauges.
+///
+/// `Relaxed` ordering throughout: every field feeds a gauge that is
+/// sampled by a scrape seconds later, so a reader that observes a value
+/// a few microseconds stale around a concurrent update publishes a
+/// number that was true a moment earlier. Nothing here guards memory
+/// another thread must see, so stronger ordering would only cost
+/// fences.
+struct SubscriberRegistry {
+    /// Live subscribers: opaque id → the `change_id` shipped to it.
+    cursors: DashMap<u64, i64>,
+    /// Source of the opaque ids above.
+    next_id: AtomicU64,
+    /// Highest `change_id` this node has seen in its own CDC log.
+    /// Monotonic (`fetch_max`) because `change_id` only grows.
+    head: AtomicI64,
+    /// Slowest live subscriber's cursor, retained after the last
+    /// subscriber detaches so lag keeps growing against a dead replica
+    /// instead of freezing.
+    shipped: AtomicI64,
+    /// Whether `shipped` has ever been set. Before the first subscriber
+    /// there is no meaningful cursor and the lag gauge is not emitted.
+    has_shipped: AtomicBool,
+}
+
+impl SubscriberRegistry {
+    fn new() -> Self {
+        Self {
+            cursors: DashMap::new(),
+            next_id: AtomicU64::new(0),
+            head: AtomicI64::new(0),
+            shipped: AtomicI64::new(0),
+            has_shipped: AtomicBool::new(false),
+        }
+    }
+
+    /// Recompute the derived gauges from current state.
+    ///
+    /// Called on every attach, detach, shipped batch, and head sample —
+    /// i.e. once per replicated transaction at worst, which is orders of
+    /// magnitude cheaper than the database write that produced it.
+    fn refresh(&self) {
+        let head = self.head.load(Ordering::Relaxed);
+        gauge!(METRIC_HEAD_CHANGE_ID).set(head as f64);
+
+        // Min over live subscribers is the slowest replica. When the map
+        // is empty we keep the previous value: a replica that died at
+        // change_id 900 while the primary is at 1500 is 600 behind, not
+        // caught up.
+        if let Some(min_live) = self.cursors.iter().map(|e| *e.value()).min() {
+            self.shipped.store(min_live, Ordering::Relaxed);
+            self.has_shipped.store(true, Ordering::Relaxed);
+        }
+
+        if self.has_shipped.load(Ordering::Relaxed) {
+            let shipped = self.shipped.load(Ordering::Relaxed);
+            gauge!(METRIC_SHIPPED_CHANGE_ID).set(shipped as f64);
+            // Clamp at zero: `head` and `shipped` are sampled without a
+            // common lock, so a subscriber can publish a cursor from a
+            // batch whose change_id has not yet reached `head`.
+            gauge!(METRIC_LAG_CHANGES).set((head - shipped).max(0) as f64);
+        }
+    }
+}
+
+/// A live CDC subscriber's slot in the registry.
+///
+/// Dropping the guard detaches the subscriber and refreshes the gauges,
+/// so a stream that ends for *any* reason — clean close, poll error,
+/// task abort, panic — leaves the subscriber count correct. That is why
+/// this is RAII rather than a matching `detach()` call: the CDC serve
+/// loop has several exit paths and `?` short-circuits most of them.
+pub struct SubscriberGuard {
+    registry: Arc<SubscriberRegistry>,
+    id: u64,
+}
+
+impl SubscriberGuard {
+    /// Record one committed batch written into this subscriber's stream.
+    ///
+    /// `commit_change_id` becomes this subscriber's cursor, and also
+    /// advances the node's head — the primary demonstrably has at least
+    /// that much log, so lag never reads negative just because the head
+    /// sampler has not ticked yet.
+    pub fn record_batch_shipped(&self, commit_change_id: i64, rows: usize) {
+        counter!(METRIC_BATCHES_SHIPPED).increment(1);
+        counter!(METRIC_ROWS_SHIPPED).increment(rows as u64);
+        self.registry.cursors.insert(self.id, commit_change_id);
+        self.registry.head.fetch_max(commit_change_id, Ordering::Relaxed);
+        self.registry.refresh();
+    }
+}
+
+impl Drop for SubscriberGuard {
+    fn drop(&mut self) {
+        self.registry.cursors.remove(&self.id);
+        gauge!(METRIC_SUBSCRIBERS).set(self.registry.cursors.len() as f64);
+        self.registry.refresh();
+    }
+}
+
+/// Attach a subscriber that has announced `from_change_id` as its
+/// applied watermark, returning the guard that keeps it counted.
+///
+/// Called after the `Subscribe` frame is read, so a stream that connects
+/// and never subscribes is never counted as a replica.
+#[must_use]
+pub fn attach_subscriber(from_change_id: i64) -> SubscriberGuard {
+    let registry = Arc::clone(&REGISTRY);
+    let id = registry.next_id.fetch_add(1, Ordering::Relaxed);
+    registry.cursors.insert(id, from_change_id);
+    gauge!(METRIC_SUBSCRIBERS).set(registry.cursors.len() as f64);
+    registry.refresh();
+    SubscriberGuard { registry, id }
+}
+
+/// Record a directly observed `MAX(turso_cdc.change_id)` for this node.
+///
+/// Fed by the primary's head sampler and by the idle path of a
+/// subscriber loop (a tailer that polls no batch has, by definition,
+/// reached the head).
+pub fn observe_head(head: i64) {
+    REGISTRY.head.fetch_max(head, Ordering::Relaxed);
+    REGISTRY.refresh();
+}
+
+// ---------------------------------------------------------------------------
+// Flat recorders. Each wraps exactly one call site in `turso_cdc` so the
+// metric name lives here rather than being spelled out inline.
+// ---------------------------------------------------------------------------
+
+/// Record a `turso_cdc` tail-poll failure. The stream is dropped and the
+/// replica resumes from the same watermark, so this is a retry signal,
+/// not a data-loss signal.
+pub fn record_tail_poll_error() {
+    counter!(METRIC_TAIL_POLL_ERRORS).increment(1);
+}
+
+/// Record an inbound stream refused because this node is not the primary.
+/// `stream` is `cdc` or `snapshot`.
+pub fn record_stream_refused(stream: &'static str) {
+    counter!(METRIC_STREAMS_REFUSED, "stream" => stream).increment(1);
+}
+
+/// Record a served snapshot bootstrap. `bytes` and `elapsed` are only
+/// meaningful on the `ok` path; an error is counted without them.
+pub fn record_snapshot_served(status: &'static str, bytes: u64, elapsed: Duration) {
+    counter!(METRIC_SNAPSHOTS_SERVED, "status" => status).increment(1);
+    if status == "ok" {
+        counter!(METRIC_SNAPSHOT_BYTES_SERVED).increment(bytes);
+        histogram!(METRIC_SNAPSHOT_DURATION, "role" => "serve").record(elapsed.as_secs_f64());
+    }
+}
+
+/// Record a received snapshot bootstrap body on the replica.
+pub fn record_snapshot_received(bytes: u64, elapsed: Duration) {
+    counter!(METRIC_SNAPSHOT_BYTES_RECEIVED).increment(bytes);
+    histogram!(METRIC_SNAPSHOT_DURATION, "role" => "fetch").record(elapsed.as_secs_f64());
+}
+
+/// Record the outcome of the cold-start bootstrap decision. `outcome` is
+/// `ok`, `skipped` (local DB already populated) or `failed` (retry budget
+/// exhausted — startup aborts).
+pub fn record_bootstrap(outcome: &'static str) {
+    counter!(METRIC_BOOTSTRAP, "outcome" => outcome).increment(1);
+}
+
+/// Record one applied CDC batch on the replica, advancing the watermark
+/// gauge to the batch's commit `change_id`.
+pub fn record_batch_applied(commit_change_id: i64, rows: usize, elapsed: Duration) {
+    counter!(METRIC_BATCHES_APPLIED).increment(1);
+    counter!(METRIC_ROWS_APPLIED).increment(rows as u64);
+    histogram!(METRIC_APPLY_DURATION).record(elapsed.as_secs_f64());
+    record_applied_watermark(commit_change_id);
+}
+
+/// Publish the replica's applied watermark. Also called on subscribe and
+/// after a snapshot bootstrap, so the gauge reflects durable local state
+/// rather than only what this process happened to apply.
+pub fn record_applied_watermark(change_id: i64) {
+    gauge!(METRIC_APPLIED_CHANGE_ID).set(change_id as f64);
+}
+
+/// Record an `apply_batch` failure. The stream is failed and the
+/// watermark deliberately does not advance.
+pub fn record_apply_error() {
+    counter!(METRIC_APPLY_ERRORS).increment(1);
+}
+
+/// Record a replica subscribe attempt by terminal outcome, so each
+/// attempt increments exactly one series. `outcome` is `closed`,
+/// `dial_error`, `stream_error` or `watermark_error`; reconnect rate is
+/// the sum across all four.
+pub fn record_connect_outcome(outcome: &'static str) {
+    counter!(METRIC_REPLICA_CONNECTS, "outcome" => outcome).increment(1);
+}
+
+/// Register the zero-valued series at CDC startup.
+///
+/// Without this, a healthy cluster's scrape omits every error counter and
+/// an operator cannot tell "no apply errors" from "this build has no CDC
+/// instrumentation" — the same reason `ephpm_db_proxy_*` seeds its gauges
+/// at boot. Only counters and the subscriber gauge are seeded: the
+/// head/shipped/lag gauges are deliberately left absent until a
+/// subscriber attaches, because a lag of `0` published by a node that has
+/// never replicated anything would be a lie.
+pub fn init() {
+    gauge!(METRIC_SUBSCRIBERS).set(0.0);
+    for name in [
+        METRIC_BATCHES_SHIPPED,
+        METRIC_ROWS_SHIPPED,
+        METRIC_TAIL_POLL_ERRORS,
+        METRIC_SNAPSHOT_BYTES_SERVED,
+        METRIC_BATCHES_APPLIED,
+        METRIC_ROWS_APPLIED,
+        METRIC_APPLY_ERRORS,
+        METRIC_SNAPSHOT_BYTES_RECEIVED,
+    ] {
+        counter!(name).increment(0);
+    }
+    for stream in ["cdc", "snapshot"] {
+        counter!(METRIC_STREAMS_REFUSED, "stream" => stream).increment(0);
+    }
+    for status in ["ok", "error"] {
+        counter!(METRIC_SNAPSHOTS_SERVED, "status" => status).increment(0);
+    }
+    for outcome in ["closed", "dial_error", "stream_error", "watermark_error"] {
+        counter!(METRIC_REPLICA_CONNECTS, "outcome" => outcome).increment(0);
+    }
+    for outcome in ["ok", "skipped", "failed"] {
+        counter!(METRIC_BOOTSTRAP, "outcome" => outcome).increment(0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry is process-global, so these tests must not run
+    /// concurrently with each other. They assert on the *state* behind
+    /// the gauges (which is deterministic) rather than on recorded metric
+    /// values (which need an installed recorder — that coverage lives in
+    /// `tests/turso_cdc_metrics_e2e.rs`, where a real scrape is parsed).
+    fn reset() {
+        REGISTRY.cursors.clear();
+        REGISTRY.head.store(0, Ordering::Relaxed);
+        REGISTRY.shipped.store(0, Ordering::Relaxed);
+        REGISTRY.has_shipped.store(false, Ordering::Relaxed);
+    }
+
+    /// Lag is head minus the *slowest* subscriber, not the fastest: one
+    /// caught-up replica must not mask another that is far behind.
+    #[test]
+    fn lag_tracks_the_slowest_subscriber() {
+        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset();
+
+        let fast = attach_subscriber(0);
+        let slow = attach_subscriber(0);
+
+        fast.record_batch_shipped(100, 10);
+        slow.record_batch_shipped(40, 4);
+
+        assert_eq!(REGISTRY.head.load(Ordering::Relaxed), 100);
+        assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 40, "min cursor, not max");
+        assert_eq!(REGISTRY.cursors.len(), 2);
+
+        // The slow one catching up moves the lag, the fast one cannot.
+        slow.record_batch_shipped(100, 60);
+        assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 100);
+    }
+
+    /// Dropping a subscriber decrements the count on every exit path,
+    /// and — the property that makes the lag gauge trustworthy — the
+    /// shipped cursor is *retained* so lag keeps growing against a dead
+    /// replica rather than freezing or resetting to zero.
+    #[test]
+    fn detached_subscriber_retains_cursor_so_lag_keeps_growing() {
+        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset();
+
+        {
+            let sub = attach_subscriber(0);
+            sub.record_batch_shipped(900, 9);
+            assert_eq!(REGISTRY.cursors.len(), 1);
+        } // replica dies here
+
+        assert_eq!(REGISTRY.cursors.len(), 0, "guard drop must detach");
+        assert!(REGISTRY.has_shipped.load(Ordering::Relaxed));
+        assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 900, "cursor must survive detach");
+
+        // Primary keeps taking writes with nobody attached.
+        observe_head(1500);
+        let lag = REGISTRY.head.load(Ordering::Relaxed) - REGISTRY.shipped.load(Ordering::Relaxed);
+        assert_eq!(lag, 600, "a dead replica must show a growing lag, not a frozen one");
+    }
+
+    /// Head is monotonic: a stale or cold `MAX(change_id)` observation
+    /// (the sampler reads `0` when `turso_cdc` does not exist yet) must
+    /// never walk the head backwards and invent negative lag.
+    #[test]
+    fn head_is_monotonic_and_lag_never_negative() {
+        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset();
+
+        let sub = attach_subscriber(0);
+        sub.record_batch_shipped(50, 5);
+        observe_head(0);
+        assert_eq!(REGISTRY.head.load(Ordering::Relaxed), 50, "a 0 sample must not lower head");
+
+        // A cursor ahead of the last sampled head clamps rather than
+        // going negative.
+        sub.record_batch_shipped(80, 3);
+        let lag = REGISTRY.head.load(Ordering::Relaxed) - REGISTRY.shipped.load(Ordering::Relaxed);
+        assert!(lag >= 0, "lag went negative: {lag}");
+    }
+
+    /// A fresh replica joining at a low watermark must *lower* the
+    /// shipped cursor — its backlog is real, and reporting the caught-up
+    /// replica's position instead would hide it.
+    #[test]
+    fn a_new_cold_subscriber_lowers_the_shipped_cursor() {
+        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset();
+
+        let warm = attach_subscriber(0);
+        warm.record_batch_shipped(1000, 10);
+        assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 1000);
+
+        let cold = attach_subscriber(0);
+        assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 0, "cold join must show its backlog");
+        drop(cold);
+
+        // ...and once it leaves, the remaining replica's position stands.
+        assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 1000);
+    }
+
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+}

--- a/crates/ephpm-server/tests/turso_cdc_e2e.rs
+++ b/crates/ephpm-server/tests/turso_cdc_e2e.rs
@@ -21,101 +21,33 @@
 //! rework was fundamentally about. The gossip-integrated election
 //! path still requires the full podman two-node bring-up (Phase 2.1
 //! deliverable).
+//!
+//! # Why there is no wire-format twin here any more
+//!
+//! This suite used to define its own `Frame`/`WireCdcRow` enums and its
+//! own serve/apply loops, on the reasoning that a black-box copy kept the
+//! test honest about the design. In practice it did the opposite: the
+//! copy could (and did) drift from `ephpm_server::turso_cdc`, and a test
+//! that re-implements the thing it is testing cannot catch a defect in
+//! the real implementation. It now drives the production
+//! [`ephpm_server::turso_cdc::serve_subscriber`] and
+//! [`ephpm_server::turso_cdc::run_replica`] directly, which is also what
+//! makes the instrumentation assertions in `turso_cdc_metrics_e2e.rs`
+//! meaningful — they observe metrics recorded by production code.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use ephpm_cluster::{
-    ChannelFeatureFlags, ChannelHandle, ChannelStream, IncomingStream, maybe_start_cluster_channel,
-    start_gossip,
+    ChannelFeatureFlags, ChannelHandle, IncomingStream, maybe_start_cluster_channel, start_gossip,
 };
 use ephpm_config::{ClusterChannelConfig, ClusterConfig};
+use ephpm_server::turso_cdc::{run_replica, serve_subscriber};
 use litewire::backend::{Backend, Value};
 use litewire::litewire_turso::Turso;
-use litewire::litewire_turso::cdc::{CdcRow, CdcTailer, TxnBatch, apply_batch, read_watermark};
-use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use litewire::litewire_turso::cdc::read_watermark;
 
 const CDC_STREAM_TYPE: &str = "cdc/default";
-const MAX_FRAME_LEN: u32 = 16 * 1024 * 1024;
-
-// -- Wire format twin (kept inline so the test remains an honest
-//    black-box exercise of the design; the module-internal Frame is
-//    private).
-
-#[derive(Serialize, Deserialize)]
-enum Frame {
-    /// Replica → primary, first frame: the watermark to resume from.
-    Subscribe {
-        from_change_id: i64,
-    },
-    Batch {
-        rows: Vec<WireCdcRow>,
-    },
-    Ping,
-}
-
-#[derive(Serialize, Deserialize)]
-struct WireCdcRow {
-    change_id: i64,
-    change_txn_id: Option<i64>,
-    change_type: i64,
-    table_name: Option<String>,
-    id: Option<i64>,
-    before: Option<Vec<u8>>,
-    after: Option<Vec<u8>>,
-    updates: Option<Vec<u8>>,
-}
-
-impl From<&CdcRow> for WireCdcRow {
-    fn from(r: &CdcRow) -> Self {
-        Self {
-            change_id: r.change_id,
-            change_txn_id: r.change_txn_id,
-            change_type: r.change_type,
-            table_name: r.table_name.clone(),
-            id: r.id,
-            before: r.before.clone(),
-            after: r.after.clone(),
-            updates: r.updates.clone(),
-        }
-    }
-}
-
-impl From<WireCdcRow> for CdcRow {
-    fn from(w: WireCdcRow) -> Self {
-        Self {
-            change_id: w.change_id,
-            change_txn_id: w.change_txn_id,
-            change_type: w.change_type,
-            table_name: w.table_name,
-            id: w.id,
-            before: w.before,
-            after: w.after,
-            updates: w.updates,
-        }
-    }
-}
-
-async fn write_frame<W: AsyncWriteExt + Unpin>(w: &mut W, frame: &Frame) -> anyhow::Result<()> {
-    let json = serde_json::to_vec(frame)?;
-    let len = u32::try_from(json.len())?;
-    anyhow::ensure!(len <= MAX_FRAME_LEN);
-    w.write_all(&len.to_be_bytes()).await?;
-    w.write_all(&json).await?;
-    w.flush().await?;
-    Ok(())
-}
-
-async fn read_frame<R: AsyncReadExt + Unpin>(r: &mut R) -> anyhow::Result<Frame> {
-    let mut len_buf = [0u8; 4];
-    r.read_exact(&mut len_buf).await?;
-    let len = u32::from_be_bytes(len_buf);
-    anyhow::ensure!(len <= MAX_FRAME_LEN);
-    let mut body = vec![0u8; len as usize];
-    r.read_exact(&mut body).await?;
-    Ok(serde_json::from_slice(&body)?)
-}
 
 // -- Cluster channel bring-up on one loopback port. We start gossip
 //    so `maybe_start_cluster_channel` has a `ClusterHandle` to derive
@@ -156,13 +88,13 @@ fn pick_free_port() -> String {
     s.local_addr().unwrap().to_string()
 }
 
-/// Register the primary's `cdc/default` handler. Each inbound stream
-/// gets its own `CdcTailer` anchored at the watermark the subscriber
-/// announces — the production shape, and the thing that makes a
-/// reconnect resume instead of skip.
+/// Register the primary's `cdc/default` handler, dispatching each
+/// inbound stream into the **production** `serve_subscriber` — one
+/// `CdcTailer` per subscriber, anchored at the watermark that subscriber
+/// announces, which is what makes a reconnect resume instead of skip.
 ///
 /// Returns the primary's channel address (what a replica dials).
-async fn spawn_primary_on_channel(
+fn spawn_primary_on_channel(
     mgmt: Arc<Turso>,
     channel: &ChannelHandle,
 ) -> (std::net::SocketAddr, Vec<tokio::task::JoinHandle<()>>) {
@@ -172,7 +104,7 @@ async fn spawn_primary_on_channel(
             let IncomingStream { stream, .. } = incoming;
             let mgmt = Arc::clone(&mgmt);
             tokio::spawn(async move {
-                if let Err(e) = serve_one_subscriber(stream, &mgmt).await {
+                if let Err(e) = serve_subscriber(stream, &mgmt).await {
                     eprintln!("serve subscriber: {e:#}");
                 }
             });
@@ -182,60 +114,16 @@ async fn spawn_primary_on_channel(
     (channel.listen_addr(), vec![dispatch])
 }
 
-async fn serve_one_subscriber(mut stream: ChannelStream, mgmt: &Turso) -> anyhow::Result<()> {
-    let from = match read_frame(&mut stream).await? {
-        Frame::Subscribe { from_change_id } => from_change_id,
-        _ => anyhow::bail!("expected Subscribe as the first frame"),
-    };
-    let mut tailer = CdcTailer::new(mgmt, from);
-    loop {
-        match tailer.poll_batch().await {
-            Ok(Some(batch)) => {
-                let frame =
-                    Frame::Batch { rows: batch.rows.iter().map(WireCdcRow::from).collect() };
-                write_frame(&mut stream, &frame).await?;
-            }
-            Ok(None) => tokio::time::sleep(Duration::from_millis(10)).await,
-            Err(e) => anyhow::bail!("tail poll: {e}"),
-        }
-    }
-}
-
-/// Spawn a replica: announce our watermark, then apply frames.
-async fn spawn_replica_on_channel(
+/// Spawn the **production** replica driver: dial, announce the local
+/// watermark, apply, retry.
+fn spawn_replica_on_channel(
     mgmt: Arc<Turso>,
     primary_addr: std::net::SocketAddr,
     channel: ChannelHandle,
 ) -> tokio::task::JoinHandle<()> {
-    let apply_conn = mgmt.raw_connection().unwrap();
     tokio::spawn(async move {
-        loop {
-            match channel.dial(primary_addr, CDC_STREAM_TYPE).await {
-                Ok(mut stream) => {
-                    let wm = read_watermark(&apply_conn).await.unwrap_or(0);
-                    let subscribed =
-                        write_frame(&mut stream, &Frame::Subscribe { from_change_id: wm }).await;
-                    if subscribed.is_ok() {
-                        loop {
-                            match read_frame(&mut stream).await {
-                                Ok(Frame::Batch { rows }) if !rows.is_empty() => {
-                                    let batch = TxnBatch {
-                                        rows: rows.into_iter().map(CdcRow::from).collect(),
-                                    };
-                                    if let Err(e) = apply_batch(&apply_conn, &batch).await {
-                                        eprintln!("apply_batch: {e:#}");
-                                        break;
-                                    }
-                                }
-                                Ok(_) => {}
-                                Err(_) => break,
-                            }
-                        }
-                    }
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                }
-                Err(_) => tokio::time::sleep(Duration::from_millis(50)).await,
-            }
+        if let Err(e) = run_replica(mgmt, primary_addr, channel).await {
+            eprintln!("replica driver exited: {e:#}");
         }
     })
 }
@@ -293,9 +181,9 @@ async fn two_node_cdc_replicates_ddl_and_dml_end_to_end_via_channel() {
     let replica_mgmt = Arc::new(Turso::open(replica_file.path().to_str().unwrap()).await.unwrap());
 
     let (primary_addr, _primary_handles) =
-        spawn_primary_on_channel(Arc::clone(&primary_mgmt), &primary_channel).await;
+        spawn_primary_on_channel(Arc::clone(&primary_mgmt), &primary_channel);
     let _replica_handle =
-        spawn_replica_on_channel(Arc::clone(&replica_mgmt), primary_addr, replica_channel).await;
+        spawn_replica_on_channel(Arc::clone(&replica_mgmt), primary_addr, replica_channel);
 
     // Let the replica connect and complete the handshake.
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -387,10 +275,10 @@ async fn replica_reconnect_via_channel_resumes_without_double_apply() {
     let replica_mgmt = Arc::new(Turso::open(replica_file.path().to_str().unwrap()).await.unwrap());
 
     let (primary_addr, _primary_handles) =
-        spawn_primary_on_channel(Arc::clone(&primary_mgmt), &primary_channel).await;
+        spawn_primary_on_channel(Arc::clone(&primary_mgmt), &primary_channel);
 
     let first_replica =
-        spawn_replica_on_channel(Arc::clone(&replica_mgmt), primary_addr, replica_channel_1).await;
+        spawn_replica_on_channel(Arc::clone(&replica_mgmt), primary_addr, replica_channel_1);
 
     tokio::time::sleep(Duration::from_millis(300)).await;
 
@@ -421,7 +309,7 @@ async fn replica_reconnect_via_channel_resumes_without_double_apply() {
     }
 
     let _second_replica =
-        spawn_replica_on_channel(Arc::clone(&replica_mgmt), primary_addr, replica_channel_2).await;
+        spawn_replica_on_channel(Arc::clone(&replica_mgmt), primary_addr, replica_channel_2);
 
     // ...and after it is back, one more.
     tokio::time::sleep(Duration::from_millis(300)).await;

--- a/crates/ephpm-server/tests/turso_cdc_metrics_e2e.rs
+++ b/crates/ephpm-server/tests/turso_cdc_metrics_e2e.rs
@@ -166,6 +166,27 @@ fn spawn_primary(mgmt: Arc<Turso>, channel: &ChannelHandle) -> std::net::SocketA
     channel.listen_addr()
 }
 
+/// The primary's CDC write head: `MAX(turso_cdc.change_id)`.
+///
+/// Read straight from the database rather than from
+/// `ephpm_cdc_primary_head_change_id`, so the quiesce gate below is
+/// anchored to a fact about the data and never to the instrumentation it
+/// is about to assert on. Answers `0` while the log does not exist yet.
+async fn primary_head(conn: &turso::Connection) -> i64 {
+    let Ok(mut stmt) = conn.prepare("SELECT COALESCE(MAX(change_id), 0) FROM turso_cdc").await
+    else {
+        return 0;
+    };
+    let Ok(mut rows) = stmt.query(()).await else { return 0 };
+    match rows.next().await {
+        Ok(Some(row)) => match row.get_value(0) {
+            Ok(turso::Value::Integer(i)) => i,
+            _ => 0,
+        },
+        _ => 0,
+    }
+}
+
 /// Replica side: dial once and run the production consume loop, which is
 /// what records the apply metrics and the watermark gauge.
 fn spawn_replica(
@@ -263,16 +284,56 @@ async fn two_node_cdc_flow_renders_every_metric_in_a_real_scrape() {
         session.execute(&format!("INSERT INTO posts VALUES ({i}, 'post-{i}')"), &[]).await.unwrap();
     }
 
-    // Converge on the replica's own durable watermark, not on a metric —
-    // otherwise the assertions below would be checking the metric against
-    // itself.
+    // Quiesce before sampling anything.
+    //
+    // This gate used to be `read_watermark(...) > 0`, which is satisfied
+    // by the FIRST of the six batches this test produces — so every
+    // assertion below raced the remaining five. That is what made the
+    // suite flaky (observed both as "batches applied did not advance:
+    // 0 -> 0" and as "applied_change_id gauge (10) disagrees with the
+    // watermark actually stored in the replica database (12)"): the
+    // scrape was rendered at one instant and compared against a database
+    // read taken a few milliseconds later, with replication still moving
+    // in between.
+    //
+    // The fix is to wait for the terminal state rather than to relax the
+    // comparison. No writes are issued after this point, so once the
+    // replica's durable watermark equals the primary's CDC head, nothing
+    // further can arrive and every series below is stable.
+    //
+    // The gauge is included in the gate on purpose: `apply_batch` commits
+    // the watermark row *inside* its own transaction and
+    // `record_batch_applied` runs immediately after it returns, so the
+    // gauge legitimately trails the database by microseconds. Waiting for
+    // it to settle is synchronisation, not a weakened assertion — if the
+    // gauge never agrees, this gate times out and fails with all three
+    // values named.
+    let primary_conn = primary_mgmt.raw_connection().unwrap();
     let replica_conn = replica_mgmt.raw_connection().unwrap();
     let converged = eventually(
-        || async { read_watermark(&replica_conn).await.unwrap_or(0) > 0 },
-        Duration::from_secs(15),
+        || async {
+            let head = primary_head(&primary_conn).await;
+            head > 0
+                && read_watermark(&replica_conn).await.unwrap_or(-1) == head
+                && metric_value(&handle.render(), cdc_metrics::METRIC_APPLIED_CHANGE_ID, &[])
+                    .map(|v| v as i64)
+                    == Some(head)
+                && metric_value(&handle.render(), cdc_metrics::METRIC_SUBSCRIBERS, &[])
+                    .map(|v| v as i64)
+                    == Some(1)
+        },
+        Duration::from_secs(30),
     )
     .await;
-    assert!(converged, "replica never applied anything");
+    assert!(
+        converged,
+        "replica never reached the primary's CDC head: primary head {}, replica watermark {}, \
+         applied_change_id gauge {:?}, subscribers {:?}",
+        primary_head(&primary_conn).await,
+        read_watermark(&replica_conn).await.unwrap_or(-1),
+        metric_value(&handle.render(), cdc_metrics::METRIC_APPLIED_CHANGE_ID, &[]),
+        metric_value(&handle.render(), cdc_metrics::METRIC_SUBSCRIBERS, &[]),
+    );
 
     // Let the ship-side idle path run at least once so the head gauge is
     // published from a caught-up tailer.
@@ -323,19 +384,34 @@ async fn two_node_cdc_flow_renders_every_metric_in_a_real_scrape() {
     assert!(apply_count > 0.0, "apply duration histogram recorded no observations");
 
     // --- the watermark gauge must equal reality ----------------------
+    //
+    // Three-way, not two: the gauge, the replica's own database, and the
+    // primary's CDC head must all agree. Comparing the gauge only against
+    // the database would be satisfiable by a gauge that is merely
+    // self-consistent; pinning both to the primary's head proves the
+    // replica actually finished the work the primary produced.
     let real_watermark = read_watermark(&replica_conn).await.unwrap();
+    let expected_head = primary_head(&primary_conn).await;
     let gauge_watermark = require_metric_i64(&scrape, cdc_metrics::METRIC_APPLIED_CHANGE_ID, &[]);
     assert_eq!(
         gauge_watermark, real_watermark,
         "applied_change_id gauge ({gauge_watermark}) disagrees with the watermark actually \
          stored in the replica database ({real_watermark})"
     );
+    assert_eq!(
+        real_watermark, expected_head,
+        "replica watermark ({real_watermark}) is not the primary's CDC head ({expected_head}) \
+         even though the quiesce gate passed"
+    );
 
     // --- lag ---------------------------------------------------------
     let head = require_metric_i64(&scrape, cdc_metrics::METRIC_HEAD_CHANGE_ID, &[]);
     let shipped_cursor = require_metric_i64(&scrape, cdc_metrics::METRIC_SHIPPED_CHANGE_ID, &[]);
     let lag = require_metric_i64(&scrape, cdc_metrics::METRIC_LAG_CHANGES, &[]);
-    assert!(head > 0, "head change_id never advanced");
+    assert_eq!(
+        head, expected_head,
+        "head_change_id gauge ({head}) is not the primary's actual CDC head ({expected_head})"
+    );
     // The documented identity: lag is a subtraction of two change_ids,
     // not an independently maintained number that could drift from them.
     assert_eq!(

--- a/crates/ephpm-server/tests/turso_cdc_metrics_e2e.rs
+++ b/crates/ephpm-server/tests/turso_cdc_metrics_e2e.rs
@@ -1,0 +1,630 @@
+//! Instrumentation proof for CDC-native Turso replication: the
+//! `ephpm_cdc_*` series must appear, with correct values, in a **real
+//! Prometheus scrape** produced by the production recorder.
+//!
+//! # Why this is not a mock test
+//!
+//! Every assertion below observes a metric recorded by production code:
+//! the primary side runs [`ephpm_server::turso_cdc::serve_subscriber`],
+//! the replica side runs
+//! [`ephpm_server::turso_cdc::subscribe_and_consume`], and the scrape is
+//! rendered by [`ephpm_server::metrics`] — the same `init()` the binary
+//! calls and the same `render()` that answers `/metrics`. A test that
+//! called `counter!` itself and then asserted the counter moved would
+//! prove only that the `metrics` crate works.
+//!
+//! # Single-process caveat
+//!
+//! Both "nodes" live in one process, so they share one global metrics
+//! registry: the primary-side and replica-side series are all present in
+//! the same scrape. That is fine because the two sides use disjoint
+//! metric names (`*_shipped_*` vs `*_applied_*`). It does mean the tests
+//! here must not run concurrently with each other — they are serialized
+//! by [`SERIAL`], since counters are process-global and a parallel test
+//! would make a delta assertion meaningless.
+
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use ephpm_cluster::{
+    ChannelFeatureFlags, ChannelHandle, IncomingStream, maybe_start_cluster_channel, start_gossip,
+};
+use ephpm_config::{ClusterChannelConfig, ClusterConfig};
+use ephpm_server::turso_cdc::{
+    fetch_and_apply_snapshot, run_replica, serve_snapshot, serve_subscriber, subscribe_and_consume,
+};
+use ephpm_server::turso_cdc_metrics as cdc_metrics;
+use litewire::backend::Backend;
+use litewire::litewire_turso::Turso;
+use litewire::litewire_turso::cdc::read_watermark;
+use metrics_exporter_prometheus::PrometheusHandle;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+const CDC_STREAM_TYPE: &str = "cdc/default";
+
+/// Serializes the tests in this binary. Counters are process-global, so
+/// two tests recording at once would break every delta assertion. An
+/// async mutex because every test holds it across `.await` points.
+static SERIAL: Mutex<()> = Mutex::const_new(());
+
+/// The production Prometheus recorder, installed exactly once. `init()`
+/// installs a *global* recorder and fails on a second call, so every test
+/// in this binary shares this handle.
+fn scrape_handle() -> &'static PrometheusHandle {
+    static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+    HANDLE.get_or_init(|| {
+        let handle = ephpm_server::metrics::init().expect("install prometheus recorder");
+        // Seed the zero-valued CDC series exactly as
+        // `start_clustered_turso_cdc` does at startup.
+        cdc_metrics::init();
+        handle
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Scrape parsing. Deliberately a dumb text parser over the rendered
+// payload rather than a peek at internal recorder state: if the series
+// does not survive rendering into the Prometheus exposition format, it
+// does not exist as far as an operator is concerned.
+// ---------------------------------------------------------------------------
+
+/// Value of `name{labels}` in a rendered scrape, or `None` if the series
+/// is absent. `labels` are matched as a subset, so a caller need not
+/// reproduce the exporter's label ordering.
+fn metric_value(scrape: &str, name: &str, labels: &[(&str, &str)]) -> Option<f64> {
+    for line in scrape.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        // A line with no space is not a sample; skip it rather than
+        // ending the search (`?` here would abandon the whole scrape).
+        let Some((series, value)) = line.rsplit_once(' ') else { continue };
+        let (series_name, series_labels) = match series.split_once('{') {
+            Some((n, rest)) => (n, rest.trim_end_matches('}')),
+            None => (series, ""),
+        };
+        if series_name != name {
+            continue;
+        }
+        if labels.iter().all(|(k, v)| series_labels.contains(&format!("{k}=\"{v}\""))) {
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
+/// Like [`metric_value`] but fails the test with the full scrape attached
+/// when the series is missing — "the metric never rendered" is the most
+/// likely failure here and the least useful to debug from a bare `None`.
+#[track_caller]
+fn require_metric(scrape: &str, name: &str, labels: &[(&str, &str)]) -> f64 {
+    metric_value(scrape, name, labels).unwrap_or_else(|| {
+        let cdc_lines: Vec<&str> =
+            scrape.lines().filter(|l| l.contains("ephpm_cdc") && !l.starts_with('#')).collect();
+        panic!(
+            "metric {name}{labels:?} did not appear in the scrape.\n\
+             ephpm_cdc_* series present:\n{}",
+            cdc_lines.join("\n")
+        )
+    })
+}
+
+/// [`require_metric`] as an integer. Every `ephpm_cdc_*` value is a
+/// count or a `change_id`, so the cast is exact and equality assertions
+/// can be written without float comparison.
+#[track_caller]
+fn require_metric_i64(scrape: &str, name: &str, labels: &[(&str, &str)]) -> i64 {
+    require_metric(scrape, name, labels) as i64
+}
+
+// ---------------------------------------------------------------------------
+// Two-node bring-up (mirrors turso_cdc_e2e.rs).
+// ---------------------------------------------------------------------------
+
+async fn start_channel(node_id: &str) -> (Arc<ephpm_cluster::ClusterHandle>, ChannelHandle) {
+    let gossip_bind = {
+        let s = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        s.local_addr().unwrap().to_string()
+    };
+    let cluster_cfg = ClusterConfig {
+        enabled: true,
+        bind: gossip_bind,
+        secret: "cdc-metrics-secret".to_string(),
+        node_id: node_id.to_string(),
+        cluster_id: "cdc-metrics".to_string(),
+        ..ClusterConfig::default()
+    };
+    let cluster = Arc::new(start_gossip(&cluster_cfg).await.expect("gossip start"));
+    let channel = maybe_start_cluster_channel(
+        &ClusterChannelConfig { listen: Some("127.0.0.1:0".to_string()), secret: None },
+        &cluster_cfg.secret,
+        &cluster,
+        ChannelFeatureFlags { cdc: true },
+    )
+    .await
+    .expect("channel start")
+    .expect("channel bound");
+    (cluster, channel)
+}
+
+/// Primary side: dispatch every inbound stream into the production
+/// `serve_subscriber`, which is what records the shipping metrics.
+fn spawn_primary(mgmt: Arc<Turso>, channel: &ChannelHandle) -> std::net::SocketAddr {
+    let mut cdc_streams = channel.register_exact(CDC_STREAM_TYPE);
+    tokio::spawn(async move {
+        while let Some(incoming) = cdc_streams.recv().await {
+            let IncomingStream { stream, .. } = incoming;
+            let mgmt = Arc::clone(&mgmt);
+            tokio::spawn(async move {
+                if let Err(e) = serve_subscriber(stream, &mgmt).await {
+                    eprintln!("serve subscriber ended: {e:#}");
+                }
+            });
+        }
+    });
+    channel.listen_addr()
+}
+
+/// Replica side: dial once and run the production consume loop, which is
+/// what records the apply metrics and the watermark gauge.
+fn spawn_replica(
+    mgmt: Arc<Turso>,
+    primary_addr: std::net::SocketAddr,
+    channel: ChannelHandle,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let apply_conn = mgmt.raw_connection().unwrap();
+        loop {
+            if let Ok(mut stream) = channel.dial(primary_addr, CDC_STREAM_TYPE).await {
+                let wm = read_watermark(&apply_conn).await.unwrap_or(0);
+                if let Err(e) = subscribe_and_consume(&mut stream, &apply_conn, wm).await {
+                    eprintln!("replica stream ended: {e:#}");
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+}
+
+async fn eventually<F, Fut>(mut check: F, timeout: Duration) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if check().await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    check().await
+}
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+
+/// **HEADLINE**: a real two-node CDC flow moves every ship-side and
+/// apply-side series, the watermark gauge equals the watermark actually
+/// stored in the replica's database, and the lag gauge closes to zero
+/// once the replica has caught up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn two_node_cdc_flow_renders_every_metric_in_a_real_scrape() {
+    let _serial = SERIAL.lock().await;
+    let handle = scrape_handle();
+
+    // Counters are process-global and this binary may have run another
+    // test first, so every counter assertion below is a delta.
+    let before = handle.render();
+    let shipped_before = require_metric(&before, cdc_metrics::METRIC_BATCHES_SHIPPED, &[]);
+    let applied_before = require_metric(&before, cdc_metrics::METRIC_BATCHES_APPLIED, &[]);
+    // The error counters too: another test in this binary deliberately
+    // provokes an apply failure, so "no errors" here means "no *new*
+    // errors", not an absolute zero.
+    let apply_errors_before = require_metric_i64(&before, cdc_metrics::METRIC_APPLY_ERRORS, &[]);
+    let tail_errors_before = require_metric_i64(&before, cdc_metrics::METRIC_TAIL_POLL_ERRORS, &[]);
+
+    let primary_file = tempfile::NamedTempFile::new().unwrap();
+    let replica_file = tempfile::NamedTempFile::new().unwrap();
+
+    let (_pc, primary_channel) = start_channel("m-primary").await;
+    let (_rc, replica_channel) = start_channel("m-replica").await;
+
+    let primary_wire = Arc::new(
+        Turso::builder(primary_file.path().to_str().unwrap())
+            .enable_cdc_on_connect(true)
+            .build()
+            .await
+            .unwrap(),
+    );
+    let primary_mgmt = Arc::new(Turso::open(primary_file.path().to_str().unwrap()).await.unwrap());
+    let replica_mgmt = Arc::new(Turso::open(replica_file.path().to_str().unwrap()).await.unwrap());
+
+    let primary_addr = spawn_primary(Arc::clone(&primary_mgmt), &primary_channel);
+    let _replica = spawn_replica(Arc::clone(&replica_mgmt), primary_addr, replica_channel);
+
+    // The subscriber gauge must reach 1 purely from the production
+    // attach path — nothing in this test touches it.
+    let attached = eventually(
+        || async {
+            metric_value(&handle.render(), cdc_metrics::METRIC_SUBSCRIBERS, &[]).map(|v| v as i64)
+                == Some(1)
+        },
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(attached, "ephpm_cdc_subscribers never reached 1 after the replica subscribed");
+
+    let session = primary_wire.connect().await.unwrap();
+    session.execute("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)", &[]).await.unwrap();
+    for i in 1..=5 {
+        session.execute(&format!("INSERT INTO posts VALUES ({i}, 'post-{i}')"), &[]).await.unwrap();
+    }
+
+    // Converge on the replica's own durable watermark, not on a metric —
+    // otherwise the assertions below would be checking the metric against
+    // itself.
+    let replica_conn = replica_mgmt.raw_connection().unwrap();
+    let converged = eventually(
+        || async { read_watermark(&replica_conn).await.unwrap_or(0) > 0 },
+        Duration::from_secs(15),
+    )
+    .await;
+    assert!(converged, "replica never applied anything");
+
+    // Let the ship-side idle path run at least once so the head gauge is
+    // published from a caught-up tailer.
+    let lag_closed = eventually(
+        || async {
+            metric_value(&handle.render(), cdc_metrics::METRIC_LAG_CHANGES, &[]).map(|v| v as i64)
+                == Some(0)
+        },
+        Duration::from_secs(15),
+    )
+    .await;
+
+    let scrape = handle.render();
+
+    // --- ship side ---------------------------------------------------
+    let shipped = require_metric(&scrape, cdc_metrics::METRIC_BATCHES_SHIPPED, &[]);
+    assert!(
+        shipped > shipped_before,
+        "batches shipped did not advance: {shipped_before} -> {shipped}"
+    );
+    let rows_shipped = require_metric(&scrape, cdc_metrics::METRIC_ROWS_SHIPPED, &[]);
+    assert!(rows_shipped > 0.0, "no CDC rows recorded as shipped");
+    assert_eq!(require_metric_i64(&scrape, cdc_metrics::METRIC_SUBSCRIBERS, &[]), 1);
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_TAIL_POLL_ERRORS, &[]),
+        tail_errors_before,
+        "a healthy flow must record no new tail-poll errors"
+    );
+
+    // --- apply side --------------------------------------------------
+    let applied = require_metric(&scrape, cdc_metrics::METRIC_BATCHES_APPLIED, &[]);
+    assert!(
+        applied > applied_before,
+        "batches applied did not advance: {applied_before} -> {applied}"
+    );
+    let rows_applied = require_metric(&scrape, cdc_metrics::METRIC_ROWS_APPLIED, &[]);
+    assert!(rows_applied > 0.0, "no CDC rows recorded as applied");
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_APPLY_ERRORS, &[]),
+        apply_errors_before,
+        "a healthy flow must record no new apply errors"
+    );
+
+    // The apply-duration histogram must have observations, not just a
+    // registered name — a bucket set with a zero count is a phantom.
+    let apply_count =
+        require_metric(&scrape, &format!("{}_count", cdc_metrics::METRIC_APPLY_DURATION), &[]);
+    assert!(apply_count > 0.0, "apply duration histogram recorded no observations");
+
+    // --- the watermark gauge must equal reality ----------------------
+    let real_watermark = read_watermark(&replica_conn).await.unwrap();
+    let gauge_watermark = require_metric_i64(&scrape, cdc_metrics::METRIC_APPLIED_CHANGE_ID, &[]);
+    assert_eq!(
+        gauge_watermark, real_watermark,
+        "applied_change_id gauge ({gauge_watermark}) disagrees with the watermark actually \
+         stored in the replica database ({real_watermark})"
+    );
+
+    // --- lag ---------------------------------------------------------
+    let head = require_metric_i64(&scrape, cdc_metrics::METRIC_HEAD_CHANGE_ID, &[]);
+    let shipped_cursor = require_metric_i64(&scrape, cdc_metrics::METRIC_SHIPPED_CHANGE_ID, &[]);
+    let lag = require_metric_i64(&scrape, cdc_metrics::METRIC_LAG_CHANGES, &[]);
+    assert!(head > 0, "head change_id never advanced");
+    // The documented identity: lag is a subtraction of two change_ids,
+    // not an independently maintained number that could drift from them.
+    assert_eq!(
+        lag,
+        head - shipped_cursor,
+        "lag ({lag}) is not head ({head}) - shipped ({shipped_cursor})"
+    );
+    assert!(lag_closed && lag == 0, "lag did not close to 0 after convergence: {lag}");
+
+    // The lag is measured in change-log rows, and the primary emitted at
+    // least one row change per statement, so a converged replica's
+    // shipped cursor must be at least as high as its applied watermark.
+    assert!(
+        shipped_cursor >= gauge_watermark,
+        "shipped cursor {shipped_cursor} is behind the applied watermark {gauge_watermark}"
+    );
+
+    println!("--- ephpm_cdc_* series after a two-node flow ---");
+    for line in scrape.lines().filter(|l| l.contains("ephpm_cdc") && !l.starts_with('#')) {
+        println!("{line}");
+    }
+}
+
+/// A failing `apply_batch` must increment the error counter **and leave
+/// the watermark gauge alone** — a gauge that advanced past a failed
+/// apply would report a convergence that did not happen.
+///
+/// Drives the production consume loop over a duplex pair, hand-writing
+/// the wire frame as raw JSON so the test does not depend on the private
+/// `Frame` type. `change_type = 99` is rejected by litewire's
+/// `apply_batch_inner` as an unknown change type, which fails
+/// deterministically without depending on SQL-layer behaviour.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_failed_apply_increments_the_error_counter_and_freezes_the_watermark() {
+    let _serial = SERIAL.lock().await;
+    let handle = scrape_handle();
+
+    let before = handle.render();
+    let errors_before = require_metric_i64(&before, cdc_metrics::METRIC_APPLY_ERRORS, &[]);
+    let applied_before = require_metric_i64(&before, cdc_metrics::METRIC_BATCHES_APPLIED, &[]);
+
+    let replica_file = tempfile::NamedTempFile::new().unwrap();
+    let replica = Turso::open(replica_file.path().to_str().unwrap()).await.unwrap();
+    let apply_conn = replica.raw_connection().unwrap();
+
+    let (mut fake_primary, mut replica_side) = tokio::io::duplex(1 << 20);
+
+    // Production consume loop under test.
+    let consumer = tokio::spawn(async move {
+        let conn = apply_conn;
+        subscribe_and_consume(&mut replica_side, &conn, 0).await
+    });
+
+    // Drain the Subscribe frame the consumer sends first.
+    {
+        use tokio::io::AsyncReadExt;
+        let mut len = [0u8; 4];
+        fake_primary.read_exact(&mut len).await.unwrap();
+        let mut body = vec![0u8; u32::from_be_bytes(len) as usize];
+        fake_primary.read_exact(&mut body).await.unwrap();
+        let text = String::from_utf8(body).unwrap();
+        assert!(text.contains("Subscribe"), "first frame from the replica was {text}");
+    }
+
+    // A batch litewire cannot apply.
+    let poison = br#"{"Batch":{"rows":[{"change_id":4242,"change_txn_id":null,"change_type":99,"table_name":"posts","id":1,"before":null,"after":null,"updates":null}]}}"#;
+    let len = u32::try_from(poison.len()).unwrap();
+    fake_primary.write_all(&len.to_be_bytes()).await.unwrap();
+    fake_primary.write_all(poison).await.unwrap();
+    fake_primary.flush().await.unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), consumer)
+        .await
+        .expect("consume loop hung on a bad batch")
+        .expect("consume task panicked");
+    let err = result.expect_err("an unknown change_type must fail the stream, not be skipped");
+    assert!(
+        err.to_string().contains("4242"),
+        "error should name the failing change_id, got: {err:#}"
+    );
+
+    let scrape = handle.render();
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_APPLY_ERRORS, &[]),
+        errors_before + 1,
+        "apply error counter did not move"
+    );
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_BATCHES_APPLIED, &[]),
+        applied_before,
+        "a failed batch must not count as applied"
+    );
+    // Subscribe published watermark 0; the failed apply must not have
+    // advanced it to 4242.
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_APPLIED_CHANGE_ID, &[]),
+        0,
+        "the watermark gauge advanced past a batch that failed to apply"
+    );
+}
+
+/// `init()` must register every zero-valued series, so a freshly booted
+/// node's scrape distinguishes "replication is on and idle" from "this
+/// build has no CDC instrumentation". Absent counters cannot say which.
+#[tokio::test]
+async fn startup_seeds_every_zero_valued_series() {
+    let _serial = SERIAL.lock().await;
+    let scrape = scrape_handle().render();
+
+    for name in [
+        cdc_metrics::METRIC_BATCHES_SHIPPED,
+        cdc_metrics::METRIC_ROWS_SHIPPED,
+        cdc_metrics::METRIC_TAIL_POLL_ERRORS,
+        cdc_metrics::METRIC_SNAPSHOT_BYTES_SERVED,
+        cdc_metrics::METRIC_BATCHES_APPLIED,
+        cdc_metrics::METRIC_ROWS_APPLIED,
+        cdc_metrics::METRIC_APPLY_ERRORS,
+        cdc_metrics::METRIC_SNAPSHOT_BYTES_RECEIVED,
+        cdc_metrics::METRIC_SUBSCRIBERS,
+    ] {
+        require_metric(&scrape, name, &[]);
+    }
+    for stream in ["cdc", "snapshot"] {
+        require_metric(&scrape, cdc_metrics::METRIC_STREAMS_REFUSED, &[("stream", stream)]);
+    }
+    for status in ["ok", "error"] {
+        require_metric(&scrape, cdc_metrics::METRIC_SNAPSHOTS_SERVED, &[("status", status)]);
+    }
+    for outcome in ["closed", "dial_error", "stream_error", "watermark_error"] {
+        require_metric(&scrape, cdc_metrics::METRIC_REPLICA_CONNECTS, &[("outcome", outcome)]);
+    }
+    for outcome in ["ok", "skipped", "failed"] {
+        require_metric(&scrape, cdc_metrics::METRIC_BOOTSTRAP, &[("outcome", outcome)]);
+    }
+
+    // The lag/head/shipped gauges are deliberately NOT seeded: a node
+    // that has never replicated anything must not publish a lag of 0,
+    // which reads as "fully caught up". They appear on first attach.
+    // (If a prior test in this binary already attached a subscriber they
+    // will be present, so this only asserts the seeding list above.)
+}
+
+/// A replica that cannot reach its primary must be visible as such. This
+/// is the failure an operator most needs the counter for — the replica
+/// logs the dial failure at `debug`, so without the metric a silently
+/// disconnected replica looks identical to an idle one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unreachable_primary_increments_the_dial_error_counter() {
+    let _serial = SERIAL.lock().await;
+    let handle = scrape_handle();
+
+    let before = require_metric_i64(
+        &handle.render(),
+        cdc_metrics::METRIC_REPLICA_CONNECTS,
+        &[("outcome", "dial_error")],
+    );
+
+    let db = tempfile::NamedTempFile::new().unwrap();
+    let mgmt = Arc::new(Turso::open(db.path().to_str().unwrap()).await.unwrap());
+    let (_c, channel) = start_channel("m-orphan").await;
+
+    // A port nothing is listening on: bind, read the address, drop.
+    let dead_addr = {
+        let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap()
+    };
+
+    // The production replica driver, pointed at nothing.
+    let driver = tokio::spawn(run_replica(mgmt, dead_addr, channel));
+
+    let observed = eventually(
+        || async {
+            metric_value(
+                &handle.render(),
+                cdc_metrics::METRIC_REPLICA_CONNECTS,
+                &[("outcome", "dial_error")],
+            )
+            .map(|v| v as i64)
+            .is_some_and(|v| v > before)
+        },
+        Duration::from_secs(15),
+    )
+    .await;
+    driver.abort();
+
+    assert!(observed, "a replica dialing a dead primary recorded no dial_error");
+}
+
+/// The snapshot bootstrap path: a cold replica fetching a base snapshot
+/// must move the served/received byte counters, the outcome counter, and
+/// the transfer histogram — and land the watermark gauge on the
+/// snapshot's watermark before any CDC batch arrives.
+///
+/// Drives the production [`serve_snapshot`] and
+/// [`fetch_and_apply_snapshot`] over a real cluster channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn snapshot_bootstrap_records_bytes_outcome_and_watermark() {
+    let _serial = SERIAL.lock().await;
+    let handle = scrape_handle();
+
+    let before = handle.render();
+    let served_before =
+        require_metric_i64(&before, cdc_metrics::METRIC_SNAPSHOTS_SERVED, &[("status", "ok")]);
+    let bytes_served_before =
+        require_metric_i64(&before, cdc_metrics::METRIC_SNAPSHOT_BYTES_SERVED, &[]);
+    let bytes_recv_before =
+        require_metric_i64(&before, cdc_metrics::METRIC_SNAPSHOT_BYTES_RECEIVED, &[]);
+
+    let primary_file = tempfile::NamedTempFile::new().unwrap();
+    let replica_file = tempfile::NamedTempFile::new().unwrap();
+    let (_pc, primary_channel) = start_channel("m-snap-primary").await;
+    let (_rc, replica_channel) = start_channel("m-snap-replica").await;
+
+    // Populate the primary BEFORE any replica exists, so the rows can
+    // only reach the replica through the snapshot.
+    let primary_wire = Turso::builder(primary_file.path().to_str().unwrap())
+        .enable_cdc_on_connect(true)
+        .build()
+        .await
+        .unwrap();
+    let session = primary_wire.connect().await.unwrap();
+    session.execute("CREATE TABLE seeded (id INTEGER PRIMARY KEY, v TEXT)", &[]).await.unwrap();
+    for i in 1..=10 {
+        session.execute(&format!("INSERT INTO seeded VALUES ({i}, 'v{i}')"), &[]).await.unwrap();
+    }
+
+    // Primary-side snapshot handler, running production `serve_snapshot`.
+    let primary_mgmt = Arc::new(Turso::open(primary_file.path().to_str().unwrap()).await.unwrap());
+    let mut snapshot_streams = primary_channel.register_exact("snapshot/default");
+    tokio::spawn(async move {
+        while let Some(incoming) = snapshot_streams.recv().await {
+            let mgmt = Arc::clone(&primary_mgmt);
+            tokio::spawn(async move {
+                if let Err(e) = serve_snapshot(incoming.stream, &mgmt).await {
+                    eprintln!("serve snapshot: {e:#}");
+                }
+            });
+        }
+    });
+
+    // Replica side, running production `fetch_and_apply_snapshot`.
+    let replica_mgmt = Turso::open(replica_file.path().to_str().unwrap()).await.unwrap();
+    let replica_conn = replica_mgmt.raw_connection().unwrap();
+    let watermark = fetch_and_apply_snapshot(
+        &replica_conn,
+        primary_channel.listen_addr(),
+        &replica_channel,
+        1 << 30,
+    )
+    .await
+    .expect("snapshot bootstrap");
+
+    let scrape = handle.render();
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_SNAPSHOTS_SERVED, &[("status", "ok")]),
+        served_before + 1,
+        "a successful snapshot was not counted"
+    );
+    assert!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_SNAPSHOT_BYTES_SERVED, &[])
+            > bytes_served_before,
+        "snapshot bytes served did not advance"
+    );
+    assert!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_SNAPSHOT_BYTES_RECEIVED, &[])
+            > bytes_recv_before,
+        "snapshot bytes received did not advance"
+    );
+    // Both sides of one transfer measured the same body.
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_SNAPSHOT_BYTES_SERVED, &[])
+            - bytes_served_before,
+        require_metric_i64(&scrape, cdc_metrics::METRIC_SNAPSHOT_BYTES_RECEIVED, &[])
+            - bytes_recv_before,
+        "served and received byte counts disagree for the same snapshot"
+    );
+    for role in ["serve", "fetch"] {
+        let count = require_metric(
+            &scrape,
+            &format!("{}_count", cdc_metrics::METRIC_SNAPSHOT_DURATION),
+            &[("role", role)],
+        );
+        assert!(count > 0.0, "snapshot duration histogram has no {role} observations");
+    }
+    // The gauge must reflect the seeded watermark, before CDC tails.
+    assert_eq!(
+        require_metric_i64(&scrape, cdc_metrics::METRIC_APPLIED_CHANGE_ID, &[]),
+        watermark,
+        "watermark gauge does not match the watermark the snapshot seeded"
+    );
+    assert_eq!(read_watermark(&replica_conn).await.unwrap(), watermark);
+}

--- a/site/content/architecture/metrics.md
+++ b/site/content/architecture/metrics.md
@@ -69,6 +69,39 @@ that the proxy records a narrower set of statements. See the
 | `ephpm_query_slow_total` | counter | — | Number of queries exceeding the slow query threshold. |
 | `ephpm_query_active_digests` | gauge | — | Number of unique query digests currently tracked. |
 
+### CDC Replication Metrics (experimental)
+
+Emitted only when the experimental CDC-native Turso replication path is running
+(`[db.sqlite] engine = "turso"` + clustering + `[db.sqlite.replication]
+cdc_experimental = true`). The full table — every series, its labels, and the
+PromQL to alert on — is in the
+[metrics reference](/reference/metrics/#cdc-native-turso-replication).
+
+The design decision worth knowing here is what "replication lag" means. Two
+positions are published: `ephpm_cdc_primary_head_change_id` (the primary's write
+head in its `turso_cdc` log) and `ephpm_cdc_applied_change_id` (the replica's
+applied watermark). `ephpm_cdc_replication_lag_changes` is the primary-local
+difference between the head and the slowest attached subscriber's shipped
+cursor.
+
+All three are counted in **`change_id`s — change-log rows, not seconds**. That is
+what the data supports: a seconds-valued lag needs a commit timestamp on the
+wire, and while `turso_cdc` records one (`change_time`), litewire's `CdcRow` does
+not carry it. Publishing a time-based lag would therefore require a litewire
+change plus a CDC wire-format change; inventing one from row counts would be
+worse than not having it, so the row lag is what ships and the unit is stated
+everywhere it appears.
+
+Two smaller consequences of that model:
+
+- The shipped cursor is the **minimum** across attached subscribers, so a single
+  caught-up replica cannot mask a lagging one, and it is **retained** after the
+  last subscriber detaches, so a primary that keeps taking writes after its
+  replica dies shows a growing lag rather than a frozen one.
+- The lag/head/shipped gauges are not pre-seeded at zero the way the counters
+  are. A node that has never replicated anything publishing `lag = 0` would read
+  as "fully caught up", which is the opposite of the truth.
+
 ---
 
 ## Histogram Buckets
@@ -81,6 +114,8 @@ Custom bucket configurations are tuned for PHP workloads:
 | `ephpm_php_execution_duration_seconds` | 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s |
 | Body size histograms | 100B, 1KB, 10KB, 50KB, 100KB, 500KB, 1MB, 5MB, 10MB |
 | `ephpm_http_compression_ratio` | 0.05, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9 |
+| `ephpm_cdc_apply_duration_seconds` | 100µs, 500µs, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 500ms, 1s, 5s |
+| `ephpm_cdc_snapshot_duration_seconds` | 10ms, 50ms, 100ms, 500ms, 1s, 2.5s, 5s, 10s, 30s, 60s, 120s, 300s |
 
 ---
 

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -119,6 +119,87 @@ These series are emitted by both the embedded SQLite paths and the MySQL/Postgre
 
 `ephpm_query_rows_total` is likewise narrower on the proxy paths, which report `0` where they cannot count rows rather than estimating: the default MySQL path has no row visibility at all, and the PostgreSQL path counts rows *returned* but not rows *affected* by a mutation. Statement coverage per path — including what the proxies deliberately do not record, such as prepared-statement executes and PostgreSQL extended-protocol traffic — is tabulated under [`[db.analysis]`](/reference/config/#dbanalysis) in the config reference.
 
+## CDC-native Turso replication
+
+These appear only when `[db.sqlite] engine = "turso"` is combined with
+clustering and `[db.sqlite.replication] cdc_experimental = true`. A
+deployment on sqld or single-node SQLite has no `ephpm_cdc_*` series at all.
+The whole path is **experimental** — see
+[Roadmap → Turso engine](/roadmap/turso-engine/).
+
+Every node registers both the primary-side and replica-side series at startup,
+zeroed, so an idle node is distinguishable from a build without the
+instrumentation. Which ones actually move depends on the elected role.
+
+### Primary (shipping) side
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ephpm_cdc_subscribers` | gauge | — | CDC subscriber streams currently attached to this node. Counted from the moment a stream sends its `Subscribe` frame until the stream ends for any reason. **This is the metric to alert on**: `0` on a primary means nothing is being replicated. |
+| `ephpm_cdc_batches_shipped_total` | counter | — | Committed transaction batches written into subscriber streams, summed across subscribers. Counted after the frame is on the wire, so a batch that failed to write is not counted. |
+| `ephpm_cdc_rows_shipped_total` | counter | — | `turso_cdc` rows contained in those batches. |
+| `ephpm_cdc_shipped_change_id` | gauge | — | The **lowest** `change_id` shipped across all attached subscribers — i.e. the slowest replica's position, so one caught-up replica cannot mask another that is far behind. Retained after the last subscriber detaches. Absent until the first subscriber ever attaches. |
+| `ephpm_cdc_primary_head_change_id` | gauge | — | `MAX(turso_cdc.change_id)` on this node: the write head of the change log. Sampled once a second while primary, and also advanced for free whenever a tailer runs dry. Monotonic. |
+| `ephpm_cdc_replication_lag_changes` | gauge | — | `primary_head_change_id - shipped_change_id`. **The headline replication-lag metric — see the unit warning below.** Clamped at `0`. Absent until the first subscriber ever attaches. |
+| `ephpm_cdc_tail_poll_errors_total` | counter | — | `turso_cdc` poll failures. The stream is dropped and the replica resumes from the same watermark, so this is a retry signal, not a data-loss signal. |
+| `ephpm_cdc_streams_refused_total` | counter | `stream` | Inbound streams refused because this node is not the elected primary — a peer is dialing a stale primary address. `stream` is `cdc` or `snapshot`. |
+| `ephpm_cdc_snapshots_served_total` | counter | `status` | Snapshot bootstraps served to cold replicas. `status` is `ok` or `error`. |
+| `ephpm_cdc_snapshot_bytes_served_total` | counter | — | Logical-dump bytes written to dialing replicas. Successful transfers only. |
+| `ephpm_cdc_snapshot_duration_seconds` | histogram | `role` | Snapshot transfer time. `role` is `serve` (primary produced and streamed the dump) or `fetch` (replica received and applied it). |
+
+### Replica (apply) side
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ephpm_cdc_batches_applied_total` | counter | — | CDC batches applied to the local database. A batch that failed to apply is **not** counted here; it appears in `ephpm_cdc_apply_errors_total`. |
+| `ephpm_cdc_rows_applied_total` | counter | — | `turso_cdc` rows applied. |
+| `ephpm_cdc_applied_change_id` | gauge | — | This replica's applied watermark, mirroring litewire's `__litewire_cdc_watermark` table. Published on subscribe, after a snapshot bootstrap, and after every applied batch — deliberately **not** advanced past a batch that failed to apply. |
+| `ephpm_cdc_apply_errors_total` | counter | — | `apply_batch` failures. The stream is failed and the watermark does not move; the replica reconnects and retries from the identical cursor. Any non-zero rate here means replication is stalled, not degraded. |
+| `ephpm_cdc_apply_duration_seconds` | histogram | — | Per-batch apply time on the replica. One batch is one replicated transaction. |
+| `ephpm_cdc_replica_connects_total` | counter | `outcome` | Subscribe attempts, one increment per attempt by terminal outcome: `closed` (primary closed the stream cleanly), `dial_error` (could not reach the primary), `stream_error` (connected, then the stream failed), `watermark_error` (could not read the local watermark). Reconnect rate is the sum across all four. |
+| `ephpm_cdc_bootstrap_total` | counter | `outcome` | Cold-start snapshot bootstrap decisions. `outcome` is `ok`, `skipped` (local database already populated) or `failed` (retry budget exhausted — startup aborts deliberately rather than serving incomplete data). |
+| `ephpm_cdc_snapshot_bytes_received_total` | counter | — | Logical-dump bytes received and successfully applied during bootstrap. |
+
+### What the lag metric means (and does not)
+
+`ephpm_cdc_replication_lag_changes` is a **row count, not a duration**. Both of
+its inputs are `change_id` values, and turso allocates one `change_id` per
+captured row change. A lag of `500` means five hundred row changes behind — which
+is sub-millisecond on an idle cluster and several minutes behind a bulk import.
+**Do not graph it with a seconds unit and do not alert on it as if it were one.**
+
+It is measured at the *ship* boundary — the moment a batch is written into the
+subscriber's stream — not at the *apply* boundary on the replica. It therefore
+excludes network flight time and the replica's apply cost. For true end-to-end
+lag, subtract across nodes:
+
+```promql
+# End-to-end replication lag, in change-log rows.
+max(ephpm_cdc_primary_head_change_id) - min(ephpm_cdc_applied_change_id)
+
+# Replication is not happening at all — the unambiguous alert.
+max(ephpm_cdc_subscribers) == 0
+
+# Replication is stalled on a failing apply (the watermark is not moving).
+rate(ephpm_cdc_apply_errors_total[5m]) > 0
+```
+
+There is deliberately **no seconds-valued lag metric**. Producing one requires a
+commit timestamp travelling with each change so the consumer can subtract it
+from its own clock. The `turso_cdc` table does store one (`change_time`), but
+litewire's `CdcRow` does not expose it, so surfacing a time-based lag needs a
+litewire change to carry `change_time` plus a matching CDC wire-format change —
+not an ePHPm-side calculation. Until both land, any "seconds behind" figure
+would be invented, so none is published.
+
+### Cardinality
+
+Every series above is either unlabelled or carries a label with a fixed, small
+set of values (`stream`: 2, `status`: 2, `role`: 2, `outcome`: 4 or 3). There are
+deliberately **no per-peer or per-address labels** — a label per replica would
+scale series count with cluster size and churn a new series on every pod
+replacement.
+
 ## Cardinality notes
 
 The per-metric `digest` label series is **capped** — by default at 1,000 distinct label values per process (`StatsConfig::metric_label_series_max`). Every additional distinct digest observed after the cap is exhausted has its Prometheus emissions folded into a single shared `digest="__other__"` bucket. Internal tracking (`top_queries()`, the digest table, the slow-query log) is **not** affected by this cap and still exposes the real normalized SQL — only the Prometheus label surface is bounded.
@@ -135,6 +216,8 @@ Buckets are custom per metric — configured with `Matcher::Full` rules in [`cra
 
 - Duration histograms (`ephpm_http_request_duration_seconds`, `ephpm_php_execution_duration_seconds`, `ephpm_worker_request_wait_seconds`): 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 seconds
 - `ephpm_worker_boot_duration_seconds`: 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30 seconds (framework boot can take seconds)
+- `ephpm_cdc_apply_duration_seconds`: 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1, 5 seconds (one replicated transaction; the healthy range is sub-millisecond, so the buckets start two decades lower than the HTTP ones)
+- `ephpm_cdc_snapshot_duration_seconds`: 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300 seconds (a logical dump of a large database is minutes, and it blocks a cold replica's startup)
 - Body-size histograms (`ephpm_http_request_body_bytes`, `ephpm_http_response_body_bytes`, `ephpm_php_output_bytes`): 100 B, 1 KB, 10 KB, 50 KB, 100 KB, 500 KB, 1 MB, 5 MB, 10 MB
 - `ephpm_http_compression_ratio`: 0.05 through 0.9
 

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -182,9 +182,24 @@ path is a **single ordered stream** with no schema-sync side channel.
   than the pinned revision's, and rejecting at decode time keeps the
   diagnostics legible (every failure past that point is reported "at
   change_id N", which an empty batch has no value for).
+- Prometheus instrumentation for the whole path — batches and rows
+  shipped and applied, subscriber count, the applied watermark, apply and
+  tail-poll errors, reconnects by outcome, snapshot bytes and outcome,
+  and a replication-lag gauge. Full table in the
+  [metrics reference](/reference/metrics/#cdc-native-turso-replication).
+  The lag is measured in **change-log rows, not seconds**; a time-based
+  lag is listed under "still deferred" below because it needs a wire
+  change, not a calculation.
 
 **Still deferred:**
 
+- A **time-based** replication lag. `ephpm_cdc_replication_lag_changes`
+  counts change-log rows, which answers "how far behind" but not "how
+  many seconds behind". A seconds-valued lag needs a commit timestamp
+  travelling with each change: `turso_cdc` stores one (`change_time`),
+  but litewire's `CdcRow` does not expose it, so this needs a litewire
+  PR adding the field plus a matching CDC wire-format change here. Not
+  fakeable from row counts, so nothing is published in the meantime.
 - Subscriber watermarks that survive a *primary change*. Resume works
   within one primary (the subscriber names its cursor); after a
   failover the new primary's `change_id` space is its own, so a


### PR DESCRIPTION
CDC-native Turso replication shipped with **zero** metrics — no lag, no batch counts, no subscriber count. There was no way to distinguish a converged replica from a dead one short of reading tracing output, which is the main reason the path cannot be trusted in production. This is the v0.6.2 headline item: make Turso *observable*.

19 new series, all under `ephpm_cdc_*`, emitted only when `cdc_experimental = true` actually starts the CDC path.

## Metric inventory

### Primary (shipping) side

| Metric | Type | Labels | Meaning |
|---|---|---|---|
| `ephpm_cdc_subscribers` | gauge | — | Subscriber streams currently attached. **`0` on a primary is the unambiguous "replication is not happening" alert.** |
| `ephpm_cdc_batches_shipped_total` | counter | — | Committed txn batches written into subscriber streams. Counted *after* the frame is on the wire. |
| `ephpm_cdc_rows_shipped_total` | counter | — | CDC rows in those batches. |
| `ephpm_cdc_shipped_change_id` | gauge | — | **Lowest** `change_id` shipped across subscribers (slowest replica). Retained after the last detach. |
| `ephpm_cdc_primary_head_change_id` | gauge | — | `MAX(turso_cdc.change_id)`. Sampled 1 Hz while primary; monotonic. |
| `ephpm_cdc_replication_lag_changes` | gauge | — | `head - shipped`. **The headline metric — rows, not seconds.** |
| `ephpm_cdc_tail_poll_errors_total` | counter | — | `turso_cdc` poll failures (retry signal, not data loss). |
| `ephpm_cdc_streams_refused_total` | counter | `stream`=cdc\|snapshot | Streams refused because this node is not primary. |
| `ephpm_cdc_snapshots_served_total` | counter | `status`=ok\|error | Snapshot bootstraps served. |
| `ephpm_cdc_snapshot_bytes_served_total` | counter | — | Dump bytes written (successful transfers only). |
| `ephpm_cdc_snapshot_duration_seconds` | histogram | `role`=serve\|fetch | Snapshot transfer time. |

### Replica (apply) side

| Metric | Type | Labels | Meaning |
|---|---|---|---|
| `ephpm_cdc_batches_applied_total` | counter | — | Batches applied locally. A failed batch is **not** counted here. |
| `ephpm_cdc_rows_applied_total` | counter | — | CDC rows applied. |
| `ephpm_cdc_applied_change_id` | gauge | — | Applied watermark. Published on subscribe, after bootstrap, and after each batch — **never advanced past a failed apply**. |
| `ephpm_cdc_apply_errors_total` | counter | — | `apply_batch` failures. Non-zero rate = replication *stalled*, not degraded. |
| `ephpm_cdc_apply_duration_seconds` | histogram | — | Per-batch apply time. |
| `ephpm_cdc_replica_connects_total` | counter | `outcome`=closed\|dial_error\|stream_error\|watermark_error | One increment per subscribe attempt, by terminal outcome. Reconnect rate = sum of all four. |
| `ephpm_cdc_bootstrap_total` | counter | `outcome`=ok\|skipped\|failed | Cold-start bootstrap decisions. |
| `ephpm_cdc_snapshot_bytes_received_total` | counter | — | Dump bytes received and applied. |

No per-peer or per-address labels — every label has a fixed set of 4 or fewer values, so series count does not scale with cluster size or pod churn.

## The lag metric: design and honest limitations

`ephpm_cdc_replication_lag_changes = primary_head_change_id - shipped_change_id`.

**It is a count of change-log rows, not seconds.** Turso allocates one `change_id` per captured row change, so "lag = 500" means five hundred row changes behind — sub-millisecond on an idle cluster, minutes behind a bulk import. Documented with that warning everywhere it appears.

**There is deliberately no time-based lag.** A seconds-valued lag needs a commit timestamp travelling with each change. `turso_cdc` *does* store one (`change_time`, column 2 of the v2 schema), but litewire's `CdcRow` does not expose it — the struct is `(change_id, change_txn_id, change_type, table_name, id, before, after, updates)`. So it needs **two upstream changes**: a litewire PR adding `change_time` to `CdcRow` (plus a pin bump), and a matching CDC wire-format change here. Rather than approximate seconds from row counts, nothing is published and the gap is filed under "still deferred" on the turso-engine roadmap.

**Known limitations, stated plainly:**

1. **Measured at the ship boundary, not the apply boundary.** It is written-into-the-stream, so it excludes network flight and replica apply cost. For true end-to-end, the docs give the cross-node PromQL: `max(ephpm_cdc_primary_head_change_id) - min(ephpm_cdc_applied_change_id)`.
2. **Absent until the first subscriber ever attaches.** The head/shipped/lag gauges are deliberately *not* seeded at zero — a node that has never replicated anything publishing `lag = 0` would read as "fully caught up", the opposite of the truth. Counters and the subscriber gauge *are* seeded, so an idle node is still distinguishable from a build without instrumentation.
3. **Bootstrap dial retries are invisible.** `replica_connects_total` covers CDC subscribe attempts; the snapshot-bootstrap dial has its own retry loop and only records a terminal `bootstrap_total{outcome}`. Visible in the live run below — the replica's first dial was refused by the gossip membership check, retried, and succeeded, and no counter moved.

Two decisions that make the gauge trustworthy:

- The shipped cursor is the **minimum** across subscribers, so one caught-up replica cannot mask a lagging one, and a cold replica joining at a low watermark correctly *lowers* it.
- The cursor is **retained** after the last subscriber detaches, and a 1 Hz `MAX(change_id)` sampler keeps the head moving while primary. Without both, a primary whose replica died would report a frozen lag forever. Proven below.

Cost: one indexed `MAX()` per second on the primary only; the ship path's idle branch observes the head for free (a tailer that polls no batch has reached the log end), and the head is monotonic via `fetch_max` so a cold `0` sample cannot produce negative lag.

## Tests now drive production code, not a twin

`tests/turso_cdc_e2e.rs` defined its **own** `Frame`/`WireCdcRow` enums and its own serve/apply loops. A test that re-implements what it tests cannot catch a defect in the real implementation — and instrumenting a twin would have measured nothing. `serve_subscriber`, `run_replica` and `subscribe_and_consume` are now `pub` (as `serve_snapshot` already was) and the suite drives them directly; roughly 130 lines of twin deleted. Both existing tests still pass against the real code.

New `tests/turso_cdc_metrics_e2e.rs` installs the **production** Prometheus recorder and parses a **real rendered scrape** — a metric that does not survive rendering does not exist to an operator.

**Test counts (all green):**

| Suite | Tests |
|---|---|
| `ephpm-server` lib (incl. 4 new lag-bookkeeping unit tests) | 275 |
| `turso_cdc_metrics_e2e` (new) | 5 |
| `turso_cdc_e2e` (converted to production code) | 2 |
| `turso_cdc_cluster_integration` (`EPHPM_CLUSTER_INTEG=1`) | 1 |
| `turso_cdc_snapshot_bootstrap` | 1 |
| `ephpm-config` (`--test-threads=1`) | 90 |

New coverage: two-node flow (ship + apply counters, subscriber gauge, lag closing to 0, **watermark gauge equal to the value actually in the replica's database**), failing apply (error counter moves, watermark gauge does *not*), unreachable primary (`dial_error`), real snapshot bootstrap (served and received byte counts agree), and zero-seeding. Unit tests cover slowest-subscriber tracking, cursor retention across detach, head monotonicity, and cold-join lowering the cursor.

`cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo +nightly fmt --all -- --check`: clean.

## Real scrape — 2-node podman cluster

Two release containers (`podman build -f docker/Dockerfile`) on `10.89.1.0/24`, `engine = "turso"` + `cdc_experimental = true`, writes driven through PHP `pdo_mysql` into litewire.

**Startup — snapshot bootstrap and subscribe, both instrumented:**

```
# PRIMARY                                             # REPLICA
ephpm_cdc_snapshots_served_total{status="ok"} 1       ephpm_cdc_bootstrap_total{outcome="ok"} 1
ephpm_cdc_snapshot_duration_seconds_count{role="serve"} 1
ephpm_cdc_subscribers 1                               ephpm_cdc_snapshot_duration_seconds_count{role="fetch"} 1
ephpm_cdc_replication_lag_changes 0                   ephpm_cdc_applied_change_id 0
```

**The headline metric, live.** 500 rows written, then the replica paused mid-stream, then resumed:

```
=== A: converged ===                   === B: paused, +800 rows ===           === C: resumed ===
ephpm_cdc_primary_head_change_id 1002  ephpm_cdc_primary_head_change_id 2602  ephpm_cdc_primary_head_change_id 2602
ephpm_cdc_shipped_change_id      1002  ephpm_cdc_shipped_change_id      2508  ephpm_cdc_shipped_change_id      2602
ephpm_cdc_replication_lag_changes   0  ephpm_cdc_replication_lag_changes  94  ephpm_cdc_replication_lag_changes   0
ephpm_cdc_subscribers               1  ephpm_cdc_subscribers               1  ephpm_cdc_subscribers               1
```

**The retained-cursor design, proven.** Replica killed outright, then 300 + 300 rows written with nothing attached — lag *grows* instead of freezing at 0:

```
--- replica dead ---                    --- +300 rows ---               --- +300 more ---
ephpm_cdc_primary_head_change_id 2602   ...head_change_id     3202      ...head_change_id     3802
ephpm_cdc_shipped_change_id      2602   ...shipped_change_id  2602      ...shipped_change_id  2602
ephpm_cdc_replication_lag_changes   0   ...lag_changes         600      ...lag_changes        1200
ephpm_cdc_subscribers               0   ...subscribers           0      ...subscribers           0
```

**Recovery and final state.** Replica restarted, caught up; its counters reset with the process, as Prometheus counters do (`rate()` handles it):

```
############ PRIMARY (10.89.1.11) ############
ephpm_cdc_apply_errors_total 0
ephpm_cdc_batches_applied_total 0
ephpm_cdc_batches_shipped_total 1901
ephpm_cdc_bootstrap_total{outcome="failed"} 0
ephpm_cdc_bootstrap_total{outcome="ok"} 0
ephpm_cdc_bootstrap_total{outcome="skipped"} 0
ephpm_cdc_primary_head_change_id 3802
ephpm_cdc_replica_connects_total{outcome="closed"} 0
ephpm_cdc_replica_connects_total{outcome="dial_error"} 0
ephpm_cdc_replica_connects_total{outcome="stream_error"} 0
ephpm_cdc_replica_connects_total{outcome="watermark_error"} 0
ephpm_cdc_replication_lag_changes 0
ephpm_cdc_rows_applied_total 0
ephpm_cdc_rows_shipped_total 3802
ephpm_cdc_shipped_change_id 3802
ephpm_cdc_snapshot_bytes_received_total 0
ephpm_cdc_snapshot_bytes_served_total 0
ephpm_cdc_snapshot_duration_seconds_count{role="serve"} 1
ephpm_cdc_snapshot_duration_seconds_sum{role="serve"} 0.000441096
ephpm_cdc_snapshots_served_total{status="error"} 0
ephpm_cdc_snapshots_served_total{status="ok"} 1
ephpm_cdc_streams_refused_total{stream="cdc"} 0
ephpm_cdc_streams_refused_total{stream="snapshot"} 0
ephpm_cdc_subscribers 1
ephpm_cdc_tail_poll_errors_total 0

############ REPLICA (10.89.1.12) ############
ephpm_cdc_applied_change_id 3802
ephpm_cdc_apply_duration_seconds_count 600
ephpm_cdc_apply_duration_seconds_sum 0.87054684
ephpm_cdc_apply_errors_total 0
ephpm_cdc_batches_applied_total 600
ephpm_cdc_batches_shipped_total 0
ephpm_cdc_bootstrap_total{outcome="failed"} 0
ephpm_cdc_bootstrap_total{outcome="ok"} 0
ephpm_cdc_bootstrap_total{outcome="skipped"} 1
ephpm_cdc_replica_connects_total{outcome="closed"} 0
ephpm_cdc_replica_connects_total{outcome="dial_error"} 0
ephpm_cdc_replica_connects_total{outcome="stream_error"} 0
ephpm_cdc_replica_connects_total{outcome="watermark_error"} 0
ephpm_cdc_rows_applied_total 1200
ephpm_cdc_rows_shipped_total 0
ephpm_cdc_snapshot_bytes_received_total 0
ephpm_cdc_snapshot_bytes_served_total 0
ephpm_cdc_snapshot_duration_seconds_count{role="fetch"} 1
ephpm_cdc_snapshot_duration_seconds_sum{role="fetch"} 0.037233502
ephpm_cdc_snapshots_served_total{status="error"} 0
ephpm_cdc_snapshots_served_total{status="ok"} 0
ephpm_cdc_streams_refused_total{stream="cdc"} 0
ephpm_cdc_streams_refused_total{stream="snapshot"} 0
ephpm_cdc_subscribers 0
ephpm_cdc_tail_poll_errors_total 0
```

Cross-node lag is 0: primary head `3802` equals the replica's `applied_change_id` `3802`, and the replica held all 1900 rows. `snapshot_bytes_*` are `0` because the cluster bootstrapped cold (empty DB, watermark 0) — correct, not a gap.

## Docs

- `site/content/reference/metrics.md` — full per-metric table (name, type, labels, meaning), the unit warning, alerting PromQL, and the cardinality note.
- `site/content/architecture/metrics.md` — lag design rationale plus the two new histogram bucket sets.
- `site/content/roadmap/turso-engine.md` — instrumentation listed as shipped; time-based lag added to "still deferred" with the exact upstream changes it needs.

Verified no phantom metrics: the 19 names in `turso_cdc_metrics.rs` and the 19 in the reference doc match exactly, in both directions.
