### PR TITLE
fix(php): retire each ZTS thread's TSRM slot on thread exit — SIGTERM after WordPress no longer aborts with zend_mm_heap corrupted (#266)

### DIFF
--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -170,13 +170,64 @@ mod ffi {
     }
 }
 
-/// Tracks whether the current thread has been registered with TSRM.
+/// Tracks whether the current thread has been registered with TSRM, and
+/// retires the thread's PHP context when the thread exits.
 ///
 /// Each `spawn_blocking` thread must call `ephpm_thread_init()` once
 /// before executing PHP. This thread-local avoids redundant registration.
+///
+/// The [`Drop`] impl is the ZTS retirement seam (issue #266): TSRM's
+/// contract is that every thread that called `ts_resource()` frees its own
+/// slot with `ts_free_thread()` **on itself** before the main thread runs
+/// `php_module_shutdown()`. If a registered thread just dies (tokio
+/// blocking-pool threads idle out after `keep_alive`, and all of them are
+/// joined when the runtime is dropped), its `tsrm_tls_entry` lingers, and
+/// module shutdown's `ts_free_id()` then walks the stale entry and runs the
+/// per-thread globals dtors **on the shutting-down thread** — for pcre that
+/// releases cached, request-lifetime `zend_string`s (named-subpattern
+/// tables) into the wrong thread's Zend MM heap: `zend_mm_heap corrupted`
+/// → SIGABRT. Running `ephpm_thread_shutdown()` from the TLS destructor
+/// performs `php_request_shutdown()` + `ts_free_thread()` on the owning
+/// thread, where every dtor frees into the heap that allocated it.
+#[cfg(php_linked)]
+struct ThreadPhpGuard {
+    registered: std::cell::Cell<bool>,
+}
+
+#[cfg(php_linked)]
+impl Drop for ThreadPhpGuard {
+    fn drop(&mut self) {
+        // Worker-mode threads retire explicitly via `worker_thread_shutdown()`
+        // (the #258 seam), which clears the flag — this guard then no-ops, so
+        // `ts_free_thread()` is never run twice for one thread.
+        if !self.registered.get() {
+            return;
+        }
+        self.registered.set(false);
+        // If the PHP module is already gone (`PhpRuntime::shutdown()` ran
+        // first), TSRM has been torn down and touching it would be UB. In
+        // serve mode this cannot happen: the tokio runtime is dropped —
+        // joining every blocking-pool thread, and running this guard —
+        // before `PhpRuntime::shutdown()` is called.
+        if !PHP_INITIALIZED.load(Ordering::Acquire) {
+            return;
+        }
+        // SAFETY: this thread is TSRM-registered (the flag was set) and is
+        // exiting, so no further PHP executes on it. ephpm_thread_shutdown
+        // runs php_request_shutdown (ending the lazily-kept-open final
+        // request on the thread that owns it — its RSHUTDOWNs free
+        // request-lifetime state, e.g. pcre subpattern-name strings, into
+        // this thread's own Zend MM heap) and then ts_free_thread, which
+        // destroys this thread's TSRM resources in reverse-id order on this
+        // thread. No logging here: tracing's own TLS may already be gone.
+        unsafe { ffi::ephpm_thread_shutdown() };
+    }
+}
+
 #[cfg(php_linked)]
 thread_local! {
-    static THREAD_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static THREAD_REGISTERED: ThreadPhpGuard =
+        const { ThreadPhpGuard { registered: std::cell::Cell::new(false) } };
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -372,6 +423,16 @@ impl PhpRuntime {
     /// Shut down the PHP runtime.
     ///
     /// Calls `php_embed_shutdown()` and cleans up.
+    ///
+    /// Mirror of the single-threaded-phase discipline `init()` documents:
+    /// just as `init()` must run before any worker thread exists, this must
+    /// run **after every PHP-registered thread has exited** (fpm mode: drop
+    /// the tokio runtime first so its blocking pool joins; worker mode:
+    /// wait for the pool to drain). Each exiting thread retires its own
+    /// TSRM slot via [`ThreadPhpGuard`]; if a registered thread is still
+    /// alive here, `php_module_shutdown()`'s `ts_free_id()` walks that
+    /// thread's live TSRM entry and frees its per-thread state on *this*
+    /// thread — cross-heap `efree` → `zend_mm_heap corrupted` (issue #266).
     ///
     /// # Errors
     ///
@@ -590,8 +651,8 @@ impl PhpRuntime {
     /// Only the first call on each thread actually registers with TSRM.
     #[cfg(php_linked)]
     fn ensure_thread_registered() -> Result<(), PhpError> {
-        THREAD_REGISTERED.with(|registered| {
-            if registered.get() {
+        THREAD_REGISTERED.with(|guard| {
+            if guard.registered.get() {
                 return Ok(());
             }
 
@@ -604,7 +665,11 @@ impl PhpRuntime {
                 return Err(PhpError::ThreadInitFailed);
             }
 
-            registered.set(true);
+            // Setting the flag arms the guard's Drop: when this thread exits
+            // (idle timeout or runtime shutdown), it retires its own TSRM
+            // slot instead of leaving a stale entry for module shutdown to
+            // trip over (issue #266).
+            guard.registered.set(true);
             tracing::debug!("TSRM thread registered for PHP execution");
             Ok(())
         })
@@ -912,11 +977,13 @@ impl PhpRuntime {
             // and logged instead of incidental.)
             db_bridge::on_request_end();
 
+            // Disarm the TLS guard FIRST so it cannot run a second
+            // ephpm_thread_shutdown at thread exit (double ts_free_thread).
+            THREAD_REGISTERED.with(|guard| guard.registered.set(false));
             // SAFETY: called on a TSRM-registered worker thread that is done
             // executing PHP. ephpm_thread_shutdown runs php_request_shutdown +
             // ts_free_thread and frees the thread-local capture buffers.
             unsafe { ffi::ephpm_thread_shutdown() };
-            THREAD_REGISTERED.with(|registered| registered.set(false));
             tracing::debug!("worker thread PHP context shut down");
         }
     }

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -885,6 +885,33 @@ async fn accept_loop(listeners: Listeners) -> anyhow::Result<()> {
         }
     }
 
+    // Worker mode: wait (bounded) for the worker OS threads themselves to
+    // finish retiring. They are detached, so nothing else joins them — and
+    // `live` only reaches 0 after every worker has run
+    // `PhpRuntime::worker_thread_shutdown()` (php_request_shutdown +
+    // ts_free_thread on its own thread). php_embed_shutdown() must not run
+    // while any of those TSRM entries are still live (issue #266), so give
+    // the drain a real window before the caller proceeds to PHP teardown.
+    if let Some(pool) = &worker_pool {
+        let deadline = tokio::time::Instant::now() + shutdown_timeout;
+        loop {
+            let live = pool.live_count();
+            if live == 0 {
+                tracing::info!("all worker threads retired");
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                tracing::warn!(
+                    live_workers = live,
+                    "shutdown timeout reached with worker threads still live — \
+                     PHP teardown may be unsafe if a worker is wedged mid-request"
+                );
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
     // The QUIC endpoint sends CONNECTION_CLOSE to its peers as the accept loop
     // exits; give that task a bounded moment to finish so clients see a clean
     // close instead of a timeout.

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -152,6 +152,16 @@ impl WorkerPool {
         self.state.ready.load(Ordering::Acquire)
     }
 
+    /// Number of worker OS threads still alive (including ones mid-boot or
+    /// mid-teardown). Decremented only *after* a worker has released its
+    /// TSRM slot ([`PhpRuntime::worker_thread_shutdown`]), so `0` during a
+    /// drain means every worker thread's PHP context is fully retired and
+    /// `php_embed_shutdown()` is safe to run (issue #266).
+    #[must_use]
+    pub fn live_count(&self) -> usize {
+        self.state.live.load(Ordering::Acquire)
+    }
+
     /// Current dispatch-queue depth (jobs enqueued, not yet pulled by a
     /// worker). Test-only accessor for the counter-pair accounting.
     #[cfg(test)]

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -972,7 +972,19 @@ fn run_with_config(
         .context("failed to create tokio runtime")?;
     let result = rt.block_on(async { ephpm_server::serve(config, dev_mode).await });
 
-    // Shutdown PHP runtime
+    // Drop the runtime BEFORE tearing down PHP (issue #266). Dropping joins
+    // every worker and blocking-pool thread; each PHP-registered blocking
+    // thread's TLS guard then runs php_request_shutdown + ts_free_thread on
+    // the thread itself, freeing its per-thread Zend state into its own heap.
+    // Only after that is php_embed_shutdown() safe: module shutdown's
+    // ts_free_id() walks all remaining TSRM entries on *this* thread, and any
+    // still-live worker entry would make it free another thread's
+    // request-lifetime allocations cross-heap (pcre's cached named-subpattern
+    // strings after WordPress traffic) — zend_mm_heap corrupted → SIGABRT.
+    drop(rt);
+
+    // Shutdown PHP runtime — all PHP threads are gone, only the main
+    // thread's TSRM entry remains.
     ephpm_php::PhpRuntime::shutdown().context("failed to shutdown PHP runtime")?;
 
     result.map(|()| ExitCode::SUCCESS)


### PR DESCRIPTION
Fixes #266.

## Mechanism

The crash is a violated ZTS teardown contract: **every thread that registered with TSRM must free its own slot (`ts_free_thread()`) on itself before the main thread runs `php_module_shutdown()`**. ePHPm registered fpm threads but never unregistered them, and then ran global shutdown while their entries were live. Chain, verified against the pinned PHP 8.5.7 sources (`ext/pcre/php_pcre.c`, `TSRM/TSRM.c`):

1. **Registration with no retirement.** Each tokio `spawn_blocking` thread that executes PHP auto-registers via `ephpm_thread_init()` (`ts_resource(0)` + `php_request_startup()`). The only caller of the unregister mirror `ephpm_thread_shutdown()` was the worker-mode retirement seam (#258). fpm threads were never unregistered — including blocking-pool threads that idle out after tokio's `keep_alive` and die mid-serve, leaving TSRM entries for **dead** threads.
2. **The final request on each thread stays open.** `ephpm_execute_request()` uses a lazy per-request lifecycle: `php_request_shutdown()` runs at the top of the *next* request. After the last WP request on a thread, that thread's request is still active, so `PHP_RSHUTDOWN(pcre)` — the code whose job is to free `pce->subpats_table` — never ran for it.
3. **What's in that table.** pcre's per-thread `pcre_cache` (module globals, one copy per TSRM thread) caches compiled patterns; for patterns with *named subpatterns* it also caches `subpats_table`: `zend_string_init(name, len, /*persistent=*/false)` — **request-lifetime strings allocated by `emalloc` on the compiling thread's own Zend MM heap** (`php_pcre.c` `make_subpats_table`). WordPress compiles named-group regexes (rewrite rules, blocks) on every serving thread; plain docroots never populate `subpats_table`, which is exactly why they don't trip it.
4. **Global shutdown frees them from the wrong thread.** `run_serve()` called `PhpRuntime::shutdown()` on the main thread **while the tokio runtime was still alive** (dropped after). `php_embed_shutdown` → `php_module_shutdown` → `zend_hash_graceful_reverse_destroy(&module_registry)` → `module_destructor(pcre)` → (ZTS) `ts_free_id(pcre_globals_id)`. `ts_free_id` (TSRM.c:544) walks **every thread's** `tsrm_tls_entry` — parked pool threads and dead idle-timeout threads alike — and invokes `PHP_GSHUTDOWN(pcre)` for each copy **on the shutting-down thread**: `zend_hash_destroy(&pcre_cache)` → `php_free_pcre_cache` → `free_subpats_table` → `zend_string_release_ex(subpat, false)` → `efree`. That `efree` releases a pointer from worker thread X's per-thread heap through the **main thread's** `AG(mm_heap)` → `zend_mm_panic("zend_mm_heap corrupted")` → `abort()` → exit 134. (The issue's symbolized frame `php_pcre_shutdown_pcre2 (php_pcre.c:253)` is the adjacent static function; the release actually comes from `free_subpats_table` inlined into the same cold region of `PHP_GSHUTDOWN(pcre)`.)

So the answers to the diagnostic questions: `php_module_shutdown` ran on the **main thread**; **every** spawn_blocking thread that ever executed PHP still had a live TSRM entry (plus entries for already-dead idle-timeout threads); `ts_free_thread` was **never** called for any of them.

## Fix shape

Chosen shape: **make every PHP thread retire its own TSRM slot at thread exit, and order global shutdown after all PHP threads are gone.** This is the mirror-image of the init discipline (init is pinned to the single-threaded phase; shutdown now returns to it) and it also covers the mid-serve leak — threads that idle out now clean up after themselves instead of leaving orphaned TSRM entries.

- **`ephpm-php/src/lib.rs`** — the `THREAD_REGISTERED` thread-local is now a `ThreadPhpGuard` whose `Drop` runs `ephpm_thread_shutdown()` (`php_request_shutdown()` + `ts_free_thread()`) on the exiting thread itself. On the owning thread both are safe by construction: RSHUTDOWNs free request-lifetime state into the heap that allocated it, and `ts_free_thread` (TSRM.c:510) destroys that thread's resources in reverse-id order (module globals before allocator). Worker-mode threads still retire explicitly via `worker_thread_shutdown()`; that path **disarms the guard first**, so `ts_free_thread` can never run twice for one thread (the #258 seam is untouched, no double-free). The guard also checks `PHP_INITIALIZED` so a thread dying after PHP teardown (impossible in serve mode given the ordering below, but reachable in test binaries) is a no-op.
- **`ephpm/src/main.rs`** — `drop(rt)` **before** `PhpRuntime::shutdown()`. Dropping the runtime joins every blocking-pool thread, which runs each guard; `php_embed_shutdown()` then sees only the main thread's TSRM entry.
- **`ephpm-server/src/{lib,worker_pool}.rs`** — worker threads are detached, so nothing joins them: after `pool.drain()`, `serve()` now waits (bounded by `shutdown_timeout`) for the new `live_count()` to reach 0. `live` is decremented only *after* `worker_thread_shutdown()`, so 0 means every worker's TSRM slot is released before `serve()` returns and PHP teardown begins. On timeout (wedged worker) it warns and proceeds — same exposure as before the fix, now with a diagnostic.

Shapes considered and rejected: running `php_module_shutdown` on a thread "with the right context" doesn't exist — the freed strings belong to *N different* heaps, no single thread is right; clearing pcre caches per-thread at retirement without `ts_free_thread` still leaves the TSRM entry for every *other* module's globals to be freed cross-thread.

Known trade-off, noted for review: retirement runs the (already lazily-deferred) final `php_request_shutdown` at thread exit, so a userland shutdown function registered by that thread's last request executes during thread teardown; if such a function called the native `ephpm_db_*` bridge it could touch bridge thread-locals whose destruction order relative to the guard is unspecified. The WP/PDO path never touches those TLS slots, and the bridge's per-request teardown already ran; flagging it as a follow-up hardening candidate (`LocalKey::try_with` in the bridge entry points).

## Verification

Repro rig: WP docroot + SQLite DB from the bench assets, isolated config/DB copy on a distinct port; 10 requests then `kill -TERM`, three runs per binary. Builds: PHP SDK 8.5.7 ZTS, `cargo xtask release --no-sqld`.

**Before (main @ f2550ff): 3/3 SIGABRT**

```
EXIT_CODE=134   (x3)
zend_mm_heap corrupted
=== ephpm fatal signal ===
signal:   SIGABRT (6)  si_code=-6 SI_TKILL (abort/pthread_kill/tgkill)
```

**After (this branch): 3/3 clean**

```
EXIT_CODE=0     (x3)
INFO ephpm_server: received SIGTERM, shutting down
INFO ephpm_php: PHP runtime shut down
```
No fatal-signal output in any after-run log.

**Also verified:**
- Plain non-WP docroot (fpm): 10× 200, SIGTERM → exit 0, no fatals.
- Worker mode (`mode = "worker"`, 3 workers, tests/worker-docroot): 10× 200, SIGTERM → exit 0, 3/3 runs; the new `all worker threads retired` wait observed in the logs. Repro-tested, though not under WP load — the WP-heavy pcre population was exercised in fpm mode only; the worker seam's correctness under the guard (disarm-then-retire, no double `ts_free_thread`) is verified by the passing suite below plus code inspection.
- E2E: `cargo xtask e2e --tests db_bridge` → 5/5 passed; `cargo xtask e2e --tests worker_mode` → 9/9 passed (both against the fixed release binary).
- Stub mode: `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p ephpm-php` (38 passed), `cargo test -p ephpm-server`, `cargo +nightly fmt --all -- --check` — all green.
