### PR TITLE
SECURITY: sanitize Host header before sites_dir join — fixes unauthenticated Host-header path traversal (#275)

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -109,6 +109,12 @@ pub struct ServerConfig {
     /// Matched sites use the subdirectory as their document root.
     /// Unmatched hosts fall back to `document_root`.
     ///
+    /// The `Host` value is normalized (port/trailing-dot stripped, lowercased)
+    /// and validated against a strict DNS-label allowlist before it is joined
+    /// onto this directory, so a crafted header cannot escape it via `..` or a
+    /// path separator (see the router's `is_valid_site_key`). Malformed hosts
+    /// are rejected with 404 independently of `[server.request] trusted_hosts`.
+    ///
     /// Omit to disable vhosting (single-site mode).
     #[serde(default)]
     pub sites_dir: Option<PathBuf>,

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -971,7 +971,7 @@ impl Router {
         if self.sites_dir.is_none() && self.sites.is_empty() {
             return crate::opcache::DEFAULT_VHOST.to_string();
         }
-        let clean = host.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase();
+        let clean = normalize_host_key(host);
         if let Some(suffix) = &self.sites_domain_suffix {
             if let Some(stripped) = clean.strip_suffix(suffix.as_str()) {
                 return stripped.to_string();
@@ -985,8 +985,17 @@ impl Router {
             return (self.document_root.clone(), &self.index_files, &self.fallback);
         }
 
-        // Strip port and trailing dot, lowercase.
-        let clean = host.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase();
+        // Strip port and trailing dot, lowercase (shared normalization).
+        let clean = normalize_host_key(host);
+
+        // Defense-in-depth: never join a host that isn't a valid vhost key
+        // onto `sites_dir`. `handle` already rejects malformed hosts with 404
+        // before routing (see `reject_malformed_host`), but resolving to the
+        // default document root here guarantees the traversal join cannot
+        // happen even if this method is ever reached by another path.
+        if !is_valid_site_key(&clean) {
+            return (self.document_root.clone(), &self.index_files, &self.fallback);
+        }
 
         // Negative-lookup fast path: a host we've already determined
         // has no site directory does not need to re-syscall the
@@ -1284,6 +1293,13 @@ impl Router {
 
         // Validate Host header against trusted hosts list.
         if let Some(resp) = self.check_trusted_host(&req) {
+            return Ok((resp, "error"));
+        }
+
+        // Reject a Host that cannot be a safe `sites_dir` vhost key (path
+        // traversal, separators, NUL, non-DNS characters) before it is used to
+        // resolve a document root. Independent of `trusted_hosts`. See #275.
+        if let Some(resp) = self.reject_malformed_host(&req) {
             return Ok((resp, "error"));
         }
 
@@ -2172,6 +2188,36 @@ impl Router {
         }
     }
 
+    /// Reject a `Host` header that cannot be a valid virtual-host directory
+    /// name **before** it is ever joined onto `sites_dir`.
+    ///
+    /// This closes the unauthenticated Host-header path traversal (issue
+    /// #275). It runs independently of `trusted_hosts` (empty by default), so a
+    /// multi-site deployment is protected out of the box: `Host:
+    /// ../../../../../etc`, `Host: ../single`, encoded/backslash variants, and
+    /// any other non-DNS host resolve to a 404 rather than escaping the sites
+    /// directory. Well-formed but unknown hosts (`random.example.com`) are
+    /// *not* rejected here — they fall through to the normal registry/lazy
+    /// lookup and its `document_root` fallback, preserving existing behavior.
+    ///
+    /// Single-site mode (`sites_dir` unset and no scanned sites) never joins
+    /// the host onto the filesystem, so the header is left untouched.
+    fn reject_malformed_host<B>(&self, req: &Request<B>) -> Option<Response<ServerBody>> {
+        if self.sites_dir.is_none() && self.sites.is_empty() {
+            return None;
+        }
+        // Use the exact value `resolve_site` will normalize, so the gate and
+        // the join can never disagree about what the key is.
+        let host = extract_server_name(req);
+        let key = normalize_host_key(&host);
+        if is_valid_site_key(&key) {
+            None
+        } else {
+            tracing::warn!(host = %host, "rejected malformed Host header — invalid vhost key");
+            Some(error_response(StatusCode::NOT_FOUND, "404 Not Found"))
+        }
+    }
+
     /// Check server readiness for the `/ready` probe.
     ///
     /// Returns 200 if PHP is initialized. Returns 503 with a reason
@@ -2497,6 +2543,71 @@ fn extract_server_name<B>(req: &Request<B>) -> String {
         .next()
         .unwrap_or("localhost")
         .to_string()
+}
+
+/// Normalize a raw `Host` value into the canonical vhost-lookup key: strip the
+/// port, strip a single trailing FQDN-root dot, and lowercase.
+///
+/// This is the one normalization shared by every host-keyed lookup —
+/// [`Router::resolve_site`] (document root), [`Router::opcache_vhost_key`]
+/// (OPcache invalidation), and the [`is_valid_site_key`] gate that guards the
+/// `sites_dir` join. Keeping them on a single function is what stops the
+/// normalizations from drifting apart (a pentest found `resolve_site` and the
+/// SERVER_NAME path lowercasing/suffix-stripping differently).
+fn normalize_host_key(host: &str) -> String {
+    host.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase()
+}
+
+/// Whether a **normalized** host key (see [`normalize_host_key`]) is safe to
+/// join onto `sites_dir` as a virtual-host directory name.
+///
+/// This is the fix for the unauthenticated `Host`-header path traversal
+/// (issue #275): `sites_dir.join(host)` with an unsanitized `Host` let
+/// `Host: ../../../../../etc` + `GET /passwd` escape `sites_dir` and serve
+/// `/etc/passwd`, and `Host: ../single` point the document root — and PHP
+/// execution — at an arbitrary directory. The downstream containment checks
+/// (`serve_file`'s `starts_with(canonical_root)` and `php_script_contained`)
+/// could not catch it because they are anchored to *this* attacker-chosen
+/// root, which canonicalizes to the escaped directory.
+///
+/// The rule is a strict allowlist rather than a `..` denylist: a key is valid
+/// only if it is a non-empty sequence of DNS-style labels drawn from
+/// `[a-z0-9._-]`, with no empty label. That single "no empty label" test
+/// rejects every dangerous dot combination at once — a bare `.`/`..`, an
+/// embedded `a..b`, and a leading/trailing dot — while `/`, `\`, NUL, and any
+/// other separator or control byte are simply outside the charset. Because no
+/// `..` segment and no path separator can survive, `sites_dir.join(key)` can
+/// only ever name a direct child of `sites_dir` — the escape is closed
+/// lexically, independent of `trusted_hosts` (empty by default).
+///
+/// Note this is a *lexical* guarantee, deliberately not a
+/// `canonicalize().starts_with(sites_dir)` check: the router intentionally
+/// supports a site directory that is a symlink to a release tree outside
+/// `sites_dir` (atomic-deploy layout — see [`Router::canonical_root`]), and a
+/// canonical-containment gate would break that supported pattern. Confining
+/// the join to a direct child is enough, since the label can no longer contain
+/// traversal primitives.
+fn is_valid_site_key(key: &str) -> bool {
+    // Cap length defensively (DNS names max 253; allow a little slack). An
+    // empty key would `join("")` back to `sites_dir` itself — reject it.
+    if key.is_empty() || key.len() > 255 {
+        return false;
+    }
+    // Allowlist charset. `/`, `\`, NUL, `:`, `%`, whitespace, and every other
+    // separator/control byte fall outside it and are rejected here.
+    if !key
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'-' | b'_' | b'.'))
+    {
+        return false;
+    }
+    // With `.` allowed for subdomains, an empty label is the one traversal the
+    // charset check can't see: it means a leading dot, a trailing dot, or a
+    // `..` segment. Any of those would traverse when joined.
+    if key.split('.').any(str::is_empty) {
+        return false;
+    }
+    true
 }
 
 /// Build a JSON response with the given status and body.
@@ -5029,6 +5140,100 @@ echo "post response";
         // Should fall back to default now.
         let (doc_root, _, _) = router.resolve_site("temp-site.com");
         assert_eq!(doc_root, dir.path());
+    }
+
+    // ── Host-header path traversal (issue #275) ────────────────────
+
+    #[test]
+    fn site_key_normalization_strips_port_dot_and_case() {
+        assert_eq!(normalize_host_key("Example.COM:8080"), "example.com");
+        assert_eq!(normalize_host_key("blog.localhost."), "blog.localhost");
+        assert_eq!(normalize_host_key("HOST"), "host");
+        assert_eq!(normalize_host_key(""), "");
+    }
+
+    #[test]
+    fn valid_site_keys_are_accepted() {
+        for key in [
+            "example.com",
+            "site-a.test",
+            "blog",
+            "pr-1234.preview.example.com",
+            "a_b.internal",
+            "123.example",
+            "xn--80ak6aa92e.com", // punycode (already ascii-lowercased)
+        ] {
+            assert!(is_valid_site_key(key), "expected `{key}` to be a valid site key");
+        }
+    }
+
+    #[test]
+    fn malicious_site_keys_are_rejected() {
+        // These are the values AFTER `normalize_host_key`. The raw Host
+        // headers that produce them are the C2 exploit payloads and their
+        // variants.
+        for key in [
+            "",                   // empty Host / bare `..` after trailing-dot strip
+            "..",                 // parent dir
+            "../single",          // sibling docroot (arbitrary-docroot RCE)
+            "../../../../../etc", // deep traversal → /etc
+            "..\\..\\windows",    // backslash separator
+            "a/b",                // embedded slash
+            "/etc",               // absolute
+            ".hidden",            // leading dot / empty first label
+            "a..b",               // embedded double-dot
+            "site.",              // trailing dot survives only if not stripped
+            "a b.com",            // space
+            "sub.%2e%2e",         // percent (never decoded into a key)
+            "host\0name",         // NUL
+            "café.com",           // non-ascii
+            "UPPER.com",          // uppercase (must be normalized first)
+        ] {
+            assert!(!is_valid_site_key(key), "expected `{key:?}` to be rejected");
+        }
+    }
+
+    #[test]
+    fn resolve_site_never_escapes_sites_dir_via_traversal_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let sites = dir.path().join("sites");
+        fs::create_dir_all(sites.join("site-a.test")).unwrap();
+        // A secret directory OUTSIDE sites_dir, reachable by `../secret`.
+        let secret = dir.path().join("secret");
+        fs::create_dir_all(&secret).unwrap();
+        fs::write(secret.join("passwd"), "root:x:0:0").unwrap();
+
+        let config = Config {
+            server: ServerConfig {
+                listen: "0.0.0.0:8080".to_string(),
+                document_root: dir.path().to_path_buf(),
+                sites_dir: Some(sites.clone()),
+                ..ServerConfig::default()
+            },
+            php: PhpConfig::default(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+            middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
+        };
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
+
+        // A legitimate vhost still resolves.
+        let (good, _, _) = router.resolve_site("site-a.test");
+        assert_eq!(good, sites.join("site-a.test"));
+
+        // Every traversal host resolves to the DEFAULT document root, never to
+        // the escaped `../secret` directory (which really exists on disk).
+        for host in ["../secret", "../../secret", "..", "/etc", "..\\secret"] {
+            let (doc_root, _, _) = router.resolve_site(host);
+            assert_eq!(
+                doc_root,
+                dir.path(),
+                "traversal host `{host}` must fall back to default doc root, not escape"
+            );
+            assert_ne!(doc_root, secret, "traversal host `{host}` escaped sites_dir");
+        }
     }
     // ── streaming compression (worker send_response_stream) ────────
 

--- a/site/content/architecture/security.md
+++ b/site/content/architecture/security.md
@@ -14,6 +14,7 @@ This document describes the threat model, trust boundaries, and security design 
 | PHP memory exhaustion | PHP `memory_limit` INI enforced inside the runtime; Rust allocator is separate |
 | Malformed HTTP requests | hyper's strict HTTP/1.1 parser rejects protocol violations before reaching PHP |
 | Path traversal in static file serving | Canonicalize paths and reject any resolved path outside `document_root` |
+| Host-header path traversal in multi-site mode | The `Host` header is validated against a strict DNS-label allowlist before it is joined onto `sites_dir`; separators, `..` segments, NUL, and non-DNS characters are rejected with 404 before routing (independent of `trusted_hosts`) |
 | Slowloris / slow-read attacks | hyper's `header_read_timeout` plus tokio-level timeouts from `[server.timeouts]` (no tower middleware is involved) |
 | DB credential exposure in config | Any config value can be overridden via `EPHPM_`-prefixed environment variables (figment), so secrets can come from the environment instead of the TOML |
 
@@ -30,7 +31,8 @@ The controls that exist today, in one place:
 - **Per-vhost `open_basedir`** — in multi-site mode, PHP filesystem access is restricted per-request to the site's directory plus the system temp directory (`std::env::temp_dir()`, so `TMPDIR` is honoured and Windows gets its real temp path). Entries are joined with the platform's `PATH_SEPARATOR` (`:` on Unix, `;` on Windows).
 - **`disable_shell_exec`** — `exec`, `shell_exec`, `system`, `passthru`, `proc_open`, `popen`, `pcntl_exec` disabled via the php.ini generated at startup (default on in multi-site mode)
 - **`blocked_paths`** — glob patterns matched against the URI path (patterns must start with `/`); matches return 403
-- **`trusted_hosts`** — Host header validation; non-matching hosts get 421. Internal endpoints (`/_ephpm/health`, `/_ephpm/ready`, `/_ephpm/requests` when the request timeline is enabled, the metrics path) are exempt so Kubernetes probes and Prometheus scrapes can address the pod by raw IP
+- **Multi-site `Host` sanitization** — in multi-site mode (`sites_dir` set) the `Host` header is normalized (port/trailing-dot stripped, lowercased) and validated against a strict DNS-label allowlist (`[a-z0-9._-]`, no empty label) **before** it is used to resolve a document root. Hosts containing `..`, `/`, `\`, NUL, or any other non-DNS character are rejected with 404. This runs independently of `trusted_hosts`, so it protects the default configuration (empty `trusted_hosts`) against Host-header path traversal
+- **`trusted_hosts`** — additional exact-match Host allowlisting; non-matching hosts get 421. Empty by default. Internal endpoints (`/_ephpm/health`, `/_ephpm/ready`, `/_ephpm/requests` when the request timeline is enabled, the metrics path) are exempt so Kubernetes probes and Prometheus scrapes can address the pod by raw IP. Note: exact-match only (no wildcards), so it cannot cover dynamic per-PR preview hostnames — the `Host` sanitization above is what protects those, not `trusted_hosts`
 - **`trusted_proxies`** — CIDR-based proxy trust for `X-Forwarded-For` / `X-Forwarded-Proto` resolution
 - **Hidden-file modes** — dotfile requests handled per `hidden_files` (`deny`=403, `ignore`=404, `allow`)
 - **Percent-decode traversal hardening** — strict `%XX` decoding before routing; encoded `/` and `\`, truncated or non-hex escapes, and invalid UTF-8 are rejected with 400

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -61,7 +61,15 @@ All sites share the single global SQLite database configured via `[db.sqlite] pa
 | `unknown.com` | `/var/www/sites/unknown.com/` | Not found → fallback to `document_root` |
 | No Host header | — | Fallback to `document_root` |
 
-Port numbers and trailing dots are stripped before matching. The match is exact — no wildcard or regex patterns. For `www.` handling, either create a symlink or handle the redirect in your fallback site.
+Port numbers and trailing dots are stripped before matching, and the host is lowercased. The match is exact — no wildcard or regex patterns. For `www.` handling, either create a symlink or handle the redirect in your fallback site.
+
+### Host Sanitization
+
+The `Host` header is used to pick a directory under `sites_dir`, so it is validated before it is ever joined onto that path. A host is only accepted as a vhost key if — after port/trailing-dot stripping and lowercasing — it is a non-empty series of DNS-style labels drawn from `[a-z0-9._-]` with no empty label. Anything else (a `..` segment, a `/` or `\`, a NUL, or any other non-DNS character) is rejected with **404 Not Found** before routing.
+
+This holds independently of `[server.request] trusted_hosts` (which is empty by default), so it cannot be bypassed by leaving that list unset. It prevents a crafted header such as `Host: ../../../../../etc` from escaping `sites_dir` and serving arbitrary host files, and `Host: ../some-dir` from pointing the document root — and PHP execution — at an arbitrary directory. Well-formed but unmatched hosts are unaffected: they still fall back to `document_root` as shown above.
+
+Single-site deployments (no `sites_dir`) never join the `Host` header onto the filesystem, so no host validation is applied there.
 
 ## Architecture
 


### PR DESCRIPTION
Fixes #275.

## The vulnerability

In multi-site (`sites_dir`) mode, `resolve_site()` built the document root as `sites_dir.join(raw_host)` with **no sanitization** of the HTTP `Host` header. The downstream containment checks (`serve_file`'s `starts_with(canonical_root)` and `php_script_contained`) are anchored to *that* attacker-chosen root, so they canonicalize to the escaped directory and pass. Result, pre-auth and with no tenant code:

- `Host: ../../../../../etc` + `GET /passwd` → served `/etc/passwd`
- `Host: ../../../../../root/...` → served a host secret outside all sites
- `Host: ../single` + `GET /pwn.php` → executed PHP from an arbitrary docroot (RCE)

The only prior mitigation, `[server.request] trusted_hosts`, is empty by default and exact-match (no wildcards), so it is unusable for dynamic per-PR preview hostnames — the default multi-site posture was fully exposed.

## The fix

1. **Sanitize the Host before the join.** New `is_valid_site_key` is a strict DNS-label allowlist: after normalization (port + trailing dot stripped, lowercased) a key is valid only if it is a non-empty series of labels from `[a-z0-9._-]` with **no empty label**. That single "no empty label" test rejects a bare `.`/`..`, an embedded `a..b`, and leading/trailing dots at once; `/`, `\`, NUL, and every other separator/control byte fall outside the charset. No `..` or separator can survive, so `sites_dir.join(key)` can only ever name a **direct child**.
2. **Reject before routing, independent of `trusted_hosts`.** `handle` calls `reject_malformed_host` right after the trusted-host check; a malformed multi-site host gets **404** before any filesystem join. Well-formed unknown hosts are unaffected — they still fall back to `document_root`.
3. **Defense-in-depth in `resolve_site`.** It re-validates the key (never joins an invalid one) and now shares one `normalize_host_key` with `opcache_vhost_key`, aligning the previously-divergent case/suffix/port normalization the pentest flagged.
4. **Both paths covered.** Because `site_root` is now guaranteed to be a real child of `sites_dir`, both the static path (`serve_file` → `starts_with(canonical_root)`) and the PHP path (`php_script_contained`) inherit correct confinement. No separate static-path change is needed — the gap was the poisoned root, not the static check itself (which already canonicalizes + `starts_with` in current `main`).

### Why lexical, not `canonicalize().starts_with(sites_dir)`

Deliberate. The router intentionally supports a site directory that is a **symlink to a release tree outside `sites_dir`** (atomic-deploy layout — see the `canonical_root` doc comment). A canonical-containment gate would break that supported pattern. Confining the join to a direct child is sufficient once the label can no longer contain traversal primitives.

### Single-site mode

Untouched — it never joins the `Host` header onto the filesystem, so no host validation is applied.

## Proof — runtime, php_linked release build, real multi-site server

Two sites under `sites_dir`, an arbitrary docroot sibling, and a host secret outside all sites. Same harness against the pre-fix binary (BEFORE) and this branch (AFTER):

| Request | BEFORE | AFTER |
|---|---|---|
| `Host: ../../../../../etc` `GET /passwd` | **200 — served `/etc/passwd`** (`root:x:0:0:...`) | **404** |
| `Host: ../../../../../root/...` `GET /host-secret.txt` (static) | **200 — served host secret** | **404** |
| `Host: ../single` `GET /pwn.php` (PHP) | **200 — `ARBITRARY_DOCROOT_RCE_EXECUTED`** | **404** |
| `Host: /etc` `GET /passwd` | **200 — served `/etc/passwd`** | **404** |
| `Host: ../../../../../ETC.` (trailing-dot + case) | **200 — served `/etc/passwd`** | **404** |
| `Host: ..%2f..%2fetc`, `....//....//etc`, `..\..\etc`, `..` | 404 | **404** |
| `Host: site-a.test` `GET /index.html` (legit static) | 200 | **200 — `SITE-A-HOME-OK`** |
| `Host: site-a.test` `GET /index.php` (legit PHP) | 200 | **200** |
| `Host: SITE-A.TEST:18099` (case+port) | 200 | **200** |
| `Host: site-b.test` `GET /` (per-vhost routing) | 200 | **200 — `SITE_B_PHP`** |

## Tests

- `is_valid_site_key`: table of malicious inputs (bare `..`, `../single`, deep traversal, backslash, embedded slash, absolute, leading/embedded/trailing dot, space, percent, NUL, non-ASCII, uppercase) → all rejected; valid single/dotted labels → accepted.
- `normalize_host_key`: port/trailing-dot/case normalization.
- `resolve_site_never_escapes_sites_dir_via_traversal_host`: with a real `../secret` directory on disk, every traversal host resolves to the **default** docroot, never the escaped path; a legit vhost still resolves.

`cargo clippy -p ephpm-server -p ephpm-config --all-targets -- -D warnings` clean, `cargo +nightly fmt --all -- --check` clean, stub `cargo test -p ephpm-server` green.

## Follow-up (recommended, not in this PR)

Add wildcard/suffix support to `trusted_hosts` (e.g. `*.preview.example.com`) for the per-PR preview use case. It is a usability improvement for that deployment model; it is **not** required for this fix, since the sanitization above holds with `trusted_hosts` empty (the default). Kept out to keep this security change tight and reviewable.

Related: #274 (DB/ATTACH cross-tenant) — separate root cause, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
