### PR TITLE
docs(tls): manual cert+key TLS never worked before #243 — document the range

### DIFF
--- a/site/content/guides/tls-acme.md
+++ b/site/content/guides/tls-acme.md
@@ -5,6 +5,26 @@ weight = 4
 
 ePHPm has TLS built in. Two modes: bring your own cert, or have ePHPm fetch one from Let's Encrypt automatically.
 
+> **Known issue — manual `cert` + `key` does not start on v0.1.0 through v0.6.1.**
+>
+> On every released version up to and including v0.6.1, starting ePHPm with
+> `[server.tls] cert` and `key` logs `TLS enabled (manual)` and then **panics
+> before binding a listener**:
+>
+> ```
+> Could not automatically determine the process-level CryptoProvider
+> ```
+>
+> The process exits with status 101 and serves nothing. This is not a
+> regression — it has never worked in any release; the bug dates to v0.1.0
+> and was found in August 2026 while adding HTTP/3.
+>
+> **ACME mode is unaffected** and is the only TLS configuration that has ever
+> worked on a released build. If you need TLS today, use ACME (below), or
+> terminate TLS at a proxy and run ePHPm plain-HTTP behind it.
+>
+> Fixed on `main`; the fix ships in the next release.
+
 ## Manual cert + key
 
 Point at PEM-encoded files:

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -111,6 +111,11 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 
 Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If both are set, manual wins.
 
+> **Known issue:** manual `cert`+`key` mode panics at startup on every release
+> from v0.1.0 through v0.6.1 — the process exits before binding a listener.
+> ACME mode is unaffected. See [TLS / ACME](/guides/tls-acme/) for details and
+> workarounds. Fixed on `main`.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `cert` | path | (none) | PEM-encoded certificate chain (manual mode). |


### PR DESCRIPTION
Documents the finding behind #243 (merged as `8d8572f`).

**Scope, verified empirically:** static-certificate TLS panics at startup on **every release from v0.1.0 through v0.6.1**. Both endpoints reproduced with real binaries (`exit 101`, no listener bound); every interior tag has a byte-identical `tls.rs`, the same `rustls 0.23.37` lock, and the same `rustls-acme` aws-lc-rs pin that unions the second provider.

**Why the framing matters:** describing this as a v0.6.x regression would have been wrong, and would have implied downgrading was a workaround. It never worked. ACME mode is unaffected — and is the only TLS configuration that has ever worked on a released build, which explains why it went unreported for seven weeks.

Adds a known-issue callout to the TLS guide (with the workarounds: ACME, or terminate at a proxy) and a shorter pointer on the `[server.tls]` config reference row. Docs-only.