### PR TITLE
fix(server): flush the response head before an aborted stream breaks the body (#271)

### DIFF
--- a/crates/ephpm-server/src/body.rs
+++ b/crates/ephpm-server/src/body.rs
@@ -51,12 +51,31 @@ pub fn streamed(file: tokio::fs::File) -> ServerBody {
 ///   so hyper abandons the response instead of completing it. The client sees a
 ///   failed transfer — the only honest outcome once a `200` status line has
 ///   already gone out and cannot be retracted.
+///
+/// The abort error is deliberately *not* produced in the same poll that sees
+/// the channel close: the stream yields one `Poll::Pending` first, so hyper
+/// flushes the response head it has buffered before the error tears the
+/// connection down (issue #271). See `AbortAwareChunks::poll_next`.
 #[must_use]
 pub fn channel_body(
     rx: tokio::sync::mpsc::Receiver<Bytes>,
     aborted: ephpm_php::worker_bridge::StreamAbortFlag,
 ) -> ServerBody {
-    StreamBody::new(AbortAwareChunks { rx, aborted, finished: false }).boxed()
+    StreamBody::new(AbortAwareChunks { rx, aborted, state: ChunkState::Streaming }).boxed()
+}
+
+/// Where an [`AbortAwareChunks`] stream is in its close sequence.
+enum ChunkState {
+    /// Forwarding chunks as the producer sends them.
+    Streaming,
+    /// The channel closed with the abort flag set. Yield `Poll::Pending`
+    /// exactly once (self-waking) before the error frame, so hyper gets a
+    /// chance to flush the response head it has buffered but not yet written
+    /// to the socket. See [`AbortAwareChunks::poll_next`] — issue #271.
+    FlushBeforeAbort,
+    /// The terminal item has been produced; report end-of-stream from here on
+    /// rather than erroring (or looping) on every subsequent poll.
+    Finished,
 }
 
 /// Chunk stream behind [`channel_body`]: forwards every [`Bytes`] the producer
@@ -65,9 +84,8 @@ pub fn channel_body(
 struct AbortAwareChunks {
     rx: tokio::sync::mpsc::Receiver<Bytes>,
     aborted: ephpm_php::worker_bridge::StreamAbortFlag,
-    /// Set once the terminal item has been produced, so the stream reports
-    /// end-of-stream afterwards instead of erroring on every poll.
-    finished: bool,
+    /// Position in the close sequence (see [`ChunkState`]).
+    state: ChunkState,
 }
 
 impl tokio_stream::Stream for AbortAwareChunks {
@@ -80,25 +98,190 @@ impl tokio_stream::Stream for AbortAwareChunks {
         use std::task::Poll;
 
         let this = self.get_mut();
-        if this.finished {
-            return Poll::Ready(None);
-        }
-        match this.rx.poll_recv(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Some(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
-            Poll::Ready(None) => {
-                // The channel is closed. Read the flag only now: the producer
-                // sets it before dropping the sender, so if it was going to be
-                // set, it is set by the time we get here.
-                this.finished = true;
-                if this.aborted.load(std::sync::atomic::Ordering::SeqCst) {
-                    Poll::Ready(Some(Err(std::io::Error::other(
-                        "PHP worker died mid-response; body is incomplete",
-                    ))))
-                } else {
-                    Poll::Ready(None)
-                }
+        match this.state {
+            ChunkState::Finished => Poll::Ready(None),
+            // Second poll of the abort path. hyper has had its flush
+            // opportunity, so break the framing now.
+            ChunkState::FlushBeforeAbort => {
+                this.state = ChunkState::Finished;
+                Poll::Ready(Some(Err(std::io::Error::other(
+                    "PHP worker died mid-response; body is incomplete",
+                ))))
             }
+            ChunkState::Streaming => match this.rx.poll_recv(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Some(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk)))),
+                Poll::Ready(None) => {
+                    // The channel is closed. Read the flag only now: the
+                    // producer sets it before dropping the sender, so if it was
+                    // going to be set, it is set by the time we get here.
+                    if this.aborted.load(std::sync::atomic::Ordering::SeqCst) {
+                        // Do NOT return the error in this poll. hyper's h1
+                        // dispatcher runs `poll_read` / `poll_write` /
+                        // `poll_flush` in that order (`proto::h1::dispatch`,
+                        // `Dispatcher::poll_loop`), and inside `poll_write` the
+                        // body is polled as
+                        // `let item = ready!(body.poll_frame(cx));` followed by
+                        // `item.map_err(...)?`. An `Err` therefore propagates
+                        // straight out of `poll_write` AND out of `poll_loop` —
+                        // `poll_flush` never runs for that iteration. If the
+                        // worker bailed before hyper's first body poll, the
+                        // response head (and any chunk already buffered) is
+                        // still sitting in the connection's write buffer, so it
+                        // is dropped with the connection: the client sees a
+                        // socket torn down with *no response head at all*,
+                        // indistinguishable from a server crash. That is the
+                        // #271 flake — `reqwest::get()` itself fails instead of
+                        // returning a 200 with a broken body.
+                        //
+                        // `Poll::Pending` is the one answer that unwinds
+                        // `poll_write` *without* an error, so `poll_loop`
+                        // proceeds to `poll_flush` and puts the head on the
+                        // wire. We wake immediately, so the very next poll
+                        // delivers the error against an already-flushed head.
+                        // The observable contract is then deterministic:
+                        // 200 + headers, then a body that never terminates.
+                        this.state = ChunkState::FlushBeforeAbort;
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    } else {
+                        this.state = ChunkState::Finished;
+                        Poll::Ready(None)
+                    }
+                }
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Wake, Waker};
+
+    use tokio_stream::Stream;
+
+    use super::*;
+
+    /// A waker that only counts how many times it was asked to re-poll.
+    struct CountingWaker(AtomicUsize);
+
+    impl Wake for CountingWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn chunks(
+        rx: tokio::sync::mpsc::Receiver<Bytes>,
+        aborted: ephpm_php::worker_bridge::StreamAbortFlag,
+    ) -> AbortAwareChunks {
+        AbortAwareChunks { rx, aborted, state: ChunkState::Streaming }
+    }
+
+    /// Regression test for #271: the abort error must not be produced in the
+    /// same poll that observed the channel close. hyper skips `poll_flush` when
+    /// the body errors, so an immediate error strands the response head in the
+    /// connection's write buffer and the client never sees a status line at
+    /// all. One `Poll::Pending` flush boundary (which self-wakes) gives hyper
+    /// the flush it needs first.
+    #[test]
+    fn aborted_stream_yields_a_flush_boundary_before_the_error() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let aborted: ephpm_php::worker_bridge::StreamAbortFlag = Arc::new(AtomicBool::new(false));
+
+        // One chunk lands, then the worker bails: flag set, sender dropped —
+        // the exact ordering `clear_in_flight_streams` produces.
+        tx.try_send(Bytes::from_static(b"chunk1")).unwrap();
+        aborted.store(true, Ordering::SeqCst);
+        drop(tx);
+
+        let mut stream = chunks(rx, aborted);
+        let mut stream = Pin::new(&mut stream);
+
+        let counter = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let waker: Waker = counter.clone().into();
+        let mut cx = Context::from_waker(&waker);
+
+        // 1) the buffered chunk still comes out.
+        let Poll::Ready(Some(Ok(frame))) = stream.as_mut().poll_next(&mut cx) else {
+            panic!("expected the buffered data chunk");
+        };
+        assert_eq!(frame.into_data().ok(), Some(Bytes::from_static(b"chunk1")));
+
+        // 2) end-of-channel + abort => a flush boundary, not the error yet.
+        assert!(
+            stream.as_mut().poll_next(&mut cx).is_pending(),
+            "abort must yield a Pending flush boundary before the error"
+        );
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            1,
+            "the flush boundary must self-wake so the runtime re-polls"
+        );
+
+        // 3) now the error frame breaks the body framing.
+        let Poll::Ready(Some(Err(err))) = stream.as_mut().poll_next(&mut cx) else {
+            panic!("expected the abort error after the flush boundary");
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+
+        // 4) terminal from here on.
+        assert!(matches!(stream.as_mut().poll_next(&mut cx), Poll::Ready(None)));
+    }
+
+    /// A stream the worker finished normally ends straight away: no flush
+    /// boundary, no spurious wake, no error.
+    #[test]
+    fn clean_stream_ends_without_error_or_extra_poll() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let aborted: ephpm_php::worker_bridge::StreamAbortFlag = Arc::new(AtomicBool::new(false));
+
+        tx.try_send(Bytes::from_static(b"only")).unwrap();
+        drop(tx); // clean EOF, abort flag left clear
+
+        let mut stream = chunks(rx, aborted);
+        let mut stream = Pin::new(&mut stream);
+
+        let counter = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let waker: Waker = counter.clone().into();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(stream.as_mut().poll_next(&mut cx), Poll::Ready(Some(Ok(_)))));
+        assert!(matches!(stream.as_mut().poll_next(&mut cx), Poll::Ready(None)));
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            0,
+            "a clean finish must not wake for an extra poll"
+        );
+    }
+
+    /// An abort with nothing buffered still flushes first — this is the case
+    /// where the worker died before producing a single chunk, and it is the one
+    /// most likely to lose the head.
+    #[test]
+    fn abort_with_no_chunks_still_flushes_first() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let aborted: ephpm_php::worker_bridge::StreamAbortFlag = Arc::new(AtomicBool::new(false));
+
+        aborted.store(true, Ordering::SeqCst);
+        drop(tx);
+
+        let mut stream = chunks(rx, aborted);
+        let mut stream = Pin::new(&mut stream);
+
+        let counter = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let waker: Waker = counter.clone().into();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(stream.as_mut().poll_next(&mut cx).is_pending());
+        assert!(matches!(stream.as_mut().poll_next(&mut cx), Poll::Ready(Some(Err(_)))));
+        assert!(matches!(stream.as_mut().poll_next(&mut cx), Poll::Ready(None)));
     }
 }

--- a/crates/ephpm-server/tests/stream_abort_head_flush.rs
+++ b/crates/ephpm-server/tests/stream_abort_head_flush.rs
@@ -1,0 +1,222 @@
+//! Regression test for issue #271: an aborted streamed worker response must
+//! still put its status line and headers on the wire.
+//!
+//! Background. `send_response_stream` delivers status + headers to the router
+//! the moment PHP calls it, then feeds body chunks over a channel. If the
+//! worker dies mid-body, `clear_in_flight_streams` sets the
+//! [`StreamAbortFlag`](ephpm_php::worker_bridge::StreamAbortFlag) and drops the
+//! sender, and the body stream turns that into an `io::Error` so hyper
+//! abandons the response instead of writing the terminating chunk. The client
+//! is supposed to observe `200 OK` + headers followed by a transfer that never
+//! completes.
+//!
+//! The bug: hyper's h1 dispatcher (`proto::h1::dispatch::Dispatcher::poll_loop`)
+//! runs `poll_read` / `poll_write` / `poll_flush` in that order, and inside
+//! `poll_write` the response body is polled as
+//! `let item = ready!(body.poll_frame(cx));` immediately followed by
+//! `item.map_err(...)?`. A body error therefore propagates out of `poll_write`
+//! *and* out of `poll_loop`, so `poll_flush` never runs for that iteration and
+//! `poll_catch` goes straight to `Dispatched::Shutdown`. When the worker loses
+//! its race with the connection task — i.e. it has already aborted by the time
+//! hyper first polls the body — the response head is still sitting in the
+//! connection's write buffer and is discarded with the connection. The client
+//! then sees a socket that closed without a single response byte, which is
+//! indistinguishable from a server crash, and `reqwest::get()` itself fails.
+//!
+//! This test pins down the ordering that used to lose the head: the abort flag
+//! is set and the channel closed **before** the response is even handed to
+//! hyper, so hyper's very first body poll sees the abort. No scheduler luck is
+//! involved, so the test is deterministic where the E2E flake was not.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ephpm_server::body::channel_body;
+use http_body_util::BodyExt;
+use hyper::service::service_fn;
+use hyper::{Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Serve exactly one HTTP/1.1 connection whose response is an already-aborted
+/// streamed worker body, and return everything the client managed to read.
+///
+/// `pre_chunk` mirrors the E2E fixture: the worker emitted one body chunk
+/// before it died. `false` covers the harsher case where it died first.
+async fn read_aborted_response(pre_chunk: bool) -> Vec<u8> {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept");
+        let service = service_fn(move |_req| async move {
+            let (tx, rx) = tokio::sync::mpsc::channel::<hyper::body::Bytes>(4);
+            if pre_chunk {
+                tx.try_send(hyper::body::Bytes::from_static(b"STREAM-CHUNK-BEFORE-BAILOUT\n"))
+                    .expect("buffer the pre-bailout chunk");
+            }
+
+            // The exact ordering `clear_in_flight_streams()` produces, applied
+            // BEFORE hyper ever polls the body: flag first, then drop the
+            // sender. This is the worker-wins-the-race case from #271.
+            let aborted: ephpm_php::worker_bridge::StreamAbortFlag =
+                Arc::new(AtomicBool::new(false));
+            aborted.store(true, Ordering::SeqCst);
+            drop(tx);
+
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/plain; charset=utf-8")
+                    .header("x-ephpm-marker", "stream-abort")
+                    .body(channel_body(rx, aborted))
+                    .expect("build streamed response"),
+            )
+        });
+
+        // The error is expected: the body deliberately fails so hyper abandons
+        // the response. What matters is what reached the socket first.
+        let _ = hyper::server::conn::http1::Builder::new()
+            .serve_connection(TokioIo::new(stream), service)
+            .await;
+    });
+
+    let mut client = TcpStream::connect(addr).await.expect("connect");
+    client
+        .write_all(b"GET /s?__stream_bailout=1 HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        .await
+        .expect("send request");
+
+    let mut received = Vec::new();
+    // Reads until the server tears the connection down, which it always does
+    // here — the body errors either way, so this cannot hang.
+    client.read_to_end(&mut received).await.expect("read response");
+
+    server.await.expect("server task");
+    received
+}
+
+/// The head must reach the client even though the worker aborted before hyper
+/// polled the body — and the body must still be left unterminated.
+#[tokio::test]
+async fn aborted_stream_still_delivers_the_response_head() {
+    let received = read_aborted_response(true).await;
+    let text = String::from_utf8_lossy(&received).into_owned();
+
+    assert!(
+        !received.is_empty(),
+        "the client received NOTHING — the response head was discarded with the \
+         connection, which is indistinguishable from a server crash (issue #271)"
+    );
+    assert!(
+        text.starts_with("HTTP/1.1 200 OK\r\n"),
+        "expected a 200 status line before the abort, got: {text:?}"
+    );
+    assert!(
+        text.to_ascii_lowercase().contains("x-ephpm-marker: stream-abort"),
+        "the response headers must be on the wire too, got: {text:?}"
+    );
+    assert!(
+        text.to_ascii_lowercase().contains("transfer-encoding: chunked"),
+        "a streamed worker response is chunked, got: {text:?}"
+    );
+    assert!(
+        text.contains("STREAM-CHUNK-BEFORE-BAILOUT"),
+        "the chunk the worker produced before dying should have been flushed too, got: {text:?}"
+    );
+
+    // The whole point: the transfer must NOT look complete. Under chunked
+    // encoding that means the terminating zero-length chunk never appears.
+    assert!(
+        !received.ends_with(b"0\r\n\r\n"),
+        "the body was terminated cleanly — a client cannot tell this from a \
+         finished download: {text:?}"
+    );
+}
+
+/// Same guarantee when the worker died without producing a single chunk: this
+/// is the case with the least buffered data, so it is the one most likely to
+/// lose the head.
+#[tokio::test]
+async fn aborted_stream_delivers_the_head_even_with_no_chunks() {
+    let received = read_aborted_response(false).await;
+    let text = String::from_utf8_lossy(&received).into_owned();
+
+    assert!(
+        text.starts_with("HTTP/1.1 200 OK\r\n"),
+        "expected a 200 status line even with no body chunk, got: {text:?}"
+    );
+    assert!(
+        !received.ends_with(b"0\r\n\r\n"),
+        "the empty body must not be terminated cleanly: {text:?}"
+    );
+}
+
+/// The control: a streamed response the worker finished normally must still
+/// complete cleanly, terminating chunk and all.
+#[tokio::test]
+async fn clean_stream_still_completes_normally() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept");
+        let service = service_fn(move |_req| async move {
+            let (tx, rx) = tokio::sync::mpsc::channel::<hyper::body::Bytes>(4);
+            tx.try_send(hyper::body::Bytes::from_static(b"all-good\n")).expect("buffer chunk");
+            let aborted: ephpm_php::worker_bridge::StreamAbortFlag =
+                Arc::new(AtomicBool::new(false));
+            drop(tx); // clean end-of-body, flag left clear
+
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .body(channel_body(rx, aborted))
+                    .expect("build streamed response"),
+            )
+        });
+        let _ = hyper::server::conn::http1::Builder::new()
+            .serve_connection(TokioIo::new(stream), service)
+            .await;
+    });
+
+    let mut client = TcpStream::connect(addr).await.expect("connect");
+    client
+        .write_all(b"GET /s HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        .await
+        .expect("send request");
+    let mut received = Vec::new();
+    client.read_to_end(&mut received).await.expect("read response");
+    server.await.expect("server task");
+
+    let text = String::from_utf8_lossy(&received).into_owned();
+    assert!(text.starts_with("HTTP/1.1 200 OK\r\n"), "got: {text:?}");
+    assert!(text.contains("all-good"), "got: {text:?}");
+    assert!(
+        received.ends_with(b"0\r\n\r\n"),
+        "a completed stream must end with the terminating chunk: {text:?}"
+    );
+}
+
+/// Sanity check on the body plumbing itself: collecting an aborted body must
+/// surface an error rather than a successful (truncated) read.
+#[tokio::test]
+async fn aborted_body_collect_fails() {
+    let (tx, rx) = tokio::sync::mpsc::channel::<hyper::body::Bytes>(4);
+    tx.try_send(hyper::body::Bytes::from_static(b"partial")).expect("buffer chunk");
+    let aborted: ephpm_php::worker_bridge::StreamAbortFlag = Arc::new(AtomicBool::new(false));
+    aborted.store(true, Ordering::SeqCst);
+    drop(tx);
+
+    // `Collected<Bytes>` is not `Debug`, so match rather than `expect_err`.
+    match channel_body(rx, aborted).collect().await {
+        Ok(collected) => {
+            panic!("an aborted body collected successfully ({} bytes)", collected.to_bytes().len())
+        }
+        Err(err) => assert!(
+            err.to_string().contains("worker died mid-response"),
+            "unexpected body error: {err}"
+        ),
+    }
+}

--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -646,6 +646,21 @@ whether anything is already on the wire:
   `ephpm_worker_stream_aborts_total`. Simply dropping the sender — what it did
   before — was indistinguishable from a normal end of body.
 
+  "Already delivered status + headers" means delivered *to the router*, which is
+  not the same as delivered *to the socket*: hyper buffers the response head and
+  flushes it in `poll_flush`, which its dispatcher runs only after `poll_write`
+  returns without an error. A body that errors on hyper's very first poll — the
+  case where the worker finishes bailing out before the connection task is next
+  scheduled — therefore used to strand the head in the write buffer and tear the
+  connection down with nothing on the wire, which a client cannot distinguish
+  from a server crash (issue #271). `AbortAwareChunks` closes that hole: on the
+  abort path it yields `Poll::Pending` exactly once (self-waking) before the
+  error, which unwinds `poll_write` *without* an error so the dispatcher reaches
+  `poll_flush` and puts the head on the socket. The error lands on the next poll,
+  against a head the client has already received. So the observable contract is
+  the same regardless of who wins the race: **200 + headers, then a body that
+  never terminates.**
+
 The governing rule for both engines: **never complete a response for a script
 that bailed out.**
 


### PR DESCRIPTION
Fixes #271.

## The flake

`streamed_response_is_broken_not_completed_when_worker_bails` drives
`/s?__stream_bailout=1`, which faults a userland stream wrapper one chunk into a
streamed response. It expects `200 OK` + headers on the wire, then a body read
that fails because the terminating `0` chunk is never written. Intermittently
`reqwest::get()` itself failed with "error sending request" and the test panicked
at `worker_mode.rs:230` before it ever reached the body assertion. Reruns were
always green. It has forced CI reruns on five PRs (#255, #278, #285, #287, #288).

## Root cause

This is a real server defect, not a test-timing artifact.

hyper's h1 dispatcher (`proto::h1::dispatch::Dispatcher::poll_loop`, hyper 1.8.1)
runs `poll_read` / `poll_write` / `poll_flush` in that order. Inside `poll_write`
the response body is polled as:

```rust
let item = ready!(body.as_mut().poll_frame(cx));
if let Some(item) = item {
    let frame = item.map_err(|e| { *clear_body = true; crate::Error::new_user_body(e) })?;
```

So a body error propagates out of `poll_write` **and** out of `poll_loop`
(`let _ = self.poll_write(cx)?;`), and `poll_flush` never runs for that
iteration — `poll_catch` goes straight to `Dispatched::Shutdown`.

`write_head` only *buffers* the status line and headers. So when the PHP worker
finished bailing out before hyper first polled the body — i.e. the abort flag was
already set and the channel already closed on the first poll — the head was still
sitting in the connection's write buffer and was discarded with the connection.
The client saw a socket torn down without a single response byte.

Whether that happened was pure scheduler luck: `response_begin` wakes the
connection task, and the worker then has to get through one more `stream_read`,
an `ini_set`, a memory-limit fatal and the zend bailout unwind. On an idle
machine the connection task wins essentially always; under CI contention it
sometimes does not.

A connection that dies before its head is indistinguishable from a server crash
to any client, so this is fixed **server-side** (option (a) in the issue) rather
than by teaching the test to accept both outcomes.

## The fix

On the abort path, `AbortAwareChunks` now yields `Poll::Pending` exactly once
(waking itself) before the error frame. `Poll::Pending` is the one answer that
unwinds `poll_write` *without* an error, so the dispatcher reaches `poll_flush`
and puts the head — plus any chunk the worker managed to produce — on the socket.
The error lands on the very next poll, against a head the client already has.

The observable contract is now the same whichever side wins the race:
**200 + headers, then a body that never terminates.** The clean-finish path is
untouched: no flush boundary, no extra wake.

## Tests

`crates/ephpm-server/tests/stream_abort_head_flush.rs` drives a **real hyper h1
connection** with the abort flag already set and the channel already closed by
the time the response reaches hyper — the exact ordering that used to lose the
head — and asserts over the raw client bytes that the status line, the headers
and the pre-bailout chunk all arrive, while the body is still left unterminated
(no `0\r\n\r\n`). It is deterministic, needs no PHP, and runs in the normal stub
lane. On the parent commit it fails with *"the client received NOTHING"*.

Unit tests in `body.rs` pin the boundary itself: exactly one self-waking
`Pending` on abort, zero on a clean finish, and the same guarantee when the
worker died before producing any chunk.

`docs/architecture/worker-mode-design.md` §5.3 said "already delivered status +
headers", which was the assumption this bug violated; it now spells out the
delivered-to-router vs delivered-to-socket distinction and the flush ordering.

## Verification

Built and run in WSL (Linux-native checkout, PHP 8.5 release build).

| | result |
|---|---|
| New head-flush test on parent commit (`c50c950`) | **2/2 head-loss scenarios FAIL** — client reads zero bytes |
| New head-flush test with fix | 4/4 pass; **0 failures in 100 consecutive runs** |
| `cargo xtask e2e --tests worker_mode` with fix | **32/32 green** (full suite, fresh node each run) |
| `cargo test -p ephpm-server` | 347 pass, 0 fail |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo +nightly fmt --all -- --check` | clean |

Note on reproducing the *flake* itself: on a 32-core idle box it would not
reproduce by scheduler luck — 0 failures in 110 E2E iterations and 0 head losses
in 300 direct `curl` probes at concurrency 16, including with the server pinned
to two CPUs, `TOKIO_WORKER_THREADS=1`, and six competing spinners. The connection
task simply always won there. That is why the regression test forces the losing
ordering directly instead of relying on load: it turns a race that only CI hits
into a deterministic assertion.

Residual: if `poll_flush` were to only partially drain the socket, the tail of
the head could still be lost. For a ~150-byte head written into an empty socket
buffer at the start of a response this does not occur in practice, and it is
strictly better than the previous behaviour of never flushing at all.
