### PR TITLE
fix(ci): the memory probe called a successful build a failure

### DIFF
--- a/.github/workflows/build-memory.yml
+++ b/.github/workflows/build-memory.yml
@@ -256,6 +256,18 @@ jobs:
             -ArgumentList @("xtask","release","${{ inputs.php_minor }}","--target","windows","--no-sqld") `
             -NoNewWindow -PassThru
 
+          # Touch .Handle BEFORE the process exits. .NET can only report
+          # ExitCode if it still holds an open handle to the process; if the
+          # first access happens after exit, $proc.ExitCode is $null forever.
+          # Runs 31145743727 and 31148330870 both hit this: the build finished
+          # ("Finished `release` profile", ephpm.exe produced), printed
+          # "exit_code            = " with nothing after it, and then failed
+          # the job -- because $null -ne 0 is TRUE in PowerShell.
+          #
+          # That is worse than a cosmetic bug: it made a successful build and
+          # a genuinely failed one indistinguishable from the job status.
+          $null = $proc.Handle
+
           $maxSum = 0
           $maxOne = 0
           $maxOneName = ""
@@ -275,15 +287,31 @@ jobs:
             Start-Sleep -Milliseconds 500
           }
           $sw.Stop()
+          # Settles the exit code even if the handle trick above ever fails.
+          $proc.WaitForExit()
+          $exitCode = $proc.ExitCode
 
           Write-Host "=== RESULT ==="
           Write-Host ("wall_seconds         = {0:N0}" -f $sw.Elapsed.TotalSeconds)
           Write-Host ("max_sum_bytes        = {0}" -f $maxSum)
           Write-Host ("max_sum_gib          = {0:N2}" -f ($maxSum / 1GB))
           Write-Host ("max_single_proc_gib  = {0:N2}  ({1})" -f ($maxOne / 1GB), $maxOneName)
-          Write-Host ("exit_code            = {0}" -f $proc.ExitCode)
+          Write-Host ("exit_code            = {0}" -f $exitCode)
 
-          if ($proc.ExitCode -ne 0) {
-            Write-Error "build failed with exit code $($proc.ExitCode)"
-            exit $proc.ExitCode
+          # Independent confirmation that a build really happened, so an
+          # unreadable exit code can never again be mistaken for either
+          # outcome. The artifact is the ground truth.
+          $exe = "target\x86_64-pc-windows-msvc\release\ephpm.exe"
+          if (Test-Path $exe) {
+            Write-Host ("binary_bytes         = {0}" -f (Get-Item $exe).Length)
+          } else {
+            Write-Host "::error::$exe was not produced -- the build did not complete"
+            exit 1
+          }
+
+          if ($null -eq $exitCode) {
+            Write-Host "::warning::exit code unreadable; falling back to the artifact check above"
+          } elseif ($exitCode -ne 0) {
+            Write-Error "build failed with exit code $exitCode"
+            exit $exitCode
           }


### PR DESCRIPTION
Found while running the codegen-units measurement. Both measurement runs ([31145743727](https://github.com/ephpm/ephpm/actions/runs/31145743727), [31148330870](https://github.com/ephpm/ephpm/actions/runs/31148330870)) **completed their builds successfully** and then reported the job as failed.

The logs show the build finishing:

```
Finished `release` profile [optimized] target(s) in 16m 46s
==> Windows binary ready:
    ...\target\x86_64-pc-windows-msvc\release\ephpm.exe
=== RESULT ===
wall_seconds         = 1,062
max_sum_gib          = 5.63
max_single_proc_gib  = 2.66  (rustc)
exit_code            =
```

`exit_code` is **empty**.

## Cause

`Start-Process -PassThru` returns a `Process` object, but .NET can only report `ExitCode` while it still holds an open handle to the process. The polling loop only ever reads `HasExited`; the first access to `ExitCode` happens *after* the process has exited, by which point the handle is gone and the property is `$null`.

Then:

```powershell
if ($proc.ExitCode -ne 0) {   # $null -ne 0  ->  TRUE
```

so the failure branch fires on every run, regardless of outcome.

## Why this is worth fixing rather than tolerating

It is not just a spurious red mark. It makes a **successful build and a genuinely failed one produce identical job status**, which defeats the purpose of a job whose entire output is a measurement. A real OOM — the thing this workflow exists to detect — would have looked exactly the same.

## Fix

- Touch `$proc.Handle` immediately after `Start-Process` so the handle is retained and `ExitCode` stays readable after exit.
- `WaitForExit()` before reading it; keep the result in `$exitCode` rather than re-reading the property.
- Assert the produced `ephpm.exe` exists as ground truth, and log its size. An unreadable exit code is now a warning backed by that artifact check, not a silent pass.

## Note on the measurements already taken

The numbers from both affected runs remain valid and are **not** being re-run: the `=== RESULT ===` block is emitted before the faulty check, and both logs independently confirm the build completed (`Finished release profile`, binary produced, 482 `Compiling` lines each).
