### PR TITLE
feat(diagnostics): per-request timeline at /_ephpm/requests + OTLP trace export (otlp feature)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,9 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mime_guess",
  "mysql_async",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "quinn",
  "rcgen",
  "rustls 0.23.37",
@@ -1478,6 +1481,8 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "turso",
 ]
 
@@ -3185,6 +3190,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,7 +3982,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -4993,6 +5070,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5092,6 +5201,20 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,17 @@ serde = { version = "1", features = ["derive"] }
 figment = { version = "0.10", features = ["toml", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# OTLP trace export — only compiled behind the `otlp` cargo feature on
+# ephpm-server (forwarded by the ephpm binary's `otlp` feature). The
+# opentelemetry / tracing-opentelemetry pair must be bumped in lockstep:
+# tracing-opentelemetry 0.32.x targets the opentelemetry 0.31.x line.
+# http-proto + reqwest-blocking-client keeps the exporter off the tokio
+# runtime (the subscriber is initialized before the runtime exists, because
+# PHP must init single-threaded).
+opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+tracing-opentelemetry = { version = "0.32", default-features = false }
 thiserror = "2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -3649,7 +3649,10 @@ alt_svc_max_age = 3600
 
         let config = Config::load(&file).unwrap();
         assert_eq!(config.server.diagnostics.request_log, Some(true));
-        assert_eq!(config.server.diagnostics.otlp_endpoint.as_deref(), Some("http://127.0.0.1:4318"));
+        assert_eq!(
+            config.server.diagnostics.otlp_endpoint.as_deref(),
+            Some("http://127.0.0.1:4318")
+        );
     }
 
     #[test]

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -181,6 +181,10 @@ pub struct ServerConfig {
     #[serde(default)]
     pub metrics: MetricsConfig,
 
+    /// Per-request diagnostics settings.
+    #[serde(default)]
+    pub diagnostics: DiagnosticsConfig,
+
     /// Rate limiting and connection limiting.
     #[serde(default)]
     pub limits: LimitsConfig,
@@ -549,6 +553,57 @@ impl Default for MetricsConfig {
 
 fn default_metrics_path() -> String {
     "/metrics".to_string()
+}
+
+/// Per-request diagnostics configuration (`[server.diagnostics]`).
+#[derive(Debug, Default, Deserialize)]
+pub struct DiagnosticsConfig {
+    /// Enable the in-memory request timeline and its `/_ephpm/requests`
+    /// endpoint. The server keeps the last 256 completed requests (method,
+    /// path, status, total duration, worker-queue wait, PHP execution time,
+    /// response size, timestamp) in a fixed-size ring buffer and serves them
+    /// as JSON, newest first.
+    ///
+    /// Unset resolves per mode (see
+    /// [`DiagnosticsConfig::effective_request_log`]): **on** under
+    /// `ephpm dev` / bare `ephpm`, **off** under `ephpm serve`. Set `true` /
+    /// `false` to force a value in either mode. When off, `/_ephpm/requests`
+    /// is not registered and the path falls through to normal routing (404
+    /// under the default fallback chain).
+    ///
+    /// Env override: `EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG`.
+    ///
+    /// Default: unset (dev: on, serve: off).
+    #[serde(default)]
+    pub request_log: Option<bool>,
+
+    /// OTLP trace exporter endpoint, e.g. `"http://127.0.0.1:4318"`
+    /// (OTLP/HTTP with protobuf payloads; `/v1/traces` is appended when the
+    /// value does not already end with it). Only acted upon in binaries built
+    /// with the `otlp` cargo feature; without that feature a set value logs a
+    /// startup warning and exports nothing.
+    ///
+    /// The standard `OTEL_EXPORTER_OTLP_ENDPOINT` /
+    /// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` environment variables take
+    /// precedence over this knob. When neither the env vars nor this knob are
+    /// set, no exporter task is started and no background threads are
+    /// spawned.
+    ///
+    /// Default: unset (no trace export).
+    #[serde(default)]
+    pub otlp_endpoint: Option<String>,
+}
+
+impl DiagnosticsConfig {
+    /// Resolve the effective request-timeline setting for the given mode.
+    ///
+    /// `dev_mode` is `true` under `ephpm dev` / bare `ephpm` and `false`
+    /// under `ephpm serve`. An explicit `request_log` value wins either way;
+    /// unset means "on in dev, off in serve".
+    #[must_use]
+    pub fn effective_request_log(&self, dev_mode: bool) -> bool {
+        self.request_log.unwrap_or(dev_mode)
+    }
 }
 
 /// Rate limiting and connection limiting (`[server.limits]`).
@@ -2052,6 +2107,7 @@ impl Default for ServerConfig {
             security: None,
             logging: LoggingConfig::default(),
             metrics: MetricsConfig::default(),
+            diagnostics: DiagnosticsConfig::default(),
             limits: LimitsConfig::default(),
             file_cache: FileCacheConfig::default(),
             tls: None,
@@ -3533,6 +3589,89 @@ alt_svc_max_age = 3600
         let _env = EnvVars::set("EPHPM_SERVER__HTTP3__ALT_SVC_MAX_AGE", "120");
         let config = Config::load(&file).unwrap();
         assert_eq!(config.server.http3.alt_svc_max_age, 120);
+    }
+
+    // ── [server.diagnostics] ─────────────────────────────────────────
+
+    /// Section absent: both knobs must be unset, and the mode-dependent
+    /// resolution must give dev "on" and serve "off". Also guards the
+    /// hand-written `ServerConfig::default()` against drifting from the
+    /// serde defaults.
+    #[test]
+    fn diagnostics_section_absent_defaults_unset() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nlisten = \"0.0.0.0:8080\"\n").unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.diagnostics.request_log, None);
+        assert_eq!(config.server.diagnostics.otlp_endpoint, None);
+        assert!(
+            config.server.diagnostics.effective_request_log(true),
+            "unset request_log must resolve ON in dev mode"
+        );
+        assert!(
+            !config.server.diagnostics.effective_request_log(false),
+            "unset request_log must resolve OFF in serve mode"
+        );
+
+        // ...and the struct default agrees with what TOML parsing produced.
+        let direct = ServerConfig::default();
+        assert_eq!(direct.diagnostics.request_log, None);
+        assert_eq!(direct.diagnostics.otlp_endpoint, None);
+    }
+
+    /// An explicit value wins over the mode default in both directions.
+    #[test]
+    fn diagnostics_explicit_request_log_beats_mode_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.diagnostics]\nrequest_log = true\n").unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.diagnostics.request_log, Some(true));
+        assert!(config.server.diagnostics.effective_request_log(false));
+
+        std::fs::write(&file, "[server.diagnostics]\nrequest_log = false\n").unwrap();
+        let config = Config::load(&file).unwrap();
+        assert!(!config.server.diagnostics.effective_request_log(true));
+    }
+
+    #[test]
+    fn diagnostics_section_parses_every_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            "[server.diagnostics]\nrequest_log = true\notlp_endpoint = \"http://127.0.0.1:4318\"\n",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.diagnostics.request_log, Some(true));
+        assert_eq!(config.server.diagnostics.otlp_endpoint.as_deref(), Some("http://127.0.0.1:4318"));
+    }
+
+    #[test]
+    fn test_env_var_overrides_diagnostics_request_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.diagnostics]\nrequest_log = false\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG", "true");
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.diagnostics.request_log, Some(true));
+    }
+
+    #[test]
+    fn test_env_var_overrides_diagnostics_otlp_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nlisten = \"0.0.0.0:8080\"\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__DIAGNOSTICS__OTLP_ENDPOINT", "http://otel:4318");
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.diagnostics.otlp_endpoint.as_deref(), Some("http://otel:4318"));
     }
 
     #[test]

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -55,8 +55,30 @@ async-channel.workspace = true
 quinn.workspace = true
 h3.workspace = true
 h3-quinn.workspace = true
+# OTLP trace export — all optional, activated together by the `otlp` feature.
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+
+[features]
+# OTLP trace export: `tracing` spans (http.request / worker.queue_wait /
+# php.execute) shipped to an OpenTelemetry collector over OTLP http/protobuf.
+# Runtime activation is still opt-in via OTEL_EXPORTER_OTLP_ENDPOINT /
+# [server.diagnostics] otlp_endpoint — see src/otlp.rs.
+otlp = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:tracing-subscriber",
+]
 
 [dev-dependencies]
+# Span-tree assertions for the router's request spans (tests use a collector
+# Layer over the registry; no OTLP needed).
+tracing-subscriber.workspace = true
 tempfile.workspace = true
 rcgen.workspace = true
 # Paused-clock (`start_paused`) support for the idle-timeout watchdog tests.

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -7,10 +7,13 @@ mod idle;
 pub mod metrics;
 pub mod middleware;
 pub mod opcache;
+#[cfg(feature = "otlp")]
+pub mod otlp;
 pub mod rate_limit;
 pub mod router;
 pub mod static_files;
 pub mod stream_compress;
+mod timeline;
 pub mod tls;
 pub mod tracked_backend;
 pub mod turso_cdc;
@@ -38,7 +41,21 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::signal;
 use tokio_rustls::{LazyConfigAcceptor, TlsAcceptor};
 
+/// `tracing` target of the request spans (`http.request`,
+/// `worker.queue_wait`, `php.execute`) emitted by the router at DEBUG level.
+///
+/// A dedicated target so the OTLP layer (see the `otlp` feature) can enable
+/// exactly these spans with a `Targets` filter without also exporting every
+/// debug log line — and so the default `info`-level stack leaves the span
+/// callsites disabled (a single static check per request).
+pub const OTEL_TRACE_TARGET: &str = "ephpm_otel";
+
 /// Start the HTTP server with the given configuration.
+///
+/// `dev_mode` is `true` under `ephpm dev` / bare `ephpm` and `false` under
+/// `ephpm serve`. It selects the default for the request-timeline ring
+/// buffer (`/_ephpm/requests`): on in dev, off in serve, unless
+/// `[server.diagnostics] request_log` says otherwise.
 ///
 /// Listens on the configured address and routes requests to either
 /// PHP execution or static file serving based on the request path.
@@ -55,7 +72,7 @@ use tokio_rustls::{LazyConfigAcceptor, TlsAcceptor};
 /// # Errors
 ///
 /// Returns an error if the listen address is invalid or binding fails.
-pub async fn serve(config: Config) -> anyhow::Result<()> {
+pub async fn serve(config: Config, dev_mode: bool) -> anyhow::Result<()> {
     // Install Prometheus recorder if metrics are enabled.
     let metrics_handle = if config.server.metrics.enabled {
         Some(metrics::init().context("failed to initialize metrics")?)
@@ -260,6 +277,20 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
     // empty and auto-derived), else None (Router falls back to config).
     let effective_node_id = cluster_handle.as_ref().map(|h| h.self_node().id.clone());
 
+    // Request timeline ring buffer (`/_ephpm/requests`): on by default in
+    // dev mode, opt-in via [server.diagnostics] request_log in serve mode.
+    let request_log = config
+        .server
+        .diagnostics
+        .effective_request_log(dev_mode)
+        .then(|| Arc::new(timeline::RequestLog::new(timeline::REQUEST_LOG_CAPACITY)));
+    if request_log.is_some() {
+        tracing::info!(
+            capacity = timeline::REQUEST_LOG_CAPACITY,
+            "request timeline enabled — last requests served at /_ephpm/requests"
+        );
+    }
+
     let listeners = bind_listeners(
         &config,
         kv_store,
@@ -268,6 +299,7 @@ pub async fn serve(config: Config) -> anyhow::Result<()> {
         middleware_chain,
         effective_node_id,
         Arc::clone(&db_health),
+        request_log,
     )
     .await?;
 
@@ -359,7 +391,11 @@ async fn bind_listeners(
     node_id: Option<String>,
     // Upstream health of the configured SQL proxies, so the readiness probe
     // reports 503 until each one has reached its upstream at least once.
+    // (`request_log` follows below: the dev-mode request timeline buffer,
+    // `None` when disabled — resolved in `serve` from
+    // `[server.diagnostics] request_log` + the mode default.)
     db_health: Arc<db_health::DbProxyHealth>,
+    request_log: Option<Arc<timeline::RequestLog>>,
 ) -> anyhow::Result<Listeners> {
     let addr: SocketAddr = config.server.listen.parse().context("invalid listen address")?;
 
@@ -571,7 +607,8 @@ async fn bind_listeners(
         // Kind). In single-node mode this is None, so Router keeps whatever it
         // derived from `[cluster] node_id`.
         .with_node_id(node_id)
-        .with_db_health(db_health);
+        .with_db_health(db_health)
+        .with_request_log(request_log);
 
         // Only advertise HTTP/3 once its UDP socket is confirmed bound.
         match alt_svc {

--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -109,10 +109,8 @@ where
     let resource =
         opentelemetry_sdk::Resource::builder().with_service_name(service_name.clone()).build();
 
-    let provider = SdkTracerProvider::builder()
-        .with_batch_exporter(exporter)
-        .with_resource(resource)
-        .build();
+    let provider =
+        SdkTracerProvider::builder().with_batch_exporter(exporter).with_resource(resource).build();
 
     // W3C trace-context propagation: the router extracts an incoming
     // `traceparent` through the global propagator, which defaults to a
@@ -161,5 +159,9 @@ pub(crate) fn set_span_parent_from_headers(span: &tracing::Span, headers: &hyper
     let parent = opentelemetry::global::get_text_map_propagator(|propagator| {
         propagator.extract(&HeaderMapExtractor(headers))
     });
-    span.set_parent(parent);
+    if let Err(e) = span.set_parent(parent) {
+        // A span the subscriber never enabled (or a malformed header) is not
+        // worth more than a debug line on a per-request path.
+        tracing::debug!(error = %e, "failed to parent request span to incoming traceparent");
+    }
 }

--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -1,0 +1,165 @@
+//! OTLP trace export (cargo feature `otlp`).
+//!
+//! Exports the router's request spans (`http.request` with children
+//! `worker.queue_wait` and `php.execute`, all emitted under
+//! [`crate::OTEL_TRACE_TARGET`]) to an OpenTelemetry collector over
+//! OTLP/HTTP with protobuf payloads.
+//!
+//! Activation is strictly opt-in at runtime, in precedence order:
+//!
+//! 1. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`
+//!    environment variables (standard OTel semantics — the exporter builder
+//!    reads them itself, so `.../v1/traces` handling follows the spec).
+//! 2. `[server.diagnostics] otlp_endpoint` from config (a base URL;
+//!    `/v1/traces` is appended when missing).
+//!
+//! When none of these are set, [`init_layer`] returns `Ok(None)`: no
+//! exporter is built, no background thread is spawned, and no global
+//! propagator is installed — the only remaining cost is the disabled-span
+//! callsite check in the router.
+//!
+//! The exporter uses a blocking `reqwest` client driven by the OTel SDK's
+//! own batch-export thread, deliberately avoiding any dependency on the
+//! tokio runtime: the tracing subscriber (and therefore this layer) is
+//! initialized in `main` *before* the runtime exists, because PHP must be
+//! initialized single-threaded.
+
+use anyhow::Context as _;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing_subscriber::Layer;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Keeps the tracer provider alive and flushes it on drop.
+///
+/// Dropping the guard shuts the provider down, which flushes any spans still
+/// sitting in the batch queue — hold it for the whole server lifetime.
+pub struct OtlpGuard {
+    provider: SdkTracerProvider,
+}
+
+impl Drop for OtlpGuard {
+    fn drop(&mut self) {
+        if let Err(e) = self.provider.shutdown() {
+            // Shutdown races the collector going away; a lost final batch is
+            // not worth a noisy exit.
+            tracing::debug!(error = %e, "OTLP tracer provider shutdown reported an error");
+        }
+    }
+}
+
+/// Resolve the endpoint and build the OTLP tracing layer.
+///
+/// `config_endpoint` is `[server.diagnostics] otlp_endpoint`. The standard
+/// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`
+/// environment variables take precedence over it. Returns `Ok(None)` when no
+/// endpoint is configured anywhere — the caller then installs no layer.
+///
+/// The returned layer is already filtered to [`crate::OTEL_TRACE_TARGET`] at
+/// DEBUG, so it exports exactly the request spans and none of the log events.
+///
+/// The service name is `OTEL_SERVICE_NAME` when set, else `"ephpm"`.
+///
+/// The returned `String` describes the resolved endpoint and its source for
+/// the caller to log — this function runs *before* the tracing subscriber is
+/// installed, so it cannot log anything itself.
+///
+/// # Errors
+///
+/// Returns an error when the exporter cannot be built (malformed endpoint).
+pub fn init_layer<S>(
+    config_endpoint: Option<&str>,
+) -> anyhow::Result<Option<(impl Layer<S>, OtlpGuard, String)>>
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    let env_endpoint = ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT"]
+        .iter()
+        .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()));
+
+    let builder = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary);
+
+    let (builder, endpoint_source) = if let Some(ref env_ep) = env_endpoint {
+        // Leave the endpoint to the builder's own env handling so the
+        // standard semantics apply (OTEL_EXPORTER_OTLP_ENDPOINT is a base
+        // URL that gets `/v1/traces` appended; the TRACES variant is used
+        // verbatim).
+        (builder, format!("env: {env_ep}"))
+    } else if let Some(cfg_ep) = config_endpoint {
+        let url = if cfg_ep.ends_with("/v1/traces") {
+            cfg_ep.to_string()
+        } else {
+            format!("{}/v1/traces", cfg_ep.trim_end_matches('/'))
+        };
+        (builder.with_endpoint(&url), format!("config: {url}"))
+    } else {
+        return Ok(None);
+    };
+
+    use opentelemetry_otlp::WithExportConfig as _;
+    let exporter = builder.build().context("failed to build the OTLP span exporter")?;
+
+    let service_name = std::env::var("OTEL_SERVICE_NAME")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "ephpm".to_string());
+
+    let resource =
+        opentelemetry_sdk::Resource::builder().with_service_name(service_name.clone()).build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    // W3C trace-context propagation: the router extracts an incoming
+    // `traceparent` through the global propagator, which defaults to a
+    // no-op — install the real one only when export is actually on.
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+
+    let tracer = provider.tracer("ephpm");
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer).with_filter(
+        tracing_subscriber::filter::Targets::new()
+            .with_target(crate::OTEL_TRACE_TARGET, tracing::level_filters::LevelFilter::DEBUG),
+    );
+
+    let description = format!("{endpoint_source} (service.name = {service_name})");
+    Ok(Some((layer, OtlpGuard { provider }, description)))
+}
+
+/// Parent `span` to the trace context carried in an incoming W3C
+/// `traceparent` header, if present.
+///
+/// Uses the global text-map propagator, which [`init_layer`] sets to the W3C
+/// `TraceContext` propagator when export is enabled; without it (the no-op
+/// default) extraction yields an empty context and this is a no-op.
+pub(crate) fn set_span_parent_from_headers(span: &tracing::Span, headers: &hyper::HeaderMap) {
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+    if !headers.contains_key("traceparent") {
+        return;
+    }
+
+    /// `Extractor` view over hyper's `HeaderMap` — a local shim so the
+    /// `opentelemetry-http` crate isn't pulled in for two methods.
+    struct HeaderMapExtractor<'a>(&'a hyper::HeaderMap);
+
+    impl opentelemetry::propagation::Extractor for HeaderMapExtractor<'_> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).and_then(|v| v.to_str().ok())
+        }
+
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(hyper::header::HeaderName::as_str).collect()
+        }
+    }
+
+    let parent = opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderMapExtractor(headers))
+    });
+    span.set_parent(parent);
+}

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1181,9 +1181,7 @@ impl Router {
                     queue_wait_ms: timings
                         .and_then(|t| t.queue_wait)
                         .map(|d| d.as_secs_f64() * 1000.0),
-                    php_ms: timings
-                        .and_then(|t| t.execute)
-                        .map(|d| d.as_secs_f64() * 1000.0),
+                    php_ms: timings.and_then(|t| t.execute).map(|d| d.as_secs_f64() * 1000.0),
                     response_bytes,
                 });
             }
@@ -1279,10 +1277,7 @@ impl Router {
             // falls through and behaves like any other unknown /_ephpm/ path.
             if uri_path == "/_ephpm/requests" {
                 if let Some(ref log) = self.request_log {
-                    return Ok((
-                        json_response_owned(StatusCode::OK, log.to_json()),
-                        "diagnostics",
-                    ));
+                    return Ok((json_response_owned(StatusCode::OK, log.to_json()), "diagnostics"));
                 }
             }
         }
@@ -1792,8 +1787,7 @@ impl Router {
         // queue time — same semantics as the histogram below). Created here,
         // inside the `http.request`-instrumented future, so it parents
         // correctly; dropped right after the timer is read.
-        let php_span =
-            tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "php.execute");
+        let php_span = tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "php.execute");
         let php_start = std::time::Instant::now();
         let result = tokio::task::spawn_blocking(move || {
             // Scope KV store to this virtual host for multi-tenant isolation.
@@ -1866,10 +1860,9 @@ impl Router {
         // Hand the measurement up to `handle` for the request timeline. No
         // queue wait on this path — spawn_blocking has no worker dispatch
         // queue, so the value is absent, not zero.
-        response.extensions_mut().insert(crate::timeline::PhpTimings {
-            queue_wait: None,
-            execute: Some(php_elapsed),
-        });
+        response
+            .extensions_mut()
+            .insert(crate::timeline::PhpTimings { queue_wait: None, execute: Some(php_elapsed) });
         response
     }
 
@@ -1954,8 +1947,7 @@ impl Router {
         // queue wait, exactly like `ephpm_php_execution_duration_seconds`.
         let queue_span =
             tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "worker.queue_wait");
-        let php_span =
-            tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "php.execute");
+        let php_span = tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "php.execute");
         let php_start = std::time::Instant::now();
         let queue_wait_start = php_start;
         let recv = pool.dispatch(owned).await;
@@ -1967,10 +1959,8 @@ impl Router {
         // Timings handed up to `handle` for the request timeline. The queue
         // wait is known from here on; `execute` is filled in only once the
         // worker actually delivers a response.
-        let queued_only = crate::timeline::PhpTimings {
-            queue_wait: Some(queue_wait),
-            execute: None,
-        };
+        let queued_only =
+            crate::timeline::PhpTimings { queue_wait: Some(queue_wait), execute: None };
 
         // Dispatch channel closed (pool draining / all workers gone) — 503.
         let Ok(rx) = recv else {
@@ -3244,13 +3234,18 @@ mod tests {
 
     // ── Request timeline (/_ephpm/requests) ──────────────────────────
 
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    /// `(span name, parent span name)` as collected by [`SpanTree`].
+    type SpanRecord = (String, Option<String>);
+
     /// Test layer collecting `(span name, parent span name)` pairs for the
     /// router's request spans (target [`crate::OTEL_TRACE_TARGET`]).
     #[derive(Clone, Default)]
-    struct SpanTree(Arc<std::sync::Mutex<Vec<(String, Option<String>)>>>);
+    struct SpanTree(Arc<std::sync::Mutex<Vec<SpanRecord>>>);
 
     impl SpanTree {
-        fn snapshot(&self) -> Vec<(String, Option<String>)> {
+        fn snapshot(&self) -> Vec<SpanRecord> {
             self.0.lock().unwrap().clone()
         }
     }
@@ -3383,23 +3378,20 @@ mod tests {
         // Short request deadline so the never-answering pool becomes a 504
         // without waiting out the 300s default (paused clock auto-advances).
         config.server.timeouts.request = 1;
-        let pool = Arc::new(crate::worker_pool::WorkerPool::spawn(
+        let pool = crate::worker_pool::WorkerPool::spawn(
             dir.path().join("worker.php"),
             0, // zero workers: dispatch queues, nobody answers
             500,
             4,
             Duration::from_secs(30),
             Duration::from_secs(60),
-        ));
+        );
         let router = Router::new(&config, test_store(), None, None, None, None, Some(pool))
             .with_request_log(Some(Arc::new(crate::timeline::RequestLog::new(8))));
         let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
 
-        let req = Request::builder()
-            .method("GET")
-            .uri("/index.php")
-            .body(Empty::<Bytes>::new())
-            .unwrap();
+        let req =
+            Request::builder().method("GET").uri("/index.php").body(Empty::<Bytes>::new()).unwrap();
         let resp = router.handle(req, addr, false).await.unwrap();
         assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
 
@@ -3447,15 +3439,18 @@ mod tests {
             .with_request_log(Some(Arc::new(crate::timeline::RequestLog::new(8))));
         let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
 
-        let req = Request::builder()
-            .method("GET")
-            .uri("/index.php")
-            .body(Empty::<Bytes>::new())
-            .unwrap();
+        let req =
+            Request::builder().method("GET").uri("/index.php").body(Empty::<Bytes>::new()).unwrap();
         let resp = router.handle(req, addr, false).await.unwrap();
-        // Stub mode: PHP execution fails, the router maps that to a 500. The
-        // timing/span instrumentation sits on the same code path either way.
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        // Stub mode: 200 (stub page) when another test already initialized
+        // the process-global stub runtime, 500 (NotInitialized) otherwise.
+        // The timing/span instrumentation sits on the same code path either
+        // way, so accept both rather than depend on test order.
+        assert!(
+            resp.status() == StatusCode::OK || resp.status() == StatusCode::INTERNAL_SERVER_ERROR,
+            "unexpected stub-mode PHP status: {}",
+            resp.status()
+        );
 
         let entries = fetch_timeline(&router).await;
         assert_eq!(entries.len(), 1, "{entries:?}");

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -360,6 +360,12 @@ pub struct Router {
     /// [`Router::readiness_check`]. `None` when the router was built without
     /// one (tests); readiness then ignores the database entirely.
     db_health: Option<Arc<crate::db_health::DbProxyHealth>>,
+    /// Per-request timeline ring buffer served at `/_ephpm/requests`.
+    /// `None` = disabled: nothing is recorded and the endpoint path falls
+    /// through to normal routing like any other unknown `/_ephpm/` path.
+    /// Enabled by default in dev mode, opt-in via
+    /// `[server.diagnostics] request_log` in serve mode.
+    request_log: Option<Arc<crate::timeline::RequestLog>>,
 }
 
 /// Header names always stripped from inbound requests at ingest, in addition
@@ -686,7 +692,20 @@ impl Router {
             canonical_scripts_swept: std::sync::Mutex::new(Instant::now()),
             ingest_strip_headers: build_ingest_strip_headers(&config.middleware),
             db_health: None,
+            request_log: None,
         }
+    }
+
+    /// Attach (or leave off) the request-timeline ring buffer resolved in
+    /// `serve()`. Kept out of `new()`'s signature so its existing call sites
+    /// stay unchanged; `None` keeps the timeline disabled.
+    #[must_use]
+    pub(crate) fn with_request_log(
+        mut self,
+        request_log: Option<Arc<crate::timeline::RequestLog>>,
+    ) -> Self {
+        self.request_log = request_log;
+        self
     }
 
     /// Canonicalized form of a site's document root, cached with a short
@@ -1076,12 +1095,51 @@ impl Router {
         gauge!("ephpm_http_requests_in_flight").increment(1.0);
         let start = std::time::Instant::now();
 
+        // Timeline capture (dev mode / [server.diagnostics] request_log):
+        // method + path have to be cloned out before `req` is consumed below.
+        // Internal endpoints (`/_ephpm/*`, the metrics path) are excluded so
+        // a dashboard polling `/_ephpm/requests` doesn't fill the buffer with
+        // its own polls. `None` when the timeline is disabled — the shared
+        // (serve-mode) hot path allocates nothing here.
+        let timeline_capture = self.request_log.as_ref().and_then(|_| {
+            let path = req.uri().path();
+            if path.starts_with("/_ephpm/") || path == self.metrics_path {
+                None
+            } else {
+                Some((req.method().as_str().to_owned(), path.to_owned()))
+            }
+        });
+
+        // Request span for OTLP export. DEBUG level under a dedicated target
+        // (`crate::OTEL_TRACE_TARGET`) so the default info-level stack leaves
+        // the callsite disabled — the span only materializes when a layer
+        // opts in (the OTLP layer's Targets filter, or RUST_LOG=debug).
+        // Timing-wise it brackets the same region as `start`/`elapsed`.
+        let span = tracing::debug_span!(
+            target: crate::OTEL_TRACE_TARGET,
+            "http.request",
+            http.request.method = %req.method(),
+            url.path = req.uri().path(),
+            http.response.status_code = tracing::field::Empty,
+        );
+        // W3C trace-context propagation: parent the request span to an
+        // incoming `traceparent` header. Only compiled with the `otlp`
+        // feature (the propagator lives in the opentelemetry crates) and
+        // only paid when the span is enabled and the header is present.
+        #[cfg(feature = "otlp")]
+        if !span.is_disabled() {
+            crate::otlp::set_span_parent_from_headers(&span, req.headers());
+        }
+
         // A `request` timeout of 0 disables the per-request deadline
         // (`[server.timeouts] request = 0`). In that mode we run the inner
         // handler directly rather than paying to arm and disarm a tokio
         // timer on every request (issue #135) - the timer registration is
         // ~0.02ms of pure overhead when the deadline never fires.
-        let inner = self.handle_inner(req, remote_addr, is_tls);
+        let inner = tracing::Instrument::instrument(
+            self.handle_inner(req, remote_addr, is_tls),
+            span.clone(),
+        );
         let (result, handler) = if self.request_timeout.is_zero() {
             let result = inner.await;
             let handler = result.as_ref().map_or("error", |(_, h)| *h);
@@ -1102,6 +1160,33 @@ impl Router {
         let mut result = result;
         if let Ok(ref mut resp) = result {
             self.apply_alt_svc(resp, is_tls);
+
+            span.record("http.response.status_code", resp.status().as_u16());
+
+            // Timeline entry: reuse the values already measured — `elapsed`
+            // (the histogram measurement below) plus the PHP-path timings the
+            // dispatch paths stashed in the response extensions. Nothing is
+            // re-measured here.
+            if let (Some(log), Some((method, path))) =
+                (self.request_log.as_deref(), timeline_capture)
+            {
+                let timings = resp.extensions_mut().remove::<crate::timeline::PhpTimings>();
+                let response_bytes = hyper::body::Body::size_hint(resp.body()).exact();
+                log.record(crate::timeline::TimelineEntry {
+                    timestamp_ms: crate::timeline::unix_now_ms(),
+                    method,
+                    path,
+                    status: resp.status().as_u16(),
+                    total_ms: elapsed * 1000.0,
+                    queue_wait_ms: timings
+                        .and_then(|t| t.queue_wait)
+                        .map(|d| d.as_secs_f64() * 1000.0),
+                    php_ms: timings
+                        .and_then(|t| t.execute)
+                        .map(|d| d.as_secs_f64() * 1000.0),
+                    response_bytes,
+                });
+            }
         }
 
         if let Ok(ref resp) = result {
@@ -1186,6 +1271,19 @@ impl Router {
             // Readiness probe — checks PHP initialization and DB proxy.
             if uri_path == "/_ephpm/ready" {
                 return Ok((self.readiness_check(), "health"));
+            }
+
+            // Request timeline (dev mode / [server.diagnostics] request_log):
+            // the ring buffer as JSON, newest first. Only mounted when the
+            // timeline is enabled — when disabled, the path deliberately
+            // falls through and behaves like any other unknown /_ephpm/ path.
+            if uri_path == "/_ephpm/requests" {
+                if let Some(ref log) = self.request_log {
+                    return Ok((
+                        json_response_owned(StatusCode::OK, log.to_json()),
+                        "diagnostics",
+                    ));
+                }
             }
         }
 
@@ -1689,6 +1787,13 @@ impl Router {
             None => None,
         };
 
+        // `php.execute` span: brackets exactly the region `php_start` /
+        // `php_elapsed` measure (the whole spawn_blocking hop, including its
+        // queue time — same semantics as the histogram below). Created here,
+        // inside the `http.request`-instrumented future, so it parents
+        // correctly; dropped right after the timer is read.
+        let php_span =
+            tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "php.execute");
         let php_start = std::time::Instant::now();
         let result = tokio::task::spawn_blocking(move || {
             // Scope KV store to this virtual host for multi-tenant isolation.
@@ -1744,19 +1849,28 @@ impl Router {
             })
         })
         .await;
-        let php_elapsed = php_start.elapsed().as_secs_f64();
+        let php_elapsed = php_start.elapsed();
+        drop(php_span);
 
-        histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed);
+        histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed.as_secs_f64());
         let exec_status = match &result {
             Ok(Ok(_)) => "ok",
             Ok(Err(_)) | Err(_) => "error",
         };
         counter!("ephpm_php_executions_total", "status" => exec_status).increment(1);
 
-        apply_response_headers(
+        let mut response = apply_response_headers(
             build_php_response(result, accepts_gzip, accepts_br, self.compression),
             &mw_response_headers,
-        )
+        );
+        // Hand the measurement up to `handle` for the request timeline. No
+        // queue wait on this path — spawn_blocking has no worker dispatch
+        // queue, so the value is absent, not zero.
+        response.extensions_mut().insert(crate::timeline::PhpTimings {
+            queue_wait: None,
+            execute: Some(php_elapsed),
+        });
+        response
     }
 
     /// Dispatch a PHP request to the persistent worker pool (worker mode).
@@ -1831,16 +1945,39 @@ impl Router {
             headers,
         };
 
+        // `worker.queue_wait` and `php.execute` spans, siblings under
+        // `http.request`. Both open at dispatch time — the same instant the
+        // existing timers start. queue_wait closes when the pool hands back
+        // its oneshot receiver; php.execute closes when the response arrives
+        // (or on the early error returns), mirroring the two histograms —
+        // note the worker-mode execution timer deliberately includes the
+        // queue wait, exactly like `ephpm_php_execution_duration_seconds`.
+        let queue_span =
+            tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "worker.queue_wait");
+        let php_span =
+            tracing::debug_span!(target: crate::OTEL_TRACE_TARGET, "php.execute");
         let php_start = std::time::Instant::now();
         let queue_wait_start = php_start;
         let recv = pool.dispatch(owned).await;
+        let queue_wait = queue_wait_start.elapsed();
+        drop(queue_span);
         #[allow(clippy::cast_precision_loss)]
-        histogram!("ephpm_worker_request_wait_seconds")
-            .record(queue_wait_start.elapsed().as_secs_f64());
+        histogram!("ephpm_worker_request_wait_seconds").record(queue_wait.as_secs_f64());
+
+        // Timings handed up to `handle` for the request timeline. The queue
+        // wait is known from here on; `execute` is filled in only once the
+        // worker actually delivers a response.
+        let queued_only = crate::timeline::PhpTimings {
+            queue_wait: Some(queue_wait),
+            execute: None,
+        };
 
         // Dispatch channel closed (pool draining / all workers gone) — 503.
         let Ok(rx) = recv else {
-            return error_response(StatusCode::SERVICE_UNAVAILABLE, "503 Service Unavailable");
+            return with_php_timings(
+                error_response(StatusCode::SERVICE_UNAVAILABLE, "503 Service Unavailable"),
+                queued_only,
+            );
         };
 
         gauge!("ephpm_worker_busy").increment(1.0);
@@ -1869,34 +2006,48 @@ impl Router {
             // Sender dropped (worker unwound with no stashed sender) — 500.
             Ok(Err(_)) => {
                 counter!("ephpm_php_executions_total", "status" => "error").increment(1);
-                return build_php_response(
-                    Ok(Err(ephpm_php::PhpError::ExecutionFailed(
-                        "worker dropped response (bailout)".into(),
-                    ))),
-                    accepts_gzip,
-                    accepts_br,
-                    self.compression,
+                return with_php_timings(
+                    build_php_response(
+                        Ok(Err(ephpm_php::PhpError::ExecutionFailed(
+                            "worker dropped response (bailout)".into(),
+                        ))),
+                        accepts_gzip,
+                        accepts_br,
+                        self.compression,
+                    ),
+                    queued_only,
                 );
             }
             // Worker never responded in time — replace it, return 504.
             Err(_) => {
                 pool.note_hung();
                 counter!("ephpm_http_timeouts_total", "stage" => "worker").increment(1);
-                return error_response(StatusCode::GATEWAY_TIMEOUT, "504 Gateway Timeout");
+                return with_php_timings(
+                    error_response(StatusCode::GATEWAY_TIMEOUT, "504 Gateway Timeout"),
+                    queued_only,
+                );
             }
         };
 
-        let php_elapsed = php_start.elapsed().as_secs_f64();
-        histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed);
+        let php_elapsed = php_start.elapsed();
+        drop(php_span);
+        histogram!("ephpm_php_execution_duration_seconds").record(php_elapsed.as_secs_f64());
         counter!("ephpm_php_executions_total", "status" => "ok").increment(1);
 
+        let timings = crate::timeline::PhpTimings {
+            queue_wait: Some(queue_wait),
+            execute: Some(php_elapsed),
+        };
         match worker_resp {
             ephpm_php::worker_bridge::WorkerResponse::Buffered { status, headers, body } => {
-                build_php_response(
-                    Ok(Ok(ephpm_php::response::PhpResponse { status, headers, body })),
-                    accepts_gzip,
-                    accepts_br,
-                    self.compression,
+                with_php_timings(
+                    build_php_response(
+                        Ok(Ok(ephpm_php::response::PhpResponse { status, headers, body })),
+                        accepts_gzip,
+                        accepts_br,
+                        self.compression,
+                    ),
+                    timings,
                 )
             }
             // Streamed response (Phase 3): flush chunks to the client as PHP
@@ -1904,12 +2055,15 @@ impl Router {
             // transfer. Optionally wrapped in a flush-per-chunk brotli
             // encoder when `[server.response] compression_streaming` says so.
             ephpm_php::worker_bridge::WorkerResponse::Streaming { status, headers, body_rx } => {
-                build_streamed_worker_response(
-                    status,
-                    headers,
-                    body_rx,
-                    accepts_br,
-                    self.compression,
+                with_php_timings(
+                    build_streamed_worker_response(
+                        status,
+                        headers,
+                        body_rx,
+                        accepts_br,
+                        self.compression,
+                    ),
+                    timings,
                 )
             }
         }
@@ -2362,6 +2516,17 @@ fn json_response(status: StatusCode, body: &'static str) -> Response<ServerBody>
         .header("content-type", "application/json")
         .body(body::buffered(Full::new(Bytes::from_static(body.as_bytes()))))
         .expect("static json response")
+}
+
+/// Stash PHP-path timings in the response extensions so `Router::handle`
+/// can hand the already-taken measurements to the request timeline without
+/// re-measuring anything.
+fn with_php_timings(
+    mut resp: Response<ServerBody>,
+    timings: crate::timeline::PhpTimings,
+) -> Response<ServerBody> {
+    resp.extensions_mut().insert(timings);
+    resp
 }
 
 /// A JSON response whose body is built at runtime.
@@ -3075,6 +3240,241 @@ mod tests {
         // Legitimate headers are preserved untouched.
         assert!(handed_to_php.iter().any(|(n, _)| n.eq_ignore_ascii_case("host")));
         assert!(handed_to_php.iter().any(|(n, _)| n.eq_ignore_ascii_case("user-agent")));
+    }
+
+    // ── Request timeline (/_ephpm/requests) ──────────────────────────
+
+    /// Test layer collecting `(span name, parent span name)` pairs for the
+    /// router's request spans (target [`crate::OTEL_TRACE_TARGET`]).
+    #[derive(Clone, Default)]
+    struct SpanTree(Arc<std::sync::Mutex<Vec<(String, Option<String>)>>>);
+
+    impl SpanTree {
+        fn snapshot(&self) -> Vec<(String, Option<String>)> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for SpanTree
+    where
+        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            _id: &tracing::span::Id,
+            ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if attrs.metadata().target() != crate::OTEL_TRACE_TARGET {
+                return;
+            }
+            let parent = attrs
+                .parent()
+                .cloned()
+                .or_else(|| {
+                    if attrs.is_contextual() { ctx.current_span().id().cloned() } else { None }
+                })
+                .and_then(|pid| ctx.span(&pid).map(|s| s.name().to_string()));
+            self.0.lock().unwrap().push((attrs.metadata().name().to_string(), parent));
+        }
+    }
+
+    async fn fetch_timeline(router: &Router) -> Vec<serde_json::Value> {
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let req = Request::builder()
+            .method("GET")
+            .uri("/_ephpm/requests")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("content-type").and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    /// A completed request lands in `/_ephpm/requests` with the shared
+    /// measurements filled in — and the endpoint's own polls (and other
+    /// `/_ephpm/` internals) are excluded from the buffer.
+    #[tokio::test]
+    async fn requests_endpoint_returns_entries_after_request() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        let router = test_router(dir.path())
+            .with_request_log(Some(Arc::new(crate::timeline::RequestLog::new(8))));
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        // One health poll (must NOT be recorded) and one static hit (must be).
+        let req = Request::builder()
+            .method("GET")
+            .uri("/_ephpm/health")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        router.handle(req, addr, false).await.unwrap();
+        let req =
+            Request::builder().method("GET").uri("/a.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let entries = fetch_timeline(&router).await;
+        assert_eq!(entries.len(), 1, "only /a.txt should be recorded: {entries:?}");
+        assert_eq!(entries[0]["method"], "GET");
+        assert_eq!(entries[0]["path"], "/a.txt");
+        assert_eq!(entries[0]["status"], 200);
+        assert!(entries[0]["total_ms"].as_f64().unwrap() >= 0.0);
+        assert!(entries[0]["timestamp_ms"].as_u64().unwrap() > 0);
+        assert!(entries[0]["queue_wait_ms"].is_null(), "static file has no queue wait");
+        assert!(entries[0]["php_ms"].is_null(), "static file has no PHP time");
+        assert_eq!(entries[0]["response_bytes"], 5);
+    }
+
+    /// With the timeline disabled (the serve-mode default), the endpoint
+    /// must behave like any other unknown `/_ephpm/` path — here a plain
+    /// 404 via the static fallback chain.
+    #[tokio::test]
+    async fn requests_endpoint_is_404_when_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let router = test_router_with_404(dir.path());
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/_ephpm/requests")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Worker-mode PHP dispatch: the timeline entry carries the queue wait
+    /// (from the existing `ephpm_worker_request_wait_seconds` measurement)
+    /// with no PHP execution value when the worker never responds, and the
+    /// request produces the 3-span tree `http.request` →
+    /// {`worker.queue_wait`, `php.execute`}.
+    ///
+    /// A zero-worker pool (stub-mode-safe: spawns no PHP threads) accepts
+    /// the dispatch but never answers, so the inner worker timeout fires.
+    #[tokio::test(start_paused = true)]
+    async fn worker_mode_records_queue_wait_and_emits_span_tree() {
+        let tree = SpanTree::default();
+        let subscriber = tracing_subscriber::registry().with(tree.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.php"), b"<?php echo 1;").unwrap();
+        let mut config = Config {
+            server: ServerConfig {
+                listen: "0.0.0.0:8080".to_string(),
+                document_root: dir.path().to_path_buf(),
+                index_files: vec!["index.php".to_string()],
+                fallback: vec!["$uri".to_string(), "=404".to_string()],
+                ..ServerConfig::default()
+            },
+            php: PhpConfig::default(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+            middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
+        };
+        // Short request deadline so the never-answering pool becomes a 504
+        // without waiting out the 300s default (paused clock auto-advances).
+        config.server.timeouts.request = 1;
+        let pool = Arc::new(crate::worker_pool::WorkerPool::spawn(
+            dir.path().join("worker.php"),
+            0, // zero workers: dispatch queues, nobody answers
+            500,
+            4,
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+        ));
+        let router = Router::new(&config, test_store(), None, None, None, None, Some(pool))
+            .with_request_log(Some(Arc::new(crate::timeline::RequestLog::new(8))));
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/index.php")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+
+        let entries = fetch_timeline(&router).await;
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert_eq!(entries[0]["path"], "/index.php");
+        assert_eq!(entries[0]["status"], 504);
+        assert!(
+            entries[0]["queue_wait_ms"].as_f64().unwrap() >= 0.0,
+            "worker mode must record the dispatch-queue wait: {entries:?}"
+        );
+        assert!(
+            entries[0]["php_ms"].is_null(),
+            "a worker that never responded produced no execution measurement: {entries:?}"
+        );
+
+        let spans = tree.snapshot();
+        let find = |name: &str| spans.iter().find(|(n, _)| n == name);
+        let http = find("http.request").expect("http.request span must exist");
+        assert_eq!(http.1, None, "http.request is the root span");
+        assert_eq!(
+            find("worker.queue_wait").expect("worker.queue_wait span must exist").1.as_deref(),
+            Some("http.request")
+        );
+        assert_eq!(
+            find("php.execute").expect("php.execute span must exist").1.as_deref(),
+            Some("http.request")
+        );
+    }
+
+    /// fpm-path PHP dispatch emits `http.request` → `php.execute` (no queue
+    /// span — there is no dispatch queue on the spawn_blocking path) and the
+    /// timeline entry records the execution time with an absent queue wait.
+    /// Runs against the stub PHP runtime, where execution fails with a 500 —
+    /// the measurement points are identical.
+    #[tokio::test]
+    async fn fpm_mode_spans_and_timeline_have_no_queue_wait() {
+        let tree = SpanTree::default();
+        let subscriber = tracing_subscriber::registry().with(tree.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.php"), b"<?php echo 1;").unwrap();
+        let router = test_router(dir.path())
+            .with_request_log(Some(Arc::new(crate::timeline::RequestLog::new(8))));
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/index.php")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        // Stub mode: PHP execution fails, the router maps that to a 500. The
+        // timing/span instrumentation sits on the same code path either way.
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let entries = fetch_timeline(&router).await;
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert!(entries[0]["queue_wait_ms"].is_null(), "fpm mode has no worker queue");
+        assert!(
+            entries[0]["php_ms"].as_f64().unwrap() >= 0.0,
+            "fpm mode records the spawn_blocking execution time: {entries:?}"
+        );
+
+        let spans = tree.snapshot();
+        assert!(spans.iter().any(|(n, p)| n == "http.request" && p.is_none()), "{spans:?}");
+        assert!(
+            spans.iter().any(|(n, p)| n == "php.execute" && p.as_deref() == Some("http.request")),
+            "{spans:?}"
+        );
+        assert!(
+            !spans.iter().any(|(n, _)| n == "worker.queue_wait"),
+            "no queue span on the fpm path: {spans:?}"
+        );
     }
 
     fn test_router_with_404(dir: &Path) -> Router {

--- a/crates/ephpm-server/src/timeline.rs
+++ b/crates/ephpm-server/src/timeline.rs
@@ -1,0 +1,157 @@
+//! Per-request timeline ring buffer (`/_ephpm/requests`).
+//!
+//! Dev-mode waterfall diagnostics: the router records one [`TimelineEntry`]
+//! per completed request into a fixed-size ring buffer, and the
+//! `/_ephpm/requests` endpoint serves the buffer as JSON, newest first.
+//!
+//! The entries reuse the measurements the router already takes for its
+//! Prometheus histograms — the total-request `Instant` in `Router::handle`,
+//! the worker-queue wait, and the PHP execution timer. Nothing here measures
+//! time itself; the dispatch paths hand their existing values over via a
+//! [`PhpTimings`] response extension.
+//!
+//! Concurrency: a plain `Mutex<VecDeque>` — the buffer is only enabled in
+//! dev mode (or explicitly via `[server.diagnostics] request_log`), where
+//! request rates are trivially low, and the critical section is a push/pop
+//! pair.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Number of entries the request timeline retains.
+pub(crate) const REQUEST_LOG_CAPACITY: usize = 256;
+
+/// PHP-path timings carried from the dispatch paths to `Router::handle` via
+/// response extensions, so the ring buffer consumes the same measurement
+/// points as the existing histograms instead of re-measuring.
+///
+/// `queue_wait` is `None` on the fpm (`spawn_blocking`) path — there is no
+/// worker dispatch queue there, so the value is genuinely absent, not zero.
+/// `execute` is `None` when the request never produced a completed PHP
+/// execution measurement (worker bailout, worker timeout, dispatch failure).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PhpTimings {
+    /// Worker-mode dispatch-queue wait (`ephpm_worker_request_wait_seconds`).
+    pub queue_wait: Option<Duration>,
+    /// PHP execution timer (`ephpm_php_execution_duration_seconds`). In
+    /// worker mode this timer starts at dispatch, so it includes the queue
+    /// wait — identical to the histogram's semantics.
+    pub execute: Option<Duration>,
+}
+
+/// One completed request, as served by `/_ephpm/requests`.
+#[derive(Clone, Debug, serde::Serialize)]
+pub(crate) struct TimelineEntry {
+    /// Completion time, milliseconds since the Unix epoch.
+    pub timestamp_ms: u64,
+    /// Request method as sent by the client.
+    pub method: String,
+    /// Percent-encoded request path as sent by the client (no query string).
+    pub path: String,
+    /// Response status code.
+    pub status: u16,
+    /// Total request duration in milliseconds (the same measurement as
+    /// `ephpm_http_request_duration_seconds`).
+    pub total_ms: f64,
+    /// Worker-mode dispatch-queue wait in milliseconds. `null` for requests
+    /// that never waited in a worker queue (static files, fpm-mode PHP).
+    pub queue_wait_ms: Option<f64>,
+    /// PHP execution time in milliseconds (in worker mode this includes the
+    /// queue wait, matching `ephpm_php_execution_duration_seconds`). `null`
+    /// for non-PHP requests and for PHP requests that never completed
+    /// execution (bailout, timeout).
+    pub php_ms: Option<f64>,
+    /// Response body size in bytes, when known up front. `null` for
+    /// streaming responses whose size is unknown at header time.
+    pub response_bytes: Option<u64>,
+}
+
+/// Fixed-size ring buffer of the most recent [`TimelineEntry`] values.
+pub(crate) struct RequestLog {
+    capacity: usize,
+    entries: Mutex<VecDeque<TimelineEntry>>,
+}
+
+impl RequestLog {
+    /// Create a ring buffer retaining at most `capacity` entries.
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self { capacity, entries: Mutex::new(VecDeque::with_capacity(capacity)) }
+    }
+
+    /// Record a completed request, evicting the oldest entry at capacity.
+    pub(crate) fn record(&self, entry: TimelineEntry) {
+        let mut entries = self.entries.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if entries.len() == self.capacity {
+            entries.pop_front();
+        }
+        entries.push_back(entry);
+    }
+
+    /// Serialize the buffer as a JSON array, newest entry first.
+    pub(crate) fn to_json(&self) -> String {
+        let snapshot: Vec<TimelineEntry> = {
+            let entries =
+                self.entries.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            entries.iter().rev().cloned().collect()
+        };
+        // TimelineEntry contains no map keys or non-string keys, so
+        // serialization cannot fail; fall back to an empty array anyway
+        // rather than panicking on a diagnostics path.
+        serde_json::to_string(&snapshot).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
+/// Milliseconds since the Unix epoch, saturating at zero for a pre-epoch
+/// clock (never happens on a sane system, but must not panic).
+pub(crate) fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str) -> TimelineEntry {
+        TimelineEntry {
+            timestamp_ms: unix_now_ms(),
+            method: "GET".to_string(),
+            path: path.to_string(),
+            status: 200,
+            total_ms: 1.0,
+            queue_wait_ms: None,
+            php_ms: None,
+            response_bytes: Some(1),
+        }
+    }
+
+    /// At capacity the oldest entry is evicted — the buffer never grows past
+    /// its capacity and always retains the most recent entries.
+    #[test]
+    fn ring_buffer_evicts_oldest_at_capacity() {
+        let log = RequestLog::new(3);
+        for i in 0..5 {
+            log.record(entry(&format!("/{i}")));
+        }
+        let json = log.to_json();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 3, "capacity must bound the buffer: {json}");
+        let paths: Vec<&str> = parsed.iter().map(|e| e["path"].as_str().unwrap()).collect();
+        assert_eq!(paths, vec!["/4", "/3", "/2"], "newest first, oldest evicted");
+    }
+
+    /// Absent measurements serialize as `null`, not zero — a request with no
+    /// worker queue must be distinguishable from one that waited 0ms.
+    #[test]
+    fn absent_timings_serialize_as_null() {
+        let log = RequestLog::new(4);
+        log.record(entry("/static.txt"));
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&log.to_json()).unwrap();
+        assert!(parsed[0]["queue_wait_ms"].is_null());
+        assert!(parsed[0]["php_ms"].is_null());
+        assert_eq!(parsed[0]["response_bytes"], 1);
+    }
+}

--- a/crates/ephpm-server/src/timeline.rs
+++ b/crates/ephpm-server/src/timeline.rs
@@ -91,8 +91,7 @@ impl RequestLog {
     /// Serialize the buffer as a JSON array, newest entry first.
     pub(crate) fn to_json(&self) -> String {
         let snapshot: Vec<TimelineEntry> = {
-            let entries =
-                self.entries.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let entries = self.entries.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             entries.iter().rev().cloned().collect()
         };
         // TimelineEntry contains no map keys or non-string keys, so
@@ -107,8 +106,7 @@ impl RequestLog {
 pub(crate) fn unix_now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
-        .unwrap_or(0)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
 #[cfg(test)]

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -11,6 +11,13 @@ description = "All-in-one PHP application server"
 name = "ephpm"
 path = "src/main.rs"
 
+[features]
+# OTLP trace export (forwards to ephpm-server's `otlp` feature): build with
+# `cargo build --features otlp` to compile the exporter in. At runtime it
+# stays inert until OTEL_EXPORTER_OTLP_ENDPOINT (or
+# [server.diagnostics] otlp_endpoint) is set.
+otlp = ["ephpm-server/otlp"]
+
 [dependencies]
 anyhow.workspace = true
 bytes.workspace = true

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -686,9 +686,36 @@ fn run_with_config(
         _ => (tracing_subscriber::fmt::layer().boxed(), None),
     };
 
+    // OTLP trace export (compiled with `--features otlp`; runtime activation
+    // is opt-in via OTEL_EXPORTER_OTLP_TRACES_ENDPOINT /
+    // OTEL_EXPORTER_OTLP_ENDPOINT or [server.diagnostics] otlp_endpoint, the
+    // env vars winning). Resolved before the subscriber is built so the
+    // export layer joins the same registry; when nothing requests it, no
+    // exporter is built and no background thread is spawned.
+    #[cfg(feature = "otlp")]
+    let otlp = ephpm_server::otlp::init_layer(config.server.diagnostics.otlp_endpoint.as_deref())
+        .context("failed to initialize OTLP trace export")?;
+
+    #[cfg(feature = "otlp")]
+    let otlp_active = otlp.is_some();
+    #[cfg(not(feature = "otlp"))]
+    let otlp_active = false;
+
+    // Layer stack. Without OTLP the env filter is installed globally (its
+    // `Layer` impl), exactly as before. With the OTLP layer active it must be
+    // scoped to the fmt layer instead: a global info-level filter would
+    // disable the DEBUG-level request spans for every layer, including the
+    // OTLP one (which carries its own target filter).
+    let mut layers: Vec<Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync>> = Vec::new();
+    if otlp_active {
+        layers.push(fmt_layer.with_filter(env_filter).boxed());
+    } else {
+        layers.push(env_filter.boxed());
+        layers.push(fmt_layer);
+    }
+
     // Set up access log file writer if configured.
     let _access_guard = if config.server.logging.access.is_empty() {
-        tracing_subscriber::registry().with(env_filter).with(fmt_layer).init();
         None
     } else {
         let access_path = PathBuf::from(&config.server.logging.access);
@@ -703,9 +730,44 @@ fn run_with_config(
             .with_writer(access_writer)
             .with_target(true)
             .with_filter(EnvFilter::new("access_log=info"));
-        tracing_subscriber::registry().with(env_filter).with(fmt_layer).with(access_layer).init();
+        layers.push(access_layer.boxed());
         Some(guard)
     };
+
+    // The guard flushes the exporter's batch queue on drop — hold it until
+    // the server has exited.
+    #[cfg(feature = "otlp")]
+    let _otlp_guard = match otlp {
+        Some((otlp_layer, guard, description)) => {
+            layers.push(otlp_layer.boxed());
+            Some((guard, description))
+        }
+        None => None,
+    };
+
+    tracing_subscriber::registry().with(layers).init();
+
+    #[cfg(feature = "otlp")]
+    if let Some((_, ref description)) = _otlp_guard {
+        tracing::info!(endpoint = %description, "OTLP trace export enabled (http/protobuf)");
+    }
+
+    // add-config-knob: never let an OTLP request die silently in a binary
+    // compiled without the exporter.
+    #[cfg(not(feature = "otlp"))]
+    {
+        let env_requested = ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT"]
+            .iter()
+            .any(|var| std::env::var(var).is_ok_and(|v| !v.is_empty()));
+        if config.server.diagnostics.otlp_endpoint.is_some() || env_requested {
+            tracing::warn!(
+                "OTLP trace export requested ([server.diagnostics] otlp_endpoint or an \
+                 OTEL_EXPORTER_OTLP_* env var is set), but this binary was built without \
+                 the `otlp` cargo feature — no spans are exported. Rebuild with \
+                 `cargo build --features otlp`."
+            );
+        }
+    }
 
     tracing::info!(
         listen = %config.server.listen,
@@ -911,7 +973,7 @@ fn run_with_config(
         .on_thread_start(fatal_signal::install_thread_altstack)
         .build()
         .context("failed to create tokio runtime")?;
-    let result = rt.block_on(async { ephpm_server::serve(config).await });
+    let result = rt.block_on(async { ephpm_server::serve(config, dev_mode).await });
 
     // Shutdown PHP runtime
     ephpm_php::PhpRuntime::shutdown().context("failed to shutdown PHP runtime")?;

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -737,13 +737,10 @@ fn run_with_config(
     // The guard flushes the exporter's batch queue on drop — hold it until
     // the server has exited.
     #[cfg(feature = "otlp")]
-    let _otlp_guard = match otlp {
-        Some((otlp_layer, guard, description)) => {
-            layers.push(otlp_layer.boxed());
-            Some((guard, description))
-        }
-        None => None,
-    };
+    let _otlp_guard = otlp.map(|(otlp_layer, guard, description)| {
+        layers.push(otlp_layer.boxed());
+        (guard, description)
+    });
 
     tracing_subscriber::registry().with(layers).init();
 

--- a/site/content/architecture/security.md
+++ b/site/content/architecture/security.md
@@ -30,7 +30,7 @@ The controls that exist today, in one place:
 - **Per-vhost `open_basedir`** — in multi-site mode, PHP filesystem access is restricted per-request to the site's directory plus the system temp directory (`std::env::temp_dir()`, so `TMPDIR` is honoured and Windows gets its real temp path). Entries are joined with the platform's `PATH_SEPARATOR` (`:` on Unix, `;` on Windows).
 - **`disable_shell_exec`** — `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`, `pcntl_exec` disabled via the php.ini generated at startup (default on in multi-site mode)
 - **`blocked_paths`** — glob patterns matched against the URI path (patterns must start with `/`); matches return 403
-- **`trusted_hosts`** — Host header validation; non-matching hosts get 421. Internal endpoints (`/_ephpm/health`, `/_ephpm/ready`, the metrics path) are exempt so Kubernetes probes and Prometheus scrapes can address the pod by raw IP
+- **`trusted_hosts`** — Host header validation; non-matching hosts get 421. Internal endpoints (`/_ephpm/health`, `/_ephpm/ready`, `/_ephpm/requests` when the request timeline is enabled, the metrics path) are exempt so Kubernetes probes and Prometheus scrapes can address the pod by raw IP
 - **`trusted_proxies`** — CIDR-based proxy trust for `X-Forwarded-For` / `X-Forwarded-Proto` resolution
 - **Hidden-file modes** — dotfile requests handled per `hidden_files` (`deny`=403, `ignore`=404, `allow`)
 - **Percent-decode traversal hardening** — strict `%XX` decoding before routing; encoded `/` and `\`, truncated or non-hex escapes, and invalid UTF-8 are rejected with 400

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -24,7 +24,7 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 |-----|------|---------|-------------|
 | `max_body_size` | u64 (bytes) | `10_485_760` (10 MiB) | Max request body. `0` = unlimited. Exceeding sends 413. |
 | `max_header_size` | usize (bytes) | `8192` | Max total request header size. |
-| `trusted_hosts` | array of strings | `[]` | Allowed `Host` header values. Empty = allow all. Mismatched hosts get 421. `/_ephpm/health`, `/_ephpm/ready`, and the metrics path are exempt (probes/scrapes address pods by IP). |
+| `trusted_hosts` | array of strings | `[]` | Allowed `Host` header values. Empty = allow all. Mismatched hosts get 421. `/_ephpm/health`, `/_ephpm/ready`, `/_ephpm/requests` (when the request timeline is enabled), and the metrics path are exempt (probes/scrapes address pods by IP). |
 
 ### `[server.timeouts]` (all in seconds)
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -87,6 +87,13 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 | `enabled` | bool | `false` | Enable the Prometheus `/metrics` endpoint. |
 | `path` | string | `"/metrics"` | URL path for the metrics endpoint. |
 
+### `[server.diagnostics]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `request_log` | bool | (mode default) | Per-request timeline: the last 256 completed requests (method, path, status, total/queue-wait/PHP durations in ms, response bytes, timestamp) served as JSON at `GET /_ephpm/requests`, newest first. Unset resolves per mode: **on** under `ephpm dev` / bare `ephpm`, **off** under `ephpm serve`. `queue_wait_ms` is `null` outside worker mode (there is no dispatch queue on the fpm path); in worker mode `php_ms` includes the queue wait, matching `ephpm_php_execution_duration_seconds`. Requests to `/_ephpm/*` and the metrics path are not recorded. When off, `/_ephpm/requests` is not registered and the path falls through to normal routing. Env override: `EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG`. |
+| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"` (OTLP **http/protobuf**; `/v1/traces` is appended when missing). Exports one `http.request` span per request (attrs: method, path, status) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. Requires a binary built with the `otlp` cargo feature — without it, a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs. |
+
 ### `[server.limits]`
 
 | Key | Type | Default | Description |


### PR DESCRIPTION
Per-request waterfall diagnostics for `ephpm dev`, plus feature-gated OTLP trace export.

## Request timeline (`/_ephpm/requests`)

- New `[server.diagnostics] request_log` knob (`Option<bool>`, env `EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG`). Unset resolves per mode: **on** under `ephpm dev` / bare `ephpm`, **off** under `ephpm serve` — same pattern as `opcache_validate_timestamps`.
- When enabled, the router keeps the last **256** completed requests in a `Mutex<VecDeque>` ring buffer (`crates/ephpm-server/src/timeline.rs`) and serves them as JSON, newest first, at `GET /_ephpm/requests` (registered next to `/_ephpm/health` / `/_ephpm/ready`).
- Entry fields: `timestamp_ms`, `method`, `path`, `status`, `total_ms`, `queue_wait_ms`, `php_ms`, `response_bytes`.
- **No re-measurement.** The entry reuses the exact values the Prometheus histograms already record: the total-request `Instant` in `Router::handle`, the worker dispatch-queue wait (`ephpm_worker_request_wait_seconds`), and the PHP execution timer (`ephpm_php_execution_duration_seconds`). The PHP dispatch paths hand their timings up via a `PhpTimings` response extension.
- `queue_wait_ms` is `null` (absent, not zero) on the fpm path — there is no dispatch queue there. In worker mode `php_ms` includes the queue wait, exactly like the histogram it mirrors.
- `/_ephpm/*` and the metrics path are excluded from the buffer so a polling dashboard doesn't fill it with its own polls.
- Disabled (serve default): nothing is recorded, and `/_ephpm/requests` falls through to normal routing like any other unknown `/_ephpm/` path (404 under a static fallback chain).

## tracing spans + OTLP export (`otlp` cargo feature)

- First real spans in the codebase: `http.request` (attrs `http.request.method`, `url.path`, `http.response.status_code`) with children `worker.queue_wait` and `php.execute`, bracketing the same regions as the existing timers (one set of instrumentation sites).
- Spans are emitted at **DEBUG** under a dedicated target (`ephpm_otel`), so the default info-level stack leaves the callsites disabled — cost without OTLP is one static callsite check per request.
- New `otlp` feature on `ephpm-server`, forwarded by `ephpm`: `tracing-opentelemetry 0.32.1` + `opentelemetry / opentelemetry_sdk 0.31.0` + `opentelemetry-otlp 0.31.1` (http/protobuf with a blocking reqwest client — deliberately no tokio dependency, because the subscriber is initialized before the runtime exists for the PHP-init ordering).
- Activation precedence (documented in `[server.diagnostics] otlp_endpoint` and `src/otlp.rs`): `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars > `[server.diagnostics] otlp_endpoint` config. `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. When nothing is set: no exporter, no background thread, no global propagator.
- W3C `traceparent` on ingress is parsed (via the global propagator, installed only when export is on) and parents the request span. PHP userland injection is out of scope.
- Binary built **without** the feature but with the knob/env set → startup `tracing::warn!` (no-silent-no-op rule).
- Subscriber wiring change in `main.rs`: layers are now composed as a `Vec<Box<dyn Layer<Registry>>>`. Without OTLP the env filter stays a global layer (behavior identical to before); with the OTLP layer active the env filter is scoped to the fmt layer so an info-level filter can't kill the DEBUG spans, and the OTLP layer carries its own `Targets` filter (`ephpm_otel=debug`) so it exports only the request spans, no log events.
- `ephpm_server::serve()` gained a `dev_mode: bool` parameter (single caller updated).

## Verified

All commands run from WSL Ubuntu against this branch (this machine has no MSVC, so native Windows cargo builds are impossible; WSL is also how the repo's release cross-builds run). Stub mode throughout — no PHP SDK present.

- `cargo check -p ephpm-config -p ephpm-server -p ephpm` (default features) — clean.
- `cargo check -p ephpm-server -p ephpm --features ephpm/otlp,ephpm-server/otlp` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo clippy -p ephpm-server -p ephpm --all-targets --features ...otlp -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo deny check` — advisories/bans/licenses/sources all ok with the new deps (no deny.toml changes).
- `cargo test -p ephpm-config` (diagnostics default/env-override tests) and `cargo test -p ephpm-server` (ring-buffer eviction, endpoint content, 404-when-disabled, worker/fpm timing semantics, span-tree assertions via a test `Layer`) — green, with and without `--features otlp`.
- **Live OTLP check** against `jaegertracing/all-in-one` via podman: stub binary built with `--features otlp`, run under `ephpm serve` in worker mode (workers can't boot in stub mode, so dispatches queue forever and the request 504s — which still exercises every instrumentation point). One `curl` with a fixed `traceparent` (`00-4bf92f...-00f067aa0ba902b7-01`). Jaeger's `/api/traces/4bf92f3577b34da6a3ce929d0e0e4736` returned the **propagated** trace id containing exactly the 3-span tree — `worker.queue_wait` and `php.execute` both `CHILD_OF` `http.request`, and `http.request` itself `CHILD_OF` the remote span `00f067aa0ba902b7` from the header — under service `ephpm-verify` (from `OTEL_SERVICE_NAME`). Startup logged `OTLP trace export enabled (http/protobuf) endpoint=env: ...`.
- In the same run, `/_ephpm/requests` (enabled in serve mode via the knob) returned the entry: `status: 504`, `total_ms ≈ 2010` (2s request timeout), `php_ms: null`. Its `queue_wait_ms` was `null` because the *outer* request timeout cancels the in-flight dispatch a hair before the inner worker timeout can attach the measurement — the deterministic worker-mode unit test (`worker_mode_records_queue_wait_and_emits_span_tree`) covers the recorded-queue-wait path.

## Not verified

- Real PHP execution timings (no PHP SDK on this machine) — the instrumentation sits on the same code paths the stub exercises, but `php.execute` durations with libphp linked were not observed.
- OTLP over TLS (`https://` collector endpoints): the exporter is built without a TLS client feature; localhost/plaintext collectors only. Documented as http/protobuf.
- gRPC OTLP (4317) is intentionally not supported — http/protobuf (4318) only.

## Notes for review

- MSRV: resolver v3 picked the dep versions against `rust-version = "1.85"`; `cargo check` on 1.85 was not run separately.
- The timeline endpoint is unauthenticated like the other `/_ephpm` endpoints; it is off by default outside dev mode and its payload contains only method/path/status/timing metadata.
