### PR TITLE
fix(tls): static-certificate TLS panics at startup — two rustls crypto providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/crates/ephpm-server/src/tls.rs
+++ b/crates/ephpm-server/src/tls.rs
@@ -26,7 +26,9 @@ pub fn build_tls_acceptor(cert_path: &Path, key_path: &Path) -> anyhow::Result<T
     let certs = load_certs(cert_path)?;
     let key = load_private_key(key_path)?;
 
-    let mut config = ServerConfig::builder()
+    let mut config = ServerConfig::builder_with_provider(crypto_provider())
+        .with_safe_default_protocol_versions()
+        .context("crypto provider does not support the default TLS versions")?
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .context("invalid TLS certificate/key pair")?;
@@ -38,14 +40,45 @@ pub fn build_tls_acceptor(cert_path: &Path, key_path: &Path) -> anyhow::Result<T
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 
+/// The rustls crypto provider this server uses.
+///
+/// **This must be named explicitly, and `ServerConfig::builder()` must never
+/// be called.** Both `ring` and `aws-lc-rs` end up compiled in: the workspace
+/// pins `rustls` to `ring`, while `rustls-acme`, `rcgen` and `hyper-rustls`
+/// (via `metrics-exporter-prometheus`) enable `aws-lc-rs`, and Cargo unions
+/// features. With both features on, rustls' `from_crate_features()` returns
+/// `None` — it does not pick one — so the bare builder panics at runtime:
+///
+/// > Could not automatically determine the process-level CryptoProvider from
+/// > Rustls crate features.
+///
+/// That is not hypothetical: it made every `[server.tls]` static-certificate
+/// startup abort with exit 101. See `tests/tls_provider_independence.rs`.
+///
+/// `ring` is chosen to match the workspace `rustls` pin. Consolidating the
+/// stack on a single provider is tracked in issue #241.
+///
+/// The `OnceLock` means every config built here shares one `Arc`, so "the
+/// whole server uses one provider" is checkable by pointer identity.
+fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    static PROVIDER: std::sync::OnceLock<Arc<rustls::crypto::CryptoProvider>> =
+        std::sync::OnceLock::new();
+    Arc::clone(PROVIDER.get_or_init(|| Arc::new(rustls::crypto::ring::default_provider())))
+}
+
 /// Load PEM-encoded certificates from a file.
 fn load_certs(path: &Path) -> anyhow::Result<Vec<CertificateDer<'static>>> {
     let file =
         File::open(path).with_context(|| format!("cannot open cert file: {}", path.display()))?;
     let mut reader = BufReader::new(file);
-    rustls_pemfile::certs(&mut reader)
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
         .collect::<Result<Vec<_>, _>>()
-        .with_context(|| format!("failed to parse PEM certificates from {}", path.display()))
+        .with_context(|| format!("failed to parse PEM certificates from {}", path.display()))?;
+    // A PEM file with no CERTIFICATE block parses "successfully" into zero
+    // certs; without this check the failure surfaces later as an opaque
+    // rustls error instead of naming the file.
+    anyhow::ensure!(!certs.is_empty(), "no certificates found in {}", path.display());
+    Ok(certs)
 }
 
 /// Load a private key from a PEM file.

--- a/crates/ephpm-server/tests/tls_provider_independence.rs
+++ b/crates/ephpm-server/tests/tls_provider_independence.rs
@@ -1,0 +1,73 @@
+//! The TLS stack must not depend on a process-default rustls crypto provider.
+//!
+//! **This file must live in its own integration-test binary and must never
+//! call `CryptoProvider::install_default()`.** That is the entire point.
+//!
+//! Both `ring` and `aws-lc-rs` end up compiled in — the workspace pins
+//! `rustls` to `ring`, while `rustls-acme`, `rcgen` and `hyper-rustls` (via
+//! `metrics-exporter-prometheus`) enable `aws-lc-rs`, and Cargo unions
+//! features. In that configuration rustls' `from_crate_features()` returns
+//! `None` rather than picking one, so `rustls::ServerConfig::builder()`
+//! panics unless something already installed a provider:
+//!
+//! > Could not automatically determine the process-level CryptoProvider from
+//! > Rustls crate features.
+//!
+//! `crates/ephpm-server/src/tls.rs` did exactly that, so every server
+//! configured with a static `[server.tls]` cert/key aborted at startup with
+//! exit 101 — reproduced on v0.6.1 and on main. It survived review and CI
+//! because:
+//!
+//! - `rustls-acme` always calls `builder_with_provider`, so the ACME path was
+//!   unaffected and kept working; and
+//! - every unit test in `tls.rs` calls `install_default()` first, which masks
+//!   the panic for the whole test binary.
+//!
+//! That second point is why this file is separate. Adding an
+//! `install_default()` call anywhere in this binary, or folding these tests
+//! into one that has such a call, silently disarms them.
+//!
+//! Provider consolidation is tracked in issue #241.
+
+use std::path::{Path, PathBuf};
+
+fn self_signed(dir: &Path) -> (PathBuf, PathBuf) {
+    let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).expect("key pair");
+    let params = rcgen::CertificateParams::new(vec!["localhost".to_owned()]).expect("params");
+    let cert = params.self_signed(&key_pair).expect("self-sign");
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    std::fs::write(&cert_path, cert.pem()).expect("write cert");
+    std::fs::write(&key_path, key_pair.serialize_pem()).expect("write key");
+    (cert_path, key_path)
+}
+
+/// Building the acceptor is what `serve()` does for `[server.tls]` cert/key.
+/// Before the fix this panicked instead of returning.
+#[test]
+fn tcp_tls_acceptor_builds_without_an_installed_provider() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (cert, key) = self_signed(dir.path());
+
+    ephpm_server::tls::build_tls_acceptor(&cert, &key)
+        .expect("static-cert TLS must not need a process-default crypto provider");
+}
+
+/// A valid PEM that simply contains no CERTIFICATE block must be rejected
+/// against the offending file, not deferred into an opaque rustls error.
+///
+/// The case used here is the one operators actually hit: `cert` pointed at
+/// the private key. That parses cleanly and yields zero certificates, so
+/// without an explicit check it slips past `load_certs`.
+#[test]
+fn certificate_pem_with_no_certificate_is_reported_against_the_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (_cert, key) = self_signed(dir.path());
+
+    // `TlsAcceptor` is not `Debug`, so unwrap the Result by hand.
+    let Err(err) = ephpm_server::tls::build_tls_acceptor(&key, &key) else {
+        panic!("a PEM with no certificate must not be accepted");
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("no certificates found"), "unexpected error: {msg}");
+}


### PR DESCRIPTION
## Reproduction: manual `[server.tls]` panics at startup on `main` and on shipped v0.6.1

Reproduced end-to-end with a real binary, not reasoned about. Unmodified `main` (39a42dc), `cargo build -p ephpm`, an openssl self-signed cert, and this config:

```toml
[server]
listen = "127.0.0.1:8443"
document_root = "/tmp/repro/www"

[server.tls]
cert = "/tmp/repro/cert.pem"
key  = "/tmp/repro/key.pem"
```

```
INFO ephpm_server: TLS enabled (manual) cert=/tmp/repro/cert.pem key=/tmp/repro/key.pem

thread 'main' (41) panicked at rustls-0.23.37/src/crypto/mod.rs:249:14:

Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make
sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.

EXIT=101
```

The process dies immediately after logging `TLS enabled (manual)`. It never binds a listener.

### Shipped releases are affected

**v0.6.1 was rebuilt from its tag and run the same way — identical panic, exit 101.**

| Release | `rustls` has both provider features (non-dev graph) | bare `ServerConfig::builder()` in `tls.rs` | verified by running |
|---|---|---|---|
| `main` (39a42dc) | yes | yes | **panics, exit 101** |
| `v0.6.1` | yes | yes | **panics, exit 101** |
| `v0.6.0` | yes | yes | not run (identical condition) |
| `v0.5.2` | yes | yes | not run (identical condition) |

So this is a user-facing regression in shipped artifacts, and **v0.6.x warrants an advisory note**: static-certificate HTTPS does not start at all. Anyone on `[server.tls]` cert/key is affected; the workaround until a patch release is ACME mode.

### Why nobody hit it in CI or review

1. **ACME mode is unaffected.** `rustls-acme` always calls `builder_with_provider`, so it never consults the process default. Verified: `main` with `[server.tls] domains = [...]` reaches `HTTPS listening` and stays up. ACME is the documented production path, so the broken path is the less-travelled one.
2. **Every unit test in `tls.rs` calls `install_default()` first**, which installs a provider for the whole test binary and masks the panic. The tests exercising `build_tls_acceptor` therefore passed while the real binary could not start.

### Mechanism

Both providers end up compiled in. The workspace pins `rustls` to `ring`; `rustls-acme`, `rcgen` and `hyper-rustls` (via `metrics-exporter-prometheus`) enable `aws-lc-rs`; Cargo unions features. Confirmed on the **non-dev** graph of the `ephpm` binary — this is not a dev-dependency artifact:

```
$ cargo tree -p ephpm -e features --no-dev-dependencies | grep -oE 'rustls feature "(ring|aws_lc_rs)"' | sort -u
rustls feature "aws_lc_rs"
rustls feature "ring"
```

With both features on, rustls' `from_crate_features()` returns `None` — it does **not** silently prefer one — and `get_default_or_install_from_crate_features()` panics.

## The fix

`build_tls_acceptor` now uses `builder_with_provider` with an explicitly named provider (`ring`, matching the workspace pin), handed out from a `OnceLock` so the whole server shares one instance and "one provider" is checkable by pointer identity.

Verified against the same reproduction: the fixed binary logs `TLS enabled (manual)` → `HTTPS listening` and runs until killed.

### Regression guard

`crates/ephpm-server/tests/tls_provider_independence.rs` is a **separate integration-test binary that deliberately never calls `install_default()`** — which is the whole point, since one such call anywhere in a test binary disarms this class of bug for every test in it. The module docs say so explicitly, so a future contributor does not "helpfully" add one. This is the guard referenced from #241.

### Also included

A cert PEM containing zero `CERTIFICATE` blocks is now rejected against the offending file. The case operators actually hit is `cert` pointed at the **key** file: that parses cleanly into zero certificates and previously slipped past `load_certs` to surface later as an opaque rustls error. Covered by a test.

## Correction on the `quinn-proto` half

The lockfile bump `quinn-proto 0.11.14 → 0.11.15` (RUSTSEC-2026-0185) is included, but **the premise that main's Cargo Deny will start failing does not hold** — I could not reproduce it, and the evidence says the opposite:

- `cargo deny check` on the **unmodified main lockfile**, using the current advisory DB, is green: `advisories ok, bans ok, licenses ok, sources ok`. The same DB in the same container image *did* flag RUSTSEC-2026-0185 on the HTTP/3 branch, so this is not a stale-database artifact.
- `cargo tree -i quinn-proto -e all --target all` on main prints **nothing** — quinn-proto is not reachable from any dependency edge, on any target.
- The reason: `quinn` is an **optional** dependency of `reqwest` (its `http3` feature, which is off). It is a lockfile entry only.

So the vulnerable code is **not compiled into any shipped binary**, and this is not a live exposure in v0.6.0/v0.6.1 — treat it as pre-emptive hygiene, not a security fix. It becomes genuinely load-bearing only when #240 makes `quinn` a real dependency, which is where `cargo deny` flagged it in the first place. Happy to move the bump back to #240 if you'd rather this PR be purely the TLS fix.

## Verification

Container `ephpm-verify:main`, branched off `main` @ 39a42dc:

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 59 test binaries, 0 failures
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- Manual-TLS startup reproduced broken before / working after, with a real binary

Follow-up: #241 (two rustls versions, two crypto providers, aws-lc-rs already first-class). #240 (HTTP/3) will be rebased onto this so it carries only the h3 feature.
