### PR TITLE
fix(docker): stub the ephpm-server example targets in the dep-precompile stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,11 +159,21 @@ RUN mkdir -p \
         crates/ephpm-php/src \
         crates/ephpm-query-stats/src \
         crates/ephpm-server/src \
+        crates/ephpm-server/examples \
         crates/ephpm-sqld/src && \
     printf 'fn main() {}\n' > xtask/src/main.rs && \
     printf 'fn main() {}\n' > crates/ephpm/src/main.rs && \
     for d in ephpm-cluster ephpm-config ephpm-db ephpm-kv ephpm-middleware ephpm-middleware-builtins ephpm-middleware-cors ephpm-middleware-jwt ephpm-middleware-ratelimit ephpm-middleware-security-headers ephpm-php ephpm-query-stats ephpm-server ephpm-sqld; do \
         touch crates/$d/src/lib.rs; \
+    done && \
+    # ephpm-server declares three `[[example]] crate-type = ["cdylib"]` targets
+    # (the middleware-ABI probes added in #230). A named [[example]] must exist
+    # as a file or cargo hard-errors during this stub stage with
+    # "can't find 'mw_probe_abi_v2' example at examples/mw_probe_abi_v2.rs" --
+    # before a single dependency is fetched. Keep this list in sync with the
+    # [[example]] blocks in crates/ephpm-server/Cargo.toml.
+    for e in mw_probe_v1 mw_probe_abi_v2 mw_probe_no_invoke; do \
+        printf 'fn main() {}\n' > crates/ephpm-server/examples/$e.rs; \
     done && \
     # ephpm-php Cargo.toml declares `build = "build.rs"` explicitly, so cargo
     # errors out (rather than silently skipping) if the file is missing during


### PR DESCRIPTION
## Release blocker

`docker build -f docker/Dockerfile .` **fails on `main` today**, at `cargo fetch` — before a single dependency is downloaded:

```
can't find 'mw_probe_abi_v2' example at examples/mw_probe_abi_v2.rs
```

#230 added three `[[example]] crate-type = ["cdylib"]` targets to `crates/ephpm-server/Cargo.toml` (the middleware-ABI probes). A **named** `[[example]]` must exist as a file or cargo hard-errors. The dependency-precompile stage stubs every crate's `src/lib.rs` and `src/main.rs` but has no notion of `examples/`.

**#230 is not in v0.6.1**, so the last released image predates the break. This means:

- every local `podman build` / `docker build` of the image fails on main right now, and
- the `docker-image` leg of a **v0.6.2 tag would fail**. `Create Release` `needs:` that job, so the release would park — the same way v0.6.1 parked on the privileged-buildx problem.

## The fix

Add `crates/ephpm-server/examples` to the `mkdir -p` list and stub the three named targets, with a comment pointing at the `[[example]]` blocks so the lists stay in sync.

## Verification

Built the `builder` stage to completion with the fix applied — it gets past `cargo fetch` and compiles every workspace crate:

```
Compiling ephpm-server v0.1.0 (/src/crates/ephpm-server)
[3/3] COMMIT
Successfully tagged localhost/ephpm-dockerfix-test:latest
```

## Found by accident, which is the real lesson

This surfaced while building a fault-injection harness, not from CI. #248's `docker-driver-smoke` canary builds a **busybox** image — it proves the fleet can do unprivileged builds, but says nothing about whether *our* Dockerfile builds. Widening that canary to build the real Dockerfile (or at least its `builder` target) would have caught this, and would catch the next one. Worth a follow-up; deliberately not in this PR.