### PR TITLE
fix(php): a bare zend_bailout() returned HTTP 200 with a truncated body

### DIFF
--- a/crates/ephpm-e2e/tests/errors.rs
+++ b/crates/ephpm-e2e/tests/errors.rs
@@ -59,6 +59,60 @@ async fn php_memory_limit_exceeded_returns_500() {
     assert_server_still_alive(&base_url, "memory_limit").await;
 }
 
+/// A script that bails out **after** producing output must not have that
+/// output completed as a response.
+///
+/// This is the silent-corruption case: a bailout leaves a truncated prefix in
+/// the SAPI capture buffer, and shipping it (at any status) hands a client half
+/// a document. The fpm path buffers the whole response before it reaches the
+/// wire, so the correct answer is always available: 500, partial body dropped,
+/// PHP's headers dropped with it — they describe a response that was never
+/// finished.
+///
+/// The assertions are deliberately specific. `status == 500` alone would pass
+/// even if the truncated body were still being served.
+#[tokio::test]
+async fn php_bailout_discards_partial_output_and_returns_500() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/bailout_after_output.php");
+
+    let resp = reqwest::get(&url).await.unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    let status = resp.status().as_u16();
+    let had_php_header = resp.headers().contains_key("x-bailout-fixture");
+    let body = resp.text().await.unwrap_or_default();
+
+    assert_eq!(status, 500, "a bailed-out script must never report success; body was: {body}");
+    assert!(
+        !body.contains("BAILOUT-FIXTURE-PARTIAL-OUTPUT"),
+        "the truncated prefix the script had already echoed must not be delivered; body: {body}"
+    );
+    assert!(
+        !body.contains("BAILOUT-FIXTURE-UNREACHABLE"),
+        "the script never got this far; body: {body}"
+    );
+    assert!(
+        !had_php_header,
+        "headers the script set describe a response it never finished — they must be dropped too"
+    );
+
+    assert_server_still_alive(&base_url, "bailout_after_output").await;
+}
+
+/// The other half of the contract, and the reason the test above cannot stand
+/// alone: a script that does NOT bail out still gets its complete body and its
+/// own headers. "Discard everything, always" would satisfy the test above.
+#[tokio::test]
+async fn normal_script_still_returns_200_with_a_complete_body() {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/custom_header.php");
+
+    let resp = reqwest::get(&url).await.unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    assert_eq!(resp.status().as_u16(), 200);
+    assert!(resp.headers().contains_key("x-custom"), "a healthy script's headers must survive");
+    let body = resp.text().await.unwrap_or_default();
+    assert_eq!(body, "done", "a healthy script's body must be delivered in full");
+}
+
 #[tokio::test]
 async fn php_syntax_error_returns_500() {
     let base_url = required_env("EPHPM_URL");

--- a/crates/ephpm-e2e/tests/worker_mode.rs
+++ b/crates/ephpm-e2e/tests/worker_mode.rs
@@ -17,6 +17,10 @@
 //! - boot-once: a boot counter that increments once per worker, not per request
 //! - concurrency: N workers serve N concurrent requests on Linux (ZTS)
 //! - fatal -> 500 + recycle + next request succeeds + server never wedges
+//! - a `zend_bailout` mid-request never delivers the partial output it had
+//!   already produced, and — when the response headers are already on the wire
+//!   (`send_response_stream`) — the body is deliberately broken rather than
+//!   completed, so the client cannot read a truncated download as a success
 //! - worker_max_requests recycle
 //! - issue #116: a `do_blocks()`-shaped nested render never recycles a worker,
 //!   and renders byte-identically on every request of a worker's life
@@ -154,6 +158,104 @@ async fn fatal_500s_then_recovers() {
 /// per-worker "request #R" counter resets after a boot, so across a long run
 /// we must see R values reset (not grow monotonically forever), and the boot
 /// id set must grow (new boots) — but stay bounded per unit time.
+/// A worker request killed by a real `zend_bailout` must not have its partial
+/// output delivered.
+///
+/// `?__bailout=1` echoes a marker and then exhausts the memory limit. The
+/// bailout is absorbed by `php_execute_script`'s own `zend_try`, so the worker
+/// loop returns with the request still in flight and the capture buffers
+/// holding a truncated prefix. The engine used to synthesize a response out of
+/// those buffers; for a bare bailout that produced a **200** carrying half a
+/// document, and even for this memory case it shipped the partial body.
+///
+/// The marker assertion is the substantive one and is unconditional — no
+/// deployment of any worker script may return output from a request that died.
+#[tokio::test]
+async fn bailout_never_delivers_partial_output() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode bailout test");
+        return;
+    };
+
+    let (status, body) = get(&base, "/trigger?__bailout=1").await;
+
+    assert!(
+        !body.contains("WORKER-BAILOUT-PARTIAL-OUTPUT"),
+        "output echoed before the bailout was delivered to the client \
+         ({status}): {body}"
+    );
+    assert!(
+        !body.contains("WORKER-BAILOUT-UNREACHABLE"),
+        "the script never got this far ({status}): {body}"
+    );
+
+    // A deployment whose worker script ignores the flag answers with the
+    // reference "hello" body; that is not this test's subject, so only the
+    // marker assertions above apply to it.
+    if body.contains("hello /trigger") {
+        eprintln!("deployed worker script ignores ?__bailout — status assertion skipped");
+    } else {
+        assert_eq!(
+            status, 500,
+            "a request that died in a bailout must be a 500, got {status}: {body}"
+        );
+    }
+
+    // ...and the pool recovers: the worker is recycled, not wedged.
+    for i in 0..10 {
+        let (status, body) = get(&base, &format!("/after-bailout-{i}")).await;
+        assert_eq!(status, 200, "request after bailout wedged the server: {status} {body}");
+    }
+}
+
+/// The case where a 500 is no longer available: the worker dies **after**
+/// `send_response_stream` has already put `200 OK` and the headers on the wire.
+///
+/// A status line cannot be retracted, so the only honest signal left is the
+/// framing. ePHPm ends the body with an error instead of closing the channel,
+/// which under `Transfer-Encoding: chunked` means the terminating `0` chunk is
+/// never written — the client's transfer fails. Closing the channel cleanly
+/// (what it did before) is byte-for-byte a *successful* truncated download.
+///
+/// `?__stream_bailout=1` faults inside a userland stream wrapper's second
+/// `stream_read()`, i.e. inside the C pump loop, one chunk into the body.
+#[tokio::test]
+async fn streamed_response_is_broken_not_completed_when_worker_bails() {
+    let Some(base) = worker_url() else {
+        eprintln!("EPHPM_WORKER_URL unset — skipping worker-mode stream-bailout test");
+        return;
+    };
+
+    let url = format!("{base}/s?__stream_bailout=1");
+    let resp = reqwest::get(&url).await.unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    // A deployment whose worker script ignores the flag answers with the
+    // reference body; nothing to assert about framing then.
+    if resp.status().as_u16() == 200 && !resp.headers().contains_key("transfer-encoding") {
+        eprintln!("deployed worker script ignores ?__stream_bailout — skipping");
+        return;
+    }
+
+    // Reading the body must FAIL. The bytes that did arrive are fine — it is
+    // the clean end-of-body that must not happen.
+    match resp.bytes().await {
+        Ok(body) => panic!(
+            "a streamed response whose worker died completed successfully with {} bytes — \
+             the client cannot tell this from a finished download",
+            body.len()
+        ),
+        Err(e) => {
+            assert!(e.is_body() || e.is_decode(), "expected a body/transfer error, got: {e}");
+        }
+    }
+
+    // ...and the pool recovers.
+    for i in 0..10 {
+        let (status, body) = get(&base, &format!("/after-stream-bailout-{i}")).await;
+        assert_eq!(status, 200, "request after stream bailout wedged the server: {status} {body}");
+    }
+}
+
 #[tokio::test]
 async fn requests_keep_succeeding_across_recycles() {
     let Some(base) = worker_url() else {

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -792,6 +792,40 @@ void ephpm_request_set_ini(const char *key, const char *value)
     request_ini_count++;
 }
 
+/* Return codes for ephpm_execute_request(). Must match the match arms in
+ * crates/ephpm-php/src/lib.rs::execute_php. */
+#define EPHPM_EXEC_OK            0
+#define EPHPM_EXEC_STARTUP_FAIL (-1)
+#define EPHPM_EXEC_SCRIPT_EXIT  (-2)
+#define EPHPM_EXEC_BAILOUT      (-3)
+
+/*
+ * Did a zend_bailout() happen since the last ephpm_bailout_reset()?
+ *
+ * This is the ONLY reliable bailout signal available to us, and the reason is
+ * worth spelling out: php_execute_script() wraps the whole compile+execute in
+ * its OWN zend_try/zend_end_try. zend_end_try does not re-raise — it restores
+ * EG(bailout) and falls through — so a bailout raised anywhere inside the
+ * script is fully absorbed there and NEVER reaches a SETJMP we installed
+ * around the call. Our guard only ever fires for a bailout raised outside
+ * php_execute_script.
+ *
+ * PG(last_error_type) covers the fatals that go through zend_error()
+ * (E_ERROR, uncaught Throwable via zend_exception_error, parse errors), but a
+ * bare zend_bailout() — which a C extension, a resource limit, or OPcache can
+ * raise directly — sets no error type at all. Before this check such a request
+ * came back as a clean HTTP 200 carrying a truncated body.
+ *
+ * _zend_bailout() sets CG(unclean_shutdown) = 1 immediately before its
+ * LONGJMP, unconditionally and regardless of which zend_try catches it, and
+ * nothing else in the engine sets that flag. init_compiler() (via
+ * zend_activate() <- php_request_startup()) clears it per request; we clear it
+ * explicitly as well so the signal can never be a leftover from a previous
+ * request on this thread.
+ */
+#define ephpm_bailout_reset()    (CG(unclean_shutdown) = 0)
+#define ephpm_bailout_observed() (CG(unclean_shutdown) != 0)
+
 /*
  * Execute a PHP request.
  *
@@ -808,9 +842,13 @@ void ephpm_request_set_ini(const char *key, const char *value)
  * __thread-local per-request state, so concurrent reuse is safe.
  *
  * Returns:
- *   0  on success
- *  -1  if php_request_startup failed (only on cold start)
- *  -2  if PHP bailed out (fatal error, exit(), die())
+ *   EPHPM_EXEC_OK          (0)  the script ran to completion
+ *   EPHPM_EXEC_STARTUP_FAIL(-1) php_request_startup failed (only on cold start)
+ *   EPHPM_EXEC_SCRIPT_EXIT (-2) the script chose to stop (exit()/die()); the
+ *                               captured response is complete and trustworthy
+ *   EPHPM_EXEC_BAILOUT     (-3) a zend_bailout() unwound the script; the
+ *                               captured response is TRUNCATED and must never
+ *                               be completed as a success (see below)
  */
 int ephpm_execute_request(const char *filename)
 {
@@ -877,7 +915,7 @@ int ephpm_execute_request(const char *filename)
     SG(server_context) = &ephpm_server_context_marker;
 
     if (php_request_startup() != SUCCESS) {
-        return -1;
+        return EPHPM_EXEC_STARTUP_FAIL;
     }
     request_active = 1;
 
@@ -913,11 +951,12 @@ int ephpm_execute_request(const char *filename)
     /* Reset PHP's last-error tracking so we can tell whether THIS script
      * raised a fatal (vs. a value carried over from a prior request). */
     PG(last_error_type) = 0;
+    /* Same for the bailout flag — see ephpm_bailout_observed() above. */
+    ephpm_bailout_reset();
 
     /* Execute the script with bailout protection.
      * PHP's zend_try/zend_catch uses setjmp/longjmp. */
-    int result = 0;
-    int fatal_bailout = 0;
+    int result = EPHPM_EXEC_OK;
     JMP_BUF *__orig_bailout = EG(bailout);
     JMP_BUF __bailout;
 
@@ -933,13 +972,13 @@ int ephpm_execute_request(const char *filename)
          * and should preserve whatever status the script set. */
         if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
             zend_clear_exception();
-            result = -2;
+            result = EPHPM_EXEC_SCRIPT_EXIT;
         }
     } else {
-        /* PHP bailed out via zend_bailout() — out-of-memory, max
-         * execution time, etc. Older fatal classes hit this path. */
-        result = -2;
-        fatal_bailout = 1;
+        /* A zend_bailout() raised OUTSIDE php_execute_script's own zend_try
+         * (rare — that guard absorbs everything raised by the script itself).
+         * The CG(unclean_shutdown) check below covers both cases. */
+        result = EPHPM_EXEC_BAILOUT;
     }
     EG(bailout) = __orig_bailout;
 
@@ -980,10 +1019,14 @@ int ephpm_execute_request(const char *filename)
     capture_response_headers();
     response_status_code = SG(sapi_headers).http_response_code;
 
-    /* Decide whether to override status with 500. There are two paths:
+    /* Decide whether to override status with 500. There are three paths:
      *
-     *   1. zend_bailout() longjmps out of execute (legacy fatal path):
-     *      caught by SETJMP above — fatal_bailout = 1.
+     *   1. zend_bailout() — out of memory, a resource limit, OPcache, or a
+     *      C extension calling zend_bailout() directly. Detected via
+     *      CG(unclean_shutdown); see the ephpm_bailout_observed() comment for
+     *      why the SETJMP above cannot see it. Checked AFTER the shutdown
+     *      functions / ob flush so a bailout in either of those (which also
+     *      truncates the response) counts too.
      *
      *   2. PHP 8.x uncaught Throwable: zend_exception_error() calls
      *      zend_error_va(... | E_DONT_BAIL ...) which prints the fatal
@@ -992,12 +1035,22 @@ int ephpm_execute_request(const char *filename)
      *      catch this case. Without it, "Fatal error: Uncaught Error:
      *      Call to undefined function ..." comes back as 200 OK.
      *
-     * Either way, we only override when the script hasn't already set
-     * an explicit error status (PHP exit() / http_response_code()). */
+     *   3. zend_error(E_ERROR, ...) — sets last_error_type AND bails out, so
+     *      both signals fire. 500 either way.
+     *
+     * A bailout forces 500 UNCONDITIONALLY: it is never something a script
+     * asks for (PHP 8's exit() throws an unwind-exit exception instead), so a
+     * status the script set earlier describes a response it never finished
+     * producing. The last_error_type path keeps its narrower rule — only
+     * override a default 200 — because a framework's own error handler
+     * legitimately sets its status before the engine records the fatal. */
     int fatal_error_mask = E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR
                            | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE;
-    int hit_fatal = fatal_bailout || (PG(last_error_type) & fatal_error_mask);
-    if (hit_fatal && response_status_code == 200) {
+    if (ephpm_bailout_observed()) {
+        result = EPHPM_EXEC_BAILOUT;
+        response_status_code = 500;
+    } else if ((PG(last_error_type) & fatal_error_mask)
+               && response_status_code == 200) {
         response_status_code = 500;
     }
 
@@ -2166,14 +2219,20 @@ void ephpm_worker_set_populate_superglobals(int enable)
  *    2  same, but the request ended on a PHP fatal (uncaught Throwable /
  *       E_ERROR). The synthesized response was forced to 500 unless the script
  *       had already chosen a status
- *   -2  a fatal / zend_bailout unwound out of the framework (recycle + the
- *       Rust supervisor fulfils any parked oneshot with a 500)
+ *   -2  a zend_bailout() killed the worker (recycle; the Rust supervisor
+ *       fulfils any parked oneshot with a 500 and ABORTS an already-begun
+ *       streaming response rather than letting it end cleanly)
  */
 int ephpm_worker_run(const char *script)
 {
     int result = 0;
     JMP_BUF *__orig_bailout = EG(bailout);
     JMP_BUF __bailout;
+
+    /* See ephpm_bailout_observed(): php_execute_script's own zend_try absorbs
+     * every bailout raised inside the worker script, so this SETJMP fires only
+     * for one raised outside it. CG(unclean_shutdown) catches both. */
+    ephpm_bailout_reset();
 
     EG(bailout) = &__bailout;
     if (SETJMP(__bailout) == 0) {
@@ -2194,15 +2253,26 @@ int ephpm_worker_run(const char *script)
             zend_clear_exception();
         }
 
-        /* The script ended with a request still in flight (exit()/die()
-         * mid-request, or a break out of the loop without send_response).
-         * Deliver what the request actually produced — SAPI status, headers
-         * emitted via header()/setcookie(), and the captured echo output —
-         * instead of letting the parked oneshot die with the thread (which
-         * would turn every wp_die()/admin-ajax exit into a bogus 500). This
-         * is safe here: unwind-exit is clean stack unwinding, not a bailout,
-         * so SAPI globals and the capture buffers are intact. */
-        if (req_in_flight && g_worker_ops.send_response) {
+        /* Branch 1 — a bailout absorbed by php_execute_script's own zend_try.
+         * Whatever the capture buffers hold is truncated, so we must NOT
+         * synthesize a response from them: a bare zend_bailout() sets no error
+         * type, so the hit_fatal check further down would see 200 and ship the
+         * partial body as a success. Return -2 with the oneshot still parked —
+         * the Rust supervisor 500s it, or aborts the body stream if the
+         * headers already went out (worker_pool.rs / clear_in_flight_streams).
+         *
+         * Branch 2 — the script ended with a request still in flight
+         * (exit()/die() mid-request, or a break out of the loop without
+         * send_response). Deliver what the request actually produced — SAPI
+         * status, headers emitted via header()/setcookie(), and the captured
+         * echo output — instead of letting the parked oneshot die with the
+         * thread (which would turn every wp_die()/admin-ajax exit into a bogus
+         * 500). That is safe only because unwind-exit is clean stack
+         * unwinding, not a bailout, so SAPI globals and the capture buffers
+         * are intact — which is exactly why branch 1 has to come first. */
+        if (ephpm_bailout_observed()) {
+            result = -2;
+        } else if (req_in_flight && g_worker_ops.send_response) {
             /* Unwind-exit skips the script's own ob_end_* calls, and worker
              * mode has no per-request RSHUTDOWN to flush buffers — content
              * still sitting in userland output buffers (WordPress wraps whole

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -72,7 +72,9 @@ mod ffi {
         );
 
         /// Execute a PHP request with full lifecycle management.
-        /// Returns 0 on success, -1 on startup failure, -2 on bailout.
+        ///
+        /// Returns one of the `EPHPM_EXEC_*` codes defined in
+        /// `ephpm_wrapper.c` — mirrored by `super::exec_code`.
         pub fn ephpm_execute_request(
             filename: *const ::std::os::raw::c_char,
         ) -> ::std::os::raw::c_int;
@@ -192,6 +194,34 @@ pub enum PhpError {
     /// TSRM thread registration failed.
     #[error("PHP thread initialization failed")]
     ThreadInitFailed,
+
+    /// The script was unwound by a `zend_bailout()` — out of memory, a
+    /// resource limit, OPcache, or a C extension calling it directly.
+    ///
+    /// Distinct from every other variant because of what it says about the
+    /// *output*: whatever the SAPI captured is a truncated prefix of a
+    /// response the script never finished producing. It must never be
+    /// completed as a success, so callers discard the partial body and answer
+    /// 500 (`build_php_response`'s error arm) rather than returning it.
+    ///
+    /// PHP 8's `exit()`/`die()` is NOT a bailout — it throws an unwind-exit
+    /// exception, which unwinds cleanly and yields a complete response.
+    #[error("PHP script bailed out (truncated response discarded): {0}")]
+    Bailout(String),
+}
+
+/// The `EPHPM_EXEC_*` return codes of `ephpm_execute_request` (defined in
+/// `crates/ephpm-php/ephpm_wrapper.c` — keep the two in sync).
+#[cfg(php_linked)]
+mod exec_code {
+    /// The script ran to completion.
+    pub const OK: std::os::raw::c_int = 0;
+    /// `php_request_startup()` failed (cold start only).
+    pub const STARTUP_FAIL: std::os::raw::c_int = -1;
+    /// The script chose to stop (`exit()`/`die()`); the response is complete.
+    pub const SCRIPT_EXIT: std::os::raw::c_int = -2;
+    /// A `zend_bailout()` unwound the script; the response is truncated.
+    pub const BAILOUT: std::os::raw::c_int = -3;
 }
 
 /// How a worker's framework loop ended (see [`PhpRuntime::run_worker`]).
@@ -210,8 +240,16 @@ pub enum WorkerExit {
     /// one; it differs only in that the worker died rather than chose to stop,
     /// which is what the recycle-reason metric reports.
     ScriptFatal,
-    /// A fatal bailout unwound out of the framework. The caller must recycle
-    /// the worker and fulfil any parked oneshot with a 500.
+    /// A `zend_bailout()` killed the worker. Nothing was delivered: unlike
+    /// [`WorkerExit::ScriptFatal`], the C layer deliberately does **not**
+    /// synthesize a response, because the capture buffers hold a truncated
+    /// prefix of one the script never finished.
+    ///
+    /// The caller must recycle the worker and make sure the request cannot be
+    /// mistaken for a success — fulfil a still-parked oneshot with a 500, and
+    /// if a streaming response already put headers on the wire, abort the body
+    /// stream instead of closing it cleanly
+    /// ([`worker_bridge::clear_in_flight_streams`]).
     Fatal,
 }
 
@@ -668,17 +706,52 @@ impl PhpRuntime {
         let status = u16::try_from(status_code).unwrap_or(200);
 
         match ret {
-            0 => Ok(PhpResponse { status, headers, body }),
-            -1 => Err(PhpError::ExecutionFailed("php_request_startup failed".into())),
-            _ => {
-                // Bailout (exit/die/fatal): return whatever output was captured
+            exec_code::OK => Ok(PhpResponse { status, headers, body }),
+            exec_code::STARTUP_FAIL => {
+                Err(PhpError::ExecutionFailed("php_request_startup failed".into()))
+            }
+            // A zend_bailout() unwound the script. `body` is a truncated
+            // prefix of a response that was never finished, so it is dropped
+            // here rather than shipped: completing it would hand a caching
+            // proxy, a health probe, or a client half a document labelled as
+            // success. The fpm path buffers the whole response before this
+            // point, so nothing has reached the wire yet and answering 500 is
+            // always possible.
+            //
+            // This is the only place the failure is visible at all — the
+            // engine prints nothing for a bare zend_bailout().
+            exec_code::BAILOUT => {
+                tracing::error!(
+                    script = %request.script_filename.display(),
+                    method = %request.method,
+                    uri = %request.uri,
+                    discarded_body_bytes = body.len(),
+                    output_tail = %truncated_output_tail(&body),
+                    "PHP script terminated in a Zend bailout (out of memory, a \
+                     resource limit, or an extension calling zend_bailout()) — \
+                     truncated response discarded, returning 500"
+                );
+                Err(PhpError::Bailout(format!(
+                    "{} ({} {})",
+                    request.script_filename.display(),
+                    request.method,
+                    request.uri
+                )))
+            }
+            // exit()/die() unwinds cleanly, so the captured response is
+            // complete and is returned as-is, keeping whatever status the
+            // script chose (an empty one is still an error — nothing was
+            // produced).
+            exec_code::SCRIPT_EXIT => {
                 if body.is_empty() {
-                    Err(PhpError::ExecutionFailed("PHP bailout (fatal error or exit)".into()))
+                    Err(PhpError::ExecutionFailed("PHP exited without output".into()))
                 } else {
-                    // exit() and die() are common in PHP — return the output
                     Ok(PhpResponse { status, headers, body })
                 }
             }
+            other => Err(PhpError::ExecutionFailed(format!(
+                "ephpm_execute_request returned an unknown code {other}"
+            ))),
         }
     }
 
@@ -936,6 +1009,22 @@ impl PhpRuntime {
     pub fn opcache_invalidate_under(_docroot: &std::path::Path) -> Option<i64> {
         None
     }
+}
+
+/// The last [`TAIL_BYTES`] of a discarded response body, for the bailout log
+/// line.
+///
+/// The body is thrown away rather than served, so this is the only place PHP's
+/// own account of what went wrong (`Fatal error: Allowed memory size ...`,
+/// which is emitted into the output stream when `display_errors` is on)
+/// survives. The tail, not the head: the fatal is always the last thing
+/// written.
+#[cfg(php_linked)]
+fn truncated_output_tail(body: &[u8]) -> String {
+    /// How much of the discarded body to keep in the log line.
+    const TAIL_BYTES: usize = 512;
+    let tail = &body[body.len().saturating_sub(TAIL_BYTES)..];
+    String::from_utf8_lossy(tail).replace(['\n', '\r'], " ")
 }
 
 impl Drop for PhpRuntime {

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -126,8 +126,28 @@ pub enum WorkerResponse {
         headers: Vec<(String, String)>,
         /// Bounded receiver of body chunks; sender close = end of body.
         body_rx: tokio::sync::mpsc::Receiver<bytes::Bytes>,
+        /// Set when the worker died before finishing this body — see
+        /// [`StreamAbortFlag`].
+        aborted: StreamAbortFlag,
     },
 }
+
+/// Marks a streamed response whose producer died before it was finished.
+///
+/// Once `response_begin` has delivered status + headers, they are on the wire
+/// and cannot be retracted. If the worker then bails out, simply dropping the
+/// chunk sender closes the body channel — and a closed channel is
+/// indistinguishable from a normal end of body, so hyper writes the
+/// terminating chunk and the client reads a well-formed, silently truncated
+/// **200**. That is the failure this flag exists to prevent.
+///
+/// [`clear_in_flight_streams`] sets it before dropping the sender; the body
+/// stream checks it once the channel is exhausted and, if set, ends the body
+/// with an `io::Error` instead of a clean EOF. hyper then abandons the
+/// response — no terminating chunk under `Transfer-Encoding: chunked`, a
+/// short read against a declared `Content-Length` — so the client's transfer
+/// fails rather than succeeding with half a document.
+pub type StreamAbortFlag = std::sync::Arc<std::sync::atomic::AtomicBool>;
 
 impl WorkerResponse {
     /// Build the canonical 500 response used when a worker bailed out before
@@ -336,6 +356,11 @@ thread_local! {
     /// The in-flight streaming-response chunk sender (`send_response_stream`).
     static RESPONSE_TX: RefCell<Option<ResponseChunkTx>> = const { RefCell::new(None) };
 
+    /// The in-flight streaming response's [`StreamAbortFlag`]. Present only
+    /// between `response_begin` and `response_end`; cleared on a clean finish
+    /// so a later bailout cannot retroactively abort a completed stream.
+    static RESPONSE_ABORT: RefCell<Option<StreamAbortFlag>> = const { RefCell::new(None) };
+
     /// Requests handled by this worker since boot (drives `worker_max_requests`).
     static REQUESTS_HANDLED: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 
@@ -451,24 +476,41 @@ pub fn take_pending_sender() -> Option<tokio::sync::oneshot::Sender<WorkerRespon
     None
 }
 
-/// Drop any in-flight streaming state left over after a bailout: the response
-/// chunk sender (closing its channel signals end-of-body to the hyper handler,
-/// so a client mid-download gets a truncated-but-not-hung response) and the
-/// body reader. Call from the pool's crash-recovery path before the worker
+/// Tear down any in-flight streaming state left over after a bailout, marking
+/// an unfinished response as aborted so it cannot be mistaken for a complete
+/// one. Call from the pool's crash-recovery path before the worker
 /// resumes/respawns. Idempotent.
+///
+/// Order matters: the [`StreamAbortFlag`] is set **before** the chunk sender is
+/// dropped, because dropping the sender is what closes the channel, and the
+/// body stream only reads the flag after it observes that close. Setting it
+/// first is what makes the flag visible in time.
+///
+/// Returns `true` if a still-open streamed body was aborted — i.e. the response
+/// headers were already on the wire, so the client is receiving a deliberately
+/// broken transfer rather than a 500.
 ///
 /// `CURRENT_REQUEST` is NOT cleared: `worker_thread_shutdown()` runs after
 /// this and its `php_request_shutdown` may still read the `SG(request_info)`
 /// pointers that borrow from it. The thread-local drops at thread exit.
 #[cfg(php_linked)]
-pub fn clear_in_flight_streams() {
-    RESPONSE_TX.with(|cell| *cell.borrow_mut() = None);
+#[must_use]
+pub fn clear_in_flight_streams() -> bool {
+    let aborted = RESPONSE_ABORT.with(|cell| cell.borrow_mut().take());
+    if let Some(flag) = &aborted {
+        flag.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+    let had_stream = RESPONSE_TX.with(|cell| cell.borrow_mut().take()).is_some();
     BODY_READER.with(|cell| *cell.borrow_mut() = BodyReader::Empty);
+    had_stream && aborted.is_some()
 }
 
-/// Stub.
+/// Stub: no worker streams exist without PHP linked.
 #[cfg(not(php_linked))]
-pub fn clear_in_flight_streams() {}
+#[must_use]
+pub fn clear_in_flight_streams() -> bool {
+    false
+}
 
 // ── Callback implementations ─────────────────────────────────────────────
 
@@ -582,8 +624,10 @@ unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int 
     PENDING_SENDER.with(|cell| *cell.borrow_mut() = Some(job.respond_to));
 
     // Any stale streaming-response sender from a prior iteration is dropped
-    // here (closing its channel) so it can never bleed into this request.
+    // here (closing its channel) so it can never bleed into this request. Its
+    // abort flag goes with it, unset — that iteration is over either way.
     RESPONSE_TX.with(|cell| *cell.borrow_mut() = None);
+    RESPONSE_ABORT.with(|cell| *cell.borrow_mut() = None);
 
     // Build owned backing storage + the body reader, and publish the pointers.
     let (current, reader) = build_current_request(job.request);
@@ -677,6 +721,10 @@ fn finish_iteration() {
     // Dropping the streaming-response sender (if any) closes the body channel,
     // signalling end-of-body to the hyper handler.
     RESPONSE_TX.with(|cell| *cell.borrow_mut() = None);
+    // The response finished on its own terms, so release the abort flag
+    // WITHOUT setting it: a bailout later in this worker's life must not
+    // retroactively break a stream that already completed.
+    RESPONSE_ABORT.with(|cell| *cell.borrow_mut() = None);
 }
 
 /// C-callable `body_read`: fill `buf` (capacity `cap`) with the next bytes of
@@ -749,9 +797,20 @@ unsafe extern "C" fn worker_response_begin(
     let (tx, rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(BODY_CHANNEL_DEPTH);
     RESPONSE_TX.with(|cell| *cell.borrow_mut() = Some(tx));
 
+    // From here on the status line and headers are unretractable, so the only
+    // way to signal a mid-stream death is to break the body framing. Both ends
+    // of that signal are wired up now: the flag goes to the hyper body stream,
+    // and a clone stays on this thread for clear_in_flight_streams().
+    let aborted: StreamAbortFlag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    RESPONSE_ABORT.with(|cell| *cell.borrow_mut() = Some(std::sync::Arc::clone(&aborted)));
+
     if let Some(sender) = PENDING_SENDER.with(|cell| cell.borrow_mut().take()) {
-        let _ =
-            sender.send(WorkerResponse::Streaming { status, headers: parsed_headers, body_rx: rx });
+        let _ = sender.send(WorkerResponse::Streaming {
+            status,
+            headers: parsed_headers,
+            body_rx: rx,
+            aborted,
+        });
     }
 }
 

--- a/crates/ephpm-server/src/body.rs
+++ b/crates/ephpm-server/src/body.rs
@@ -40,9 +40,65 @@ pub fn streamed(file: tokio::fs::File) -> ServerBody {
 /// Each [`Bytes`] the worker produces via `send_response_stream` flows straight
 /// to the client as a data frame, so bytes reach the client before PHP has
 /// produced the whole body. The sender closing ends the body.
+///
+/// `aborted` is the streamed response's
+/// [`StreamAbortFlag`](ephpm_php::worker_bridge::StreamAbortFlag). It is read
+/// **after** the channel is exhausted, and decides what that exhaustion means:
+///
+/// - clear → the worker finished the body; end it normally (hyper writes the
+///   terminating chunk / satisfies `Content-Length`);
+/// - set → the worker died mid-body. Yield an `io::Error` as the final frame
+///   so hyper abandons the response instead of completing it. The client sees a
+///   failed transfer — the only honest outcome once a `200` status line has
+///   already gone out and cannot be retracted.
 #[must_use]
-pub fn channel_body(rx: tokio::sync::mpsc::Receiver<Bytes>) -> ServerBody {
-    let stream = tokio_stream::wrappers::ReceiverStream::new(rx)
-        .map(|chunk| Ok::<_, std::io::Error>(Frame::data(chunk)));
-    StreamBody::new(stream).boxed()
+pub fn channel_body(
+    rx: tokio::sync::mpsc::Receiver<Bytes>,
+    aborted: ephpm_php::worker_bridge::StreamAbortFlag,
+) -> ServerBody {
+    StreamBody::new(AbortAwareChunks { rx, aborted, finished: false }).boxed()
+}
+
+/// Chunk stream behind [`channel_body`]: forwards every [`Bytes`] the producer
+/// sends, then decides at end-of-channel whether that was a completed body or
+/// an abandoned one.
+struct AbortAwareChunks {
+    rx: tokio::sync::mpsc::Receiver<Bytes>,
+    aborted: ephpm_php::worker_bridge::StreamAbortFlag,
+    /// Set once the terminal item has been produced, so the stream reports
+    /// end-of-stream afterwards instead of erroring on every poll.
+    finished: bool,
+}
+
+impl tokio_stream::Stream for AbortAwareChunks {
+    type Item = Result<Frame<Bytes>, std::io::Error>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+
+        let this = self.get_mut();
+        if this.finished {
+            return Poll::Ready(None);
+        }
+        match this.rx.poll_recv(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
+            Poll::Ready(None) => {
+                // The channel is closed. Read the flag only now: the producer
+                // sets it before dropping the sender, so if it was going to be
+                // set, it is set by the time we get here.
+                this.finished = true;
+                if this.aborted.load(std::sync::atomic::Ordering::SeqCst) {
+                    Poll::Ready(Some(Err(std::io::Error::other(
+                        "PHP worker died mid-response; body is incomplete",
+                    ))))
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+        }
+    }
 }

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1903,15 +1903,19 @@ impl Router {
             // produces them. No content-length (unknown up front) — chunked
             // transfer. Optionally wrapped in a flush-per-chunk brotli
             // encoder when `[server.response] compression_streaming` says so.
-            ephpm_php::worker_bridge::WorkerResponse::Streaming { status, headers, body_rx } => {
-                build_streamed_worker_response(
-                    status,
-                    headers,
-                    body_rx,
-                    accepts_br,
-                    self.compression,
-                )
-            }
+            ephpm_php::worker_bridge::WorkerResponse::Streaming {
+                status,
+                headers,
+                body_rx,
+                aborted,
+            } => build_streamed_worker_response(
+                status,
+                headers,
+                body_rx,
+                aborted,
+                accepts_br,
+                self.compression,
+            ),
         }
     }
 
@@ -2629,10 +2633,18 @@ fn stream_request_body<B: RequestBody>(
 /// pre-knob code path, no wrapper allocated. Otherwise the channel is wrapped
 /// in a flush-per-chunk brotli encoder task ([`crate::stream_compress`]) and
 /// `Content-Encoding: br` + `Vary: Accept-Encoding` are added.
+///
+/// `aborted` travels with the body all the way to hyper: if the worker dies
+/// before finishing, the body ends in an error rather than a clean EOF, so the
+/// client cannot read the truncation as a successful `200`. It is threaded past
+/// the brotli wrapper unchanged — the wrapper's own channel closes only after
+/// the worker's does, so the flag is already set by the time the outer stream
+/// observes the end.
 fn build_streamed_worker_response(
     status: u16,
     headers: Vec<(String, String)>,
     body_rx: tokio::sync::mpsc::Receiver<Bytes>,
+    aborted: ephpm_php::worker_bridge::StreamAbortFlag,
     accepts_br: bool,
     compression: CompressionSettings,
 ) -> Response<ServerBody> {
@@ -2651,9 +2663,9 @@ fn build_streamed_worker_response(
 
     let body = if compress {
         resp = resp.header("content-encoding", "br").header("vary", "Accept-Encoding");
-        body::channel_body(crate::stream_compress::brotli_stream_body(body_rx))
+        body::channel_body(crate::stream_compress::brotli_stream_body(body_rx), aborted)
     } else {
-        body::channel_body(body_rx)
+        body::channel_body(body_rx, aborted)
     };
     resp.body(body).unwrap_or_else(|_| {
         error_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
@@ -4636,6 +4648,12 @@ echo "post response";
         ]
     }
 
+    /// A fresh, un-tripped abort flag — the state `response_begin` hands to
+    /// hyper for a healthy streamed response.
+    fn live_stream() -> ephpm_php::worker_bridge::StreamAbortFlag {
+        Arc::new(std::sync::atomic::AtomicBool::new(false))
+    }
+
     #[test]
     fn streaming_compression_parse() {
         assert_eq!(StreamingCompression::parse("off"), Some(StreamingCompression::Off));
@@ -4684,6 +4702,7 @@ echo "post response";
             200,
             sse_headers(),
             rx,
+            live_stream(),
             true,
             compression_with(StreamingCompression::Off),
         );
@@ -4723,6 +4742,7 @@ data: two
             200,
             sse_headers(),
             rx,
+            live_stream(),
             true,
             compression_with(StreamingCompression::Sse),
         );
@@ -4779,6 +4799,7 @@ data: two
             200,
             headers,
             rx,
+            live_stream(),
             true,
             compression_with(StreamingCompression::Sse),
         );
@@ -4787,6 +4808,105 @@ data: two
         drop(tx);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(&body[..], b" raw");
+    }
+
+    // -- a bailout mid-stream must break the response, not finish it ----
+    //
+    // Once `send_response_stream` has delivered status + headers they are on
+    // the wire and cannot be retracted. The only remaining way to tell the
+    // client "this failed" is to refuse to terminate the body correctly: hyper
+    // must see an error, so it emits no terminating chunk under
+    // `Transfer-Encoding: chunked`. A clean short body and an aborted short
+    // body carry identical bytes — only the terminal item differs, which is
+    // what these tests pin.
+
+    /// Worker dies mid-stream, uncompressed: the body resolves to an **error**.
+    /// Before the fix, dropping the chunk sender was indistinguishable from a
+    /// normal end of body, so the client read a well-formed, truncated `200`.
+    #[tokio::test]
+    async fn streamed_response_aborts_when_worker_bails_mid_body() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let aborted = live_stream();
+        let resp = build_streamed_worker_response(
+            200,
+            sse_headers(),
+            rx,
+            Arc::clone(&aborted),
+            true,
+            compression_with(StreamingCompression::Off),
+        );
+        // The 200 status line already went out. That is the premise here, not
+        // a bug — it cannot be retracted, only contradicted by the framing.
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        tx.send(Bytes::from_static(b"data: one\n\n")).await.unwrap();
+        // Reproduce `clear_in_flight_streams`'s ordering exactly: set the flag,
+        // THEN drop the sender. The reverse order would race.
+        aborted.store(true, std::sync::atomic::Ordering::SeqCst);
+        drop(tx);
+
+        let err = resp
+            .into_body()
+            .collect()
+            .await
+            .expect_err("an aborted stream must not collect into a complete body");
+        assert!(
+            err.to_string().contains("incomplete"),
+            "the error should say why the transfer failed, got: {err}"
+        );
+    }
+
+    /// Same, through the brotli streaming wrapper: the flag is read on the
+    /// outer stream, which ends only after the encoder task's upstream does, so
+    /// compression must not swallow the abort.
+    #[tokio::test]
+    async fn streamed_brotli_response_aborts_when_worker_bails_mid_body() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let aborted = live_stream();
+        let resp = build_streamed_worker_response(
+            200,
+            sse_headers(),
+            rx,
+            Arc::clone(&aborted),
+            true,
+            compression_with(StreamingCompression::Sse),
+        );
+        assert_eq!(
+            resp.headers().get("content-encoding").and_then(|v| v.to_str().ok()),
+            Some("br"),
+            "precondition: this test must exercise the compressed path"
+        );
+
+        tx.send(Bytes::from_static(b"data: one\n\n")).await.unwrap();
+        aborted.store(true, std::sync::atomic::Ordering::SeqCst);
+        drop(tx);
+
+        assert!(
+            resp.into_body().collect().await.is_err(),
+            "an aborted brotli stream must not collect into a complete body"
+        );
+    }
+
+    /// The inverse guard: a stream that ends with the flag clear still
+    /// completes normally. Without it, "always error" would satisfy the two
+    /// tests above while breaking every streamed response in the product.
+    #[tokio::test]
+    async fn streamed_response_completes_when_abort_flag_stays_clear() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let aborted = live_stream();
+        let resp = build_streamed_worker_response(
+            200,
+            sse_headers(),
+            rx,
+            Arc::clone(&aborted),
+            true,
+            compression_with(StreamingCompression::Off),
+        );
+        tx.send(Bytes::from_static(b"data: one\n\n")).await.unwrap();
+        drop(tx);
+        assert!(!aborted.load(std::sync::atomic::Ordering::SeqCst));
+        let body = resp.into_body().collect().await.expect("clean EOF").to_bytes();
+        assert_eq!(&body[..], b"data: one\n\n");
     }
 
     // -- metrics label helper (#136) --------------------------------

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -383,27 +383,46 @@ fn worker_main(
                 );
             }
             Ok(ephpm_php::WorkerExit::Fatal) => {
-                // Fatal bailout unwound past send_response. Fulfil the parked
-                // oneshot with a 500 so the in-flight request never hangs, then
-                // recycle (never resume on a possibly-corrupt kernel).
-                if let Some(sender) = ephpm_php::worker_bridge::take_pending_sender() {
+                // A zend_bailout() killed the worker. Nothing was delivered
+                // (the C layer refuses to synthesize a response from truncated
+                // capture buffers), so the request must be terminated here —
+                // and it must not look like a success. Two shapes:
+                let sender = ephpm_php::worker_bridge::take_pending_sender();
+                let had_parked_sender = sender.is_some();
+                //   1. Nothing on the wire yet: the oneshot is still parked, so
+                //      the request becomes a clean 500.
+                if let Some(sender) = sender {
                     let _ = sender.send(WorkerResponse::internal_error());
-                    tracing::warn!(
+                    tracing::error!(
                         worker_id,
-                        "worker bailed out mid-request — 500 sent, recycling"
-                    );
-                } else {
-                    // No parked oneshot: the response was already begun. For a
-                    // mid-stream bailout, closing the chunk channel below
-                    // truncates the body without hanging.
-                    tracing::warn!(
-                        worker_id,
-                        "worker bailed out between/after response — recycling"
+                        "PHP worker terminated in a Zend bailout mid-request — \
+                         500 sent, recycling worker"
                     );
                 }
-                // Close any still-open streaming channels so a mid-download
-                // client sees EOF rather than hanging.
-                ephpm_php::worker_bridge::clear_in_flight_streams();
+                //   2. `send_response_stream` already put status+headers on the
+                //      wire, so the 200 cannot be retracted. Setting the abort
+                //      flag makes the body end in an error instead of a clean
+                //      EOF: the client's transfer fails rather than completing
+                //      with a partial document.
+                let aborted_stream = ephpm_php::worker_bridge::clear_in_flight_streams();
+                if aborted_stream {
+                    counter!("ephpm_worker_stream_aborts_total").increment(1);
+                    tracing::error!(
+                        worker_id,
+                        "PHP worker terminated in a Zend bailout after its response \
+                         headers were already sent — response body deliberately \
+                         aborted (no terminating chunk), recycling worker"
+                    );
+                }
+                //   3. Neither: the bailout landed between requests. No client
+                //      is waiting, but it still must not be silent.
+                if !had_parked_sender && !aborted_stream {
+                    tracing::error!(
+                        worker_id,
+                        "PHP worker terminated in a Zend bailout with no request in \
+                         flight — recycling worker"
+                    );
+                }
                 counter!("ephpm_worker_recycles_total", "reason" => "fatal").increment(1);
             }
             Err(e) => {
@@ -425,7 +444,9 @@ fn worker_main(
         if let Some(sender) = ephpm_php::worker_bridge::take_pending_sender() {
             let _ = sender.send(WorkerResponse::internal_error());
         }
-        ephpm_php::worker_bridge::clear_in_flight_streams();
+        // A worker that never booted cannot have an open stream, but abort
+        // whatever is there rather than letting it end cleanly.
+        let _ = ephpm_php::worker_bridge::clear_in_flight_streams();
         pool.state.boot_failures.fetch_add(1, Ordering::AcqRel);
         counter!("ephpm_worker_boot_failures_total").increment(1);
         match outcome {

--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -617,6 +617,38 @@ with the fatal text as its body. `ephpm_worker_run` returns `2` for this case
 than `reason="script_exit"`; the response is already delivered, so the supervisor
 must not send another.
 
+**And a bailout that IS a bailout still does not reach the `SETJMP`.** The point
+above generalises further than it first appeared: `php_execute_script`'s own
+`zend_try` absorbs *every* bailout raised inside the script, including a bare
+`zend_bailout()` from a C extension or an allocator failure — the `SETJMP` in
+`ephpm_worker_run` only ever fires for one raised outside that call. A bare
+`zend_bailout()` sets no `PG(last_error_type)` either, so for a while the
+exit-synthesis branch handled it as a normal end-of-request and shipped the
+truncated capture buffer as a **200**.
+
+The reliable signal is `CG(unclean_shutdown)`: `_zend_bailout()` sets it
+immediately before its `LONGJMP`, unconditionally and regardless of which
+`zend_try` catches the jump, and nothing else in the engine writes it.
+`ephpm_worker_run` clears it before the boot and checks it after
+`php_execute_script` returns; when set it returns `-2` (`WorkerExit::Fatal`)
+**without synthesizing a response**, because the capture buffers hold a prefix of
+a response that was never finished. What the supervisor does then depends on
+whether anything is already on the wire:
+
+- **Nothing sent yet** (the usual case — the parked `oneshot` is still stashed):
+  the request becomes a clean 500.
+- **`send_response_stream` already delivered status + headers**: the 200 cannot
+  be retracted, so the response is *deliberately broken instead of completed*.
+  `clear_in_flight_streams()` sets the response's `StreamAbortFlag` before
+  dropping the chunk sender; the hyper body stream reads the flag when the
+  channel closes and ends the body with an `io::Error`, so hyper writes no
+  terminating chunk and the client's transfer fails. Counted as
+  `ephpm_worker_stream_aborts_total`. Simply dropping the sender — what it did
+  before — was indistinguishable from a normal end of body.
+
+The governing rule for both engines: **never complete a response for a script
+that bailed out.**
+
 ### 5.4 Detecting dead / hung workers; timeouts
 
 - **Hung request (infinite loop / blocked syscall in PHP).** SIGPROF-based

--- a/site/content/architecture/http.md
+++ b/site/content/architecture/http.md
@@ -104,15 +104,20 @@ PHP uses `setjmp`/`longjmp` for error handling. All PHP calls go through `ephpm_
 
 ### PHP Fatal → HTTP 500
 
-A PHP fatal error must surface as an HTTP 500 even though the embed SAPI gives us several different ways for one to happen. `ephpm_execute_request()` in `ephpm_wrapper.c` covers two distinct detection paths:
+A PHP fatal error must surface as an HTTP 500 even though the embed SAPI gives us several different ways for one to happen. `ephpm_execute_request()` in `ephpm_wrapper.c` covers two distinct detection paths — and, importantly, **neither of them is the `SETJMP` guard**.
 
-1. **`zend_bailout()` longjmp.** Out-of-memory, max-execution-time, and the older fatal-class errors call `zend_bailout()`, which longjmps out of `php_execute_script`. The `SETJMP(__bailout) == 0` guard in the wrapper catches that case and sets `fatal_bailout = 1`.
+`php_execute_script()` wraps the whole compile-and-execute in its own `zend_try` / `zend_end_try`. `zend_end_try` does not re-raise: it restores `EG(bailout)` and falls through. So a `zend_bailout()` raised anywhere inside the script is absorbed *there* and never reaches a `SETJMP` we installed around the call. Ours fires only for a bailout raised outside `php_execute_script`.
 
-2. **PHP 8.x uncaught `Throwable`.** When a script throws and nothing catches it, `zend_exception_error()` formats the message via `zend_error_va(... | E_DONT_BAIL ...)` and lets `php_execute_script` return normally. `SETJMP` sees nothing — no longjmp ever happens. To catch this path the wrapper also checks `PG(last_error_type)` against a fatal-class mask (`E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE`). Without that second check, "Fatal error: Uncaught Error: Call to undefined function …" comes back as `200 OK`.
+1. **`zend_bailout()`.** Out-of-memory, resource limits, OPcache, and a C extension calling `zend_bailout()` directly. Detected by reading `CG(unclean_shutdown)` after `php_execute_script` returns: `_zend_bailout()` sets that flag immediately before its `LONGJMP`, unconditionally and regardless of which `zend_try` catches the jump, and nothing else in the engine writes it. It is cleared before each request (both by `init_compiler()` during request startup and explicitly by the wrapper) so a bailout cannot leak into the next request on the same thread.
 
-`PG(last_error_type)` is reset to `0` before each request so a fatal from a previous reuse of the embed request can't leak into the next one.
+2. **PHP 8.x uncaught `Throwable`.** When a script throws and nothing catches it, `zend_exception_error()` formats the message via `zend_error_va(... | E_DONT_BAIL ...)` and lets `php_execute_script` return normally. No longjmp happens at all, so `CG(unclean_shutdown)` stays clear. To catch this path the wrapper checks `PG(last_error_type)` against a fatal-class mask (`E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE`). Without it, "Fatal error: Uncaught Error: Call to undefined function …" comes back as `200 OK`.
 
-Once a fatal has been detected by either path, the wrapper only overrides the status when it is still the default `200`. Anything the script set explicitly via `http_response_code()` or `exit($status)` is preserved — the contract is "200 → 500 on fatal", not "always 500 on fatal".
+`PG(last_error_type)` is likewise reset to `0` before each request.
+
+The two paths get **different** status policies, because they say different things about the response body:
+
+- A **bailout truncates the response**: the script never finished producing it. So the wrapper forces `500` unconditionally (a status the script set earlier describes a response that does not exist), the partial body and the script's headers are discarded rather than served, and ePHPm logs a `tracing::error!` naming the script, the request, and the tail of the discarded output — the only record of the failure, since a bare `zend_bailout()` prints nothing itself. The governing rule is **never complete a response for a script that bailed out**.
+- An **uncaught `Throwable` leaves a complete response**: `php_execute_script` returned normally, shutdown functions ran, output buffers flushed. So the older, narrower policy still applies — override only a default `200`, and preserve anything the script chose via `http_response_code()` or a framework error handler.
 
 ## SAPI Callbacks
 

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -80,6 +80,8 @@ These appear when `[php] mode = "worker"`.
 | `ephpm_worker_boot_timeouts_total` | counter | — | Boots still running when `worker_boot_timeout` expired. The thread is not killed; it still becomes ready if the boot completes. |
 | `ephpm_worker_boot_failures_total` | counter | — | Worker boots that failed (thread spawn/TSRM init failure, or the script exited before its first `take_request()`). The pool respawns with exponential backoff. |
 | `ephpm_worker_recycles_total` | counter | `reason` | Workers recycled. `reason` is `max_requests` (hit `worker_max_requests`), `script_exit` (script called `exit()`/`die()` mid-request), `fatal` (fatal error / bailout), or `hung` (never responded within the request timeout; replaced). |
+| `ephpm_worker_stream_stalls_total` | counter | — | Streamed responses (`send_response_stream`) abandoned because the client stopped reading for longer than `stream_send_timeout`. |
+| `ephpm_worker_stream_aborts_total` | counter | — | Streamed responses whose worker died in a bailout after the headers were already sent. The body is deliberately ended with an error (no terminating chunk) so the client sees a failed transfer rather than a truncated 200. Any non-zero value is a PHP crash. |
 
 ## OPcache clustering
 

--- a/tests/docroot/bailout_after_output.php
+++ b/tests/docroot/bailout_after_output.php
@@ -1,0 +1,18 @@
+<?php
+// A script that produces real output and a real header, and THEN dies in a
+// Zend bailout (memory exhaustion). php_execute_script's own zend_try absorbs
+// the bailout, so nothing unwinds out to ephpm's SETJMP guard and the request
+// looks, from the outside, like it simply returned.
+//
+// The contract: none of what is below the marker exists, so none of it may be
+// delivered. The client must get a 500 and must NOT get the marker, the
+// header, or a 200.
+header('X-Bailout-Fixture: emitted-before-the-bailout');
+echo "BAILOUT-FIXTURE-PARTIAL-OUTPUT\n";
+// Force the allocator past the limit -> zend_error_noreturn(E_ERROR) -> bailout.
+ini_set('memory_limit', '2M');
+$chunks = [];
+for ($i = 0; $i < 100; $i++) {
+    $chunks[] = str_repeat('x', 1024 * 1024); // 1 MB per iteration
+}
+echo "BAILOUT-FIXTURE-UNREACHABLE\n";

--- a/tests/worker-docroot/worker.php
+++ b/tests/worker-docroot/worker.php
@@ -10,6 +10,8 @@
  * plus three trigger routes the suite drives:
  *
  *   ?__fatal=1     an uncatchable fatal mid-request (bailout -> 500 + recycle)
+ *   ?__bailout=1   output, then a real zend_bailout (memory exhaustion), with
+ *                  the response never sent (-> 500 + recycle, no partial body)
  *   ?__exit=1      output followed by exit() mid-request (exit synthesis)
  *   ?__blocks=<n>  a WordPress-`do_blocks()`-shaped render workload (issue #116)
  *
@@ -67,6 +69,55 @@ function ephpm_e2e_render_blocks(int $depth, int $breadth): string
     return implode('', array_map(static fn (string $s): string => $s, [$level]));
 }
 
+/**
+ * A stream whose SECOND read dies in a Zend bailout.
+ *
+ * `\Ephpm\Worker\send_response_stream()` delivers status + headers first, then
+ * pumps this stream chunk by chunk. Faulting on the second read therefore puts
+ * the bailout *after* the response line is already on the wire — the one case
+ * where a 500 is no longer available, and ePHPm has to break the body framing
+ * instead so the client's transfer fails rather than completing.
+ */
+class EphpmE2eBailoutStream
+{
+    /** @var resource|null set by the stream layer */
+    public $context;
+
+    private int $reads = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        $this->reads++;
+        if ($this->reads === 1) {
+            return "STREAM-CHUNK-BEFORE-BAILOUT\n";
+        }
+        // Blow the memory limit from inside php_stream_read(), i.e. from
+        // inside the C pump loop of send_response_stream().
+        ini_set('memory_limit', '2M');
+        $chunks = [];
+        for ($i = 0; $i < 100; $i++) {
+            $chunks[] = str_repeat('x', 1024 * 1024);
+        }
+
+        return "STREAM-CHUNK-UNREACHABLE\n";
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_stat(): array
+    {
+        return [];
+    }
+}
+
 // ── Request loop ─────────────────────────────────────────────────────
 while (($envelope = \Ephpm\Worker\take_request()) !== null) {
     $requestCount++;
@@ -79,6 +130,39 @@ while (($envelope = \Ephpm\Worker\take_request()) !== null) {
     // recycle this worker without wedging the pool.
     if (isset($query['__fatal'])) {
         ephpm_e2e_this_function_does_not_exist(); // intentional fatal
+    }
+
+    // Bailout trigger: echo a marker, then blow the memory limit. That is a
+    // real zend_bailout, absorbed by php_execute_script's own zend_try, so the
+    // worker loop simply "returns" with this request still in flight and the
+    // capture buffers holding a truncated prefix. The engine must refuse to
+    // synthesize a response from them — the client gets a 500, never the
+    // marker.
+    if (isset($query['__bailout'])) {
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "WORKER-BAILOUT-PARTIAL-OUTPUT\n";
+        ini_set('memory_limit', '2M');
+        $chunks = [];
+        for ($i = 0; $i < 100; $i++) {
+            $chunks[] = str_repeat('x', 1024 * 1024);
+        }
+        echo "WORKER-BAILOUT-UNREACHABLE\n";
+    }
+
+    // Streaming-bailout trigger: status + headers go out first, then the pump
+    // dies mid-body. There is no 500 left to send, so the body must NOT be
+    // terminated cleanly — the client has to see a broken transfer.
+    if (isset($query['__stream_bailout'])) {
+        if (!in_array('ephpmbail', stream_get_wrappers(), true)) {
+            stream_wrapper_register('ephpmbail', EphpmE2eBailoutStream::class);
+        }
+        $fh = fopen('ephpmbail://go', 'r');
+        \Ephpm\Worker\send_response_stream(
+            200,
+            ['Content-Type' => 'text/plain; charset=utf-8'],
+            $fh
+        );
+        continue;
     }
 
     // exit() trigger: output already echoed plus output still sitting in a


### PR DESCRIPTION
## The bug

A PHP script terminated by a bare `zend_bailout()` came back as a clean **HTTP 200 with a truncated body**, and logged nothing at all.

Reproduced on `main` against a PHP-linked release build with a real shared ZTS extension calling `zend_bailout()`:

```
HTTP/1.1 200 OK
content-type: text/html; charset=UTF-8
content-length: 31

calling ephpm_crash('bailout')
```

A crash is loud. This is silent: a caching proxy caches the 200, a health probe calls the server healthy, and a client parses half a document as success. Same *family* as #116/#245, different code path — #245 did not fix it.

## Why the existing guard could never catch it

`php_execute_script()` wraps compile+execute in its **own** `zend_try` / `zend_end_try`. `zend_end_try` does not re-raise — it restores `EG(bailout)` and falls through — so a bailout raised anywhere inside the script is absorbed there and **never reaches the `SETJMP` we install around the call**. Our guard only ever fires for a bailout raised *outside* `php_execute_script`, which is why it looked like it was working. `PG(last_error_type)` covers `zend_error()`-routed fatals, but a bare `zend_bailout()` sets no error type at all.

The reliable signal is **`CG(unclean_shutdown)`**: `_zend_bailout()` sets it immediately before its `LONGJMP`, unconditionally and regardless of which `zend_try` catches the jump, and nothing else in the engine writes it. It is cleared per request by `init_compiler()` (and explicitly by the wrapper), so it cannot leak across requests on a reused thread.

## The rule: never complete a response for a script that bailed out

The fix branches on whether output has already been flushed. **ePHPm's fpm path buffers the entire response before it reaches the wire**, so the flushed case exists only in worker mode's `send_response_stream`.

| Case | Behaviour |
|---|---|
| **fpm** (always buffered) | Force **500** unconditionally, discard the truncated body *and* the script's headers, and `tracing::error!` with script / method / URI / discarded byte count / tail of the discarded output. New `EPHPM_EXEC_BAILOUT` (-3) + `PhpError::Bailout` keep this distinct from `exit()`. |
| **worker, headers not sent** | `ephpm_worker_run` stops synthesizing a response from the capture buffers on a bailout; returns -2 with the oneshot still parked, supervisor 500s it. |
| **worker, headers already sent** | The `200` cannot be retracted, so the response is **deliberately broken**. A new `StreamAbortFlag` is set *before* the chunk sender is dropped; the hyper body stream reads it at end-of-channel and ends the body with an `io::Error`. Verified framing: worker streaming uses `Transfer-Encoding: chunked`, so hyper writes **no terminating chunk**. New `ephpm_worker_stream_aborts_total`. |

Previously the flushed case just dropped the sender — byte-for-byte indistinguishable from a finished download.

## Validated against a real PHP-linked build

Fault-injection lab (real shared ZTS extension, `[php] extensions`), plus the repo's own e2e fixtures served by the rebuilt binary:

| Probe | Before | After |
|---|---|---|
| bare `zend_bailout()` | **200**, 31-byte truncated body, no log | **500**, body discarded, `ERROR` log with the output tail |
| `zend_error(E_ERROR)` | 500 | 500 (no regression) |
| uncaught `Throwable` | 500 + fatal text | 500 + fatal text (unchanged) |
| parse error | 500 | 500 (unchanged) |
| `exit()` / `http_response_code(201)` / normal | 200 / 201 / 200 | identical |
| worker `?__bailout=1` | 500 **carrying the partial output** | 500, `Internal Server Error`, recycled |
| worker `?__stream_bailout=1` | clean 200, 28 bytes, curl rc **0** | first chunk delivered, no terminating chunk, curl rc **18** |

Server stayed healthy throughout (20/20 and 15/15 follow-up requests; interleaved bailout/healthy rounds show no state leakage across reused TSRM threads).

## Tests

Three new e2e regression tests, **each verified to fail against a pre-fix binary and pass against the fixed one**:

- `errors::php_bailout_discards_partial_output_and_returns_500` — new fixture emits a marker + a header, then bails. Asserts 500 **and** that neither the marker nor the header is delivered.
- `worker_mode::bailout_never_delivers_partial_output`
- `worker_mode::streamed_response_is_broken_not_completed_when_worker_bails` — faults inside a userland stream wrapper's second `stream_read()`, i.e. inside the C pump loop one chunk into the body; asserts reading the body *fails*.

Plus a paired `normal_script_still_returns_200_with_a_complete_body` and stub-mode unit tests for the abort-flag → body-error mapping (including through the brotli streaming wrapper) with an inverse guard, so "always error" cannot pass. No `status == 500 || status == 200`.

Full `errors` (5) and `worker_mode` (9) suites pass against the new binary; `ephpm-server --lib` 298/298; clippy pedantic and nightly fmt clean.

## Behaviour change worth reviewing

Fatals that **do** bail out — memory-limit exhaustion, `zend_error(E_ERROR)`, `E_USER_ERROR` — previously returned 500 *with* the partial output and PHP's fatal text in the body. They now return a generic 500 and that text goes to the **server log** instead (`output_tail=` on the error line). A framework error page rendered by a shutdown function after an OOM is discarded along with the rest of the truncated body. That follows the "discard the partial body" rule, but it is the one user-visible change beyond the bug itself — easy to relax to "force 500, keep the body" if you'd rather.

## Not verified

- HTTP/2 and HTTP/3 streamed responses: the abort surfaces as a body error either way, and hyper should turn it into `RST_STREAM`, but only HTTP/1.1 chunked was exercised end to end.
- A bare `zend_bailout()` mid-stream cannot be triggered from pure PHP, so the streaming test uses memory exhaustion inside the pump loop. The bare-bailout case is covered end to end only in the fpm path, via the out-of-tree fault-injection extension.

Docs: `site/content/architecture/http.md` claimed the `SETJMP` guard caught `zend_bailout()` — never true; corrected. Worker-mode design §5.3 and the metrics reference updated.
