### PR TITLE
feat(php): ephpm_db_* bridge — in-process SQL through a litewire Session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2624,7 +2624,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "anyhow",
  "futures",
@@ -2632,6 +2632,7 @@ dependencies = [
  "litewire-hrana",
  "litewire-mysql",
  "litewire-postgres",
+ "litewire-session",
  "litewire-tds",
  "litewire-translate",
  "litewire-turso",
@@ -2642,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2660,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2675,10 +2676,11 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "async-trait",
  "litewire-backend",
+ "litewire-session",
  "litewire-translate",
  "opensrv-mysql",
  "thiserror 2.0.18",
@@ -2689,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "async-trait",
  "futures",
@@ -2702,9 +2704,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "litewire-session"
+version = "0.1.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+dependencies = [
+ "litewire-backend",
+ "litewire-translate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2717,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2729,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b086ddaa869a#b086ddaa869af8f1ad24d9ed63ed0d924215dc2d"
+source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3611,7 +3623,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3648,7 +3660,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "cc",
  "ephpm-kv",
  "http",
+ "litewire",
  "metrics",
  "serial_test",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,15 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ b086ddaa — CDC replay hardening (litewire#17). Two things.
+# litewire main @ 541290c4 — Session extraction (litewire#18). The dialect
+# translation + transaction-state + error-mapping core of the MySQL handler now
+# lives in the public `litewire-session` crate (`Session`), which the ephpm_db_*
+# in-process bridge consumes. Also fixes a silent multi-statement drop: the old
+# handler executed only the FIRST translated statement, so `ALTER TABLE ... ADD
+# KEY` expansions (Laravel schema builder) never created their secondary
+# indexes; Session executes all translated statements in order.
+#
+# Previous pin b086ddaa — CDC replay hardening (litewire#17). Two things.
 # (1) Replayed schema DDL is parsed and allowlisted before it reaches the
 # engine. A CDC batch carrying a `sqlite_schema` row used to have its stored
 # `sql` text executed as-is, so a peer whose frames reached `apply_batch` could
@@ -158,7 +166,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 # sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
 # DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
 # applies it at every extraction site.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "b086ddaa869a", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "541290c446b6", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -10,6 +10,9 @@ build = "build.rs"
 
 [dependencies]
 ephpm-kv.workspace = true
+# db_bridge: per-thread litewire Session executing PHP `ephpm_db_*` calls
+# against the same backend the wire frontends serve.
+litewire.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 http.workspace = true

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -2593,6 +2593,223 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_wait, 0, 0, 3)
     ZEND_ARG_INFO(0, timeout_ms)
 ZEND_END_ARG_INFO()
 
+/* ===================================================================
+ * Embedded database native PHP functions
+ *
+ * ephpm_db_query() / ephpm_db_execute() execute SQL through a per-thread
+ * litewire Session on the Rust side (db_bridge.rs) — the SAME backend the
+ * MySQL wire frontend serves, so MySQL-dialect SQL, SHOW/DESCRIBE
+ * emulation, SET-NAMES no-ops, and BEGIN/COMMIT/ROLLBACK all behave
+ * exactly as they do over the wire, without a TCP round trip.
+ *
+ * All state lives in Rust thread-locals; g_db_ops is written once at
+ * startup (ephpm_set_db_ops) before any PHP thread runs, then read-only —
+ * same ZTS discipline as g_kv_ops.
+ * =================================================================== */
+
+typedef struct {
+    /* Reset the staged parameter list for this thread. */
+    void (*params_begin)(void);
+    void (*param_null)(void);
+    void (*param_int)(long long v);
+    void (*param_float)(double v);
+    /* Bytes param: valid UTF-8 binds as TEXT, anything else as BLOB
+     * (mirrors the MySQL wire frontend's parameter decoding). */
+    void (*param_bytes)(const char *p, size_t len);
+    /* Execute sql with the staged params through the per-thread Session.
+     * Returns 1 = result set staged, 2 = OK staged, -1 = error staged,
+     * -2 = no backend registered ([db.sqlite] not active). */
+    int  (*run)(const char *sql, size_t sql_len);
+    /* Result-set accessors — valid after run() returned 1, on the same
+     * thread, until the next run()/finish(). */
+    size_t (*row_count)(void);
+    size_t (*col_count)(void);
+    void (*col_name)(size_t col, const char **p, size_t *len);
+    /* Cell accessor: *type = 0 null, 1 int (*ival), 2 float (*fval),
+     * 3 text / 4 blob (*p / *len). */
+    void (*cell)(size_t row, size_t col, int *type, long long *ival,
+                 double *fval, const char **p, size_t *len);
+    /* OK accessor — valid after run() returned 2 (zeros after 1). */
+    void (*ok_info)(unsigned long long *affected_rows,
+                    unsigned long long *last_insert_id);
+    /* Error accessor — valid after run() returned -1. *sqlstate points at
+     * 5 bytes (NOT NUL-terminated). */
+    void (*error_info)(unsigned int *code, const char **sqlstate,
+                       const char **msg, size_t *msg_len);
+    /* Drop the staged result/error, releasing memory.
+     * Must stay LAST-appended: the layout mirrors db_bridge.rs. */
+    void (*finish)(void);
+} EphpmDbOps;
+
+static EphpmDbOps g_db_ops = {0};
+
+/* Stage the optional $params array. Only null, bool, int, float, and
+ * string bind (matching what the MySQL binary protocol can carry); any
+ * other type throws. Returns 0 on success, -1 if an exception was thrown. */
+static int ephpm_db_push_params(HashTable *params)
+{
+    zval *entry;
+    g_db_ops.params_begin();
+    if (!params) { return 0; }
+    ZEND_HASH_FOREACH_VAL(params, entry) {
+        ZVAL_DEREF(entry);
+        switch (Z_TYPE_P(entry)) {
+            case IS_NULL:   g_db_ops.param_null(); break;
+            case IS_TRUE:   g_db_ops.param_int(1); break;
+            case IS_FALSE:  g_db_ops.param_int(0); break;
+            case IS_LONG:   g_db_ops.param_int((long long)Z_LVAL_P(entry)); break;
+            case IS_DOUBLE: g_db_ops.param_float(Z_DVAL_P(entry)); break;
+            case IS_STRING: g_db_ops.param_bytes(Z_STRVAL_P(entry), Z_STRLEN_P(entry)); break;
+            default:
+                zend_throw_exception_ex(zend_ce_exception, 0,
+                    "ephpm_db: unsupported parameter type %s (only null, bool, "
+                    "int, float, and string parameters bind)",
+                    zend_zval_type_name(entry));
+                return -1;
+        }
+    } ZEND_HASH_FOREACH_END();
+    return 0;
+}
+
+/* Sentinel: an exception has been thrown; the PHP_FUNCTION must
+ * RETURN_THROWS(). */
+#define EPHPM_DB_THREW (-1000)
+
+/* Run sql through the bridge, converting error outcomes into PHP
+ * exceptions. Returns the bridge's run() code (1 = rows, 2 = OK) or
+ * EPHPM_DB_THREW after throwing.
+ *
+ * Error shape follows PDO's convention: message "SQLSTATE[xxxxx]: <backend
+ * message>", exception code = the mapped MySQL error code (e.g. 1062). */
+static int ephpm_db_run_or_throw(const char *sql, size_t sql_len, HashTable *params)
+{
+    if (!g_db_ops.run) {
+        zend_throw_exception(zend_ce_exception,
+            "ephpm_db: no embedded database is active (requires [db.sqlite])", 0);
+        return EPHPM_DB_THREW;
+    }
+    if (ephpm_db_push_params(params) != 0) {
+        return EPHPM_DB_THREW;
+    }
+    int rc = g_db_ops.run(sql, sql_len);
+    if (rc == -2) {
+        zend_throw_exception(zend_ce_exception,
+            "ephpm_db: no embedded database is active (requires [db.sqlite])", 0);
+        return EPHPM_DB_THREW;
+    }
+    if (rc < 0) {
+        unsigned int code = 0;
+        const char *sqlstate = NULL;
+        const char *msg = NULL;
+        size_t msg_len = 0;
+        g_db_ops.error_info(&code, &sqlstate, &msg, &msg_len);
+        zend_throw_exception_ex(zend_ce_exception, (zend_long)code,
+            "SQLSTATE[%.5s]: %.*s",
+            sqlstate ? sqlstate : "HY000",
+            (int)msg_len, msg ? msg : "");
+        g_db_ops.finish();
+        return EPHPM_DB_THREW;
+    }
+    return rc;
+}
+
+/* ephpm_db_query(string $sql, array $params = []): array
+ *
+ * Execute SQL and return the rows as a list of associative arrays keyed
+ * by column name (a duplicate column name — SELECT a, a — keeps the last
+ * value, like mysqli_fetch_assoc()). Integer/float columns come back as
+ * PHP int/float, NULL as null, text/blob as string. A statement with no
+ * result set (e.g. SET NAMES routed through the query function) returns
+ * an empty array. Errors throw Exception (see ephpm_db_run_or_throw). */
+PHP_FUNCTION(ephpm_db_query)
+{
+    char *sql; size_t sql_len;
+    HashTable *params = NULL;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(sql, sql_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ARRAY_HT(params)
+    ZEND_PARSE_PARAMETERS_END();
+
+    int rc = ephpm_db_run_or_throw(sql, sql_len, params);
+    if (rc == EPHPM_DB_THREW) { RETURN_THROWS(); }
+
+    array_init(return_value);
+    if (rc != 1) {
+        /* OK result (no rowset) — empty array, not an error. */
+        g_db_ops.finish();
+        return;
+    }
+
+    size_t nrows = g_db_ops.row_count();
+    size_t ncols = g_db_ops.col_count();
+    for (size_t r = 0; r < nrows; r++) {
+        zval rowz;
+        array_init(&rowz);
+        for (size_t c = 0; c < ncols; c++) {
+            const char *name = NULL; size_t name_len = 0;
+            g_db_ops.col_name(c, &name, &name_len);
+
+            int type = 0; long long ival = 0; double fval = 0;
+            const char *bytes = NULL; size_t bytes_len = 0;
+            g_db_ops.cell(r, c, &type, &ival, &fval, &bytes, &bytes_len);
+
+            zval cellz;
+            switch (type) {
+                case 1:  ZVAL_LONG(&cellz, (zend_long)ival); break;
+                case 2:  ZVAL_DOUBLE(&cellz, fval); break;
+                case 3:  /* text */
+                case 4:  /* blob — PHP strings are binary-safe */
+                         ZVAL_STRINGL(&cellz, bytes, bytes_len); break;
+                default: ZVAL_NULL(&cellz); break;
+            }
+            add_assoc_zval_ex(&rowz, name ? name : "", name_len, &cellz);
+        }
+        add_next_index_zval(return_value, &rowz);
+    }
+    g_db_ops.finish();
+}
+
+/* ephpm_db_execute(string $sql, array $params = [])
+ *     : array{affected_rows: int, last_insert_id: int}
+ *
+ * Execute SQL and return the OK metadata. Transactions flow through as
+ * SQL — BEGIN / COMMIT / ROLLBACK here behave exactly as on the wire
+ * path (the per-thread Session tracks the transaction state). A SELECT
+ * routed through execute returns zeros rather than throwing. Errors
+ * throw Exception (see ephpm_db_run_or_throw). */
+PHP_FUNCTION(ephpm_db_execute)
+{
+    char *sql; size_t sql_len;
+    HashTable *params = NULL;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(sql, sql_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_ARRAY_HT(params)
+    ZEND_PARSE_PARAMETERS_END();
+
+    int rc = ephpm_db_run_or_throw(sql, sql_len, params);
+    if (rc == EPHPM_DB_THREW) { RETURN_THROWS(); }
+
+    unsigned long long affected = 0, last_id = 0;
+    g_db_ops.ok_info(&affected, &last_id);
+    g_db_ops.finish();
+
+    array_init(return_value);
+    add_assoc_long(return_value, "affected_rows", (zend_long)affected);
+    add_assoc_long(return_value, "last_insert_id", (zend_long)last_id);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_db_query, 0, 0, 1)
+    ZEND_ARG_INFO(0, sql)
+    ZEND_ARG_INFO(0, params)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_db_execute, 0, 0, 1)
+    ZEND_ARG_INFO(0, sql)
+    ZEND_ARG_INFO(0, params)
+ZEND_END_ARG_INFO()
+
 /* ── Function entry table (null-terminated) ──────────────────── */
 
 static const zend_function_entry ephpm_kv_functions[] = {
@@ -2609,6 +2826,9 @@ static const zend_function_entry ephpm_kv_functions[] = {
     PHP_FE(ephpm_kv_pttl,      arginfo_ephpm_kv_pttl)
     PHP_FE(ephpm_kv_flush_all, arginfo_ephpm_kv_flush_all)
     PHP_FE(ephpm_kv_wait,      arginfo_ephpm_kv_wait)
+    /* Embedded database bridge (per-thread litewire Session). */
+    PHP_FE(ephpm_db_query,     arginfo_ephpm_db_query)
+    PHP_FE(ephpm_db_execute,   arginfo_ephpm_db_execute)
     PHP_FE_END
 };
 
@@ -3211,6 +3431,19 @@ void ephpm_set_kv_ops(const EphpmKvOps *ops)
 {
     if (ops) {
         g_kv_ops = *ops;
+    }
+}
+
+/*
+ * Set the DB ops function pointer table backing ephpm_db_query() /
+ * ephpm_db_execute(). Same timing contract as ephpm_set_kv_ops: called
+ * once at startup, before any PHP scripts execute; g_db_ops is read-only
+ * afterwards (ZTS-safe without locking).
+ */
+void ephpm_set_db_ops(const EphpmDbOps *ops)
+{
+    if (ops) {
+        g_db_ops = *ops;
     }
 }
 

--- a/crates/ephpm-php/src/db_bridge.rs
+++ b/crates/ephpm-php/src/db_bridge.rs
@@ -1,0 +1,859 @@
+//! Bridge between the C `ephpm_db_*` PHP functions and a litewire
+//! [`Session`].
+//!
+//! Modeled on [`crate::kv_bridge`]: a C-compatible function pointer table
+//! ([`EphpmDbOps`]) is handed to `ephpm_set_db_ops()` at startup, and the
+//! PHP native functions (`ephpm_db_query`, `ephpm_db_execute`) call through
+//! it into this module. Results and errors are staged in thread-local
+//! buffers so the C side copies data without malloc/free across the FFI
+//! boundary (same contract as `KV_GET_BUF`).
+//!
+//! # Backend sharing
+//!
+//! [`set_backend`] receives the **same** erased backend instance the wire
+//! frontends serve — including ephpm-server's `TrackedBackend` query-stats
+//! wrapper — so bridge queries appear in query-stats exactly like wire
+//! queries. Registration happens only when a `[db.sqlite]` backend is
+//! active (see `share_backend_with_php` in ephpm-server); when nothing is
+//! registered, [`run_sql_bytes`] reports [`RunStatus::Unavailable`] and the
+//! C side throws a clean PHP exception instead of crashing.
+//!
+//! # One Session per PHP thread
+//!
+//! Each OS thread that executes PHP gets its own lazily-created
+//! [`Session`] (thread-local), opened via `Backend::connect()` on first
+//! use. The session translates MySQL-dialect SQL, runs the metadata
+//! emulation for `SHOW`/`DESCRIBE`, returns OK for dialect no-ops like
+//! `SET NAMES`, and tracks transaction state — `BEGIN`/`COMMIT`/`ROLLBACK`
+//! flow through as plain SQL, exactly as they do on the wire path.
+//!
+//! v1 caveat: the session (and therefore any transaction PHP left open)
+//! lives for the thread, not the request. Always `COMMIT`/`ROLLBACK`
+//! before the end of a request; an unfinished transaction stays open on
+//! that worker thread until its next `ephpm_db_*` call.
+//!
+//! # Async boundary
+//!
+//! `Session::query` is async but PHP FFI callbacks are synchronous, so the
+//! bridge pins the server's tokio [`Handle`](tokio::runtime::Handle) at
+//! registration time and uses `Handle::block_on`. This is legal ONLY
+//! because PHP FFI callbacks run on PHP worker OS threads or the tokio
+//! `spawn_blocking` pool, never on async tasks — the invariant documented
+//! on `EphpmKvOps::wait` in `kv_bridge.rs` ("Blocking is safe here:
+//! callers are PHP worker OS threads or the tokio `spawn_blocking` pool,
+//! never async tasks"). The same pinned-`Handle` sync bridge is the
+//! established precedent in `ephpm-cluster`'s `KvReplicator`
+//! (`clustered_store.rs`).
+
+use std::cell::RefCell;
+use std::sync::{Arc, OnceLock};
+
+use litewire::backend::{SharedBackend, Value};
+use litewire::session::ER_PARSE_ERROR;
+use litewire::session::error_map::ER_UNKNOWN_ERROR;
+use litewire::translate::{Dialect, TranslateCache};
+use litewire::{Session, SessionError, SessionResult};
+
+// ── Global bridge handle ────────────────────────────────────────────────
+
+/// Everything a thread needs to open and drive a session.
+struct DbBridge {
+    /// The erased backend shared with the wire frontends (including the
+    /// `TrackedBackend` stats wrapper).
+    backend: SharedBackend,
+    /// The server's tokio runtime, pinned so sync FFI callbacks can
+    /// `block_on` session work.
+    handle: tokio::runtime::Handle,
+    /// Translation cache shared by every bridge session on this process
+    /// (the wire frontends keep their own; both are per-frontend by
+    /// design in litewire).
+    cache: Arc<TranslateCache>,
+}
+
+static DB_BRIDGE: OnceLock<DbBridge> = OnceLock::new();
+
+/// Register the backend + runtime handle backing the PHP `ephpm_db_*`
+/// functions. First registration wins; later calls are no-ops (mirrors
+/// [`crate::kv_bridge::set_store`]).
+///
+/// Returns `true` if this call performed the registration.
+pub fn set_backend(backend: SharedBackend, handle: tokio::runtime::Handle) -> bool {
+    let registered = DB_BRIDGE
+        .set(DbBridge { backend, handle, cache: Arc::new(TranslateCache::default()) })
+        .is_ok();
+    if registered {
+        tracing::debug!("db backend registered for PHP native functions");
+    }
+    registered
+}
+
+/// Whether a backend has been registered.
+#[must_use]
+pub fn is_configured() -> bool {
+    DB_BRIDGE.get().is_some()
+}
+
+// ── Thread-local state ──────────────────────────────────────────────────
+
+thread_local! {
+    /// The per-thread session, created lazily on first use.
+    static DB_SESSION: RefCell<Option<Session>> = const { RefCell::new(None) };
+    /// Parameters staged by `param_*` calls for the next `run`.
+    static DB_PARAMS: RefCell<Vec<Value>> = const { RefCell::new(Vec::new()) };
+    /// Result of the last successful `run` on this thread.
+    static DB_RESULT: RefCell<Option<SessionResult>> = const { RefCell::new(None) };
+    /// Error from the last failed `run` on this thread.
+    static DB_ERROR: RefCell<Option<BridgeError>> = const { RefCell::new(None) };
+}
+
+/// The MySQL error triple staged for the C side after a failed `run`.
+struct BridgeError {
+    code: u16,
+    sqlstate: [u8; 5],
+    message: String,
+}
+
+impl From<SessionError> for BridgeError {
+    fn from(e: SessionError) -> Self {
+        Self { code: e.code(), sqlstate: e.sqlstate(), message: e.to_string() }
+    }
+}
+
+// ── Core operations (stub-safe: no PHP types involved) ──────────────────
+
+/// Outcome of [`run_sql_bytes`], mapped by the C shim onto the
+/// `EphpmDbOps::run` return codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunStatus {
+    /// A result set is staged; read it via the row/col/cell accessors.
+    Rows,
+    /// An OK result is staged; read it via [`ok_info`].
+    Ok,
+    /// An error is staged; read it via the error accessor.
+    Err,
+    /// No backend registered — `[db.sqlite]` is not active.
+    Unavailable,
+}
+
+/// Clear the staged parameter list for this thread.
+pub fn params_reset() {
+    DB_PARAMS.with(|p| p.borrow_mut().clear());
+}
+
+/// Stage one parameter for the next [`run_sql_bytes`] on this thread.
+pub fn param_push(v: Value) {
+    DB_PARAMS.with(|p| p.borrow_mut().push(v));
+}
+
+/// Convert PHP string bytes to a bind [`Value`]: valid UTF-8 binds as
+/// `Text`, anything else as `Blob` — the same decoding the MySQL wire
+/// frontend applies to `COM_STMT_EXECUTE` byte parameters.
+#[must_use]
+pub fn bytes_to_value(bytes: &[u8]) -> Value {
+    match std::str::from_utf8(bytes) {
+        Ok(s) => Value::Text(s.to_string()),
+        Err(_) => Value::Blob(bytes.to_vec()),
+    }
+}
+
+/// Drop the staged result/error, releasing their memory. Also called
+/// implicitly at the start of every [`run_sql_bytes`].
+pub fn finish() {
+    DB_RESULT.with(|r| *r.borrow_mut() = None);
+    DB_ERROR.with(|e| *e.borrow_mut() = None);
+}
+
+fn stage_error(err: BridgeError) -> RunStatus {
+    DB_ERROR.with(|e| *e.borrow_mut() = Some(err));
+    RunStatus::Err
+}
+
+/// Execute `sql` (raw PHP string bytes) with the staged parameters through
+/// this thread's [`Session`], staging the result or error for the
+/// accessors below.
+///
+/// The staged parameter list is consumed (cleared) whether or not
+/// execution succeeds.
+pub fn run_sql_bytes(sql: &[u8]) -> RunStatus {
+    let params: Vec<Value> = DB_PARAMS.with(|p| std::mem::take(&mut *p.borrow_mut()));
+    finish();
+
+    let Some(bridge) = DB_BRIDGE.get() else {
+        return RunStatus::Unavailable;
+    };
+
+    let Ok(sql) = std::str::from_utf8(sql) else {
+        return stage_error(BridgeError {
+            code: ER_PARSE_ERROR,
+            sqlstate: *b"42000",
+            message: "SQL must be valid UTF-8".to_string(),
+        });
+    };
+
+    let outcome = DB_SESSION.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let session = match slot.as_mut() {
+            Some(session) => session,
+            None => {
+                // Lazily open this thread's session against the shared
+                // backend. block_on is legal here — see the module docs
+                // (`Async boundary`): FFI callbacks never run on async
+                // tasks.
+                match bridge.handle.block_on(bridge.backend.connect()) {
+                    Ok(conn) => slot.insert(Session::with_cache(
+                        conn,
+                        Dialect::MySQL,
+                        Arc::clone(&bridge.cache),
+                    )),
+                    Err(e) => {
+                        return Err(BridgeError {
+                            code: ER_UNKNOWN_ERROR,
+                            sqlstate: *b"HY000",
+                            message: format!("failed to open embedded database session: {e}"),
+                        });
+                    }
+                }
+            }
+        };
+        bridge.handle.block_on(session.query(sql, &params)).map_err(BridgeError::from)
+    });
+
+    match outcome {
+        Ok(result) => {
+            let status = match result {
+                SessionResult::Rows(_) => RunStatus::Rows,
+                SessionResult::Ok(_) => RunStatus::Ok,
+            };
+            DB_RESULT.with(|r| *r.borrow_mut() = Some(result));
+            status
+        }
+        Err(e) => stage_error(e),
+    }
+}
+
+/// Number of rows in the staged result set (0 when none is staged).
+#[must_use]
+pub fn row_count() -> usize {
+    DB_RESULT.with(|r| match &*r.borrow() {
+        Some(SessionResult::Rows(rs)) => rs.rows.len(),
+        _ => 0,
+    })
+}
+
+/// Number of columns in the staged result set (0 when none is staged).
+#[must_use]
+pub fn col_count() -> usize {
+    DB_RESULT.with(|r| match &*r.borrow() {
+        Some(SessionResult::Rows(rs)) => rs.columns.len(),
+        _ => 0,
+    })
+}
+
+/// Look at a column name of the staged result set.
+pub fn with_col_name<R>(col: usize, f: impl FnOnce(Option<&str>) -> R) -> R {
+    DB_RESULT.with(|r| match &*r.borrow() {
+        Some(SessionResult::Rows(rs)) => f(rs.columns.get(col).map(|c| c.name.as_str())),
+        _ => f(None),
+    })
+}
+
+/// Look at a cell of the staged result set.
+pub fn with_cell<R>(row: usize, col: usize, f: impl FnOnce(Option<&Value>) -> R) -> R {
+    DB_RESULT.with(|r| match &*r.borrow() {
+        Some(SessionResult::Rows(rs)) => f(rs.rows.get(row).and_then(|cells| cells.get(col))),
+        _ => f(None),
+    })
+}
+
+/// `(affected_rows, last_insert_id)` of the staged result. A staged result
+/// set (or nothing staged) reports `(0, 0)` — `ephpm_db_execute` on a
+/// SELECT is defined to return zeros rather than error.
+#[must_use]
+pub fn ok_info() -> (u64, u64) {
+    DB_RESULT.with(|r| match &*r.borrow() {
+        Some(SessionResult::Ok(ok)) => (ok.affected_rows, ok.last_insert_id),
+        _ => (0, 0),
+    })
+}
+
+/// Look at the staged error, if any.
+pub fn with_error<R>(f: impl FnOnce(Option<(u16, &[u8; 5], &str)>) -> R) -> R {
+    DB_ERROR.with(|e| match &*e.borrow() {
+        Some(err) => f(Some((err.code, &err.sqlstate, err.message.as_str()))),
+        None => f(None),
+    })
+}
+
+// ── C-compatible ops struct (php_linked only) ───────────────────────────
+
+/// Function pointer table passed to C so the PHP native `ephpm_db_*`
+/// functions can call into the Rust bridge without knowing Rust types.
+///
+/// Layout mirrors `EphpmDbOps` in `ephpm_wrapper.c` — keep the two in
+/// sync, appending only (same rule as `EphpmKvOps`).
+#[cfg(php_linked)]
+#[repr(C)]
+pub struct EphpmDbOps {
+    /// Reset the staged parameter list for this thread.
+    pub params_begin: Option<unsafe extern "C" fn()>,
+    /// Stage a NULL parameter.
+    pub param_null: Option<unsafe extern "C" fn()>,
+    /// Stage an integer parameter.
+    pub param_int: Option<unsafe extern "C" fn(v: std::os::raw::c_longlong)>,
+    /// Stage a float parameter.
+    pub param_float: Option<unsafe extern "C" fn(v: f64)>,
+    /// Stage a bytes parameter (UTF-8 → TEXT, else BLOB).
+    pub param_bytes: Option<unsafe extern "C" fn(p: *const std::os::raw::c_char, len: usize)>,
+    /// Execute SQL with the staged parameters. Returns 1 = result set
+    /// staged, 2 = OK staged, -1 = error staged, -2 = no backend
+    /// registered.
+    pub run: Option<
+        unsafe extern "C" fn(
+            sql: *const std::os::raw::c_char,
+            sql_len: usize,
+        ) -> std::os::raw::c_int,
+    >,
+    /// Rows in the staged result set.
+    pub row_count: Option<unsafe extern "C" fn() -> usize>,
+    /// Columns in the staged result set.
+    pub col_count: Option<unsafe extern "C" fn() -> usize>,
+    /// Column name; `*p`/`*len` point into the staged result (valid until
+    /// the next `run`/`finish` on this thread).
+    pub col_name: Option<
+        unsafe extern "C" fn(col: usize, p: *mut *const std::os::raw::c_char, len: *mut usize),
+    >,
+    /// Cell accessor. `*type_` = 0 null, 1 int (`*ival`), 2 float
+    /// (`*fval`), 3 text / 4 blob (`*p`/`*len`, valid until the next
+    /// `run`/`finish` on this thread).
+    pub cell: Option<
+        unsafe extern "C" fn(
+            row: usize,
+            col: usize,
+            type_: *mut std::os::raw::c_int,
+            ival: *mut std::os::raw::c_longlong,
+            fval: *mut f64,
+            p: *mut *const std::os::raw::c_char,
+            len: *mut usize,
+        ),
+    >,
+    /// `affected_rows` / `last_insert_id` of the staged OK result
+    /// (zeros when a result set is staged instead).
+    pub ok_info: Option<
+        unsafe extern "C" fn(
+            affected_rows: *mut std::os::raw::c_ulonglong,
+            last_insert_id: *mut std::os::raw::c_ulonglong,
+        ),
+    >,
+    /// Staged error triple. `*sqlstate` points at 5 bytes (NOT
+    /// NUL-terminated); `*msg`/`*msg_len` at the message bytes. Valid
+    /// until the next `run`/`finish` on this thread.
+    pub error_info: Option<
+        unsafe extern "C" fn(
+            code: *mut std::os::raw::c_uint,
+            sqlstate: *mut *const std::os::raw::c_char,
+            msg: *mut *const std::os::raw::c_char,
+            msg_len: *mut usize,
+        ),
+    >,
+    /// Drop the staged result/error, releasing memory.
+    pub finish: Option<unsafe extern "C" fn()>,
+}
+
+// ── C shims (php_linked only) ───────────────────────────────────────────
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_params_begin() {
+    params_reset();
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_param_null() {
+    param_push(Value::Null);
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_param_int(v: std::os::raw::c_longlong) {
+    param_push(Value::Integer(v));
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_param_float(v: f64) {
+    param_push(Value::Float(v));
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_param_bytes(p: *const std::os::raw::c_char, len: usize) {
+    // SAFETY: `p` points to `len` bytes of a PHP string obtained via
+    // zend_parse_parameters, valid for the duration of this call.
+    let bytes = unsafe { std::slice::from_raw_parts(p.cast::<u8>(), len) };
+    param_push(bytes_to_value(bytes));
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_run(
+    sql: *const std::os::raw::c_char,
+    sql_len: usize,
+) -> std::os::raw::c_int {
+    // SAFETY: `sql` points to `sql_len` bytes of a PHP string obtained via
+    // zend_parse_parameters, valid for the duration of this call.
+    let bytes = unsafe { std::slice::from_raw_parts(sql.cast::<u8>(), sql_len) };
+    match run_sql_bytes(bytes) {
+        RunStatus::Rows => 1,
+        RunStatus::Ok => 2,
+        RunStatus::Err => -1,
+        RunStatus::Unavailable => -2,
+    }
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_row_count() -> usize {
+    row_count()
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_col_count() -> usize {
+    col_count()
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_col_name(col: usize, p: *mut *const std::os::raw::c_char, len: *mut usize) {
+    with_col_name(col, |name| {
+        let (ptr, n) = name.map_or((std::ptr::null(), 0), |s| (s.as_ptr().cast(), s.len()));
+        // SAFETY: `p` and `len` are valid pointers to locals in our C
+        // wrapper (`PHP_FUNCTION(ephpm_db_query)`). The returned pointer
+        // aims into the thread-local staged result, which is not dropped
+        // or mutated until the next `run`/`finish` on this same thread —
+        // the C side copies the bytes before returning to PHP.
+        unsafe {
+            *p = ptr;
+            *len = n;
+        }
+    });
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_cell(
+    row: usize,
+    col: usize,
+    type_: *mut std::os::raw::c_int,
+    ival: *mut std::os::raw::c_longlong,
+    fval: *mut f64,
+    p: *mut *const std::os::raw::c_char,
+    len: *mut usize,
+) {
+    with_cell(row, col, |cell| {
+        // SAFETY: all out-pointers are valid locals in our C wrapper.
+        // Byte pointers aim into the thread-local staged result — stable
+        // until the next `run`/`finish` on this thread; the C side copies
+        // them into zvals before returning to PHP.
+        unsafe {
+            *p = std::ptr::null();
+            *len = 0;
+            match cell {
+                None | Some(Value::Null) => *type_ = 0,
+                Some(Value::Integer(v)) => {
+                    *type_ = 1;
+                    *ival = *v;
+                }
+                Some(Value::Float(v)) => {
+                    *type_ = 2;
+                    *fval = *v;
+                }
+                Some(Value::Text(s)) => {
+                    *type_ = 3;
+                    *p = s.as_ptr().cast();
+                    *len = s.len();
+                }
+                Some(Value::Blob(b)) => {
+                    *type_ = 4;
+                    *p = b.as_ptr().cast();
+                    *len = b.len();
+                }
+            }
+        }
+    });
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_ok_info(
+    affected_rows: *mut std::os::raw::c_ulonglong,
+    last_insert_id: *mut std::os::raw::c_ulonglong,
+) {
+    let (affected, last_id) = ok_info();
+    // SAFETY: both out-pointers are valid locals in our C wrapper
+    // (`PHP_FUNCTION(ephpm_db_execute)`).
+    unsafe {
+        *affected_rows = affected;
+        *last_insert_id = last_id;
+    }
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_error_info(
+    code: *mut std::os::raw::c_uint,
+    sqlstate: *mut *const std::os::raw::c_char,
+    msg: *mut *const std::os::raw::c_char,
+    msg_len: *mut usize,
+) {
+    with_error(|err| {
+        // SAFETY: all out-pointers are valid locals in our C wrapper. The
+        // sqlstate/message pointers aim into the thread-local staged
+        // error, stable until the next `run`/`finish` on this thread; the
+        // C side formats them into the exception before returning.
+        unsafe {
+            match err {
+                Some((c, state, message)) => {
+                    *code = u32::from(c);
+                    *sqlstate = state.as_ptr().cast();
+                    *msg = message.as_ptr().cast();
+                    *msg_len = message.len();
+                }
+                None => {
+                    *code = 0;
+                    *sqlstate = std::ptr::null();
+                    *msg = std::ptr::null();
+                    *msg_len = 0;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn db_finish() {
+    finish();
+}
+
+// ── Static ops table ────────────────────────────────────────────────────
+
+/// The C-compatible function pointer table, ready to pass to
+/// `ephpm_set_db_ops()`.
+#[cfg(php_linked)]
+pub static DB_OPS: EphpmDbOps = EphpmDbOps {
+    params_begin: Some(db_params_begin),
+    param_null: Some(db_param_null),
+    param_int: Some(db_param_int),
+    param_float: Some(db_param_float),
+    param_bytes: Some(db_param_bytes),
+    run: Some(db_run),
+    row_count: Some(db_row_count),
+    col_count: Some(db_col_count),
+    col_name: Some(db_col_name),
+    cell: Some(db_cell),
+    ok_info: Some(db_ok_info),
+    error_info: Some(db_error_info),
+    finish: Some(db_finish),
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────
+//
+// The bridge core is deliberately stub-safe (no PHP types), so its
+// semantics — SET NAMES noop, SHOW TABLES metadata emulation, CRUD with
+// params, error mapping, transaction flow — are covered by plain
+// `cargo test` without a PHP SDK. The `php_linked`-gated module below
+// additionally exercises the raw C shims (pointer contracts), mirroring
+// kv_bridge's FFI tests; it requires a real libphp link to compile the
+// ops table but does not need a PHP runtime.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use litewire::backend::Rusqlite;
+    use serial_test::serial;
+
+    use super::*;
+
+    /// One shared runtime + in-memory backend for every test in this
+    /// process (the bridge's `OnceLock` can only be set once). Tables are
+    /// namespaced per test to avoid cross-test interference.
+    static TEST_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+    pub(super) fn init_bridge() {
+        let rt = TEST_RT.get_or_init(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("test runtime")
+        });
+        let backend: SharedBackend =
+            std::sync::Arc::new(Rusqlite::memory().expect("in-memory backend"));
+        let _ = set_backend(backend, rt.handle().clone());
+    }
+
+    fn run(sql: &str) -> RunStatus {
+        run_sql_bytes(sql.as_bytes())
+    }
+
+    fn cell_text(row: usize, col: usize) -> Option<String> {
+        with_cell(row, col, |c| match c {
+            Some(Value::Text(s)) => Some(s.clone()),
+            _ => None,
+        })
+    }
+
+    // (a) SET NAMES — the Noop path: proves the bridge sits above
+    // translate, not on raw SQLite (raw SQLite rejects SET NAMES).
+
+    #[test]
+    #[serial]
+    fn set_names_returns_ok_noop() {
+        init_bridge();
+        assert_eq!(run("SET NAMES utf8mb4"), RunStatus::Ok);
+        assert_eq!(ok_info(), (0, 0));
+        finish();
+    }
+
+    // (b) SHOW TABLES — the metadata emulation path.
+
+    #[test]
+    #[serial]
+    fn show_tables_returns_metadata_emulation() {
+        init_bridge();
+        assert_eq!(run("CREATE TABLE bridge_show_t (id INTEGER PRIMARY KEY)"), RunStatus::Ok);
+        assert_eq!(run("SHOW TABLES"), RunStatus::Rows);
+        assert_eq!(col_count(), 1);
+        let names: Vec<String> = (0..row_count()).filter_map(|r| cell_text(r, 0)).collect();
+        assert!(
+            names.contains(&"bridge_show_t".to_string()),
+            "SHOW TABLES must list bridge_show_t, got: {names:?}"
+        );
+        finish();
+    }
+
+    // (c) Basic CRUD with params.
+
+    #[test]
+    #[serial]
+    fn crud_with_params() {
+        init_bridge();
+        assert_eq!(
+            run("CREATE TABLE bridge_crud (id INTEGER PRIMARY KEY, name TEXT, score REAL)"),
+            RunStatus::Ok
+        );
+
+        params_reset();
+        param_push(Value::Text("alice".into()));
+        param_push(Value::Float(2.5));
+        assert_eq!(run("INSERT INTO bridge_crud (name, score) VALUES (?, ?)"), RunStatus::Ok);
+        let (affected, last_id) = ok_info();
+        assert_eq!(affected, 1);
+        assert_eq!(last_id, 1);
+
+        params_reset();
+        param_push(Value::Integer(1));
+        assert_eq!(run("SELECT id, name, score FROM bridge_crud WHERE id = ?"), RunStatus::Rows);
+        assert_eq!(row_count(), 1);
+        assert_eq!(col_count(), 3);
+        with_col_name(1, |n| assert_eq!(n, Some("name")));
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(1))));
+        assert_eq!(cell_text(0, 1).as_deref(), Some("alice"));
+        with_cell(0, 2, |c| assert_eq!(c, Some(&Value::Float(2.5))));
+
+        params_reset();
+        param_push(Value::Text("bob".into()));
+        param_push(Value::Integer(1));
+        assert_eq!(run("UPDATE bridge_crud SET name = ? WHERE id = ?"), RunStatus::Ok);
+        assert_eq!(ok_info().0, 1);
+
+        params_reset();
+        param_push(Value::Integer(1));
+        assert_eq!(run("DELETE FROM bridge_crud WHERE id = ?"), RunStatus::Ok);
+        assert_eq!(run("SELECT COUNT(*) FROM bridge_crud"), RunStatus::Rows);
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(0))));
+        finish();
+    }
+
+    // (d) Errors surface with the mapped MySQL error info.
+
+    #[test]
+    #[serial]
+    fn bad_sql_stages_parse_error() {
+        init_bridge();
+        assert_eq!(run("NOT VALID SQL !!! @@@ {{{}}"), RunStatus::Err);
+        with_error(|e| {
+            let (code, sqlstate, msg) = e.expect("error must be staged");
+            assert_eq!(code, ER_PARSE_ERROR);
+            assert_eq!(sqlstate, b"42000");
+            assert!(!msg.is_empty());
+        });
+        finish();
+    }
+
+    #[test]
+    #[serial]
+    fn duplicate_key_stages_1062() {
+        init_bridge();
+        assert_eq!(run("CREATE TABLE bridge_dup (id INTEGER PRIMARY KEY)"), RunStatus::Ok);
+        assert_eq!(run("INSERT INTO bridge_dup (id) VALUES (1)"), RunStatus::Ok);
+        assert_eq!(run("INSERT INTO bridge_dup (id) VALUES (1)"), RunStatus::Err);
+        with_error(|e| {
+            let (code, sqlstate, msg) = e.expect("error must be staged");
+            assert_eq!(code, litewire::session::error_map::ER_DUP_ENTRY);
+            assert_eq!(sqlstate, b"23000");
+            assert!(msg.to_ascii_lowercase().contains("unique"), "got: {msg}");
+        });
+        finish();
+    }
+
+    #[test]
+    #[serial]
+    fn invalid_utf8_sql_is_a_clean_error() {
+        init_bridge();
+        assert_eq!(run_sql_bytes(&[0xFF, 0xFE, 0x00]), RunStatus::Err);
+        with_error(|e| {
+            let (code, ..) = e.expect("error must be staged");
+            assert_eq!(code, ER_PARSE_ERROR);
+        });
+        finish();
+    }
+
+    // Transactions flow through as SQL and the Session tracks state.
+
+    #[test]
+    #[serial]
+    fn transactions_flow_through_as_sql() {
+        init_bridge();
+        assert_eq!(run("CREATE TABLE bridge_txn (id INTEGER PRIMARY KEY)"), RunStatus::Ok);
+        assert_eq!(run("BEGIN"), RunStatus::Ok);
+        assert_eq!(run("INSERT INTO bridge_txn (id) VALUES (1)"), RunStatus::Ok);
+        assert_eq!(run("ROLLBACK"), RunStatus::Ok);
+        assert_eq!(run("SELECT COUNT(*) FROM bridge_txn"), RunStatus::Rows);
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(0))));
+
+        assert_eq!(run("BEGIN"), RunStatus::Ok);
+        assert_eq!(run("INSERT INTO bridge_txn (id) VALUES (2)"), RunStatus::Ok);
+        assert_eq!(run("COMMIT"), RunStatus::Ok);
+        assert_eq!(run("SELECT COUNT(*) FROM bridge_txn"), RunStatus::Rows);
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(1))));
+        finish();
+    }
+
+    // Param byte classification mirrors the wire frontend.
+
+    #[test]
+    fn bytes_to_value_classifies_utf8_vs_blob() {
+        assert_eq!(bytes_to_value(b"hello"), Value::Text("hello".into()));
+        assert_eq!(bytes_to_value(&[0xFF, 0xFE]), Value::Blob(vec![0xFF, 0xFE]));
+        assert_eq!(bytes_to_value(b""), Value::Text(String::new()));
+    }
+
+    // Accessors are inert when nothing is staged.
+
+    #[test]
+    #[serial]
+    fn accessors_are_inert_without_a_staged_result() {
+        finish();
+        assert_eq!(row_count(), 0);
+        assert_eq!(col_count(), 0);
+        assert_eq!(ok_info(), (0, 0));
+        with_col_name(0, |n| assert!(n.is_none()));
+        with_cell(0, 0, |c| assert!(c.is_none()));
+        with_error(|e| assert!(e.is_none()));
+    }
+}
+
+// FFI shim tests: exercise the raw C-ABI layer (pointer contracts) the
+// same way kv_bridge's php_linked tests do. Compiled and run only with a
+// real libphp link (`cargo test` after `cargo xtask release`); they need
+// no PHP runtime, only the `php_linked` cfg that gates the ops table.
+#[cfg(all(test, php_linked))]
+mod ffi_tests {
+    use serial_test::serial;
+
+    use super::tests::init_bridge;
+    use super::*;
+
+    unsafe fn run_c(sql: &str) -> std::os::raw::c_int {
+        // SAFETY (caller): sql lives for the duration of the call.
+        unsafe { db_run(sql.as_ptr().cast(), sql.len()) }
+    }
+
+    #[test]
+    #[serial]
+    fn ffi_set_names_returns_ok() {
+        init_bridge();
+        // SAFETY: valid pointer + length.
+        let rc = unsafe { run_c("SET NAMES utf8mb4") };
+        assert_eq!(rc, 2, "SET NAMES must be an OK (noop) result");
+        let mut affected: std::os::raw::c_ulonglong = 9;
+        let mut last_id: std::os::raw::c_ulonglong = 9;
+        // SAFETY: valid out-pointers.
+        unsafe { db_ok_info(&mut affected, &mut last_id) };
+        assert_eq!((affected, last_id), (0, 0));
+        // SAFETY: no arguments.
+        unsafe { db_finish() };
+    }
+
+    #[test]
+    #[serial]
+    fn ffi_show_tables_and_cells() {
+        init_bridge();
+        // SAFETY: valid pointer + length.
+        assert_eq!(
+            unsafe { run_c("CREATE TABLE bridge_ffi_t (id INTEGER PRIMARY KEY, name TEXT)") },
+            2
+        );
+        unsafe { db_params_begin() };
+        let name = b"ffi";
+        // SAFETY: valid pointer + length.
+        unsafe { db_param_bytes(name.as_ptr().cast(), name.len()) };
+        // SAFETY: valid pointer + length.
+        assert_eq!(unsafe { run_c("INSERT INTO bridge_ffi_t (name) VALUES (?)") }, 2);
+
+        // SAFETY: valid pointer + length.
+        assert_eq!(unsafe { run_c("SHOW TABLES") }, 1);
+        // SAFETY: no arguments.
+        let rows = unsafe { db_row_count() };
+        assert!(rows >= 1);
+
+        // SAFETY: valid pointer + length.
+        assert_eq!(unsafe { run_c("SELECT id, name FROM bridge_ffi_t") }, 1);
+        let mut ty: std::os::raw::c_int = -1;
+        let mut ival: std::os::raw::c_longlong = 0;
+        let mut fval: f64 = 0.0;
+        let mut p: *const std::os::raw::c_char = std::ptr::null();
+        let mut len: usize = 0;
+        // SAFETY: valid out-pointers.
+        unsafe { db_cell(0, 0, &mut ty, &mut ival, &mut fval, &mut p, &mut len) };
+        assert_eq!((ty, ival), (1, 1));
+        // SAFETY: valid out-pointers.
+        unsafe { db_cell(0, 1, &mut ty, &mut ival, &mut fval, &mut p, &mut len) };
+        assert_eq!(ty, 3);
+        // SAFETY: p/len come from the staged result, valid until finish.
+        let got = unsafe { std::slice::from_raw_parts(p.cast::<u8>(), len) };
+        assert_eq!(got, b"ffi");
+
+        let mut np: *const std::os::raw::c_char = std::ptr::null();
+        let mut nlen: usize = 0;
+        // SAFETY: valid out-pointers.
+        unsafe { db_col_name(1, &mut np, &mut nlen) };
+        // SAFETY: np/nlen come from the staged result, valid until finish.
+        let cname = unsafe { std::slice::from_raw_parts(np.cast::<u8>(), nlen) };
+        assert_eq!(cname, b"name");
+        // SAFETY: no arguments.
+        unsafe { db_finish() };
+    }
+
+    #[test]
+    #[serial]
+    fn ffi_error_info_carries_mapped_triple() {
+        init_bridge();
+        // SAFETY: valid pointer + length.
+        assert_eq!(unsafe { run_c("TOTALLY ((( not sql") }, -1);
+        let mut code: std::os::raw::c_uint = 0;
+        let mut state: *const std::os::raw::c_char = std::ptr::null();
+        let mut msg: *const std::os::raw::c_char = std::ptr::null();
+        let mut msg_len: usize = 0;
+        // SAFETY: valid out-pointers.
+        unsafe { db_error_info(&mut code, &mut state, &mut msg, &mut msg_len) };
+        assert_eq!(code, u32::from(ER_PARSE_ERROR));
+        // SAFETY: state points at 5 staged bytes, valid until finish.
+        let sqlstate = unsafe { std::slice::from_raw_parts(state.cast::<u8>(), 5) };
+        assert_eq!(sqlstate, b"42000");
+        assert!(msg_len > 0);
+        // SAFETY: no arguments.
+        unsafe { db_finish() };
+    }
+}

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -2,6 +2,7 @@
 // are documented with comments before each unsafe block.
 #![allow(unsafe_code)]
 
+pub mod db_bridge;
 pub mod kv_bridge;
 pub mod request;
 pub mod response;
@@ -115,6 +116,11 @@ mod ffi {
         /// Set the KV ops function pointer table. Can be called after
         /// `php_embed_init()`, before any PHP scripts execute.
         pub fn ephpm_set_kv_ops(ops: *const crate::kv_bridge::EphpmKvOps);
+
+        /// Set the DB ops function pointer table backing the native
+        /// `ephpm_db_*` functions. Same timing contract as
+        /// `ephpm_set_kv_ops`.
+        pub fn ephpm_set_db_ops(ops: *const crate::db_bridge::EphpmDbOps);
 
         // ── Worker mode ─────────────────────────────────────────────
 
@@ -707,6 +713,44 @@ impl PhpRuntime {
         {
             let _ = store;
             tracing::debug!("KV store set_kv_store no-op (stub mode)");
+        }
+    }
+
+    /// Register the litewire backend that backs the PHP native
+    /// `ephpm_db_*` functions (`ephpm_db_query`, `ephpm_db_execute`).
+    ///
+    /// `backend` must be the **same** erased instance the wire frontends
+    /// serve — including ephpm-server's `TrackedBackend` wrapper — so
+    /// bridge queries land in query-stats exactly like wire queries.
+    /// `handle` is the server's tokio runtime handle, pinned so the sync
+    /// FFI callbacks can `block_on` session work (see the async-boundary
+    /// note in [`db_bridge`]).
+    ///
+    /// Call only when a `[db.sqlite]` backend is active; when never
+    /// called, the PHP functions throw a clean exception instead of
+    /// executing. First registration wins (mirrors [`Self::set_kv_store`]).
+    ///
+    /// In stub mode (no `php_linked`) the Rust-side registration still
+    /// happens (it is used by stub tests) but no PHP wiring occurs.
+    pub fn set_db_backend(
+        backend: litewire::backend::SharedBackend,
+        handle: tokio::runtime::Handle,
+    ) {
+        let registered = db_bridge::set_backend(backend, handle);
+
+        #[cfg(php_linked)]
+        if registered {
+            // Safety: DB_OPS is a static with a stable address.
+            // ephpm_set_db_ops copies the struct into the C global — the
+            // pointer only needs to be valid for the duration of this call.
+            unsafe { ffi::ephpm_set_db_ops(&db_bridge::DB_OPS) };
+
+            tracing::info!("db backend wired to PHP native functions");
+        }
+
+        #[cfg(not(php_linked))]
+        if registered {
+            tracing::debug!("db backend registered (stub mode, no PHP wiring)");
         }
     }
 

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1643,7 +1643,10 @@ async fn start_single_node_sqlite(
         );
         spawn_single_node_litewire(
             sqlite_config,
-            tracked_backend::TrackedBackend::new(backend, query_stats.clone()),
+            share_backend_with_php(tracked_backend::TrackedBackend::new(
+                backend,
+                query_stats.clone(),
+            )),
             handles,
         );
     } else {
@@ -1675,11 +1678,53 @@ async fn start_single_node_sqlite(
         spawn_reuse_stats_logger(&backend, handles);
         spawn_single_node_litewire(
             sqlite_config,
-            tracked_backend::TrackedBackend::new(SharedRusqlite(backend), query_stats.clone()),
+            share_backend_with_php(tracked_backend::TrackedBackend::new(
+                SharedRusqlite(backend),
+                query_stats.clone(),
+            )),
             handles,
         );
     }
     Ok(())
+}
+
+/// Erase `backend` behind an `Arc`, register that same instance as the
+/// target of the PHP native `ephpm_db_*` functions, and return a
+/// forwarding wrapper for the litewire builder.
+///
+/// This is how wire clients and in-process PHP bridge sessions come to
+/// share ONE backend object — including the [`tracked_backend::TrackedBackend`]
+/// wrapper passed in by every SQLite startup path, so bridge queries land
+/// in query-stats exactly like wire queries. Called only from the
+/// `[db.sqlite]` startup paths; when none of them runs, the bridge stays
+/// unregistered and `ephpm_db_*` throws a clean PHP exception.
+///
+/// Must be called from within the server's tokio runtime (it pins
+/// [`tokio::runtime::Handle::current`] for the bridge's sync-to-async
+/// boundary).
+pub(crate) fn share_backend_with_php(backend: impl litewire::backend::Backend) -> PhpSharedBackend {
+    let shared: litewire::backend::SharedBackend = std::sync::Arc::new(backend);
+    ephpm_php::PhpRuntime::set_db_backend(
+        std::sync::Arc::clone(&shared),
+        tokio::runtime::Handle::current(),
+    );
+    PhpSharedBackend(shared)
+}
+
+/// Forwarding wrapper handing an already-erased [`litewire::backend::SharedBackend`]
+/// back to `LiteWire::new`, which insists on taking `impl Backend` by value.
+/// Same shape as [`SharedRusqlite`] below; the default `query`/`execute`
+/// convenience methods route through `connect()`, whose returned connections
+/// carry the stats wrapper.
+pub(crate) struct PhpSharedBackend(litewire::backend::SharedBackend);
+
+#[async_trait::async_trait]
+impl litewire::backend::Backend for PhpSharedBackend {
+    async fn connect(
+        &self,
+    ) -> Result<Box<dyn litewire::backend::BackendConn>, litewire::backend::BackendError> {
+        self.0.connect().await
+    }
 }
 
 /// Shares one [`litewire::backend::Rusqlite`] between litewire — which takes
@@ -1894,8 +1939,10 @@ async fn start_clustered_sqlite(
     }
     let tracked = tracked_backend::TrackedBackend::new(backend, query_stats.clone());
 
-    // Start litewire with the tracked backend.
-    let mut builder = litewire::LiteWire::new(tracked);
+    // Start litewire with the tracked backend, shared with the PHP
+    // `ephpm_db_*` bridge (single-node and clustered sit behind the same
+    // Backend object — no mode-specific bridge paths).
+    let mut builder = litewire::LiteWire::new(share_backend_with_php(tracked));
     builder = builder.mysql(&sqlite_config.proxy.mysql_listen);
     tracing::info!(
         listen = %sqlite_config.proxy.mysql_listen,
@@ -1974,6 +2021,23 @@ fn parse_duration(s: &str) -> anyhow::Result<std::time::Duration> {
 #[cfg(test)]
 mod lib_tests {
     use super::*;
+
+    /// `share_backend_with_php` must register the erased backend with the
+    /// PHP bridge AND hand back a wrapper whose `connect()` reaches the
+    /// same instance. Runs in stub mode — the bridge core is stub-safe.
+    #[tokio::test]
+    async fn share_backend_with_php_registers_and_forwards() {
+        let backend = litewire::backend::Rusqlite::memory().expect("in-memory backend");
+        let wrapper = share_backend_with_php(backend);
+        assert!(ephpm_php::db_bridge::is_configured());
+
+        // The wrapper still opens working sessions for the wire frontends.
+        use litewire::backend::Backend as _;
+        let conn = wrapper.connect().await.expect("connect through wrapper");
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", &[])
+            .await
+            .expect("execute through wrapper");
+    }
 
     #[test]
     fn parse_memory_size_megabytes() {

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -522,9 +522,11 @@ pub async fn start_clustered_turso_cdc(
             .await?;
     }
 
-    // Start litewire wire frontends. Wire factory is moved in here.
+    // Start litewire wire frontends. Wire factory is moved in here, shared
+    // with the PHP `ephpm_db_*` bridge so in-process queries hit the same
+    // tracked backend as wire clients.
     let tracked = tracked_backend::TrackedBackend::new(wire_factory, query_stats.clone());
-    spawn_litewire_serve(sqlite_config, tracked, handles);
+    spawn_litewire_serve(sqlite_config, crate::share_backend_with_php(tracked), handles);
 
     // Kick off role-appropriate work for the initial role.
     let initial_driver =


### PR DESCRIPTION
> **DRAFT — depends on ephpm/litewire#18.** This branch is written against the `Session` layer introduced there and was built/tested locally via the documented local-patch mechanism (a local, uncommitted `[patch."https://github.com/ephpm/litewire.git"]` pointing at the litewire PR worktree). **CI will not compile until litewire#18 merges and the `rev` pin is bumped** (`cargo update -p litewire`) — that bump is deliberately not part of this diff.

## What

v1 of the in-process PHP database bridge — two native functions, registered only when a `[db.sqlite]` backend is active:

```php
ephpm_db_query(string $sql, array $params = []): array
// rows as a list of associative arrays keyed by column name
// (duplicate names keep the last value, like mysqli_fetch_assoc)

ephpm_db_execute(string $sql, array $params = []): array
// ['affected_rows' => int, 'last_insert_id' => int]
```

Both execute through a **per-thread litewire `Session`** (lazily created, thread-local) against the **same erased backend instance the wire frontends serve — including the `TrackedBackend` query-stats wrapper** — so bridge queries appear in query-stats exactly like wire queries. MySQL-dialect translation, `SHOW`/`DESCRIBE`/`information_schema` emulation, `SET NAMES` no-ops, and the MySQL error mapping all behave exactly as on the wire path, with no TCP round trip. Transactions flow through as SQL (`BEGIN`/`COMMIT`/`ROLLBACK`); the Session tracks state; no dedicated txn functions in v1.

Errors throw `Exception` with PDO-style message `SQLSTATE[xxxxx]: <backend message>` and the mapped MySQL error code (e.g. 1062) as the exception code. Calling `ephpm_db_*` when no `[db.sqlite]` backend is active throws a clean exception ("no embedded database is active") — never crashes.

## How

- **`crates/ephpm-php/src/db_bridge.rs`** — modeled on `kv_bridge.rs`: a `#[repr(C)]` ops table (`EphpmDbOps`) handed to `ephpm_set_db_ops()` once at startup; results/errors staged in Rust thread-locals so C copies without cross-FFI malloc. The bridge **core is stub-safe** (no PHP types) — only the C-ABI shims and ops table are `#[cfg(php_linked)]`.
- **Async boundary** — a tokio `Handle` pinned at registration + `Handle::block_on`, legal only because PHP FFI callbacks run on worker OS threads or the `spawn_blocking` pool, never async tasks (the invariant documented on `EphpmKvOps::wait` in kv_bridge.rs, cited in the module docs; same pattern as `KvReplicator` in `ephpm-cluster/src/clustered_store.rs`).
- **`crates/ephpm-php/ephpm_wrapper.c`** — `EphpmDbOps` mirror struct, `PHP_FUNCTION(ephpm_db_query/ephpm_db_execute)`, arginfo, entries appended to the `additional_functions` table, `ephpm_set_db_ops()`. `g_db_ops` follows the `g_kv_ops` ZTS discipline (written once pre-thread, read-only after); all mutable state lives in Rust thread-locals; params bind null/bool/int/float/string (UTF-8 string → TEXT, non-UTF-8 → BLOB, mirroring the wire frontend's param decoding — anything else throws).
- **`crates/ephpm-server`** — one `share_backend_with_php()` helper Arc-erases the tracked backend, registers it with the bridge, and hands a forwarding wrapper to `LiteWire::new`. Applied on all four `[db.sqlite]` startup paths (single-node rusqlite, single-node turso, clustered sqld, clustered turso-CDC) — single-node and clustered sit behind the same litewire `Backend` object, so there are no mode-specific bridge paths.

v1 caveat (documented in the module docs): the Session lives for the thread, not the request — a transaction PHP leaves open persists on that worker thread. Always commit/roll back before the end of a request.

## Verified locally (WSL Ubuntu, rustc 1.97.1, stub mode, litewire#18 patched in)

- `cargo test -p ephpm-php` — green, including the new stub-safe bridge tests: **(a)** `SET NAMES utf8mb4` → OK via the Noop path (proves the bridge sits above translate), **(b)** `SHOW TABLES` → metadata emulation rows, **(c)** CRUD with typed params incl. `last_insert_id`/`affected_rows`, **(d)** bad SQL → 1064/42000 and duplicate key → 1062/23000 with message, plus BEGIN/ROLLBACK/COMMIT flow, UTF-8/blob param classification, invalid-UTF-8 SQL as a clean error.
- `cargo test -p ephpm-server` and `cargo test --workspace` — green, including the new `share_backend_with_php_registers_and_forwards` plumbing test. (`sqlite_handle_reuse::concurrent_sessions_do_not_force_discards` failed intermittently ~1/5 runs; reproduced at the same rate on **unmodified main** against the pinned litewire — pre-existing timing flake, unrelated.)
- `cargo clippy --workspace --all-targets -- -D warnings` (pedantic) — clean.
- `cargo +nightly fmt --all -- --check` — clean.

## Written but NOT verified here

- **The C code paths** (`PHP_FUNCTION`s, param staging from zvals, exception throwing) and the `php_linked`-gated Rust FFI shim tests (`db_bridge::ffi_tests`) — this machine has no PHP SDK build, so nothing `php_linked` was compiled or executed. The FFI tests are written to compile under the cfg and mirror kv_bridge's FFI test suite; they need a `cargo xtask release` environment to run.
- End-to-end behavior through a real PHP script (`ephpm_db_query()` from userland).

## Out of scope (per plan)

WordPress `db.php` drop-in, Doctrine/Laravel adapters, PDO driver, PG/TDS Session migration, performance claims.
