### PR TITLE
chore(deps): bump litewire to cb707ab9 — WP fixes #28-#31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ipnet",
+ "libc",
  "libloading",
  "litewire",
  "metrics",
@@ -2147,7 +2148,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2619,7 +2620,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "anyhow",
  "futures",
@@ -2638,10 +2639,11 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "async-trait",
  "parking_lot",
+ "regex",
  "rusqlite",
  "thiserror 2.0.18",
  "tokio",
@@ -2651,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2666,7 +2668,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -2683,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "async-trait",
  "futures",
@@ -2698,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "litewire-session"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "litewire-backend",
  "litewire-translate",
@@ -2709,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2722,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "lru 0.12.5",
  "parking_lot",
@@ -2734,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=b16d874b73a3#b16d874b73a376d634e3324fc31405c806489240"
+source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3686,7 +3688,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3723,7 +3725,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,27 @@ ephpm-server = { path = "crates/ephpm-server" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ b16d874b — per-connection backend selection (litewire#27).
+# litewire main @ cb707ab9 — WordPress wire-fidelity fixes (litewire#28–#31).
+# Four things, all surfaced by running real WordPress over the MySQL frontend:
+# (1) litewire#28: unparseable/unsupported client commands no longer get a
+# default OK packet from opensrv-mysql's fallthrough — an OK of the wrong
+# shape desynced persistent connections (the client attributed the stray
+# packet to its NEXT command and every later response was off by one).
+# (2) litewire#29: REGEXP / NOT REGEXP and YEAR()/MONTH()/DAYOFMONTH() are
+# translated to SQLite equivalents — WordPress core uses these in date
+# archives and wp_posts date queries.
+# (3) litewire#30: one server version string for the handshake, VERSION() and
+# @@version — they previously disagreed, and WordPress Site Health / wpdb
+# read VERSION() to decide utf8mb4 support.
+# (4) litewire#31: MySQL errno fidelity — no-such-table maps to 1146 (was a
+# generic error) and duplicate-key 1062 carries a MySQL-shaped message, so
+# wpdb/plugin code that matches on errno or message text behaves.
+# Strictly additive on the wire path: no dependency or feature changes, and
+# opensrv-mysql keeps its default features, so the CLIENT_SSL analysis in the
+# b16d874b entry below still holds (litewire#32 tracks pinning that property
+# upstream; still open at this bump).
+#
+# Previous pin b16d874b — per-connection backend selection (litewire#27).
 # Adds `LiteWire::with_authenticator` + the `ConnectionAuthenticator` trait,
 # which is what lets ONE MySQL listener front many per-site databases: the
 # backend is resolved during the handshake from the *authenticated* username,
@@ -240,7 +260,7 @@ ephpm-server = { path = "crates/ephpm-server" }
 # both — this is purely ePHPm de-linking them from the binary. The embedded
 # SQLite-family engine is `turso` only. `hrana` (the Hrana *server* wire
 # frontend, independent of the removed Hrana *client*) is kept.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "b16d874b73a3", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "cb707ab98428", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)


### PR DESCRIPTION
Bumps the litewire pin `b16d874b73a3` → `cb707ab98428` (litewire main HEAD). The compare range contains **exactly four merged PRs, all WordPress wire-fidelity fixes — nothing else rides along**:

- **litewire#28** — unparseable/unsupported client commands (e.g. `COM_STATISTICS`, byte `0x09`) are answered with a proper `ER_UNKNOWN_COM_ERROR` (1047/`08S01`) instead of opensrv-mysql's stray default OK packet, which put persistent connections one packet out of step (every later response belonged to the previous command).
- **litewire#29** — `REGEXP` and `YEAR()`/`MONTH()`/`DAYOFMONTH()`/`DAY()` translate to SQLite equivalents (`CAST(strftime(...) AS INTEGER)`), used by `wp_old_slug_redirect` and `redirect_guess_404_permalink`.
- **litewire#30** — one server version string (`8.0.36-litewire`) for the handshake, `VERSION()` and `@@version`; they previously disagreed (`8.0.36` vs `8.0.0`).
- **litewire#31** — no-such-table maps to errno **1146** / SQLSTATE `42S02` (was the 1105 catch-all); duplicate-key **1062** carries a MySQL-shaped `Duplicate entry ... for key ...` message.

Dependency-wise the bump is inert: the `Cargo.lock` delta is the litewire crate revs only — no transitive version changes, no feature changes. opensrv-mysql keeps its default features, so the `CLIENT_SSL` auth analysis documented on the previous pin still holds (litewire#32, the request to pin that property upstream, is still open and unaffected by this rev).

## Validation (php 8.5.7, linux x86_64-gnu, WSL ext4)

- `cargo test --workspace` (stub) — pass; `cargo clippy --workspace --all-targets -- -D warnings` — clean; `cargo +nightly fmt --check` — clean; `cargo deny check` — advisories/bans/licenses/sources all ok.
- Fresh `cargo xtask release 8.5` build; freshness verified by version-string fingerprint (binary contains `8.0.36-litewire` only; the old pin's `8.0.0-litewire` string is gone). sha256 `48e288b3bd90b2d9d71f1ce3256cd7ad1dcd4339ec2abd4e6a884a480f59ef62`.
- **Full bare-process E2E: all 49 suites passed** against that binary. (One earlier run had 3 suites 504 while the shared box sat at load 40–100 from sibling builds; an old-pin vs new-pin A/B of those suites passed both ways and the full rerun was green, so that was environment, not the pin.)

## WordPress-behavior spot-checks (pdo_mysql through the fresh binary)

| Check | Result |
|---|---|
| `SELECT VERSION()` / `@@version` / handshake (`PDO::ATTR_SERVER_VERSION`) | all three `8.0.36-litewire` |
| `post_name REGEXP '^wp-'` | matches exactly the right row |
| `WHERE YEAR(post_date)=2024 AND MONTH(post_date)=5 AND DAYOFMONTH(post_date)=17` | returns the row, integer values `2024/5/17` |
| 300 sequential mixed queries (plain/prepared/parameterized) on ONE connection, `COM_STATISTICS` injected mid-burst | 300/300 in-order, no desync; the 0x09 draws 1047/`08S01` and the connection continues (server log: `litewire_mysql::command_filter: unsupported MySQL command; replying ER_UNKNOWN_COM_ERROR (1047) command=0x09`) |
| `SELECT` from unknown table | errno **1146**, SQLSTATE **42S02** |
| duplicate key on `UNIQUE` | errno **1062**, SQLSTATE **23000**, `Duplicate entry '<unknown>' for key 'wp_check_posts.post_name ...'` |
| post-error connection sanity | `SELECT 42` → 42 |

One client-side observation (not a litewire bug, no action needed): PHP's mysqlnd parses the ERR reply to `COM_STATISTICS` as if it were the statistics string, so `PDO::ATTR_SERVER_INFO` returns the raw ERR payload bytes rather than throwing. The connection stays in sync either way — which is the property litewire#28 exists to guarantee.
