### PR TITLE
fix(db): implement caching_sha2_password full auth (RSA-OAEP) — proxy can authenticate to default MySQL 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ name = "ephpm-db"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "base64ct",
  "bytes",
  "ephpm-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,12 @@ hmac = "0.12"
 hkdf = "0.12"
 chacha20poly1305 = "0.10"
 md5 = "0.8"
+# RSA-OAEP public-key encryption for the caching_sha2_password full-auth
+# handshake (crates/ephpm-db/src/mysql.rs). Already in the dependency graph via
+# rustls-acme and rcgen, so this pulls in nothing new — and it lets us avoid the
+# pure-Rust `rsa` crate, which still carries the unpatched RUSTSEC-2023-0071
+# (Marvin timing sidechannel).
+aws-lc-rs = "1.16"
 base64ct = { version = "1", features = ["alloc"] }
 redis = { version = "0.27", default-features = false, features = ["tokio-comp"] }
 chitchat = "0.10"

--- a/crates/ephpm-db/Cargo.toml
+++ b/crates/ephpm-db/Cargo.toml
@@ -21,6 +21,7 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 hmac = { workspace = true }
 md5 = { workspace = true }
+aws-lc-rs = { workspace = true }
 base64ct = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -27,14 +27,27 @@
 //!
 //! Supports both `mysql_native_password` and `caching_sha2_password`.
 //! `MySQL` 8+ defaults to `caching_sha2_password`, which is handled
-//! transparently. For `caching_sha2_password`, the proxy supports the
-//! "fast auth" path (server has password hash cached) and the "full auth"
-//! path (RSA public key exchange over non-TLS connections).
+//! transparently. For `caching_sha2_password`, the proxy supports both:
+//!
+//! - **Fast auth** — the server already has the password hash in its
+//!   in-memory cache and answers the initial token with `0x01 0x03`.
+//! - **Full auth** — the cache has no entry (first connect for this account,
+//!   or the first connect after a server restart, which flushes the cache).
+//!   The server answers `0x01 0x04`; the proxy then requests the server's RSA
+//!   public key, XORs the NUL-terminated password with the connection
+//!   scramble, RSA-OAEP encrypts the result and sends the ciphertext.
+//!
+//! The proxy always dials its upstream in plaintext — there is no TLS to the
+//! backend (no `CLIENT_SSL` in our capability set, no config knob for it), so
+//! the cleartext full-auth variant the protocol permits over a secure channel
+//! is deliberately not implemented. If upstream TLS is ever added, that branch
+//! becomes available and should be added alongside it.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
+use base64ct::Encoding as _;
 use ephpm_query_stats::QueryStats;
 use sha1::{Digest as _, Sha1};
 use sha2::Sha256;
@@ -802,11 +815,17 @@ async fn handle_caching_sha2(
 ///
 /// The server may respond with:
 /// - `0x01 0x03`: fast auth success — read the final OK packet.
-/// - `0x01 0x04`: full auth required — send the password via RSA or plaintext.
+/// - `0x01 0x04`: full auth required — fetch the server's RSA public key and
+///   send the scrambled password encrypted under it.
+///
+/// `challenge` must be the scramble the server most recently sent us — the
+/// nonce from `HandshakeV10`, or the replacement nonce from an
+/// `AuthSwitchRequest` if one was issued. Full auth XORs the password with it,
+/// and the server XORs with its own copy, so a stale scramble fails auth.
 async fn handle_caching_sha2_more_data(
     stream: &mut TcpStream,
     password: &str,
-    _challenge: &[u8; 20],
+    challenge: &[u8; 20],
     resp: &[u8],
     seq: u8,
 ) -> Result<(), DbError> {
@@ -836,31 +855,26 @@ async fn handle_caching_sha2_more_data(
                 return Err(DbError::Auth(format!("failed to get RSA public key: {msg}")));
             }
 
-            // The response is the public key in PEM format (0x01 prefix + PEM data).
+            // The response is `[0x01][PEM-encoded X.509 SubjectPublicKeyInfo]`.
             //
-            // KNOWN GAP: the correct wire behaviour for non-TLS caching_sha2
-            // full-auth is to XOR the null-terminated password with the
-            // 20-byte scramble (repeated to cover the plaintext length) and
-            // RSA-PKCS1-OAEP encrypt the result under the server's public
-            // key, then send the ciphertext. The current implementation
-            // sends the password as null-terminated plaintext instead —
-            // this works when the backend is on a trusted network (our
-            // loopback proxy pool, the common ePHPm deployment), but any
-            // operator running the pool over a non-loopback network gets
-            // plaintext password exposure on the *initial* cache-miss
-            // connect. Fast-auth caches the password hash on the backend
-            // so subsequent connects skip this branch, bounding the
-            // exposure to first-connect-per-user.
+            // Encrypt the password under that key exactly the way libmysql's
+            // `caching_sha2_password_auth_client` does:
             //
-            // Full RSA-OAEP is a follow-up PR: it needs the `rsa` and
-            // `sha1` crates (sha1 is already a transitive dep, rsa is
-            // new + license-clean but nontrivial to license-audit for
-            // cargo deny) plus integration tests against a real MySQL 8.4
-            // instance to catch OAEP padding edge cases. Deferred to the
-            // DB-auth harness cycle.
-            let mut pwd_bytes = password.as_bytes().to_vec();
-            pwd_bytes.push(0);
-            write_packet(stream, key_seq + 1, &pwd_bytes).await?;
+            //   1. Take the password bytes plus its NUL terminator.
+            //   2. XOR that buffer with the 20-byte auth scramble, repeating
+            //      the scramble cyclically to cover the whole buffer.
+            //   3. RSA-encrypt with OAEP padding (SHA-1 hash, MGF1-SHA1, no
+            //      label) — OpenSSL's `RSA_PKCS1_OAEP_PADDING` defaults, which
+            //      is what the server decrypts with.
+            //   4. Send the raw ciphertext as the next packet.
+            //
+            // The XOR step is what makes this replay-proof: the scramble is
+            // per-connection, so a captured ciphertext is useless on any other
+            // connection even though the password never changes.
+            let key_der = parse_rsa_public_key_pem(&key_resp)?;
+            let scrambled = xor_password_with_scramble(password, challenge);
+            let encrypted = rsa_oaep_encrypt(&key_der, &scrambled)?;
+            write_packet(stream, key_seq + 1, &encrypted).await?;
 
             let (_, final_resp) = read_packet(stream).await?;
             match final_resp.first() {
@@ -878,6 +892,92 @@ async fn handle_caching_sha2_more_data(
             Err(DbError::Protocol(format!("unexpected caching_sha2 more-data flag: {other:#x}")))
         }
     }
+}
+
+/// XOR the NUL-terminated password with the 20-byte auth scramble.
+///
+/// This is libmysql's `xor_string`: the scramble is applied cyclically over a
+/// buffer of `password.len() + 1` bytes (the trailing NUL is part of the
+/// plaintext the server expects, not a framing artefact).
+///
+/// An empty password yields a single byte — `0x00 ^ scramble[0]` — which is
+/// exactly what the client sends; the server XORs it back to an empty string.
+fn xor_password_with_scramble(password: &str, scramble: &[u8; 20]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(password.len() + 1);
+    buf.extend_from_slice(password.as_bytes());
+    buf.push(0);
+    for (i, byte) in buf.iter_mut().enumerate() {
+        *byte ^= scramble[i % scramble.len()];
+    }
+    buf
+}
+
+/// Extract DER-encoded X.509 `SubjectPublicKeyInfo` bytes from the server's
+/// public-key response.
+///
+/// The payload is `[0x01][PEM text]`. `MySQL` writes the key with
+/// `PEM_write_bio_RSA_PUBKEY`, so the PEM label is `PUBLIC KEY` (SPKI), not the
+/// PKCS#1 `RSA PUBLIC KEY` form.
+fn parse_rsa_public_key_pem(payload: &[u8]) -> Result<Vec<u8>, DbError> {
+    let pem_bytes = payload
+        .strip_prefix(&[0x01])
+        .ok_or_else(|| DbError::Protocol("RSA public key response missing 0x01 prefix".into()))?;
+    let pem = std::str::from_utf8(pem_bytes)
+        .map_err(|_| DbError::Protocol("RSA public key is not valid UTF-8".into()))?;
+
+    const BEGIN: &str = "-----BEGIN PUBLIC KEY-----";
+    const END: &str = "-----END PUBLIC KEY-----";
+
+    let start = pem.find(BEGIN).ok_or_else(|| {
+        // A PKCS#1 key would need a different decoder; say so rather than
+        // failing later with an opaque "key rejected".
+        if pem.contains("-----BEGIN RSA PUBLIC KEY-----") {
+            DbError::Protocol("server sent a PKCS#1 RSA public key; expected X.509 SPKI".into())
+        } else {
+            DbError::Protocol("RSA public key response is not PEM".into())
+        }
+    })? + BEGIN.len();
+    let end = pem[start..]
+        .find(END)
+        .ok_or_else(|| DbError::Protocol("RSA public key PEM is missing its END line".into()))?
+        + start;
+
+    // Strip line breaks and any surrounding whitespace before base64-decoding.
+    let body: String = pem[start..end].chars().filter(|c| !c.is_whitespace()).collect();
+    base64ct::Base64::decode_vec(&body)
+        .map_err(|_| DbError::Protocol("RSA public key PEM body is not valid base64".into()))
+}
+
+/// RSA-encrypt `plaintext` under the DER-encoded SPKI public key using OAEP
+/// with SHA-1 for both the hash and MGF1 — the padding OpenSSL applies for
+/// `RSA_PKCS1_OAEP_PADDING`, and therefore the padding `MySQL` decrypts with.
+fn rsa_oaep_encrypt(key_der: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, DbError> {
+    use aws_lc_rs::rsa::{OAEP_SHA1_MGF1SHA1, OaepPublicEncryptingKey, PublicEncryptingKey};
+
+    let public_key = PublicEncryptingKey::from_der(key_der)
+        .map_err(|e| DbError::Auth(format!("backend RSA public key rejected: {e}")))?;
+    let oaep_key = OaepPublicEncryptingKey::new(public_key)
+        .map_err(|_| DbError::Auth("backend RSA public key unusable for OAEP".into()))?;
+
+    // OAEP-SHA1 overhead is 2*20 + 2 bytes; a 2048-bit key leaves 214 bytes,
+    // far more than MySQL's 32-character password limit — but a very long
+    // password against a small key would otherwise fail inside aws-lc with an
+    // opaque error, so check explicitly.
+    let max = oaep_key.max_plaintext_size(&OAEP_SHA1_MGF1SHA1);
+    if plaintext.len() > max {
+        return Err(DbError::Auth(format!(
+            "password too long for backend RSA key: {} bytes, max {max}",
+            plaintext.len()
+        )));
+    }
+
+    let mut ciphertext = vec![0u8; oaep_key.ciphertext_size()];
+    let written = oaep_key
+        .encrypt(&OAEP_SHA1_MGF1SHA1, plaintext, &mut ciphertext, None)
+        .map_err(|_| DbError::Auth("RSA-OAEP encryption of the password failed".into()))?
+        .len();
+    ciphertext.truncate(written);
+    Ok(ciphertext)
 }
 
 // ── Client greeting & handshake ───────────────────────────────────────────────
@@ -2781,5 +2881,181 @@ mod tests {
         // essentially never produce all zeros.
         let c = fresh_challenge();
         assert!(c.iter().any(|&b| b != 0), "challenge should not be all zeros");
+    }
+
+    // ── caching_sha2_password full auth ───────────────────────────────
+
+    /// A scramble with no repeating structure, so a cyclic-wrap bug can't
+    /// accidentally produce the right answer.
+    const SCRAMBLE: [u8; 20] = [
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+        0x01, 0x02, 0x03, 0x04, 0x05,
+    ];
+
+    #[test]
+    fn xor_password_includes_the_nul_terminator() {
+        // libmysql XORs `strlen(passwd) + 1` bytes — the NUL is part of the
+        // plaintext the server decrypts and compares, not framing. Dropping it
+        // produces a buffer the server reads as a different password.
+        let out = xor_password_with_scramble("secret", &SCRAMBLE);
+        assert_eq!(out.len(), 7, "6 password bytes + NUL");
+        // The terminator is NUL, so XORing it yields the scramble byte itself.
+        assert_eq!(out[6], SCRAMBLE[6], "terminator must be XORed too");
+    }
+
+    #[test]
+    fn xor_password_matches_hand_computed_vector() {
+        let out = xor_password_with_scramble("ab", &SCRAMBLE);
+        // Third byte is the NUL terminator XORed with scramble[2] == 0x33.
+        assert_eq!(out, vec![b'a' ^ 0x11, b'b' ^ 0x22, 0x33]);
+    }
+
+    #[test]
+    fn xor_password_repeats_scramble_cyclically() {
+        // 25 chars + NUL = 26 bytes, so the scramble wraps at index 20. This is
+        // the case a naive `zip()` silently truncates.
+        let password = "a".repeat(25);
+        let out = xor_password_with_scramble(&password, &SCRAMBLE);
+        assert_eq!(out.len(), 26);
+        assert_eq!(out[20], b'a' ^ SCRAMBLE[0], "byte 20 must reuse scramble[0]");
+        assert_eq!(out[24], b'a' ^ SCRAMBLE[4]);
+        assert_eq!(out[25], SCRAMBLE[5], "terminator lands at scramble[5]");
+    }
+
+    #[test]
+    fn xor_password_empty_is_one_byte() {
+        // An empty password still sends the terminator, XORed with scramble[0].
+        let out = xor_password_with_scramble("", &SCRAMBLE);
+        assert_eq!(out, vec![SCRAMBLE[0]]);
+    }
+
+    #[test]
+    fn xor_password_is_its_own_inverse() {
+        // The server recovers the plaintext by XORing with its copy of the
+        // scramble, so the transform must be an involution.
+        let password = "correct horse battery staple";
+        let once = xor_password_with_scramble(password, &SCRAMBLE);
+        let twice: Vec<u8> =
+            once.iter().enumerate().map(|(i, b)| b ^ SCRAMBLE[i % SCRAMBLE.len()]).collect();
+        let mut expected = password.as_bytes().to_vec();
+        expected.push(0);
+        assert_eq!(twice, expected);
+    }
+
+    /// Generate a 2048-bit key and return `(spki_der, private_key)` — the same
+    /// shape `MySQL` hands us, so the parser and the encryptor are tested
+    /// against a real key rather than a fixture.
+    fn generate_test_key() -> (Vec<u8>, aws_lc_rs::rsa::PrivateDecryptingKey) {
+        use aws_lc_rs::encoding::{AsDer, PublicKeyX509Der};
+        use aws_lc_rs::rsa::{KeySize, PrivateDecryptingKey};
+
+        let private_key = PrivateDecryptingKey::generate(KeySize::Rsa2048).unwrap();
+        let der = AsDer::<PublicKeyX509Der>::as_der(&private_key.public_key()).unwrap();
+        (der.as_ref().to_vec(), private_key)
+    }
+
+    /// Wrap DER in the `[0x01][PEM]` envelope `MySQL` sends, with the 64-column
+    /// line wrapping OpenSSL emits.
+    fn pem_response(der: &[u8]) -> Vec<u8> {
+        let b64 = base64ct::Base64::encode_string(der);
+        let mut pem = String::from("-----BEGIN PUBLIC KEY-----\n");
+        for chunk in b64.as_bytes().chunks(64) {
+            pem.push_str(std::str::from_utf8(chunk).unwrap());
+            pem.push('\n');
+        }
+        pem.push_str("-----END PUBLIC KEY-----\n");
+
+        let mut payload = vec![0x01];
+        payload.extend_from_slice(pem.as_bytes());
+        payload
+    }
+
+    #[test]
+    fn parse_rsa_public_key_pem_round_trips_der() {
+        let (der, _key) = generate_test_key();
+        let parsed = parse_rsa_public_key_pem(&pem_response(&der)).unwrap();
+        assert_eq!(parsed, der, "line-wrapped PEM must decode back to the DER");
+    }
+
+    #[test]
+    fn parse_rsa_public_key_pem_rejects_missing_prefix() {
+        let (der, _key) = generate_test_key();
+        let payload = &pem_response(&der)[1..]; // drop the 0x01
+        let err = parse_rsa_public_key_pem(payload).unwrap_err();
+        assert!(err.to_string().contains("0x01 prefix"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_rsa_public_key_pem_names_the_pkcs1_case() {
+        // A PKCS#1 key would fail deep inside aws-lc with an opaque rejection;
+        // the parser should say which encoding it got instead.
+        let payload = b"\x01-----BEGIN RSA PUBLIC KEY-----\nAAAA\n-----END RSA PUBLIC KEY-----\n";
+        let err = parse_rsa_public_key_pem(payload).unwrap_err();
+        assert!(err.to_string().contains("PKCS#1"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_rsa_public_key_pem_rejects_truncated_pem() {
+        // A short read that lost the END line must not be decoded as a key.
+        let (der, _key) = generate_test_key();
+        let full = pem_response(&der);
+        let truncated = &full[..full.len() / 2];
+        assert!(parse_rsa_public_key_pem(truncated).is_err());
+    }
+
+    #[test]
+    fn rsa_oaep_encrypt_decrypts_back_to_the_scrambled_password() {
+        // End-to-end over the exact bytes the wire carries: XOR, encrypt with
+        // OAEP-SHA1, then decrypt with the matching private key. This pins the
+        // padding choice — swapping to SHA-256 or PKCS#1 v1.5 fails here.
+        use aws_lc_rs::rsa::{OAEP_SHA1_MGF1SHA1, OaepPrivateDecryptingKey};
+
+        let (der, private_key) = generate_test_key();
+        let parsed_der = parse_rsa_public_key_pem(&pem_response(&der)).unwrap();
+
+        let scrambled = xor_password_with_scramble("secret", &SCRAMBLE);
+        let ciphertext = rsa_oaep_encrypt(&parsed_der, &scrambled).unwrap();
+        assert_eq!(ciphertext.len(), 256, "2048-bit key yields 256-byte ciphertext");
+        assert_ne!(ciphertext, scrambled);
+
+        let decrypter = OaepPrivateDecryptingKey::new(private_key).unwrap();
+        let mut out = vec![0u8; decrypter.min_output_size()];
+        let plaintext =
+            decrypter.decrypt(&OAEP_SHA1_MGF1SHA1, &ciphertext, &mut out, None).unwrap();
+        assert_eq!(plaintext, scrambled.as_slice());
+
+        // And un-XORing recovers the original NUL-terminated password, which is
+        // exactly what the server does before comparing against its hash.
+        let recovered: Vec<u8> =
+            plaintext.iter().enumerate().map(|(i, b)| b ^ SCRAMBLE[i % SCRAMBLE.len()]).collect();
+        assert_eq!(recovered, b"secret\0");
+    }
+
+    #[test]
+    fn rsa_oaep_encrypt_is_randomised() {
+        // OAEP seeds every operation, so two encryptions of identical plaintext
+        // must differ. A deterministic ciphertext would mean padding is off.
+        let (der, _key) = generate_test_key();
+        let scrambled = xor_password_with_scramble("secret", &SCRAMBLE);
+        let a = rsa_oaep_encrypt(&der, &scrambled).unwrap();
+        let b = rsa_oaep_encrypt(&der, &scrambled).unwrap();
+        assert_ne!(a, b, "OAEP must not produce a deterministic ciphertext");
+    }
+
+    #[test]
+    fn rsa_oaep_encrypt_rejects_an_oversized_password() {
+        // 2048-bit key with OAEP-SHA1 leaves 214 bytes. Beyond that we want a
+        // named error, not an opaque failure from the crypto library.
+        let (der, _key) = generate_test_key();
+        let long = "x".repeat(300);
+        let scrambled = xor_password_with_scramble(&long, &SCRAMBLE);
+        let err = rsa_oaep_encrypt(&der, &scrambled).unwrap_err();
+        assert!(err.to_string().contains("too long"), "got: {err}");
+    }
+
+    #[test]
+    fn rsa_oaep_encrypt_rejects_garbage_key() {
+        let err = rsa_oaep_encrypt(b"not a der key", b"payload").unwrap_err();
+        assert!(err.to_string().contains("rejected"), "got: {err}");
     }
 }

--- a/crates/ephpm-db/tests/caching_sha2_auth.rs
+++ b/crates/ephpm-db/tests/caching_sha2_auth.rs
@@ -1,0 +1,360 @@
+//! End-to-end authentication tests against a **default-configured** `MySQL` 8.
+//!
+//! The point of this file is what it does *not* do: no
+//! `ALTER USER ... IDENTIFIED WITH mysql_native_password`. Every other DB test
+//! in this crate reaches for that ALTER, and it was exactly that workaround
+//! which hid issue #234 — the proxy could not complete the
+//! `caching_sha2_password` **full-auth** exchange, so it only ever worked
+//! against accounts the server had already cached (or accounts downgraded to
+//! the legacy plugin).
+//!
+//! ## Forcing the cache miss
+//!
+//! `caching_sha2_password` only runs full auth when the server has no cached
+//! entry for the account. Two ways to guarantee that, both used here:
+//!
+//! - **A freshly created account.** The cache is populated only by a successful
+//!   authentication, so an account created moments ago has no entry by
+//!   construction. This is the deterministic path and needs no server restart.
+//! - **`FLUSH PRIVILEGES`.** Documented to clear the password cache, so an
+//!   *existing, already-cached* account is pushed back onto the full-auth path.
+//!   This reproduces the shape of the bug report (first connect after a server
+//!   restart) without restarting anything.
+//!
+//! ## Bootstrapping
+//!
+//! All setup SQL is issued **through a proxy**, not with `mysql_async` directly.
+//! That is not stylistic: `mysql_async` (as built here, no TLS, no `rsa` crate
+//! in the dependency graph) cannot perform the RSA full-auth exchange either.
+//! It can only reach a `MySQL` 8 backend over fast auth or `mysql_native_password`
+//! — the very limitation this test exists to rule out for our proxy. The proxy
+//! is therefore both the thing under test and the only available admin client.
+//!
+//! Set `MYSQL_SHA2_TEST_URL` to an admin connection string against a stock
+//! `MySQL` 8 (e.g. `mysql://root:secret@127.0.0.1:3306/mysql`) to enable these.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use ephpm_db::ResetStrategy;
+use ephpm_db::mysql::{MySqlProxy, RwSplitParams};
+use ephpm_db::pool::PoolConfig;
+use mysql_async::prelude::*;
+
+/// Admin URL for a stock `MySQL` 8, or `None` (caller should skip).
+fn admin_url() -> Option<String> {
+    std::env::var("MYSQL_SHA2_TEST_URL").ok()
+}
+
+fn test_pool_config() -> PoolConfig {
+    PoolConfig {
+        min_connections: 1,
+        max_connections: 3,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(10),
+        health_check_interval: Duration::from_secs(30),
+    }
+}
+
+/// Boot a [`MySqlProxy`] against `backend_url` on an OS-assigned port.
+///
+/// Returns `Err` with the proxy's own error text when the backend handshake
+/// fails, so a test can assert on an auth failure instead of hanging.
+async fn start_proxy(backend_url: &str) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listen_addr = listener.local_addr().unwrap().to_string();
+    drop(listener);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let proxy = MySqlProxy::new(
+        backend_url,
+        &listen_addr,
+        None,
+        test_pool_config(),
+        ResetStrategy::Always,
+        vec![],
+        RwSplitParams { enabled: false, sticky_duration: Duration::from_secs(0) },
+        ephpm_query_stats::QueryStats::new(ephpm_query_stats::StatsConfig::default()),
+    )
+    .await
+    .expect("MySqlProxy::new failed — backend handshake did not complete");
+
+    tokio::spawn(async move {
+        if let Err(e) = proxy.run().await {
+            eprintln!("proxy stopped: {e}");
+        }
+    });
+
+    for _ in 0..100 {
+        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
+            return listen_addr;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("proxy did not become ready at {listen_addr}");
+}
+
+/// `mysql_async` opts pointed at the proxy. The proxy accepts any client
+/// credentials (loopback-only listener), so these are placeholders.
+fn proxy_opts(proxy_addr: &str, db: &str) -> mysql_async::Opts {
+    mysql_async::OptsBuilder::default()
+        .ip_or_hostname(proxy_addr.split(':').next().unwrap())
+        .tcp_port(proxy_addr.split(':').nth(1).unwrap().parse().unwrap())
+        .user(Some("ignored"))
+        .pass(Some("ignored"))
+        .db_name(Some(db.to_string()))
+        .into()
+}
+
+/// Replace the credentials in a `mysql://user:pass@host:port/db` URL.
+fn with_credentials(url: &str, user: &str, password: &str, db: &str) -> String {
+    let rest = url.strip_prefix("mysql://").expect("admin URL must start with mysql://");
+    let host_and_db = rest.rsplit_once('@').map_or(rest, |(_creds, tail)| tail);
+    let host = host_and_db.split('/').next().unwrap();
+    format!("mysql://{user}:{password}@{host}/{db}")
+}
+
+/// Unique-per-run account name. `MySQL` caps usernames at 32 characters.
+fn unique_user(tag: &str) -> String {
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("s2_{tag}_{pid}_{n}")
+}
+
+/// Create an account and a database for it, and return `(user, password, db)`.
+///
+/// `plugin` is `None` to take the **server default** — which on a stock
+/// `MySQL` 8 is `caching_sha2_password`. That default is the whole point; the
+/// caller asserts it rather than trusting it.
+async fn create_account(
+    admin: &mut mysql_async::Conn,
+    tag: &str,
+    plugin: Option<&str>,
+) -> (String, String, String) {
+    let user = unique_user(tag);
+    let password = "Pa55word!sha2";
+    let db = format!("{user}_db");
+
+    admin.query_drop(format!("DROP USER IF EXISTS '{user}'@'%'")).await.unwrap();
+    let identified = match plugin {
+        Some(p) => format!("IDENTIFIED WITH {p} BY '{password}'"),
+        None => format!("IDENTIFIED BY '{password}'"),
+    };
+    admin.query_drop(format!("CREATE USER '{user}'@'%' {identified}")).await.unwrap();
+    admin.query_drop(format!("CREATE DATABASE IF NOT EXISTS `{db}`")).await.unwrap();
+    admin.query_drop(format!("GRANT ALL ON `{db}`.* TO '{user}'@'%'")).await.unwrap();
+    admin.query_drop("FLUSH PRIVILEGES").await.unwrap();
+
+    (user, password.to_string(), db)
+}
+
+/// The authentication plugin the server actually recorded for `user`.
+async fn account_plugin(admin: &mut mysql_async::Conn, user: &str) -> String {
+    admin
+        .query_first::<String, _>(format!(
+            "SELECT plugin FROM mysql.user WHERE user = '{user}' AND host = '%'"
+        ))
+        .await
+        .unwrap()
+        .expect("account should exist")
+}
+
+/// Prove the connection is usable, not merely authenticated: round-trip a row
+/// through DDL + DML + a read.
+async fn assert_query_roundtrip(proxy_addr: &str, db: &str) {
+    let pool = mysql_async::Pool::new(proxy_opts(proxy_addr, db));
+    let mut conn = pool.get_conn().await.expect("client could not reach the proxy");
+
+    conn.query_drop("CREATE TABLE IF NOT EXISTS auth_probe (id INT PRIMARY KEY, val VARCHAR(32))")
+        .await
+        .unwrap();
+    conn.query_drop("DELETE FROM auth_probe").await.unwrap();
+    conn.query_drop("INSERT INTO auth_probe (id, val) VALUES (1, 'authenticated')").await.unwrap();
+
+    let val: Option<String> =
+        conn.query_first("SELECT val FROM auth_probe WHERE id = 1").await.unwrap();
+    assert_eq!(val.as_deref(), Some("authenticated"), "query through the proxy returned no row");
+
+    drop(conn);
+    pool.disconnect().await.unwrap();
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// The issue-#234 case: an account using the server's default plugin whose
+/// password the server has never cached.
+///
+/// This is the **negative control target**. Revert `handle_caching_sha2_more_data`
+/// to sending a NUL-terminated plaintext password and this test fails with
+/// `caching_sha2 full auth error: Access denied for user ...` — the exact error
+/// from the bug report. That failure is the proof the test reaches full auth
+/// rather than silently riding the fast path.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires MYSQL_SHA2_TEST_URL — a stock MySQL 8"]
+async fn full_auth_with_an_uncached_caching_sha2_account() {
+    let Some(url) = admin_url() else {
+        println!("MYSQL_SHA2_TEST_URL not set — skipping");
+        return;
+    };
+
+    let admin_addr = start_proxy(&url).await;
+    let admin_pool = mysql_async::Pool::new(proxy_opts(&admin_addr, "mysql"));
+    let mut admin = admin_pool.get_conn().await.unwrap();
+
+    let (user, password, db) = create_account(&mut admin, "full", None).await;
+
+    // Guard against a vacuous pass: if this server was started with
+    // default_authentication_plugin=mysql_native_password, the account below
+    // would never exercise caching_sha2 at all and the test would prove nothing.
+    let plugin = account_plugin(&mut admin, &user).await;
+    assert_eq!(
+        plugin, "caching_sha2_password",
+        "server is not default-configured — this test only means something \
+         against a stock MySQL 8 (got plugin '{plugin}')"
+    );
+
+    // First connect for this account ⇒ no cache entry ⇒ the server demands full
+    // auth (auth-more-data 0x04) and the proxy must complete the RSA exchange.
+    let addr = start_proxy(&with_credentials(&url, &user, &password, &db)).await;
+    assert_query_roundtrip(&addr, &db).await;
+
+    admin.query_drop(format!("DROP DATABASE IF EXISTS `{db}`")).await.unwrap();
+    admin.query_drop(format!("DROP USER IF EXISTS '{user}'@'%'")).await.unwrap();
+    drop(admin);
+    admin_pool.disconnect().await.unwrap();
+}
+
+/// `FLUSH PRIVILEGES` clears the password cache, which pushes an
+/// **already-cached** account back onto the full-auth path. This is the shape
+/// of the reported failure — "works until the database restarts" — without
+/// restarting the server.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires MYSQL_SHA2_TEST_URL — a stock MySQL 8"]
+async fn full_auth_again_after_flush_privileges_evicts_the_cache() {
+    let Some(url) = admin_url() else {
+        println!("MYSQL_SHA2_TEST_URL not set — skipping");
+        return;
+    };
+
+    let admin_addr = start_proxy(&url).await;
+    let admin_pool = mysql_async::Pool::new(proxy_opts(&admin_addr, "mysql"));
+    let mut admin = admin_pool.get_conn().await.unwrap();
+
+    let (user, password, db) = create_account(&mut admin, "flush", None).await;
+    assert_eq!(account_plugin(&mut admin, &user).await, "caching_sha2_password");
+
+    let user_url = with_credentials(&url, &user, &password, &db);
+
+    // Connect once to populate the server's cache for this account.
+    let first = start_proxy(&user_url).await;
+    assert_query_roundtrip(&first, &db).await;
+
+    // Evict it.
+    admin.query_drop("FLUSH PRIVILEGES").await.unwrap();
+
+    // A brand-new proxy dials fresh connections, which now miss the cache again.
+    let second = start_proxy(&user_url).await;
+    assert_query_roundtrip(&second, &db).await;
+
+    admin.query_drop(format!("DROP DATABASE IF EXISTS `{db}`")).await.unwrap();
+    admin.query_drop(format!("DROP USER IF EXISTS '{user}'@'%'")).await.unwrap();
+    drop(admin);
+    admin_pool.disconnect().await.unwrap();
+}
+
+/// The common case must not regress: once the cache is warm the server answers
+/// the initial token with `0x01 0x03` and no RSA exchange happens at all.
+///
+/// Warming necessarily goes through full auth first (nothing else in this
+/// dependency graph can authenticate an uncached caching_sha2 account), so this
+/// test depends on the fix rather than being independent of it — but it does
+/// pin that the fast path still terminates correctly afterwards.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires MYSQL_SHA2_TEST_URL — a stock MySQL 8"]
+async fn fast_auth_still_works_once_the_cache_is_warm() {
+    let Some(url) = admin_url() else {
+        println!("MYSQL_SHA2_TEST_URL not set — skipping");
+        return;
+    };
+
+    let admin_addr = start_proxy(&url).await;
+    let admin_pool = mysql_async::Pool::new(proxy_opts(&admin_addr, "mysql"));
+    let mut admin = admin_pool.get_conn().await.unwrap();
+
+    let (user, password, db) = create_account(&mut admin, "fast", None).await;
+    let user_url = with_credentials(&url, &user, &password, &db);
+
+    // Full auth caches the hash server-side...
+    let first = start_proxy(&user_url).await;
+    assert_query_roundtrip(&first, &db).await;
+
+    // ...so these connects take the 0x03 fast path. No FLUSH PRIVILEGES between.
+    for _ in 0..3 {
+        let addr = start_proxy(&user_url).await;
+        assert_query_roundtrip(&addr, &db).await;
+    }
+
+    admin.query_drop(format!("DROP DATABASE IF EXISTS `{db}`")).await.unwrap();
+    admin.query_drop(format!("DROP USER IF EXISTS '{user}'@'%'")).await.unwrap();
+    drop(admin);
+    admin_pool.disconnect().await.unwrap();
+}
+
+/// Legacy accounts must keep working — the auth-switch branch is untouched by
+/// this change but it is the path every other DB test in this crate relies on.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires MYSQL_SHA2_TEST_URL — a stock MySQL 8"]
+async fn mysql_native_password_account_still_authenticates() {
+    let Some(url) = admin_url() else {
+        println!("MYSQL_SHA2_TEST_URL not set — skipping");
+        return;
+    };
+
+    let admin_addr = start_proxy(&url).await;
+    let admin_pool = mysql_async::Pool::new(proxy_opts(&admin_addr, "mysql"));
+    let mut admin = admin_pool.get_conn().await.unwrap();
+
+    // MySQL 8.4 removed mysql_native_password from the default plugin set; skip
+    // rather than fail if the server will not create such an account.
+    let Some((user, password, db)) = create_account_native(&mut admin, "native").await else {
+        println!("server does not offer mysql_native_password — skipping");
+        return;
+    };
+
+    assert_eq!(account_plugin(&mut admin, &user).await, "mysql_native_password");
+
+    let addr = start_proxy(&with_credentials(&url, &user, &password, &db)).await;
+    assert_query_roundtrip(&addr, &db).await;
+
+    admin.query_drop(format!("DROP DATABASE IF EXISTS `{db}`")).await.unwrap();
+    admin.query_drop(format!("DROP USER IF EXISTS '{user}'@'%'")).await.unwrap();
+    drop(admin);
+    admin_pool.disconnect().await.unwrap();
+}
+
+/// Like [`create_account`] but pinned to `mysql_native_password`, returning
+/// `None` when the server does not have that plugin available (`MySQL` 8.4+
+/// ships it disabled by default).
+async fn create_account_native(
+    admin: &mut mysql_async::Conn,
+    tag: &str,
+) -> Option<(String, String, String)> {
+    let user = unique_user(tag);
+    let password = "Pa55word!native";
+    let db = format!("{user}_db");
+
+    admin.query_drop(format!("DROP USER IF EXISTS '{user}'@'%'")).await.ok()?;
+    admin
+        .query_drop(format!(
+            "CREATE USER '{user}'@'%' IDENTIFIED WITH mysql_native_password BY '{password}'"
+        ))
+        .await
+        .ok()?;
+    admin.query_drop(format!("CREATE DATABASE IF NOT EXISTS `{db}`")).await.ok()?;
+    admin.query_drop(format!("GRANT ALL ON `{db}`.* TO '{user}'@'%'")).await.ok()?;
+    admin.query_drop("FLUSH PRIVILEGES").await.ok()?;
+
+    Some((user, password.to_string(), db))
+}

--- a/site/content/architecture/database/db-proxy.md
+++ b/site/content/architecture/database/db-proxy.md
@@ -7,7 +7,7 @@ This document covers the SQL connection pooling proxy, wire protocol implementat
 ## Status
 
 **Currently Implemented:**
-- MySQL transparent proxy with wire protocol handshake (`mysql_native_password` and `caching_sha2_password` backend auth)
+- MySQL transparent proxy with wire protocol handshake. Backend auth covers `mysql_native_password` and `caching_sha2_password` — the latter on **both** its paths: the fast path against the server's password cache, and the full-auth RSA public-key exchange the server demands when the account is not cached (a new account, or any account on the first connect after a server restart). No `ALTER USER ... IDENTIFIED WITH mysql_native_password` is needed against a stock MySQL 8
 - PostgreSQL transparent proxy (`crates/ephpm-db/src/postgres.rs`)
 - Connection pooling with configurable min/max connections
 - Connection reset strategy (always/smart/never) to reset session state between clients


### PR DESCRIPTION
Fixes #234.

## The defect

`handle_caching_sha2_more_data` in `crates/ephpm-db/src/mysql.rs` handles the `caching_sha2_password` full-auth branch. It correctly asked the server for its RSA public key (`0x02`), read the PEM back — and then threw it away, sending the password as a NUL-terminated **plaintext** packet. MySQL rejects cleartext over a non-TLS connection, producing the reported error:

```
caching_sha2 full auth error: Access denied for user 'root'@'…' (using password: YES)
```

A `KNOWN GAP` comment at the call site described the correct behaviour and deferred it. This PR does it.

### Why it hid for so long

`caching_sha2_password` has two paths. The **fast** path answers the initial token from the server's in-memory password cache and never touches RSA. The **full** path runs only when the account is not cached. Once any client authenticates successfully the account is cached, and every later connect takes the fast path — so the proxy appeared to work.

The cache is process-local and non-persistent: it empties on server restart. That gives the failure its characteristic shape — *the proxy works until the database restarts, then it does not* — and a proxy is the workload most exposed to it, since it dials fresh connections at startup and on every pool refill.

The second reason it hid: every existing DB test in this crate reaches for `ALTER USER … IDENTIFIED WITH mysql_native_password`, which sidesteps the plugin entirely.

## Wire steps implemented

On full auth (`auth-more-data 0x01 0x04`) over a non-TLS connection, matching libmysql's `caching_sha2_password_auth_client`:

1. Request the public key (`0x02`) — unchanged.
2. Parse the `[0x01][PEM]` response. MySQL writes it with `PEM_write_bio_RSA_PUBKEY`, so the label is `PUBLIC KEY` (X.509 SPKI), not the PKCS#1 `RSA PUBLIC KEY` form; the parser names that case explicitly rather than failing opaquely inside the crypto library.
3. XOR the password bytes **plus the NUL terminator** with the 20-byte scramble, repeating the scramble cyclically. The terminator is part of the plaintext the server compares, not framing. This step is what makes the exchange replay-proof — the scramble is per-connection.
4. RSA-encrypt with **OAEP, SHA-1 hash, MGF1-SHA1, no label** — OpenSSL's `RSA_PKCS1_OAEP_PADDING` defaults, which is what the server decrypts with.
5. Send the raw ciphertext; read OK/ERR.

The `challenge: &[u8; 20]` parameter was previously `_challenge`, unused. It is now threaded through and load-bearing. Both callers already pass the correct nonce: the `HandshakeV10` scramble on the direct path, and the replacement nonce from `AuthSwitchRequest` on the switch path. A stale scramble here fails auth, so the doc comment now states which one is required.

## TLS branch: deliberately not implemented

The protocol permits sending the cleartext password on full auth when the connection to the backend is already encrypted. **ePHPm has no upstream TLS.** `CLIENT_SSL` is explicitly excluded from the proxy's capability allowlist in `build_handshake_response`, there is a unit test asserting it stays cleared (`handshake_response_strips_unsupported_caps`), and there is no config knob for backend TLS. Implementing that branch would be dead code. The module docs now say so, and say it should be added alongside upstream TLS if that ever lands.

## Dependency

**`aws-lc-rs` 1.16** — promoted to a direct dependency of `ephpm-db`. It was already in the graph via `rustls-acme` and `rcgen`, so **no new packages enter the build**. The entire `Cargo.lock` delta is one line:

```
 name = "ephpm-db"
 dependencies = [
   "anyhow",
+  "aws-lc-rs",
```

`cargo deny check` → **`advisories ok, bans ok, licenses ok, sources ok`**. No new `deny.toml` ignores.

This was chosen over the obvious `rsa` crate specifically because `rsa` still carries the unpatched **RUSTSEC-2023-0071** (Marvin timing sidechannel). That advisory concerns private-key decryption and we only do public-key encryption, so it would have been defensible to ignore it — but taking a zero-new-crate path meant not having to argue the point, and not adding an ignore that outlives the reasoning behind it.

## Testing

### Unit — `crates/ephpm-db/src/mysql.rs` (11 new, 106 total in the crate lib)

Cover the XOR step (terminator included, cyclic wrap past byte 20, empty password, involution), PEM parsing (round-trip against a real generated key, missing `0x01` prefix, PKCS#1 label, truncated PEM), and encryption (decrypt-back round-trip that pins the padding choice — swapping to SHA-256 or PKCS#1 v1.5 fails it; ciphertext non-determinism; oversized password; garbage key).

### E2E — `crates/ephpm-db/tests/caching_sha2_auth.rs` (4 tests)

Against **default-configured** MySQL 8 containers with **no `ALTER USER`**. Unit tests alone would not have caught this — the defect survived because nothing exercised the real path.

**How the cache miss is forced.** Two independent mechanisms, both used:

- **A freshly created account.** The cache is populated only by a successful authentication, so an account created seconds earlier has no entry *by construction*. Deterministic, no restart required.
- **`FLUSH PRIVILEGES`**, which clears the password cache and pushes an *already-cached* account back onto full auth. This reproduces the bug report's shape (first connect after a restart) inside a single test.

Additionally, every run below was performed against a **freshly restarted container**, so even the admin connection as `root` was cache-cold and took full auth — the literal reproduction from the issue.

Two guards against a vacuous pass:

- Each test asserts `SELECT plugin FROM mysql.user` is actually `caching_sha2_password`, so a server started with `default_authentication_plugin=mysql_native_password` fails the test rather than silently proving nothing.
- Each test asserts a real query round-trips (`CREATE TABLE` / `INSERT` / `SELECT` returning the expected row), not merely that auth returned `Ok`.

All setup SQL is issued **through a proxy** rather than with `mysql_async` directly. That is not stylistic: `mysql_async` as built here (no TLS, no `rsa` in the graph) cannot do the RSA exchange either, so it cannot reach an uncached MySQL 8 account. The proxy is both the thing under test and the only available admin client.

| | MySQL 8.0.46 | MySQL 8.4.11 |
|---|---|---|
| `full_auth_with_an_uncached_caching_sha2_account` | pass | pass |
| `full_auth_again_after_flush_privileges_evicts_the_cache` | pass | pass |
| `fast_auth_still_works_once_the_cache_is_warm` | pass | pass |
| `mysql_native_password_account_still_authenticates` | pass | skipped (plugin removed in 8.4) |

Fast auth and `mysql_native_password` are covered explicitly so the common cases cannot regress silently.

### Negative control

Reverted step 4 to the previous plaintext behaviour, restarted MySQL 8.0 to empty the cache, and re-ran. All four tests failed at the backend handshake with exactly the error from the issue:

```
MySqlProxy::new failed — backend handshake did not complete:
Auth("caching_sha2 full auth error: Access denied for user 'root'@'10.89.4.10' (using password: YES)")
```

That failure is the proof the suite reaches full auth rather than silently riding the fast path. Restoring the encryption returned all four to green on both server versions.

## Security note

The previous behaviour was a **credential-disclosure** bug, not only a functional one. On every cache-miss connect the proxy wrote the password in cleartext to the upstream socket. For the common ePHPm deployment (loopback pool) the exposure is limited, but any operator pointing `[db.mysql] url` at a non-loopback MySQL leaked the backend password on the wire — on first connect per account, and again after every upstream restart, which is precisely when a fleet reconnects en masse. The proxy holds credentials PHP never sees, so this was the one place those credentials could escape.

## Verification

- `cargo test -p ephpm-db` — 106 lib + all integration suites pass; `-p ephpm-server` 271 pass; `-p ephpm-config` 90 pass (all `--test-threads=1`)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`

## Note for reviewers

The new E2E tests are `#[ignore]` and gated on `MYSQL_SHA2_TEST_URL`, following the existing convention. **Nothing in CI sets that variable** — nightly runs `--run-ignored ignored-only` but starts no MySQL, so these tests (and the pre-existing `MYSQL_TEST_URL` ones) skip themselves everywhere except a developer machine. That is the same blind spot that let #234 ship. Wiring a MySQL service container into nightly is out of scope here and unverifiable from a local worktree, but it should be tracked separately.

Reproduce locally:

```
podman network create sha2net
podman run -d --name my8 --network sha2net -e MYSQL_ROOT_PASSWORD=secret mysql:8.0
MYSQL_SHA2_TEST_URL='mysql://root:secret@my8:3306/mysql' \
  cargo test -p ephpm-db --test caching_sha2_auth -- --ignored --test-threads=1
```
