### PR TITLE
feat(server): HTTP/3 (QUIC) support, opt-in via [server.http3]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,8 @@ dependencies = [
  "ephpm-query-stats",
  "ephpm-sqld",
  "flate2",
+ "h3",
+ "h3-quinn",
  "http",
  "http-body-util",
  "hyper",
@@ -1461,6 +1463,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mime_guess",
  "mysql_async",
+ "quinn",
  "rcgen",
  "rustls 0.23.37",
  "rustls-acme",
@@ -1911,6 +1914,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3",
+ "quinn",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2151,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3573,12 +3604,13 @@ checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3615,7 +3647,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ tracing-appender = "0.2"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 tokio-rustls = "0.26"
 rustls-pemfile = "2"
+# HTTP/3 (QUIC). The rustls-ring feature keeps QUIC on the SAME rustls
+# crypto provider the TCP TLS path installs as the process default (see
+# the rustls pin above) - mixing providers is a runtime panic risk.
+quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring", "log"] }
+h3 = "0.0.8"
+h3-quinn = "0.0.10"
 rustls-acme = { version = "0.15", default-features = false, features = ["tokio", "aws-lc-rs", "tls12", "webpki-roots"] }
 tokio-stream = "0.1"
 tempfile = "3"

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -192,6 +192,10 @@ pub struct ServerConfig {
     /// TLS configuration. When present, enables HTTPS.
     #[serde(default)]
     pub tls: Option<TlsConfig>,
+
+    /// HTTP/3 (QUIC) settings.
+    #[serde(default)]
+    pub http3: Http3Config,
 }
 
 /// Request limits configuration (`[server.request]`).
@@ -756,6 +760,64 @@ impl TlsConfig {
     #[must_use]
     pub fn is_acme(&self) -> bool {
         !self.domains.is_empty() && !self.is_manual()
+    }
+}
+
+/// HTTP/3 (QUIC) configuration (`[server.http3]`).
+///
+/// HTTP/3 runs over **UDP**, alongside — never instead of — the TCP
+/// listeners that serve HTTP/1.1 and HTTP/2. Enabling it therefore binds an
+/// additional UDP socket; nothing about the TCP side changes.
+///
+/// QUIC mandates TLS 1.3, so HTTP/3 only starts when TLS is configured with a
+/// static certificate (`[server.tls] cert` + `key`). ACME-provisioned
+/// certificates are **not** wired into the QUIC endpoint yet — see
+/// [`Http3Config::enabled`].
+#[derive(Debug, Deserialize, Clone)]
+pub struct Http3Config {
+    /// Enable the HTTP/3 (QUIC) listener.
+    ///
+    /// Default: `false`. HTTP/3 is opt-in because it binds an extra UDP
+    /// socket and requires a static TLS certificate.
+    ///
+    /// When `true` but TLS is absent or is in ACME mode, startup logs a
+    /// warning and the QUIC listener does not start — the TCP listeners are
+    /// unaffected. ePHPm never silently continues without the HTTP/3
+    /// listener an operator asked for.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// UDP address for the QUIC listener (e.g. `"0.0.0.0:443"`).
+    ///
+    /// Absent (the default) means "derive from the HTTPS listener": the UDP
+    /// socket binds the same address and port that serves HTTPS over TCP
+    /// (`[server.tls] listen` when set, otherwise `[server] listen`). That
+    /// matches how browsers expect to find HTTP/3 — same authority, same
+    /// port number, different transport.
+    ///
+    /// Set explicitly only to move QUIC to a different port; the port used
+    /// here is what gets advertised in `Alt-Svc`.
+    #[serde(default)]
+    pub listen: Option<String>,
+
+    /// `max-age` in seconds for the `Alt-Svc` response header advertised on
+    /// HTTPS responses (`Alt-Svc: h3=":443"; ma=86400`).
+    ///
+    /// Browsers do not attempt HTTP/3 until they have seen this header over
+    /// TCP, so it is the discovery mechanism, not a hint. It caps how long a
+    /// client may keep using the advertised HTTP/3 endpoint without
+    /// re-confirming it.
+    ///
+    /// Default: `86400` (24 hours). Set to `0` to suppress the header
+    /// entirely — HTTP/3 then only serves clients that were told about it
+    /// some other way (e.g. `curl --http3-only`, `HTTPS`/`SVCB` DNS records).
+    #[serde(default = "default_alt_svc_max_age")]
+    pub alt_svc_max_age: u64,
+}
+
+impl Default for Http3Config {
+    fn default() -> Self {
+        Self { enabled: false, listen: None, alt_svc_max_age: default_alt_svc_max_age() }
     }
 }
 
@@ -1993,6 +2055,7 @@ impl Default for ServerConfig {
             limits: LimitsConfig::default(),
             file_cache: FileCacheConfig::default(),
             tls: None,
+            http3: Http3Config::default(),
         }
     }
 }
@@ -3224,6 +3287,11 @@ fn default_max_body_size() -> u64 {
     10 * 1024 * 1024 // 10 MiB
 }
 
+/// Default `Alt-Svc` max-age: 24 hours, the value nginx and Caddy advertise.
+fn default_alt_svc_max_age() -> u64 {
+    86400
+}
+
 fn default_header_read() -> u64 {
     30
 }
@@ -3384,6 +3452,88 @@ mod tests {
     // must install it with `EnvVars` — see `crate::test_env`; nothing else in
     // this module may touch `std::env` directly.
     use crate::test_env::EnvVars;
+
+    // ── [server.http3] ───────────────────────────────────────────────
+
+    /// Section absent: HTTP/3 must be off, with the documented Alt-Svc
+    /// max-age. `ServerConfig` has a hand-written `Default`, so this also
+    /// guards against that impl and the serde field defaults drifting apart.
+    #[test]
+    fn http3_section_absent_defaults_to_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nlisten = \"0.0.0.0:8080\"\n").unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(!config.server.http3.enabled, "HTTP/3 must be opt-in");
+        assert_eq!(config.server.http3.listen, None);
+        assert_eq!(config.server.http3.alt_svc_max_age, 86400);
+
+        // ...and the struct default agrees with what TOML parsing produced.
+        let direct = ServerConfig::default();
+        assert!(!direct.http3.enabled);
+        assert_eq!(direct.http3.alt_svc_max_age, 86400);
+    }
+
+    /// Section present but partial: the unset fields must fall back to their
+    /// field-level defaults, not to zero/None-by-derive.
+    #[test]
+    fn http3_section_present_keeps_field_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.http3]\nenabled = true\n").unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.http3.enabled);
+        assert_eq!(config.server.http3.listen, None, "listen derives from the HTTPS address");
+        assert_eq!(
+            config.server.http3.alt_svc_max_age, 86400,
+            "a partial [server.http3] section must not zero the Alt-Svc max-age"
+        );
+    }
+
+    #[test]
+    fn http3_section_parses_every_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server.http3]
+enabled = true
+listen = "0.0.0.0:8443"
+alt_svc_max_age = 3600
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.http3.enabled);
+        assert_eq!(config.server.http3.listen.as_deref(), Some("0.0.0.0:8443"));
+        assert_eq!(config.server.http3.alt_svc_max_age, 3600);
+    }
+
+    #[test]
+    fn test_env_var_overrides_http3_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.http3]\nenabled = false\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__HTTP3__ENABLED", "true");
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.http3.enabled);
+    }
+
+    #[test]
+    fn test_env_var_overrides_http3_alt_svc_max_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nlisten = \"0.0.0.0:8080\"\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__HTTP3__ALT_SVC_MAX_AGE", "120");
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.http3.alt_svc_max_age, 120);
+    }
 
     #[test]
     fn cluster_disabled_empty_secret_is_ok() {

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -52,6 +52,9 @@ tokio-util.workspace = true
 bytes.workspace = true
 sha2.workspace = true
 async-channel.workspace = true
+quinn.workspace = true
+h3.workspace = true
+h3-quinn.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/ephpm-server/src/http3.rs
+++ b/crates/ephpm-server/src/http3.rs
@@ -1,0 +1,670 @@
+//! HTTP/3 (QUIC) listener.
+//!
+//! HTTP/3 runs over UDP and is served *alongside* the TCP listeners, never
+//! instead of them. Everything above the transport is shared: an accepted h3
+//! request is turned into a plain [`hyper::Request`] and handed to
+//! [`Router::handle`] — the same entry point HTTP/1.1 and HTTP/2 use — so
+//! `$_SERVER`, middleware, vhost resolution, static files, rate limiting and
+//! the `ephpm_http_*` metrics behave identically regardless of transport.
+//! There is deliberately no second request pipeline here.
+//!
+//! # Discovery
+//!
+//! Clients do not guess that HTTP/3 exists. They learn about it from an
+//! `Alt-Svc: h3=":443"; ma=86400` header on the TCP (HTTPS) responses, which
+//! [`Router`] emits when HTTP/3 is enabled. A client that never sees that
+//! header — or a `curl` invocation without `--http3` — will keep using TCP
+//! forever, which is the correct fallback behaviour, not a bug.
+//!
+//! # Certificates
+//!
+//! QUIC mandates TLS 1.3, and the certificate is baked into the QUIC endpoint
+//! at bind time. Only static `[server.tls] cert`/`key` are supported; ACME is
+//! a documented limitation (see [`build_endpoint`]).
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use anyhow::Context as _;
+use bytes::{Buf, Bytes};
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame, SizeHint};
+use hyper::{Request, Response};
+use metrics::{counter, gauge, histogram};
+use quinn::crypto::rustls::QuicServerConfig;
+
+use crate::body::ServerBody;
+use crate::router::Router;
+
+/// ALPN protocol identifier for HTTP/3 (RFC 9114).
+const ALPN_H3: &[u8] = b"h3";
+
+/// Build the QUIC endpoint that serves HTTP/3.
+///
+/// The rustls config comes from [`crate::tls::build_server_config`] — the
+/// exact function the TCP HTTPS listener uses — so both transports present
+/// the same certificate and, critically, resolve the same rustls crypto
+/// provider. Only the ALPN list differs (`h3` here, `h2`/`http/1.1` there).
+///
+/// # ACME limitation
+///
+/// ACME-provisioned certificates are not supported on this path. `rustls-acme`
+/// hands out certificates through a `ResolvesServerCert` that rotates
+/// mid-process, whereas `quinn::ServerConfig` captures its crypto config when
+/// the endpoint is created. Wiring rotation through
+/// [`quinn::Endpoint::set_server_config`] is possible but is deliberately not
+/// attempted here; callers must refuse to start HTTP/3 in ACME mode rather
+/// than silently serving no h3 (see [`Http3Params::resolve`]).
+///
+/// # Errors
+///
+/// Returns an error if the cert/key cannot be loaded, if the resulting rustls
+/// config has no QUIC-capable cipher suite, or if the UDP socket cannot be
+/// bound.
+pub fn build_endpoint(
+    addr: SocketAddr,
+    cert_path: &Path,
+    key_path: &Path,
+) -> anyhow::Result<quinn::Endpoint> {
+    let crypto = crate::tls::build_server_config(cert_path, key_path, &[ALPN_H3.to_vec()])
+        .context("failed to build the HTTP/3 TLS configuration")?;
+
+    let quic_crypto = QuicServerConfig::try_from(crypto)
+        .context("TLS configuration has no QUIC-capable cipher suite (TLS 1.3 required)")?;
+
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_crypto));
+
+    quinn::Endpoint::server(server_config, addr)
+        .with_context(|| format!("failed to bind the HTTP/3 (UDP) listener to {addr}"))
+}
+
+/// Everything the HTTP/3 listener needs, resolved from config at startup.
+#[derive(Debug, Clone)]
+pub struct Http3Params {
+    /// UDP address the QUIC endpoint binds.
+    pub listen: SocketAddr,
+    /// Static certificate chain (PEM).
+    pub cert: std::path::PathBuf,
+    /// Static private key (PEM).
+    pub key: std::path::PathBuf,
+}
+
+impl Http3Params {
+    /// Resolve `[server.http3]` against the rest of the server config.
+    ///
+    /// Returns `Ok(None)` when HTTP/3 is simply switched off. Returns an error
+    /// — deliberately fatal rather than a warning-and-continue — when HTTP/3
+    /// is enabled but cannot run, so an operator who asked for HTTP/3 never
+    /// ends up with a server that quietly serves only TCP.
+    ///
+    /// `https_addr` is the address that terminates TLS over TCP; when
+    /// `[server.http3] listen` is absent the QUIC socket reuses it (same port,
+    /// UDP instead of TCP), which is what browsers expect.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HTTP/3 is enabled without TLS, with ACME TLS, or
+    /// with an unparseable `listen` address.
+    pub fn resolve(
+        config: &ephpm_config::Config,
+        https_addr: SocketAddr,
+    ) -> anyhow::Result<Option<Self>> {
+        let http3 = &config.server.http3;
+        if !http3.enabled {
+            return Ok(None);
+        }
+
+        let Some(tls) = config.server.tls.as_ref() else {
+            anyhow::bail!(
+                "[server.http3] enabled = true requires TLS: QUIC mandates TLS 1.3. \
+                 Configure [server.tls] cert and key, or set enabled = false."
+            );
+        };
+
+        if tls.is_acme() {
+            anyhow::bail!(
+                "[server.http3] enabled = true is not supported with ACME TLS yet. \
+                 HTTP/3 requires a static [server.tls] cert/key; ACME support is \
+                 planned. Set enabled = false to start with HTTPS over TCP only."
+            );
+        }
+
+        let (Some(cert), Some(key)) = (tls.cert.as_ref(), tls.key.as_ref()) else {
+            anyhow::bail!("[server.http3] enabled = true requires both [server.tls] cert and key");
+        };
+
+        let listen = match http3.listen.as_deref() {
+            Some(raw) => raw
+                .parse::<SocketAddr>()
+                .with_context(|| format!("invalid [server.http3] listen address: {raw}"))?,
+            None => https_addr,
+        };
+
+        Ok(Some(Self { listen, cert: cert.clone(), key: key.clone() }))
+    }
+}
+
+/// Format the `Alt-Svc` header value that advertises this HTTP/3 endpoint.
+///
+/// Only the port is advertised (`h3=":443"`), never a host: RFC 7838 treats a
+/// missing host as "same host as the origin", which is what we want — the
+/// server has no reliable idea what authority the client used.
+///
+/// Returns `None` when `max_age` is 0, which is how an operator suppresses
+/// advertisement entirely.
+#[must_use]
+pub fn alt_svc_value(port: u16, max_age: u64) -> Option<String> {
+    if max_age == 0 {
+        return None;
+    }
+    Some(format!("h3=\":{port}\"; ma={max_age}"))
+}
+
+/// Accept QUIC connections until `shutdown` resolves.
+///
+/// Each connection is handled on its own task; each request within a
+/// connection gets a further task, mirroring how HTTP/2 streams are handled by
+/// hyper on the TCP path.
+pub async fn accept_loop(
+    endpoint: quinn::Endpoint,
+    router: Arc<Router>,
+    in_flight: Arc<AtomicUsize>,
+    shutdown: impl std::future::Future<Output = ()> + Send,
+) {
+    tokio::pin!(shutdown);
+
+    loop {
+        tokio::select! {
+            incoming = endpoint.accept() => {
+                let Some(incoming) = incoming else {
+                    // `None` means the endpoint was closed.
+                    break;
+                };
+                let router = Arc::clone(&router);
+                let in_flight = Arc::clone(&in_flight);
+                tokio::spawn(async move {
+                    in_flight.fetch_add(1, Ordering::Relaxed);
+                    handle_connection(incoming, router).await;
+                    in_flight.fetch_sub(1, Ordering::Relaxed);
+                });
+            }
+            () = &mut shutdown => {
+                tracing::info!("HTTP/3 listener stopping");
+                break;
+            }
+        }
+    }
+
+    // `0` here is an HTTP/3 H3_NO_ERROR application close code.
+    endpoint.close(quinn::VarInt::from_u32(0), b"server shutting down");
+}
+
+/// Drive one QUIC connection: complete the handshake, then serve requests.
+async fn handle_connection(incoming: quinn::Incoming, router: Arc<Router>) {
+    let remote_addr = incoming.remote_address();
+
+    let connection = match incoming.await {
+        Ok(conn) => conn,
+        Err(err) => {
+            // A failed handshake is a per-connection event (bad ALPN, client
+            // gave up, version negotiation), never fatal to the listener.
+            counter!("ephpm_http3_connection_errors_total", "stage" => "handshake").increment(1);
+            tracing::debug!(%remote_addr, %err, "HTTP/3 handshake failed");
+            return;
+        }
+    };
+
+    counter!("ephpm_http3_connections_total").increment(1);
+    gauge!("ephpm_http3_connections_active").increment(1.0);
+
+    let result = serve_requests(connection, remote_addr, router).await;
+
+    gauge!("ephpm_http3_connections_active").decrement(1.0);
+
+    if let Err(err) = result {
+        counter!("ephpm_http3_connection_errors_total", "stage" => "session").increment(1);
+        tracing::debug!(%remote_addr, %err, "HTTP/3 connection error");
+    }
+}
+
+/// Serve every request multiplexed over one established QUIC connection.
+async fn serve_requests(
+    connection: quinn::Connection,
+    remote_addr: SocketAddr,
+    router: Arc<Router>,
+) -> anyhow::Result<()> {
+    let mut h3 = h3::server::builder()
+        .build(h3_quinn::Connection::new(connection))
+        .await
+        .context("HTTP/3 session setup failed")?;
+
+    loop {
+        match h3.accept().await {
+            Ok(Some(resolver)) => {
+                let router = Arc::clone(&router);
+                tokio::spawn(async move {
+                    if let Err(err) = handle_request(resolver, remote_addr, router).await {
+                        tracing::debug!(%remote_addr, %err, "HTTP/3 request failed");
+                    }
+                });
+            }
+            // Clean end of the connection.
+            Ok(None) => return Ok(()),
+            Err(err) => return Err(anyhow::anyhow!(err)),
+        }
+    }
+}
+
+/// The receive half of a request stream, after `split()`.
+type H3RecvStream = h3_quinn::RecvStream;
+/// The send half of a request stream, after `split()`.
+type H3SendStream = h3_quinn::SendStream<Bytes>;
+
+/// Handle a single HTTP/3 request end to end.
+///
+/// The request is normalized into the shape the shared pipeline expects and
+/// passed to [`Router::handle`] with `is_tls = true` (QUIC is always TLS).
+async fn handle_request(
+    resolver: h3::server::RequestResolver<h3_quinn::Connection, Bytes>,
+    remote_addr: SocketAddr,
+    router: Arc<Router>,
+) -> anyhow::Result<()> {
+    let (request, stream) = resolver.resolve_request().await.context("malformed HTTP/3 request")?;
+
+    counter!("ephpm_http3_requests_total").increment(1);
+    let started = std::time::Instant::now();
+
+    let (send, recv) = stream.split();
+
+    // No request-side normalization is needed: h3 already stamps
+    // `Version::HTTP_3` (so `$_SERVER['SERVER_PROTOCOL']` reads `HTTP/3.0`)
+    // and treats connection-specific request fields as a stream error before
+    // we ever see them. The response side is where h3 leaves work for us —
+    // see `strip_forbidden_response_headers`.
+    let (parts, ()) = request.into_parts();
+    let request = Request::from_parts(parts, H3RequestBody::new(recv));
+
+    let response = router
+        .handle(request, remote_addr, true)
+        .await
+        .context("HTTP/3 request handling failed")?;
+
+    let result = send_response(send, response).await;
+
+    histogram!("ephpm_http3_request_duration_seconds").record(started.elapsed().as_secs_f64());
+
+    result
+}
+
+/// Header fields RFC 9114 §4.2 forbids in HTTP/3 messages.
+///
+/// h3 rejects these on *requests* (a malformed request is a stream error), but
+/// it does not filter *responses* — it QPACK-encodes whatever it is handed. A
+/// PHP script calling `header('Connection: close')`, or a
+/// `[server.response] headers` entry setting one of these, would therefore put
+/// an illegal field on the wire and a strict client would reset the stream.
+/// The TCP path has no such problem: hyper owns connection management there.
+///
+/// `TE` is deliberately absent: RFC 9114 permits it when the value is exactly
+/// `trailers`, and ePHPm never generates it otherwise.
+const FORBIDDEN_H3_RESPONSE_HEADERS: [hyper::header::HeaderName; 5] = [
+    hyper::header::CONNECTION,
+    hyper::header::TRANSFER_ENCODING,
+    hyper::header::UPGRADE,
+    hyper::header::HeaderName::from_static("keep-alive"),
+    hyper::header::HeaderName::from_static("proxy-connection"),
+];
+
+/// Strip HTTP/3-illegal fields from a response produced by the shared pipeline.
+///
+/// Returns how many forbidden *names* were removed (`HeaderMap::remove` drops
+/// every value bound to a name), so the caller can log a misbehaving
+/// application rather than silently papering over it.
+fn strip_forbidden_response_headers(headers: &mut hyper::HeaderMap) -> usize {
+    FORBIDDEN_H3_RESPONSE_HEADERS.iter().filter(|name| headers.remove(*name).is_some()).count()
+}
+
+/// Write a finished [`ServerBody`] response out over an HTTP/3 stream.
+///
+/// Data frames are forwarded as they arrive rather than collected, so large
+/// static files and streamed PHP output keep flat memory on h3 exactly as they
+/// do on the TCP path.
+async fn send_response(
+    mut send: h3::server::RequestStream<H3SendStream, Bytes>,
+    response: Response<ServerBody>,
+) -> anyhow::Result<()> {
+    let (mut parts, mut body) = response.into_parts();
+
+    let removed = strip_forbidden_response_headers(&mut parts.headers);
+    if removed > 0 {
+        counter!("ephpm_http3_stripped_headers_total").increment(removed as u64);
+        tracing::debug!(removed, "stripped connection-specific headers from an HTTP/3 response");
+    }
+
+    let head = Response::from_parts(parts, ());
+
+    send.send_response(head).await.context("failed to send HTTP/3 response headers")?;
+
+    while let Some(frame) = body.frame().await {
+        let frame = frame.context("response body error")?;
+        match frame.into_data() {
+            Ok(data) => {
+                if !data.is_empty() {
+                    send.send_data(data).await.context("failed to send HTTP/3 response data")?;
+                }
+            }
+            // A trailers frame; anything else is ignored the way hyper does.
+            Err(frame) => {
+                if let Ok(trailers) = frame.into_trailers() {
+                    send.send_trailers(trailers).await.context("failed to send HTTP/3 trailers")?;
+                }
+            }
+        }
+    }
+
+    send.finish().await.context("failed to finish the HTTP/3 response stream")?;
+    Ok(())
+}
+
+/// Adapts an HTTP/3 receive stream to [`hyper::body::Body`].
+///
+/// This is what lets HTTP/3 reuse the shared request pipeline unchanged: the
+/// router's body handling (`Limited`, `collect`, frame-by-frame streaming into
+/// a PHP worker) is already generic over `Body`, so it works on QUIC streams
+/// without a parallel implementation. Nothing is buffered here — each QUIC
+/// data chunk becomes one body frame.
+pub struct H3RequestBody {
+    stream: h3::server::RequestStream<H3RecvStream, Bytes>,
+    /// Set once the peer signals end-of-stream, so later polls stay `None`.
+    finished: bool,
+}
+
+impl H3RequestBody {
+    fn new(stream: h3::server::RequestStream<H3RecvStream, Bytes>) -> Self {
+        Self { stream, finished: false }
+    }
+}
+
+/// Error surfaced when reading an HTTP/3 request body fails.
+#[derive(Debug, thiserror::Error)]
+#[error("HTTP/3 request body error: {0}")]
+pub struct H3BodyError(String);
+
+impl Body for H3RequestBody {
+    type Data = Bytes;
+    type Error = H3BodyError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        // `H3RequestBody` holds no self-references and `poll_recv_data` takes
+        // `&mut self`, so projecting through the pin is sound without any
+        // pin-projection machinery.
+        let this = self.get_mut();
+        if this.finished {
+            return Poll::Ready(None);
+        }
+
+        match this.stream.poll_recv_data(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(Some(mut buf))) => {
+                let remaining = buf.remaining();
+                Poll::Ready(Some(Ok(Frame::data(buf.copy_to_bytes(remaining)))))
+            }
+            Poll::Ready(Ok(None)) => {
+                this.finished = true;
+                Poll::Ready(None)
+            }
+            Poll::Ready(Err(err)) => {
+                this.finished = true;
+                Poll::Ready(Some(Err(H3BodyError(err.to_string()))))
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.finished
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        // QUIC gives no framing-level length; `Content-Length`, when the client
+        // sent one, is already enforced by the router's own body cap.
+        SizeHint::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    /// Load a `Config` from an inline TOML document.
+    ///
+    /// The `TempDir` is kept alive for the duration of the call only —
+    /// `Config::load` reads the file eagerly.
+    fn cfg_toml(body: &str) -> ephpm_config::Config {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ephpm.toml");
+        std::fs::write(&path, body).expect("write config");
+        ephpm_config::Config::load(&path).expect("load config")
+    }
+
+    fn https_addr() -> SocketAddr {
+        "127.0.0.1:8443".parse().expect("addr")
+    }
+
+    // ── Alt-Svc ──────────────────────────────────────────────────────
+
+    #[test]
+    fn alt_svc_advertises_port_and_max_age() {
+        assert_eq!(alt_svc_value(443, 86400).as_deref(), Some("h3=\":443\"; ma=86400"));
+        assert_eq!(alt_svc_value(8443, 60).as_deref(), Some("h3=\":8443\"; ma=60"));
+    }
+
+    #[test]
+    fn alt_svc_suppressed_when_max_age_is_zero() {
+        assert_eq!(alt_svc_value(443, 0), None);
+    }
+
+    // ── Http3Params::resolve ─────────────────────────────────────────
+
+    #[test]
+    fn disabled_by_default_resolves_to_none() {
+        let config = cfg_toml("[server]\nlisten = \"127.0.0.1:8080\"\n");
+        assert!(
+            Http3Params::resolve(&config, https_addr()).expect("resolve").is_none(),
+            "http3 must be off unless explicitly enabled"
+        );
+    }
+
+    #[test]
+    fn enabled_without_tls_is_a_startup_error() {
+        let config =
+            cfg_toml("[server]\nlisten = \"127.0.0.1:8080\"\n\n[server.http3]\nenabled = true\n");
+        let err = Http3Params::resolve(&config, https_addr())
+            .expect_err("http3 without TLS must not start silently");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("requires TLS"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn enabled_with_acme_tls_is_a_startup_error() {
+        let config = cfg_toml(
+            "[server]\nlisten = \"127.0.0.1:8080\"\n\n\
+             [server.tls]\ndomains = [\"example.com\"]\n\n\
+             [server.http3]\nenabled = true\n",
+        );
+        let err = Http3Params::resolve(&config, https_addr())
+            .expect_err("http3 + ACME must fail loudly, not start without h3");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("ACME"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn listen_defaults_to_the_https_address() {
+        let config = cfg_toml(
+            "[server]\nlisten = \"127.0.0.1:8080\"\n\n\
+             [server.tls]\ncert = \"/tmp/c.pem\"\nkey = \"/tmp/k.pem\"\n\n\
+             [server.http3]\nenabled = true\n",
+        );
+        let params = Http3Params::resolve(&config, https_addr()).expect("resolve").expect("some");
+        assert_eq!(params.listen, https_addr());
+        assert_eq!(params.cert, PathBuf::from("/tmp/c.pem"));
+        assert_eq!(params.key, PathBuf::from("/tmp/k.pem"));
+    }
+
+    #[test]
+    fn explicit_listen_overrides_the_derived_address() {
+        let config = cfg_toml(
+            "[server]\nlisten = \"127.0.0.1:8080\"\n\n\
+             [server.tls]\ncert = \"/tmp/c.pem\"\nkey = \"/tmp/k.pem\"\n\n\
+             [server.http3]\nenabled = true\nlisten = \"0.0.0.0:9443\"\n",
+        );
+        let params = Http3Params::resolve(&config, https_addr()).expect("resolve").expect("some");
+        assert_eq!(params.listen, "0.0.0.0:9443".parse::<SocketAddr>().expect("addr"));
+    }
+
+    #[test]
+    fn unparseable_listen_is_a_startup_error() {
+        let config = cfg_toml(
+            "[server]\nlisten = \"127.0.0.1:8080\"\n\n\
+             [server.tls]\ncert = \"/tmp/c.pem\"\nkey = \"/tmp/k.pem\"\n\n\
+             [server.http3]\nenabled = true\nlisten = \"not-an-address\"\n",
+        );
+        let err = Http3Params::resolve(&config, https_addr()).expect_err("bad listen must fail");
+        assert!(format!("{err:#}").contains("invalid [server.http3] listen"));
+    }
+
+    // ── RFC 9114 §4.2 response-header normalization ──────────────────
+
+    #[test]
+    fn strips_connection_specific_response_headers() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(hyper::header::CONNECTION, "close".parse().expect("value"));
+        headers.insert(hyper::header::TRANSFER_ENCODING, "chunked".parse().expect("value"));
+        headers.insert(hyper::header::UPGRADE, "websocket".parse().expect("value"));
+        headers.insert("keep-alive", "timeout=5".parse().expect("value"));
+        headers.insert("proxy-connection", "close".parse().expect("value"));
+        // ...and one that must survive.
+        headers.insert(hyper::header::CONTENT_TYPE, "text/html".parse().expect("value"));
+
+        let removed = strip_forbidden_response_headers(&mut headers);
+
+        assert_eq!(removed, 5);
+        for name in &FORBIDDEN_H3_RESPONSE_HEADERS {
+            assert!(!headers.contains_key(name), "{name} must not reach an HTTP/3 client");
+        }
+        assert_eq!(
+            headers.get(hyper::header::CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+            Some("text/html"),
+            "ordinary headers must be left alone"
+        );
+    }
+
+    #[test]
+    fn leaves_a_clean_response_untouched() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(hyper::header::CONTENT_LENGTH, "12".parse().expect("value"));
+        headers.insert(hyper::header::ETAG, "\"abc\"".parse().expect("value"));
+
+        assert_eq!(strip_forbidden_response_headers(&mut headers), 0);
+        assert_eq!(headers.len(), 2);
+    }
+
+    /// A repeated forbidden field must go entirely, not just its first value.
+    #[test]
+    fn strips_every_value_of_a_repeated_forbidden_header() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.append(hyper::header::CONNECTION, "close".parse().expect("value"));
+        headers.append(hyper::header::CONNECTION, "keep-alive".parse().expect("value"));
+
+        assert_eq!(strip_forbidden_response_headers(&mut headers), 1, "one name removed");
+        assert!(
+            !headers.contains_key(hyper::header::CONNECTION),
+            "no value of a forbidden field may survive"
+        );
+        assert!(headers.is_empty());
+    }
+
+    // ── Endpoint construction ────────────────────────────────────────
+
+    #[test]
+    fn endpoint_build_fails_on_missing_cert() {
+        crate::tls::tests_support::init_crypto();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = dir.path().join("key.pem");
+        std::fs::write(&key, "irrelevant").expect("write");
+        let err = build_endpoint(
+            "127.0.0.1:0".parse().expect("addr"),
+            &dir.path().join("nope.pem"),
+            &key,
+        )
+        .expect_err("missing cert must fail");
+        assert!(format!("{err:#}").contains("cannot open cert file"), "{err:#}");
+    }
+
+    #[test]
+    fn endpoint_build_fails_on_garbage_cert_pem() {
+        crate::tls::tests_support::init_crypto();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (cert, key) = crate::tls::tests_support::generate_ec_cert(dir.path());
+        std::fs::write(&cert, "-----BEGIN NOT A CERT-----\nzzz\n").expect("write");
+        let err = build_endpoint("127.0.0.1:0".parse().expect("addr"), &cert, &key)
+            .expect_err("garbage cert PEM must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no certificates found") || msg.contains("failed to parse"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// Binding needs a tokio reactor: quinn registers the UDP socket with it.
+    #[tokio::test]
+    async fn endpoint_binds_a_udp_socket() {
+        crate::tls::tests_support::init_crypto();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (cert, key) = crate::tls::tests_support::generate_ec_cert(dir.path());
+
+        // Port 0: let the OS pick, so the test never collides with anything.
+        let endpoint = build_endpoint("127.0.0.1:0".parse().expect("addr"), &cert, &key)
+            .expect("endpoint should build from a valid EC cert/key");
+
+        let bound = endpoint.local_addr().expect("bound address");
+        assert_ne!(bound.port(), 0, "the UDP socket must actually be bound");
+        endpoint.close(quinn::VarInt::from_u32(0), b"test over");
+    }
+
+    /// The single-crypto-provider invariant, asserted rather than assumed.
+    ///
+    /// `ring` and `aws-lc-rs` are both compiled into this binary, so "which
+    /// provider does TLS use?" has a real answer that could differ per
+    /// transport. `tls::build_server_config` hands out one cached `Arc`, so
+    /// pointer identity is a genuine check that HTTP/3 and HTTPS-over-TCP got
+    /// the *same* provider instance — not merely two equivalent ones.
+    #[test]
+    fn http3_and_tcp_tls_share_one_crypto_provider() {
+        crate::tls::tests_support::init_crypto();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (cert, key) = crate::tls::tests_support::generate_ec_cert(dir.path());
+
+        let h3_config = crate::tls::build_server_config(&cert, &key, &[ALPN_H3.to_vec()])
+            .expect("h3 server config");
+        let tcp_config =
+            crate::tls::build_server_config(&cert, &key, &[b"h2".to_vec(), b"http/1.1".to_vec()])
+                .expect("tcp server config");
+
+        assert!(
+            Arc::ptr_eq(h3_config.crypto_provider(), tcp_config.crypto_provider()),
+            "HTTP/3 and TCP TLS resolved different rustls crypto providers"
+        );
+        // ...and the ALPN lists are the only thing that differs.
+        assert_eq!(h3_config.alpn_protocols, vec![b"h3".to_vec()]);
+        assert_eq!(tcp_config.alpn_protocols, vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
+    }
+}

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod acme;
 pub mod body;
 pub mod db_health;
 pub mod file_cache;
+pub mod http3;
 mod idle;
 pub mod metrics;
 pub mod middleware;
@@ -325,6 +326,10 @@ struct Listeners {
     file_cache_eviction_interval: Duration,
     /// Persistent worker pool (worker mode), drained on shutdown.
     worker_pool: Option<Arc<worker_pool::WorkerPool>>,
+    /// Bound QUIC endpoint serving HTTP/3, when `[server.http3]` is enabled.
+    /// `None` means HTTP/3 is off — the TCP listeners are unaffected either
+    /// way, since HTTP/3 is additive (UDP) rather than a replacement.
+    http3_endpoint: Option<quinn::Endpoint>,
 }
 
 /// Connection-level settings passed into spawned tasks.
@@ -407,6 +412,59 @@ async fn bind_listeners(
             anyhow::bail!("TLS config must provide both cert and key, or neither (for ACME mode)");
         }
         _ => TlsMode::None,
+    };
+
+    // HTTP/3 (UDP) is bound before the router is built so the `Alt-Svc`
+    // advertisement can be attached only if the QUIC socket really came up.
+    //
+    // The address it defaults to is whatever terminates TLS over TCP:
+    // `[server.tls] listen` when a separate HTTPS listener is configured,
+    // otherwise `[server] listen`. Same authority and port as HTTPS, different
+    // transport — which is exactly what an `Alt-Svc: h3=":<port>"` promises.
+    let https_addr: SocketAddr = match config.server.tls.as_ref().and_then(|t| t.listen.as_ref()) {
+        Some(raw) => raw.parse().context("invalid TLS listen address")?,
+        None => addr,
+    };
+    let (http3_endpoint, alt_svc) = match http3::Http3Params::resolve(config, https_addr)? {
+        Some(params) => {
+            let endpoint = http3::build_endpoint(params.listen, &params.cert, &params.key)?;
+            // Read the port back off the socket rather than trusting config:
+            // with `listen = "…:0"` the OS picks it, and advertising `:0`
+            // would send every client to a port that is not there.
+            let bound = endpoint
+                .local_addr()
+                .context("HTTP/3 endpoint has no local address after binding")?;
+            let max_age = config.server.http3.alt_svc_max_age;
+            tracing::info!(
+                listen = %bound,
+                alt_svc_max_age = max_age,
+                "HTTP/3 (QUIC) listening on UDP"
+            );
+            if max_age == 0 {
+                tracing::warn!(
+                    "[server.http3] alt_svc_max_age = 0 suppresses the Alt-Svc header — \
+                     browsers will never discover HTTP/3 and will stay on TCP"
+                );
+            }
+            (Some(endpoint), Some((bound.port(), max_age)))
+        }
+        None => {
+            // add-config-knob: the two supporting knobs only mean anything when
+            // `enabled = true`. Warn rather than let them read as effective.
+            if config.server.http3.listen.is_some() {
+                tracing::warn!(
+                    "[server.http3] listen is ignored while enabled = false — \
+                     no QUIC socket is bound"
+                );
+            }
+            if config.server.http3.alt_svc_max_age != 86400 {
+                tracing::warn!(
+                    "[server.http3] alt_svc_max_age is ignored while enabled = false — \
+                     no Alt-Svc header is advertised"
+                );
+            }
+            (None, None)
+        }
     };
 
     // Worker mode: wire the worker ops table and spawn the persistent worker
@@ -495,8 +553,8 @@ async fn bind_listeners(
         None
     };
 
-    let router = Arc::new(
-        Router::new(
+    let router = Arc::new({
+        let router = Router::new(
             config,
             kv_store,
             multi_tenant_kv,
@@ -512,8 +570,14 @@ async fn bind_listeners(
         // Kind). In single-node mode this is None, so Router keeps whatever it
         // derived from `[cluster] node_id`.
         .with_node_id(node_id)
-        .with_db_health(db_health),
-    );
+        .with_db_health(db_health);
+
+        // Only advertise HTTP/3 once its UDP socket is confirmed bound.
+        match alt_svc {
+            Some((port, max_age)) => router.with_alt_svc(port, max_age),
+            None => router,
+        }
+    });
 
     let has_tls = !matches!(tls_mode, TlsMode::None);
 
@@ -583,6 +647,7 @@ async fn bind_listeners(
         file_cache,
         file_cache_eviction_interval,
         worker_pool,
+        http3_endpoint,
     })
 }
 
@@ -640,10 +705,30 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
         file_cache,
         file_cache_eviction_interval,
         worker_pool,
+        http3_endpoint,
     } = listeners;
 
     // Track in-flight connections for graceful shutdown.
     let in_flight = Arc::new(AtomicUsize::new(0));
+
+    // HTTP/3 accepts on its own task: QUIC connections arrive on a UDP socket
+    // that has nothing to do with the TCP `accept()` calls below. It shares
+    // `in_flight` so the drain loop at the end of this function waits for
+    // in-progress HTTP/3 requests exactly as it does for TCP connections.
+    let http3_shutdown = tokio::sync::watch::channel(false);
+    let http3_task = http3_endpoint.map(|endpoint| {
+        let router = Arc::clone(&router);
+        let in_flight = Arc::clone(&in_flight);
+        let mut rx = http3_shutdown.0.subscribe();
+        tokio::spawn(async move {
+            http3::accept_loop(endpoint, router, in_flight, async move {
+                // `changed()` only errors if every sender is gone, which also
+                // means shutdown; either way, stop accepting.
+                let _ = rx.changed().await;
+            })
+            .await;
+        })
+    });
 
     // Spawn background cleanup task for rate limiter state.
     if let Some(ref l) = limiter {
@@ -725,6 +810,10 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
         }
     }
 
+    // Stop accepting new QUIC connections. In-flight HTTP/3 requests keep
+    // running and are covered by the `in_flight` drain below.
+    let _ = http3_shutdown.0.send(true);
+
     // Worker mode: stop accepting new dispatch so in-flight worker iterations
     // finish and workers exit their loops cleanly (design §4.5).
     if let Some(pool) = &worker_pool {
@@ -756,6 +845,13 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
+    }
+
+    // The QUIC endpoint sends CONNECTION_CLOSE to its peers as the accept loop
+    // exits; give that task a bounded moment to finish so clients see a clean
+    // close instead of a timeout.
+    if let Some(task) = http3_task {
+        let _ = tokio::time::timeout(Duration::from_secs(5), task).await;
     }
 
     Ok(())

--- a/crates/ephpm-server/src/metrics.rs
+++ b/crates/ephpm-server/src/metrics.rs
@@ -58,6 +58,13 @@ pub fn init() -> anyhow::Result<PrometheusHandle> {
             PHP_DURATION_BUCKETS,
         )
         .context("failed to configure http_request_duration buckets")?
+        // HTTP/3 gets its own duration series so h3-vs-h2 latency is
+        // comparable; same buckets, so the two are directly overlayable.
+        .set_buckets_for_metric(
+            Matcher::Full("ephpm_http3_request_duration_seconds".to_string()),
+            PHP_DURATION_BUCKETS,
+        )
+        .context("failed to configure http3_request_duration buckets")?
         .set_buckets_for_metric(
             Matcher::Full("ephpm_php_execution_duration_seconds".to_string()),
             PHP_DURATION_BUCKETS,

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -21,7 +21,7 @@ use ephpm_php::request::PhpRequest;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use http_body_util::{BodyExt, Full};
-use hyper::body::{Bytes, Incoming};
+use hyper::body::Bytes;
 use hyper::{Request, Response, StatusCode};
 use ipnet::IpNet;
 
@@ -173,6 +173,31 @@ impl CompiledGlob {
     }
 }
 
+/// What the request pipeline needs from a request body, whatever transport
+/// produced it.
+///
+/// The TCP path supplies hyper's [`hyper::body::Incoming`]; HTTP/3 supplies
+/// [`crate::http3::H3RequestBody`]. Naming the bounds once — rather than
+/// hard-coding `Incoming` — is what lets HTTP/3 reuse [`Router::handle`]
+/// instead of growing a second request pipeline. The TCP path monomorphizes
+/// to exactly the code it had before, so this costs nothing at runtime.
+pub trait RequestBody:
+    hyper::body::Body<Data = Bytes, Error = Self::BodyError> + Send + Unpin + 'static
+{
+    /// The body's error type, re-stated so it can carry the bounds the
+    /// pipeline needs: `Display` for logging and the blanket
+    /// `Into<Box<dyn Error>>` that `http_body_util::Limited` requires.
+    type BodyError: std::error::Error + Send + Sync + 'static;
+}
+
+impl<B, E> RequestBody for B
+where
+    B: hyper::body::Body<Data = Bytes, Error = E> + Send + Unpin + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type BodyError = E;
+}
+
 pub struct Router {
     document_root: PathBuf,
     sites: HashMap<String, SiteConfig>,
@@ -209,6 +234,13 @@ pub struct Router {
     /// invalid names or values are dropped at startup with a warning
     /// so we don't repeat the parse per response.
     response_headers: Vec<(hyper::header::HeaderName, hyper::header::HeaderValue)>,
+    /// Precomputed `Alt-Svc` value advertising the HTTP/3 endpoint, e.g.
+    /// `h3=":443"; ma=86400`.
+    ///
+    /// `None` when HTTP/3 is disabled or `alt_svc_max_age = 0`. This header is
+    /// the *only* way a browser learns HTTP/3 exists, so it goes on every
+    /// TLS-terminated response — see [`Router::apply_alt_svc`].
+    alt_svc: Option<hyper::header::HeaderValue>,
     store: Arc<Store>,
     /// Per-vhost KV stores. Cloned from the single instance `start_kv_service`
     /// builds and shares with the RESP listener, so a vhost's keyspace is the
@@ -602,6 +634,8 @@ impl Router {
                     }
                 })
                 .collect(),
+            // Filled in by `with_alt_svc` once the QUIC endpoint has bound.
+            alt_svc: None,
             open_basedir,
             multi_tenant_kv,
             store,
@@ -791,6 +825,45 @@ impl Router {
         self
     }
 
+    /// Advertise an HTTP/3 endpoint via `Alt-Svc` on TLS responses.
+    ///
+    /// Called by `serve()` **after** the QUIC endpoint has actually bound, so
+    /// ePHPm never advertises an HTTP/3 port that isn't listening — a stale
+    /// `Alt-Svc` costs clients a failed connection attempt and a fallback on
+    /// every request until `ma` expires.
+    ///
+    /// `port` is the UDP port the QUIC endpoint bound; `max_age` of 0
+    /// suppresses the header (see `[server.http3] alt_svc_max_age`).
+    #[must_use]
+    pub fn with_alt_svc(mut self, port: u16, max_age: u64) -> Self {
+        self.alt_svc = crate::http3::alt_svc_value(port, max_age).and_then(|value| {
+            match hyper::header::HeaderValue::from_str(&value) {
+                Ok(header) => Some(header),
+                Err(err) => {
+                    tracing::warn!(%err, %value, "computed Alt-Svc value is not a valid header");
+                    None
+                }
+            }
+        });
+        self
+    }
+
+    /// Add the `Alt-Svc` HTTP/3 advertisement to a response.
+    ///
+    /// Only TLS-terminated responses get it: an `http://` origin cannot
+    /// upgrade to HTTP/3 (QUIC mandates TLS), so advertising there would just
+    /// be noise. Responses served *over* HTTP/3 carry it too, matching nginx
+    /// and Caddy — it keeps the advertisement fresh for clients that later
+    /// fall back to TCP.
+    fn apply_alt_svc(&self, response: &mut Response<ServerBody>, is_tls: bool) {
+        if !is_tls {
+            return;
+        }
+        if let Some(value) = &self.alt_svc {
+            response.headers_mut().insert(hyper::header::ALT_SVC, value.clone());
+        }
+    }
+
     /// Override this node's `EPHPM_NODE_ID` (injected into PHP `$_SERVER`)
     /// with the effective runtime cluster identity.
     ///
@@ -975,12 +1048,15 @@ impl Router {
     /// # Panics
     ///
     /// Panics if a static HTTP response builder fails (should never happen).
-    pub async fn handle(
+    pub async fn handle<B>(
         &self,
-        req: Request<Incoming>,
+        req: Request<B>,
         remote_addr: SocketAddr,
         is_tls: bool,
-    ) -> Result<Response<ServerBody>, hyper::Error> {
+    ) -> Result<Response<ServerBody>, hyper::Error>
+    where
+        B: RequestBody,
+    {
         // Metrics label for the request method. Standard HTTP methods map to
         // a `&'static str` so the two metric sites below allocate nothing per
         // request (issue #136); non-standard methods collapse to `"OTHER"`,
@@ -1020,6 +1096,14 @@ impl Router {
 
         let elapsed = start.elapsed().as_secs_f64();
         gauge!("ephpm_http_requests_in_flight").decrement(1.0);
+
+        // Advertise HTTP/3 on every TLS response, including error and timeout
+        // paths — a client that only ever sees 404s should still discover h3.
+        let mut result = result;
+        if let Ok(ref mut resp) = result {
+            self.apply_alt_svc(resp, is_tls);
+        }
+
         if let Ok(ref resp) = result {
             // Map the status to a `&'static str` label. The `metrics` macros
             // require label values to be `'static` (they intern into
@@ -1050,12 +1134,15 @@ impl Router {
     ///
     /// Returns the response paired with a handler label for metrics.
     #[allow(clippy::too_many_lines)]
-    async fn handle_inner(
+    async fn handle_inner<B>(
         &self,
-        req: Request<Incoming>,
+        req: Request<B>,
         remote_addr: SocketAddr,
         is_tls: bool,
-    ) -> Result<(Response<ServerBody>, &'static str), hyper::Error> {
+    ) -> Result<(Response<ServerBody>, &'static str), hyper::Error>
+    where
+        B: RequestBody,
+    {
         // Use the percent-decoded path for routing and static-file lookup.
         // hyper hands us the raw URI, so `/test%2Ehtml` would otherwise be
         // looked up as the literal name `test%2Ehtml`. percent_decode_path
@@ -1363,16 +1450,19 @@ impl Router {
 
     /// Handle a PHP request by executing it in a blocking task.
     #[allow(clippy::too_many_arguments)]
-    async fn handle_php(
+    async fn handle_php<B>(
         &self,
-        req: Request<Incoming>,
+        req: Request<B>,
         remote_addr: SocketAddr,
         is_https: bool,
         script_filename: PathBuf,
         accepts_gzip: bool,
         accepts_br: bool,
         document_root: PathBuf,
-    ) -> Response<ServerBody> {
+    ) -> Response<ServerBody>
+    where
+        B: RequestBody,
+    {
         let method = req.method().to_string();
         // `method` is the client's raw verb and belongs in PHP's `$_SERVER`,
         // never in a Prometheus label — that is exactly what
@@ -1826,7 +1916,7 @@ impl Router {
     }
 
     /// Return 413 if Content-Length exceeds the limit.
-    fn check_body_size(&self, req: &Request<Incoming>) -> Option<Response<ServerBody>> {
+    fn check_body_size<B>(&self, req: &Request<B>) -> Option<Response<ServerBody>> {
         if self.max_body_size == 0 {
             return None;
         }
@@ -1883,9 +1973,9 @@ impl Router {
     ///
     /// When the request comes from a trusted proxy, reads `X-Forwarded-For`
     /// (rightmost untrusted IP) and `X-Forwarded-Proto` for HTTPS detection.
-    fn resolve_proxy_info(
+    fn resolve_proxy_info<B>(
         &self,
-        req: &Request<Incoming>,
+        req: &Request<B>,
         remote_addr: SocketAddr,
         is_tls: bool,
     ) -> (SocketAddr, bool) {
@@ -1912,7 +2002,7 @@ impl Router {
     /// Validate the `Host` header against the trusted hosts list.
     ///
     /// Returns a 421 Misdirected Request if the host is not trusted.
-    fn check_trusted_host(&self, req: &Request<Incoming>) -> Option<Response<ServerBody>> {
+    fn check_trusted_host<B>(&self, req: &Request<B>) -> Option<Response<ServerBody>> {
         if self.trusted_hosts.is_empty() {
             return None;
         }
@@ -2250,7 +2340,7 @@ fn status_metric_label(status: StatusCode) -> &'static str {
     }
 }
 
-fn extract_server_name(req: &Request<Incoming>) -> String {
+fn extract_server_name<B>(req: &Request<B>) -> String {
     req.headers()
         .get("host")
         .and_then(|v| v.to_str().ok())
@@ -2465,8 +2555,8 @@ fn error_response_owned(status: StatusCode, body: String) -> Response<ServerBody
 /// hyper read, so ePHPm never buffers more than a few chunks regardless of the
 /// upload size. The task ends (closing the channel = EOF) on the last frame, a
 /// read error, or when the worker drops the receiver (request done early).
-fn stream_request_body(
-    req: Request<Incoming>,
+fn stream_request_body<B: RequestBody>(
+    req: Request<B>,
     content_length: Option<u64>,
     max_body_size: u64,
 ) -> (ephpm_php::worker_bridge::WorkerBody, Arc<std::sync::atomic::AtomicBool>) {
@@ -2712,7 +2802,7 @@ fn split_path_query(expanded: &str) -> (&str, &str) {
 }
 
 /// Check if the request's Accept-Encoding header contains the given encoding.
-fn accepts_encoding(req: &Request<Incoming>, encoding: &str) -> bool {
+fn accepts_encoding<B>(req: &Request<B>, encoding: &str) -> bool {
     req.headers()
         .get("accept-encoding")
         .and_then(|v| v.to_str().ok())
@@ -2808,6 +2898,7 @@ mod tests {
 
     use ephpm_config::{ClusterConfig, Config, DbConfig, KvConfig, PhpConfig, ServerConfig};
     use ephpm_kv::store::StoreConfig;
+    use http_body_util::Empty;
 
     use super::*;
 
@@ -2863,6 +2954,76 @@ mod tests {
             strip.iter().any(|h| h == "proxy"),
             "Proxy (httpoxy) must always be stripped even with no middleware: {strip:?}"
         );
+    }
+
+    // ── Alt-Svc (HTTP/3 discovery) ───────────────────────────────────
+
+    /// Browsers only try HTTP/3 after seeing `Alt-Svc` on a TCP response, so
+    /// this asserts it lands on the ordinary HTTP/1.1+2 path — not just on
+    /// HTTP/3 responses, where it would be useless for discovery.
+    #[tokio::test]
+    async fn alt_svc_is_emitted_on_tls_responses() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+        let router = test_router(dir.path()).with_alt_svc(443, 86400);
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/a.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, true).await.unwrap();
+
+        assert_eq!(
+            resp.headers().get(hyper::header::ALT_SVC).and_then(|v| v.to_str().ok()),
+            Some("h3=\":443\"; ma=86400")
+        );
+    }
+
+    /// An `http://` origin cannot upgrade to HTTP/3 (QUIC mandates TLS), so
+    /// advertising there would only cost bytes.
+    #[tokio::test]
+    async fn alt_svc_is_absent_on_plaintext_responses() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+        let router = test_router(dir.path()).with_alt_svc(443, 86400);
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/a.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+
+        assert!(resp.headers().get(hyper::header::ALT_SVC).is_none());
+    }
+
+    /// `alt_svc_max_age = 0` must suppress the header outright.
+    #[tokio::test]
+    async fn alt_svc_absent_when_max_age_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+        let router = test_router(dir.path()).with_alt_svc(443, 0);
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/a.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, true).await.unwrap();
+
+        assert!(resp.headers().get(hyper::header::ALT_SVC).is_none());
+    }
+
+    /// A router that was never told about an HTTP/3 endpoint must not
+    /// advertise one — this is what keeps `Alt-Svc` from pointing at a port
+    /// that never bound.
+    #[tokio::test]
+    async fn alt_svc_absent_when_http3_is_off() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+        let router = test_router(dir.path());
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/a.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, true).await.unwrap();
+
+        assert!(resp.headers().get(hyper::header::ALT_SVC).is_none());
     }
 
     #[test]
@@ -4046,8 +4207,11 @@ mod tests {
     #[cfg(all(test, php_linked))]
     mod php_etag_tests {
         use ephpm_php::PhpRuntime;
-        use http_body_util::BodyExt;
-        use hyper::body::Empty;
+        // `Empty` lives in `http_body_util`, not `hyper::body` — this module
+        // is `cfg(php_linked)`, so the wrong path went unnoticed until
+        // `Router::handle` became generic over the body type and made
+        // `Request<Empty<Bytes>>` a legal argument at all.
+        use http_body_util::{BodyExt, Empty};
         use serial_test::serial;
 
         use super::*;
@@ -4058,7 +4222,11 @@ mod tests {
         }
 
         /// Helper to create a test request
-        fn make_request(method: &str, path: &str, if_none_match: Option<&str>) -> Request<Empty> {
+        fn make_request(
+            method: &str,
+            path: &str,
+            if_none_match: Option<&str>,
+        ) -> Request<Empty<Bytes>> {
             let mut builder = Request::builder().method(method).uri(path);
             if let Some(tag) = if_none_match {
                 builder = builder.header("if-none-match", tag);

--- a/crates/ephpm-server/src/tls.rs
+++ b/crates/ephpm-server/src/tls.rs
@@ -23,6 +23,30 @@ use tokio_rustls::TlsAcceptor;
 /// Returns an error if the files cannot be read, parsed, or if the cert/key
 /// pair is invalid.
 pub fn build_tls_acceptor(cert_path: &Path, key_path: &Path) -> anyhow::Result<TlsAcceptor> {
+    // Advertise HTTP/2 and HTTP/1.1 (preference order: h2 first).
+    // Clients that support h2 will negotiate it; others fall back to http/1.1.
+    let config = build_server_config(cert_path, key_path, &[b"h2".to_vec(), b"http/1.1".to_vec()])?;
+    Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
+/// Build a [`rustls::ServerConfig`] from PEM cert/key files with the given
+/// ALPN protocol list.
+///
+/// Both transports go through this one function: the TCP listener asks for
+/// `["h2", "http/1.1"]`, the QUIC listener asks for `["h3"]`. Sharing it is
+/// what guarantees they agree on the crypto provider (see
+/// [`crypto_provider`]) — "HTTP/3 negotiated a different provider than HTTPS"
+/// is not representable.
+///
+/// # Errors
+///
+/// Returns an error if the files cannot be read or parsed, or if the
+/// cert/key pair is invalid.
+pub fn build_server_config(
+    cert_path: &Path,
+    key_path: &Path,
+    alpn: &[Vec<u8>],
+) -> anyhow::Result<ServerConfig> {
     let certs = load_certs(cert_path)?;
     let key = load_private_key(key_path)?;
 
@@ -33,11 +57,9 @@ pub fn build_tls_acceptor(cert_path: &Path, key_path: &Path) -> anyhow::Result<T
         .with_single_cert(certs, key)
         .context("invalid TLS certificate/key pair")?;
 
-    // Advertise HTTP/2 and HTTP/1.1 (preference order: h2 first).
-    // Clients that support h2 will negotiate it; others fall back to http/1.1.
-    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    config.alpn_protocols = alpn.to_vec();
 
-    Ok(TlsAcceptor::from(Arc::new(config)))
+    Ok(config)
 }
 
 /// The rustls crypto provider this server uses.
@@ -59,7 +81,9 @@ pub fn build_tls_acceptor(cert_path: &Path, key_path: &Path) -> anyhow::Result<T
 /// stack on a single provider is tracked in issue #241.
 ///
 /// The `OnceLock` means every config built here shares one `Arc`, so "the
-/// whole server uses one provider" is checkable by pointer identity.
+/// whole server uses one provider" is checkable by pointer identity — which
+/// is exactly how the HTTP/3 tests assert that QUIC and HTTPS-over-TCP did
+/// not diverge.
 fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     static PROVIDER: std::sync::OnceLock<Arc<rustls::crypto::CryptoProvider>> =
         std::sync::OnceLock::new();
@@ -76,7 +100,8 @@ fn load_certs(path: &Path) -> anyhow::Result<Vec<CertificateDer<'static>>> {
         .with_context(|| format!("failed to parse PEM certificates from {}", path.display()))?;
     // A PEM file with no CERTIFICATE block parses "successfully" into zero
     // certs; without this check the failure surfaces later as an opaque
-    // rustls error instead of naming the file.
+    // rustls error instead of naming the file (or, for QUIC, as a handshake
+    // that never completes).
     anyhow::ensure!(!certs.is_empty(), "no certificates found in {}", path.display());
     Ok(certs)
 }
@@ -93,24 +118,32 @@ fn load_private_key(path: &Path) -> anyhow::Result<PrivateKeyDer<'static>> {
         .ok_or_else(|| anyhow::anyhow!("no private key found in {}", path.display()))
 }
 
+/// Certificate fixtures shared by the TLS and HTTP/3 test modules.
+///
+/// HTTP/3 has to build its endpoint from the *same* cert-loading path the TCP
+/// listener uses, so its tests need the same fixtures; duplicating them would
+/// let the two drift.
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests_support {
+    use std::path::Path;
     use std::sync::Once;
-
-    use super::*;
 
     static CRYPTO_INIT: Once = Once::new();
 
-    fn init_crypto() {
+    /// Install the process-wide rustls crypto provider exactly once.
+    ///
+    /// Both `ring` and `aws-lc-rs` are compiled into this binary (the TLS pin
+    /// selects ring; `rustls-acme` pulls aws-lc-rs), so rustls refuses to pick
+    /// one implicitly in some configurations. Tests pin it explicitly and
+    /// ignore an `Err` — another test module may have won the race.
+    pub(crate) fn init_crypto() {
         CRYPTO_INIT.call_once(|| {
-            rustls::crypto::ring::default_provider()
-                .install_default()
-                .expect("install ring crypto provider");
+            let _ = rustls::crypto::ring::default_provider().install_default();
         });
     }
 
     /// Generate a self-signed RSA cert+key pair using rcgen.
-    fn generate_rsa_cert(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    pub(crate) fn generate_rsa_cert(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
         let cert_path = dir.join("cert.pem");
         let key_path = dir.join("key.pem");
         let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_RSA_SHA256)
@@ -124,7 +157,7 @@ mod tests {
     }
 
     /// Generate a self-signed EC (P-256) cert+key pair using rcgen.
-    fn generate_ec_cert(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    pub(crate) fn generate_ec_cert(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
         let cert_path = dir.join("ec-cert.pem");
         let key_path = dir.join("ec-key.pem");
         let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
@@ -136,6 +169,12 @@ mod tests {
         std::fs::write(&key_path, key_pair.serialize_pem()).expect("write EC key");
         (cert_path, key_path)
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tests_support::{generate_ec_cert, generate_rsa_cert, init_crypto};
+    use super::*;
 
     #[test]
     fn load_valid_rsa_cert_and_key() {

--- a/crates/ephpm-server/tests/http3_e2e.rs
+++ b/crates/ephpm-server/tests/http3_e2e.rs
@@ -1,0 +1,415 @@
+//! End-to-end HTTP/3 tests: a real QUIC client over a real UDP socket.
+//!
+//! These are not mocks. Each test binds the production QUIC endpoint
+//! ([`ephpm_server::http3::build_endpoint`]), runs the production accept loop
+//! ([`ephpm_server::http3::accept_loop`]) against a real [`Router`], and drives
+//! it with the `h3` client over loopback UDP — full TLS 1.3 handshake, ALPN
+//! negotiation, QPACK header encoding, QUIC stream framing.
+//!
+//! # What these prove, and what they do not
+//!
+//! **Proven:** a third-party HTTP/3 client can complete a QUIC handshake
+//! against ePHPm, that requests traverse the *same* [`Router::handle`] pipeline
+//! HTTP/1.1 and HTTP/2 use (static files, PHP dispatch, body limits, `Alt-Svc`),
+//! and that request bodies sent over QUIC streams reach that pipeline.
+//!
+//! **Not proven:** actual PHP execution. Unless the crate is built with
+//! `PHP_SDK_PATH` set (`php_linked`), `ephpm-php` is compiled in stub mode and
+//! the "PHP" response is its stub page. The PHP-route test below therefore
+//! asserts that the request *reached PHP dispatch with the correctly resolved
+//! script* — which is the part HTTP/3 is responsible for — rather than
+//! asserting on PHP-generated output. `curl --http3` is also not exercised:
+//! the CI container's curl is not built with HTTP/3 support.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+
+use bytes::{Buf, Bytes};
+use ephpm_config::{
+    ClusterConfig, Config, DbConfig, KvConfig, PhpConfig, RequestConfig, ServerConfig,
+};
+use ephpm_kv::store::{Store, StoreConfig};
+use ephpm_server::router::Router;
+use http::{Method, Request, StatusCode};
+
+/// Alt-Svc max-age the tests advertise, distinct from the default so an
+/// accidental fallback to the default would fail the assertion.
+const TEST_ALT_SVC_MAX_AGE: u64 = 4242;
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+/// A CA plus a `localhost` leaf signed by it.
+///
+/// A CA-signed chain (rather than a bare self-signed leaf plus a disabled
+/// verifier) means the client below performs *real* certificate verification —
+/// so a broken cert chain on the server fails these tests instead of sliding
+/// through.
+struct TestCa {
+    /// PEM chain: leaf followed by the CA.
+    cert_pem: String,
+    /// PEM private key for the leaf.
+    key_pem: String,
+    /// DER of the CA, for the client's root store.
+    ca_der: rustls::pki_types::CertificateDer<'static>,
+}
+
+fn issue_certs() -> TestCa {
+    let ca_key = rcgen::KeyPair::generate().expect("ca key");
+    let mut ca_params = rcgen::CertificateParams::new(Vec::new()).expect("ca params");
+    ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params.distinguished_name.push(rcgen::DnType::CommonName, "ephpm http3 test ca");
+    let ca_cert = ca_params.self_signed(&ca_key).expect("self-sign ca");
+
+    let leaf_key = rcgen::KeyPair::generate().expect("leaf key");
+    let leaf_params =
+        rcgen::CertificateParams::new(vec!["localhost".to_owned()]).expect("leaf params");
+    let leaf = leaf_params.signed_by(&leaf_key, &ca_cert, &ca_key).expect("sign leaf");
+
+    TestCa {
+        cert_pem: format!("{}{}", leaf.pem(), ca_cert.pem()),
+        key_pem: leaf_key.serialize_pem(),
+        ca_der: ca_cert.der().clone(),
+    }
+}
+
+/// Install the process-wide rustls provider. Both `ring` and `aws-lc-rs` are
+/// linked into this binary, so pin one rather than letting rustls guess.
+fn init_crypto() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+fn test_config(document_root: &std::path::Path, max_body_size: u64) -> Config {
+    Config {
+        server: ServerConfig {
+            listen: "127.0.0.1:0".to_owned(),
+            document_root: document_root.to_path_buf(),
+            index_files: vec!["index.php".to_owned(), "index.html".to_owned()],
+            fallback: vec![
+                "$uri".to_owned(),
+                "$uri/".to_owned(),
+                "/index.php?$query_string".to_owned(),
+            ],
+            request: RequestConfig { max_body_size, ..RequestConfig::default() },
+            ..ServerConfig::default()
+        },
+        php: PhpConfig::default(),
+        db: DbConfig::default(),
+        kv: KvConfig::default(),
+        cluster: ClusterConfig::default(),
+        middleware: Vec::new(),
+        opcache: ephpm_config::OpcacheConfig::default(),
+    }
+}
+
+/// A running HTTP/3 server: bound endpoint plus the task serving it.
+struct TestServer {
+    addr: SocketAddr,
+    ca_der: rustls::pki_types::CertificateDer<'static>,
+    shutdown: tokio::sync::watch::Sender<bool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl TestServer {
+    /// Bind and start the production HTTP/3 accept loop on an ephemeral port.
+    fn start(document_root: &std::path::Path, max_body_size: u64) -> Self {
+        Self::start_with(test_config(document_root, max_body_size))
+    }
+
+    /// Same, with a caller-supplied config.
+    fn start_with(config: Config) -> Self {
+        init_crypto();
+        let certs = issue_certs();
+        let dir = tempfile::tempdir().expect("cert dir");
+        let cert_path = dir.path().join("chain.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, &certs.cert_pem).expect("write chain");
+        std::fs::write(&key_path, &certs.key_pem).expect("write key");
+
+        let endpoint = ephpm_server::http3::build_endpoint(
+            "127.0.0.1:0".parse().expect("addr"),
+            &cert_path,
+            &key_path,
+        )
+        .expect("bind quic endpoint");
+        let addr = endpoint.local_addr().expect("local addr");
+
+        let store: Arc<Store> = Store::new(StoreConfig::default());
+        let router = Arc::new(
+            Router::new(&config, store, None, None, None, None, None)
+                .with_alt_svc(addr.port(), TEST_ALT_SVC_MAX_AGE),
+        );
+
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        let task = tokio::spawn(async move {
+            ephpm_server::http3::accept_loop(
+                endpoint,
+                router,
+                Arc::new(AtomicUsize::new(0)),
+                async move {
+                    let _ = rx.changed().await;
+                },
+            )
+            .await;
+        });
+
+        // The temp dir holding the PEM files can go away now: quinn read them
+        // at bind time.
+        drop(dir);
+
+        Self { addr, ca_der: certs.ca_der, shutdown: tx, task }
+    }
+
+    /// Open a real HTTP/3 connection and issue one request.
+    async fn request(
+        &self,
+        request: Request<()>,
+        body: Option<Bytes>,
+    ) -> (http::Response<()>, Vec<u8>) {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(self.ca_der.clone()).expect("trust the test CA");
+
+        let mut tls =
+            rustls::ClientConfig::builder().with_root_certificates(roots).with_no_client_auth();
+        tls.alpn_protocols = vec![b"h3".to_vec()];
+
+        let quic_client = quinn::crypto::rustls::QuicClientConfig::try_from(tls)
+            .expect("client crypto supports quic");
+        let mut endpoint =
+            quinn::Endpoint::client("127.0.0.1:0".parse().expect("addr")).expect("client endpoint");
+        endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(quic_client)));
+
+        let connection =
+            endpoint.connect(self.addr, "localhost").expect("connect").await.expect("handshake");
+
+        let (mut driver, mut send_request) =
+            h3::client::new(h3_quinn::Connection::new(connection)).await.expect("h3 client");
+
+        // The driver future must be polled for the connection to make
+        // progress; it resolves when the connection closes.
+        let drive = tokio::spawn(async move {
+            let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+        });
+
+        let mut stream = send_request.send_request(request).await.expect("send request");
+        if let Some(body) = body {
+            stream.send_data(body).await.expect("send body");
+        }
+        stream.finish().await.expect("finish request");
+
+        let response = stream.recv_response().await.expect("recv response");
+
+        let mut bytes = Vec::new();
+        while let Some(mut chunk) = stream.recv_data().await.expect("recv data") {
+            let remaining = chunk.remaining();
+            bytes.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
+        }
+
+        drop(send_request);
+        drive.abort();
+        endpoint.wait_idle().await;
+
+        (response, bytes)
+    }
+
+    async fn stop(self) {
+        let _ = self.shutdown.send(true);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), self.task).await;
+    }
+
+    fn uri(&self, path: &str) -> String {
+        format!("https://localhost:{}{path}", self.addr.port())
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+/// The headline end-to-end: a real HTTP/3 client fetches a static file and
+/// gets its exact bytes back, having negotiated `h3` over TLS 1.3 on UDP.
+#[tokio::test]
+async fn serves_a_static_file_over_real_http3() {
+    let dir = tempfile::tempdir().expect("docroot");
+    std::fs::write(dir.path().join("hello.txt"), b"hello over quic\n").expect("write file");
+
+    let server = TestServer::start(dir.path(), 10 * 1024 * 1024);
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(server.uri("/hello.txt"))
+        .body(())
+        .expect("build request");
+    let (response, body) = server.request(request, None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body, b"hello over quic\n");
+    assert_eq!(
+        response.headers().get(http::header::CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+        Some("text/plain"),
+        "static-file content-type detection must work identically on HTTP/3"
+    );
+
+    server.stop().await;
+}
+
+/// `Alt-Svc` is how clients discover HTTP/3 at all, so it must actually appear
+/// on responses — with the configured max-age, not the default.
+#[tokio::test]
+async fn advertises_alt_svc_with_the_configured_max_age() {
+    let dir = tempfile::tempdir().expect("docroot");
+    std::fs::write(dir.path().join("hello.txt"), b"x").expect("write file");
+
+    let server = TestServer::start(dir.path(), 10 * 1024 * 1024);
+    let expected = format!("h3=\":{}\"; ma={TEST_ALT_SVC_MAX_AGE}", server.addr.port());
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(server.uri("/hello.txt"))
+        .body(())
+        .expect("build request");
+    let (response, _) = server.request(request, None).await;
+
+    assert_eq!(
+        response.headers().get(http::header::ALT_SVC).and_then(|v| v.to_str().ok()),
+        Some(expected.as_str())
+    );
+
+    server.stop().await;
+}
+
+/// An HTTP/3 request for a `.php` file must land in the shared PHP dispatch
+/// path with the script resolved from the document root.
+///
+/// Without `php_linked` the response body is `ephpm-php`'s stub page, which
+/// names the script it *would* have executed — so this asserts the routing and
+/// hand-off HTTP/3 is responsible for, not PHP's own output. On a PHP-linked
+/// build the same request executes PHP for real; the status assertion holds in
+/// both cases.
+#[tokio::test]
+async fn routes_a_php_request_through_the_shared_pipeline() {
+    let dir = tempfile::tempdir().expect("docroot");
+    std::fs::write(dir.path().join("index.php"), "<?php echo \"php over quic\";").expect("write");
+
+    // The router 500s when the PHP runtime was never booted; boot it so the
+    // test exercises dispatch rather than the not-ready guard. In stub builds
+    // this is a flag flip, in PHP-linked builds it starts the real SAPI.
+    let _ = ephpm_php::PhpRuntime::init_with_ini_file(None);
+
+    let server = TestServer::start(dir.path(), 10 * 1024 * 1024);
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(server.uri("/index.php"))
+        .body(())
+        .expect("build request");
+    let (response, body) = server.request(request, None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("php over quic") || text.contains("index.php"),
+        "the PHP handler ran and resolved the script; got: {text}"
+    );
+
+    server.stop().await;
+}
+
+/// Request bodies sent on a QUIC stream must flow through the shared body
+/// pipeline — including its size cap.
+///
+/// This is the strongest transport-independent proof that `H3RequestBody` is
+/// really feeding [`Router::handle`]: the 413 can only come from the router
+/// having read more body bytes than `max_body_size` allows.
+#[tokio::test]
+async fn enforces_the_shared_body_limit_on_http3_uploads() {
+    let dir = tempfile::tempdir().expect("docroot");
+    std::fs::write(dir.path().join("index.php"), "<?php echo \"ok\";").expect("write");
+
+    // 64-byte cap; the upload below is deliberately larger.
+    let server = TestServer::start(dir.path(), 64);
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(server.uri("/index.php"))
+        .body(())
+        .expect("build request");
+    let (response, _) = server.request(request, Some(Bytes::from(vec![b'a'; 4096]))).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::PAYLOAD_TOO_LARGE,
+        "an oversized HTTP/3 upload must hit the same 413 as an HTTP/1.1 one"
+    );
+
+    server.stop().await;
+}
+
+/// Connection-specific header fields are illegal in HTTP/3 (RFC 9114 §4.2)
+/// and `h3` does not filter responses, so ePHPm must.
+///
+/// A `[server.response] headers` entry is the reproducible stand-in for a PHP
+/// script calling `header('Connection: close')`: the shared pipeline adds it to
+/// every response, and the HTTP/3 path must remove it before it reaches the
+/// wire — while leaving an ordinary custom header alone.
+#[tokio::test]
+async fn strips_connection_specific_headers_before_the_wire() {
+    let dir = tempfile::tempdir().expect("docroot");
+    std::fs::write(dir.path().join("hello.txt"), b"x").expect("write file");
+
+    let mut config = test_config(dir.path(), 10 * 1024 * 1024);
+    config.server.response.headers = vec![
+        ["Connection".to_owned(), "close".to_owned()],
+        ["Keep-Alive".to_owned(), "timeout=5".to_owned()],
+        ["X-Custom".to_owned(), "kept".to_owned()],
+    ];
+
+    let server = TestServer::start_with(config);
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(server.uri("/hello.txt"))
+        .body(())
+        .expect("build request");
+    let (response, _) = server.request(request, None).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get(http::header::CONNECTION).is_none(),
+        "Connection is illegal in HTTP/3 and must not reach the client"
+    );
+    assert!(response.headers().get("keep-alive").is_none(), "Keep-Alive is illegal in HTTP/3");
+    assert_eq!(
+        response.headers().get("x-custom").and_then(|v| v.to_str().ok()),
+        Some("kept"),
+        "ordinary custom headers must still be delivered"
+    );
+
+    server.stop().await;
+}
+
+/// A client that does not offer the `h3` ALPN must be rejected at the
+/// handshake — the listener speaks HTTP/3 and nothing else.
+#[tokio::test]
+async fn rejects_a_client_without_the_h3_alpn() {
+    let dir = tempfile::tempdir().expect("docroot");
+    let server = TestServer::start(dir.path(), 10 * 1024 * 1024);
+
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(server.ca_der.clone()).expect("trust the test CA");
+    let mut tls =
+        rustls::ClientConfig::builder().with_root_certificates(roots).with_no_client_auth();
+    tls.alpn_protocols = vec![b"not-h3".to_vec()];
+
+    let quic_client =
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls).expect("client crypto");
+    let mut endpoint =
+        quinn::Endpoint::client("127.0.0.1:0".parse().expect("addr")).expect("client endpoint");
+    endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(quic_client)));
+
+    let result = endpoint.connect(server.addr, "localhost").expect("connect").await;
+    assert!(result.is_err(), "ALPN mismatch must fail the QUIC handshake");
+
+    server.stop().await;
+}

--- a/crates/ephpm-server/tests/tls_provider_independence.rs
+++ b/crates/ephpm-server/tests/tls_provider_independence.rs
@@ -53,6 +53,19 @@ fn tcp_tls_acceptor_builds_without_an_installed_provider() {
         .expect("static-cert TLS must not need a process-default crypto provider");
 }
 
+/// HTTP/3 builds its QUIC endpoint through the same `tls.rs` code path, so it
+/// inherits the fix — asserted here rather than assumed.
+#[tokio::test]
+async fn http3_endpoint_builds_without_an_installed_provider() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (cert, key) = self_signed(dir.path());
+
+    let endpoint =
+        ephpm_server::http3::build_endpoint("127.0.0.1:0".parse().expect("addr"), &cert, &key)
+            .expect("HTTP/3 endpoint must not need a process-default crypto provider");
+    endpoint.close(quinn::VarInt::from_u32(0), b"test over");
+}
+
 /// A valid PEM that simply contains no CERTIFICATE block must be rejected
 /// against the offending file, not deferred into an opaque rustls error.
 ///

--- a/ephpm.toml
+++ b/ephpm.toml
@@ -87,6 +87,14 @@ ini_overrides = [
 # listen = "0.0.0.0:443"          # separate HTTPS port (omit to make server.listen HTTPS-only)
 # redirect_http = true             # 301 redirect HTTP → HTTPS (requires tls.listen)
 
+# HTTP/3 (QUIC). Runs on UDP alongside the TCP listeners - HTTP/1.1 and
+# HTTP/2 are unaffected. Requires a static [server.tls] cert+key above;
+# enabling it with ACME is a startup error, not a silent downgrade.
+# [server.http3]
+# enabled = true                   # default: false
+# listen = "0.0.0.0:443"           # omit to reuse the HTTPS address on UDP
+# alt_svc_max_age = 86400          # ma= in the Alt-Svc header; 0 disables it
+
 # ──────────────────────────────────────────────────────────
 # Database Proxy & Connection Pooling (planned)
 # ──────────────────────────────────────────────────────────

--- a/site/content/architecture/_index.md
+++ b/site/content/architecture/_index.md
@@ -106,7 +106,7 @@ Every ePHPm node runs as a serving node. The Node API is always present — it's
 │  (hyper /   │  (MySQL/PG)   │  (gRPC :4317 /         │
 │   tokio)    │  + query      │   HTTP :4318)          │
 │  + HTTP/2   │    digest     │                        │
-│  + QUIC     │  + slow query │                        │
+│  + HTTP/3   │  + slow query │                        │
 │             │    analysis   │                        │
 ├─────────────┼───────────────┼────────────────────────┤
 │  ACME TLS   │  Clustered KV │  Node API :9090        │
@@ -270,7 +270,7 @@ password = "changeme"                 # admin UI auth (separate from node API au
 |---|---|
 | Async runtime | `tokio` |
 | HTTP/1.1 + HTTP/2 | `hyper` |
-| HTTP/3 (QUIC) | `quinn` (planned) |
+| HTTP/3 (QUIC) | `quinn` + `h3` (opt-in via `[server.http3]`) |
 | TLS | `rustls` |
 | Automatic ACME TLS | `rustls-acme` |
 | PHP embedding | Custom Rust FFI + `libphp` (linked via `ephpm-php`'s `build.rs` + `bindgen`) |

--- a/site/content/architecture/http.md
+++ b/site/content/architecture/http.md
@@ -244,6 +244,23 @@ TCP Accept → TLS Handshake (tokio-rustls) → HTTP/1.1 or HTTP/2 → Router
 - `is_tls` flag propagated to router so `$_SERVER['HTTPS']` is set correctly
 - When behind a trusted proxy, `X-Forwarded-Proto` takes precedence over native TLS status
 
+## HTTP/3 (QUIC)
+
+Opt-in via `[server.http3] enabled = true` (default off). HTTP/3 is **additive**: it binds a UDP socket next to the TCP listeners, which keep serving HTTP/1.1 and HTTP/2 unchanged. By default the UDP socket takes the same address and port as the HTTPS listener.
+
+```
+UDP Recv → QUIC handshake (quinn, TLS 1.3, ALPN "h3") → h3 session
+        → per-request stream → Router::handle → same pipeline as TCP
+```
+
+Design points:
+
+- **One pipeline, two transports.** `Router::handle` is generic over the request-body type (`RequestBody` in `router.rs`). The TCP path passes hyper's `Incoming`; HTTP/3 passes `http3::H3RequestBody`, an adapter over a QUIC receive stream. Everything downstream — vhost resolution, middleware, static files, `$_SERVER`, body limits, `ephpm_http_*` metrics — is shared code, not a parallel implementation. The TCP path monomorphizes to what it compiled to before, so there is no added runtime cost.
+- **One crypto provider.** The QUIC endpoint's `rustls::ServerConfig` is built by the same `tls::build_server_config` the TCP listener uses; only the ALPN list differs (`h3` vs `h2`/`http/1.1`). A unit test asserts both configs resolve the identical provider — two live rustls providers in one process is a runtime hazard.
+- **Discovery is via `Alt-Svc`.** Browsers speak TCP first and only try HTTP/3 after seeing `Alt-Svc: h3=":443"; ma=86400` on an HTTPS response. ePHPm adds that header to every TLS-terminated response (never to plain `http://`, which cannot upgrade), and only after the QUIC socket has actually bound.
+- **Static certificates only.** `quinn::ServerConfig` captures its crypto at endpoint-creation time, while `rustls-acme` rotates certificates mid-process. Enabling HTTP/3 with ACME is a **startup error** rather than a quiet fall back to TCP-only. ACME support is planned.
+- **Graceful shutdown.** The QUIC accept loop stops on the same shutdown signal and sends `CONNECTION_CLOSE`; in-flight HTTP/3 work is counted in the same in-flight gauge the TCP drain waits on.
+
 ### Automatic TLS (ACME)
 
 Zero-config HTTPS via Let's Encrypt, like Caddy. Uses `rustls-acme` crate with TLS-ALPN-01 challenge (works on port 443 alone, no port 80 needed).

--- a/site/content/migration/nginx-php-fpm.md
+++ b/site/content/migration/nginx-php-fpm.md
@@ -277,7 +277,7 @@ sudo systemctl disable nginx php8.2-fpm
 - **Nginx as a reverse proxy** — if you're proxying to non-PHP backends (Node, Python, etc.), you still need a reverse proxy for those.
 - **Multiple FPM pools** — ePHPm has one shared thread pool. If you run separate pools for different sites with different users, use ePHPm's virtual hosts instead (same isolation, simpler config).
 - **Nginx modules** — `ngx_pagespeed`, `ngx_brotli`, etc. Most functionality is built into ePHPm or handled at the application level.
-- **HTTP/3 (QUIC)** — not yet implemented in ePHPm. Nginx supports it via `nginx-quic`.
+- **ACME certificates on HTTP/3** — ePHPm serves HTTP/3 (QUIC), but only with a static TLS cert/key; see [`[server.http3]`](/reference/config/#serverhttp3). Nginx has the same constraint in practice.
 
 ## Laravel-Specific Notes
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -122,6 +122,32 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `listen` | string | (none) | Separate HTTPS listener. When set, `[server] listen` serves HTTP and this serves HTTPS. |
 | `redirect_http` | bool | `false` | When `listen` is set, the HTTP listener redirects everything to HTTPS (301). |
 
+### `[server.http3]`
+
+HTTP/3 runs over **UDP**, *in addition to* the TCP listeners — HTTP/1.1 and HTTP/2 keep working exactly as before. Enabling it binds one extra UDP socket.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the HTTP/3 (QUIC) listener. Requires a static `[server.tls]` `cert`+`key`; startup **fails** if TLS is absent or in ACME mode rather than silently serving TCP only. |
+| `listen` | string | (none) | UDP address for QUIC. Unset derives it from the HTTPS listener — `[server.tls] listen` when set, otherwise `[server] listen` — i.e. the same port as HTTPS, on UDP. |
+| `alt_svc_max_age` | u64 (sec) | `86400` (24 h) | `ma=` value of the `Alt-Svc` header advertised on HTTPS responses. `0` suppresses the header entirely. |
+
+**Clients only reach HTTP/3 after seeing `Alt-Svc`.** A browser speaks TCP first and switches to HTTP/3 on a later request, once it has seen `Alt-Svc: h3=":443"; ma=86400` on an HTTPS response. ePHPm emits that header on every TLS-terminated response (not on plain `http://`, which cannot upgrade). Setting `alt_svc_max_age = 0` means no browser will ever discover HTTP/3 — only clients told about it out of band (`curl --http3-only`, or an `HTTPS`/`SVCB` DNS record) will connect.
+
+**Limitation — ACME is not supported on HTTP/3 yet.** QUIC bakes its certificate into the endpoint at bind time, whereas `rustls-acme` rotates certificates during the process lifetime. `enabled = true` together with ACME TLS is a startup error, deliberately: ePHPm refuses to come up quietly without the HTTP/3 listener you asked for. Use a static `cert`/`key` for now; ACME support is planned.
+
+**Firewalls:** QUIC is UDP. Opening TCP/443 is not enough — UDP on the same port must also be reachable, or clients will try HTTP/3, fail, and silently fall back to TCP.
+
+```toml
+[server.tls]
+cert = "/etc/ephpm/fullchain.pem"
+key  = "/etc/ephpm/privkey.pem"
+
+[server.http3]
+enabled = true          # binds UDP on the HTTPS address
+alt_svc_max_age = 86400
+```
+
 ## `[php]`
 
 | Key | Type | Default | Description |

--- a/site/content/reference/environment-variables.md
+++ b/site/content/reference/environment-variables.md
@@ -69,6 +69,11 @@ EPHPM_CLUSTER__NODE_ID=$HOSTNAME                     # pod name as ordinal hint
 EPHPM_SERVER__TLS__DOMAINS='["example.com"]'
 EPHPM_SERVER__TLS__EMAIL=admin@example.com
 EPHPM_SERVER__TLS__CACHE_DIR=/data/certs
+
+# HTTP/3 (QUIC). Needs a static [server.tls] cert+key — enabling this with
+# ACME is a startup error, not a silent downgrade to TCP-only.
+EPHPM_SERVER__HTTP3__ENABLED=true
+EPHPM_SERVER__HTTP3__ALT_SVC_MAX_AGE=86400
 ```
 
 ## Logging-only env var

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -34,6 +34,21 @@ Metrics are emitted via the [`metrics`](https://docs.rs/metrics/) façade and ex
 | `ephpm_http_timeouts_total` | counter | `stage` | Requests killed by the request timeout. Only value: `request`. |
 | `ephpm_rate_limited_total` | counter | — | Rejections from `[server.limits]`. Incremented only for per-IP rate limiting. |
 
+## HTTP/3 (QUIC)
+
+Emitted only when `[server.http3] enabled = true`; the series are absent otherwise. HTTP/3 requests **also** increment every `ephpm_http_*` metric above — the shared request pipeline records those regardless of transport — so these are transport-level counters on top, not a separate accounting.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ephpm_http3_connections_total` | counter | — | QUIC connections that completed their handshake. |
+| `ephpm_http3_connections_active` | gauge | — | Currently established QUIC connections. |
+| `ephpm_http3_connection_errors_total` | counter | `stage` | Per-connection failures. `stage="handshake"` (bad ALPN, version negotiation, client gave up before the handshake completed) or `stage="session"` (the HTTP/3 session failed after the handshake). |
+| `ephpm_http3_requests_total` | counter | — | Requests accepted on HTTP/3 streams. |
+| `ephpm_http3_request_duration_seconds` | histogram | — | HTTP/3 request time including writing the response body out over QUIC. Uses the same buckets as `ephpm_http_request_duration_seconds`, so the two overlay directly. |
+| `ephpm_http3_stripped_headers_total` | counter | — | Connection-specific response header names removed before sending (RFC 9114 §4.2 forbids `Connection`, `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding`, `Upgrade` in HTTP/3). Non-zero means an app or a `[server.response] headers` entry is emitting a header that is meaningless over HTTP/3 — worth fixing at the source. |
+
+A rising `ephpm_http3_connection_errors_total{stage="handshake"}` with `ephpm_http3_connections_total` flat usually means UDP is being blocked on the path — clients are trying HTTP/3 and falling back to TCP.
+
 ## PHP
 
 | Metric | Type | Labels | Description |
@@ -133,7 +148,7 @@ The `path`-style labels you might expect on HTTP metrics (`/users/123`) are deli
 
 Buckets are custom per metric — configured with `Matcher::Full` rules in [`crates/ephpm-server/src/metrics.rs`](https://github.com/ephpm/ephpm/blob/main/crates/ephpm-server/src/metrics.rs), not the `metrics_exporter_prometheus` builder defaults:
 
-- Duration histograms (`ephpm_http_request_duration_seconds`, `ephpm_php_execution_duration_seconds`, `ephpm_worker_request_wait_seconds`): 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 seconds
+- Duration histograms (`ephpm_http_request_duration_seconds`, `ephpm_http3_request_duration_seconds`, `ephpm_php_execution_duration_seconds`, `ephpm_worker_request_wait_seconds`): 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 seconds
 - `ephpm_worker_boot_duration_seconds`: 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30 seconds (framework boot can take seconds)
 - Body-size histograms (`ephpm_http_request_body_bytes`, `ephpm_http_response_body_bytes`, `ephpm_php_output_bytes`): 100 B, 1 KB, 10 KB, 50 KB, 100 KB, 500 KB, 1 MB, 5 MB, 10 MB
 - `ephpm_http_compression_ratio`: 0.05 through 0.9

--- a/site/content/roadmap/webserver-feature-parity.md
+++ b/site/content/roadmap/webserver-feature-parity.md
@@ -84,7 +84,7 @@ How ephpm stacks up against the traditional servers PHP developers reach for. Ev
 | IP allow/deny lists | Require ip | allow/deny | remote_ip matcher | Not yet | path-based blocking is covered |
 | Regex `[[server.redirects]]` (301/302 from regex) | mod_rewrite `[R]` | rewrite ... permanent | redir | Not yet | SEO migrations / vanity URLs |
 | Regex `[[server.rewrites]]` with conditions | mod_rewrite `RewriteCond` | rewrite if blocks | rewrite matcher | Not yet | Beyond `server.fallback` |
-| HTTP/3 (QUIC) | Not supported | Experimental | Built-in | Not yet | Would need `quinn` integration |
+| HTTP/3 (QUIC) | Not supported | Experimental | Built-in | **Yes** | `quinn` + `h3`, opt-in via `[server.http3]`. Static TLS cert only — ACME not wired in yet |
 | Basic auth | mod_auth_basic | auth_basic | basic_auth | Not yet | Useful for staging gating |
 | Directory listing / autoindex | Options +Indexes | autoindex | file_server browse | Not yet | Largely replaced by S3-style buckets these days |
 | Zstd compression (HTTP responses) | N/A | N/A | Plugin | Not yet | KV store supports zstd; HTTP response negotiation does not |


### PR DESCRIPTION
> **#243 is merged; this is now purely the HTTP/3 feature.** Rebased onto `main` @ ae832b1 (which includes #243, #236 and #230). Git dropped the duplicated TLS commit automatically, so the diff no longer replays it - the only remaining `tls.rs` change here is the `build_server_config` extraction HTTP/3 needs, and the only `tls_provider_independence.rs` change is the added HTTP/3 case. Re-verified against the new base: fmt/clippy clean, 63 test binaries, 0 failures.

Adds HTTP/3 (QUIC) to the HTTP server, opt-in via `[server.http3] enabled` (default **false**).

## Design

**UDP listener vs TCP.** HTTP/3 is *additive*. Enabling it binds one extra UDP socket; the TCP listeners keep serving HTTP/1.1 and HTTP/2 with no behavior change. By default the UDP socket takes the same address and port as the HTTPS listener (`[server.tls] listen` when set, otherwise `[server] listen`) — same authority, same port number, different transport, which is what browsers expect. `[server.http3] listen` overrides it.

**One pipeline, two transports.** `Router::handle` is now generic over the request-body type via a new `RequestBody` trait alias in `router.rs`. The TCP path passes hyper's `Incoming`; HTTP/3 passes `http3::H3RequestBody`, an adapter over a QUIC receive stream. Everything downstream — vhost resolution, middleware, static files, `$_SERVER`, rate limiting, body limits, the `ephpm_http_*` metrics — is shared code. There is no second request pipeline. The TCP path monomorphizes to exactly what it compiled to before, so there is no added runtime cost on the hot path.

Five helper functions that only read headers/URI (`extract_server_name`, `accepts_encoding`, `check_body_size`, `check_trusted_host`, `resolve_proxy_info`) became generic over `B` as a consequence. No logic changed.

**Alt-Svc discovery.** Browsers speak TCP first and only try HTTP/3 after seeing `Alt-Svc: h3=":443"; ma=86400` on an HTTPS response. ePHPm emits it on every TLS-terminated response — not on plain `http://`, which cannot upgrade to QUIC. `Router::with_alt_svc` is called from `serve()` **after** the UDP socket has bound, and the port is read back off the socket rather than from config, so a `listen = "…:0"` never advertises `:0` and a failed bind never advertises anything. `alt_svc_max_age = 0` suppresses the header; startup warns that browsers will then never discover h3.

**Cert sourcing, and the ACME limitation.** The QUIC endpoint's rustls config comes from `tls::build_server_config` — the exact function the TCP listener uses. Only the ALPN list differs (`h3` vs `h2`/`http/1.1`).

ACME is **not** wired into HTTP/3. `quinn::ServerConfig` captures its crypto config when the endpoint is created, while `rustls-acme` hands out certificates through a `ResolvesServerCert` that rotates mid-process. Plumbing rotation through `Endpoint::set_server_config` is possible but is a second subsystem that needs live ACME to test, so it is deliberately out of scope here. Per the brief, ePHPm does **not** silently start without h3: `enabled = true` with ACME TLS (or with no TLS at all) is a **startup error** with an actionable message. Documented as "HTTP/3 requires static `[server.tls]` cert/key; ACME support is planned."

**RFC 9114 §4.2 normalization.** No request-side work is needed — h3 already stamps `Version::HTTP_3` (so `$_SERVER['SERVER_PROTOCOL']` reads `HTTP/3.0`) and treats connection-specific request fields as a stream error. The *response* side is different: h3 QPACK-encodes whatever it is handed, so a PHP script setting a `Connection: close` response header, or a `[server.response] headers` entry, would put an illegal field on the wire. `Connection`, `Keep-Alive`, `Proxy-Connection`, `Transfer-Encoding` and `Upgrade` are stripped and counted. `TE` is left alone — RFC 9114 permits it with value `trailers`.

**Graceful shutdown.** The QUIC accept loop stops on the same shutdown path and sends `CONNECTION_CLOSE`; in-flight HTTP/3 work shares the `in_flight` counter the TCP drain waits on.

## Crypto provider

The underlying hazard — two rustls providers compiled in, and the bare `ServerConfig::builder()` that panicked because of it — is fixed in **#243**, along with its regression guard. This PR depends on that fix: `http3::build_endpoint` goes through the same `tls.rs` provider, so QUIC and HTTPS-over-TCP cannot diverge.

Two assertions here rather than assumptions:

- `http3_and_tcp_tls_share_one_crypto_provider` builds both configs and checks `Arc::ptr_eq` on their providers. Because #243's `crypto_provider()` caches one `Arc`, that is a genuine identity check, not "two equivalent instances".
- `tls_provider_independence.rs` gains an HTTP/3 case, so the QUIC endpoint is also proven to build in a process where no provider was ever installed.

For the record on the new deps: `cargo tree -e features` confirms `rustls 0.23.37` had **both** `ring` and `aws-lc-rs` enabled *before* this PR. Adding quinn with the `rustls-ring` feature introduces **no** provider that was not already in the graph. `quinn-proto`'s `QuicServerConfig::try_from` is provider-agnostic; the feature only gates convenience constructors we do not use.

The `build_server_config` extraction (same loader and provider, parameterised by ALPN list) happens here, since HTTP/3 is its only second caller.

## Dependencies and cargo deny

**Verdict: `advisories ok, bans ok, licenses ok, sources ok`** (cargo-deny 0.19.8, the version nightly CI pins). No new `deny.toml` ignores.

| Crate | Version | New? | License |
|---|---|---|---|
| `h3` | 0.0.8 | new | MIT |
| `h3-quinn` | 0.0.10 | new | MIT |
| `quinn` | 0.11.9 | already in `Cargo.lock` | MIT OR Apache-2.0 |

Only **two** new packages. `quinn` was already in the lockfile as an **unused optional dependency of `reqwest`** (its `http3` feature, which is off) — so it had no path in the dependency graph and was not compiled into any binary. This PR promotes it to a real, reachable dependency with `default-features = false, features = ["runtime-tokio", "rustls-ring", "log"]`.

That promotion is precisely why `cargo deny` flagged **RUSTSEC-2026-0185** in `quinn-proto 0.11.14` here and not on main — remote memory exhaustion via unbounded out-of-order QUIC stream reassembly, in exactly the code this PR starts exercising. The `0.11.15` bump lives in **#243** and this branch inherits it. Duplicate-version warnings are pre-existing (`multiple-versions = "warn"`).

## What the e2e actually proves — and what it does not

`crates/ephpm-server/tests/http3_e2e.rs` is a real HTTP/3 client over a real UDP socket, not a mock. Each test binds the production endpoint (`http3::build_endpoint`), runs the production accept loop (`http3::accept_loop`) against a real `Router`, and drives it with the `h3` client over loopback — full TLS 1.3 handshake, ALPN negotiation, QPACK, QUIC stream framing. The client verifies the certificate for real (rcgen CA + `localhost` leaf, CA in a `RootCertStore`), so a broken chain fails the tests rather than sliding through.

**Proven (6 tests, all passing):**

- `serves_a_static_file_over_real_http3` — exact file bytes and content-type back over h3
- `advertises_alt_svc_with_the_configured_max_age` — asserts a non-default `ma`, so a fallback to the default would fail
- `routes_a_php_request_through_the_shared_pipeline` — a `.php` request reaches PHP dispatch with the script resolved from the docroot
- `enforces_the_shared_body_limit_on_http3_uploads` — an oversized POST gets 413. This is the strongest proof the QUIC body really feeds the shared pipeline: the client sends no `Content-Length`, so the 413 can only come from the router streaming and counting actual body bytes through `H3RequestBody`
- `strips_connection_specific_headers_before_the_wire` — a `Connection`/`Keep-Alive` pair configured on every response is absent on the h3 wire while an ordinary custom header survives
- `rejects_a_client_without_the_h3_alpn` — ALPN mismatch fails the handshake

**Not proven — stated plainly rather than implied:**

- **Real PHP execution.** Without `PHP_SDK_PATH`, `ephpm-php` compiles in stub mode, so the "PHP" response is its stub page. The test asserts the routing and hand-off HTTP/3 is responsible for, not PHP-generated output. On a PHP-linked build the same request executes PHP and the status assertion still holds.
- **`curl --http3`.** The CI container's curl is not built with HTTP/3 support (most distro curls are not). A Rust h3 client was used instead. No cross-implementation interop beyond `h3` is claimed.
- **Browsers.** No real-browser Alt-Svc upgrade was exercised; the header content is asserted, the browser's reaction to it is not.
- **Loss, congestion, 0-RTT, connection migration.** Loopback only.

Also fixed a **pre-existing dormant test module** found on the way: `router::tests::php_etag_tests` is `#[cfg(all(test, php_linked))]` and imported `hyper::body::Empty`, which does not exist — so it had never compiled. Corrected to `http_body_util::Empty`. Note this is still not compiled by CI — no job runs `cargo test` with PHP linked — so the fix is correct by inspection rather than proven by a green check.

## Metrics

All recorded at a live call site; no phantom series. Documented in `site/content/reference/metrics.md`, and the duration histogram's buckets are registered in `metrics.rs` alongside the existing duration metrics.

| Metric | Type | Labels |
|---|---|---|
| `ephpm_http3_connections_total` | counter | — |
| `ephpm_http3_connections_active` | gauge | — |
| `ephpm_http3_connection_errors_total` | counter | `stage` = `handshake` or `session` |
| `ephpm_http3_requests_total` | counter | — |
| `ephpm_http3_request_duration_seconds` | histogram | — |
| `ephpm_http3_stripped_headers_total` | counter | — |

HTTP/3 requests also increment every `ephpm_http_*` metric, since they go through the shared pipeline — these are transport-level counters on top, not separate accounting.

## Config knob

`[server.http3]`, following the `add-config-knob` checklist in full — field, `default_*` fn, doc comment, enforcement, reference-docs row, and tests, all here.

| Key | Type | Default | Notes |
|---|---|---|---|
| `enabled` | bool | **`false`** | Opt-in. Requires static TLS; ACME or no-TLS is a startup error |
| `listen` | string | (none) | Derives from the HTTPS address (same port, UDP) |
| `alt_svc_max_age` | u64 secs | `86400` | `ma=` in `Alt-Svc`; `0` suppresses the header |

Default choice: off, because it binds an extra socket and needs a certificate — an operator should opt in. Neither supporting knob can become a silent no-op: with `enabled = false`, a non-default `listen` or `alt_svc_max_age` logs a startup warning.

Config tests cover **section absent** (defaults, and that the hand-written `ServerConfig::default()` agrees with what serde produces), **section present but partial** (field defaults are not zeroed), all fields parsed, and both `EPHPM_SERVER__HTTP3__*` env overrides — installed with `test_env::EnvVars`, never `std::env::set_var`.

## Docs

`reference/config.md` (new section, worked example, firewall note that UDP must be open, explicit ACME limitation), `reference/metrics.md`, `reference/environment-variables.md`, `architecture/http.md` (new HTTP/3 section), `architecture/_index.md`, `roadmap/webserver-feature-parity.md` and `migration/nginx-php-fpm.md` (all three previously said HTTP/3 was unimplemented), plus a commented block in `ephpm.toml`.

## Verification

Run in the `ephpm-verify:main` container:

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 60 test binaries, 0 failures
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`

All re-run after the rebase onto main @ ae832b1. Earlier revisions of this branch were 8/8 green in CI, including all three E2E bare-process PHP versions.

Edits are confined to `crates/ephpm-server/src/{http3,router,tls,lib,metrics}.rs` and `ephpm-config`, so no overlap with #231 (`turso_cdc.rs`), #236 (`ephpm-db`) or #230 (`xtask/e2e_bare.rs`). Follow-up on provider consolidation: #241. Do not merge — #243 first, then CI here.


