### PR TITLE
docs: bump image pins to v0.6.3

### DIFF
--- a/docs/guides/wordpress.md
+++ b/docs/guides/wordpress.md
@@ -377,7 +377,7 @@ spec:
               mountPath: /etc/ephpm
 
         - name: wordpress-install
-          image: ephpm/ephpm:v0.2.0-php8.5.7
+          image: ephpm/ephpm:v0.6.3-php8.5.7
           command:
             - sh
             - -c
@@ -405,7 +405,7 @@ spec:
 
       containers:
         - name: ephpm
-          image: ephpm/ephpm:v0.2.0-php8.5.7
+          image: ephpm/ephpm:v0.6.3-php8.5.7
           command: [ephpm, serve, --config, /etc/ephpm/ephpm.toml]
           ports:
             - name: http

--- a/examples/wordpress-compose/compose.yaml
+++ b/examples/wordpress-compose/compose.yaml
@@ -78,7 +78,7 @@ services:
     # includes the fix for the MySQL 8 backend handshake; older images
     # ("Bad handshake" against MySQL 8.x) won't work for this demo.
     # Use ephpm/ephpm:8.5 to track the rolling latest-release / PHP 8.5.
-    image: ephpm/ephpm:v0.2.0-php8.5.7
+    image: ephpm/ephpm:v0.6.3-php8.5.7
     depends_on:
       init:
         condition: service_completed_successfully

--- a/site/content/guides/wordpress.md
+++ b/site/content/guides/wordpress.md
@@ -380,7 +380,7 @@ spec:
               mountPath: /etc/ephpm
 
         - name: wordpress-install
-          image: ephpm/ephpm:v0.6.2-php8.5
+          image: ephpm/ephpm:v0.6.3-php8.5
           command:
             - sh
             - -c
@@ -408,7 +408,7 @@ spec:
 
       containers:
         - name: ephpm
-          image: ephpm/ephpm:v0.6.2-php8.5
+          image: ephpm/ephpm:v0.6.3-php8.5
           command: [ephpm, serve, --config, /etc/ephpm/ephpm.toml]
           ports:
             - name: http


### PR DESCRIPTION
Pre-tag docs pin bump for the v0.6.3 release (release-skill pre-flight step).

- `site/content/guides/wordpress.md`: `ephpm/ephpm:v0.6.2-php8.5` -> `v0.6.3-php8.5` (2 pins)
- `docs/guides/wordpress.md` (guide mirror): stale `v0.2.0-php8.5.7` -> `v0.6.3-php8.5.7` (2 pins)
- `examples/wordpress-compose/compose.yaml`: stale `v0.2.0-php8.5.7` -> `v0.6.3-php8.5.7` (1 pin)

`v0.6.3-php8.5.7` matches the current PHP 8.5 pin in `xtask::PHP_SDK_VERSIONS` / release.yml matrix.

**Do not merge until the v0.6.3 release is actually being cut; must be merged on main before the tag is pushed** (the pinned image tags only exist once the release publishes).