### PR TITLE
chore(deps): bump litewire — LIKE ESCAPE, FOUND_ROWS emulation, plain-LIMIT fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ name = "ephpm-php"
 version = "0.1.0"
 dependencies = [
  "async-channel",
+ "async-trait",
  "bindgen 0.72.1",
  "bytes",
  "cc",
@@ -2157,7 +2158,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2629,7 +2630,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "anyhow",
  "futures",
@@ -2648,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2666,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2681,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2696,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "async-trait",
  "futures",
@@ -2711,17 +2712,18 @@ dependencies = [
 [[package]]
 name = "litewire-session"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "litewire-backend",
  "litewire-translate",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2734,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2746,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=541290c446b6#541290c446b6e962bab5d37033cb82d8a804884b"
+source = "git+https://github.com/ephpm/litewire.git?rev=e34c63928ed9#e34c63928ed90b6ca67b24d0e45fac5ef9e34674"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3698,7 +3700,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3735,7 +3737,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4651,6 +4653,18 @@ dependencies = [
  "log",
  "recursive",
  "serde",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,17 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ 541290c4 — Session extraction (litewire#18). The dialect
+# litewire main @ e34c6392 — WordPress-correctness fixes (litewire#25, #26).
+# Three things, all found by benchmarking real WordPress on ephpm:
+# (1) MySQL LIKE patterns now get the implicit ESCAPE '\' clause SQLite
+# lacks, so wpdb::esc_like()-escaped %/_ match literally (litewire#20).
+# (2) SQL_CALC_FOUND_ROWS / FOUND_ROWS() are emulated via session state —
+# WordPress found_posts / X-WP-Total were 0 site-wide before (litewire#23).
+# (3) A plain `LIMIT n` was silently DELETED from every translated MySQL
+# query (only the `LIMIT offset, count` comma form survived a take());
+# LIMITed queries returned every row. Fixed + regression-pinned.
+#
+# Previous pin 541290c4 — Session extraction (litewire#18). The dialect
 # translation + transaction-state + error-mapping core of the MySQL handler now
 # lives in the public `litewire-session` crate (`Session`), which the ephpm_db_*
 # in-process bridge consumes. Also fixes a silent multi-statement drop: the old
@@ -177,7 +187,7 @@ ephpm-sqld = { path = "crates/ephpm-sqld" }
 # sqlparser, so a crafted identifier in SHOW CREATE TABLE / SHOW INDEX /
 # DESCRIBE becomes arbitrary SQL. 7a0b59c4 adds sanitize_identifier() and
 # applies it at every extraction site.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "541290c446b6", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "e34c63928ed9", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "backend-rusqlite", "backend-hrana-client", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)


### PR DESCRIPTION
Bumps the litewire pin 541290c4 → e34c6392, picking up litewire#25 and #26 (found by benchmarking real WordPress 7.0.3 on ephpm):

- **LIKE gains MySQL's implicit `ESCAPE '\'`** — `wpdb::esc_like()`-escaped `%`/`_` now match literally instead of staying wildcards (litewire#20).
- **`SQL_CALC_FOUND_ROWS` / `FOUND_ROWS()` emulated via session state** — WordPress `found_posts` / REST `X-WP-Total` were 0 site-wide before (litewire#23). One extra COUNT(*) round trip only for queries carrying the hint; prepared path covered.
- **Plain `LIMIT n` was silently deleted from every translated MySQL query** (only the comma form survived); LIMITed queries returned every row. Fixed and regression-pinned upstream.

All three fixes land in the shared translate/session layer, so the wire path and the `ephpm_db_*` bridge get them identically. No ephpm code changes — pin + lockfile only.