### PR TITLE
docs: max_execution_time is enforced now — sweep stale "not enforced" claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ index_files = ["index.php", "index.html"]
 [php]
 mode = "fpm"
 memory_limit = "128M"
-# Note: [php] max_execution_time is parsed but NOT enforced (PHP's SIGPROF
-# timer is deliberately neutralized). The per-request deadline is
-# [server.timeouts] request — default 300 seconds.
+max_execution_time = 30       # inner PHP deadline (default). Natively enforced
+                              # on Linux ZTS builds (catchable fatal → HTTP 500,
+                              # wall-clock, set_time_limit()-able); not enforced
+                              # on macOS/Windows. Keep it below the outer 504
+                              # backstop, [server.timeouts] request.
 
 # Load a custom php.ini before applying overrides (optional)
 # ini_file = "/etc/php/php.ini"

--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -651,9 +651,13 @@ that bailed out.**
 
 ### 5.4 Detecting dead / hung workers; timeouts
 
-- **Hung request (infinite loop / blocked syscall in PHP).** SIGPROF-based
-  `max_execution_time` is no-op'd in this codebase (`ephpm_wrapper.c:532-566`)
-  — enforcement is at the HTTP layer. The existing outer
+- **Hung request (infinite loop / blocked syscall in PHP).** On Linux ZTS builds
+  with per-thread execution timers, `max_execution_time` is armed per request and
+  interrupts a pure-PHP infinite loop (catchable fatal → 500); only the legacy
+  process-wide SIGPROF timer is `--wrap`-neutralized (`ephpm_wrapper.c`), which is
+  why macOS/Windows (no per-thread timers) fall back to the HTTP layer alone. A
+  request wedged in a blocked syscall or C extension never returns to the VM to
+  observe the inner timer either way, so the existing outer
   `tokio::time::timeout(request_timeout, ...)` (`router.rs:377-386`) fires and
   returns 504 to the client. **But the worker thread is still stuck** running
   PHP — tokio's timeout cancels the *await*, not the OS thread. So: when the

--- a/site/content/getting-started/configuration.md
+++ b/site/content/getting-started/configuration.md
@@ -44,8 +44,11 @@ enabled = true                 # exposes /metrics for Prometheus
 
 [php]
 memory_limit = "256M"
-# [php] max_execution_time is parsed but NOT enforced — use
-# [server.timeouts] request (default 300s) for the per-request deadline.
+max_execution_time = 30              # inner PHP deadline (default). Natively
+                                     # enforced on Linux ZTS: catchable fatal →
+                                     # HTTP 500, wall-clock, set_time_limit()-able.
+                                     # Not enforced on macOS/Windows. Keep it below
+                                     # [server.timeouts] request, the 504 backstop.
 ini_overrides = [
     ["display_errors", "Off"],
     ["error_reporting", "E_ALL"],

--- a/site/content/guides/laravel.md
+++ b/site/content/guides/laravel.md
@@ -19,8 +19,11 @@ fallback = ["$uri", "$uri/", "/index.php?$query_string"]
 
 [php]
 memory_limit = "256M"
-# [php] max_execution_time is parsed but NOT enforced — use
-# [server.timeouts] request (default 300s) for the per-request deadline.
+max_execution_time = 30              # inner PHP deadline (default). Natively
+                                     # enforced on Linux ZTS: catchable fatal →
+                                     # HTTP 500, wall-clock, set_time_limit()-able.
+                                     # Not enforced on macOS/Windows. Keep it below
+                                     # [server.timeouts] request, the 504 backstop.
 ini_overrides = [
     ["display_errors", "Off"],
     ["error_reporting", "E_ALL"],

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -46,7 +46,7 @@ Removing a site: delete the directory. Requests to that domain hit the fallback.
 
 Today, per-site configuration is intentionally minimal. What's discovered per site from `sites_dir` is the document root (the directory itself) plus that site's `index_files` and `fallback`. Everything else — PHP settings, timeouts, security rules, database — comes from the global `ephpm.toml` and is shared by all sites.
 
-A richer per-site override system (a `site.toml` dropped into the site directory with `[php]` and `[db.sqlite]` overrides) is planned for [Phase 2](#phase-2-per-site-databases-and-overrides-future). Until then, if one site needs a larger `memory_limit`, raise the global value in `ephpm.toml`; if one site needs longer to run, raise the global `[server.timeouts] request` (the `[php] max_execution_time` key is parsed but never enforced).
+A richer per-site override system (a `site.toml` dropped into the site directory with `[php]` and `[db.sqlite]` overrides) is planned for [Phase 2](#phase-2-per-site-databases-and-overrides-future). Until then, if one site needs a larger `memory_limit`, raise the global value in `ephpm.toml`; if one site needs longer to run, raise the global `[php] max_execution_time` (natively enforced on Linux ZTS builds — see [Signal handling and `max_execution_time`](/architecture/http/#signal-handling-and-max_execution_time)) and, above it, the `[server.timeouts] request` hard 504 backstop.
 
 ### SQLite Database Location
 

--- a/site/content/migration/apache-mod-php.md
+++ b/site/content/migration/apache-mod-php.md
@@ -98,7 +98,7 @@ This means: try the exact file, try as a directory (with index files), fall back
 | `deny from all` on `.env` | Default (dotfiles blocked automatically) |
 | `Header set X-Frame-Options DENY` | `[server.response] headers = [["X-Frame-Options", "DENY"]]` |
 | `php_value upload_max_filesize 10M` | `[server.request] max_body_size = 10485760` |
-| `php_value max_execution_time 60` | `[server.timeouts] request = 60` — **not** `[php] max_execution_time`, which is parsed but never enforced |
+| `php_value max_execution_time 60` | `[php] max_execution_time = 60` (enforced on Linux ZTS; not on macOS/Windows) — set a higher `[server.timeouts] request` above it as the hard 504 backstop |
 
 ### 4. Translate PHP Settings
 
@@ -116,15 +116,16 @@ ePHPm:
 ```toml
 [php]
 memory_limit = "256M"
+max_execution_time = 60
 ini_overrides = [
     ["display_errors", "Off"],
 ]
 
-# max_execution_time has no ePHPm equivalent under [php] — that key is
-# parsed but never enforced, because PHP's SIGPROF-based timer is
-# deliberately neutralized. The enforced deadline is HTTP-layer:
+# max_execution_time is the inner PHP deadline — natively enforced on Linux ZTS
+# (catchable fatal → HTTP 500, wall-clock, set_time_limit()-able); not enforced
+# on macOS/Windows. Put a higher request timeout above it as the hard 504 backstop:
 [server.timeouts]
-request = 60
+request = 90
 
 [server.request]
 max_body_size = 20971520   # 20 MB in bytes

--- a/site/content/migration/docker-compose.md
+++ b/site/content/migration/docker-compose.md
@@ -117,8 +117,10 @@ volumes:
 # ePHPm
 [php]
 memory_limit = "256M"
-# [php] max_execution_time is parsed but NOT enforced — use
-# [server.timeouts] request (default 300s) for the per-request deadline.
+max_execution_time = 30              # inner PHP deadline (default). Enforced on
+                                     # Linux ZTS (catchable fatal → 500); not on
+                                     # macOS/Windows. Keep below the outer 504
+                                     # backstop, [server.timeouts] request.
 ini_overrides = [
     ["display_errors", "Off"],
 ]

--- a/site/content/migration/laravel-forge.md
+++ b/site/content/migration/laravel-forge.md
@@ -84,8 +84,10 @@ redirect_http = true
 [php]
 memory_limit = "256M"
 workers = 8
-# [php] max_execution_time is parsed but NOT enforced — use
-# [server.timeouts] request (default 300s) for the per-request deadline.
+max_execution_time = 30              # inner PHP deadline (default). Enforced on
+                                     # Linux ZTS (catchable fatal → 500); not on
+                                     # macOS/Windows. Keep below the outer 504
+                                     # backstop, [server.timeouts] request.
 
 [db.sqlite]
 path = "/home/forge/example.com/database/database.sqlite"

--- a/site/content/migration/nginx-php-fpm.md
+++ b/site/content/migration/nginx-php-fpm.md
@@ -92,10 +92,11 @@ ePHPm equivalent:
 [php]
 workers = 8            # replaces pm.max_children (auto-detected from CPU count)
 memory_limit = "256M"
+max_execution_time = 30   # ← php_admin_value[max_execution_time]. Enforced on
+                          # Linux ZTS (catchable fatal → 500); not on macOS/Windows.
 
 [server.timeouts]
-request = 30           # replaces max_execution_time; the [php] key of that
-                       # name is parsed but NOT enforced
+request = 45           # outer hard 504 backstop — keep it above max_execution_time
 
 [server.request]
 max_body_size = 67108864   # 64 MB

--- a/site/content/migration/shared-hosting.md
+++ b/site/content/migration/shared-hosting.md
@@ -117,11 +117,12 @@ document_root = "/var/www/html"
 
 [php]
 memory_limit = "256M"
+max_execution_time = 90              # inner PHP deadline: catchable fatal → 500
+                                     # on Linux ZTS (not on macOS/Windows)
 
 [server.timeouts]
-request = 120                        # the real per-request deadline
-                                     # ([php] max_execution_time is parsed
-                                     # but NOT enforced)
+request = 120                        # outer hard 504 backstop — keep it above
+                                     # [php] max_execution_time
 
 [server.tls]
 listen = "0.0.0.0:443"               # HTTPS listener


### PR DESCRIPTION
## What

`[php] max_execution_time` became a **real, natively enforced deadline** when #277 (per-thread `ZEND_MAX_EXECUTION_TIMERS`) and #281 (`ini_get` writeback) merged. A pile of docs still claimed it was "parsed but not enforced" / "deliberately neutralized" and told users the only enforced ceiling was `[server.timeouts] request`. This sweeps every stale hit across the docs surface.

## The truth being documented (verified against merged source)

- **Enforced on Linux ZTS builds** via a per-thread POSIX timer (`timer_create` + `SIGRTMIN` via `SIGEV_THREAD_ID`, `CLOCK_BOOTTIME`) — `ephpm_wrapper.c` (`EPHPM_NATIVE_EXEC_TIMER`, `zend_set_timeout(g_configured_max_exec_secs, 1)`), armed per request from `[php] max_execution_time` (`crates/ephpm-config/src/lib.rs`, default `30`).
- Exceeding it → **catchable** "Maximum execution time exceeded" fatal → **HTTP 500** (shutdown functions run, buffered output flushed) — not a hard worker-kill.
- **Wall-clock** (`sleep()` counts); overridable at runtime with `set_time_limit()`; `ini_get('max_execution_time')` reflects the effective value (#281).
- `[server.timeouts] request` remains the **outer hard 504 backstop** for a script wedged in a C-extension/syscall the timer can't interrupt — keep `max_execution_time` below it.
- **Not** natively enforced on macOS/Windows (no per-thread timers) — there the request timeout is the only ceiling. This caveat is kept wherever the enforced claim is made.

Framing matches what already shipped in `reference/config.md`, `architecture/http.md` (Signal Handling section), and `architecture/security.md`.

## Files changed (stale → corrected)

| File | Was | Now |
|------|-----|-----|
| `README.md` | comment: "parsed but NOT enforced (SIGPROF timer deliberately neutralized)" | sets `max_execution_time = 30` + enforced/backstop/platform framing |
| `site/content/getting-started/configuration.md` | "parsed but NOT enforced — use [server.timeouts] request" | enforced framing + platform caveat |
| `site/content/guides/laravel.md` | same stale comment | enforced framing |
| `site/content/guides/virtual-hosts.md` | prose: raise `[server.timeouts] request` "(max_execution_time is parsed but never enforced)" | raise `[php] max_execution_time` (links to http.md Signal-Handling section) + request backstop |
| `site/content/migration/apache-mod-php.md` | mapping table mapped `php_value max_execution_time` → `[server.timeouts] request` "not `[php] max_execution_time` which is never enforced"; code block said "no ePHPm equivalent, SIGPROF neutralized" | table maps to working `[php] max_execution_time = 60`; code block sets it + request as backstop |
| `site/content/migration/nginx-php-fpm.md` | `php_admin_value[max_execution_time]` mapped only to `[server.timeouts] request` "the [php] key is parsed but NOT enforced" | maps to `[php] max_execution_time = 30`, request as backstop above it |
| `site/content/migration/docker-compose.md` | "parsed but NOT enforced" comment | enforced framing |
| `site/content/migration/laravel-forge.md` | "parsed but NOT enforced" comment | enforced framing |
| `site/content/migration/shared-hosting.md` | inline "max_execution_time is parsed but NOT enforced" | sets `max_execution_time`, request as outer backstop |
| `docs/architecture/worker-mode-design.md` | "SIGPROF-based max_execution_time is no-op'd in this codebase — enforcement is at the HTTP layer" | native per-thread timer catches pure-PHP loops on Linux ZTS; SIGPROF `--wrap` only on non-native builds; HTTP layer backstops syscall/C-ext wedges |

**10 files, 11 stale hits.** Already-correct files (`reference/config.md`, `architecture/http.md`, `architecture/security.md`) were left untouched.

## Verification

- Every claim checked against merged source (`ephpm_wrapper.c`, `ephpm-config/src/lib.rs`) before writing.
- `hugo --gc` builds clean, no errors.
- The one internal anchor link added (`/architecture/http/#signal-handling-and-max_execution_time`) is byte-identical to the already-merged working link in `http.md`, pointing at the same heading — no new anchor mismatch.

Docs-only. No code changes.
