### PR TITLE
fix(db): multi-result MySQL desync (#223) + close the PostgreSQL query-stats gap

### DIFF
--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -63,6 +63,20 @@ const CLIENT_PS_MULTI_RESULTS: u32 = 0x0004_0000;
 const CLIENT_PLUGIN_AUTH: u32 = 0x0008_0000;
 const CLIENT_PLUGIN_AUTH_LENENC: u32 = 0x0020_0000;
 
+// ── Server status flags ───────────────────────────────────────────────────────
+
+/// `SERVER_MORE_RESULTS_EXISTS` — set in the status field of the `OK`/`EOF`
+/// packet that terminates a result set when *another* result set follows on
+/// the same command.
+///
+/// The proxy asks the backend for `CLIENT_MULTI_STATEMENTS`,
+/// `CLIENT_MULTI_RESULTS` and `CLIENT_PS_MULTI_RESULTS` (see
+/// [`build_handshake_response`]) and advertises the same to its own clients
+/// (see [`send_greeting`]), so multi-result responses are not hypothetical:
+/// `CALL`ing a stored procedure produces one, and so does any client that
+/// takes us up on the multi-statement capability we offered.
+const SERVER_MORE_RESULTS_EXISTS: u16 = 0x0008;
+
 // ── MySQL command bytes ──────────────────────────────────────────────────────
 
 const COM_QUIT: u8 = 0x01;
@@ -1450,6 +1464,35 @@ fn decode_lenenc_int(buf: &[u8]) -> Option<(u64, usize)> {
     }
 }
 
+/// Status flags of an `OK_Packet`, or `None` if the packet is truncated.
+///
+/// Layout under `CLIENT_PROTOCOL_41` (which the proxy always negotiates):
+/// `[0x00][affected_rows: lenenc][last_insert_id: lenenc][status: 2LE][warnings: 2LE]`.
+///
+/// A packet too short to carry the field yields `None`, which every caller
+/// treats as "no further result sets" — the conservative reading, since it
+/// makes the proxy stop rather than block on bytes that may never arrive.
+fn ok_packet_status(payload: &[u8]) -> Option<u16> {
+    let rest = payload.get(1..)?;
+    let (_, affected_len) = decode_lenenc_int(rest)?;
+    let rest = rest.get(affected_len..)?;
+    let (_, insert_id_len) = decode_lenenc_int(rest)?;
+    let rest = rest.get(insert_id_len..)?;
+    Some(u16::from_le_bytes([*rest.first()?, *rest.get(1)?]))
+}
+
+/// Status flags of a classic `EOF_Packet`: `[0xFE][warnings: 2LE][status: 2LE]`.
+///
+/// Same truncation rule as [`ok_packet_status`].
+fn eof_packet_status(payload: &[u8]) -> Option<u16> {
+    Some(u16::from_le_bytes([*payload.get(3)?, *payload.get(4)?]))
+}
+
+/// Whether a terminating `OK`/`EOF` packet says another result set follows.
+fn more_results_follow(status: Option<u16>) -> bool {
+    status.is_some_and(|s| s & SERVER_MORE_RESULTS_EXISTS != 0)
+}
+
 /// Forward a complete `COM_QUERY` response from backend to client.
 ///
 /// The Smart-reset routing loop returns each pooled backend to the pool after
@@ -1460,7 +1503,48 @@ fn decode_lenenc_int(buf: &[u8]) -> Option<(u64, usize)> {
 /// was truncated after the column-defs EOF, the row packets stayed in the
 /// backend's read buffer, and the client blocked forever waiting for them).
 ///
-/// COM_QUERY responses have four shapes:
+/// ## One command, possibly many result sets
+///
+/// "One full response" is not "one result set". `CALL`ing a stored procedure,
+/// or any client using the multi-statement capability the proxy advertises,
+/// produces a *sequence* of result sets: each is terminated by an `OK`/`EOF`
+/// packet whose status field carries [`SERVER_MORE_RESULTS_EXISTS`], and the
+/// last one does not. This function therefore loops over
+/// [`forward_one_result_set`] until that flag clears.
+///
+/// Returning after the first result set — as this used to do (issue #223) —
+/// leaves the remainder buffered on the *pooled* backend socket. Because the
+/// routing loop parks the connection immediately afterwards, the leftovers
+/// outlive the session that caused them and desynchronise whichever session
+/// checks the connection out next. Checkout validation does not rescue that:
+/// [`crate::pool::has_unread_bytes`] is best-effort, and a leftover `OK`
+/// packet is indistinguishable from a `COM_PING` reply.
+///
+/// ## Aggregation
+///
+/// The returned [`ResponseOutcome`] covers the whole command: `rows` is the
+/// sum across result sets and `ok` is false if *any* of them carried an
+/// `ERR_Packet`. That matches how a client sees the statement — one command,
+/// one digest entry — and every field still comes from bytes this function
+/// had to parse anyway. Nothing is estimated.
+async fn forward_mysql_response(
+    backend: &mut TcpStream,
+    client: &mut TcpStream,
+) -> Result<ResponseOutcome, DbError> {
+    let mut total = ResponseOutcome { ok: true, rows: 0 };
+    loop {
+        let (outcome, more) = forward_one_result_set(backend, client).await?;
+        total.ok &= outcome.ok;
+        total.rows = total.rows.saturating_add(outcome.rows);
+        if !more {
+            return Ok(total);
+        }
+    }
+}
+
+/// Forward exactly one result set, reporting whether another follows.
+///
+/// A single result set has four shapes:
 ///
 /// 1. `OK_Packet`    — `[0x00] …`           (single packet)
 /// 2. `ERR_Packet`   — `[0xFF] …`           (single packet)
@@ -1476,14 +1560,12 @@ fn decode_lenenc_int(buf: &[u8]) -> Option<(u64, usize)> {
 /// from real MySQL servers uses the two-EOF layout — we don't have to handle
 /// the deprecated-EOF row terminator.
 ///
-/// The returned [`ResponseOutcome`] is assembled purely from bytes this
-/// function already had to look at: the `OK_Packet`'s length-encoded
-/// affected-row count, the presence of an `ERR_Packet`, or the number of
-/// row packets in a result set. Nothing is estimated.
-async fn forward_mysql_response(
+/// `ERR_Packet` always ends the sequence: it carries no status field, so the
+/// server has no way to announce a successor and does not send one.
+async fn forward_one_result_set(
     backend: &mut TcpStream,
     client: &mut TcpStream,
-) -> Result<ResponseOutcome, DbError> {
+) -> Result<(ResponseOutcome, bool), DbError> {
     let (seq, payload) = read_packet(backend).await?;
     write_packet(client, seq, &payload).await?;
 
@@ -1492,10 +1574,14 @@ async fn forward_mysql_response(
         Some(0x00) => {
             // OK_Packet: [0x00][affected_rows: lenenc][last_insert_id: lenenc]…
             let affected = decode_lenenc_int(&payload[1..]).map_or(0, |(v, _)| v);
-            return Ok(ResponseOutcome { ok: true, rows: affected });
+            let more = more_results_follow(ok_packet_status(&payload));
+            return Ok((ResponseOutcome { ok: true, rows: affected }, more));
         }
-        Some(0xFF) => return Ok(ResponseOutcome { ok: false, rows: 0 }),
-        Some(0xFE) if payload.len() < 9 => return Ok(ResponseOutcome::ok_unknown_rows()),
+        Some(0xFF) => return Ok((ResponseOutcome { ok: false, rows: 0 }, false)),
+        Some(0xFE) if payload.len() < 9 => {
+            let more = more_results_follow(eof_packet_status(&payload));
+            return Ok((ResponseOutcome::ok_unknown_rows(), more));
+        }
         Some(0xFB) => {
             return Err(DbError::Protocol(
                 "LOCAL INFILE response not supported by smart-reset proxy path".into(),
@@ -1513,12 +1599,14 @@ async fn forward_mysql_response(
         write_packet(client, s, &p).await?;
     }
 
-    // Intermediate EOF terminating the column-definition block.
+    // Intermediate EOF terminating the column-definition block. Its status
+    // field describes the *column block*, not the command, so it is never
+    // consulted for SERVER_MORE_RESULTS_EXISTS.
     let (s, p) = read_packet(backend).await?;
     write_packet(client, s, &p).await?;
     if p.first() == Some(&0xFF) {
         // ERR_Packet here (e.g. cursor open failed) — no rows follow.
-        return Ok(ResponseOutcome { ok: false, rows: 0 });
+        return Ok((ResponseOutcome { ok: false, rows: 0 }, false));
     }
     if !(p.first() == Some(&0xFE) && p.len() < 9) {
         return Err(DbError::Protocol(
@@ -1532,11 +1620,15 @@ async fn forward_mysql_response(
         let (s, p) = read_packet(backend).await?;
         write_packet(client, s, &p).await?;
         match p.first().copied() {
-            // Terminating EOF.
-            Some(0xFE) if p.len() < 9 => return Ok(ResponseOutcome { ok: true, rows }),
+            // Terminating EOF — the only packet in a result set whose status
+            // field can announce a successor.
+            Some(0xFE) if p.len() < 9 => {
+                let more = more_results_follow(eof_packet_status(&p));
+                return Ok((ResponseOutcome { ok: true, rows }, more));
+            }
             // ERR mid-stream: the rows already forwarded are real, but the
             // statement did not complete successfully.
-            Some(0xFF) => return Ok(ResponseOutcome { ok: false, rows }),
+            Some(0xFF) => return Ok((ResponseOutcome { ok: false, rows }, false)),
             _ => rows += 1,
         }
     }
@@ -2439,6 +2531,271 @@ mod tests {
         assert_eq!(outcome.rows, 0, "an empty result set must report zero rows");
     }
 
+    // ── multi-result responses (issue #223) ──────────────────────────
+
+    /// `SERVER_STATUS_AUTOCOMMIT` — noise the flag check must see past.
+    const STATUS_AUTOCOMMIT: u16 = 0x0002;
+
+    /// Build a classic `EOF_Packet`: `[0xFE][warnings: 2LE][status: 2LE]`.
+    fn eof(status: u16) -> Vec<u8> {
+        let s = status.to_le_bytes();
+        vec![0xFE, 0, 0, s[0], s[1]]
+    }
+
+    /// Build an `OK_Packet` with an explicit affected-row count and status.
+    ///
+    /// `[0x00][affected: lenenc][last_insert_id: lenenc][status: 2LE][warnings: 2LE]`
+    fn ok_packet(affected: u8, status: u16) -> Vec<u8> {
+        let s = status.to_le_bytes();
+        vec![0x00, affected, 0, s[0], s[1], 0, 0]
+    }
+
+    /// Write one single-column, single-row result set.
+    ///
+    /// `marker` is the row's only byte, so a test can tell which result set a
+    /// packet the client received actually came from. `end_status` goes in the
+    /// terminating EOF — set [`SERVER_MORE_RESULTS_EXISTS`] there to announce a
+    /// successor.
+    async fn write_result_set(sock: &mut TcpStream, seq: &mut u8, marker: u8, end_status: u16) {
+        for payload in [
+            vec![0x01],             // column count
+            vec![0xAA; 16],         // column definition
+            eof(STATUS_AUTOCOMMIT), // end of column definitions
+            vec![0x01, marker],     // one row: a 1-byte lenenc string
+            eof(end_status),        // end of this result set
+        ] {
+            *seq += 1;
+            write_packet(sock, *seq, &payload).await.unwrap();
+        }
+    }
+
+    /// Read packets from `client` until the terminating `OK_Packet` of a
+    /// `CALL`-shaped response, returning every row marker seen along the way.
+    async fn collect_markers_until_ok(client: &mut TcpStream) -> Vec<u8> {
+        let mut markers = Vec::new();
+        loop {
+            let (_, p) = read_packet(client).await.unwrap();
+            match p.first().copied() {
+                Some(0x00) if p.len() == 7 => return markers,
+                // A one-byte lenenc string is the row shape `write_result_set`
+                // emits; column defs are 16 bytes of 0xAA and EOFs start 0xFE.
+                Some(0x01) if p.len() == 2 => markers.push(p[1]),
+                _ => {}
+            }
+        }
+    }
+
+    /// The regression test for issue #223.
+    ///
+    /// A `CALL` returns two result sets followed by a terminating `OK`. The
+    /// old code returned after the *first* terminating EOF, leaving result set
+    /// two and the final `OK` buffered on the backend socket — so the next
+    /// command read the previous command's leftovers. The sentinel response
+    /// written after the multi-result response is what proves the boundary is
+    /// exact: the second call must land on it, not inside the first response.
+    #[tokio::test]
+    async fn forward_mysql_response_consumes_every_result_set() {
+        let (mut backend_write, mut backend_read) = make_tcp_pair().await;
+        let (mut client_write, mut client_read) = make_tcp_pair().await;
+
+        let mut seq = 0u8;
+        // Result set one announces a successor…
+        write_result_set(&mut backend_write, &mut seq, b'a', STATUS_AUTOCOMMIT | 0x0008).await;
+        // …result set two announces the trailing OK…
+        write_result_set(&mut backend_write, &mut seq, b'b', STATUS_AUTOCOMMIT | 0x0008).await;
+        // …and the OK ends the command, exactly as a stored-procedure CALL does.
+        seq += 1;
+        write_packet(&mut backend_write, seq, &ok_packet(0, STATUS_AUTOCOMMIT)).await.unwrap();
+
+        // The *next* command's response. Nothing may consume this.
+        seq = 0;
+        write_result_set(&mut backend_write, &mut seq, b'z', STATUS_AUTOCOMMIT).await;
+
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 2, "rows are summed across every result set of the command");
+
+        let markers = collect_markers_until_ok(&mut client_read).await;
+        assert_eq!(markers, vec![b'a', b'b'], "both result sets must reach the client");
+
+        // The sentinel is still on the backend socket, untouched, and the next
+        // command picks up exactly there.
+        let next = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        assert_eq!(next.rows, 1);
+        let (_, header) = read_packet(&mut client_read).await.unwrap();
+        assert_eq!(header, vec![0x01], "the next response starts at its own column-count packet");
+    }
+
+    /// The multi-statement shape: `INSERT; INSERT` is answered with two `OK`
+    /// packets, the first carrying `SERVER_MORE_RESULTS_EXISTS`. Affected rows
+    /// accumulate across both.
+    #[tokio::test]
+    async fn forward_mysql_response_follows_chained_ok_packets() {
+        let (mut backend_write, mut backend_read) = make_tcp_pair().await;
+        let (mut client_write, mut client_read) = make_tcp_pair().await;
+
+        write_packet(&mut backend_write, 1, &ok_packet(2, STATUS_AUTOCOMMIT | 0x0008))
+            .await
+            .unwrap();
+        write_packet(&mut backend_write, 2, &ok_packet(3, STATUS_AUTOCOMMIT)).await.unwrap();
+        drop(backend_write);
+
+        let outcome = forward_mysql_response(&mut backend_read, &mut client_write).await.unwrap();
+        drop(client_write);
+
+        assert!(outcome.ok);
+        assert_eq!(outcome.rows, 5, "affected rows accumulate across chained OK packets");
+
+        let mut seen = 0;
+        while read_packet(&mut client_read).await.is_ok() {
+            seen += 1;
+        }
+        assert_eq!(seen, 2, "both OK packets must reach the client");
+    }
+
+    /// An `ERR_Packet` ends the sequence: it carries no status field, so the
+    /// server cannot announce a successor and does not send one. Blocking on a
+    /// further packet here would hang the session.
+    #[tokio::test]
+    async fn forward_mysql_response_stops_at_an_error_packet() {
+        let (mut backend_write, mut backend_read) = make_tcp_pair().await;
+        let (mut client_write, _client_read) = make_tcp_pair().await;
+
+        write_packet(&mut backend_write, 1, &ok_packet(1, STATUS_AUTOCOMMIT | 0x0008))
+            .await
+            .unwrap();
+        let mut err = vec![0xFF];
+        err.extend_from_slice(&1146_u16.to_le_bytes());
+        err.push(b'#');
+        err.extend_from_slice(b"42S02");
+        err.extend_from_slice(b"Table 'x' doesn't exist");
+        write_packet(&mut backend_write, 2, &err).await.unwrap();
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            forward_mysql_response(&mut backend_read, &mut client_write),
+        )
+        .await
+        .expect("an ERR_Packet must terminate the sequence, not wait for another")
+        .unwrap();
+
+        assert!(!outcome.ok, "the failed statement must mark the whole command failed");
+        assert_eq!(outcome.rows, 1, "rows from the statement that did succeed are real");
+    }
+
+    #[test]
+    fn status_flags_come_out_of_the_right_offsets() {
+        // OK: [0x00][affected: lenenc][last_insert_id: lenenc][status][warnings]
+        assert_eq!(ok_packet_status(&ok_packet(0, 0x000A)), Some(0x000A));
+        // A 2-byte lenenc affected-row count must not shift the status read.
+        let shifted = vec![0x00, 0xFC, 0x34, 0x12, 0, 0x0A, 0x00, 0, 0];
+        assert_eq!(ok_packet_status(&shifted), Some(0x000A));
+        // Truncation reads as "no more results" rather than panicking.
+        assert_eq!(ok_packet_status(&[0x00]), None);
+        assert_eq!(eof_packet_status(&[0xFE, 0, 0]), None);
+        assert!(!more_results_follow(None));
+        assert!(more_results_follow(Some(0x000A)));
+        assert!(!more_results_follow(Some(0x0002)));
+    }
+
+    /// The pooled variant: a multi-result command must not poison the
+    /// connection it ran on. The routing loop parks the backend after every
+    /// command, so leftovers from a `CALL` would be read as the *next
+    /// session's* response — the corruption outliving the session that caused
+    /// it is what #221's working pool turned from a session bug into a
+    /// cross-session one.
+    #[tokio::test]
+    async fn routing_loop_multi_result_leaves_the_pooled_backend_clean() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let backend_task = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+
+            // Command one: a CALL returning two result sets plus a final OK.
+            read_packet(&mut sock).await.unwrap();
+            let mut seq = 0u8;
+            write_result_set(&mut sock, &mut seq, b'a', STATUS_AUTOCOMMIT | 0x0008).await;
+            write_result_set(&mut sock, &mut seq, b'b', STATUS_AUTOCOMMIT | 0x0008).await;
+            seq += 1;
+            write_packet(&mut sock, seq, &ok_packet(0, STATUS_AUTOCOMMIT)).await.unwrap();
+
+            // Command two: an ordinary single-result SELECT.
+            read_packet(&mut sock).await.unwrap();
+            let mut seq = 0u8;
+            write_result_set(&mut sock, &mut seq, b'z', STATUS_AUTOCOMMIT).await;
+
+            // Hold the socket open so the pool keeps seeing a live connection.
+            std::future::pending::<()>().await;
+        });
+
+        let dials = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let pool = pool_dialing_counted(addr, Arc::clone(&dials));
+        let (mut driver, proxy_side) = make_tcp_pair().await;
+
+        let pool_for_proxy = pool.clone();
+        let proxy = tokio::spawn(async move {
+            let rr = AtomicUsize::new(0);
+            let rw_split = RwSplitParams {
+                enabled: false,
+                sticky_duration: std::time::Duration::from_secs(1),
+            };
+            // `Never` keeps COM_RESET_CONNECTION away from the scripted backend.
+            proxy_routing_loop(
+                proxy_side,
+                &pool_for_proxy,
+                &[],
+                &rr,
+                &rw_split,
+                crate::ResetStrategy::Never,
+                None,
+            )
+            .await
+        });
+
+        // Session one: the multi-result command.
+        send_query(&mut driver, "CALL two_result_sets()").await;
+        let markers = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            collect_markers_until_ok(&mut driver),
+        )
+        .await
+        .expect("the whole multi-result response must reach the client");
+        assert_eq!(markers, vec![b'a', b'b']);
+
+        // Session two, on the connection session one parked. If the CALL had
+        // left result set two buffered, this read would return the `b` row
+        // instead of `z` — or the trailing OK, which is not a result-set
+        // header at all.
+        send_query(&mut driver, "SELECT id FROM t").await;
+        let (_, header) =
+            tokio::time::timeout(std::time::Duration::from_secs(10), read_packet(&mut driver))
+                .await
+                .expect("the follow-up query must get a response")
+                .unwrap();
+        assert_eq!(header, vec![0x01], "the follow-up must read its own column-count packet");
+
+        let mut row = None;
+        for _ in 0..4 {
+            let (_, p) = read_packet(&mut driver).await.unwrap();
+            if p.len() == 2 && p[0] == 0x01 {
+                row = Some(p[1]);
+            }
+        }
+        assert_eq!(row, Some(b'z'), "the follow-up must read its own row, not leftovers");
+
+        assert_eq!(
+            dials.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "both commands must have run on one pooled connection"
+        );
+
+        drop(driver);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy).await;
+        assert_eq!(pool.idle_len(), 1, "the backend must be parked, not retired");
+        backend_task.abort();
+    }
+
     // ── query stats: what a command is attributed to ─────────────────
 
     /// Build a `COM_QUERY` payload.
@@ -2716,6 +3073,42 @@ mod tests {
         };
         let config = PoolConfig {
             min_connections: 1,
+            max_connections: 2,
+            idle_timeout: std::time::Duration::from_secs(60),
+            max_lifetime: std::time::Duration::from_secs(300),
+            pool_timeout: std::time::Duration::from_secs(5),
+            health_check_interval: std::time::Duration::from_secs(30),
+        };
+        Pool::new(config, connect, reset, ping)
+    }
+
+    /// A `Pool` whose connections dial `addr` with no `MySQL` handshake,
+    /// counting every dial in `dials`.
+    ///
+    /// The counter is what turns "the second command worked" into "the second
+    /// command worked *on the same pooled connection*" — without it a test
+    /// cannot tell a clean recycle from a silent retire-and-redial.
+    fn pool_dialing_counted(
+        addr: std::net::SocketAddr,
+        dials: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Pool {
+        let connect = move || -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
+            let dials = Arc::clone(&dials);
+            Box::pin(async move {
+                dials.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                TcpStream::connect(addr).await.map_err(DbError::from)
+            })
+        };
+        // No-op reset and always-alive ping: the scripted backends in these
+        // tests speak only the responses they were written to speak.
+        let reset = |s: TcpStream| -> crate::pool::BoxFuture<Result<TcpStream, DbError>> {
+            Box::pin(async { Ok(s) })
+        };
+        let ping = |s: TcpStream| -> crate::pool::BoxFuture<Result<(TcpStream, bool), DbError>> {
+            Box::pin(async { Ok((s, true)) })
+        };
+        let config = PoolConfig {
+            min_connections: 0,
             max_connections: 2,
             idle_timeout: std::time::Duration::from_secs(60),
             max_lifetime: std::time::Duration::from_secs(300),

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -9,7 +9,9 @@
 //! 2. When PHP connects to the proxy (e.g. `127.0.0.1:5432`), the proxy
 //!    reads the client's `StartupMessage`, sends `AuthenticationOk` (no
 //!    credential validation — loopback only), sends synthetic metadata,
-//!    and starts bidirectional byte forwarding.
+//!    and starts bidirectional message forwarding. Both directions are
+//!    framed on every path, which is what lets `[db.analysis]` see statements
+//!    regardless of `reset_strategy`.
 //!
 //! 3. When the client closes or sends `Terminate`, the proxy closes only the
 //!    client-facing socket. `Terminate` is **intercepted, never forwarded** —
@@ -24,7 +26,7 @@
 //! Client-facing auth is always `AuthenticationOk` (loopback only).
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use base64ct::Encoding;
 use ephpm_query_stats::QueryStats;
@@ -62,6 +64,16 @@ const MSG_DATA_ROW: u8 = b'D';
 const MSG_QUERY: u8 = b'Q';
 /// `Terminate` — frontend connection close.
 const MSG_TERMINATE: u8 = b'X';
+/// `Sync` — frontend end of an extended-query batch, answered by one
+/// `ReadyForQuery`.
+///
+/// Shares its byte with the backend's `ParameterStatus`; the two never travel
+/// in the same direction, and this constant is only ever matched against
+/// frontend traffic.
+const MSG_SYNC: u8 = b'S';
+/// `FunctionCall` — frontend fastpath call, likewise answered by one
+/// `ReadyForQuery`.
+const MSG_FUNCTION_CALL: u8 = b'F';
 /// `CopyInResponse` — backend is waiting for the client to stream `COPY ... FROM STDIN` data.
 const MSG_COPY_IN_RESPONSE: u8 = b'G';
 /// `CopyBothResponse` — backend entered bidirectional copy mode.
@@ -373,14 +385,21 @@ impl PgProxy {
             )
             .await
         } else {
-            // Fast path: simple bidirectional copy. No message framing in
-            // either direction, so no statement is ever visible here and
-            // query stats record nothing — see `stats.rs`. Only reachable
-            // with `reset_strategy = "never"`/`"always"` and no replicas.
+            // Single-backend path: one pooled connection held for the whole
+            // session. Reachable with `reset_strategy = "never"`/`"always"`
+            // and no replicas.
+            //
+            // It is *not* an unframed fast path any more. Both directions are
+            // framed, so statements on this path are recorded exactly as the
+            // routing loop records them — see `pg_proxy_bidirectional_sniff`.
+            // It stays a separate path from the routing loop because the
+            // routing loop re-acquires a backend per command, which would
+            // scatter a session's `SET`s, temp tables and advisory locks
+            // across different connections.
             let mut checkout = self.pool.acquire().await?;
             let backend = checkout.take_stream();
 
-            match pg_proxy_bidirectional(client, backend).await {
+            match pg_proxy_bidirectional_sniff(client, backend, self.stats()).await {
                 Some(backend) => match self.reset_strategy {
                     ResetStrategy::Never => {
                         checkout.return_to_pool(backend);
@@ -812,15 +831,64 @@ async fn write_pg_message(stream: &mut TcpStream, tag: u8, payload: &[u8]) -> Re
     Ok(())
 }
 
-/// Forward a raw PG message from one stream to another.
-async fn forward_pg_message(from: &mut TcpStream, to: &mut TcpStream) -> Result<u8, DbError> {
-    let tag = from.read_u8().await?;
-    let len = from.read_i32().await?;
+/// Which side of a relay failed, when one did.
+///
+/// The splice path needs this distinction: a read failure condemns the
+/// pooled backend, a write failure to the client does not (see
+/// [`PgSessionEnd`]). Collapsing both into one error — which is all a
+/// `Result` can express — is how a live backend gets discarded, or worse, a
+/// dead one recycled.
+enum Relayed {
+    /// A complete message with this tag reached the destination.
+    Message(u8),
+    /// The source stream failed or closed mid-message.
+    SourceGone(DbError),
+    /// The destination stream failed.
+    SinkGone(DbError),
+}
+
+/// Forward one PG message from `from` to `to`, reporting which side failed.
+///
+/// The single framing primitive for both directions on every PG path.
+/// Generic over the endpoints so it serves the whole-stream routing loop
+/// (`&mut TcpStream`) and the split, buffered halves of
+/// [`pg_proxy_bidirectional_sniff`] alike — there is deliberately no second
+/// copy of this framing to keep in sync.
+///
+/// # Cancellation
+///
+/// This function is **not** cancel-safe, and cannot be: framing requires
+/// several awaits, so dropping it part-way leaves bytes consumed from `from`
+/// that were never written to `to`. `partial` exists so a caller that races
+/// this against another future can find out. It is set once the first byte of
+/// a message has been consumed and cleared when the message has been fully
+/// forwarded, so a caller reading it after a cancellation learns exactly
+/// whether the source stream was left mid-message. Parked waiting for the
+/// *next* message — the idle state — leaves it clear, which is what keeps a
+/// normal end-of-session from condemning a perfectly good connection.
+async fn relay_pg_message<R, W>(from: &mut R, to: &mut W, partial: &AtomicBool) -> Relayed
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let tag = match from.read_u8().await {
+        Ok(t) => t,
+        Err(e) => return Relayed::SourceGone(e.into()),
+    };
+    partial.store(true, Ordering::Relaxed);
+    let len = match from.read_i32().await {
+        Ok(l) => l,
+        Err(e) => return Relayed::SourceGone(e.into()),
+    };
     let payload_len = if len >= 4 { usize::try_from(len - 4).unwrap_or(0) } else { 0 };
 
     // Write tag + length.
-    to.write_u8(tag).await?;
-    to.write_all(&len.to_be_bytes()).await?;
+    if let Err(e) = to.write_u8(tag).await {
+        return Relayed::SinkGone(e.into());
+    }
+    if let Err(e) = to.write_all(&len.to_be_bytes()).await {
+        return Relayed::SinkGone(e.into());
+    }
 
     // Forward payload in chunks to avoid allocating for large results.
     if payload_len > 0 {
@@ -828,13 +896,31 @@ async fn forward_pg_message(from: &mut TcpStream, to: &mut TcpStream) -> Result<
         let mut buf = vec![0u8; remaining.min(8192)];
         while remaining > 0 {
             let to_read = remaining.min(buf.len());
-            from.read_exact(&mut buf[..to_read]).await?;
-            to.write_all(&buf[..to_read]).await?;
+            if let Err(e) = from.read_exact(&mut buf[..to_read]).await {
+                return Relayed::SourceGone(e.into());
+            }
+            if let Err(e) = to.write_all(&buf[..to_read]).await {
+                return Relayed::SinkGone(e.into());
+            }
             remaining -= to_read;
         }
     }
 
-    Ok(tag)
+    partial.store(false, Ordering::Relaxed);
+    Relayed::Message(tag)
+}
+
+/// Forward a raw PG message from one stream to another.
+///
+/// The turn-based routing loop awaits this to completion and discards the
+/// backend on any failure, so it needs neither the side attribution nor the
+/// partial-message flag [`relay_pg_message`] carries.
+async fn forward_pg_message(from: &mut TcpStream, to: &mut TcpStream) -> Result<u8, DbError> {
+    let partial = AtomicBool::new(false);
+    match relay_pg_message(from, to, &partial).await {
+        Relayed::Message(tag) => Ok(tag),
+        Relayed::SourceGone(e) | Relayed::SinkGone(e) => Err(e),
+    }
 }
 
 /// Read the client's `StartupMessage` (no tag byte).
@@ -990,7 +1076,52 @@ enum PgSessionEnd {
     Backend,
 }
 
-/// Relay `client` ↔ `backend` until the session ends.
+/// A client message the backend will answer with exactly one `ReadyForQuery`.
+///
+/// `sql` is `Some` only for a simple `Query` — the one frontend message the
+/// proxy can attribute to a digest.
+struct PgTurn {
+    /// The statement text, when this turn is recordable.
+    sql: Option<String>,
+    /// When the message was handed to the backend.
+    started: std::time::Instant,
+}
+
+/// Largest number of un-answered turns a session may have in flight.
+///
+/// The pending-turn queue drains on `ReadyForQuery`, so its length is the
+/// number of commands the client has pipelined without their responses having
+/// been delivered. Nothing in the PHP ecosystem pipelines at all; a client
+/// that does, and that also stops reading, would otherwise grow this queue
+/// without bound. Reached only by a client working to reach it, and the
+/// session simply ends.
+const MAX_PENDING_TURNS: usize = 4096;
+
+/// Whether a frontend message ends a protocol turn — i.e. is answered by a
+/// `ReadyForQuery`.
+///
+/// `Query` and `FunctionCall` each get one; in the extended query protocol an
+/// entire `Parse`/`Bind`/`Describe`/`Execute` batch gets exactly one, at
+/// `Sync`. Enqueuing a turn for *all* of them rather than only for `Query` is
+/// what keeps the queue aligned with the `ReadyForQuery` stream in a session
+/// that mixes both protocols: the extended-protocol turn pops its own
+/// unrecordable entry instead of stealing a simple query's.
+const fn pg_ends_a_turn(tag: u8) -> bool {
+    matches!(tag, MSG_QUERY | MSG_SYNC | MSG_FUNCTION_CALL)
+}
+
+/// The statement text a `Query` payload should be attributed to, if any.
+///
+/// The payload is a null-terminated string. Empty queries — which PG answers
+/// with `EmptyQueryResponse` — are not statements and are left unrecorded
+/// rather than folded into a blank digest.
+fn pg_recordable_sql(payload: &[u8]) -> Option<String> {
+    let sql = String::from_utf8_lossy(payload);
+    let sql = sql.trim_end_matches('\0');
+    (!sql.trim().is_empty()).then(|| sql.to_string())
+}
+
+/// Relay `client` ↔ `backend` until the session ends, recording statements.
 ///
 /// Returns the backend stream when the *client* ended the session, and `None`
 /// when the backend failed and must be discarded rather than recycled.
@@ -1005,18 +1136,57 @@ enum PgSessionEnd {
 ///
 /// ## Framing
 ///
-/// Post-startup PG frontend messages are uniformly `[tag: 1][len: 4BE][payload]`,
-/// so the client→backend direction can be framed without understanding any
-/// individual message — enough to spot `Terminate`. The backend→client
-/// direction is copied in bulk but hand-rolled so an I/O error can be
-/// attributed to the side that produced it.
-async fn pg_proxy_bidirectional(
+/// Both directions are framed. Post-startup PG messages are uniformly
+/// `[tag: 1][len: 4BE][payload]` in *both* directions, so this costs no
+/// protocol understanding beyond the tag byte.
+///
+/// The backend→client direction used to be copied in bulk, which made this the
+/// only proxy path that could not see a statement: with `reset_strategy =
+/// "never"`/`"always"` and no replicas, a whole deployment's traffic was
+/// invisible to `[db.analysis]`. Framing it closes that gap — and unlike the
+/// MySQL splice path, which has to infer completion from the arrival of the
+/// *next* client command, PG hands the proxy an explicit end-of-turn marker in
+/// `ReadyForQuery`. Durations, row counts and error status here are therefore
+/// exactly what the routing loop reports, not an approximation.
+///
+/// Framing is not paid for in syscalls: the backend read half is buffered and
+/// the client write half is coalesced, flushed whenever the read buffer drains
+/// (the point at which the relay is about to block anyway). A large result set
+/// still crosses in `BufReader`-sized reads, not one syscall per message.
+///
+/// ## What is still not recorded
+///
+/// Extended-protocol executions. `Parse` carries SQL and `Execute` is the
+/// execution, but mapping one to the other means tracking named statements and
+/// portals across the session; the turn-based routing loop does not do it
+/// either, and recording `Parse` alone would publish planning time as query
+/// time. Same reasoning as `COM_STMT_PREPARE` on the MySQL side — see
+/// [`crate::stats`].
+async fn pg_proxy_bidirectional_sniff(
     mut client: TcpStream,
     mut backend: TcpStream,
+    stats: Option<&QueryStats>,
 ) -> Option<TcpStream> {
-    let end = {
-        let (mut cr, mut cw) = client.split();
-        let (mut br, mut bw) = backend.split();
+    use std::collections::VecDeque;
+
+    use parking_lot::Mutex;
+    use tokio::io::{BufReader, BufWriter};
+
+    let turns: Arc<Mutex<VecDeque<PgTurn>>> = Arc::new(Mutex::new(VecDeque::new()));
+    let turns_w = Arc::clone(&turns);
+    // Set while a backend message has been partly consumed. Framing takes
+    // several awaits, so unlike the bulk copy this replaced, the reader half
+    // is not cancel-safe — see `relay_pg_message`.
+    let partial = AtomicBool::new(false);
+
+    let (end, buffered_response) = {
+        let (mut cr, cw) = client.split();
+        let (br, mut bw) = backend.split();
+        // Buffered so that per-message framing does not become per-message
+        // syscalls. The client write half is flushed below at every point the
+        // relay is about to wait.
+        let mut br = BufReader::new(br);
+        let mut cw = BufWriter::new(cw);
 
         let client_to_backend = async {
             let mut header = [0u8; 5];
@@ -1041,6 +1211,24 @@ async fn pg_proxy_bidirectional(
                     return PgSessionEnd::Client;
                 }
 
+                // Enqueue before the message hits the wire: the response
+                // cannot arrive before the write, so the reader half can never
+                // see a `ReadyForQuery` for a turn that is not queued yet.
+                // Costs one branch per message when stats are off.
+                if stats.is_some() && pg_ends_a_turn(header[0]) {
+                    let sql =
+                        if header[0] == MSG_QUERY { pg_recordable_sql(&payload) } else { None };
+                    let mut queue = turns_w.lock();
+                    if queue.len() >= MAX_PENDING_TURNS {
+                        debug!(
+                            "client pipelined more than {MAX_PENDING_TURNS} unanswered turns; \
+                             ending session"
+                        );
+                        return PgSessionEnd::Client;
+                    }
+                    queue.push_back(PgTurn { sql, started: std::time::Instant::now() });
+                }
+
                 if bw.write_all(&header).await.is_err() || bw.write_all(&payload).await.is_err() {
                     return PgSessionEnd::Backend;
                 }
@@ -1048,26 +1236,61 @@ async fn pg_proxy_bidirectional(
         };
 
         let backend_to_client = async {
-            let mut buf = vec![0u8; 16 * 1024];
+            let mut outcome = ResponseOutcome { ok: true, rows: 0 };
             loop {
-                match br.read(&mut buf).await {
-                    Ok(n) if n > 0 => {
-                        if cw.write_all(&buf[..n]).await.is_err() {
-                            return PgSessionEnd::Client;
+                let tag = match relay_pg_message(&mut br, &mut cw, &partial).await {
+                    Relayed::Message(tag) => tag,
+                    // Source EOF or failure. With `Terminate` no longer
+                    // forwarded, EOF means the server genuinely closed the
+                    // connection — either way it is not reusable.
+                    Relayed::SourceGone(_) => return PgSessionEnd::Backend,
+                    Relayed::SinkGone(_) => return PgSessionEnd::Client,
+                };
+
+                match tag {
+                    MSG_DATA_ROW => outcome.rows += 1,
+                    MSG_ERROR_RESPONSE => outcome.ok = false,
+                    _ => {}
+                }
+
+                if tag == MSG_READY_FOR_QUERY {
+                    if let Some(collector) = stats {
+                        // Pop unconditionally: an extended-protocol or copy
+                        // turn carries no SQL but still owns this
+                        // `ReadyForQuery`, and leaving its entry behind would
+                        // misattribute every later statement on the session.
+                        if let Some(turn) = turns.lock().pop_front() {
+                            if let Some(sql) = turn.sql {
+                                collector.record(
+                                    &sql,
+                                    turn.started.elapsed(),
+                                    outcome.ok,
+                                    outcome.rows,
+                                );
+                            }
                         }
                     }
-                    // `Ok(0)` is backend EOF; `Err` is a backend read failure.
-                    // With `Terminate` no longer forwarded, EOF means the
-                    // server genuinely closed the connection.
-                    Ok(_) | Err(_) => return PgSessionEnd::Backend,
+                    outcome = ResponseOutcome { ok: true, rows: 0 };
+                }
+
+                // Nothing more is buffered, so the next read will wait: get
+                // what has been forwarded in front of the client first.
+                if br.buffer().is_empty() && cw.flush().await.is_err() {
+                    return PgSessionEnd::Client;
                 }
             }
         };
 
-        tokio::select! {
+        let end = tokio::select! {
             e = client_to_backend => e,
             e = backend_to_client => e,
-        }
+        };
+        // Bytes the reader pulled off the socket but has not forwarded belong
+        // to a response nobody consumed. `has_unread_bytes` cannot see them —
+        // they are no longer on the socket — so they have to be reported out.
+        // Two shapes: whole messages sitting in the read buffer, and a single
+        // message the reader was cancelled part-way through.
+        (end, !br.buffer().is_empty() || partial.load(Ordering::Relaxed))
     };
 
     let reusable = match end {
@@ -1076,7 +1299,12 @@ async fn pg_proxy_bidirectional(
         // connection carrying an unconsumed asynchronous `NoticeResponse` or
         // `NotificationResponse`, which is the right call: the next session's
         // `DISCARD ALL` would read it as its own reply.
-        PgSessionEnd::Client if crate::pool::has_unread_bytes(&backend) => {
+        //
+        // The two checks are complementary, not redundant: `has_unread_bytes`
+        // probes bytes still on the socket, `buffered_response` covers bytes
+        // that have already left it for the relay's own buffers. Neither can
+        // see the other's case.
+        PgSessionEnd::Client if buffered_response || crate::pool::has_unread_bytes(&backend) => {
             debug!("client ended mid-response, leaving unread backend bytes; discarding");
             false
         }
@@ -1234,7 +1462,8 @@ async fn pg_proxy_routing_loop(
                 checkout.retire();
                 return Err(e);
             }
-            return pg_relay_pinned_session(client, backend, checkout, reset_strategy).await;
+            return pg_relay_pinned_session(client, backend, checkout, reset_strategy, recorder)
+                .await;
         }
 
         // Query payload is null-terminated SQL. Borrowed, not copied: the
@@ -1299,9 +1528,13 @@ async fn pg_proxy_routing_loop(
 
         if copy_mode {
             // The statement is still in flight — its outcome belongs to the
-            // copy stream we are about to splice, so recording it now would
-            // publish a truncated duration. Left out deliberately.
-            return pg_relay_pinned_session(client, backend, checkout, reset_strategy).await;
+            // copy stream we are about to relay, so recording it now would
+            // publish a truncated duration. Left out deliberately: its
+            // `ReadyForQuery` arrives inside the pinned session, whose turn
+            // queue starts empty, so it settles nothing rather than being
+            // misattributed.
+            return pg_relay_pinned_session(client, backend, checkout, reset_strategy, recorder)
+                .await;
         }
 
         if let (Some(collector), Some(started)) = (recorder, started) {
@@ -1334,22 +1567,26 @@ async fn pg_proxy_routing_loop(
     Ok(())
 }
 
-/// Pin an already-acquired `backend` to `client` and splice both directions
+/// Pin an already-acquired `backend` to `client` and relay both directions
 /// until either side closes, then recycle the backend.
 ///
 /// Used for the extended query protocol and the copy sub-protocols, where
-/// message boundaries do not line up with turn boundaries and the proxy
-/// therefore cannot tell when it is safe to block on the backend. Because no
-/// per-statement state can be tracked through an opaque splice, the connection
-/// is always reset before being parked unless the operator explicitly opted
-/// out with [`ResetStrategy::Never`].
+/// message boundaries do not line up with *turn* boundaries and the proxy
+/// therefore cannot tell when it is safe to block on the backend. Message
+/// boundaries themselves stay visible, so a simple `Query` issued later on the
+/// same pinned session is still recorded — `stats` is threaded through for
+/// that. The connection is always reset before being parked unless the
+/// operator explicitly opted out with [`ResetStrategy::Never`], because
+/// extended-protocol session state (named statements, portals) cannot be
+/// tracked per command.
 async fn pg_relay_pinned_session(
     client: TcpStream,
     backend: TcpStream,
     checkout: Checkout,
     reset_strategy: ResetStrategy,
+    stats: Option<&QueryStats>,
 ) -> Result<(), DbError> {
-    match pg_proxy_bidirectional(client, backend).await {
+    match pg_proxy_bidirectional_sniff(client, backend, stats).await {
         Some(backend) => {
             if matches!(reset_strategy, ResetStrategy::Never) {
                 checkout.return_to_pool(backend);
@@ -1938,6 +2175,250 @@ mod tests {
         });
         drive_pg_query(Some(disabled.clone()), 2, false).await;
         assert_eq!(disabled.digest_count(), 0);
+    }
+
+    // ── relay cancellation safety ───────────────────────────────────
+
+    /// The idle state must not look like a partly consumed message.
+    ///
+    /// The reader half of the single-backend relay spends most of a session
+    /// parked here. If that set the flag, every clean end-of-session would
+    /// condemn its pooled backend and the pool would never reuse anything.
+    #[tokio::test]
+    async fn relay_flag_stays_clear_while_waiting_for_a_message() {
+        let (_src_write, mut src_read) = make_tcp_pair().await;
+        let (mut sink, _sink_read) = make_tcp_pair().await;
+        let partial = AtomicBool::new(false);
+
+        let timed_out = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            relay_pg_message(&mut src_read, &mut sink, &partial),
+        )
+        .await;
+
+        assert!(timed_out.is_err(), "no message was sent, so the relay must still be waiting");
+        assert!(!partial.load(Ordering::Relaxed), "waiting for the next message is not partial");
+    }
+
+    /// A message the relay was cancelled part-way through must be reported.
+    ///
+    /// Framing takes several awaits, so unlike the bulk copy this replaced,
+    /// the reader half is not cancel-safe: the tag byte is gone from the
+    /// stream and was never forwarded. Recycling that backend hands the next
+    /// session a connection whose stream starts mid-message.
+    #[tokio::test]
+    async fn relay_flag_is_set_when_cancelled_mid_message() {
+        let (mut src_write, mut src_read) = make_tcp_pair().await;
+        let (mut sink, _sink_read) = make_tcp_pair().await;
+        let partial = AtomicBool::new(false);
+
+        // A tag byte and nothing else: the relay consumes it, then blocks on
+        // the length field.
+        src_write.write_all(&[MSG_DATA_ROW]).await.unwrap();
+
+        let timed_out = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            relay_pg_message(&mut src_read, &mut sink, &partial),
+        )
+        .await;
+
+        assert!(
+            timed_out.is_err(),
+            "the message is incomplete, so the relay must still be waiting"
+        );
+        assert!(partial.load(Ordering::Relaxed), "a consumed tag byte must condemn the connection");
+    }
+
+    /// A completed message clears the flag again, so a session that ends
+    /// between messages stays recyclable.
+    #[tokio::test]
+    async fn relay_flag_clears_after_a_complete_message() {
+        let (mut src_write, mut src_read) = make_tcp_pair().await;
+        let (mut sink, _sink_read) = make_tcp_pair().await;
+        let partial = AtomicBool::new(false);
+
+        write_pg_message(&mut src_write, MSG_DATA_ROW, b"\0\0").await.unwrap();
+
+        let relayed = relay_pg_message(&mut src_read, &mut sink, &partial).await;
+        assert!(matches!(relayed, Relayed::Message(MSG_DATA_ROW)));
+        assert!(
+            !partial.load(Ordering::Relaxed),
+            "a fully forwarded message leaves nothing behind"
+        );
+    }
+
+    // ── query stats on the single-backend path ──────────────────────
+    //
+    // Before this path framed the backend→client direction it recorded
+    // nothing at all, so `reset_strategy = "never"`/`"always"` without
+    // replicas made a whole deployment's traffic invisible to
+    // `[db.analysis]`. These pin the closed gap.
+
+    /// Read client-bound messages until `ReadyForQuery`, returning the tags.
+    ///
+    /// Also proves the coalescing client writer flushed: a message that stayed
+    /// in the `BufWriter` would never arrive and this would time out.
+    async fn read_to_ready(client: &mut TcpStream) -> Vec<u8> {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let mut seen = Vec::new();
+            loop {
+                let (tag, _) = read_pg_message(client).await.unwrap();
+                seen.push(tag);
+                if tag == MSG_READY_FOR_QUERY {
+                    return seen;
+                }
+            }
+        })
+        .await
+        .expect("the response must reach the client")
+    }
+
+    /// Answer one simple `Query` on the fake backend with `rows` data rows.
+    async fn answer_query(backend: &mut TcpStream, rows: usize, fail: bool) {
+        let (tag, _) = read_pg_message(backend).await.unwrap();
+        assert_eq!(tag, MSG_QUERY);
+        write_pg_message(backend, b'T', b"\0\0").await.unwrap();
+        for _ in 0..rows {
+            write_pg_message(backend, MSG_DATA_ROW, b"\0\0").await.unwrap();
+        }
+        if fail {
+            write_pg_message(backend, MSG_ERROR_RESPONSE, b"Mboom\0\0").await.unwrap();
+        } else {
+            write_pg_message(backend, b'C', b"SELECT 0\0").await.unwrap();
+        }
+        send_ready_for_query(backend, b'I').await.unwrap();
+    }
+
+    /// Run one simple `Query` through the single-backend relay and return the
+    /// backend the relay decided was reusable.
+    async fn drive_sniff_query(
+        stats: Option<&QueryStats>,
+        rows: usize,
+        fail: bool,
+    ) -> Option<TcpStream> {
+        let (mut driver, proxy_client) = make_tcp_pair().await;
+        let (proxy_backend, mut fake_backend) = make_tcp_pair().await;
+
+        let handed = stats.cloned();
+        let proxy = tokio::spawn(async move {
+            pg_proxy_bidirectional_sniff(proxy_client, proxy_backend, handed.as_ref()).await
+        });
+
+        write_pg_message(&mut driver, MSG_QUERY, b"SELECT * FROM users WHERE id = 1\0")
+            .await
+            .unwrap();
+        answer_query(&mut fake_backend, rows, fail).await;
+        read_to_ready(&mut driver).await;
+
+        // Orderly close, exactly as PDO does when the request ends.
+        write_pg_message(&mut driver, MSG_TERMINATE, &[]).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), proxy)
+            .await
+            .expect("an intercepted Terminate must end the session")
+            .expect("proxy task must not panic")
+    }
+
+    #[tokio::test]
+    async fn pg_single_backend_path_records_simple_queries() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        let backend = drive_sniff_query(Some(&stats), 2, false).await;
+        assert!(backend.is_some(), "an intercepted Terminate must leave the backend recyclable");
+
+        assert_eq!(stats.digest_count(), 1);
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert_eq!(top[0].error_count, 0);
+        assert_eq!(
+            top[0].total_rows, 2,
+            "DataRow messages are counted here now, exactly as the routing loop counts them"
+        );
+        assert!(top[0].digest_text.contains('?'), "literals must be normalized away");
+        assert!(top[0].total_time > std::time::Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn pg_single_backend_path_records_errors() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        drive_sniff_query(Some(&stats), 1, true).await;
+
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert_eq!(top[0].error_count, 1, "ErrorResponse in the turn marks the statement failed");
+        assert_eq!(top[0].total_rows, 1, "rows forwarded before the error are real");
+    }
+
+    /// Negative control for `[db.analysis] query_stats = false`: the same
+    /// session with no collector, and with a present-but-disabled one, must
+    /// record nothing and still relay every message.
+    #[tokio::test]
+    async fn pg_single_backend_path_records_nothing_when_stats_are_off() {
+        // `None` is what `PgProxy::stats()` yields when the toggle is off.
+        assert!(drive_sniff_query(None, 2, false).await.is_some());
+
+        let disabled = QueryStats::new(ephpm_query_stats::StatsConfig {
+            enabled: false,
+            ..Default::default()
+        });
+        drive_sniff_query(Some(&disabled), 2, false).await;
+        assert_eq!(disabled.digest_count(), 0, "the toggle must reach this tap point");
+    }
+
+    /// Turn alignment under pipelining.
+    ///
+    /// `ReadyForQuery` is the completion marker, and the extended query
+    /// protocol produces one at `Sync` just as a simple `Query` produces one
+    /// of its own. If only `Query` enqueued a turn, an extended batch whose
+    /// `ReadyForQuery` arrives *after* a later `Query` was sent would pop that
+    /// query's entry and publish the batch's numbers under the query's digest.
+    ///
+    /// Nothing in the PHP ecosystem pipelines, so this pins the invariant
+    /// rather than a shipped scenario — but the invariant is what makes the
+    /// numbers trustworthy.
+    #[tokio::test]
+    async fn pg_single_backend_path_keeps_turns_aligned_under_pipelining() {
+        let stats = QueryStats::new(ephpm_query_stats::StatsConfig::default());
+        let (mut driver, proxy_client) = make_tcp_pair().await;
+        let (proxy_backend, mut fake_backend) = make_tcp_pair().await;
+
+        let handed = stats.clone();
+        let proxy = tokio::spawn(async move {
+            pg_proxy_bidirectional_sniff(proxy_client, proxy_backend, Some(&handed)).await
+        });
+
+        // An extended-protocol batch and a simple query, both in flight before
+        // either is answered.
+        write_pg_message(&mut driver, b'P', b"\0SELECT 1\0\0\0").await.unwrap();
+        write_pg_message(&mut driver, MSG_SYNC, &[]).await.unwrap();
+        write_pg_message(&mut driver, MSG_QUERY, b"SELECT * FROM users WHERE id = 1\0")
+            .await
+            .unwrap();
+
+        // The backend drains all three, then answers in order: the batch
+        // returns no rows, the query returns two.
+        for _ in 0..3 {
+            read_pg_message(&mut fake_backend).await.unwrap();
+        }
+        write_pg_message(&mut fake_backend, b'1', &[]).await.unwrap();
+        write_pg_message(&mut fake_backend, b'C', b"SELECT 0\0").await.unwrap();
+        send_ready_for_query(&mut fake_backend, b'I').await.unwrap();
+        write_pg_message(&mut fake_backend, b'T', b"\0\0").await.unwrap();
+        write_pg_message(&mut fake_backend, MSG_DATA_ROW, b"\0\0").await.unwrap();
+        write_pg_message(&mut fake_backend, MSG_DATA_ROW, b"\0\0").await.unwrap();
+        write_pg_message(&mut fake_backend, b'C', b"SELECT 2\0").await.unwrap();
+        send_ready_for_query(&mut fake_backend, b'I').await.unwrap();
+
+        read_to_ready(&mut driver).await;
+        read_to_ready(&mut driver).await;
+        write_pg_message(&mut driver, MSG_TERMINATE, &[]).await.unwrap();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), proxy).await;
+
+        assert_eq!(stats.digest_count(), 1, "only the simple query is recordable");
+        let top = stats.top_queries(1);
+        assert_eq!(top[0].count, 1);
+        assert_eq!(
+            top[0].total_rows, 2,
+            "the query must carry its own row count, not the extended batch's zero"
+        );
     }
 
     // ── Test helpers ─────────────────────────────────────────────────

--- a/crates/ephpm-db/src/stats.rs
+++ b/crates/ephpm-db/src/stats.rs
@@ -31,25 +31,43 @@
 //!
 //! # What is *not* recorded
 //!
-//! Recording only happens on code paths where the proxy already frames the
-//! protocol. Anything it forwards as an opaque byte splice is invisible to
-//! it, and is left out rather than estimated:
+//! Every proxy path frames the wire protocol, on both engines and under every
+//! `reset_strategy` — there is no opaque byte-splice path left, so no
+//! configuration makes a deployment's traffic wholesale invisible. What is
+//! still left out is left out for protocol reasons, and is left out rather
+//! than estimated:
 //!
 //! - MySQL `COM_STMT_EXECUTE` on the single-backend (non R/W-split) path.
-//!   That path never parses the backend→client direction, so it never sees
-//!   the statement ID that `COM_STMT_PREPARE` returned and cannot map an
-//!   execute back to SQL text.
+//!   That path frames the client→backend direction only, so it never sees the
+//!   statement ID that `COM_STMT_PREPARE` returned and cannot map an execute
+//!   back to SQL text. The R/W-split routing loop parses the prepare response
+//!   and therefore can.
 //! - MySQL `COM_STMT_PREPARE` itself, on every path. Preparing is a metadata
 //!   operation, not an execution; recording its round trip under the same
 //!   digest as the statement would report parse latency as query latency.
 //!   This matches `TrackedBackend`, which deliberately passes
 //!   `describe_columns` through unrecorded for the same reason.
-//! - PostgreSQL extended-query-protocol traffic (`Parse`/`Bind`/`Execute`)
-//!   and both copy sub-protocols. Those pin the session to one backend and
-//!   splice it verbatim, because message boundaries stop lining up with turn
-//!   boundaries.
-//! - Every statement on a session using `reset_strategy = "never"` or
-//!   `"always"` *without* R/W splitting, which is spliced end to end.
+//! - PostgreSQL extended-query-protocol executions (`Parse`/`Bind`/`Execute`)
+//!   and both copy sub-protocols. Messages stay framed, but mapping an
+//!   `Execute` back to the SQL a `Parse` carried means tracking named
+//!   statements and portals across the session, and recording the `Parse`
+//!   alone would publish planning time as query time — the same argument as
+//!   `COM_STMT_PREPARE` above. Simple `Query` messages issued later on such a
+//!   session *are* recorded.
+//!
+//! # How completion is established
+//!
+//! The two engines differ, and the difference shows up in the numbers:
+//!
+//! - PostgreSQL sends an explicit `ReadyForQuery` at the end of every turn, on
+//!   every path. Durations, row counts and error status are therefore exact
+//!   everywhere, and identical between the routing loop and the
+//!   single-backend relay.
+//! - MySQL has no such marker on the single-backend path, which does not frame
+//!   the backend→client direction. There, completion is inferred from the
+//!   arrival of the *next* client command — see [`SpliceWatch`] — which costs
+//!   row counts and makes the timing an upper bound. The R/W-split routing
+//!   loop, which does frame both directions, is exact.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};

--- a/crates/ephpm-db/tests/pg_proxy_integration.rs
+++ b/crates/ephpm-db/tests/pg_proxy_integration.rs
@@ -314,3 +314,149 @@ async fn prepared_statement_lifecycle() {
 
     client.batch_execute("DROP TABLE IF EXISTS _ephpm_pg_ps").await.unwrap();
 }
+
+// ── Multi-result responses, and the single-backend framed path ───────────────
+
+/// PostgreSQL's counterpart to the MySQL multi-result desync (issue #223).
+///
+/// The MySQL bug was that a `CALL` returns several result sets and the proxy
+/// stopped after the first. PG cannot have that bug by construction: a
+/// multi-statement simple `Query` produces several `RowDescription` /
+/// `DataRow` / `CommandComplete` groups but exactly *one* `ReadyForQuery`, and
+/// both PG paths relay until they see it. This test pins that against a real
+/// server rather than against a reading of the protocol spec.
+///
+/// It runs on `reset_strategy = "never"` with no replicas — the single-backend
+/// path, which nothing else in this file exercises — so it also covers the
+/// framed relay that replaced the opaque byte copy.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn multi_statement_query_does_not_desync_the_pooled_backend() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let config = PoolConfig {
+        min_connections: 1,
+        max_connections: 1,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        health_check_interval: Duration::from_secs(30),
+    };
+    // `Never` + no replicas selects the single-backend relay.
+    let addr = start_proxy(&url, config, ResetStrategy::Never).await;
+
+    // A desync shows up as a hang, so bound the whole thing.
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        // Session A: a multi-statement simple query, then a follow-up.
+        {
+            let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+            let handle = tokio::spawn(async move {
+                let _ = connection.await;
+            });
+
+            let messages = client.simple_query("SELECT 11 AS a; SELECT 22 AS b").await.unwrap();
+            let values: Vec<String> = messages
+                .iter()
+                .filter_map(|m| match m {
+                    tokio_postgres::SimpleQueryMessage::Row(r) => {
+                        Some(r.get(0).unwrap().to_string())
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(values, vec!["11", "22"], "both result sets must reach the client");
+
+            let rows = client.simple_query("SELECT 33").await.unwrap();
+            let follow_up: Vec<String> = rows
+                .iter()
+                .filter_map(|m| match m {
+                    tokio_postgres::SimpleQueryMessage::Row(r) => {
+                        Some(r.get(0).unwrap().to_string())
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(follow_up, vec!["33"], "the next command must read its own response");
+
+            drop(client);
+            let _ = handle.await;
+        }
+
+        // Let the proxy finish parking the backend.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Session B: a different client session on the same pooled backend
+        // (`max_connections = 1`, so it is provably the same one).
+        {
+            let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+            let handle = tokio::spawn(async move {
+                let _ = connection.await;
+            });
+
+            let rows = client.simple_query("SELECT 44").await.unwrap();
+            let values: Vec<String> = rows
+                .iter()
+                .filter_map(|m| match m {
+                    tokio_postgres::SimpleQueryMessage::Row(r) => {
+                        Some(r.get(0).unwrap().to_string())
+                    }
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                values,
+                vec!["44"],
+                "a pooled backend must not carry a previous session's result sets"
+            );
+
+            drop(client);
+            let _ = handle.await;
+        }
+    })
+    .await;
+
+    result.expect("a multi-statement query desynchronised the PG proxy (timed out)");
+}
+
+/// A large result set through the single-backend framed relay.
+///
+/// The relay coalesces client-bound writes and flushes only when its read
+/// buffer drains. A response bigger than that buffer is what proves the flush
+/// rule never strands bytes: get it wrong and the client waits forever for the
+/// tail of the result set.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires PG_TEST_URL — nightly CI only"]
+async fn large_result_set_streams_through_the_single_backend_path() {
+    let Some(url) = pg_url() else {
+        println!("PG_TEST_URL not set — skipping");
+        return;
+    };
+
+    let addr = start_proxy(&url, test_pool_config(), ResetStrategy::Never).await;
+
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        let (client, connection) = proxy_config(&addr).connect(NoTls).await.unwrap();
+        let handle = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        let messages = client
+            .simple_query("SELECT i, repeat('x', 200) FROM generate_series(1, 5000) AS i")
+            .await
+            .unwrap();
+        let rows = messages
+            .iter()
+            .filter(|m| matches!(m, tokio_postgres::SimpleQueryMessage::Row(_)))
+            .count();
+        assert_eq!(rows, 5000, "every row of a multi-megabyte result set must reach the client");
+
+        drop(client);
+        let _ = handle.await;
+    })
+    .await;
+
+    result.expect("a large result set stalled in the relay (timed out)");
+}

--- a/crates/ephpm-db/tests/proxy_integration.rs
+++ b/crates/ephpm-db/tests/proxy_integration.rs
@@ -80,6 +80,51 @@ async fn start_proxy(
     panic!("proxy did not become ready at {listen_addr}");
 }
 
+/// Boot a [`MySqlProxy`] with read/write splitting enabled and one replica
+/// pointed at the same backend URL.
+///
+/// This is the combination that selects `proxy_routing_loop`, the per-command
+/// path that frames responses and returns the backend to the pool after every
+/// command. Nothing else reaches it.
+async fn start_proxy_rw_split(
+    backend_url: &str,
+    pool_config: PoolConfig,
+    reset_strategy: ResetStrategy,
+) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listen_addr = listener.local_addr().unwrap().to_string();
+
+    let proxy = MySqlProxy::new(
+        backend_url,
+        &listen_addr,
+        None,
+        pool_config,
+        reset_strategy,
+        vec![backend_url.to_string()],
+        RwSplitParams { enabled: true, sticky_duration: Duration::from_secs(0) },
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
+    )
+    .await
+    .expect("failed to create MySqlProxy");
+
+    drop(listener);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    tokio::spawn(async move {
+        if let Err(e) = proxy.run().await {
+            eprintln!("proxy stopped: {e}");
+        }
+    });
+
+    for _ in 0..50 {
+        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
+            return listen_addr;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("proxy did not become ready at {listen_addr}");
+}
+
 /// Build a `mysql_async` connection opts that route through the proxy.
 fn proxy_opts(proxy_addr: &str) -> mysql_async::Opts {
     mysql_async::OptsBuilder::default()
@@ -431,4 +476,107 @@ async fn prepared_statement_lifecycle() {
 
     drop(conn);
     pool.disconnect().await.unwrap();
+}
+
+// ── Multi-result responses (issue #223) ──────────────────────────────────────
+
+/// A stored-procedure `CALL` returns two result sets followed by a terminating
+/// `OK`. `forward_mysql_response` used to return after the first terminating
+/// `EOF`, leaving the rest buffered on the *pooled* backend socket — so the
+/// corruption outlived the session that caused it.
+///
+/// Three things are asserted against a real `MySQL` server, in the order they
+/// break:
+///
+/// 1. both result sets reach the client;
+/// 2. the next command *on the same client session* reads its own response;
+/// 3. a *different* client session, drawing the same pooled backend, reads its
+///    own response too.
+///
+/// `max_connections = 1` makes (3) load-bearing: there is exactly one backend
+/// connection, so the second session provably gets the one the `CALL` ran on.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires MYSQL_TEST_URL — nightly CI only"]
+async fn multi_result_call_does_not_desync_the_pooled_backend() {
+    let Some(url) = mysql_url() else {
+        println!("MYSQL_TEST_URL not set — skipping");
+        return;
+    };
+
+    let config = PoolConfig {
+        min_connections: 1,
+        max_connections: 1,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        health_check_interval: Duration::from_secs(30),
+    };
+    let addr = start_proxy_rw_split(&url, config, ResetStrategy::Smart).await;
+
+    // A desync shows up as a hang, so bound the whole thing.
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        // Setup. `BEGIN … END` is scoped by the server's parser, so no
+        // DELIMITER games are needed over the wire.
+        {
+            let pool = mysql_async::Pool::new(proxy_opts(&addr));
+            let mut conn = pool.get_conn().await.unwrap();
+            conn.query_drop("DROP PROCEDURE IF EXISTS _ephpm_two_results").await.unwrap();
+            conn.query_drop(
+                "CREATE PROCEDURE _ephpm_two_results() \
+                 BEGIN SELECT 11 AS a; SELECT 22 AS b; END",
+            )
+            .await
+            .unwrap();
+            drop(conn);
+            pool.disconnect().await.unwrap();
+        }
+
+        // Session A: the multi-result command, then a follow-up on the same
+        // session.
+        {
+            let pool = mysql_async::Pool::new(proxy_opts(&addr));
+            let mut conn = pool.get_conn().await.unwrap();
+
+            let mut call = conn.query_iter("CALL _ephpm_two_results()").await.unwrap();
+            let first: Vec<(i32,)> = call.collect().await.unwrap();
+            assert_eq!(first, vec![(11,)], "the first result set must reach the client");
+            let second: Vec<(i32,)> = call.collect().await.unwrap();
+            assert_eq!(second, vec![(22,)], "the second result set must reach the client too");
+            drop(call);
+
+            let rows: Vec<(i32,)> = conn.query("SELECT 33").await.unwrap();
+            assert_eq!(rows[0].0, 33, "the next command must read its own response");
+
+            drop(conn);
+            pool.disconnect().await.unwrap();
+        }
+
+        // Let the proxy finish parking the backend.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Session B: a different client session on the same pooled backend.
+        {
+            let pool = mysql_async::Pool::new(proxy_opts(&addr));
+            let mut conn = pool.get_conn().await.unwrap();
+            let rows: Vec<(i32,)> = conn.query("SELECT 44").await.unwrap();
+            assert_eq!(
+                rows[0].0, 44,
+                "a pooled backend must not carry a previous session's result sets"
+            );
+            drop(conn);
+            pool.disconnect().await.unwrap();
+        }
+
+        // Cleanup.
+        {
+            let pool = mysql_async::Pool::new(proxy_opts(&addr));
+            let mut conn = pool.get_conn().await.unwrap();
+            conn.query_drop("DROP PROCEDURE IF EXISTS _ephpm_two_results").await.unwrap();
+            drop(conn);
+            pool.disconnect().await.unwrap();
+        }
+    })
+    .await;
+
+    result.expect("a multi-result CALL desynchronised the proxy (timed out)");
 }

--- a/site/content/architecture/database/db-proxy.md
+++ b/site/content/architecture/database/db-proxy.md
@@ -15,8 +15,9 @@ This document covers the SQL connection pooling proxy, wire protocol implementat
 - TCP listener on configurable port
 - Read/write splitting based on first-keyword query classification, with sticky-after-write routing and replica round-robin
 - Replication support (primary + replica pools via `[db.mysql.replicas]`)
+- Multi-result MySQL responses (stored-procedure `CALL`, multi-statement queries): every result set of a command is forwarded before the pooled backend is parked, so a `CALL` cannot leave leftovers for the next session to read ([issue #223](https://github.com/ephpm/ephpm/issues/223))
 - Slow query detection and logging (`ephpm-query-stats`, `[db.analysis].slow_query_threshold`)
-- Query digest / statistics collection with Prometheus export, recorded into the same collector the embedded-SQLite paths use. The proxy can only observe statements where it already parses the wire protocol, so coverage is narrower than the embedded path — the [`[db.analysis]` coverage table](/reference/config/#dbanalysis) lists exactly what each path records, and what it deliberately does not (prepared-statement executes on the default MySQL path, PostgreSQL extended-protocol traffic, and PostgreSQL sessions using `reset_strategy = "never"`/`"always"` without replicas)
+- Query digest / statistics collection with Prometheus export, recorded into the same collector the embedded-SQLite paths use. Every proxy path frames the wire protocol under every `reset_strategy`, so no configuration turns recording off — but the proxy can only attribute statements it can map back to SQL text, so coverage is still narrower than the embedded path. The [`[db.analysis]` coverage table](/reference/config/#dbanalysis) lists exactly what each path records, and what it deliberately does not (prepared-statement executes on the default MySQL path, PostgreSQL extended-protocol executions and `COPY`)
 
 **Planned / Not Yet Implemented:**
 - TDS proxying to a real SQL Server — the `[db.tds]` config is accepted, but startup logs a warning and no proxy is started (litewire's TDS frontend for embedded SQLite is separate and does work)

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -211,7 +211,7 @@ All three share the same backend config schema. Adding a `[db.mysql]` or `[db.po
 | `pool_timeout` | duration string | `"5s"` | Time to wait for a connection before failing. |
 | `health_check_interval` | duration string | `"30s"` | Frequency of backend health checks. |
 | `inject_env` | bool | `true` | Inject `DB_CONNECTION`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DATABASE_URL` into PHP. |
-| `reset_strategy` | string | `"smart"` | `"smart"` (reset after non-SELECT), `"always"`, `"never"`. On PostgreSQL it also decides whether [query stats](#dbanalysis) see proxied statements — `"always"`/`"never"` without replicas take an opaque splice and record nothing. The MySQL proxy frames every session regardless, so its stats coverage does not depend on this knob. |
+| `reset_strategy` | string | `"smart"` | `"smart"` (reset after non-SELECT), `"always"`, `"never"`. Both proxies frame every session under every strategy, so [query stats](#dbanalysis) coverage does not depend on this knob on either engine. |
 | `replicas.urls` | array of strings | `[]` | Read replica URLs. Reads distributed across; writes go to primary. |
 
 > **The proxy listener is unauthenticated — keep it on loopback.**
@@ -323,16 +323,18 @@ One collector serves every database path, so proxied and embedded queries land o
 |------|--------------------|-------------------|------------|
 | Embedded SQLite (`[db.sqlite]`, any engine or replication mode) | All queries and mutations | In-process execution time | Rows returned / rows affected |
 | MySQL proxy, single-backend path (any reset strategy) | `COM_QUERY` only | Wire round trip: command written to the backend → last response byte read back | Not available |
-| MySQL proxy, R/W splitting enabled with replicas | `COM_QUERY` and `COM_STMT_EXECUTE` | Same wire round trip | Rows returned, or affected rows from the `OK` packet |
-| PostgreSQL proxy, `reset_strategy = "smart"` (default) or R/W splitting | Simple `Query` messages | Wire round trip: message written → `ReadyForQuery` | Rows returned (`DataRow` count); mutations record `0` |
-| PostgreSQL proxy, `reset_strategy = "never"`/`"always"` without replicas | None | — | — |
+| MySQL proxy, R/W splitting enabled with replicas | `COM_QUERY` and `COM_STMT_EXECUTE` | Same wire round trip | Rows returned, or affected rows from the `OK` packet — summed across every result set of a multi-result command (`CALL`, multi-statement), which is recorded as one statement |
+| PostgreSQL proxy, any reset strategy, with or without replicas | Simple `Query` messages | Wire round trip: message written → `ReadyForQuery` | Rows returned (`DataRow` count); mutations record `0` |
+
+No `reset_strategy` value turns recording off on either engine — every proxy path frames the wire protocol.
 
 Notable gaps, all deliberate:
 
 - **Proxy durations include the network.** The embedded-SQLite numbers are in-process execution time; the proxy numbers are a round trip to your database server. Comparing them directly is comparing two different things.
 - **`COM_STMT_PREPARE` is never recorded.** Preparing is a metadata round trip, not an execution — recording it under the statement's digest would publish parse latency as query latency.
 - **`COM_STMT_EXECUTE` is invisible on the default MySQL path.** Attributing an execute to its SQL requires having parsed the *prepare response*, which only the R/W-split routing loop does. Applications that turn off PDO's emulated prepares (`PDO::ATTR_EMULATE_PREPARES = false`) will therefore see little or no proxy query-stat traffic unless R/W splitting is on.
-- **PostgreSQL extended-protocol traffic is invisible.** `Parse`/`Bind`/`Execute` pin the session to one backend and splice it verbatim, because message boundaries stop lining up with turn boundaries. Same for `COPY`, and for PostgreSQL sessions using `reset_strategy = "never"`/`"always"` without replicas.
+- **PostgreSQL extended-protocol executions are invisible.** Messages stay framed, but attributing an `Execute` to the SQL a `Parse` carried means tracking named statements and portals across the session; recording the `Parse` alone would publish planning time as query time, exactly as for `COM_STMT_PREPARE`. Same for `COPY`. A simple `Query` issued later on such a session *is* recorded.
+- **MySQL durations on the single-backend path are an upper bound.** That path does not frame the backend→client direction, so completion is inferred from the arrival of the next client command. PostgreSQL has an explicit `ReadyForQuery` marker on every path and is exact everywhere.
 - **Rows the proxy cannot count are reported as `0`, never estimated.**
 
 ## `[kv]`


### PR DESCRIPTION
Two `ephpm-db` defects for v0.6.2. Both are in the DB proxy; nothing outside `crates/ephpm-db/` and its docs is touched.

Closes #223.

## 1. Multi-result desync — MySQL (#223)

`forward_mysql_response` returned after the **first** result set's terminating EOF, ignoring `SERVER_MORE_RESULTS_EXISTS` (0x0008) — while the proxy asks the backend for `CLIENT_MULTI_STATEMENTS` / `CLIENT_MULTI_RESULTS` / `CLIENT_PS_MULTI_RESULTS` in `build_handshake_response` and advertises the same to its own clients in `send_greeting`. A stored-procedure `CALL` therefore left its remaining result sets buffered on the backend socket, and because the R/W-split routing loop parks the connection immediately afterwards, the desync outlived the session that caused it. Checkout validation does not rescue that: `has_unread_bytes` is best-effort, and a leftover `OK` packet is indistinguishable from a `COM_PING` reply.

The fix loops over a new `forward_one_result_set` while the terminating `OK`/`EOF` carries the flag, and returns one aggregated `ResponseOutcome` per command — rows summed across result sets, `ok` false if any of them errored. That keeps the #224 stats contract (one command, one digest entry, nothing estimated) and the #221 `ResponseOutcome` plumbing intact. An `ERR_Packet` ends the sequence: it carries no status field, so the server cannot announce a successor and does not send one — blocking for another packet there would hang the session.

**The single-backend path never had this bug.** It copies the backend→client direction in bulk, so trailing result sets pass straight through; only the routing loop framed responses.

## 2. PostgreSQL query-stats coverage gap

`pg_proxy_bidirectional` copied the backend→client direction in bulk, so `reset_strategy = "never"`/`"always"` without replicas recorded nothing at all — a whole deployment invisible to `[db.analysis]`.

Universal framing is correct here, but **not** by routing those sessions through `pg_proxy_routing_loop`: that re-acquires a backend from the pool for every command, which would scatter a session's `SET`s, temp tables and advisory locks across different connections. PG also genuinely needs a session-pinned path that MySQL does not — the extended query protocol and the copy sub-protocols produce no backend output until a later *client* message, so the proxy cannot block on the backend between turns.

What was actually opaque was the *byte copy*, not the path. Both directions of the single-backend relay are now framed (`pg_proxy_bidirectional_sniff`), with the backend read half wrapped in a `BufReader` and the client write half in a `BufWriter` flushed whenever the read buffer drains — the point at which the relay is about to block anyway. Framing therefore costs no extra syscalls; a large result set still crosses in buffer-sized reads. There is no opaque byte-splice path left on either engine.

Because PG sends an explicit `ReadyForQuery` at the end of every turn, durations, row counts and error status on this path are **exact** — identical to what the routing loop reports, with no equivalent of MySQL's infer-from-the-next-command heuristic. Turns are enqueued for `Query`, `Sync` and `FunctionCall` alike, so the pending queue stays aligned with the `ReadyForQuery` stream in a session that mixes the simple and extended protocols; only `Query` carries recordable SQL.

`pg_relay_pinned_session` now receives the collector too, so a simple `Query` issued after a session pinned itself to the extended protocol is recorded as well.

### Did PG have the multi-result flaw?

No, and it cannot: a multi-statement simple `Query` produces several `RowDescription`/`DataRow`/`CommandComplete` groups but exactly **one** `ReadyForQuery`, and both PG paths relay until they see it. Pinned against a real server by a new integration test rather than left as a reading of the spec.

### Cancellation safety

Framing takes several awaits, so unlike the bulk copy it replaces, the reader half is not cancel-safe: a client that sends `Terminate` mid-response would leave bytes consumed from the socket and never forwarded, invisible to `has_unread_bytes`. `relay_pg_message` now sets a flag once a message's first byte is consumed and clears it when the message is fully forwarded, so the relay can condemn a backend it left mid-message — while the idle state (parked waiting for the *next* message) stays clear, which is what keeps a normal end-of-session recyclable.

## Tests

Unit (`cargo test -p ephpm-db --lib`): 98 → 105.

- `mysql.rs` — multi-result forwarding with a trailing sentinel response (proves the boundary is exact, not just that both sets arrive), chained `OK` packets, `ERR` termination under a timeout, status-flag offsets including a 2-byte lenenc affected-row count, and a pooled routing-loop test asserting a single dial served both commands and the backend was parked rather than retired.
- `postgres.rs` — stats on the single-backend path (rows, errors, both stats-off controls), turn alignment under pipelining, and the three relay-cancellation cases (idle / mid-message / complete).

Integration, run locally against containers:

- `mysql:8.0` — 9/9, including `multi_result_call_does_not_desync_the_pooled_backend`: a real stored procedure returning two result sets through the routing loop, a follow-up on the same session, and a **second client session** on the same pooled backend (`max_connections = 1`, so it is provably the same connection).
- `postgres:17` — 8/8, including a multi-statement query with the same three-stage assertion and a 5000-row / ~1 MB result set through the framed relay (which is what proves the flush rule never strands bytes).

### Negative controls

Reverting the loop to the pre-#223 "stop after one result set":

- `forward_mysql_response_consumes_every_result_set` — rows 1, expected 2
- `forward_mysql_response_follows_chained_ok_packets` — rows 2, expected 5
- `routing_loop_multi_result_leaves_the_pooled_backend_clean` — **hangs** (10s timeout)
- against real MySQL 8.0, `multi_result_call_does_not_desync_the_pooled_backend` — **hangs** (30s timeout)

Replacing the PG framed reader with the old opaque byte copy:

- `pg_single_backend_path_records_simple_queries` — 0 digests, expected 1
- `pg_single_backend_path_records_errors` — no digest at all
- `pg_single_backend_path_keeps_turns_aligned_under_pipelining` — 0 digests, expected 1
- `pg_single_backend_path_records_nothing_when_stats_are_off` — still passes, as it must

All restored; the suites below are the restored tree.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `ephpm-db` (105 lib + integration), `ephpm-server` (275), `ephpm-query-stats` (57), `ephpm-config` (90), all `--test-threads=1`, run twice — identical, zero failures

## Docs

`site/content/reference/config.md` and `site/content/architecture/database/db-proxy.md` said the never/always stats gap was PostgreSQL-only. That is now false, so both are corrected: the coverage table collapses the two PG rows into one, the `reset_strategy` row no longer claims stats depend on it, and two accurate gaps are added in place of the removed one (PG extended-protocol *executions* are still unattributable; MySQL single-backend durations are an upper bound, PG's are exact). The MySQL row also notes that a multi-result command records as one statement with rows summed.

## Out of scope, found on the way

The proxy cannot authenticate to a **default** MySQL 8 account: `caching_sha2 full auth error: Access denied for user 'root'@'...'` against both `mysql:8.0` and `mysql:8.4`, with credentials that work through the `mysql` CLI. A user created `IDENTIFIED WITH mysql_native_password` authenticates fine, so the defect is specifically in the `caching_sha2_password` **full auth** path (RSA public-key exchange), which is required whenever the server has not cached that account's password — i.e. the proxy's first connection after a server restart. Not filed yet; not touched here.
