### PR TITLE
fix: four code-side bugs found by the v0.6.3 docs audit

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -454,28 +454,55 @@ pub struct SecurityConfig {
 
     /// Restrict PHP filesystem access to each site's document root.
     ///
-    /// When `true` and `sites_dir` is configured, PHP's `open_basedir` is
-    /// set per-request to the site's directory + `/tmp`. PHP cannot read
-    /// or write files outside that directory.
+    /// **Multi-tenant only.** The restriction is applied on the vhost
+    /// request path in `ephpm-server`, which runs only when `sites_dir` is
+    /// set: PHP's `open_basedir` is set per-request to the site's directory
+    /// plus the system temp dir, so a site cannot read or write outside it.
+    ///
+    /// **In single-site mode (`sites_dir` unset) this flag does nothing** —
+    /// no `open_basedir` is applied, whatever it resolves to. The
+    /// multi-tenant value is the *site container* directory
+    /// (`sites_dir/<host>`), which holds the whole application; a
+    /// single-site `document_root` is the *web root*, and confining PHP to
+    /// it would break every framework that keeps its code above the web
+    /// root (Laravel/Symfony `require __DIR__.'/../vendor/autoload.php'`).
+    /// So the mechanism is not transferable as-is, and enabling this knob
+    /// in single-site mode logs a warning at startup instead of silently
+    /// doing nothing. To sandbox a single-site deployment today, set PHP's
+    /// own directive through `[php] ini_overrides` (it is written into the
+    /// generated php.ini and read at MINIT):
+    /// `ini_overrides = [["open_basedir", "/app:/tmp"]]`.
     ///
     /// An explicitly set value always wins. When unset, resolves to `true`
     /// if the `[server.security]` section is present OR `server.sites_dir`
     /// is set (multi-tenant mode); otherwise `false`. Use
-    /// [`ServerConfig::effective_open_basedir`] to read the resolved value.
+    /// [`ServerConfig::effective_open_basedir`] to read the resolved value
+    /// and [`ServerConfig::inert_security_flags`] to detect the
+    /// enabled-but-inert case.
     #[serde(default)]
     pub open_basedir: Option<bool>,
 
     /// Disable dangerous PHP functions in multi-tenant mode.
     ///
-    /// When `true`, `exec`, `shell_exec`, `system`, `passthru`,
-    /// `proc_open`, `popen`, and `pcntl_exec` are disabled via
-    /// `disable_functions`. Prevents shell escape from `open_basedir`.
+    /// **Multi-tenant only.** When `true` *and* `sites_dir` is set,
+    /// `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`,
+    /// and `pcntl_exec` are disabled via a `disable_functions` line in the
+    /// php.ini ePHPm generates at startup. Prevents shell escape from
+    /// `open_basedir`.
+    ///
+    /// **In single-site mode (`sites_dir` unset) this flag does nothing** —
+    /// the `disable_functions` line is not emitted and the functions stay
+    /// callable. Enabling it there logs a warning at startup. The
+    /// equivalent single-site setting is
+    /// `[php] ini_overrides = [["disable_functions", "exec,shell_exec,…"]]`,
+    /// which lands in the same generated php.ini and takes effect at MINIT.
     ///
     /// An explicitly set value always wins. When unset, resolves to `true`
     /// if the `[server.security]` section is present OR `server.sites_dir`
     /// is set (multi-tenant mode); otherwise `false`. Use
     /// [`ServerConfig::effective_disable_shell_exec`] to read the resolved
-    /// value.
+    /// value and [`ServerConfig::inert_security_flags`] to detect the
+    /// enabled-but-inert case.
     #[serde(default)]
     pub disable_shell_exec: Option<bool>,
 }
@@ -488,6 +515,10 @@ impl ServerConfig {
     /// historical present-section default) OR `sites_dir` is set (so a
     /// multi-tenant deployment never silently runs without filesystem
     /// isolation); otherwise `false`.
+    ///
+    /// Resolving to `true` does **not** mean the restriction is applied:
+    /// only the multi-tenant path acts on it. See
+    /// [`Self::inert_security_flags`].
     #[must_use]
     pub fn effective_open_basedir(&self) -> bool {
         self.resolve_security_flag(|s| s.open_basedir)
@@ -497,10 +528,36 @@ impl ServerConfig {
     ///
     /// Same resolution rules as [`Self::effective_open_basedir`]: explicit
     /// value wins; unset resolves to `true` when the `[server.security]`
-    /// section is present or `sites_dir` is set, `false` otherwise.
+    /// section is present or `sites_dir` is set, `false` otherwise. Same
+    /// caveat too — a `true` here is only acted upon in multi-tenant mode.
     #[must_use]
     pub fn effective_disable_shell_exec(&self) -> bool {
         self.resolve_security_flag(|s| s.disable_shell_exec)
+    }
+
+    /// The `[server.security]` isolation flags that resolve to `true` but
+    /// have no effect, because both are implemented only on the
+    /// multi-tenant path and `sites_dir` is unset.
+    ///
+    /// Returns the config key names, in declaration order. Empty in
+    /// multi-tenant mode, and empty in single-site mode when neither flag
+    /// resolves to `true` — so a config that never mentions
+    /// `[server.security]` stays quiet. `ephpm` warns once at startup for
+    /// each name returned here (the no-silent-knob rule): an operator who
+    /// asked for sandboxing must never be left believing they got it.
+    #[must_use]
+    pub fn inert_security_flags(&self) -> Vec<&'static str> {
+        if self.sites_dir.is_some() {
+            return Vec::new();
+        }
+        let mut inert = Vec::new();
+        if self.effective_open_basedir() {
+            inert.push("open_basedir");
+        }
+        if self.effective_disable_shell_exec() {
+            inert.push("disable_shell_exec");
+        }
+        inert
     }
 
     /// Shared resolution for the two isolation flags.
@@ -1365,6 +1422,8 @@ pub struct KvConfig {
     /// Eviction policy when the memory limit is reached.
     ///
     /// Values: `"noeviction"`, `"allkeys-lru"`, `"volatile-lru"`, `"allkeys-random"`.
+    /// Anything else is rejected by [`Config::validate`] at startup — an
+    /// unrecognised value used to fall back to `"allkeys-lru"` silently.
     ///
     /// Default: `"allkeys-lru"`.
     #[serde(default = "default_kv_eviction_policy")]
@@ -1393,8 +1452,10 @@ pub struct KvConfig {
 
     /// Master secret for per-site RESP authentication. When set, per-site
     /// passwords are derived as `HMAC-SHA256(secret, hostname)`. ePHPm injects
-    /// the derived password into PHP `$_ENV` as `EPHPM_REDIS_PASSWORD` for
-    /// each request.
+    /// the derived password into PHP's `$_SERVER` superglobal as
+    /// `EPHPM_REDIS_PASSWORD` for each request. (It is a `$_SERVER` variable,
+    /// registered through the SAPI's `register_server_variables` hook — not a
+    /// process environment variable, so `$_ENV` and `getenv()` do not see it.)
     ///
     /// This secret is **required** to run the RESP listener in multi-tenant
     /// (`sites_dir`) mode: with `[kv.redis_compat] enabled = true` and
@@ -1443,12 +1504,22 @@ impl KvConfig {
 
 /// RESP protocol listener configuration (`[kv.redis_compat]`).
 ///
-/// **Security note for virtual hosting:** The RESP endpoint provides raw
-/// access to the entire KV store — there is no per-tenant namespace
-/// filtering. In multi-tenant (`sites_dir`) deployments, disable RESP
-/// or restrict access to admin use only. PHP applications should use the
-/// `ephpm_kv_*` SAPI functions instead, which are automatically namespaced
-/// per virtual host.
+/// **Security note for virtual hosting:** whether the RESP endpoint is
+/// per-tenant scoped depends entirely on `[kv] secret`.
+///
+/// - **`secret` set, in multi-tenant mode** (`[server] sites_dir` set, which
+///   is what wires the `MultiTenantStore`): a client must send
+///   `AUTH <hostname> <HMAC-SHA256(secret, hostname)>`, and the connection is
+///   then bound to that hostname's own `Store` for its lifetime. That is real
+///   per-tenant isolation — separate stores, not a key-prefix convention — and
+///   it is the same store the site's `ephpm_kv_*` SAPI calls use.
+/// - **`secret` unset:** there is no per-tenant scoping. Every connection
+///   dispatches against the process-wide default store, so any client that can
+///   reach the listener sees every key, including other tenants'. The optional
+///   `password` below gates access but does not scope it. In multi-tenant
+///   deployments, either set `[kv] secret` or leave `enabled = false` and let
+///   PHP use the `ephpm_kv_*` SAPI functions, which are namespaced per vhost
+///   regardless of this listener.
 #[derive(Debug, Deserialize)]
 pub struct KvRedisCompatConfig {
     /// Enable the RESP protocol listener. When `false`, the KV store is
@@ -2042,6 +2113,20 @@ impl Config {
                  deployments (no [server] sites_dir) are unaffected."
                     .to_string(),
             ));
+        }
+
+        // [kv] eviction_policy: `EvictionPolicy::from_str_lossy` maps every
+        // unrecognised string to `allkeys-lru`, so a typo like
+        // "allkey-lru" would silently turn `noeviction` into eviction —
+        // data loss under memory pressure that the operator explicitly
+        // asked not to happen. Reject it here, the same way `[php] mode`
+        // rejects a typo'd mode (the no-silent-knob rule).
+        if !KV_EVICTION_POLICIES.contains(&self.kv.eviction_policy.as_str()) {
+            return Err(ConfigError::Validation(format!(
+                "[kv] eviction_policy must be one of {}, got \"{}\"",
+                KV_EVICTION_POLICIES.join(", "),
+                self.kv.eviction_policy,
+            )));
         }
 
         Ok(())
@@ -3429,6 +3514,15 @@ fn default_kv_memory_limit() -> String {
     "256MB".to_string()
 }
 
+/// Every accepted `[kv] eviction_policy` value.
+///
+/// Must stay in sync with `ephpm_kv::store::EvictionPolicy::from_str_lossy`,
+/// which is the parser the server actually calls. That parser is lossy by
+/// design (it has no error channel), so [`Config::validate`] is what turns a
+/// typo into a startup failure instead of a silent switch to `allkeys-lru`.
+const KV_EVICTION_POLICIES: [&str; 4] =
+    ["noeviction", "allkeys-lru", "volatile-lru", "allkeys-random"];
+
 fn default_kv_eviction_policy() -> String {
     "allkeys-lru".to_string()
 }
@@ -4504,6 +4598,171 @@ sites_dir = "/var/www/sites"
         // The env var materializes the section, so the unset sibling
         // still resolves true (and sites_dir is set anyway).
         assert!(config.server.effective_disable_shell_exec());
+    }
+
+    // ── Enabled-but-inert isolation flags (single-site mode) ───────────
+    //
+    // Both flags are implemented only on the multi-tenant path. Resolving
+    // to `true` without `sites_dir` therefore buys nothing, and `ephpm`
+    // warns at startup for every name `inert_security_flags` returns.
+
+    #[test]
+    fn test_inert_security_flags_quiet_when_nothing_enabled() {
+        let config = Config::default_config().unwrap();
+        assert!(
+            config.server.inert_security_flags().is_empty(),
+            "a config that never mentions [server.security] must not warn"
+        );
+    }
+
+    #[test]
+    fn test_inert_security_flags_empty_in_multi_tenant_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server]
+sites_dir = "/var/www/sites"
+
+[server.security]
+open_basedir = true
+disable_shell_exec = true
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(
+            config.server.inert_security_flags().is_empty(),
+            "with sites_dir set, both flags are actually applied"
+        );
+    }
+
+    #[test]
+    fn test_inert_security_flags_lists_both_in_single_site_mode() {
+        // The audit case: a single-site operator adds [server.security]
+        // for trusted_proxies, both isolation flags silently resolve to
+        // `true`, and nothing sandboxes anything.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server.security]
+trusted_proxies = ["10.0.0.0/8"]
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.sites_dir.is_none());
+        assert_eq!(
+            config.server.inert_security_flags(),
+            vec!["open_basedir", "disable_shell_exec"],
+        );
+    }
+
+    #[test]
+    fn test_inert_security_flags_reports_only_the_enabled_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[server.security]
+open_basedir = true
+disable_shell_exec = false
+",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.inert_security_flags(), vec!["open_basedir"]);
+    }
+
+    #[test]
+    fn test_inert_security_flags_quiet_when_explicitly_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[server.security]
+open_basedir = false
+disable_shell_exec = false
+",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(
+            config.server.inert_security_flags().is_empty(),
+            "nothing was asked for, so there is nothing to warn about"
+        );
+    }
+
+    // ── [kv] eviction_policy validation ────────────────────────────────
+    //
+    // `EvictionPolicy::from_str_lossy` folds every unknown string into
+    // `allkeys-lru`, so validation is the only thing standing between a
+    // typo and a silent change of eviction behaviour.
+
+    #[test]
+    fn test_kv_eviction_policy_accepts_every_documented_value() {
+        for policy in KV_EVICTION_POLICIES {
+            let mut cfg = Config::default_config().unwrap();
+            cfg.kv.eviction_policy = policy.to_string();
+            cfg.validate().unwrap_or_else(|e| panic!("{policy} must validate, got: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_kv_eviction_policy_default_validates() {
+        let cfg = Config::default_config().unwrap();
+        assert_eq!(cfg.kv.eviction_policy, "allkeys-lru");
+        cfg.validate().expect("the default must validate");
+    }
+
+    #[test]
+    fn test_kv_eviction_policy_typo_is_rejected() {
+        let mut cfg = Config::default_config().unwrap();
+        cfg.kv.eviction_policy = "allkey-lru".to_string();
+        let err = cfg.validate().expect_err("a typo must not silently mean allkeys-lru");
+        assert!(matches!(err, ConfigError::Validation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("allkey-lru"), "the error must name the bad value: {msg}");
+        for policy in KV_EVICTION_POLICIES {
+            assert!(msg.contains(policy), "the error must list {policy}: {msg}");
+        }
+    }
+
+    #[test]
+    fn test_kv_eviction_policy_is_case_sensitive() {
+        // `from_str_lossy` matches the exact lowercase spellings, so
+        // "AllKeys-LRU" would have fallen through to the default.
+        let mut cfg = Config::default_config().unwrap();
+        cfg.kv.eviction_policy = "AllKeys-LRU".to_string();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_kv_eviction_policy_rejected_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[kv]
+eviction_policy = "lru"
+"#,
+        )
+        .unwrap();
+
+        // Parsing still succeeds — the field is a plain String; it is
+        // `validate()` (called by `ephpm` before startup) that rejects it.
+        let config = Config::load(&file).unwrap();
+        assert!(config.validate().is_err());
     }
 
     // ── OPcache timestamp validation ────────────────────────────────────

--- a/crates/ephpm-kv/src/auth.rs
+++ b/crates/ephpm-kv/src/auth.rs
@@ -3,7 +3,10 @@
 //! In multi-tenant deployments, each virtual host receives its own RESP
 //! password derived from a master secret and the hostname. This allows
 //! PHP applications to use standard Redis clients (`predis`, `phpredis`)
-//! with per-site credentials injected via `$_ENV`.
+//! with per-site credentials injected as `$_SERVER` variables
+//! (`EPHPM_REDIS_HOST` / `_PORT` / `_USERNAME` / `_PASSWORD`). They are
+//! registered through the SAPI's `register_server_variables` hook, so they
+//! live in `$_SERVER` only — not in `$_ENV`, and not in `getenv()`.
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -34,7 +34,13 @@ pub enum EvictionPolicy {
 }
 
 impl EvictionPolicy {
-    /// Parse from the config string. Falls back to `AllKeysLru` on unknown values.
+    /// Parse from the config string. Falls back to `AllKeysLru` on unknown
+    /// values — it has no error channel, so it cannot reject a typo.
+    ///
+    /// On the `[kv] eviction_policy` path an unknown value never reaches
+    /// here: `Config::validate` in `ephpm-config` rejects anything outside
+    /// its `KV_EVICTION_POLICIES` list at startup. Keep that list in sync
+    /// with the arms below.
     #[must_use]
     pub fn from_str_lossy(s: &str) -> Self {
         match s {

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -193,7 +193,7 @@ enum Commands {
         password: Option<String>,
     },
 
-    /// Cache management subcommands (OPcache introspection and local reset).
+    /// Cache management subcommands (currently: OPcache reset).
     Cache {
         /// RESP server host (default: 127.0.0.1)
         #[arg(long, default_value = "127.0.0.1")]
@@ -225,9 +225,16 @@ enum Commands {
 
 #[derive(Subcommand, Debug)]
 enum CacheSubcommand {
-    /// Local-only OPcache reset (bypasses KV — does not propagate to peers).
-    /// Behaves identically to `deploy` on a single-node server; use `deploy`
-    /// on a cluster to broadcast the reset.
+    /// Invalidate the OPcache for one vhost, or every vhost via `--all`.
+    ///
+    /// Wire-identical to `deploy`: the reset is written as
+    /// `opcache:version:<vhost>` through the running server's RESP listener,
+    /// so on a cluster gossip replicates it to every peer within seconds.
+    /// `deploy` is the same operation plus an optional `--rev` stamp — use
+    /// whichever names the intent better in shell history and audit logs.
+    ///
+    /// Requires the running server to have `[kv.redis_compat] enabled = true`
+    /// so the CLI (a separate process) can reach the in-process KV store.
     Reset {
         /// Reset the OPcache under one vhost's docroot. Mutually exclusive
         /// with `--all`.
@@ -612,12 +619,20 @@ fn warn_max_execution_time(config: &ephpm_config::Config) {
 }
 
 /// Warn once at startup for every config knob that is parsed but not acted
-/// upon, so a silently-ignored setting can never look like it took effect.
+/// upon *in this configuration*, so a silently-ignored setting can never look
+/// like it took effect.
 ///
-/// Each field is compared against its own section's `Default`, so an untouched
-/// config stays quiet and only a deliberate override produces a line. Whenever
-/// one of these knobs gains a real implementation, delete its branch here and
-/// the matching "Planned: not yet implemented" doc comment in `ephpm-config`.
+/// Two categories:
+/// - **Never implemented** — the knob has no code behind it at all. Each
+///   field is compared against its own section's `Default`, so an untouched
+///   config stays quiet and only a deliberate override produces a line.
+/// - **Implemented, but not on this path** — `[server.security]`
+///   `open_basedir` / `disable_shell_exec` exist only for multi-tenant
+///   deployments and do nothing when `[server] sites_dir` is unset.
+///
+/// Whenever one of these knobs gains a real implementation (or gains one for
+/// the missing mode), delete its branch here and update the matching doc
+/// comment in `ephpm-config`.
 fn warn_unimplemented_knobs(config: &ephpm_config::Config) {
     warn_max_execution_time(config);
 
@@ -654,6 +669,31 @@ fn warn_unimplemented_knobs(config: &ephpm_config::Config) {
             "[db.analysis] auto_explain_target is parsed but not acted upon — \
              EXPLAIN analysis is not implemented, so nothing is written to any \
              target"
+        );
+    }
+
+    // [server.security] open_basedir / disable_shell_exec are implemented
+    // only on the multi-tenant path: the per-request `open_basedir` is set
+    // from the resolved vhost's directory, and `disable_functions` is only
+    // emitted into the generated php.ini when `sites_dir` is set. An
+    // operator who turns either on in single-site mode was getting no
+    // sandbox and no warning — the worst possible combination, because the
+    // config reads as if the process were hardened.
+    for flag in config.server.inert_security_flags() {
+        let remedy = if flag == "disable_shell_exec" {
+            "[[\"disable_functions\", \
+             \"exec,passthru,shell_exec,system,proc_open,popen,pcntl_exec\"]]"
+        } else {
+            "[[\"open_basedir\", \"/app:/tmp\"]]"
+        };
+        tracing::warn!(
+            flag,
+            "[server.security] {flag} is enabled but has no effect — it is \
+             implemented only for multi-tenant deployments ([server] \
+             sites_dir), and this process is single-site. Nothing is \
+             sandboxing PHP here. Set PHP's own directive through [php] \
+             ini_overrides instead (ini_overrides = {remedy}) — those lines \
+             are written into the generated php.ini and applied at MINIT."
         );
     }
 }
@@ -1509,7 +1549,7 @@ async fn run_deploy(
     Ok(ExitCode::SUCCESS)
 }
 
-/// `ephpm cache reset` / `ephpm cache status` dispatcher.
+/// `ephpm cache` subcommand dispatcher (currently only `reset`).
 async fn run_cache(
     host: &str,
     port: u16,

--- a/site/content/architecture/kv-store.md
+++ b/site/content/architecture/kv-store.md
@@ -84,9 +84,11 @@ Supported command groups: strings, hashes (`HSET`, `HGET`, `HDEL`, `HGETALL`, `H
 
 ## Multi-tenant isolation
 
-In vhost mode (`[server] sites_dir = ...`), the RESP listener is a sharp tool: it gives raw access to *every* site's keys. Recommended posture is to leave `[kv.redis_compat] enabled = false` in multi-tenant deployments and let PHP use the SAPI functions, which are automatically namespaced per host.
+In vhost mode (`[server] sites_dir = ...`), whether the RESP listener is isolated per tenant depends entirely on `[kv] secret`.
 
-When the RESP listener is enabled and AUTH is required, ePHPm derives per-site passwords from `[kv] secret`:
+**Without `[kv] secret`**, it is a sharp tool: every connection dispatches against the process-wide default store, so any client that can reach the listener sees *every* site's keys. The optional `[kv.redis_compat] password` gates access but does not scope it. Recommended posture is to leave `[kv.redis_compat] enabled = false` and let PHP use the SAPI functions, which are namespaced per host regardless of this listener.
+
+**With `[kv] secret` set**, a connection must authenticate as a specific host and is then bound to that host's own store for its lifetime — separate `Store` instances, not a key-prefix convention, and the same store the site's `ephpm_kv_*` calls use. ePHPm derives per-site passwords from `[kv] secret`:
 
 ```
 password = HMAC-SHA256(secret, hostname)

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -83,6 +83,18 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 
 **Note:** an explicitly set value always wins. When unset, these two resolve to `true` if either the `[server.security]` section is present (matching earlier releases) or `server.sites_dir` is set — so multi-tenant deployments get filesystem isolation and shell-exec hardening by default, even without a `[server.security]` section. To opt out in multi-tenant mode you must set them to `false` explicitly (ephpm logs a warning at startup when you do).
 
+**Both flags do nothing in single-site mode** (`server.sites_dir` unset). They are implemented only on the vhost request path: `open_basedir` is set per-request from the resolved site's directory, and the `disable_functions` line is only written into the generated php.ini when `sites_dir` is set. Because a single-site `document_root` is the *web root* rather than a site container directory, confining PHP to it would break any application that keeps its code above the web root — so the multi-tenant mechanism is not reused here. ephpm logs a warning at startup for each flag that resolves to `true` while inert, rather than silently doing nothing.
+
+To sandbox a single-site deployment, set PHP's own directives through `[php] ini_overrides` — those lines go into the generated php.ini and are applied at MINIT:
+
+```toml
+[php]
+ini_overrides = [
+  ["open_basedir", "/app:/tmp"],
+  ["disable_functions", "exec,passthru,shell_exec,system,proc_open,popen,pcntl_exec"],
+]
+```
+
 ### `[server.logging]`
 
 | Key | Type | Default | Description |
@@ -388,7 +400,7 @@ Notable gaps, all deliberate:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `memory_limit` | string | `"256MB"` | Max memory for **stored key/value payloads**. Per-connection RESP protocol buffers are NOT counted here — bound those with `[kv.redis_compat]` `max_connections` / `max_input_buffer`. |
-| `eviction_policy` | string | `"allkeys-lru"` | `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`. |
+| `eviction_policy` | string | `"allkeys-lru"` | `noeviction`, `allkeys-lru`, `volatile-lru`, `allkeys-random`. Case-sensitive; any other value is rejected at startup with an error listing the four valid options. |
 | `compression` | string | `"none"` | `none`, `gzip`, `brotli`, `zstd`. |
 | `compression_level` | u32 | `6` | 1=fastest, 9=best. |
 | `compression_min_size` | usize (bytes) | `1024` | Values below this are stored uncompressed. |

--- a/site/content/roadmap/opcache-clustering.md
+++ b/site/content/roadmap/opcache-clustering.md
@@ -176,9 +176,9 @@ ephpm deploy --site blog --rev a8f13d2
 # Invalidate every vhost via the broadcast key opcache:version:_all
 ephpm deploy --all
 
-# Local-only reset (functionally identical to deploy on a single node;
-# on a cluster, still propagates via gossip because the RESP listener
-# writes to the same in-process store)
+# Same reset, named for a non-deploy context. Wire-identical to `deploy`
+# minus --rev, so on a cluster it still propagates via gossip: the RESP
+# listener writes to the same in-process store.
 ephpm cache reset --site blog
 ephpm cache reset --all
 ```


### PR DESCRIPTION
Fixes the four code-side (not doc) bugs the docs audit (#272) surfaced. Every claim below was re-verified against source — one of the audit's four was partly wrong, noted inline.

Verified in WSL, stub mode (no PHP SDK): `cargo test --workspace` all green (ephpm-config 116, ephpm-kv 220 + 57, incl. 10 new tests); `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo +nightly fmt --all --check` clean.

## 1. `ephpm cache reset --help` was wrong

**Audit was right.** The clap about-line said *"Local-only OPcache reset (bypasses KV — does not propagate to peers)"*. `run_cache_reset` does the opposite: it calls `kv_set_raw` on `opcache:version:<vhost>` through the running server's RESP listener — byte-for-byte the same wire operation `run_deploy` performs, minus the optional `--rev` key. On a cluster that write gossips to every peer.

One correction to the audit's framing: the rustdoc on `run_cache_reset` itself was already accurate ("on a cluster, both propagate via gossip") — only the user-visible clap `about` contradicted it. Two adjacent falsehoods were found while fixing it and are corrected in the same commit: the `Cache` about-line promised "OPcache introspection", and `run_cache`'s rustdoc called itself the "`ephpm cache reset` / `ephpm cache status` dispatcher" — `CacheSubcommand` has exactly one variant, `Reset`, and `cache status` is listed as unimplemented in the roadmap.

`-h` now reads *"Invalidate the OPcache for one vhost, or every vhost via `--all`"*, with the wire-identical-to-`deploy` detail and the `[kv.redis_compat] enabled = true` prerequisite in the long help. The same "Local-only reset" label in `site/content/roadmap/opcache-clustering.md` — whose very next line already contradicted it — is fixed too.

## 2. `open_basedir` / `disable_shell_exec` inert in single-site mode

**Audit was right, and it is the security-relevant one.** Both resolve to `true` whenever a `[server.security]` section exists (even one written only for `trusted_proxies`), but both are gated on `sites_dir.is_some()`:

- `router.rs:1746` — `let vhost_open_basedir = self.sites_dir.is_some() && self.open_basedir;` is the only thing that reaches `set_request_ini("open_basedir", …)`.
- `main.rs` — `vhost_disable_shell = config.server.sites_dir.is_some() && …` is the only thing that emits the `disable_functions` line into the generated php.ini.

So a single-site operator got no sandbox and no warning: the config reads as if the process were hardened.

**Decision: (b), warn — not (a), apply.** Option (a) is not safe with this mechanism. In multi-site, `scan_sites_dir` sets each site's `document_root` to `sites_dir/<host>` — the *site container* directory, which holds the whole application. A single-site `document_root` is the *web root*. Confining PHP to it would break every framework that keeps code above the web root — Laravel/Symfony's `index.php` does `require __DIR__.'/../vendor/autoload.php'` on the first line. The two values are not the same kind of path, so the multi-tenant computation does not transfer, and silently turning it on would break running installs the moment they added any `[server.security]` key.

This also covers worker mode: `Config::validate` already rejects `mode = "worker"` together with `sites_dir`, so a worker deployment is always single-site and these two flags can never do anything there.

Implemented as `ServerConfig::inert_security_flags()` (returns the enabled-but-inert key names; empty in multi-tenant mode and empty when nothing was asked for, so a default config stays quiet) plus one `warn!` per flag in `warn_unimplemented_knobs`, the repo's existing home for no-silent-knob warnings. Each warning names the flag and points at the `[php] ini_overrides` equivalent, which *does* work single-site — those lines are written into the generated php.ini and applied at MINIT, the same path `vhost_disable_shell` uses. Actual output:

```
WARN ephpm: [server.security] open_basedir is enabled but has no effect — it is
implemented only for multi-tenant deployments ([server] sites_dir), and this
process is single-site. Nothing is sandboxing PHP here. Set PHP's own directive
through [php] ini_overrides instead (ini_overrides = [["open_basedir",
"/app:/tmp"]]) — those lines are written into the generated php.ini and applied
at MINIT. flag="open_basedir"
```

No change to `router.rs` or site handling — deliberately, since a concurrent multi-site isolation pen-test is working in that area.

## 3. Unknown `[kv] eviction_policy` silently became `allkeys-lru`

**Audit was right.** `EvictionPolicy::from_str_lossy` matches three arms and returns `AllKeysLru` for everything else, so `"allkey-lru"` — or worse, a typo'd `"noevicton"` — silently enabled eviction on a store the operator asked never to evict.

**Decision: hard error, matching existing convention.** `Config::validate` already rejects a typo'd `[php] mode` with the comment *"Reject unknown modes outright: a typo like 'workr' would otherwise silently mean fpm (the no-silent-knob rule)"* — same failure shape, so the same treatment. Also rejects empty `[php] extensions` entries and empty `[[middleware]] library`. Startup now fails with:

```
invalid configuration: [kv] eviction_policy must be one of noeviction,
allkeys-lru, volatile-lru, allkeys-random, got "allkey-lru"
```

**BREAKING:** a deployment currently booting with a misspelled policy (silently running `allkeys-lru`) will now fail to start. That is the intent — flagging it for the changelog. `from_str_lossy` itself stays lossy (it has no error channel); its rustdoc now says validation is the enforced boundary and that the list must stay in sync. Every in-repo config (`ephpm.toml`, `tests/ephpm-test.toml`, `xtask/src/e2e_bare.rs`) already uses valid values.

## 4. Stale comments in ephpm-config

**Audit was right on both.**

- `[kv] secret` said the derived password is injected into PHP `$_ENV`. It is registered through the SAPI's `register_server_variables` hook, so it is a `$_SERVER` variable — `$_ENV` and `getenv()` never see it. `crates/ephpm-server/src/router.rs:263` already said `$_SERVER`. Fixed here and in `ephpm-kv/src/auth.rs`, which carried the same `$_ENV` claim.
- `KvRedisCompatConfig` flatly claimed *"The RESP endpoint provides raw access to the entire KV store — there is no per-tenant namespace filtering."* Half true. `handle_auth` requires `AUTH <hostname> <HMAC-SHA256(secret, hostname)>` when `[kv] secret` is set alongside a `MultiTenantStore` (wired exactly when `sites_dir` is set) and binds the connection to `get_site_store(hostname)` for its lifetime — separate `Store` instances, not a key-prefix convention, and the same store that site's `ephpm_kv_*` calls use. The "raw access" description is only correct when `secret` is unset. Both the comment and `site/content/architecture/kv-store.md` now split the two cases.

## Docs

Per the add-config-knob rule, `site/content/reference/config.md` is updated in the same PR: `[server.security]` gains a "both flags do nothing in single-site mode" section with the `ini_overrides` recipe and the reason the mechanism does not transfer; `[kv] eviction_policy` states that it is case-sensitive and that anything else is rejected at startup.

## Tests

10 new tests in `ephpm-config`, all using the existing `Config::load` / `EnvVars` serialisation pattern:

- `inert_security_flags`: quiet by default, quiet in multi-tenant mode, quiet when both are explicitly `false`, lists both for the audit's exact case (`[server.security]` present for `trusted_proxies` only, no `sites_dir`), lists only the enabled one when the sibling is `false`.
- `eviction_policy`: every documented value validates, the default validates, a typo is rejected with an error naming both the bad value and all four valid options, casing is rejected, and rejection also fires through a real TOML load.

Both new behaviours were also exercised end to end against a running `ephpm serve` in WSL — the warnings appear at startup, and the bad policy exits 1 before binding.

## Out of scope, noted

`[kv] compression` has the identical silent-typo bug: `CompressionAlgo::from_str_lossy` folds `"gzp"` to `None`, silently disabling compression. Not touched here to keep this PR to the four audited items — worth a follow-up alongside any other `from_str_lossy` config consumers.
