### PR TITLE
spike(zts): stack-overflow crash containment for single-process ZTS [DO NOT MERGE]

### DIFF
--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -37,6 +37,9 @@ tempfile.workspace = true
 # db_bridge recycle tests: mock Backend/BackendConn impls (litewire's
 # backend traits are async_trait-based).
 async-trait.workspace = true
+# crash_guard tests: install a sigaltstack + SIGSEGV handler and drive a real
+# stack overflow to prove the containment mechanism without libphp.
+libc = "0.2"
 
 [lints]
 workspace = true

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -14,12 +14,24 @@ fn main() {
     println!("cargo::rerun-if-changed=wrapper.h");
     println!("cargo::rerun-if-changed=ephpm_wrapper.c");
     println!("cargo::rerun-if-changed=resolver_shim.c");
+    println!("cargo::rerun-if-changed=crash_guard.c");
     println!("cargo::rerun-if-env-changed=PHP_SDK_PATH");
 
     println!(
         "cargo::warning=ephpm-php build.rs running. PHP_SDK_PATH={:?}",
         env::var_os("PHP_SDK_PATH")
     );
+
+    // The stack-overflow crash-containment shim is pure libc (no PHP headers),
+    // so it is compiled on every Unix build — stub AND php_linked — which lets
+    // the mechanism be unit-tested without libphp.
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
+    if target_family == "unix" {
+        cc::Build::new()
+            .file("crash_guard.c")
+            .define("_GNU_SOURCE", None)
+            .compile("ephpm_crash_guard");
+    }
 
     let Some(sdk_path) = env::var_os("PHP_SDK_PATH").map(PathBuf::from) else {
         // No PHP SDK available — build in stub mode.

--- a/crates/ephpm-php/crash_guard.c
+++ b/crates/ephpm-php/crash_guard.c
@@ -1,0 +1,194 @@
+/* crash_guard.c — stack-overflow crash-containment primitive.
+ *
+ * This is the C half of the ZTS single-process crash-containment spike. It is
+ * deliberately PURE libc — <setjmp.h>, <pthread.h>, <signal.h> — with NO PHP
+ * dependency, so it compiles on every Unix build (stub AND php_linked) and the
+ * mechanism can be unit-tested without libphp.
+ *
+ * # What it does
+ *
+ * `ephpm_guard_run(work, ctx)` runs `work(ctx)` inside a per-thread recovery
+ * region established with `sigsetjmp`. If a *stack-overflow* SIGSEGV/SIGBUS is
+ * delivered while inside that region, the fatal-signal handler (in the `ephpm`
+ * binary crate, src/fatal_signal.rs) calls `ephpm_guard_try_recover()`, which
+ * `siglongjmp`s back into `ephpm_guard_run`, which then returns 1 ("contained")
+ * instead of the process dying.
+ *
+ * # Why ONLY stack overflow
+ *
+ * A stack overflow exhausts a *thread-local* resource (the thread's own stack)
+ * and, for the ePHPm crash this targets — a deep `zend_object_std_dtor` <->
+ * `zend_objects_store_del` C recursion freeing a large plain-object graph —
+ * every write is into thread-local Zend state (the per-thread ZMM heap and
+ * `EG(objects_store)`). No other thread's memory and no process-global
+ * allocator lock is touched at the fault instant (the Zend MM manager mmaps its
+ * own 2 MiB chunks; it does not go through glibc `malloc`, so the arena lock is
+ * not held). The rest of the process is therefore intact, and abandoning the
+ * poisoned thread contains the blast.
+ *
+ * A wild write / heap corruption produces the SAME SIGSEGV but may already have
+ * corrupted another thread's or a shared allocator's memory — continuing is
+ * unsafe. The two are told apart by the fault address: a stack overflow faults
+ * at/just below THIS thread's stack low bound (the guard region); anything else
+ * is NOT contained and the handler proceeds to its normal die-with-diagnostic
+ * path. See `ephpm_guard_try_recover`.
+ *
+ * # Async-signal-safety
+ *
+ * `ephpm_guard_try_recover` is reached from a signal handler. It touches only
+ * `__thread` integer state (initial-exec TLS: a fixed offset from the thread
+ * pointer, no lazy allocation, no lock), does integer comparisons, and calls
+ * `siglongjmp` — all on the POSIX async-signal-safe list. It never allocates,
+ * never locks, never calls back into libphp.
+ */
+
+#if defined(__unix__) || defined(__APPLE__)
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <setjmp.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stddef.h>
+
+/* Per-thread recovery state. `__thread` (not pthread_key_create) so that reads
+ * from a signal handler are async-signal-safe. */
+static __thread sigjmp_buf g_recover_buf;
+static __thread int        g_armed;     /* 1 while inside a guarded region */
+static __thread uintptr_t  g_stack_lo;  /* lowest usable stack address, 0 = unknown */
+static __thread uintptr_t  g_stack_hi;  /* one past the highest usable stack address */
+
+/* How far below the stack's low bound a fault is still classified as a stack
+ * overflow. A thread guard is normally one page, but glibc can place several
+ * guard pages, and the faulting access (a `sub rsp` + write, or a `call`
+ * pushing a return address) can land a little past the guard. 64 KiB is
+ * comfortably wider than any real guard and far narrower than the gap to any
+ * other mapping, so it neither misses a real overflow nor mistakes a heap wild
+ * write (which lands nowhere near this thread's stack) for one. */
+#define EPHPM_GUARD_WINDOW ((uintptr_t)(64 * 1024))
+
+/* A fault at/above the stack low bound but within this slack still counts as an
+ * overflow: the guard-page trip can be the first byte of the new (too-low)
+ * frame, an address marginally above `g_stack_lo`. One page is plenty. */
+#define EPHPM_GUARD_SLACK ((uintptr_t)4096)
+
+/* Capture this thread's stack bounds at ARM time (normal context), never from
+ * the handler: `pthread_getattr_np` reads the pthread descriptor (and, for the
+ * main thread, /proc/self/maps) and is not async-signal-safe. On an unknown
+ * platform the bounds stay 0 and `ephpm_guard_try_recover` refuses to contain
+ * anything — fail-safe (a real fatal still dies with its diagnostic). */
+static void ephpm_guard_capture_bounds(void)
+{
+    g_stack_lo = 0;
+    g_stack_hi = 0;
+#if defined(__linux__)
+    pthread_attr_t attr;
+    if (pthread_getattr_np(pthread_self(), &attr) == 0) {
+        void  *base = NULL;
+        size_t size = 0;
+        if (pthread_attr_getstack(&attr, &base, &size) == 0 && base && size) {
+            /* glibc returns `base` = lowest usable address (the guard page
+             * sits BELOW it) and `size` = usable bytes. */
+            g_stack_lo = (uintptr_t)base;
+            g_stack_hi = (uintptr_t)base + size;
+        }
+        pthread_attr_destroy(&attr);
+    }
+#elif defined(__APPLE__)
+    void  *hi   = pthread_get_stackaddr_np(pthread_self()); /* highest address */
+    size_t size = pthread_get_stacksize_np(pthread_self());
+    if (hi && size) {
+        g_stack_hi = (uintptr_t)hi;
+        g_stack_lo = (uintptr_t)hi - (uintptr_t)size;
+    }
+#endif
+}
+
+/*
+ * Run `work(ctx)` inside a stack-overflow recovery region.
+ *
+ * Returns 0 if `work` returned normally, or 1 if a stack overflow was contained
+ * — in which case `work` did NOT finish, and the calling thread's PHP context
+ * is POISONED: the caller must retire the thread and must never run PHP on it
+ * again (see the Rust `crash_guard::run_guarded` docs).
+ *
+ * Nested guards are not supported (ePHPm never nests PHP execution); a nested
+ * call runs `work` without establishing a second recovery point so it cannot
+ * clobber the outer `sigjmp_buf`.
+ */
+int ephpm_guard_run(void (*work)(void *), void *ctx)
+{
+    if (g_armed) {
+        work(ctx);
+        return 0;
+    }
+
+    ephpm_guard_capture_bounds();
+
+    /* sigsetjmp with savesigs=1: the signal mask is saved here and restored on
+     * siglongjmp, so SIGSEGV — auto-blocked on handler entry because the
+     * handler is installed without SA_NODEFER — is unblocked again after
+     * recovery and a subsequent overflow can still be caught. */
+    if (sigsetjmp(g_recover_buf, 1) != 0) {
+        /* Returned here via siglongjmp from ephpm_guard_try_recover. */
+        g_armed = 0;
+        return 1;
+    }
+
+    g_armed = 1;
+    work(ctx);
+    g_armed = 0;
+    return 0;
+}
+
+/*
+ * Classify a SIGSEGV/SIGBUS fault and, if it is a contained stack overflow,
+ * recover. Called from the fatal-signal handler with the faulting address
+ * (`siginfo_t.si_addr`).
+ *
+ * Returns 0 (and the handler proceeds to its normal fatal path) when the fault
+ * is NOT a contained stack overflow: not inside a guarded region, bounds
+ * unknown, or the address is not within this thread's stack guard window. When
+ * it IS a contained stack overflow this function does not return — it
+ * siglongjmps back into ephpm_guard_run.
+ *
+ * Async-signal-safe (see file header).
+ */
+int ephpm_guard_try_recover(uintptr_t fault_addr)
+{
+    if (!g_armed) {
+        return 0;
+    }
+    if (g_stack_lo == 0) {
+        return 0; /* bounds unknown on this platform — never contain */
+    }
+    /* Below the guard window? (written to avoid unsigned underflow) */
+    if (fault_addr + EPHPM_GUARD_WINDOW < g_stack_lo) {
+        return 0;
+    }
+    /* Well above the low bound — inside or above the live stack, i.e. a wild
+     * write, not an overflow. (A write into the *mapped* live stack would not
+     * fault at all, so any fault this high is not a stack overflow.) */
+    if (fault_addr > g_stack_lo + EPHPM_GUARD_SLACK) {
+        return 0;
+    }
+
+    /* Contained. Disarm and jump back into ephpm_guard_run, which returns 1. */
+    g_armed = 0;
+    siglongjmp(g_recover_buf, 1);
+    return 0; /* unreachable */
+}
+
+/*
+ * Test-only: report whether the current thread is inside a guarded region.
+ * Used by the unit tests to assert arm/disarm bookkeeping.
+ */
+int ephpm_guard_is_armed(void)
+{
+    return g_armed;
+}
+
+#endif /* unix */

--- a/crates/ephpm-php/src/crash_guard.rs
+++ b/crates/ephpm-php/src/crash_guard.rs
@@ -1,0 +1,374 @@
+//! Stack-overflow crash containment for the single-process ZTS model (spike).
+//!
+//! # The problem
+//!
+//! ePHPm runs every tenant's PHP in one process on ZTS threads. A single
+//! hostile (or buggy) tenant can crash the **whole** process — taking every
+//! other tenant down — with a deep object-graph free: building a ~50 000-node
+//! plain-object linked list and dropping it recurses in C
+//! (`zend_object_std_dtor` <-> `zend_objects_store_del`), overflows the thread
+//! stack, and the resulting SIGSEGV aborts the process. No `disable_functions`
+//! or ini reaches it, because the trigger is ordinary object creation + scope
+//! exit and the fault is in the C runtime below the VM's stack guard. (ePHPm
+//! disables that guard anyway — `EG(max_allowed_stack_size) = 0` — and even
+//! enabled it would not fire, because a plain-object destructor cascade passes
+//! no VM/`zend_call_function` checkpoint.)
+//!
+//! # The mechanism
+//!
+//! This module contains exactly that fault class and nothing else:
+//!
+//! 1. [`run_guarded`] establishes a per-thread `sigsetjmp` recovery point (in
+//!    the pure-libc C shim `crash_guard.c`) and runs the request inside it.
+//! 2. The process fatal-signal handler ([`crate`]'s sibling in the `ephpm`
+//!    binary, `src/fatal_signal.rs`) calls [`recover_hook`] — i.e. the C
+//!    `ephpm_guard_try_recover` — first thing for every SIGSEGV/SIGBUS. If the
+//!    current thread is inside a guarded region **and** the faulting address is
+//!    at/just below this thread's own stack low bound (a stack overflow), it
+//!    `siglongjmp`s back into [`run_guarded`], which returns [`Guarded::Contained`].
+//!    Otherwise it returns and the handler proceeds to its normal
+//!    die-with-diagnostic path (a genuine fatal still kills the process).
+//!
+//! # The soundness boundary — stated precisely
+//!
+//! Recovering from SIGSEGV is undefined behaviour in general. This is sound for
+//! **stack overflow only**, and only because that fault exhausts a
+//! *thread-local* resource: the ePHPm crash it targets frees a plain-object
+//! graph entirely within thread-local Zend state (the per-thread ZMM heap and
+//! `EG(objects_store)`), and the ZMM allocates its chunks with `mmap`, not glibc
+//! `malloc`, so no process-global allocator lock is held at the fault instant.
+//! The rest of the process is intact.
+//!
+//! It is **NOT** sound for heap corruption / wild writes: a bad write may have
+//! already corrupted another thread's or the shared allocator's memory, so
+//! continuing is unsafe. Those produce the same SIGSEGV, and are told apart by
+//! the fault address (see `crash_guard.c`): a wild write lands nowhere near this
+//! thread's stack and is therefore **not** contained.
+//!
+//! # After containment: the thread is poisoned
+//!
+//! When [`run_guarded`] returns [`Guarded::Contained`] the recovery skipped the
+//! rest of `zend_object_std_dtor`, so the thread's ZMM free lists and
+//! `EG(objects_store)` are mid-mutation and inconsistent. That state is confined
+//! to this one thread, but the thread must never run PHP again and must never be
+//! torn down through `php_request_shutdown` / `ts_free_thread` (both walk the
+//! poisoned heap and would re-crash). The caller ([`crate::PhpRuntime`]) marks
+//! the thread poisoned and refuses further PHP on it. Fully *retiring* the
+//! poisoned OS thread and replacing it is the piece the tokio blocking pool
+//! cannot do — see the crate design notes; this spike stops PHP running on a
+//! poisoned thread but does not respawn it.
+
+#[cfg(unix)]
+mod imp {
+    use std::os::raw::c_void;
+
+    unsafe extern "C" {
+        /// Run `work(ctx)` inside a stack-overflow recovery region. Returns 0
+        /// on normal completion, 1 if a stack overflow was contained.
+        fn ephpm_guard_run(work: extern "C" fn(*mut c_void), ctx: *mut c_void) -> i32;
+
+        /// Classify a SIGSEGV/SIGBUS fault; recover (does not return) if it is a
+        /// contained stack overflow, else return 0. Async-signal-safe.
+        fn ephpm_guard_try_recover(fault_addr: usize) -> i32;
+
+        /// Test-only: whether the current thread is inside a guarded region.
+        #[cfg(test)]
+        fn ephpm_guard_is_armed() -> i32;
+    }
+
+    /// Result of [`run_guarded`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum Guarded {
+        /// `work` ran to completion normally.
+        Completed,
+        /// A stack overflow was contained; `work` did **not** finish and the
+        /// calling thread's PHP context is poisoned (see the module docs).
+        Contained,
+    }
+
+    /// Run `work` inside the per-thread stack-overflow recovery region.
+    ///
+    /// On [`Guarded::Contained`], `work` was abandoned mid-flight by a
+    /// `siglongjmp` out of the signal handler: any Rust value created **inside**
+    /// `work` is leaked (its destructor does not run), which is acceptable for a
+    /// contained crash. Keep `work` minimal — in ePHPm it wraps only the single
+    /// `ephpm_execute_request` FFI call, so the leak is the abandoned Zend
+    /// request, not Rust state.
+    pub fn run_guarded<F: FnOnce()>(work: F) -> Guarded {
+        // The closure is moved into an `Option` so the trampoline can take it by
+        // value exactly once. A raw pointer to it crosses the C boundary.
+        let mut slot: Option<F> = Some(work);
+
+        extern "C" fn trampoline<F: FnOnce()>(ctx: *mut c_void) {
+            // SAFETY: `ctx` is the `&mut Option<F>` handed to `ephpm_guard_run`
+            // below; it is live for the whole call and touched by no other
+            // thread. `take()` runs the closure at most once.
+            let slot = unsafe { &mut *(ctx.cast::<Option<F>>()) };
+            if let Some(work) = slot.take() {
+                work();
+            }
+        }
+
+        // SAFETY: `trampoline::<F>` matches the `void(*)(void*)` C signature and
+        // `slot` outlives the call. `ephpm_guard_run` either returns normally or
+        // (on containment) via `siglongjmp` back to its own `sigsetjmp`, which
+        // unwinds only C frames it owns — never across this Rust frame.
+        let ret = unsafe {
+            ephpm_guard_run(trampoline::<F>, std::ptr::from_mut(&mut slot).cast::<c_void>())
+        };
+        if ret == 0 { Guarded::Completed } else { Guarded::Contained }
+    }
+
+    /// The async-signal-safe fault-classification hook to register with the
+    /// process fatal-signal handler.
+    ///
+    /// The returned function takes a faulting address (`siginfo_t.si_addr`) and,
+    /// if the current thread is inside [`run_guarded`] and the fault is a stack
+    /// overflow, does **not** return (it recovers). Otherwise it returns and the
+    /// caller must fall through to its normal fatal handling. Wire it once at
+    /// startup, from the binary crate, into `fatal_signal::set_recover_hook`.
+    #[must_use]
+    pub fn recover_hook() -> unsafe extern "C" fn(usize) -> i32 {
+        ephpm_guard_try_recover
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::undocumented_unsafe_blocks)]
+    mod tests {
+        use std::os::raw::c_void;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        use libc::{c_int, siginfo_t};
+
+        use super::*;
+
+        // ── A self-contained test handler ────────────────────────────────────
+        //
+        // In these unit tests there is no `fatal_signal` handler (that lives in
+        // the `ephpm` binary crate), so the test installs its own minimal
+        // SIGSEGV/SIGBUS handler that does exactly what the real one will:
+        //   - call the recover hook first (which does not return on a contained
+        //     stack overflow);
+        //   - if it returns, restore SIG_DFL and re-raise (a genuine fatal dies,
+        //     preserving wait status) — mirroring fatal_signal::die.
+
+        /// How many times the test handler was entered (per process).
+        static HANDLER_HITS: AtomicU32 = AtomicU32::new(0);
+
+        extern "C" fn test_handler(sig: c_int, info: *mut siginfo_t, _ctx: *mut c_void) {
+            HANDLER_HITS.fetch_add(1, Ordering::SeqCst);
+            if !info.is_null() {
+                // si_addr is the faulting address (SA_SIGINFO).
+                let addr = unsafe { (*info).si_addr() } as usize;
+                // Recover if this is a contained stack overflow; does not return
+                // in that case.
+                let _ = unsafe { recover_hook()(addr) };
+            }
+            // Not contained: revert to default disposition and re-raise so the
+            // (forked) process dies with the real signal, exactly like the
+            // production die path.
+            unsafe {
+                let mut dfl: libc::sigaction = std::mem::zeroed();
+                libc::sigemptyset(&raw mut dfl.sa_mask);
+                dfl.sa_sigaction = libc::SIG_DFL;
+                libc::sigaction(sig, &raw const dfl, std::ptr::null_mut());
+                let mut set: libc::sigset_t = std::mem::zeroed();
+                libc::sigemptyset(&raw mut set);
+                libc::sigaddset(&raw mut set, sig);
+                libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, std::ptr::null_mut());
+                libc::raise(sig);
+            }
+        }
+
+        /// Give the current thread a 32 KiB alternate signal stack (required to
+        /// run a handler for a stack-overflow fault, where the normal stack is
+        /// exhausted) and install `test_handler` for SIGSEGV + SIGBUS.
+        fn install_test_handler() {
+            unsafe {
+                let size = 32 * 1024;
+                let sp = libc::mmap(
+                    std::ptr::null_mut(),
+                    size,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    -1,
+                    0,
+                );
+                assert_ne!(sp, libc::MAP_FAILED, "altstack mmap failed");
+                let ss = libc::stack_t { ss_sp: sp, ss_flags: 0, ss_size: size };
+                assert_eq!(
+                    libc::sigaltstack(&raw const ss, std::ptr::null_mut()),
+                    0,
+                    "sigaltstack failed"
+                );
+
+                let mut act: libc::sigaction = std::mem::zeroed();
+                act.sa_sigaction = test_handler as *const () as usize;
+                act.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK;
+                libc::sigemptyset(&raw mut act.sa_mask);
+                for sig in [libc::SIGSEGV, libc::SIGBUS] {
+                    assert_eq!(
+                        libc::sigaction(sig, &raw const act, std::ptr::null_mut()),
+                        0,
+                        "sigaction failed"
+                    );
+                }
+            }
+        }
+
+        /// Recurse forever, touching a 1 KiB frame each level so the compiler
+        /// cannot elide the frames or tail-call it away — guarantees a real
+        /// stack-overflow guard-page fault. The unbounded recursion is the whole
+        /// point (it overflows the stack), so the lint is expected.
+        #[inline(never)]
+        #[allow(unconditional_recursion)]
+        fn blow_the_stack(depth: u64) -> u64 {
+            let mut frame = [0u8; 1024];
+            let idx = usize::try_from(depth % 1024).unwrap_or(0);
+            // Volatile touch keeps the frame live and defeats tail-call opt.
+            // `depth.to_le_bytes()[0]` is the low byte with no truncating cast.
+            unsafe {
+                std::ptr::write_volatile(&raw mut frame[idx], depth.to_le_bytes()[0]);
+            }
+            let deeper = blow_the_stack(depth.wrapping_add(1));
+            // Use both results so nothing is dead.
+            deeper.wrapping_add(u64::from(frame[0]))
+        }
+
+        // ── Test 1: the mechanism itself, in-process ─────────────────────────
+        //
+        // A real stack overflow inside run_guarded is contained, the thread
+        // survives, and — because in stub mode there is no PHP heap to poison —
+        // the SAME thread can run another guarded region afterward. This proves
+        // the pure signal/setjmp/longjmp mechanism independent of libphp.
+        #[test]
+        fn stack_overflow_is_contained_and_thread_survives() {
+            // Run on a dedicated std::thread with a known 8 MiB stack so the
+            // overflow is bounded and reproducible.
+            let handle = std::thread::Builder::new()
+                .name("crashguard-test".into())
+                .stack_size(8 * 1024 * 1024)
+                .spawn(|| {
+                    install_test_handler();
+
+                    assert_eq!(unsafe { ephpm_guard_is_armed() }, 0, "should start disarmed");
+
+                    let outcome = run_guarded(|| {
+                        // Never returns normally: overflows the stack.
+                        std::hint::black_box(blow_the_stack(std::hint::black_box(0)));
+                    });
+                    assert_eq!(outcome, Guarded::Contained, "overflow must be contained");
+                    assert_eq!(
+                        unsafe { ephpm_guard_is_armed() },
+                        0,
+                        "guard must be disarmed after recovery"
+                    );
+
+                    // The thread is alive and usable: a normal guarded region
+                    // now completes.
+                    let ran = std::cell::Cell::new(false);
+                    let outcome2 = run_guarded(|| ran.set(true));
+                    assert_eq!(outcome2, Guarded::Completed);
+                    assert!(ran.get(), "post-recovery guarded work must run");
+
+                    // And a SECOND overflow on the same thread is contained too
+                    // (no one-shot latch left armed).
+                    let outcome3 = run_guarded(|| {
+                        std::hint::black_box(blow_the_stack(std::hint::black_box(0)));
+                    });
+                    assert_eq!(outcome3, Guarded::Contained, "second overflow must contain");
+
+                    "survived"
+                })
+                .expect("spawn");
+
+            assert_eq!(handle.join().expect("thread must not panic/abort"), "survived");
+        }
+
+        // ── Test 2: a normal (non-crashing) guarded region completes ─────────
+        #[test]
+        fn normal_work_completes_without_containment() {
+            let n = std::cell::Cell::new(0u32);
+            for _ in 0..1000 {
+                let outcome = run_guarded(|| n.set(n.get() + 1));
+                assert_eq!(outcome, Guarded::Completed);
+            }
+            assert_eq!(n.get(), 1000);
+            assert_eq!(unsafe { ephpm_guard_is_armed() }, 0);
+        }
+
+        // ── Test 3: a wild write is NOT contained (it re-raises and dies) ────
+        //
+        // Forked child so the death is observable without killing the test
+        // runner, mirroring fatal_signal's own fault-injection harness. A null
+        // dereference inside a guarded region faults far from the stack, so the
+        // classifier refuses to contain it; the test handler then re-raises and
+        // the child must die with SIGSEGV.
+        #[test]
+        fn wild_write_inside_guard_is_not_contained() {
+            let pid = unsafe { libc::fork() };
+            assert!(pid >= 0, "fork failed");
+
+            if pid == 0 {
+                // Child. Suppress core dumps, install the handler, fault.
+                unsafe {
+                    let no_core = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+                    libc::setrlimit(libc::RLIMIT_CORE, &raw const no_core);
+                }
+                install_test_handler();
+                let _ = run_guarded(|| unsafe {
+                    // Wild write through null — a genuine fatal, not an overflow.
+                    std::ptr::write_volatile(std::ptr::null_mut::<u32>(), 0x41);
+                });
+                // Must not reach here: either the fault killed us, or (bug) it
+                // was wrongly contained and run_guarded returned.
+                unsafe { libc::_exit(97) };
+            }
+
+            let mut status: c_int = 0;
+            unsafe { libc::waitpid(pid, &raw mut status, 0) };
+            assert!(
+                libc::WIFSIGNALED(status),
+                "child should have died from a signal, not exited (was it wrongly contained?)"
+            );
+            assert_eq!(
+                libc::WTERMSIG(status),
+                libc::SIGSEGV,
+                "a wild write must NOT be contained — it must re-raise and die with SIGSEGV"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+pub use imp::{Guarded, recover_hook, run_guarded};
+
+// ── Windows: no signals, no containment (single-process ZTS is Unix-only) ────
+
+/// Result of [`run_guarded`] (Windows stub).
+#[cfg(not(unix))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Guarded {
+    /// `work` ran to completion.
+    Completed,
+    /// Never produced on Windows.
+    Contained,
+}
+
+/// Run `work` with no containment (Windows delivers faults as SEH exceptions,
+/// not signals; the mechanism does not apply). Always [`Guarded::Completed`].
+#[cfg(not(unix))]
+pub fn run_guarded<F: FnOnce()>(work: F) -> Guarded {
+    work();
+    Guarded::Completed
+}
+
+/// No-op recovery hook on Windows.
+#[cfg(not(unix))]
+#[must_use]
+pub fn recover_hook() -> unsafe extern "C" fn(usize) -> i32 {
+    unsafe extern "C" fn noop(_addr: usize) -> i32 {
+        0
+    }
+    noop
+}

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -2,6 +2,7 @@
 // are documented with comments before each unsafe block.
 #![allow(unsafe_code)]
 
+pub mod crash_guard;
 pub mod db_bridge;
 pub mod kv_bridge;
 pub mod request;
@@ -238,6 +239,37 @@ thread_local! {
         const { ThreadPhpGuard { registered: std::cell::Cell::new(false) } };
 }
 
+#[cfg(php_linked)]
+thread_local! {
+    /// Latched once this thread has contained a stack-overflow crash. Its Zend
+    /// context is then poisoned (the recovery `siglongjmp`ed out mid-object-
+    /// destruction, leaving the per-thread ZMM free lists and
+    /// `EG(objects_store)` inconsistent), so the thread must never run PHP
+    /// again and must never be torn down through `php_request_shutdown` /
+    /// `ts_free_thread`.
+    static THREAD_POISONED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Mark the current thread poisoned after a contained crash.
+///
+/// Latches the poison flag (so [`PhpRuntime::execute`] refuses further PHP on
+/// this thread) and disarms the [`ThreadPhpGuard`] so thread exit does NOT run
+/// `ephpm_thread_shutdown()` — its `php_request_shutdown` + `ts_free_thread`
+/// walk the poisoned heap and would re-crash. The poisoned per-thread Zend
+/// state is deliberately leaked (a bounded, measured leak per contained crash);
+/// abandoning it is the only safe option.
+#[cfg(php_linked)]
+fn mark_thread_poisoned() {
+    THREAD_POISONED.with(|p| p.set(true));
+    THREAD_REGISTERED.with(|g| g.registered.set(false));
+}
+
+/// Whether the current thread has contained a crash and must not run PHP.
+#[cfg(php_linked)]
+fn is_thread_poisoned() -> bool {
+    THREAD_POISONED.with(std::cell::Cell::get)
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum PhpError {
     /// PHP module initialization (`php_embed_init`) failed.
@@ -273,6 +305,16 @@ pub enum PhpError {
     /// exception, which unwinds cleanly and yields a complete response.
     #[error("PHP script bailed out (truncated response discarded): {0}")]
     Bailout(String),
+
+    /// A request overflowed the C stack — a deep object-graph free
+    /// (`zend_object_std_dtor` <-> `zend_objects_store_del` recursion) — and
+    /// the crash guard contained it instead of the process aborting. The
+    /// partial response is discarded and answered 500, and the thread that ran
+    /// it is poisoned and retired from PHP service (see
+    /// [`crate::crash_guard`]). Distinct from [`Self::Bailout`]: the fault was a
+    /// hardware SIGSEGV recovered via `siglongjmp`, not a PHP-level bailout.
+    #[error("PHP request contained after a C-stack overflow (thread retired): {0}")]
+    Contained(String),
 }
 
 /// The `EPHPM_EXEC_*` return codes of `ephpm_execute_request` (defined in
@@ -634,6 +676,16 @@ impl PhpRuntime {
             return Err(PhpError::NotInitialized);
         }
 
+        // A thread that contained a prior crash has a poisoned Zend context and
+        // must never run PHP again. Refuse before touching TSRM. (In the tokio
+        // blocking-pool model this thread can still be handed future requests,
+        // which then fail 500 — the structural limitation the crash-containment
+        // design notes call out; a bespoke pool would remove it from rotation.)
+        #[cfg(php_linked)]
+        if is_thread_poisoned() {
+            return Err(PhpError::Contained("worker thread retired after a prior crash".into()));
+        }
+
         #[cfg(php_linked)]
         Self::ensure_thread_registered()?;
 
@@ -777,11 +829,47 @@ impl PhpRuntime {
             }
         }
 
-        // Execute the PHP request on this thread's TSRM context.
-        // SAFETY: This thread is registered with TSRM. All PHP globals
-        // accessed by ephpm_execute_request are thread-local under ZTS.
-        // The C function uses setjmp/longjmp bailout protection.
-        let ret = unsafe { ffi::ephpm_execute_request(script_filename.as_ptr()) };
+        // Execute the PHP request inside the stack-overflow crash-containment
+        // guard. The recovery point wraps the whole ephpm_execute_request call,
+        // so a C-stack overflow during object destruction — the script's own
+        // (`$x = null` on a deep graph), the lazy php_request_shutdown of the
+        // previous request at the top of ephpm_execute_request, or a shutdown
+        // function — is contained here instead of aborting the process.
+        let filename_ptr = script_filename.as_ptr();
+        let mut ret: std::os::raw::c_int = exec_code::BAILOUT;
+        let guarded = crash_guard::run_guarded(|| {
+            // SAFETY: This thread is registered with TSRM. All PHP globals
+            // accessed by ephpm_execute_request are thread-local under ZTS. The
+            // C function uses setjmp/longjmp bailout protection for PHP-level
+            // bailouts; a hardware stack-overflow SIGSEGV escapes that and is
+            // caught by the crash guard's signal-handler recovery instead.
+            ret = unsafe { ffi::ephpm_execute_request(filename_ptr) };
+        });
+
+        if guarded == crash_guard::Guarded::Contained {
+            // The recovery jumped out mid-object-destruction: this thread's ZMM
+            // free lists and EG(objects_store) are inconsistent. The damage is
+            // confined to THIS thread, but it must never run PHP again nor be
+            // torn down through php_request_shutdown / ts_free_thread (both walk
+            // the poisoned heap and would re-crash). mark_thread_poisoned()
+            // latches the refusal and disarms the TLS retirement guard; the
+            // poisoned Zend context is deliberately leaked.
+            mark_thread_poisoned();
+            tracing::error!(
+                script = %request.script_filename.display(),
+                method = %request.method,
+                uri = %request.uri,
+                "PHP request overflowed the C stack (deep object-graph free) — \
+                 contained on this thread, returning 500; thread retired from \
+                 PHP service"
+            );
+            return Err(PhpError::Contained(format!(
+                "{} ({} {})",
+                request.script_filename.display(),
+                request.method,
+                request.uri
+            )));
+        }
 
         // Retrieve the captured response from C
         let body = {

--- a/crates/ephpm/src/fatal_signal.rs
+++ b/crates/ephpm/src/fatal_signal.rs
@@ -123,6 +123,28 @@ pub fn install_thread_altstack() {
     unix::install_thread_altstack();
 }
 
+/// Register a stack-overflow crash-containment hook.
+///
+/// The hook is called **first** for every `SIGSEGV`/`SIGBUS`, before any
+/// diagnostic, chaining, or die work — with the faulting address
+/// (`siginfo_t.si_addr`). When the fault is a stack overflow inside a guarded
+/// PHP request the hook recovers via `siglongjmp` and never returns; otherwise
+/// it returns and the handler falls through to its normal report-and-die path,
+/// so a genuine fatal (heap corruption, null deref, a fault outside a guarded
+/// request) still dies with a diagnostic and an unchanged wait status.
+///
+/// The hook **must** be async-signal-safe: it runs in a signal handler that may
+/// be executing on an alternate stack after a stack-overflow fault. ePHPm wires
+/// [`ephpm_php::crash_guard::recover_hook`] here.
+///
+/// Idempotent-ish: the last registration wins. On Windows this is a no-op.
+pub fn set_recover_hook(hook: unsafe extern "C" fn(usize) -> i32) {
+    #[cfg(unix)]
+    unix::set_recover_hook(hook);
+    #[cfg(not(unix))]
+    let _ = hook;
+}
+
 #[cfg(unix)]
 mod unix {
     use std::cell::RefCell;
@@ -261,6 +283,16 @@ mod unix {
 
     /// Installed exactly once.
     static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+    /// Stack-overflow crash-containment hook, as a raw
+    /// `unsafe extern "C" fn(usize) -> i32` address (`0` = none). Consulted
+    /// first thing in [`handler`] for SIGSEGV/SIGBUS. An atomic rather than a
+    /// lock because it is read from a signal handler.
+    static RECOVER_HOOK: AtomicUsize = AtomicUsize::new(0);
+
+    pub(super) fn set_recover_hook(hook: unsafe extern "C" fn(usize) -> i32) {
+        RECOVER_HOOK.store(hook as usize, Ordering::SeqCst);
+    }
 
     /// Captured return addresses. A `static` rather than a local so the
     /// handler's own frame stays small enough for a cramped alternate stack;
@@ -476,6 +508,30 @@ mod unix {
     /// terminates the process, or [`die`] re-raises with the default
     /// disposition.
     extern "C" fn handler(sig: c_int, info: *mut siginfo_t, ctx: *mut c_void) {
+        // Stack-overflow crash containment, first thing: give a registered hook
+        // the faulting address for SIGSEGV/SIGBUS. When the fault is a stack
+        // overflow inside a guarded PHP request the hook siglongjmps back into
+        // that request and never returns here; otherwise it returns and we fall
+        // through to the normal report-and-die path below. Checked before the
+        // OWNER gate so a contained fault never touches the shared handler
+        // state and cannot interfere with a concurrent genuine fatal on another
+        // thread.
+        if matches!(sig, libc::SIGSEGV | libc::SIGBUS) && !info.is_null() {
+            let hook = RECOVER_HOOK.load(Ordering::Acquire);
+            if hook != 0 {
+                // SAFETY: `RECOVER_HOOK` holds a valid
+                // `unsafe extern "C" fn(usize) -> i32` installed by
+                // `set_recover_hook`, contractually async-signal-safe. It may
+                // not return (it siglongjmps on a contained stack overflow),
+                // which is why nothing above it has taken a lock or claimed the
+                // OWNER gate yet.
+                let hook: unsafe extern "C" fn(usize) -> i32 = unsafe {
+                    std::mem::transmute::<usize, unsafe extern "C" fn(usize) -> i32>(hook)
+                };
+                unsafe { hook(fault_addr(info)) };
+            }
+        }
+
         let me = thread_id().wrapping_add(1);
 
         match OWNER.compare_exchange(0, me, Ordering::SeqCst, Ordering::SeqCst) {

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -295,6 +295,13 @@ fn main() -> ExitCode {
     // for the case where the handler itself misbehaves.
     fatal_signal::install();
 
+    // Register the stack-overflow crash-containment hook so the fatal-signal
+    // handler recovers (rather than dying) when a guarded PHP request overflows
+    // the C stack. Harmless in stub mode and until a request arms a guard: the
+    // hook only recovers when the faulting thread is inside `run_guarded` and
+    // the fault address is at this thread's stack guard page.
+    fatal_signal::set_recover_hook(ephpm_php::crash_guard::recover_hook());
+
     match run() {
         Ok(code) => code,
         Err(e) => {


### PR DESCRIPTION
## Spike — DO NOT MERGE

Prototype + rigorous evaluation of **SIGSEGV containment** for ePHPm's single-process ZTS model: when one tenant's PHP overflows the C stack (the pentest's process-killer — a ~50 000-node plain-object linked list whose destruction recurses `zend_object_std_dtor` ↔ `zend_objects_store_del` in C), contain the blast to that request + that thread and keep the process alive, instead of aborting every tenant's site.

**Verdict:** The containment mechanism is **sound and proven for the stack-overflow fault class at runtime**, but two **structural walls** — both rooted in the tokio blocking pool giving no thread-retirement primitive — mean this cannot ship as-is. It is delivered as a reviewable spike + these findings, not a merge candidate, and **not** a crash-recovery-on-a-watcher.

---

## What was built

Unix-only, `#[cfg(php_linked)]`/`#[cfg(unix)]`-gated, stub-testable without libphp.

1. **`crates/ephpm-php/crash_guard.c`** — pure-libc primitive (no PHP headers; compiled on every Unix build so the mechanism is unit-testable):
   - `ephpm_guard_run(work, ctx)` — a per-thread `sigsetjmp(savesigs=1)` recovery region.
   - `ephpm_guard_try_recover(fault_addr)` — **async-signal-safe** classifier: recovers (via `siglongjmp`) **only** when the thread is inside a guarded region *and* `fault_addr` is at/just below this thread's own stack low bound (captured at arm time with `pthread_getattr_np`, never in the handler). Everything else returns 0 → normal fatal path.
2. **`crates/ephpm/src/fatal_signal.rs`** — the existing #253 handler now consults a registered hook **first** for every `SIGSEGV`/`SIGBUS`, before the OWNER gate / report / chain / die. A contained overflow `siglongjmp`s back and never returns; a genuine fatal still dies with an unchanged wait status.
3. **`crates/ephpm-php/src/{crash_guard.rs,lib.rs}`** — `run_guarded` wraps the whole `ephpm_execute_request` call; on containment the thread is marked **poisoned** (its ZMM free lists / `EG(objects_store)` are mid-destruction), the TLS retirement guard is disarmed (so thread exit does **not** run `php_request_shutdown`/`ts_free_thread` on the poisoned heap), and `execute()` refuses further PHP on that thread. New `PhpError::Contained` → 500 via the router's existing error arm.

## The soundness boundary — stated precisely

**Contains:** a C-stack overflow whose fault is confined to **thread-local** Zend state — principally the pentest's plain-object destructor cascade. The freed graph lives entirely in the per-thread ZMM heap and `EG(objects_store)`; the ZMM `mmap`s its own 2 MiB chunks (it does **not** go through glibc `malloc`), so **no process-global allocator lock is held at the fault instant**. The rest of the process is intact, and abandoning the one poisoned thread contains the blast.

**Deliberately re-raises (NOT contained):** heap corruption / wild writes. They produce the same SIGSEGV but may already have corrupted another thread's or the shared allocator's memory; continuing is UB. Told apart by fault address — a wild write lands nowhere near this thread's stack. **Also not covered:** worker mode (`ephpm_worker_run`, a different code path); non-stack SIGABRT (glibc double-free, `abort()`); anything on a thread not inside `run_guarded`.

---

## Proof — measured on a live php_linked build (PHP 8.5.7 ZTS, 2 tenants)

Mechanism, in isolation (stub-mode unit tests, no PHP): a **real** stack overflow inside `run_guarded` is contained, the thread survives and stays reusable, a second overflow is contained too; a **wild write** (null deref) is **not** contained (forked child dies SIGSEGV); normal work is unaffected. 3/3 pass.

Live, `site-a` (data-integrity round-trip through its own tenant DB) + `site-b` (the exact crash):

| Property | Result |
|---|---|
| `site-b` crash | **500 contained** (~19 ms), not a hang, not process death |
| Process survival | **PID survived 100 concurrent + 120 paced crashes**; 0 runtime deaths |
| Survivor data integrity | **0 corruption** across **3 591** concurrent `site-a` requests during the 100-crash storm (491 OK / 0 MISMATCH / 3100 × 500) |
| Self-heal after storm | `site-a` serves 200 OK in 6 ms with correct data; `site-b` still contains |
| False positives | `site-a`'s real DB path **never** falsely contained (8/8 isolation + 491 live OK) |
| Steady-state RSS leak | **Bounded** — plateaus at **~1.1 MB** and stops growing (converged by round 3 of 4; ~0 marginal/crash after settle). Poisoned per-thread heaps reclaim as threads idle out. |
| Normal shutdown | clean SIGTERM, no crash → **exit 0** (unchanged) |

## The two structural walls (why this can't ship as-is)

**1. Co-tenant availability degrades under sustained crashing.** During the 100-crash storm with 16 concurrent `site-a` workers, `site-a`'s success rate was **13.7 %**. Each genuine containment (17 threads got genuinely poisoned) poisons a tokio blocking thread that then **refuses all PHP** (500), and tokio exposes no way to retire+respawn it — so a shrinking pool of healthy threads serves a growing share of 500s until crashing stops and idle-out recycles the pool. Containment converts *permanent whole-process death* into *degraded-but-alive + full recovery* — strictly better than the status quo (one crash = every tenant down until restart), but not isolation.

**2. Graceful shutdown after a contained crash aborts.** SIGTERM after even **one** contained crash → **exit 134**: `php_module_shutdown()`'s `ts_free_id()` walks the **abandoned poisoned TSRM entries** and frees the corrupted heap cross-thread → `zend_mm_heap corrupted` → SIGABRT (the #266 hazard, on the poisoned entries we deliberately leaked). Breaks clean drain for rolling deploys after any tenant crash.

Both walls require moving PHP off tokio's blocking pool onto a **bespoke, lifecycle-controlled thread pool** where a poisoned worker's OS thread is genuinely exited-and-replaced (fixes #1) **and** its TSRM entry is removed before shutdown — a `ts_abandon_thread`-style primitive (remove the `tsrm_tls_table` entry without running dtors) or a skip-`php_module_shutdown`-at-exit (`_exit(0)` after drain) — (fixes #2). That is the real production shape and is **not** a small, safe change for `main`.

## Gates

Stub build green; `crash_guard` unit tests pass; clippy pedantic `-D warnings` clean (stub); nightly fmt clean. `unsafe` blocks carry `// SAFETY:`; the handler path is async-signal-safe (only `__thread` int reads + `siglongjmp`).
