### PR TITLE
fix(php): db bridge follow-ups — rollback at request end, session recycling, committed E2E

### DIFF
--- a/crates/ephpm-e2e/tests/db_bridge.rs
+++ b/crates/ephpm-e2e/tests/db_bridge.rs
@@ -1,0 +1,185 @@
+//! In-process `ephpm_db_*` bridge e2e tests.
+//!
+//! Exercises the native `ephpm_db_query()` / `ephpm_db_execute()` PHP
+//! functions end to end over HTTP: PHP → C ops table → Rust db_bridge →
+//! per-thread litewire Session → embedded SQLite. No PDO, no TCP hop —
+//! this is the in-process lane, distinct from the `sqlite` suite's
+//! pdo_mysql wire path. Requires ephpm configured with `[db.sqlite]` and
+//! `db_bridge_test.php` in the docroot.
+//!
+//! The suite mutates shared DB state (it creates/drops `bridge_e2e`), so
+//! `cargo xtask e2e` runs it as an ISOLATED_DB_SUITE: a fresh node with a
+//! fresh database, single-threaded within the suite.
+//!
+//! Environment variables:
+//! - `EPHPM_URL` — base URL of the ephpm instance. Read via
+//!   [`required_env`], so the suite FAILS (loudly) rather than skips when
+//!   the harness did not provide a server — the fail-don't-skip convention
+//!   from #244.
+
+use ephpm_e2e::required_env;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct BridgeResponse {
+    status: String,
+    #[serde(default)]
+    rows: Vec<serde_json::Value>,
+    #[serde(default)]
+    tables: Vec<String>,
+    #[serde(default)]
+    affected_rows: Option<i64>,
+    #[serde(default)]
+    last_insert_id: Option<i64>,
+    #[serde(default)]
+    code: Option<i64>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    leaked: Option<i64>,
+    #[serde(default)]
+    probe: Option<String>,
+}
+
+/// GET db_bridge_test.php with an action (+ extra query params), asserting
+/// HTTP 200 and parsing the JSON body.
+async fn bridge_action(action: &str, params: &str) -> BridgeResponse {
+    let (status, body) = bridge_raw(action, params).await;
+    assert_eq!(status, 200, "action={action}&{params} returned HTTP {status}: {body}");
+    serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("failed to parse JSON for action={action}: {e}\nbody: {body}"))
+}
+
+/// GET db_bridge_test.php returning the raw (status, body) — for actions
+/// that are expected to fail (the deliberate fatal).
+async fn bridge_raw(action: &str, params: &str) -> (u16, String) {
+    let base_url = required_env("EPHPM_URL");
+    let sep = if params.is_empty() { "" } else { "&" };
+    let url = format!("{base_url}/db_bridge_test.php?action={action}{sep}{params}");
+    let resp = reqwest::get(&url).await.unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+    let status = resp.status().as_u16();
+    let body = resp.text().await.unwrap_or_default();
+    (status, body)
+}
+
+async fn setup() {
+    let resp = bridge_action("setup", "").await;
+    assert_eq!(resp.status, "ok", "setup failed: {:?}", resp.message);
+}
+
+async fn cleanup() {
+    let resp = bridge_action("cleanup", "").await;
+    assert_eq!(resp.status, "ok", "cleanup failed: {:?}", resp.message);
+}
+
+/// CREATE TABLE + INSERT with bound params (checking affected_rows /
+/// last_insert_id) + SELECT (checking row values and column-name keys).
+#[tokio::test]
+async fn create_insert_query_roundtrip() {
+    setup().await;
+
+    let ins = bridge_action("insert", "name=alice&value=hello").await;
+    assert_eq!(ins.status, "ok", "insert failed: {:?}", ins.message);
+    assert_eq!(ins.affected_rows, Some(1), "INSERT must report 1 affected row");
+    let first_id = ins.last_insert_id.expect("insert must report last_insert_id");
+    assert!(first_id >= 1, "last_insert_id must be >= 1, got {first_id}");
+
+    let ins2 = bridge_action("insert", "name=bob&value=world").await;
+    assert_eq!(ins2.affected_rows, Some(1));
+    let second_id = ins2.last_insert_id.expect("second insert must report last_insert_id");
+    assert!(second_id > first_id, "ids must advance: {first_id} then {second_id}");
+
+    let q = bridge_action("query", "").await;
+    assert_eq!(q.status, "ok", "query failed: {:?}", q.message);
+    assert_eq!(q.rows.len(), 2, "expected 2 rows, got {:?}", q.rows);
+    // Rows are assoc arrays keyed by column name, with native types.
+    assert_eq!(q.rows[0]["id"], first_id, "row 0: {:?}", q.rows[0]);
+    assert_eq!(q.rows[0]["name"], "alice");
+    assert_eq!(q.rows[0]["value"], "hello");
+    assert_eq!(q.rows[1]["name"], "bob");
+    assert_eq!(q.rows[1]["value"], "world");
+
+    cleanup().await;
+}
+
+/// SET NAMES is a dialect noop: OK result, rendered as an empty array.
+#[tokio::test]
+async fn set_names_is_a_noop_empty_result() {
+    let resp = bridge_action("set_names", "").await;
+    assert_eq!(resp.status, "ok", "set_names failed: {:?}", resp.message);
+    assert!(resp.rows.is_empty(), "SET NAMES must return [], got {:?}", resp.rows);
+}
+
+/// SHOW TABLES runs the metadata emulation and lists the created table.
+#[tokio::test]
+async fn show_tables_lists_the_bridge_table() {
+    setup().await;
+
+    let resp = bridge_action("show_tables", "").await;
+    assert_eq!(resp.status, "ok", "show_tables failed: {:?}", resp.message);
+    assert!(
+        resp.tables.iter().any(|t| t == "bridge_e2e"),
+        "SHOW TABLES must list bridge_e2e, got {:?}",
+        resp.tables
+    );
+
+    cleanup().await;
+}
+
+/// Invalid SQL surfaces as a PHP Exception with the mapped MySQL error:
+/// code 1064, message starting with "SQLSTATE[42000]" (PDO convention).
+#[tokio::test]
+async fn bad_sql_throws_exception_1064() {
+    let resp = bridge_action("bad_sql", "").await;
+    assert_eq!(resp.status, "ok", "bad_sql script error: {:?}", resp.message);
+    assert_eq!(resp.code, Some(1064), "exception code must be ER_PARSE_ERROR (1064)");
+    let message = resp.message.expect("exception message must be reported");
+    assert!(
+        message.starts_with("SQLSTATE[42000]"),
+        "message must start with SQLSTATE[42000], got: {message}"
+    );
+}
+
+/// Fix-1 acceptance: a request that BEGINs + INSERTs and deliberately does
+/// NOT commit must have its transaction rolled back at request end — the
+/// uncommitted row is GONE for every later request, and the connection
+/// stays healthy (no leaked write lock wedging autocommit writes). Covers
+/// both the forgot-to-COMMIT return and the mid-transaction PHP fatal.
+#[tokio::test]
+async fn abandoned_transaction_is_rolled_back_between_requests() {
+    setup().await;
+
+    // Request 1: BEGIN + INSERT 'leaked', return without COMMIT.
+    let leak = bridge_action("leak", "").await;
+    assert_eq!(leak.status, "ok", "leak request failed: {:?}", leak.message);
+
+    // Requests 2..: the uncommitted row must be gone and writes must work.
+    // Checked several times so the assertions land on multiple PHP worker
+    // threads — including, probabilistically, the one that ran the BEGIN.
+    for i in 0..5 {
+        let check = bridge_action("check", "").await;
+        assert_eq!(check.status, "ok", "check {i} failed: {:?}", check.message);
+        assert_eq!(
+            check.leaked,
+            Some(0),
+            "check {i}: uncommitted 'leaked' row survived — rollback at request end missing"
+        );
+        assert_eq!(
+            check.probe.as_deref(),
+            Some("ok"),
+            "check {i}: write probe unhealthy — a leaked transaction is holding the write lock"
+        );
+    }
+
+    // Same leak via a mid-transaction PHP fatal (uncaught Error → 500).
+    let (status, body) = bridge_raw("leak_fatal", "").await;
+    assert_eq!(status, 500, "leak_fatal must end in a 500, got {status}: {body}");
+
+    for i in 0..5 {
+        let check = bridge_action("check", "").await;
+        assert_eq!(check.leaked, Some(0), "check {i} after fatal: leaked row survived");
+        assert_eq!(check.probe.as_deref(), Some("ok"), "check {i} after fatal: probe unhealthy");
+    }
+
+    cleanup().await;
+}

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -34,6 +34,9 @@ cc = "1"
 [dev-dependencies]
 serial_test.workspace = true
 tempfile.workspace = true
+# db_bridge recycle tests: mock Backend/BackendConn impls (litewire's
+# backend traits are async_trait-based).
+async-trait.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -2845,9 +2845,12 @@ PHP_FUNCTION(ephpm_db_query)
  *
  * Execute SQL and return the OK metadata. Transactions flow through as
  * SQL — BEGIN / COMMIT / ROLLBACK here behave exactly as on the wire
- * path (the per-thread Session tracks the transaction state). A SELECT
- * routed through execute returns zeros rather than throwing. Errors
- * throw Exception (see ephpm_db_run_or_throw). */
+ * path (the per-thread Session tracks the transaction state). A
+ * transaction still open when the request ends is rolled back by the
+ * server with a warning (db_bridge.rs on_request_end) — it never leaks
+ * into the next request served by this thread. A SELECT routed through
+ * execute returns zeros rather than throwing. Errors throw Exception
+ * (see ephpm_db_run_or_throw). */
 PHP_FUNCTION(ephpm_db_execute)
 {
     char *sql; size_t sql_len;

--- a/crates/ephpm-php/src/db_bridge.rs
+++ b/crates/ephpm-php/src/db_bridge.rs
@@ -27,10 +27,30 @@
 //! `SET NAMES`, and tracks transaction state — `BEGIN`/`COMMIT`/`ROLLBACK`
 //! flow through as plain SQL, exactly as they do on the wire path.
 //!
-//! v1 caveat: the session (and therefore any transaction PHP left open)
-//! lives for the thread, not the request. Always `COMMIT`/`ROLLBACK`
-//! before the end of a request; an unfinished transaction stays open on
-//! that worker thread until its next `ephpm_db_*` call.
+//! # Transactions end with the request
+//!
+//! The session lives for the thread, but transactions do not. At
+//! per-request teardown ([`on_request_end`], wired into both execution
+//! modes — see its docs for the exact seams) any explicit transaction the
+//! script left open is rolled back with a `tracing::warn!`, and the staged
+//! result/error buffers are released. A script that runs `BEGIN` and then
+//! fatals (or simply forgets to `COMMIT`) therefore cannot leak its open
+//! transaction into the next, unrelated request dispatched to the same
+//! worker thread. Scripts should still `COMMIT`/`ROLLBACK` explicitly —
+//! the automatic rollback is a safety net, not an API.
+//!
+//! # Session recycling on connection failure
+//!
+//! A thread's session holds its `BackendConn` indefinitely. If the
+//! connection dies underneath it (sqld restart on clustered failover), the
+//! failed call is reported to PHP as an error, and — when the error
+//! classifies as connection-shaped (`is_connection_error`) and the
+//! session is **not** inside an explicit transaction — the session is
+//! dropped so the next call lazily reconnects, mirroring how wire clients
+//! recover by reconnecting. SQL-level errors (1062, 1064, ...) never
+//! recycle: that would discard live transaction state on every constraint
+//! violation. See `is_connection_error` for why the classification is
+//! substring-based and deliberately conservative.
 //!
 //! # Async boundary
 //!
@@ -157,7 +177,8 @@ pub fn bytes_to_value(bytes: &[u8]) -> Value {
 }
 
 /// Drop the staged result/error, releasing their memory. Also called
-/// implicitly at the start of every [`run_sql_bytes`].
+/// implicitly at the start of every [`run_sql_bytes`] and at per-request
+/// teardown ([`on_request_end`]).
 pub fn finish() {
     DB_RESULT.with(|r| *r.borrow_mut() = None);
     DB_ERROR.with(|e| *e.borrow_mut() = None);
@@ -168,17 +189,99 @@ fn stage_error(err: BridgeError) -> RunStatus {
     RunStatus::Err
 }
 
+/// Message substrings that mark a [`SessionError`] as connection-shaped —
+/// the backend connection (not the SQL) is what failed.
+///
+/// litewire's `BackendError` is stringly typed (`Sqlite(String)` /
+/// `Other(String)`) and `SessionError::Db` flattens it further into a
+/// `(code, sqlstate, message)` triple, so there is no structured
+/// "connection failure" variant to key off — substring matching against
+/// the known producer sites is the only classification available. Every
+/// marker below is anchored to a concrete error `format!` in
+/// litewire-backend's `hrana_client.rs` (the only backend whose
+/// connections can die independently of the process; the rusqlite backend
+/// is in-process) or to the transport wording reqwest/hyper nest inside
+/// those messages.
+const CONNECTION_ERROR_MARKERS: &[&str] = &[
+    // hrana_client transport failures: the pipeline POST never completed
+    // or returned garbage ("HTTP request failed: {reqwest}", "failed to
+    // parse response: {e}", "empty pipeline response", "unexpected close
+    // response", "health check failed: {e}").
+    "http request failed",
+    "health check failed",
+    "failed to parse response",
+    "empty pipeline response",
+    "unexpected close response",
+    // "sqld returned {status}: {body}" — emitted only for a non-success
+    // HTTP status. SQL errors always come back in-band with HTTP 200, so
+    // an HTTP-level failure is a stream/transport problem by construction
+    // (a restarted sqld rejecting a stale baton answers 4xx here).
+    "sqld returned ",
+    // Hrana stream loss after a sqld restart, surfaced as an in-band
+    // ErrorResponse without a SQLITE code ("Invalid baton", "The stream
+    // has expired ...", stream not found).
+    "baton",
+    "stream has expired",
+    "stream not found",
+    // Transport wording reqwest/hyper nest inside their Display output.
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "error sending request",
+    "channel closed",
+];
+
+/// Whether `err` indicates a dead/broken backend connection, as opposed to
+/// a SQL-level error the statement earned on its own.
+///
+/// Conservative on purpose:
+///
+/// * Anything litewire's `error_map` managed to classify (1062 duplicate
+///   key, 1064 parse, 1205 busy, 1290 read-only, 1452 FK, ...) is a SQL
+///   error — never connection-shaped. Only the `ER_UNKNOWN_ERROR` (1105)
+///   fallback is considered further.
+/// * Within 1105, only messages matching [`CONNECTION_ERROR_MARKERS`]
+///   qualify.
+///
+/// Known limitation: the match is substring-based because the underlying
+/// error is stringly typed. A false positive (e.g. `no such column:
+/// baton`) costs one needless reconnect on an autocommit session — cheap
+/// and self-healing. A false negative leaves the session broken until the
+/// thread's next connection-shaped error, which the next call will
+/// produce. Callers additionally refuse to recycle mid-transaction (see
+/// [`run_sql_bytes`]) so a misclassification can never discard live
+/// transaction state.
+fn is_connection_error(err: &SessionError) -> bool {
+    if err.code() != ER_UNKNOWN_ERROR {
+        return false;
+    }
+    let msg = err.to_string().to_ascii_lowercase();
+    CONNECTION_ERROR_MARKERS.iter().any(|marker| msg.contains(marker))
+}
+
 /// Execute `sql` (raw PHP string bytes) with the staged parameters through
 /// this thread's [`Session`], staging the result or error for the
 /// accessors below.
 ///
 /// The staged parameter list is consumed (cleared) whether or not
 /// execution succeeds.
+///
+/// On a connection-shaped failure (`is_connection_error`) outside an
+/// explicit transaction, the thread's session is dropped so the next call
+/// reconnects (see the module docs, `Session recycling`).
 pub fn run_sql_bytes(sql: &[u8]) -> RunStatus {
+    run_on(DB_BRIDGE.get(), sql)
+}
+
+/// [`run_sql_bytes`] against an explicit bridge. Split out so unit tests
+/// can drive a locally-constructed [`DbBridge`] (with a mock backend)
+/// without going through the process-wide, set-once [`DB_BRIDGE`].
+fn run_on(bridge: Option<&DbBridge>, sql: &[u8]) -> RunStatus {
     let params: Vec<Value> = DB_PARAMS.with(|p| std::mem::take(&mut *p.borrow_mut()));
     finish();
 
-    let Some(bridge) = DB_BRIDGE.get() else {
+    let Some(bridge) = bridge else {
         return RunStatus::Unavailable;
     };
 
@@ -215,7 +318,26 @@ pub fn run_sql_bytes(sql: &[u8]) -> RunStatus {
                 }
             }
         };
-        bridge.handle.block_on(session.query(sql, &params)).map_err(BridgeError::from)
+        let result = bridge.handle.block_on(session.query(sql, &params));
+        if let Err(e) = &result {
+            // Recycle a session whose connection looks dead so the NEXT
+            // call reconnects — but never mid-transaction: recycling
+            // there would silently discard the transaction state a
+            // misclassified SQL error (the match is substring-based, see
+            // is_connection_error) may still legitimately own. A
+            // mid-transaction connection death is instead cleaned up at
+            // request end: on_request_end's ROLLBACK fails over the same
+            // dead connection and drops the session then.
+            if !session.in_transaction && is_connection_error(e) {
+                tracing::warn!(
+                    error = %e,
+                    "embedded db session hit a connection-class error — dropping it so the \
+                     next call reconnects"
+                );
+                *slot = None;
+            }
+        }
+        result.map_err(BridgeError::from)
     });
 
     match outcome {
@@ -229,6 +351,74 @@ pub fn run_sql_bytes(sql: &[u8]) -> RunStatus {
         }
         Err(e) => stage_error(e),
     }
+}
+
+/// Per-request teardown for this thread's bridge state.
+///
+/// Must run at the end of **every** PHP request, on the thread that ran
+/// it. The wired seams, per execution mode:
+///
+/// * **fpm mode** — `PhpRuntime::execute()` calls this right after
+///   `execute_php` returns (success, script exit, or bailout alike). That
+///   is the single choke point every fpm-style request passes through on
+///   its own `spawn_blocking` thread.
+/// * **worker mode** — `worker_bridge::finish_iteration()` (runs on the
+///   worker thread inside `send_response` / `response_end`, i.e. at every
+///   normal request end), again at the top of the next `take_request`
+///   (covering framework terminate hooks that touch the DB *after* the
+///   response was delivered), and from
+///   `PhpRuntime::worker_thread_shutdown()` when the thread recycles
+///   after a fatal (the in-flight request never reached `send_response`).
+///
+/// Two jobs:
+///
+/// 1. If the script left an explicit transaction open (`BEGIN` without
+///    `COMMIT`/`ROLLBACK` — a mid-transaction fatal looks identical),
+///    issue a `ROLLBACK` through the session and `tracing::warn!`.
+///    Without this the transaction stays open on the worker thread and
+///    the next unrelated request's writes silently join it.
+/// 2. Release the staged result/error buffers ([`finish`]) so the memory
+///    of a request's last query does not sit around until the thread's
+///    next request.
+///
+/// If the rollback itself fails (typically because the connection under
+/// the transaction died), the session is dropped entirely: the server
+/// side abandons an uncommitted transaction when its connection goes
+/// away, and the next request reconnects with clean state.
+///
+/// Idempotent and cheap when there is nothing to do (no session, or no
+/// open transaction). Safe in stub mode — no PHP types are involved.
+pub fn on_request_end() {
+    finish();
+    let Some(bridge) = DB_BRIDGE.get() else {
+        return;
+    };
+    DB_SESSION.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let Some(session) = slot.as_mut() else {
+            return;
+        };
+        if !session.in_transaction {
+            return;
+        }
+        tracing::warn!(
+            "PHP script left a database transaction open at request end — rolling it back \
+             (scripts must COMMIT or ROLLBACK before the request finishes)"
+        );
+        // block_on is legal here for the same reason as the query path:
+        // request teardown runs on a PHP worker OS thread or the tokio
+        // spawn_blocking pool, never on an async task (module docs,
+        // `Async boundary`). On success Session::query clears
+        // `in_transaction` itself.
+        if let Err(e) = bridge.handle.block_on(session.query("ROLLBACK", &[])) {
+            tracing::warn!(
+                error = %e,
+                "rollback of the abandoned transaction failed — dropping the session so \
+                 the next request reconnects with clean state"
+            );
+            *slot = None;
+        }
+    });
 }
 
 /// Number of rows in the staged result set (0 when none is staged).
@@ -566,8 +756,10 @@ mod tests {
 
     /// One shared runtime + in-memory backend for every test in this
     /// process (the bridge's `OnceLock` can only be set once). Tables are
-    /// namespaced per test to avoid cross-test interference.
-    static TEST_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    /// namespaced per test to avoid cross-test interference. `pub(super)`
+    /// so the sibling `recycle_tests` module can borrow the runtime for
+    /// its locally-constructed bridges.
+    pub(super) static TEST_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
     pub(super) fn init_bridge() {
         let rt = TEST_RT.get_or_init(|| {
@@ -751,6 +943,273 @@ mod tests {
         with_col_name(0, |n| assert!(n.is_none()));
         with_cell(0, 0, |c| assert!(c.is_none()));
         with_error(|e| assert!(e.is_none()));
+    }
+
+    // ── Per-request teardown (on_request_end) ──────────────────────────
+
+    /// Whether this thread's session currently believes it is inside an
+    /// explicit transaction (None = no session open).
+    fn thread_in_transaction() -> Option<bool> {
+        DB_SESSION.with(|s| s.borrow().as_ref().map(|sess| sess.in_transaction))
+    }
+
+    #[test]
+    #[serial]
+    fn request_end_rolls_back_an_abandoned_transaction() {
+        init_bridge();
+        assert_eq!(run("CREATE TABLE bridge_req_end (id INTEGER PRIMARY KEY)"), RunStatus::Ok);
+
+        // Simulate a script that BEGINs, writes, and never COMMITs.
+        assert_eq!(run("BEGIN"), RunStatus::Ok);
+        assert_eq!(run("INSERT INTO bridge_req_end (id) VALUES (1)"), RunStatus::Ok);
+        assert_eq!(thread_in_transaction(), Some(true));
+
+        on_request_end();
+
+        // The transaction is gone and the write with it; the session (and
+        // its connection) survive for the next request.
+        assert_eq!(thread_in_transaction(), Some(false));
+        assert_eq!(run("SELECT COUNT(*) FROM bridge_req_end"), RunStatus::Rows);
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(0))));
+
+        // And a committed transaction on the recovered session works.
+        assert_eq!(run("BEGIN"), RunStatus::Ok);
+        assert_eq!(run("INSERT INTO bridge_req_end (id) VALUES (2)"), RunStatus::Ok);
+        assert_eq!(run("COMMIT"), RunStatus::Ok);
+        assert_eq!(run("SELECT COUNT(*) FROM bridge_req_end"), RunStatus::Rows);
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(1))));
+        finish();
+    }
+
+    #[test]
+    #[serial]
+    fn request_end_clears_staged_results_and_is_noop_without_a_transaction() {
+        init_bridge();
+        assert_eq!(run("SELECT 1"), RunStatus::Rows);
+        assert_eq!(row_count(), 1);
+
+        on_request_end();
+
+        // Staged result released; autocommit session untouched.
+        assert_eq!(row_count(), 0);
+        assert_eq!(thread_in_transaction(), Some(false));
+        assert_eq!(run("SELECT 1"), RunStatus::Rows);
+        finish();
+    }
+
+    #[test]
+    fn request_end_without_a_session_is_a_noop() {
+        // This test's thread never ran a query, so no session exists.
+        // (Thread-locals are per-test-thread; no #[serial] needed.)
+        assert_eq!(thread_in_transaction(), None);
+        on_request_end();
+        assert_eq!(thread_in_transaction(), None);
+    }
+}
+
+// ── Session-recycling tests (mock backend, local bridge) ────────────────
+//
+// These drive `run_on` with a locally-constructed `DbBridge` wrapping a
+// mock backend, so they never touch the process-wide set-once DB_BRIDGE
+// and need no #[serial]: every thread-local involved (DB_SESSION,
+// DB_PARAMS, DB_RESULT, DB_ERROR) is private to the test's own thread.
+#[cfg(test)]
+mod recycle_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use litewire::backend::{
+        Backend, BackendConn, BackendError, ExecuteResult, ResultSet, Rusqlite,
+    };
+
+    use super::tests::init_bridge;
+    use super::*;
+
+    /// Counters shared between a test and its [`FlakyBackend`].
+    #[derive(Default)]
+    struct Flags {
+        /// Successful `connect()` calls — proves when a reconnect happened.
+        connects: AtomicUsize,
+        /// While set, every query/execute on existing connections fails
+        /// with a connection-shaped error (the backend is "down").
+        down: AtomicBool,
+    }
+
+    /// A backend whose connections start failing on demand, with a
+    /// counting `connect()` that keeps succeeding — the "counting factory"
+    /// proving that dropping the session makes the next call reconnect.
+    struct FlakyBackend {
+        /// Real in-memory engine serving the non-failing calls.
+        inner: Rusqlite,
+        flags: Arc<Flags>,
+    }
+
+    struct FlakyConn {
+        inner: Box<dyn BackendConn>,
+        flags: Arc<Flags>,
+    }
+
+    impl FlakyConn {
+        fn outage() -> BackendError {
+            // Verbatim shape of hrana_client's pipeline-POST failure with
+            // a reqwest connect error nested inside.
+            BackendError::Other(
+                "HTTP request failed: error sending request for url \
+                 (http://127.0.0.1:8081/v2/pipeline): connection refused"
+                    .to_string(),
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Backend for FlakyBackend {
+        async fn connect(&self) -> Result<Box<dyn BackendConn>, BackendError> {
+            let inner = self.inner.connect().await?;
+            self.flags.connects.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(FlakyConn { inner, flags: Arc::clone(&self.flags) }))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl BackendConn for FlakyConn {
+        async fn query(&self, sql: &str, params: &[Value]) -> Result<ResultSet, BackendError> {
+            if self.flags.down.load(Ordering::SeqCst) {
+                return Err(Self::outage());
+            }
+            self.inner.query(sql, params).await
+        }
+
+        async fn execute(
+            &self,
+            sql: &str,
+            params: &[Value],
+        ) -> Result<ExecuteResult, BackendError> {
+            if self.flags.down.load(Ordering::SeqCst) {
+                return Err(Self::outage());
+            }
+            self.inner.execute(sql, params).await
+        }
+    }
+
+    /// A local bridge over a [`FlakyBackend`] (plus the shared flags).
+    fn flaky_bridge() -> (DbBridge, Arc<Flags>) {
+        init_bridge(); // ensures the shared test runtime exists
+        let flags = Arc::new(Flags::default());
+        let backend: SharedBackend = Arc::new(FlakyBackend {
+            inner: Rusqlite::memory().expect("in-memory backend"),
+            flags: Arc::clone(&flags),
+        });
+        let handle = super::tests::TEST_RT.get().expect("runtime").handle().clone();
+        (DbBridge { backend, handle, cache: Arc::new(TranslateCache::default()) }, flags)
+    }
+
+    fn run(bridge: &DbBridge, sql: &str) -> RunStatus {
+        run_on(Some(bridge), sql.as_bytes())
+    }
+
+    #[test]
+    fn connection_error_recycles_and_next_call_reconnects() {
+        let (bridge, flags) = flaky_bridge();
+
+        // First call opens the session: one connect.
+        assert_eq!(run(&bridge, "SELECT 1"), RunStatus::Rows);
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 1);
+
+        // Backend "restarts": the existing connection now fails with a
+        // connection-shaped error. The error is surfaced to PHP...
+        flags.down.store(true, Ordering::SeqCst);
+        assert_eq!(run(&bridge, "SELECT 1"), RunStatus::Err);
+        with_error(|e| {
+            let (code, sqlstate, msg) = e.expect("error must be staged");
+            assert_eq!(code, ER_UNKNOWN_ERROR);
+            assert_eq!(sqlstate, b"HY000");
+            assert!(msg.contains("connection refused"), "got: {msg}");
+        });
+        // ...without opening a new connection during the failing call.
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 1);
+
+        // Backend is back: the NEXT call reconnects (counting factory
+        // shows a second connect) and succeeds.
+        flags.down.store(false, Ordering::SeqCst);
+        assert_eq!(run(&bridge, "SELECT 1"), RunStatus::Rows);
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 2);
+        finish();
+    }
+
+    #[test]
+    fn sql_errors_do_not_recycle_the_session() {
+        let (bridge, flags) = flaky_bridge();
+
+        assert_eq!(run(&bridge, "CREATE TABLE rt_keep (id INTEGER PRIMARY KEY)"), RunStatus::Ok);
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 1);
+
+        // 1062 duplicate key: classified, never connection-shaped.
+        assert_eq!(run(&bridge, "INSERT INTO rt_keep (id) VALUES (1)"), RunStatus::Ok);
+        assert_eq!(run(&bridge, "INSERT INTO rt_keep (id) VALUES (1)"), RunStatus::Err);
+
+        // 1105 fallback with a non-connection message ("no such table").
+        assert_eq!(run(&bridge, "SELECT * FROM rt_missing"), RunStatus::Err);
+
+        // 1064 translate error: never reaches the backend at all.
+        assert_eq!(run(&bridge, "NOT VALID SQL !!!"), RunStatus::Err);
+
+        // Same session throughout — no reconnect happened, and the
+        // session still sees the table it created.
+        assert_eq!(run(&bridge, "SELECT COUNT(*) FROM rt_keep"), RunStatus::Rows);
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 1);
+        finish();
+    }
+
+    #[test]
+    fn connection_error_inside_a_transaction_does_not_recycle() {
+        let (bridge, flags) = flaky_bridge();
+
+        assert_eq!(run(&bridge, "CREATE TABLE rt_txn (id INTEGER PRIMARY KEY)"), RunStatus::Ok);
+        assert_eq!(run(&bridge, "BEGIN"), RunStatus::Ok);
+        assert_eq!(run(&bridge, "INSERT INTO rt_txn (id) VALUES (1)"), RunStatus::Ok);
+
+        // A connection-shaped failure mid-transaction must NOT drop the
+        // session (that would silently discard transaction state on a
+        // possible misclassification).
+        flags.down.store(true, Ordering::SeqCst);
+        assert_eq!(run(&bridge, "SELECT 1"), RunStatus::Err);
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 1);
+
+        // The session survived, still mid-transaction, and recovers once
+        // the backend does.
+        flags.down.store(false, Ordering::SeqCst);
+        assert_eq!(run(&bridge, "ROLLBACK"), RunStatus::Ok);
+        assert_eq!(run(&bridge, "SELECT COUNT(*) FROM rt_txn"), RunStatus::Rows);
+        with_cell(0, 0, |c| assert_eq!(c, Some(&Value::Integer(0))));
+        assert_eq!(flags.connects.load(Ordering::SeqCst), 1);
+        finish();
+    }
+
+    #[test]
+    fn classification_is_conservative() {
+        // Connection-shaped: 1105 + a known transport marker.
+        let conn_err = SessionError::Db {
+            code: ER_UNKNOWN_ERROR,
+            sqlstate: *b"HY000",
+            message: "sqld returned 400 Bad Request: Invalid baton".to_string(),
+        };
+        assert!(is_connection_error(&conn_err));
+
+        // 1105 with an ordinary SQL message: not connection-shaped.
+        let sql_err = SessionError::Db {
+            code: ER_UNKNOWN_ERROR,
+            sqlstate: *b"HY000",
+            message: "no such table: sprockets".to_string(),
+        };
+        assert!(!is_connection_error(&sql_err));
+
+        // A classified code never qualifies, whatever the message says.
+        let classified = SessionError::Db {
+            code: litewire::session::error_map::ER_DUP_ENTRY,
+            sqlstate: *b"23000",
+            message: "UNIQUE constraint failed: connection refused".to_string(),
+        };
+        assert!(!is_connection_error(&classified));
     }
 }
 

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -551,7 +551,18 @@ impl PhpRuntime {
 
         #[cfg(php_linked)]
         {
-            Self::execute_php(&request)
+            let result = Self::execute_php(&request);
+            // Per-request DB-bridge teardown (fpm-mode seam). This is the
+            // single choke point every fpm-style request passes through on
+            // the same spawn_blocking thread that ran the script, whatever
+            // the outcome (OK, exit(), bailout, startup failure) — so a
+            // transaction the script left open is rolled back before this
+            // thread can serve an unrelated request, and the staged
+            // result/error memory is released instead of sitting until the
+            // thread's next request. Pure Rust + litewire — no Zend calls,
+            // so no zend_try guard is needed.
+            db_bridge::on_request_end();
+            result
         }
 
         #[cfg(not(php_linked))]
@@ -890,6 +901,17 @@ impl PhpRuntime {
     pub fn worker_thread_shutdown() {
         #[cfg(php_linked)]
         {
+            // Worker-mode crash seam: a fatal kills the worker before its
+            // in-flight request ever reaches send_response, so
+            // finish_iteration's per-request teardown never ran. Roll back
+            // any transaction that request left open (and release staged
+            // bridge buffers) here, on the same thread, before the PHP
+            // context goes away. (The thread-local session would also drop
+            // at thread exit, which closes the connection and abandons the
+            // transaction server-side — this makes the rollback explicit
+            // and logged instead of incidental.)
+            db_bridge::on_request_end();
+
             // SAFETY: called on a TSRM-registered worker thread that is done
             // executing PHP. ephpm_thread_shutdown runs php_request_shutdown +
             // ts_free_thread and frees the thread-local capture buffers.

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -603,6 +603,14 @@ unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int 
         return 0;
     };
 
+    // Framework terminate hooks may run PHP (including ephpm_db_*) between
+    // send_response and this call — after finish_iteration's per-request
+    // sweep. Sweep again BEFORE parking in recv so a transaction a
+    // terminate hook left open is rolled back now rather than held (with
+    // its SQLite write lock) for however long this worker sits idle.
+    // Idempotent and a cheap flag check when there is nothing to do.
+    crate::db_bridge::on_request_end();
+
     // The worker is idle exactly while it is parked in this recv.
     metrics::gauge!("ephpm_worker_idle").increment(1.0);
     let recv = rx.recv_blocking();
@@ -716,6 +724,16 @@ unsafe extern "C" fn worker_send_response(
 /// thread exit.
 #[cfg(php_linked)]
 fn finish_iteration() {
+    // Per-request DB-bridge teardown (worker-mode seam): runs on the
+    // worker thread, inside send_response / response_end — i.e. at every
+    // normal request end — so a transaction the script left open is rolled
+    // back before the thread parks for its next request, and the staged
+    // result/error memory is released. The crash path (fatal before
+    // send_response) is covered by worker_thread_shutdown, and terminate
+    // hooks that touch the DB after the response are swept at the top of
+    // the next take_request.
+    crate::db_bridge::on_request_end();
+
     REQUESTS_HANDLED.with(|c| c.set(c.get().saturating_add(1)));
     BODY_READER.with(|cell| *cell.borrow_mut() = BodyReader::Empty);
     // Dropping the streaming-response sender (if any) closes the body channel,

--- a/tests/docroot/db_bridge_test.php
+++ b/tests/docroot/db_bridge_test.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * ephpm_db_* in-process bridge test.
+ *
+ * Exercises the native ephpm_db_query() / ephpm_db_execute() functions,
+ * which run SQL through a per-thread litewire Session against the same
+ * embedded backend the MySQL wire frontend serves — no TCP, no PDO.
+ * Requires ephpm configured with [db.sqlite].
+ *
+ * Usage: GET /db_bridge_test.php?action=<action>
+ *   - setup:       CREATE TABLE bridge_e2e
+ *   - insert:      INSERT with bound params (&name=..&value=..),
+ *                  returns affected_rows + last_insert_id
+ *   - query:       SELECT all rows (assoc arrays keyed by column name)
+ *   - set_names:   SET NAMES utf8mb4 through the query path (noop => [])
+ *   - show_tables: SHOW TABLES (metadata emulation)
+ *   - bad_sql:     invalid SQL, catches the Exception and reports
+ *                  code + message
+ *   - leak:        BEGIN + INSERT a 'leaked' row and deliberately do NOT
+ *                  commit — the server must roll this back at request end
+ *   - leak_fatal:  BEGIN + INSERT a 'leaked' row, then hit a PHP fatal
+ *                  (uncaught Error) mid-transaction — same rollback path
+ *   - check:       count 'leaked' rows (must be 0 after a leak) and prove
+ *                  the connection is healthy with a write+read+delete probe
+ *   - cleanup:     DROP TABLE bridge_e2e
+ */
+
+header('Content-Type: application/json');
+
+$action = $_GET['action'] ?? 'query';
+
+if (!function_exists('ephpm_db_query') || !function_exists('ephpm_db_execute')) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'ephpm_db_query/ephpm_db_execute native functions are not registered',
+    ]);
+    return;
+}
+
+try {
+    switch ($action) {
+        case 'setup':
+            ephpm_db_execute(
+                'CREATE TABLE IF NOT EXISTS bridge_e2e '
+                . '(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, value TEXT)'
+            );
+            echo json_encode(['status' => 'ok', 'action' => 'setup']);
+            break;
+
+        case 'insert':
+            $name = $_GET['name'] ?? 'unnamed';
+            $value = $_GET['value'] ?? '';
+            $r = ephpm_db_execute(
+                'INSERT INTO bridge_e2e (name, value) VALUES (?, ?)',
+                [$name, $value]
+            );
+            echo json_encode([
+                'status' => 'ok',
+                'affected_rows' => $r['affected_rows'],
+                'last_insert_id' => $r['last_insert_id'],
+            ]);
+            break;
+
+        case 'query':
+            $rows = ephpm_db_query('SELECT id, name, value FROM bridge_e2e ORDER BY id');
+            echo json_encode(['status' => 'ok', 'rows' => $rows]);
+            break;
+
+        case 'set_names':
+            // Dialect noop: returns OK without touching the backend; the
+            // query path renders that as an empty array.
+            $rows = ephpm_db_query('SET NAMES utf8mb4');
+            echo json_encode(['status' => 'ok', 'rows' => $rows]);
+            break;
+
+        case 'show_tables':
+            // Metadata emulation path. Column name varies (MySQL uses
+            // "Tables_in_<db>"), so flatten each row to its first value.
+            $rows = ephpm_db_query('SHOW TABLES');
+            $tables = array_map(static fn (array $row) => (string) array_values($row)[0], $rows);
+            echo json_encode(['status' => 'ok', 'tables' => $tables]);
+            break;
+
+        case 'bad_sql':
+            try {
+                ephpm_db_query('SELECT FROM WHERE (((');
+                http_response_code(500);
+                echo json_encode(['status' => 'error', 'message' => 'bad SQL did not throw']);
+            } catch (Exception $e) {
+                echo json_encode([
+                    'status' => 'ok',
+                    'code' => $e->getCode(),
+                    'message' => $e->getMessage(),
+                ]);
+            }
+            break;
+
+        case 'leak':
+            // Deliberately leave the transaction open: the request ends
+            // without COMMIT/ROLLBACK. The server's per-request teardown
+            // must roll it back so the next request (possibly on this very
+            // worker thread) never inherits it.
+            ephpm_db_execute('BEGIN');
+            ephpm_db_execute(
+                'INSERT INTO bridge_e2e (name, value) VALUES (?, ?)',
+                ['leaked', 'uncommitted']
+            );
+            echo json_encode(['status' => 'ok', 'action' => 'leak']);
+            break;
+
+        case 'leak_fatal':
+            // Same leak, but the script dies on an uncaught Error instead
+            // of returning — the rollback must happen on the fatal path
+            // too. The response is a 500; this JSON is never delivered.
+            ephpm_db_execute('BEGIN');
+            ephpm_db_execute(
+                'INSERT INTO bridge_e2e (name, value) VALUES (?, ?)',
+                ['leaked', 'uncommitted-fatal']
+            );
+            ephpm_e2e_undefined_function_to_trigger_a_fatal();
+            echo json_encode(['status' => 'error', 'message' => 'fatal did not fire']);
+            break;
+
+        case 'check':
+            // 1) The uncommitted 'leaked' rows must be gone (rolled back).
+            $rows = ephpm_db_query(
+                'SELECT COUNT(*) AS n FROM bridge_e2e WHERE name = ?',
+                ['leaked']
+            );
+            $leaked = (int) $rows[0]['n'];
+            // 2) The connection is healthy: an autocommit write succeeds
+            // (a still-open leaked transaction elsewhere would hold the
+            // write lock and fail this), reads back, and cleans up.
+            $r = ephpm_db_execute(
+                'INSERT INTO bridge_e2e (name, value) VALUES (?, ?)',
+                ['probe', 'alive']
+            );
+            $probe_id = $r['last_insert_id'];
+            $back = ephpm_db_query('SELECT value FROM bridge_e2e WHERE id = ?', [$probe_id]);
+            ephpm_db_execute('DELETE FROM bridge_e2e WHERE id = ?', [$probe_id]);
+            $healthy = count($back) === 1 && $back[0]['value'] === 'alive';
+            echo json_encode([
+                'status' => 'ok',
+                'leaked' => $leaked,
+                'probe' => $healthy ? 'ok' : 'unhealthy',
+            ]);
+            break;
+
+        case 'cleanup':
+            ephpm_db_execute('DROP TABLE IF EXISTS bridge_e2e');
+            echo json_encode(['status' => 'ok', 'action' => 'cleanup']);
+            break;
+
+        default:
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'message' => "unknown action: {$action}"]);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => $e->getMessage(), 'code' => $e->getCode()]);
+}

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -54,7 +54,15 @@ const CLUSTER_SUITES: &[&str] = &["cluster"];
 /// Each of these reuses the single-node DB-proxy ports (3306, ...), so they
 /// run strictly sequentially -- spawned, run, torn down -- one at a time,
 /// BEFORE the shared node claims those ports.
-const ISOLATED_DB_SUITES: &[&str] = &["sqlite", "sqlite_advanced", "rw_split", "query_stats"];
+///
+/// `db_bridge` is DB-stateful for the same reason as `sqlite` (it
+/// creates/drops its own table and asserts exact row counts), it just
+/// reaches the database through the in-process `ephpm_db_*` native
+/// functions instead of pdo_mysql. Its rollback-at-request-end assertions
+/// additionally depend on no OTHER suite leaving transactions around,
+/// which the fresh node guarantees.
+const ISOLATED_DB_SUITES: &[&str] =
+    &["sqlite", "sqlite_advanced", "rw_split", "query_stats", "db_bridge"];
 
 /// Single-node suites that need a bespoke server config and their own fresh
 /// node (also sequential, also reusing the single-node ports).


### PR DESCRIPTION
Three known follow-ups to the `ephpm_db_*` in-process bridge (#257).

## 1. Transaction leak across requests

The thread-local litewire `Session` outlives the request, so a script that ran `BEGIN` via `ephpm_db_execute` and then fataled (or just forgot to `COMMIT`) left the transaction **open on that worker thread** — the next unrelated request dispatched to the same thread inherited it, and its writes silently joined a transaction that could later roll back.

New `db_bridge::on_request_end()` runs at per-request teardown on the thread that ran the request, in **both** execution modes:

- **fpm** — `PhpRuntime::execute()` right after `execute_php` returns (the single choke point every fpm request passes through, on its own `spawn_blocking` thread, whatever the outcome: OK, `exit()`, bailout, startup failure).
- **worker** — `worker_bridge::finish_iteration()` (inside `send_response`/`response_end`, i.e. every normal request end), again at the top of the next `take_request` (framework terminate hooks may touch the DB *after* the response — swept before the worker parks idle holding a write lock), and `PhpRuntime::worker_thread_shutdown()` for the fatal/recycle path (the in-flight request never reached `send_response`).

It rolls back any abandoned transaction through the existing pinned-`Handle::block_on` pattern with a `tracing::warn!`, and clears the staged result/error (`finish()`) so the last query's memory doesn't sit until the thread's next request. If the rollback itself fails, the session is dropped so the next request reconnects clean. Pure Rust + litewire — no new Zend calls, so no `zend_try` needed. The `db_bridge.rs` module docs' v1 caveat paragraph is replaced with the new behavior.

## 2. Session recycling on connection failure

After a backend restart (sqld failover), existing bridge sessions errored permanently while wire clients recovered by reconnecting. Now a failed `Session::query` whose error classifies as **connection-shaped** drops the thread-local session so the next call lazily reconnects.

Classification (`is_connection_error`): litewire's `BackendError` is stringly typed and `SessionError::Db` flattens it to `(code, sqlstate, message)`, so there is no structured variant to key off. The classifier therefore requires **both**:
- code == `ER_UNKNOWN_ERROR` (1105) — anything `error_map` classified (1062/1064/1205/1290/1452) is a SQL error, never recycled; and
- a message marker anchored to litewire-backend's `hrana_client.rs` producer sites (`HTTP request failed`, `sqld returned <status>` — non-2xx never carries a SQL error, those come in-band with HTTP 200 —, baton/stream-expiry wording, reqwest/hyper transport phrases).

Additionally recycling **never happens mid-transaction** (`in_transaction == true`), so a substring misclassification can never discard live transaction state; a mid-transaction connection death is cleaned up by Fix 1's request-end rollback, which fails over the same dead connection and drops the session then. The limitation (substring matching; a false positive costs one needless reconnect on an autocommit session) is documented on the classifier.

Unit-tested with a mock `Backend`/`BackendConn` (counting factory whose `connect()` keeps succeeding, connections fail on demand): a connection-class error recycles and the next call reconnects (connect count 1 → 2); SQL errors (1062, 1064, 1105 `no such table`) never recycle; a connection error inside a transaction never recycles.

## 3. Committed E2E coverage

New bare-process suite `crates/ephpm-e2e/tests/db_bridge.rs` + `tests/docroot/db_bridge_test.php`, wired as an `ISOLATED_DB_SUITES` entry in `xtask/src/e2e_bare.rs` (fresh node + fresh DB, `--test-threads=1`, `[db.sqlite]` active per the existing single-node template). Reads `EPHPM_URL` via `required_env` — fails loudly rather than skips (#244 convention). Covers:

- `ephpm_db_execute` CREATE TABLE + INSERT with bound params (asserts `affected_rows`/`last_insert_id`, ids advancing)
- `ephpm_db_query` SELECT (row values + column-name keys, native types)
- `SET NAMES` → `[]` (noop path)
- `SHOW TABLES` contains the table (metadata emulation)
- bad SQL caught as `Exception` with code **1064** and message starting **`SQLSTATE[42000]`**
- Fix-1 acceptance: a request that `BEGIN`s + `INSERT`s and does NOT commit, then repeated checks asserting the uncommitted row is **gone** and an autocommit write probe stays healthy (a leaked transaction would hold the SQLite write lock and fail it) — for both the forgot-to-COMMIT return and a mid-transaction PHP fatal (500).

## Verified

All verification ran in WSL Ubuntu (no MSVC on the Windows host):

- **Stub mode**: `cargo build`, `cargo test -p ephpm-php` (38 passed, incl. the new recycle + request-end tests), `cargo test -p ephpm-server` (all green), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo +nightly fmt --all -- --check` clean.
- **E2E crate** compiles (`cargo check --tests`, workspace-excluded crate).
- **E2E executed locally** against a real PHP 8.5.7 release build (`cargo xtask release --no-sqld`, then `cargo xtask e2e --tests db_bridge --ephpm-binary …`): **5/5 passed**, including `abandoned_transaction_is_rolled_back_between_requests`.

Worker-mode seams compile under `php_linked` (release build) and are unit/doc-covered; the E2E suite exercises the fpm path.