### PR TITLE
fix(worker): a PHP fatal must be a 500, and wire up the dormant worker-mode E2E suite (#116)

### DIFF
--- a/crates/ephpm-e2e/tests/worker_mode.rs
+++ b/crates/ephpm-e2e/tests/worker_mode.rs
@@ -7,15 +7,21 @@
 //!
 //! Because worker mode is a whole-server switch, this needs a SEPARATE server
 //! instance from the default fpm docroot the other e2e tests use. The harness
-//! provides its base URL via `EPHPM_WORKER_URL`. Tests self-skip (pass) when
-//! that variable is unset, so they don't break fpm-only CI lanes — set it to
-//! opt in once the worker-mode deployment is wired into the E2E stack.
+//! provides its base URL via `EPHPM_WORKER_URL`. `cargo xtask e2e` spawns that
+//! node (`tests/worker-docroot`, `[php] mode = "worker"`, 3 workers) and
+//! exports the variable — see `xtask/src/e2e_bare.rs`. Tests still self-skip
+//! when it is unset so the suite can be run standalone against an existing
+//! deployment.
 //!
 //! Exit criteria covered:
 //! - boot-once: a boot counter that increments once per worker, not per request
 //! - concurrency: N workers serve N concurrent requests on Linux (ZTS)
 //! - fatal -> 500 + recycle + next request succeeds + server never wedges
 //! - worker_max_requests recycle
+//! - issue #116: a `do_blocks()`-shaped nested render never recycles a worker,
+//!   and renders byte-identically on every request of a worker's life
+//! - `exit()` mid-request delivers the request's output and leaves the server
+//!   serving
 //!
 //! The reference worker.php emits, per request:
 //!   hello <REQUEST_URI> (boot #<B>, request #<R>)
@@ -105,11 +111,10 @@ async fn concurrent_requests_all_succeed() {
 /// fatal returns 500, the worker recycles, and the NEXT request succeeds — the
 /// server never wedges.
 ///
-/// This drives a `fatal.php`-style path served by the same worker instance:
-/// the reference worker.php only says hello, so the harness's worker docroot
-/// must additionally route a "please fatal" trigger (e.g. `/__fatal`). If the
-/// deployed worker script does not support a fatal trigger, this test only
-/// asserts the server keeps serving after hammering it.
+/// The trigger is a query flag the worker script must honor. The harness's
+/// fixture (`tests/worker-docroot/worker.php`) routes `?__fatal=1` to an
+/// uncaught `Error`; a deployment whose script ignores the flag still gets the
+/// "server keeps serving" half of this test.
 #[tokio::test]
 async fn fatal_500s_then_recovers() {
     let Some(base) = worker_url() else {
@@ -120,11 +125,21 @@ async fn fatal_500s_then_recovers() {
     // Trigger a fatal (best-effort: depends on the deployed worker script
     // honoring a `?__fatal=1` query). Accept either a 500 (fatal handled) or a
     // 200 (script ignored the trigger) — but in NO case may the request hang.
-    let (fatal_status, _) = get(&base, "/trigger?__fatal=1").await;
+    let (fatal_status, fatal_body) = get(&base, "/trigger?__fatal=1").await;
     assert!(
         fatal_status == 500 || fatal_status == 200,
         "fatal trigger returned unexpected status {fatal_status}"
     );
+    // If the worker script honored the trigger, the request DIED — a response
+    // carrying PHP's fatal-error text must never be a 200. Worker mode used to
+    // ship exactly that (the synthesized response kept the default 200), so
+    // caches and uptime monitors saw a crashed request as healthy.
+    if fatal_body.contains("Fatal error") {
+        assert_eq!(
+            fatal_status, 500,
+            "a request that ended on a PHP fatal returned {fatal_status}, not 500: {fatal_body}"
+        );
+    }
 
     // The server must still serve normal requests afterwards.
     for i in 0..10 {
@@ -156,6 +171,149 @@ async fn requests_keep_succeeding_across_recycles() {
     }
 }
 
+/// Extract a `key=value` field from the fixture's blocks trailer comment
+/// (`<!-- blocks depth=3 len=… sha1=… boot=… request=… -->`).
+fn trailer_field<'a>(body: &'a str, key: &str) -> Option<&'a str> {
+    let needle = format!("{key}=");
+    let start = body.rfind(&needle)? + needle.len();
+    let rest = &body[start..];
+    let end = rest.find(|c: char| c == ' ' || c == '\n').unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+/// Total `ephpm_worker_recycles_total` across every `reason` label, scraped
+/// from `/metrics`.
+///
+/// This — not the worker script's own `boot #N` counter — is the reliable
+/// "did a worker die?" signal: under ZTS each worker thread gets its own PHP
+/// globals, so a per-worker `static $bootCount` reads 1 on every worker AND on
+/// every respawned replacement. Boot ids cannot tell a recycle from a sibling.
+async fn worker_recycles(base: &str) -> f64 {
+    let (status, body) = get(base, "/metrics").await;
+    assert_eq!(status, 200, "/metrics not available on the worker node: {body}");
+    body.lines()
+        // Skip the `# HELP` / `# TYPE` lines, which also carry the metric name.
+        .filter(|l| l.starts_with("ephpm_worker_recycles_total"))
+        .filter_map(|l| l.rsplit(' ').next())
+        .filter_map(|v| v.trim().parse::<f64>().ok())
+        .sum()
+}
+
+/// Issue #116 regression: a nested, output-buffered, recursive render — the
+/// shape WordPress' `do_blocks()` produces — must not take the resident worker
+/// down, and must render identically on every request of a worker's life.
+///
+/// The fixture route (`?__blocks=N`, `tests/worker-docroot/worker.php`)
+/// deliberately combines the three engine behaviours #116 implicated:
+/// userland recursion re-entering through internal functions
+/// (`preg_replace_callback`/`array_map`), a userland output buffer opened and
+/// closed at every nesting level, and a response big enough to grow the SAPI
+/// capture buffer through several reallocs — repeated on a worker that never
+/// runs `php_request_shutdown` between requests.
+///
+/// What this proves: the engine survives that workload and produces stable
+/// output across a worker's whole life. What it does NOT prove: that a real
+/// WordPress block theme renders correctly — WordPress' own per-request
+/// registries (`$wp_styles`/`$wp_scripts`, `WP_Style_Engine_CSS_Rules_Store`)
+/// are worker-lifetime state that only a framework adapter can reset, and no
+/// black-box test in this repo exercises them.
+#[tokio::test]
+async fn nested_block_render_never_recycles_the_worker() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode block-render test");
+        return;
+    };
+
+    // Warm every worker, then take the recycle baseline. Other tests in this
+    // suite deliberately kill workers (fatal, exit), so the baseline must be
+    // read here rather than assumed to be zero.
+    for i in 0..30 {
+        let (status, body) = get(&base, &format!("/warm-{i}")).await;
+        assert_eq!(status, 200, "warmup request {i} failed: {body}");
+    }
+    let recycles_before = worker_recycles(&base).await;
+
+    // Render the nested workload many times over. A worker that dies mid-render
+    // shows up two ways: a non-200 (or a hang) here, or a bump in the recycle
+    // counter checked below.
+    let mut digest: Option<String> = None;
+    for i in 0..120 {
+        let (status, body) = get(&base, "/blocks?__blocks=4").await;
+        assert_eq!(status, 200, "block render {i} returned {status}: {body}");
+
+        let sha = trailer_field(&body, "sha1")
+            .unwrap_or_else(|| panic!("block render {i} produced no sha1 trailer: {body}"))
+            .to_string();
+        let len: usize = trailer_field(&body, "len")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| panic!("block render {i} produced no len trailer"));
+        // Guards against the workload being silently defanged (a fixture edit
+        // that drops the recursion depth would make the test pass vacuously).
+        assert!(len > 10_000, "block render {i} produced only {len} bytes — workload too small");
+
+        match &digest {
+            None => digest = Some(sha),
+            Some(first) => assert_eq!(
+                first, &sha,
+                "block render {i} differs from the first render — per-request state leaked \
+                 into the renderer"
+            ),
+        }
+    }
+
+    // The render must not have cost a single worker.
+    let recycles_after = worker_recycles(&base).await;
+    assert!(
+        recycles_after <= recycles_before,
+        "the nested block render recycled {} worker(s) (issue #116)",
+        recycles_after - recycles_before
+    );
+
+    // And the pool must still be serving normally.
+    for i in 0..30 {
+        let (status, body) = get(&base, &format!("/after-blocks-{i}")).await;
+        assert_eq!(status, 200, "post-render request {i} failed: {body}");
+        assert!(body.contains("hello /after-blocks-"), "post-render body wrong: {body}");
+    }
+}
+
+/// `exit()` mid-request must deliver that request's output — including bytes
+/// still sitting in a userland output buffer, which worker mode has no
+/// per-request RSHUTDOWN to flush — and must leave the server serving.
+///
+/// This is the second finding on issue #116. It pins the CURRENT contract:
+/// the response is synthesized from SAPI state and the pool recovers. It does
+/// not assert that the worker itself survives — today an `exit()` ends the
+/// worker's loop and the pool respawns it.
+#[tokio::test]
+async fn exit_mid_request_delivers_output_and_server_keeps_serving() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode exit test");
+        return;
+    };
+
+    for round in 0..5 {
+        let (status, body) = get(&base, "/exit-route?__exit=1").await;
+        assert_eq!(status, 200, "exit round {round} returned {status}: {body}");
+        assert!(
+            body.contains("exit-route echoed"),
+            "exit round {round} lost the echoed output: {body}"
+        );
+        assert!(
+            body.contains("exit-route buffered"),
+            "exit round {round} lost output still held in a userland buffer — the engine did \
+             not flush it before synthesizing the response: {body}"
+        );
+
+        // The pool must keep serving immediately afterwards.
+        for i in 0..5 {
+            let (status, body) = get(&base, &format!("/after-exit-{round}-{i}")).await;
+            assert_eq!(status, 200, "request after exit wedged the server: {status} {body}");
+            assert!(body.contains("hello /after-exit-"), "post-exit body wrong: {body}");
+        }
+    }
+}
+
 /// Streaming round-trip (Phase 3): upload a large body and get the same bytes
 /// back. Proves `Envelope::bodyStream()` + `send_response_stream()` move the
 /// body without the worker buffering it whole. Requires a worker docroot whose
@@ -168,8 +326,7 @@ async fn requests_keep_succeeding_across_recycles() {
 /// black-box HTTP test cannot observe worker memory.
 #[tokio::test]
 async fn streaming_upload_echoes_back_identically() {
-    let Some(base) = std::env::var("EPHPM_WORKER_STREAM_URL").ok().filter(|s| !s.is_empty())
-    else {
+    let Some(base) = std::env::var("EPHPM_WORKER_STREAM_URL").ok().filter(|s| !s.is_empty()) else {
         eprintln!("EPHPM_WORKER_STREAM_URL unset — skipping worker-mode streaming test");
         return;
     };

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -2163,6 +2163,9 @@ void ephpm_worker_set_populate_superglobals(int enable)
  *    1  the script ended while a request was still in flight (exit()/die()
  *       mid-request — e.g. WordPress wp_die()/admin-ajax — or a loop break);
  *       the response was synthesized from SAPI state and delivered
+ *    2  same, but the request ended on a PHP fatal (uncaught Throwable /
+ *       E_ERROR). The synthesized response was forced to 500 unless the script
+ *       had already chosen a status
  *   -2  a fatal / zend_bailout unwound out of the framework (recycle + the
  *       Rust supervisor fulfils any parked oneshot with a 500)
  */
@@ -2226,7 +2229,32 @@ int ephpm_worker_run(const char *script)
             smart_str_0(&hbuf);
 
             int status = SG(sapi_headers).http_response_code;
-            g_worker_ops.send_response(status > 0 ? status : 200,
+            if (status <= 0) {
+                status = 200;
+            }
+
+            /* Fatal -> 500, mirroring the fpm path (:997-1002).
+             *
+             * A PHP 8 uncaught Throwable does NOT reach the SETJMP above:
+             * zend_exception_error() prints "Fatal error: Uncaught ..." via
+             * zend_error_va(... | E_DONT_BAIL ...) and php_execute_script's
+             * own zend_try swallows the bailout, so the script simply
+             * "returns" with a request still in flight and lands here. Without
+             * this check the synthesized response carries the DEFAULT 200 and
+             * ships the fatal-error text as a successful body — caches and
+             * uptime monitors then treat a crashed request as healthy.
+             *
+             * Only override when the script did not set an explicit status
+             * itself, so a deliberate exit() after http_response_code(201) (or
+             * a framework's own 500) keeps what it chose. Same mask as fpm. */
+            const int fatal_error_mask = E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR
+                                         | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE;
+            int hit_fatal = (PG(last_error_type) & fatal_error_mask) != 0;
+            if (hit_fatal && status == 200) {
+                status = 500;
+            }
+
+            g_worker_ops.send_response(status,
                                        hbuf.s ? ZSTR_VAL(hbuf.s) : "",
                                        hbuf.s ? ZSTR_LEN(hbuf.s) : 0,
                                        output_buf ? output_buf : "",
@@ -2234,7 +2262,10 @@ int ephpm_worker_run(const char *script)
             smart_str_free(&hbuf);
             output_len = 0;
             req_in_flight = 0;
-            result = 1;
+            /* 2 = the request died on a fatal (response synthesized as 500);
+             * 1 = the script deliberately exit()ed mid-request. Both deliver a
+             * response and both recycle; the distinction is observability. */
+            result = hit_fatal ? 2 : 1;
         }
     } else {
         /* zend_bailout() — a fatal unwound past the current iteration's

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -203,6 +203,13 @@ pub enum WorkerExit {
     /// mid-request, or a break out of the loop). The C layer synthesized the
     /// response from SAPI state and delivered it; the worker must be recycled.
     ScriptExit,
+    /// The in-flight request ended on a PHP fatal (uncaught `Throwable`,
+    /// `E_ERROR`, …). Like [`WorkerExit::ScriptExit`] the C layer already
+    /// synthesized and delivered the response — forced to 500 unless the
+    /// script had set an explicit status — so the caller must NOT send another
+    /// one; it differs only in that the worker died rather than chose to stop,
+    /// which is what the recycle-reason metric reports.
+    ScriptFatal,
     /// A fatal bailout unwound out of the framework. The caller must recycle
     /// the worker and fulfil any parked oneshot with a 500.
     Fatal,
@@ -808,6 +815,7 @@ impl PhpRuntime {
             Ok(match ret {
                 0 => WorkerExit::Clean,
                 1 => WorkerExit::ScriptExit,
+                2 => WorkerExit::ScriptFatal,
                 _ => WorkerExit::Fatal,
             })
         }

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -368,6 +368,20 @@ fn worker_main(
                 counter!("ephpm_worker_recycles_total", "reason" => "script_exit").increment(1);
                 tracing::debug!(worker_id, "worker script exited mid-request — recycling");
             }
+            Ok(ephpm_php::WorkerExit::ScriptFatal) => {
+                // The request died on a PHP fatal. The C layer synthesized the
+                // response (500 unless the script chose a status) and delivered
+                // it, so the oneshot is already fulfilled; the drain below is
+                // the same defensive path ScriptExit uses.
+                if let Some(sender) = ephpm_php::worker_bridge::take_pending_sender() {
+                    let _ = sender.send(WorkerResponse::internal_error());
+                }
+                counter!("ephpm_worker_recycles_total", "reason" => "fatal").increment(1);
+                tracing::warn!(
+                    worker_id,
+                    "worker request ended on a PHP fatal — 500 delivered, recycling"
+                );
+            }
             Ok(ephpm_php::WorkerExit::Fatal) => {
                 // Fatal bailout unwound past send_response. Fulfil the parked
                 // oneshot with a 500 so the in-flight request never hangs, then

--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -602,6 +602,21 @@ worker request `longjmp`s out of the framework handler. Three things must hold:
    `ephpm_worker_run` returns, and `WorkerPool` respawns a fresh worker with a
    clean boot. Cost: one framework re-boot per fatal. Correct: yes.
 
+**Not every fatal is a bailout.** The most common one in practice — a PHP 8
+uncaught `Throwable` — never reaches the `SETJMP` above: `zend_exception_error()`
+prints `Fatal error: Uncaught …` through `zend_error_va(… | E_DONT_BAIL …)`, and
+`php_execute_script`'s own `zend_try` swallows the bailout, so the script simply
+"returns" with the request still in flight and lands in the exit-synthesis branch
+alongside `exit()`/`die()`. That branch therefore checks
+`PG(last_error_type) & (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR |
+E_RECOVERABLE_ERROR | E_PARSE)` and forces the synthesized status to 500 when the
+script did not choose one itself — the same override `ephpm_execute_request` has
+always applied on the fpm path. Without it the response carried the default 200
+with the fatal text as its body. `ephpm_worker_run` returns `2` for this case
+(`WorkerExit::ScriptFatal`), so the recycle is counted as `reason="fatal"` rather
+than `reason="script_exit"`; the response is already delivered, so the supervisor
+must not send another.
+
 ### 5.4 Detecting dead / hung workers; timeouts
 
 - **Hung request (infinite loop / blocked syscall in PHP).** SIGPROF-based

--- a/site/content/guides/wordpress-worker.md
+++ b/site/content/guides/wordpress-worker.md
@@ -107,6 +107,23 @@ requests and workers, and replicates across nodes in cluster mode. See the
 
 ## Limitations
 
+- **Block themes render, but their CSS is emitted only on the first request a
+  worker serves.** WordPress tracks what it has already printed in
+  worker-lifetime state — `$wp_styles` / `$wp_scripts` (`WP_Dependencies::$done`)
+  and the static `WP_Style_Engine_CSS_Rules_Store`. On a persistent worker those
+  survive the request, so the second and later requests print no
+  `<style>` blocks at all: measured on WordPress 6.7.1 with Twenty Twenty-Five,
+  the homepage drops from ~50 KB (21 inline stylesheets, including
+  `global-styles-inline-css` and `core-block-supports-inline-css`) to ~12 KB
+  with zero. `wp_unique_id()`'s counter also keeps climbing, so the generated
+  `wp-container-core-*-is-layout-N` classes drift away from the CSS that was
+  printed. Resetting those registries per request is the **adapter's** job, not
+  the engine's — until the adapter does it, serve block themes in fpm mode.
+  (The engine itself renders blocks fine: `do_blocks()`, nested template parts,
+  the Query loop, the Interactivity API and REST all survive a persistent
+  worker. This was previously reported as an engine crash in
+  [ephpm#116](https://github.com/ephpm/ephpm/issues/116); it no longer
+  reproduces.)
 - Worker mode is a whole-server switch; it is **not supported with
   `[server] sites_dir`** (config load hard-errors), so multi-tenant vhosting —
   including WordPress multisite behind vhosts — stays on fpm mode for now.

--- a/tests/worker-docroot/worker.php
+++ b/tests/worker-docroot/worker.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Worker-mode E2E fixture script (document_root: tests/worker-docroot).
+ *
+ * Serves the reference contract the `worker_mode` e2e suite asserts against:
+ *
+ *   hello <REQUEST_URI> (boot #<B>, request #<R>)
+ *
+ * plus three trigger routes the suite drives:
+ *
+ *   ?__fatal=1     an uncatchable fatal mid-request (bailout -> 500 + recycle)
+ *   ?__exit=1      output followed by exit() mid-request (exit synthesis)
+ *   ?__blocks=<n>  a WordPress-`do_blocks()`-shaped render workload (issue #116)
+ *
+ * This is a fixture, not a framework adapter — the shipped reference script is
+ * `examples/worker/worker.php`. It is deliberately kept close to that one so a
+ * divergence between the two is obvious.
+ */
+
+declare(strict_types=1);
+
+// ── Boot-once section ────────────────────────────────────────────────
+static $bootCount = 0;
+$bootCount++;
+$myBoot = $bootCount;
+$requestCount = 0;
+
+error_log("[worker] booted (boot #{$myBoot})");
+
+/**
+ * Render nested markup the way WordPress' block renderer does, so the engine
+ * paths issue #116 implicated are all on the request hot path:
+ *
+ *  - userland recursion that re-enters through *internal* functions
+ *    (`preg_replace_callback`, `array_map`) — the C-stack re-entry shape that
+ *    `do_blocks()` -> `render_block()` -> `apply_filters()` produces;
+ *  - a nested userland output buffer per nesting level, opened and closed
+ *    inside the recursion (worker mode has no per-request RSHUTDOWN to clean
+ *    these up, which is why the reset path has to);
+ *  - a response large enough to force the SAPI capture buffer to grow through
+ *    several reallocs on every request.
+ *
+ * Deterministic: the same $depth always produces byte-identical markup, so the
+ * suite can assert render fidelity across requests on a persistent worker.
+ */
+function ephpm_e2e_render_blocks(int $depth, int $breadth): string
+{
+    if ($depth <= 0) {
+        return '<p>leaf</p>';
+    }
+
+    ob_start();
+    for ($i = 0; $i < $breadth; $i++) {
+        $inner = ephpm_e2e_render_blocks($depth - 1, $breadth);
+        // Internal function -> userland callback: the same re-entry the block
+        // renderer performs through the filter chain.
+        $inner = (string) preg_replace_callback(
+            '/<p>([a-z]+)<\/p>/',
+            static fn (array $m): string => '<p class="d' . $depth . '">' . strrev($m[1]) . '</p>',
+            $inner
+        );
+        echo '<div class="lvl-', $depth, '-', $i, '">', $inner, '</div>';
+    }
+    $level = (string) ob_get_clean();
+
+    return implode('', array_map(static fn (string $s): string => $s, [$level]));
+}
+
+// ── Request loop ─────────────────────────────────────────────────────
+while (($envelope = \Ephpm\Worker\take_request()) !== null) {
+    $requestCount++;
+
+    $server = $envelope->serverVars();
+    $uri = $server['REQUEST_URI'] ?? '/';
+    $query = $envelope->query();
+
+    // Fatal trigger: an uncatchable fatal must 500 the in-flight request and
+    // recycle this worker without wedging the pool.
+    if (isset($query['__fatal'])) {
+        ephpm_e2e_this_function_does_not_exist(); // intentional fatal
+    }
+
+    // exit() trigger: output already echoed plus output still sitting in a
+    // userland buffer must both reach the client (engine-side exit synthesis
+    // flushes the buffers), and the server must keep serving afterwards.
+    if (isset($query['__exit'])) {
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "exit-route echoed\n";
+        ob_start();
+        echo "exit-route buffered\n";
+        exit;
+    }
+
+    // Block-render-shaped workload (issue #116).
+    if (isset($query['__blocks'])) {
+        $depth = max(1, min(5, (int) $query['__blocks']));
+        $html = ephpm_e2e_render_blocks($depth, 4);
+        $body = $html . sprintf(
+            "\n<!-- blocks depth=%d len=%d sha1=%s boot=%d request=%d -->\n",
+            $depth,
+            strlen($html),
+            sha1($html),
+            $myBoot,
+            $requestCount
+        );
+
+        \Ephpm\Worker\send_response(
+            200,
+            ['Content-Type' => 'text/html; charset=utf-8'],
+            $body
+        );
+        continue;
+    }
+
+    \Ephpm\Worker\send_response(
+        200,
+        ['Content-Type' => 'text/plain; charset=utf-8'],
+        "hello {$uri} (boot #{$myBoot}, request #{$requestCount})\n"
+    );
+}
+
+error_log("[worker] loop ended (boot #{$myBoot}, served {$requestCount} requests)");

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -77,12 +77,28 @@ const ISOLATED_DB_SUITES: &[&str] = &["sqlite", "sqlite_advanced", "rw_split", "
 /// cdylib, which every other suite must NOT have (the CORS module appends
 /// response headers to every PHP response, and `custom_headers`/`etag_cache`
 /// assert exact header sets).
-const ISOLATED_CONFIG_SUITES: &[&str] = &["opcache_invalidation", "rate_limit", "middleware"];
+///
+/// `worker_mode` needs `[php] mode = "worker"`, which is a WHOLE-SERVER switch
+/// (every request is served by the persistent worker pool, so the fpm docroot's
+/// scripts are unreachable) and hard-errors when combined with
+/// `[server] sites_dir`. It therefore gets its own node, its own docroot
+/// (`tests/worker-docroot`), and no sites_dir. Before this suite was wired up,
+/// nothing in the repo ever set `EPHPM_WORKER_URL`, so all of
+/// `crates/ephpm-e2e/tests/worker_mode.rs` self-skipped in every lane —
+/// worker mode had zero end-to-end coverage.
+const ISOLATED_CONFIG_SUITES: &[&str] =
+    &["opcache_invalidation", "rate_limit", "middleware", "worker_mode"];
 
 /// Suites that run single-threaded (a superset of the DB suites). Kept as a
 /// helper so `run_suite` can pick the right `--test-threads` value.
+///
+/// `worker_mode` is serial for a different reason than the DB suites: several
+/// of its tests deliberately kill a worker (`?__fatal=1`, `?__exit=1`) while
+/// another asserts that a workload recycled *no* worker, reading the
+/// `ephpm_worker_recycles_total` counter before and after. That counter is
+/// process-global, so a concurrent sibling test would make the assertion flap.
 fn suite_is_serial(name: &str) -> bool {
-    ISOLATED_DB_SUITES.contains(&name)
+    ISOLATED_DB_SUITES.contains(&name) || name == "worker_mode"
 }
 
 /// Whether a suite needs its own freshly-spawned, then-torn-down single node
@@ -135,6 +151,19 @@ pub fn run(args: &[String]) -> ExitCode {
         Ok(p) => p,
         Err(e) => {
             eprintln!("error: failed to canonicalize {}: {e}", docroot.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Worker mode is a whole-server switch, so its node serves a separate tree
+    // holding only the worker entrypoint (`worker_script` must resolve under
+    // document_root). Resolved eagerly so a missing fixture fails before any
+    // node is spawned.
+    let worker_docroot = root.join("tests").join("worker-docroot");
+    let worker_docroot = match worker_docroot.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: worker docroot {} unusable: {e}", worker_docroot.display());
             return ExitCode::FAILURE;
         }
     };
@@ -236,14 +265,16 @@ pub fn run(args: &[String]) -> ExitCode {
         );
         for (name, path) in &isolated_suites {
             let opts = SingleNodeOptions::for_suite(name, middleware_lib.as_deref());
-            let fixture = match SingleNodeSpawn::start(&ephpm_bin, &docroot, &scratch_root, &opts) {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("error: failed to start fresh node for suite {name}: {e}");
-                    failed.push((*name).clone());
-                    continue;
-                }
-            };
+            let node_docroot = if opts.worker { &worker_docroot } else { &docroot };
+            let fixture =
+                match SingleNodeSpawn::start(&ephpm_bin, node_docroot, &scratch_root, &opts) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        eprintln!("error: failed to start fresh node for suite {name}: {e}");
+                        failed.push((*name).clone());
+                        continue;
+                    }
+                };
             let env = fixture.env(&php_version);
             let suite_failed = if run_suite(name, path, &env) {
                 Vec::new()
@@ -625,6 +656,7 @@ ini_overrides = [
     ["display_errors", "On"],
     ["error_reporting", "E_ALL"],
 ]
+{PHP_WORKER_BLOCK}
 
 [server.limits]
 max_connections = 100
@@ -736,6 +768,10 @@ struct SingleNodeOptions {
     /// to every PHP response, which other suites assert exact header sets
     /// against.
     middleware_lib: Option<PathBuf>,
+    /// Emit `[php] mode = "worker"` + `worker_script`. Only the `worker_mode`
+    /// suite; implies `with_sites_dir = false` (the combination hard-errors at
+    /// config load) and the `tests/worker-docroot` document root.
+    worker: bool,
 }
 
 impl SingleNodeOptions {
@@ -747,6 +783,7 @@ impl SingleNodeOptions {
             opcache_invalidation: false,
             tight_rate_limit: false,
             middleware_lib: None,
+            worker: false,
         }
     }
 
@@ -764,6 +801,18 @@ impl SingleNodeOptions {
                 opcache_invalidation: true,
                 tight_rate_limit: false,
                 middleware_lib: None,
+                worker: false,
+            },
+            // worker_mode: persistent worker pool over tests/worker-docroot.
+            // sites_dir MUST stay off — worker mode + sites_dir is rejected at
+            // config load, so the node would never start.
+            "worker_mode" => Self {
+                slug,
+                with_sites_dir: false,
+                opcache_invalidation: false,
+                tight_rate_limit: false,
+                middleware_lib: None,
+                worker: true,
             },
             // rate_limit: small bucket, on its own node. See
             // ISOLATED_CONFIG_SUITES for why this can't share the shared node.
@@ -773,6 +822,7 @@ impl SingleNodeOptions {
                 opcache_invalidation: false,
                 tight_rate_limit: true,
                 middleware_lib: None,
+                worker: false,
             },
             // middleware: mount the freshly built cors cdylib by explicit
             // path, exercising the dlopen lane in a real server.
@@ -782,6 +832,7 @@ impl SingleNodeOptions {
                 opcache_invalidation: false,
                 tight_rate_limit: false,
                 middleware_lib: middleware_lib.map(Path::to_path_buf),
+                worker: false,
             },
             // DB suites: fresh DB, but otherwise the same shape as the shared
             // node (sites_dir present is harmless; they don't use it).
@@ -791,6 +842,7 @@ impl SingleNodeOptions {
                 opcache_invalidation: false,
                 tight_rate_limit: false,
                 middleware_lib: None,
+                worker: false,
             },
         }
     }
@@ -819,6 +871,9 @@ struct SingleNodeSpawn {
     /// `EPHPM_MIDDLEWARE_LIB` so the suite can reuse the same artifact for
     /// its own spawns instead of re-deriving the build path.
     middleware_lib: Option<PathBuf>,
+    /// This node runs `[php] mode = "worker"`; `env()` additionally exports
+    /// `EPHPM_WORKER_URL`, which is what the `worker_mode` suite gates on.
+    worker: bool,
 }
 
 impl SingleNodeSpawn {
@@ -872,6 +927,16 @@ impl SingleNodeSpawn {
         // Only the rate_limit suite runs a bucket small enough to trip. Every
         // other node gets a budget large enough that the whole suite's traffic
         // never reaches it, which is what stops the spurious 429s.
+        // Worker mode: a small, fixed pool so `boot #B` ids stay bounded and
+        // the suite can tell "no worker was recycled" from "a worker rebooted".
+        // worker_max_requests is left generous on purpose — the recycle test
+        // asserts requests keep succeeding, not that a recycle happens.
+        let php_worker_block = if opts.worker {
+            "mode = \"worker\"\nworker_script = \"worker.php\"\nworker_count = 3\n\
+             worker_max_requests = 10000\nworker_boot_timeout = 60"
+        } else {
+            ""
+        };
         let limits_block = if opts.tight_rate_limit {
             "per_ip_rate = 500.0\nper_ip_burst = 100"
         } else {
@@ -905,6 +970,7 @@ impl SingleNodeSpawn {
             .replace("{OPCACHE_BLOCK}", &opcache_block)
             .replace("{MIDDLEWARE_BLOCK}", &middleware_block)
             .replace("{LIMITS_BLOCK}", limits_block)
+            .replace("{PHP_WORKER_BLOCK}", php_worker_block)
             .replace("{KV_SOCKET}", &escape_toml(&kv_socket))
             .replace("{DOCROOT}", &escape_toml(docroot));
 
@@ -928,7 +994,19 @@ impl SingleNodeSpawn {
             .stderr(Stdio::from(stderr_file))
             .spawn()?;
 
-        wait_for_health(http_port, Duration::from_secs(10))?;
+        // Worker mode has to boot the framework in every worker before the
+        // first request can be served, so it gets a longer readiness window.
+        let health_timeout =
+            if opts.worker { Duration::from_secs(60) } else { Duration::from_secs(10) };
+        wait_for_health(http_port, health_timeout)?;
+        if opts.worker {
+            // `/_ephpm/health` is pure liveness (200 as soon as the listener is
+            // up), so on a worker node it says nothing about whether any worker
+            // has finished booting the framework. Wait for a real request to be
+            // served before handing the node to the suite, otherwise the first
+            // test races the boot and sees a 504.
+            wait_for_worker(http_port, health_timeout)?;
+        }
         eprintln!("    single-node ephpm [{}] ready on 127.0.0.1:{http_port}", opts.slug);
 
         Ok(Self {
@@ -942,6 +1020,7 @@ impl SingleNodeSpawn {
             middleware_lib: opts.middleware_lib.clone(),
             stderr_log,
             stdout_log,
+            worker: opts.worker,
         })
     }
 
@@ -982,6 +1061,14 @@ impl SingleNodeSpawn {
         if let Some(lib) = &self.middleware_lib {
             env.push(("EPHPM_BINARY".to_string(), self.binary.to_string_lossy().into_owned()));
             env.push(("EPHPM_MIDDLEWARE_LIB".to_string(), lib.to_string_lossy().into_owned()));
+        }
+        // The worker_mode suite gates on EPHPM_WORKER_URL rather than EPHPM_URL
+        // precisely so it cannot be pointed at an fpm-mode node by accident.
+        if self.worker {
+            env.push((
+                "EPHPM_WORKER_URL".to_string(),
+                format!("http://127.0.0.1:{}", self.http_port),
+            ));
         }
         env
     }
@@ -1157,6 +1244,25 @@ fn wait_for_health(port: u16, timeout: Duration) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::TimedOut,
         format!("ephpm on 127.0.0.1:{port} did not become healthy within {timeout:?}: {last_err}"),
+    ))
+}
+
+/// Wait until a worker-mode node actually serves a PHP request (not just the
+/// liveness probe). Proves at least one worker finished booting the framework.
+fn wait_for_worker(port: u16, timeout: Duration) -> io::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut last_err = String::from("no attempts made");
+    while Instant::now() < deadline {
+        match tcp_get(port, "/_xtask_worker_warmup") {
+            Ok(200) => return Ok(()),
+            Ok(status) => last_err = format!("worker request returned HTTP {status}"),
+            Err(e) => last_err = format!("connect error: {e}"),
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+    Err(io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("no worker on 127.0.0.1:{port} served a request within {timeout:?}: {last_err}"),
     ))
 }
 


### PR DESCRIPTION
Investigating #116 ("block themes / `do_blocks()` crash the resident worker") turned
up two things: **the reported crash no longer reproduces**, and **worker mode has
never had any end-to-end coverage** to notice either way — which was hiding a
separate, real bug.

## 1. The reported crash does not reproduce

Reproduced on a PHP-linked build against WordPress 6.7.1 + Twenty Twenty-Five in
worker mode (`worker_populate_superglobals = true`, the `ephpm/wordpress-worker`
adapter, SQLite backend):

- 120 sequential + 8 concurrent streams × 25 requests to `/` — **0 failures, 0
  worker recycles**, RSS flat at ~104 MB
- single posts, `/wp-json/` (185 KB), `?s=`, `?feed=rss2` — all 200
- isolated probes over the block pipeline, each repeated on a warm worker:
  `parse_blocks`, `do_blocks` on simple / nested / block-supports markup, dynamic
  blocks, `get_block_template`, `<!-- wp:template-part -->`, the Query loop,
  Navigation + the Interactivity API, `WP_Theme_JSON_Resolver::get_merged_data()`,
  `wp_get_global_stylesheet()`, `WP_HTML_Tag_Processor` — all fine

#116 predates #117 (exit-synthesis + pool lifecycle) and #121 (ob-flush on exit),
which are the likely fix.

**What is still broken for block themes is WordPress state, not engine state.**
With `worker_count = 1`, request 1 renders 50704 B with 21 inline stylesheets;
request 2 **on the same worker** renders 12012 B with **zero**. Probing right after
the first render: `$wp_styles->done` = 30, `wp_style_is('global-styles','done')` =
true, `WP_Style_Engine_CSS_Rules_Store` still holding a `block-supports` store,
`wp_unique_id()` climbing (so `wp-container-core-*-is-layout-N` class names drift
away from CSS that is never re-emitted). Those registries are worker-lifetime state
only a framework adapter can reset — filed as ephpm/wordpress-worker#5, and
documented as a limitation in the WordPress worker guide here.

## 2. The bug this actually found: a PHP fatal returned **200**

`ephpm_execute_request` (fpm) maps `PG(last_error_type) & fatal_mask` to a 500,
because a PHP 8 uncaught `Throwable` never reaches our `SETJMP`:
`zend_exception_error()` prints the fatal through `zend_error_va(... | E_DONT_BAIL ...)`
and `php_execute_script`'s own `zend_try` swallows the bailout, so the script
"returns" with the request still in flight and lands in the exit-synthesis branch
next to `exit()`/`die()`.

`ephpm_worker_run` resets `last_error_type` per iteration but never consulted it. A
fatal inside a worker request was therefore delivered as:

```
HTTP/1.1 200 OK

Fatal error: Uncaught Error: Call to undefined function ... in /wdocroot/worker.php:81
```

Caches, CDNs and uptime monitors all read that as a healthy request. The worker-mode
guide already claimed the client gets a 500, so this was a docs-vs-code divergence
too.

Worker mode now applies the same override (same error mask, same "only when the
script did not choose a status itself" rule), and distinguishes *the script chose to
stop* from *the request died*: new `WorkerExit::ScriptFatal` (C return code `2`), so
`ephpm_worker_recycles_total` reports `reason="fatal"` instead of
`reason="script_exit"`. The response is already delivered on that path, so the arm
does not send a second one.

Verified against both builds with the same test binary:

| | before | after |
|---|---|---|
| `?__fatal=1` status | `200` | `500` |
| recycle reason | `script_exit` | `fatal` |
| `?__exit=1` status / body | `200`, echoed + buffered | unchanged |

## 3. Why nothing caught it: the worker-mode E2E suite was dormant

`crates/ephpm-e2e/tests/worker_mode.rs` gates every test on `EPHPM_WORKER_URL` —
and **nothing in this repo has ever set it**. Not `e2e_bare.rs`, not any workflow.
All five worker-mode acceptance tests self-skipped in every lane and reported green,
so worker mode shipped with zero end-to-end coverage. The one test that could have
caught the fatal bug asserted `status == 500 || status == 200`.

`cargo xtask e2e` now spawns a worker-mode node and exports `EPHPM_WORKER_URL`:

- its own docroot, `tests/worker-docroot/` — worker mode is a whole-server switch,
  and `worker_script` must resolve under `document_root`
- no `sites_dir` — that combination hard-errors at config load
- serial (`--test-threads=1`): several tests deliberately kill a worker while
  another asserts a workload recycled none, and `ephpm_worker_recycles_total` is
  process-global
- readiness waits for a real served request, not `/_ephpm/health` — that probe 200s
  before any worker has booted

`.github/workflows/e2e.yml` already runs `cargo xtask e2e`, so no workflow change is
needed; the suite is picked up by binary discovery.

### New coverage

- **`nested_block_render_never_recycles_the_worker`** — the #116 regression. The
  fixture route drives the three engine behaviours #116 implicated: userland
  recursion re-entering through internal functions (`preg_replace_callback`,
  `array_map`), a userland output buffer opened and closed at every nesting level,
  and ~15 KB of output growing the SAPI capture buffer through several reallocs —
  120 renders on workers that never run `php_request_shutdown`. Asserts byte-stable
  output (sha1 of the render) and **no movement in `ephpm_worker_recycles_total`**.

  *Being straight about what this proves:* it proves the engine survives that shape
  and renders deterministically across a worker's life. It does **not** prove a real
  WordPress block theme renders correctly — that failure is the `$wp_styles` state
  above, which no black-box test in this repo can reach. Said so in the test's doc
  comment rather than letting the name imply more.

- **`exit_mid_request_delivers_output_and_server_keeps_serving`** — pins the current
  `exit()` contract (both echoed and still-buffered output reach the client; the pool
  keeps serving). Explicitly does *not* assert the worker itself survives — today an
  `exit()` ends the loop and the pool respawns. That is #116's second acceptance
  criterion and remains open; see below.

- **`fatal_500s_then_recovers`** now requires 500 whenever the body carries PHP's
  fatal text.

Recycle detection deliberately uses `/metrics`, **not** the worker script's `boot #N`
counter: under ZTS each worker thread has its own PHP globals, so a per-worker
`static $bootCount` reads `1` on every worker *and* on every respawned replacement.
Boot ids cannot tell a recycle from a sibling — the pre-existing boot-once test is
weaker than it looks for that reason.

## What is still open on #116

Acceptance criterion 2 — *"a request calling `exit`/`die` ends only that request; the
worker survives"* — is **not** fixed here. `exit` throws an unwind-exit that destroys
the userland `while (take_request())` loop, so the loop cannot be resumed; today the
pool respawns (measured ~11 ms warm, since OPcache is hot). Making the worker truly
survive needs either a `ZEND_EXIT` user-opcode handler turning `exit` into a
catchable throwable (Swoole's approach — PHP-version-sensitive, since 8.4 also
registers `exit()` as a real function) or a C-driven per-request callback so the
unwind lands in C instead of userland. Both change the adapter contract, so they want
their own design pass rather than riding along here.

## Verification

- `cargo xtask e2e --tests worker_mode` — 7/7 pass on a PHP-linked build
- same binary against an **unfixed** build — `fatal_500s_then_recovers` fails with
  `left: 200, right: 500`, so the regression test is not vacuous
- `cargo xtask e2e --tests php|rate_limit|metrics` — harness unaffected
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p ephpm-php -p ephpm-server -p ephpm-config` — 397 pass
- no dependency changes, so `cargo deny` is unaffected

Addresses #116's first acceptance criterion and the fatal-status half of its second;
the block-theme rendering half is ephpm/wordpress-worker#5, and worker survival
across `exit` is called out above as still open.
