### PR TITLE
fix(kv): fail closed when a multi-tenant RESP listener has no [kv] secret

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1396,10 +1396,14 @@ pub struct KvConfig {
     /// the derived password into PHP `$_ENV` as `EPHPM_REDIS_PASSWORD` for
     /// each request.
     ///
-    /// If unset, per-site RESP AUTH is disabled: in multi-tenant (`sites_dir`)
-    /// deployments with the RESP listener enabled, any client that can reach
-    /// the listener can access the default store (a warning is logged at
-    /// startup). In single-site (no `sites_dir`) mode, AUTH is not required.
+    /// This secret is **required** to run the RESP listener in multi-tenant
+    /// (`sites_dir`) mode: with `[kv.redis_compat] enabled = true` and
+    /// `sites_dir` set but no secret, per-site AUTH cannot be derived and the
+    /// listener would serve one shared global store to every tenant — so
+    /// [`Config::validate`] **refuses to start** (fail closed). In single-site
+    /// (no `sites_dir`) mode the shared store is the intended behavior and a
+    /// secret is not required; RESP AUTH is then a no-op unless a
+    /// `[kv.redis_compat] password` is set.
     ///
     /// Default: `None`.
     #[serde(default)]
@@ -1421,6 +1425,19 @@ impl Default for KvConfig {
             secret: None,
             redis_compat: KvRedisCompatConfig::default(),
         }
+    }
+}
+
+impl KvConfig {
+    /// Whether a usable `[kv] secret` is configured.
+    ///
+    /// A secret that is absent, empty, or whitespace-only cannot derive
+    /// per-site RESP AUTH passwords (`HMAC-SHA256(secret, hostname)`), so it is
+    /// treated as unset. This is the fail-closed signal used to decide whether
+    /// a multi-tenant RESP listener may start — see [`Config::validate`].
+    #[must_use]
+    pub fn secret_is_set(&self) -> bool {
+        self.secret.as_deref().is_some_and(|s| !s.trim().is_empty())
     }
 }
 
@@ -2001,6 +2018,32 @@ impl Config {
                 )));
             }
         }
+
+        // Fail closed: a multi-tenant RESP listener with no `[kv] secret` would
+        // serve ONE shared global KV store to every tenant with no per-site
+        // authentication. The RESP AUTH scoping that isolates tenants
+        // (`AUTH <hostname> <derived-password>` → that vhost's store) can only
+        // be derived from `[kv] secret`; without it every client reaching the
+        // listener talks to the shared default store and can read and write
+        // every site's KV. Refuse to start rather than expose it silently.
+        if self.server.sites_dir.is_some()
+            && self.kv.redis_compat.enabled
+            && !self.kv.secret_is_set()
+        {
+            return Err(ConfigError::Validation(
+                "[kv.redis_compat] enabled = true with [server] sites_dir \
+                 (multi-tenant vhosting) but no [kv] secret: the RESP listener \
+                 would serve a single shared KV store to every tenant with no \
+                 authentication, exposing every site's keys to every other \
+                 site. Set [kv] secret (e.g. `openssl rand -base64 32`) so \
+                 per-site RESP AUTH (`AUTH <hostname> <derived-password>`) \
+                 scopes each connection to its own site store, or disable the \
+                 listener with [kv.redis_compat] enabled = false. Single-site \
+                 deployments (no [server] sites_dir) are unaffected."
+                    .to_string(),
+            ));
+        }
+
         Ok(())
     }
 
@@ -5014,6 +5057,130 @@ worker_stream_threshold = 262144
 
         cfg.php.mode = "fpm".to_string();
         assert!(cfg.validate().is_ok());
+    }
+
+    // ── KV RESP listener fail-closed (multi-tenant needs [kv] secret) ──
+    //
+    // Trigger: sites_dir set (multi-tenant) AND [kv.redis_compat] enabled
+    // AND no usable [kv] secret. Only that exact combination must refuse to
+    // start — every other combination keeps working.
+
+    /// Build a `Config` for the KV fail-closed matrix.
+    fn kv_matrix_config(multi_tenant: bool, resp_enabled: bool, secret: Option<&str>) -> Config {
+        let mut cfg = Config::default();
+        if multi_tenant {
+            cfg.server.sites_dir = Some(PathBuf::from("/var/www/sites"));
+        }
+        cfg.kv.redis_compat.enabled = resp_enabled;
+        cfg.kv.secret = secret.map(str::to_string);
+        cfg
+    }
+
+    #[test]
+    fn kv_multi_tenant_resp_without_secret_fails_closed() {
+        // The vuln: multi-tenant + RESP listener + no secret would serve a
+        // shared global store to all tenants. Must refuse to start.
+        let cfg = kv_matrix_config(true, true, None);
+        let err = cfg.validate().expect_err("must fail closed");
+        assert!(matches!(err, ConfigError::Validation(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("secret"), "error should point at [kv] secret: {msg}");
+        assert!(msg.contains("sites_dir"), "error should mention multi-tenant: {msg}");
+    }
+
+    #[test]
+    fn kv_multi_tenant_resp_empty_secret_fails_closed() {
+        // An empty / whitespace-only secret cannot derive per-site AUTH and
+        // must be treated as unset (fail closed), not accepted.
+        for secret in ["", "   ", "\t"] {
+            let cfg = kv_matrix_config(true, true, Some(secret));
+            let err = cfg.validate().expect_err("empty secret must fail closed like an unset one");
+            assert!(matches!(err, ConfigError::Validation(_)));
+        }
+    }
+
+    #[test]
+    fn kv_multi_tenant_resp_with_secret_starts() {
+        // The secure config: per-site AUTH scoping is derivable — must start.
+        let cfg = kv_matrix_config(true, true, Some("s3cret-value"));
+        assert!(cfg.validate().is_ok(), "multi-tenant + secret is the secure mode");
+    }
+
+    #[test]
+    fn kv_single_tenant_resp_without_secret_starts() {
+        // Single-site: the shared store IS the correct behavior. Unaffected.
+        let cfg = kv_matrix_config(false, true, None);
+        assert!(cfg.validate().is_ok(), "single-tenant RESP must keep working");
+    }
+
+    #[test]
+    fn kv_multi_tenant_resp_disabled_without_secret_starts() {
+        // Multi-tenant but the RESP listener is off — no exposure, no secret
+        // needed (PHP uses the per-vhost ephpm_kv_* functions).
+        let cfg = kv_matrix_config(true, false, None);
+        assert!(cfg.validate().is_ok(), "no RESP listener means no shared-store exposure");
+    }
+
+    #[test]
+    fn kv_fail_closed_survives_absent_kv_section() {
+        // Section-absent guard (the [server.security] serde-default lesson):
+        // sites_dir + [kv.redis_compat] enabled with NO [kv] secret key and no
+        // explicit secret must still fail closed — the serde default (None)
+        // must not mask the exposure.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server]
+sites_dir = "/var/www/sites"
+
+[kv.redis_compat]
+enabled = true
+"#,
+        )
+        .unwrap();
+        let cfg = Config::load(&file).unwrap();
+        assert!(cfg.kv.secret.is_none(), "no secret key present");
+        let err = cfg.validate().expect_err("absent [kv] secret must still fail closed");
+        assert!(matches!(err, ConfigError::Validation(_)));
+    }
+
+    #[test]
+    fn kv_fail_closed_secret_present_in_toml_starts() {
+        // Section-present counterpart: same multi-tenant + RESP config but with
+        // the secret set in TOML must validate.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[server]
+sites_dir = "/var/www/sites"
+
+[kv]
+secret = "openssl-rand-base64-32-here"
+
+[kv.redis_compat]
+enabled = true
+"#,
+        )
+        .unwrap();
+        let cfg = Config::load(&file).unwrap();
+        assert!(cfg.kv.secret_is_set());
+        cfg.validate().expect("multi-tenant + RESP + secret is the secure config");
+    }
+
+    #[test]
+    fn kv_secret_is_set_treats_blank_as_unset() {
+        let mut kv = KvConfig::default();
+        assert!(!kv.secret_is_set(), "None is unset");
+        kv.secret = Some(String::new());
+        assert!(!kv.secret_is_set(), "empty string is unset");
+        kv.secret = Some("   ".to_string());
+        assert!(!kv.secret_is_set(), "whitespace is unset");
+        kv.secret = Some("real".to_string());
+        assert!(kv.secret_is_set(), "non-blank is set");
     }
 
     // ── [db.analysis] metric_label_series_max ─────────────────────────

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1344,25 +1344,31 @@ fn start_kv_service(config: &Config) -> anyhow::Result<KvService> {
         idle_timeout_secs: config.kv.redis_compat.idle_timeout_secs,
     };
 
-    // Multi-tenant mode with the RESP listener enabled but no master secret:
-    // per-site AUTH cannot be derived, so every tenant (and anything else that
-    // can reach the listener) talks to the shared default store unauthenticated.
-    if config.server.sites_dir.is_some() && secret.is_none() {
-        tracing::warn!(
-            "[kv].secret is not set while server.sites_dir (multi-tenant mode) and \
-             kv.redis_compat are enabled — per-site RESP AUTH is disabled and any \
-             client that can reach the RESP listener can access the default store; \
-             set [kv].secret to enable per-site authentication"
+    // Fail closed: in multi-tenant mode a RESP listener with no master secret
+    // cannot derive per-site AUTH, so every tenant (and anything else that can
+    // reach the listener) would talk to the single shared default store
+    // unauthenticated — cross-tenant KV read/write. `Config::validate` already
+    // rejects this before `serve()`, but guard here too so any embedding or
+    // test path that skips validation still refuses rather than silently
+    // exposing every site's KV.
+    if config.server.sites_dir.is_some() && !config.kv.secret_is_set() {
+        anyhow::bail!(
+            "refusing to start the KV RESP listener: [kv.redis_compat] enabled \
+             with [server] sites_dir (multi-tenant vhosting) but no [kv] secret \
+             — the listener would serve one shared KV store to every tenant \
+             with no authentication. Set [kv] secret to enable per-site RESP \
+             AUTH scoping, or disable the listener with [kv.redis_compat] \
+             enabled = false."
         );
     }
 
     // Hand the RESP listener the *same* multi-tenant handle the router gets,
     // so `AUTH <hostname> <derived>` resolves to the identical `Arc<Store>`
-    // that PHP's `ephpm_kv_*` functions write through for that vhost. Only
-    // wired when a secret exists: without one the listener has no way to
-    // derive per-site credentials and stays on the shared default store
-    // (warned about just above).
-    let resp_multi_tenant = if secret.is_some() { multi_tenant.clone() } else { None };
+    // that PHP's `ephpm_kv_*` functions write through for that vhost. In
+    // single-site mode there is no per-vhost store, so this is `None` and the
+    // listener serves the (correct) shared store; the multi-tenant + no-secret
+    // case never reaches here (rejected just above).
+    let resp_multi_tenant = if config.kv.secret_is_set() { multi_tenant.clone() } else { None };
 
     let store_for_resp = Arc::clone(&store);
     let handle = tokio::spawn(async move {
@@ -2036,6 +2042,69 @@ mod lib_tests {
         let a = router_side.get_site_store("blog.example.com");
         let b = resp_side.get_site_store("blog.example.com");
         assert!(Arc::ptr_eq(&a, &b), "PHP and RESP must share one store per vhost");
+    }
+
+    /// Multi-tenant config with the RESP listener enabled, secret optional.
+    fn kv_resp_config(sites_dir: Option<&std::path::Path>, secret: Option<&str>) -> Config {
+        Config {
+            server: ephpm_config::ServerConfig {
+                sites_dir: sites_dir.map(std::path::Path::to_path_buf),
+                ..ephpm_config::ServerConfig::default()
+            },
+            kv: ephpm_config::KvConfig {
+                secret: secret.map(str::to_string),
+                redis_compat: ephpm_config::KvRedisCompatConfig {
+                    enabled: true,
+                    // Ephemeral port so the Ok path doesn't fight for 6379.
+                    listen: "127.0.0.1:0".to_string(),
+                    ..ephpm_config::KvRedisCompatConfig::default()
+                },
+                ..ephpm_config::KvConfig::default()
+            },
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn start_kv_service_refuses_multi_tenant_resp_without_secret() {
+        // Defense in depth: even if `Config::validate` is bypassed (embedding,
+        // tests), startup itself must fail closed rather than serve a shared
+        // global store to every tenant. The bail is before any `tokio::spawn`,
+        // so no runtime is needed here.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = kv_resp_config(Some(dir.path()), None);
+        // `KvService` (the Ok type) isn't `Debug`, so match rather than
+        // `expect_err`.
+        let err = match start_kv_service(&config) {
+            Ok(_) => panic!("must refuse to start a multi-tenant RESP listener without a secret"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("secret"), "error should point at [kv] secret: {msg}");
+    }
+
+    #[tokio::test]
+    async fn start_kv_service_multi_tenant_resp_with_secret_starts() {
+        // The secure config starts and returns a live RESP listener handle.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = kv_resp_config(Some(dir.path()), Some("s3cret-value"));
+        let (_store, multi_tenant, handle) =
+            start_kv_service(&config).expect("secure multi-tenant config must start");
+        assert!(multi_tenant.is_some(), "sites_dir set → per-vhost stores exist");
+        let handle = handle.expect("RESP listener enabled → a listener task exists");
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn start_kv_service_single_tenant_resp_without_secret_starts() {
+        // Single-site is unaffected: the shared store is correct, no secret
+        // required, RESP listener still starts.
+        let config = kv_resp_config(None, None);
+        let (_store, multi_tenant, handle) =
+            start_kv_service(&config).expect("single-tenant RESP must keep working");
+        assert!(multi_tenant.is_none(), "no sites_dir → no per-vhost stores");
+        let handle = handle.expect("RESP listener enabled → a listener task exists");
+        handle.abort();
     }
 
     // ── idle timeout ────────────────────────────────────────────────────────

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -181,7 +181,7 @@ When `sites_dir` is not configured, all KV operations go to the global store. No
 
 ### RESP Protocol (Redis-Compatible) with AUTH
 
-The RESP protocol listener supports per-site isolation via the Redis `AUTH` command. Multi-tenant auth requires a `[kv] secret`:
+The RESP protocol listener supports per-site isolation via the Redis `AUTH` command. Multi-tenant auth requires a `[kv] secret` — and in multi-tenant mode it is **mandatory**: enabling `[kv.redis_compat]` with `sites_dir` set but no `[kv] secret` is a **hard startup error** (fail closed). Without the secret, per-site AUTH scoping can't be derived and the listener would serve one shared global store to every tenant, so ePHPm refuses to start rather than expose it. Set the secret, or leave `[kv.redis_compat] enabled = false` (the default) and use the per-vhost `ephpm_kv_*` PHP functions.
 
 ```toml
 [kv]

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -392,13 +392,13 @@ Notable gaps, all deliberate:
 | `compression` | string | `"none"` | `none`, `gzip`, `brotli`, `zstd`. |
 | `compression_level` | u32 | `6` | 1=fastest, 9=best. |
 | `compression_min_size` | usize (bytes) | `1024` | Values below this are stored uncompressed. |
-| `secret` | string | (none) | Master secret for per-site RESP AUTH. Not auto-generated — if unset, multi-tenant HMAC AUTH is disabled. |
+| `secret` | string | (none) | Master secret for per-site RESP AUTH (`HMAC-SHA256(secret, hostname)`). Not auto-generated. **Required to run the RESP listener in multi-tenant mode:** with `sites_dir` set and `[kv.redis_compat] enabled = true`, an unset (or empty/whitespace-only) secret is a **hard startup error** — without it every tenant would share one unauthenticated global store. Single-site deployments (no `sites_dir`) don't need it. |
 
 ### `[kv.redis_compat]`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | bool | `false` | Enable the RESP listener. Off by default; in multi-tenant mode keep it off. |
+| `enabled` | bool | `false` | Enable the RESP listener. Off by default. In multi-tenant (`sites_dir`) mode, enabling it **requires** `[kv] secret` so per-site `AUTH <hostname> <derived-password>` scopes each connection to its own site store; without the secret startup fails closed (see `[kv] secret`). Prefer keeping it off in multi-tenant mode and using the per-vhost `ephpm_kv_*` PHP functions. |
 | `listen` | string | `"127.0.0.1:6379"` | RESP listener address (TCP only). |
 | `socket` | string | (none) | **Not yet implemented** — parsed but unused; startup logs a warning if set. |
 | `password` | string | (none) | RESP `AUTH` password. |


### PR DESCRIPTION
## Problem (pentest finding M1 / issue #274 related-findings)

In multi-tenant mode (`server.sites_dir` set), enabling the RESP listener (`[kv.redis_compat] enabled = true`) **without** setting `[kv] secret` silently served **one shared global KV store to every tenant, unauthenticated**. Per-site AUTH scoping (`AUTH <hostname> <derived-password>` → that vhost''s `Store`) can only be derived from `[kv] secret`; with no secret the listener stays on the shared default store and any client reaching loopback reads and writes **every** site''s keys. Startup only `warn!`d — it did not refuse.

## Fix — fail closed

Refuse to start on exactly this combination: **multi-tenant (`sites_dir`) AND RESP listener enabled AND `[kv] secret` unset/blank**.

- `Config::validate()` (ephpm-config) returns a clear `Validation` error — runs before `serve()`.
- `start_kv_service()` (ephpm-server) also bails, as defense in depth for any embedding/test path that skips validation.
- New `KvConfig::secret_is_set()` treats an empty/whitespace-only secret as unset (fail closed), mirroring the existing `[cluster] secret` gate.

The secure mode the pentest confirmed works (`handle_auth` → `get_site_store` with a secret set) is unchanged and remains the intended posture.

## Trigger condition (exact)

Refuse **iff** `server.sites_dir.is_some() && kv.redis_compat.enabled && !kv.secret_is_set()`.

## Start-vs-refuse matrix

| sites_dir | redis_compat | secret | Result |
|-----------|--------------|--------|--------|
| set (multi-tenant) | enabled | unset/blank | **REFUSE** (the vuln) |
| set | enabled | set | start (secure per-site AUTH) |
| set | disabled | unset | start (no listener, no exposure) |
| unset (single-site) | enabled | unset | start (shared store is correct) |
| unset | enabled | set | start |

Single-tenant is explicitly unaffected — the shared store is the correct behavior there.

## Tests

- ephpm-config: full matrix on `validate()`, plus a **section-absent** TOML case (no `[kv]` secret key) proving the serde default `None` can''t mask the exposure, and a **section-present** counterpart; `secret_is_set()` blank-handling.
- ephpm-server: `start_kv_service()` refuses the bad multi-tenant config and starts the secure and single-tenant ones.

## Docs

`site/content/reference/config.md` (the `[kv] secret` and `[kv.redis_compat] enabled` rows) and `site/content/guides/virtual-hosts.md` now state the requirement.

Verified in WSL stub mode: clippy pedantic `-D warnings` clean, nightly fmt clean, ephpm-config (114) + targeted ephpm-server tests green.