### PR TITLE
chore(deps): bump litewire — CDC schema-replay allowlist, non-panicking commit_change_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "anyhow",
  "futures",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "async-trait",
  "futures",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=62636c4c2ba8#62636c4c2ba81ba85614fadce80f24e4c4f0b021"
+source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
 dependencies = [
  "async-trait",
  "litewire-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,25 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ 62636c4c — write admission control for the Hrana/sqld backend
+# litewire main @ b086ddaa — CDC replay hardening (litewire#17). Two things.
+# (1) Replayed schema DDL is parsed and allowlisted before it reaches the
+# engine. A CDC batch carrying a `sqlite_schema` row used to have its stored
+# `sql` text executed as-is, so a peer whose frames reached `apply_batch` could
+# run arbitrary SQL on a replica — confirmed by short-circuiting the new
+# allowlist, where `PRAGMA writable_schema=ON` applied successfully.
+# `classify_replayed_ddl` now admits only a *single* CREATE TABLE /
+# CREATE [UNIQUE] INDEX / CREATE VIEW / CREATE TRIGGER, which is the whole set
+# `sqlite_schema.sql` can hold (ALTER surfaces as the rewritten CREATE TABLE;
+# DROP arrives as a DELETE that litewire answers with its own DROP ... IF
+# EXISTS). CREATE VIRTUAL TABLE is refused deliberately — it invokes a module
+# with peer-chosen arguments. CREATE TRIGGER is recognised and *skipped*, not
+# replayed: CDC already carries the rows a trigger produced on the primary, so
+# a replica holding the trigger would double-apply them. That matches what
+# ephpm's snapshot bootstrap already does with triggers.
+# (2) `TxnBatch::commit_change_id()` returns `Option<i64>` instead of panicking
+# on an empty batch, and `apply_batch` reports an empty batch as an error.
+#
+# On top of write admission control for the Hrana/sqld backend
 # (litewire#16): an opt-in write-permit semaphore (`HranaClient::write_permits`,
 # 0 = unlimited = default) that queues excess writers instead of letting sqld
 # collapse, wired to [db.sqlite.sqld] write_permits in the clustered path only.
@@ -113,13 +131,23 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 # a local workaround for this — `cold_primary_holds_subscriber_open_until_first_write`
 # in turso_cdc.rs fails if a pin without the fix is ever selected.
 #
-# SECURITY: do not move this pin backwards. 699e6345 and earlier interpolate the
+# The empty-batch half of litewire#17 does NOT remove a workaround. ephpm's
+# frame-level rejection in `consume_frames` stays, downgraded from a
+# workaround to defence in depth: validating a peer's frame is ephpm's job
+# rather than the pinned revision's, and rejecting at decode time keeps the
+# diagnostics legible, since every failure past that point is reported "at
+# change_id N" — which an empty batch has no value for.
+#
+# SECURITY: do not move this pin backwards. Pins before litewire#17 execute
+# peer-supplied `sqlite_schema.sql` text verbatim on the CDC apply path, which
+# hands any node that clears the cluster handshake ATTACH and PRAGMA on every
+# replica. 699e6345 and earlier interpolate the
 # client-supplied table name straight into SQL text in
 # litewire-translate/src/metadata.rs, and detect_metadata_query() runs before
 # sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
 # DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
 # applies it at every extraction site.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "62636c4c2ba8", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "b086ddaa869a", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -825,15 +825,20 @@ async fn consume_frames(
         let frame = read_frame(stream).await?;
         match frame {
             Frame::Batch { rows } => {
-                // `TxnBatch::commit_change_id` reads the last row and
-                // panics on an empty batch, and `apply_batch` calls it
-                // unconditionally — so a peer sending `{"rows":[]}`
-                // would take down this task, which nothing joins, and
-                // replication would stop forever with no error path.
-                // Reject the frame instead of constructing the batch.
-                anyhow::ensure!(!rows.is_empty(), "peer sent an empty CDC batch frame");
+                // Kept as defence in depth, not because litewire still
+                // needs it: since litewire#17 `commit_change_id` returns
+                // `Option<i64>` and `apply_batch` reports an empty batch
+                // as an error instead of panicking the applying task
+                // (which nothing joins). Two reasons this stays anyway.
+                // Validating a peer's frame is our job, not that of
+                // whichever litewire revision the pin happens to name.
+                // And rejecting here keeps the error legible: past this
+                // point every failure is reported "at change_id N",
+                // which an empty batch has no value for.
                 let batch = TxnBatch { rows: rows.into_iter().map(CdcRow::from).collect() };
-                let change_id = batch.commit_change_id();
+                let Some(change_id) = batch.commit_change_id() else {
+                    anyhow::bail!("peer sent an empty CDC batch frame");
+                };
                 // A failed apply must NOT be skipped: continuing to the
                 // next batch would let the watermark advance past the
                 // failure and make the divergence permanent and silent.

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -125,7 +125,7 @@ path is a **single ordered stream** with no schema-sync side channel.
 - litewire `CdcTailer` + `apply_batch` API (per-transaction batches,
   monotonic `__litewire_cdc_watermark` for exactly-once apply, SQLite
   record-format decoder for DML replay, sqlite_schema-SQL replay for
-  DDL). 25 unit + integration tests in `litewire-turso`.
+  DDL). 45 unit + integration tests in `litewire-turso`.
 - ephpm `turso_cdc` module: two `Turso` factories per node (wire +
   mgmt); on the primary each inbound subscriber stream gets its **own**
   `CdcTailer`, anchored at the watermark the subscriber sends in its
@@ -151,6 +151,37 @@ path is a **single ordered stream** with no schema-sync side channel.
 - Additive config knob: `cdc_experimental` defaults to `false`;
   `engine = "turso"` + clustered mode without it is still a hard startup
   error pointing at the knob. v0.4.x-compatible under versioning policy.
+- **Schema replay is allowlisted (v0.6.2, litewire#17).** A CDC batch
+  carrying a `sqlite_schema` row used to have its stored `sql` text run
+  directly, so a peer whose frames reached `apply_batch` could run
+  arbitrary SQL on a replica — including `ATTACH` and `PRAGMA`. That
+  asymmetry with the snapshot path (dump checked, CDC not) is closed:
+  `classify_replayed_ddl` now parses the text first and admits only
+  what `sqlite_schema.sql` can hold — a **single** `CREATE TABLE`,
+  `CREATE [UNIQUE] INDEX`, `CREATE VIEW` or `CREATE TRIGGER`. That is
+  the whole legitimate set, because `ALTER TABLE ... ADD COLUMN`
+  surfaces as an UPDATE whose text is the *rewritten* `CREATE TABLE`
+  and `DROP` arrives as a DELETE that litewire answers with a
+  `DROP ... IF EXISTS` of its own construction. `CREATE VIRTUAL TABLE`
+  is refused as well, deliberately: it invokes a module with
+  peer-chosen arguments, which is a larger capability than building a
+  b-tree. The statement scan is quote- and comment-aware, so a `;`
+  inside a literal, a quoted identifier or a comment is not a
+  separator, and an unterminated quote or comment is refused rather
+  than guessed at. Triggers are recognised and skipped rather than
+  replayed (see the deferred note below). Reaching `apply_batch` still
+  requires the cluster secret and gossip membership; what this removes
+  is a trusted peer's ability to do more than corrupt rows.
+- **Empty CDC batch frames no longer depend on a local workaround
+  (v0.6.2, litewire#17).** `TxnBatch::commit_change_id()` returned
+  `i64` and panicked on an empty batch, which a peer could reach by
+  sending `{"rows":[]}` — taking down an applying task nothing joins.
+  It now returns `Option<i64>`, and litewire's `apply_batch` reports an
+  empty batch as an error. ePHPm keeps its frame-level rejection as
+  defence in depth: validating a peer's frame is ePHPm's job rather
+  than the pinned revision's, and rejecting at decode time keeps the
+  diagnostics legible (every failure past that point is reported "at
+  change_id N", which an empty batch has no value for).
 
 **Still deferred:**
 
@@ -171,23 +202,13 @@ path is a **single ordered stream** with no schema-sync side channel.
 - Read-only enforcement on replica wire frontends. litewire has no
   read-only mode, so a replica's MySQL/Hrana frontend accepts writes
   that nothing replicates; the replica logs a warning at startup.
-- Schema replay executes wire-supplied SQL. Note the asymmetry with the
-  snapshot path above: the snapshot dump *is* checked against a
-  `CREATE`/`INSERT` allowlist, but the CDC apply path is not. When a
-  batch carries a `sqlite_schema` row, `apply_batch` runs its stored
-  `sql` text directly (`litewire-turso/src/cdc.rs`) with no allowlist of
-  statement kinds. The DML path is safe — values bind as parameters and
-  identifiers go through `escape_ident` — but a peer whose frames reach
-  `apply_batch` can run arbitrary SQL on a replica, including `ATTACH`
-  and `PRAGMA`. Reaching it requires the cluster secret *and* passing
-  the gossip-membership check, so the peer is already a trusted node
-  that dictates replicated data anyway; the residual gap is that a
-  compromised primary can do more than corrupt rows. Closing it needs a
-  litewire PR to parse and allowlist the replayed DDL, plus a pin bump.
-- Triggers in the snapshot. They are deliberately not shipped (CDC
-  already carries the rows a trigger produced on the primary), which is
-  correct for replay but means a replica promoted to primary has no
-  triggers until an operator recreates them.
+- Triggers reach a replica by neither path. The snapshot deliberately
+  does not ship them and CDC replay deliberately skips them — CDC
+  already carries the rows a trigger produced on the primary, so a
+  replica holding the trigger would fire it again on top of those
+  replayed rows and diverge. That is correct for replay, but it means a
+  replica promoted to primary has no triggers until an operator
+  recreates them.
 - 2-node podman/kind e2e test running the full ephpm binary against a
   real MySQL wire client. The in-process integration test proves the
   replication pipeline; the podman lift is largely test-orchestration.
@@ -201,10 +222,6 @@ path is a **single ordered stream** with no schema-sync side channel.
   is enabled on every node's wire factory (`enable_cdc_on_connect =
   true`, so a node promoted mid-life still captures), but a session
   that uses `raw_connection()` bypasses it — a documented gotcha.
-- `TxnBatch::commit_change_id()` panics on an empty batch inside
-  litewire; ephpm rejects empty batch frames on the wire instead.
-  Making the litewire API return `Option<i64>` needs a litewire PR and
-  a pin bump.
 
 ### Phase 3 — default engine (a major-version decision)
 


### PR DESCRIPTION
Bumps the litewire pin to [litewire#17](https://github.com/ephpm/litewire/pull/17) (`b086ddaa869a`), which closes the last two CDC items ePHPm carried as known limitations in [the Turso engine roadmap](https://ephpm.dev/roadmap/turso-engine/).

## The vulnerability, demonstrated rather than asserted

Before this pin, a CDC batch carrying a `sqlite_schema` row had its stored `sql` text executed verbatim on the replica. To show that this was reachable and not merely theoretical, litewire#17's allowlist was short-circuited and the new tests re-run:

```
test schema_replay_refuses_attach_and_pragma ... FAILED
  hostile schema replay must be refused: ()
```

`expect_err` panicking on `()` means `apply_batch` returned **`Ok`** — `PRAGMA writable_schema=ON`, arriving as a peer's CDC frame, **executed successfully on the replica**. With the `ATTACH` case ordered first, the same test instead fails with:

```
  SQLite error: Parse error: ATTACH is an experimental feature.
  Enable with --experimental-attach flag
```

The peer's text reached the engine and was stopped only by turso 0.7.0's own experimental-feature gate — nothing in litewire refused it, and `PRAGMA` has no such gate. Reaching `apply_batch` does require the cluster secret *and* passing the gossip membership check, so the peer is already trusted to dictate the replica's **data**; what this closes is its ability to do more than corrupt rows.

## What the pin brings

**1. Replayed schema DDL is allowlisted.** The DML path was never exposed this way — values bind as parameters, identifiers go through `escape_ident` — the gap was DDL-only. `classify_replayed_ddl` now parses the text first and admits only a **single** `CREATE TABLE`, `CREATE [UNIQUE] INDEX`, `CREATE VIEW` or `CREATE TRIGGER`.

That is the whole legitimate set, and it is a structural fact rather than a policy choice: `ALTER TABLE ... ADD COLUMN` surfaces as an UPDATE whose text is the *rewritten* `CREATE TABLE`, and `DROP` arrives as a DELETE that litewire answers with a `DROP ... IF EXISTS` of its own construction. `CREATE VIRTUAL TABLE` is refused deliberately — it invokes a module with peer-chosen arguments, a larger capability than building a b-tree.

The single-statement scan is quote- and comment-aware (string literals with `''` escapes, all four identifier-quoting forms, line and block comments), and refuses an unterminated quote or comment rather than guessing. Comments in legitimate positions are skipped, not rejected, because `sqlite_schema.sql` stores the exact `CREATE` text an operator wrote. This is the same treatment `validate_snapshot_dump` already gave the snapshot path — the asymmetry between the two bootstrap paths is what closes here.

`CREATE TRIGGER` is recognised and **skipped** rather than replayed. CDC already carries the rows a trigger produced on the primary, so a replica holding the trigger would fire it again on top of those replayed rows and diverge. ePHPm's snapshot bootstrap already omits triggers for exactly that reason; the two paths now agree.

**2. `TxnBatch::commit_change_id()` returns `Option<i64>`** instead of panicking on an empty batch, and litewire's `apply_batch` reports an empty batch as an error rather than a silent no-op.

## ePHPm-side change: the empty-batch workaround stays

`consume_frames` rejected empty batch frames on the wire specifically because `commit_change_id` panicked, taking down an applying task nothing joins. That reason is gone, but the guard stays — reworded from workaround to defence in depth, and restructured into a `let ... else` on the `Option` rather than a separate `ensure!`, so there is one check and no panic path at all:

- Validating a peer's frame is ePHPm's job, not that of whichever litewire revision the pin happens to name.
- Rejecting at frame-decode time keeps the diagnostics legible. Every failure past that point is reported "at change_id N", which an empty batch has no value for.

## Docs

Both items move out of "Still deferred" into the landed list in `site/content/roadmap/turso-engine.md`, with the allowlist's contents and reasoning spelled out. The triggers bullet is rewritten: it used to say only the snapshot omits them, and now both paths do, so the consequence — a replica promoted to primary has no triggers until an operator recreates them — is stated once for both. The litewire CDC test count in the landed list goes 25 → 45.

The pin comment gains the usual per-change rationale block, and the `SECURITY: do not move this pin backwards` note gains a second reason: pins before litewire#17 execute peer-supplied `sqlite_schema.sql` verbatim, which hands any node that clears the cluster handshake `ATTACH` and `PRAGMA` on every replica.

## Verification

Run in the podman verify container against the merged pin `b086ddaa869a`:

- `cargo test -p ephpm-server --lib` — 271 passed
- `cargo test -p ephpm-server --test turso_cdc_e2e` (`EPHPM_CLUSTER_INTEG=1`) — 2 passed
- `cargo test -p ephpm-server --test turso_cdc_cluster_integration` — 1 passed
- `cargo test -p ephpm-server --test turso_cdc_snapshot_bootstrap` — 1 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean

litewire#17 itself added 16 unit tests and 3 integration tests. The integration tests build the `sqlite_schema` record blob by hand — what a peer can actually put on the wire, which is not limited to what a well-behaved primary emits — with a positive control proving the hand-built batch shape applies cleanly when the DDL is legitimate, so a rejection is the allowlist talking and not a malformed blob. They also assert the watermark does **not** advance past a refused batch, so the stream resumes at the same place instead of skipping it.
