### PR TITLE
fix(ci): make the Windows memory probe actually able to build

### DIFF
--- a/.github/workflows/build-memory.yml
+++ b/.github/workflows/build-memory.yml
@@ -163,7 +163,15 @@ jobs:
           # two numbers: the max SUM of working sets (total pressure on the
           # Hyper-V container) and the max SINGLE process working set (the
           # rustc-LLVM allocation-failure metric).
-          $proc = Start-Process -FilePath "cargo" `
+          #
+          # Start-Process does NOT resolve a bare command name through PATH the
+          # way the shell does -- "cargo" fails with "The system cannot find the
+          # file specified" even when `cargo --version` works in the same step.
+          # Resolve to an absolute path first.
+          $cargoCmd = Get-Command cargo -ErrorAction Stop
+          Write-Host "cargo         = $($cargoCmd.Source)"
+
+          $proc = Start-Process -FilePath $cargoCmd.Source `
             -ArgumentList @("xtask","release","${{ inputs.php_minor }}","--target","windows","--no-sqld") `
             -NoNewWindow -PassThru
 

--- a/.github/workflows/build-memory.yml
+++ b/.github/workflows/build-memory.yml
@@ -142,6 +142,87 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The next three steps are lifted verbatim from release.yml's
+      # build-windows. They are NOT optional here: the probe's whole purpose is
+      # to reproduce the release build, and without them it does not build at
+      # all. `C:\BuildTools` and `%USERPROFILE%\.cargo` persist on the Windows
+      # host between jobs (hence the Test-Path guards, which make these
+      # near-no-ops on a warm runner), but the vcvars64 environment and
+      # LIBCLANG_PATH do NOT -- GITHUB_ENV is per-job. Without them cargo
+      # cannot find link.exe and bindgen cannot find libclang.dll, so the
+      # measurement would report a build failure instead of a peak-memory
+      # number.
+      - name: Install Rust toolchain
+        shell: powershell
+        run: |
+          $cargoBin = "$env:USERPROFILE\.cargo\bin"
+          if (-not (Test-Path "$cargoBin\rustup.exe")) {
+            Write-Host "Installing rustup..."
+            Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+            .\rustup-init.exe -y --default-toolchain stable --profile minimal
+            Remove-Item rustup-init.exe
+          }
+          $env:PATH = "$cargoBin;$env:PATH"
+          $cargoBin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & "$cargoBin\rustup.exe" show
+
+      - name: Install Visual Studio Build Tools
+        shell: powershell
+        run: |
+          $installPath = "C:\BuildTools"
+          $msbuild = "$installPath\MSBuild\Current\Bin\MSBuild.exe"
+          if (Test-Path $msbuild) {
+            Write-Host "VS Build Tools already present at $installPath"
+          } else {
+            Write-Host "Downloading VS Build Tools bootstrapper..."
+            Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile vs_buildtools.exe
+            $proc = Start-Process -FilePath .\vs_buildtools.exe `
+              -ArgumentList @(
+                '--quiet', '--wait', '--norestart', '--nocache',
+                '--installPath', $installPath,
+                '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--add', 'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
+                '--includeRecommended'
+              ) -Wait -PassThru -NoNewWindow
+            Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
+            Remove-Item vs_buildtools.exe
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while (-not (Test-Path $msbuild) -and $sw.Elapsed.TotalMinutes -lt 20) {
+              Start-Sleep -Seconds 30
+              Write-Host ("  ...waiting for VS install ({0:F0}s)" -f $sw.Elapsed.TotalSeconds)
+            }
+            if (-not (Test-Path $msbuild)) {
+              Write-Host "::error::VS install timed out - $msbuild never appeared"
+              exit 1
+            }
+            Write-Host ("MSBuild.exe found after {0:F0}s" -f $sw.Elapsed.TotalSeconds)
+          }
+
+      - name: Enter MSVC developer environment
+        shell: powershell
+        run: |
+          $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { Write-Error "vcvars64.bat not found"; exit 1 }
+          $envBefore = @{}
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+            $envBefore[$e.Key] = $e.Value
+          }
+          $cmdLine = 'call "' + $vcvars + '" >NUL & set'
+          $output = & cmd /c $cmdLine
+          foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              if ($envBefore[$matches[1]] -ne $matches[2]) {
+                "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+              }
+            }
+          }
+          $libclangDir = "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+          if (Test-Path "$libclangDir\libclang.dll") {
+            "LIBCLANG_PATH=$libclangDir" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          } else {
+            Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
+          }
+
       - name: Build under measurement
         shell: powershell
         env:


### PR DESCRIPTION
First dispatch of the probe (run 31138906557) failed on both legs, for two unrelated reasons. This fixes the Windows one — which turned out to be two bugs, not one.

## Windows bug 1 — `Start-Process` does not search PATH

```
Start-Process : This command cannot be run due to the error: The system cannot find the file specified.
+ $proc = Start-Process -FilePath "cargo"
```

`Start-Process` does not resolve a bare command name through `PATH` the way the shell does. Resolved via `Get-Command` and passed as an absolute path; the resolved path is now logged.

## Windows bug 2 — the probe had no toolchain setup at all

Found while verifying that fixing bug 1 would be enough. It would not have been.

The job went straight from `actions/checkout` to `cargo xtask release --target windows --no-sqld`, skipping the three setup steps that **both** `release.yml`'s `build-windows` and `nightly.yml`'s Windows leg run first.

`C:\BuildTools` and `%USERPROFILE%\.cargo` persist on the Windows host between jobs, so the two install steps are near-no-ops on a warm runner (both are `Test-Path` guarded) — which is why `cargo` was on `PATH` at all. The step that actually matters is **Enter MSVC developer environment**: it forwards the `vcvars64` environment and `LIBCLANG_PATH` into `GITHUB_ENV`, and **`GITHUB_ENV` is per-job**. Without it `cargo` has no `link.exe` and `bindgen` has no `libclang.dll`.

So with only bug 1 fixed, the probe would have started, run for the better part of an hour, and then reported a build failure instead of a peak-memory number. All three steps are lifted verbatim from `release.yml` so the probe measures the same build the release performs.

The first run did get far enough to report one number worth keeping:

```
host_ram_gib  = 10.0
```

**The Windows build host has 10 GiB.** That is the ceiling every LTO decision in `release.yml` has been working against, and it makes the codegen-units question sharper rather than academic.

## linux-aarch64 — NOT ours, and a release risk

The arm64 leg never reached the build. The job container failed to start:

```
Pulling from ephpm/ephpm-ci
Using cached image from shared namespace
Status: Downloaded newer image for ephpm/ephpm-ci:latest-arm64
Error response from daemon: creating container:
  content digest sha256:2d006697...ffcb948e: not found
```

The mechanism is visible in ephemerd's source (`pkg/dind/dind.go`, the image-create handler). On pull it checks the shared `ephemerd` containerd namespace first:

```go
img, err := s.client.GetImage(sharedCtx, ref)
if err == nil {
    writeProgress("Using cached image from shared namespace")
} else {
    img, err = s.client.Pull(jobCtx, ref, client.WithPullUnpack)
}
```

The `else` branch pulls **into the per-job namespace** and works. The `if` branch does not: it takes an image handle from the *shared* namespace and then registers the image record in the *job* namespace pointing at that digest — but containerd's content store is namespaced, so the blobs are not visible from the job namespace. `docker create` then fails with exactly `content digest ...: not found`.

That predicts the failure is sticky rather than transient: it recurs for as long as `ephpm/ephpm-ci:latest-arm64` resolves in the shared namespace, and it only affects jobs that use `container:` — which is why `ci.yml` (no `container:`) is unaffected, and why the arm64 legs of `nightly.yml` succeeded as recently as 2026-08-06 06:25Z, before the image was rebuilt at 23:52Z.

**This matters beyond the probe:** `release.yml`'s `build-linux-arm64` uses the *same* container. If the diagnosis holds, the arm64 leg of a v0.6.2 tag fails identically — and arm64 is historically the leg that parks a release, since `Create Release` `needs:` it.

Not fixed here (the fix belongs in ephemerd); flagging it as its own problem.
