### PR TITLE
perf(db): per-site registry locking — drop the global open-DB mutex

### DIFF
--- a/crates/ephpm-php/src/db_bridge.rs
+++ b/crates/ephpm-php/src/db_bridge.rs
@@ -257,6 +257,16 @@ struct HeldSession {
     /// The site this session's connection belongs to ([`SINGLE_SITE_KEY`] in
     /// single-backend mode).
     site: Box<str>,
+    /// The litewire session driving this thread's queries for `site`.
+    ///
+    /// **Declared before `_backend` on purpose.** Struct fields drop in
+    /// declaration order, so this releases the site's *connection* before the
+    /// pin below releases the site's *database*. The registry treats
+    /// "`strong_count == 1`" as "idle, safe to close" (see ephpm-server's
+    /// `site_backends`, invariant 2); dropping the pin first would open a
+    /// window — however narrow — in which the registry could close and re-open
+    /// the file while this connection was still alive.
+    session: Session,
     /// Clone of the registry backend `Arc`, held so the site's database stays
     /// open for the session's lifetime and the registry's refcount-aware LRU
     /// never evicts a site with a live session. Never read — its `Drop` (when
@@ -264,8 +274,6 @@ struct HeldSession {
     /// as it releases the site's pin.
     #[allow(dead_code)]
     _backend: SharedBackend,
-    /// The litewire session driving this thread's queries for `site`.
-    session: Session,
 }
 
 /// The MySQL error triple staged for the C side after a failed `run`.
@@ -416,23 +424,40 @@ pub fn run_sql_bytes(sql: &[u8]) -> RunStatus {
     run_on(DB_BRIDGE.get(), sql)
 }
 
-/// The site key this request's queries belong to, from a bridge's
-/// [`BackendSource`]. In per-site mode this reads the thread-local key set by
-/// [`set_current_site`] and **fails closed** if none is present — it never
-/// substitutes a shared/default database. Cheap: no backend is opened here, so
-/// same-site consecutive queries never touch the registry.
-fn current_site_key(source: &BackendSource) -> Result<Box<str>, BridgeError> {
+/// The site this thread's session must belong to, compared against the site it
+/// *does* belong to (`held_site`, `None` when the thread has no session yet).
+///
+/// Returns `None` when the held session already matches — the common case, on
+/// which nothing is allocated and the registry is never touched. Returns
+/// `Some(key)` (a fresh owned copy, needed to re-key the session) only when a
+/// swap is required.
+///
+/// In per-site mode the key comes from the thread-local set by
+/// [`set_current_site`] and this **fails closed** if none is present — it never
+/// substitutes a shared/default database.
+fn site_swap_target(
+    source: &BackendSource,
+    held_site: Option<&str>,
+) -> Result<Option<Box<str>>, BridgeError> {
     match source {
-        BackendSource::Single(_) => Ok(Box::from(SINGLE_SITE_KEY)),
-        BackendSource::PerSite(_) => {
-            DB_CURRENT_SITE.with(|s| s.borrow().clone()).ok_or_else(|| BridgeError {
-                code: ER_UNKNOWN_ERROR,
-                sqlstate: *b"HY000",
-                message: "no per-site database context for this request — multi-site database \
-                          isolation could not determine the tenant"
-                    .to_string(),
-            })
-        }
+        BackendSource::Single(_) => Ok(if held_site == Some(SINGLE_SITE_KEY) {
+            None
+        } else {
+            Some(Box::from(SINGLE_SITE_KEY))
+        }),
+        BackendSource::PerSite(_) => DB_CURRENT_SITE.with(|s| {
+            let current = s.borrow();
+            let Some(current) = current.as_deref() else {
+                return Err(BridgeError {
+                    code: ER_UNKNOWN_ERROR,
+                    sqlstate: *b"HY000",
+                    message: "no per-site database context for this request — multi-site \
+                              database isolation could not determine the tenant"
+                        .to_string(),
+                });
+            };
+            Ok(if held_site == Some(current) { None } else { Some(Box::from(current)) })
+        }),
     }
 }
 
@@ -481,11 +506,6 @@ fn run_on(bridge: Option<&DbBridge>, sql: &[u8]) -> RunStatus {
         });
     }
 
-    let site = match current_site_key(&bridge.source) {
-        Ok(site) => site,
-        Err(e) => return stage_error(e),
-    };
-
     let outcome = DB_HELD.with(|slot| {
         let mut slot = slot.borrow_mut();
 
@@ -493,9 +513,10 @@ fn run_on(bridge: Option<&DbBridge>, sql: &[u8]) -> RunStatus {
         // a thread that served site A must never run site B's query on A's
         // connection. Within one request the site is fixed, so this only ever
         // fires between requests. The registry lookup happens only here — a
-        // same-site consecutive query reuses the held session untouched.
-        let needs_new = slot.as_ref().is_none_or(|held| held.site.as_ref() != site.as_ref());
-        if needs_new {
+        // same-site consecutive query reuses the held session untouched, and
+        // does not even copy the site key.
+        let swap_to = site_swap_target(&bridge.source, slot.as_ref().map(|h| h.site.as_ref()))?;
+        if let Some(site) = swap_to {
             let backend = backend_for(&bridge.source, &site)?;
             if let Some(old) = slot.as_mut() {
                 // Defensive: the previous site's session should not be
@@ -519,13 +540,13 @@ fn run_on(bridge: Option<&DbBridge>, sql: &[u8]) -> RunStatus {
             match bridge.handle.block_on(backend.connect()) {
                 Ok(conn) => {
                     *slot = Some(HeldSession {
-                        site: site.clone(),
-                        _backend: backend,
+                        site,
                         session: Session::with_cache(
                             conn,
                             Dialect::MySQL,
                             Arc::clone(&bridge.cache),
                         ),
+                        _backend: backend,
                     });
                 }
                 Err(e) => {

--- a/crates/ephpm-server/src/site_backends.rs
+++ b/crates/ephpm-server/src/site_backends.rs
@@ -19,51 +19,138 @@
 //! evicts the least-recently-used **idle** site (one with no live bridge
 //! session) to make room. A later request for an evicted site re-opens it.
 //!
-//! # The correctness core: LRU eviction vs. live sessions, and single-open
+//! # Shape: one permanent slot per site, one lock per slot
 //!
-//! Two invariants must hold together:
+//! The registry is a [`DashMap`] from site key to a **permanent**
+//! [`SiteSlot`]. The slot — not the map — owns that site's database:
 //!
-//! 1. **Never evict a site with a live session.** The `ephpm_db_*` bridge keeps
+//! ```text
+//!   DashMap<site key, Arc<SiteSlot>>        (sharded; never removes an entry)
+//!                       │
+//!                       └── SiteSlot { current: RwLock<Option<backend>>, … }
+//!                                              ▲
+//!                            read  = resolve an already-open database
+//!                            write = open it, or evict (close) it
+//! ```
+//!
+//! Consequences, in the order they matter:
+//!
+//! * **A hit takes no global lock.** Resolving an already-open site is a
+//!   sharded map read plus a *read* acquisition of that one site's lock. Two
+//!   requests for different sites never touch the same lock, and two requests
+//!   for the *same* site share the read side.
+//! * **A miss serializes per site, not globally.** Opening `<site>.db` happens
+//!   under that slot's **write** lock, so concurrent first-requests for one
+//!   site open it once and the rest observe the result — but opening site A
+//!   does not delay resolving site B. (Before v0.7.1 a single registry mutex
+//!   was held across every open, which is what made the past-cap open/evict
+//!   path collapse throughput ~3.6× in the multi-tenant scaling benchmark:
+//!   every request, hit or miss, queued behind whichever request was opening a
+//!   file.)
+//! * **Slots are never removed.** Eviction closes the database *inside* the
+//!   slot; the slot itself stays in the map forever. See the invariants below —
+//!   this is what makes per-slot locking sound.
+//!
+//! # The correctness core: three invariants
+//!
+//! 1. **One slot per site key, for the life of the process.** A slot is the
+//!    per-site lock, so two slots for one key would be two independent locks —
+//!    and therefore two concurrent opens of one file. `slots` is append-only:
+//!    nothing ever removes an entry, so an `Arc<SiteSlot>` cloned out of the
+//!    map is *always* the current slot for that key and can be used after the
+//!    map guard is dropped. (Removing idle slots would save a few dozen bytes
+//!    per site and reintroduce that race; the slot map is bounded by the number
+//!    of distinct **valid** site keys the process serves, which is bounded by
+//!    the vhost directories on disk — an unknown host resolves to no site key
+//!    at all, and the per-site MySQL listener verifies the tenant's password
+//!    before it ever resolves. An invalid key is rejected *before* a slot is
+//!    created, so no caller can grow the map by naming files.)
+//!
+//! 2. **Never evict a site with a live session.** The `ephpm_db_*` bridge keeps
 //!    a per-thread [`Session`](litewire::Session) that holds a clone of a site's
-//!    backend `Arc`. Eviction is therefore *refcount-aware*: a site is a victim
-//!    only when `Arc::strong_count` of its backend is `1` (only the registry
-//!    holds it → no live session). This makes the fd cap a **soft** bound — a
-//!    site pinned by a live session stays open past the cap — but it guarantees
-//!    eviction never yanks a database out from under a running query.
+//!    backend `Arc`, as does every `pdo_mysql` connection on the per-site wire
+//!    listener. Eviction is therefore *refcount-aware*: a site is a victim only
+//!    when `Arc::strong_count` of its backend is `1` (only the slot holds it →
+//!    no live session). This makes the fd cap a **soft** bound — a site pinned
+//!    by a live session stays open past the cap — but it guarantees eviction
+//!    never yanks a database out from under a running query. The count is read
+//!    while holding the slot's **write** lock, and a resolver can only clone
+//!    the backend while holding its **read** lock, so the check can never race
+//!    a clone: a resolver that got there first has already raised the count to
+//!    2 and the slot is skipped.
 //!
-//! 2. **At most one open handle per file at any instant.** Turso's
+//! 3. **At most one open handle per file at any instant.** Turso's
 //!    multi-*process* restriction is documented, but two `Database` handles on
-//!    one file *in one process* is unverified and treated as unsafe. To make it
-//!    impossible, the registry serializes all opens/evicts/lookups under a
-//!    single async mutex and holds it **across** the open. Combined with
-//!    invariant 1 (a removed entry always had `strong_count == 1`, so removing
-//!    it drops the last reference and closes the file before any re-open can
-//!    begin), no two handles for one file can ever coexist. The cost — opens
-//!    serialize behind the mutex — is paid only on a site's first request
-//!    (rare) and naturally damps cold-start open storms.
+//!    one file *in one process* is unverified and treated as unsafe. Every
+//!    transition of `current` — `None → Some` (open) and `Some → None`
+//!    (evict) — happens under that slot's write lock, and the open `await`s
+//!    and the close `drop`s *inside* the guarded region. Since invariant 1
+//!    guarantees exactly one slot (and therefore one such lock) per file, an
+//!    open can never overlap another open or a close of the same file. On the
+//!    close side, invariant 2 means the taken `Arc` is the last reference, so
+//!    dropping it under the guard closes the file before any re-open can begin.
+//!
+//! # Cap accounting
+//!
+//! With slots permanent, "how many databases are open" is no longer the map's
+//! length: it is `open_count`, an atomic bumped on `None → Some` and dropped on
+//! `Some → None`, both under the owning slot's write lock. Eviction runs after
+//! an open pushes the count over `max_open`, walks the open slots oldest-first
+//! and closes idle ones until the count is back under the cap. Two concurrent
+//! opens can both trigger a pass; that is harmless (each close is individually
+//! guarded, and the passes re-read the count), it just means the cap is
+//! enforced eventually rather than instantaneously — as it already was, given
+//! invariant 2 lets live sessions exceed it outright.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Instant;
 
 use anyhow::Context as _;
+use dashmap::DashMap;
 use ephpm_php::db_bridge::SiteBackendResolver;
 use litewire::backend::SharedBackend;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::tracked_backend::TrackedBackend;
 
-/// One cached open database.
-struct Entry {
-    /// The erased, stats-wrapped Turso backend for this site. Its
-    /// `Arc::strong_count` is what makes eviction refcount-aware: `1` means
-    /// only the registry holds it (idle), `> 1` means at least one thread has a
-    /// live [`Session`](litewire::Session) into it.
-    backend: SharedBackend,
+/// One site's permanent registry slot: its database (when open) plus the lock
+/// that serializes opening and closing *that site* and nothing else.
+struct SiteSlot {
+    /// The site's erased, stats-wrapped Turso backend while it is open.
+    ///
+    /// Read-locked to resolve (hot path), write-locked to open or evict. The
+    /// `Arc::strong_count` of the value inside is what makes eviction
+    /// refcount-aware: `1` means only this slot holds it (idle), `> 1` means at
+    /// least one thread has a live [`Session`](litewire::Session) or wire
+    /// connection into it.
+    current: RwLock<Option<SharedBackend>>,
+    /// Lock-free hint for the eviction scan: roughly "is `current` populated".
+    /// Written under the write lock alongside `current`, read with no lock at
+    /// all, and only ever used to *skip* slots — the authoritative check
+    /// happens under the write lock in [`SiteBackends::close_if_idle`], so a
+    /// stale read can at worst cost one wasted candidate or skip a victim this
+    /// pass.
+    open: AtomicBool,
     /// Milliseconds since the registry epoch at the last access — the LRU key.
     last_used: AtomicU64,
+}
+
+impl SiteSlot {
+    /// A fresh slot for a site whose database is not open yet.
+    fn new(now: u64) -> Self {
+        Self {
+            current: RwLock::new(None),
+            open: AtomicBool::new(false),
+            last_used: AtomicU64::new(now),
+        }
+    }
+
+    /// Record an access for the LRU.
+    fn touch(&self, now: u64) {
+        self.last_used.store(now, Ordering::Relaxed);
+    }
 }
 
 /// Shared inner state, held behind an `Arc` so [`SiteBackends`] is cheap to
@@ -81,9 +168,18 @@ struct Inner {
     handle: tokio::runtime::Handle,
     /// Monotonic base for `last_used` timestamps.
     epoch: Instant,
-    /// The open-database cache. A single async mutex guards it and is held
-    /// across opens — see the module docs, invariant 2.
-    open: Mutex<HashMap<Box<str>, Entry>>,
+    /// Append-only map of site key → its permanent slot. See the module docs,
+    /// invariant 1, for why entries are never removed.
+    slots: DashMap<Box<str>, Arc<SiteSlot>>,
+    /// How many slots currently hold an open database — the quantity
+    /// `max_open` bounds. Maintained under the owning slot's write lock.
+    open_count: AtomicUsize,
+    /// Total databases opened since startup (diagnostics and tests: it is how
+    /// a test proves a concurrent stampede opened one file once).
+    opens_total: AtomicU64,
+    /// Registry-epoch milliseconds of the last "cannot meet the cap" warning,
+    /// `0` for never. Throttles it — see [`SiteBackends::warn_cap_pinned`].
+    last_cap_warn: AtomicU64,
 }
 
 /// Per-site backend registry. Cheap to clone (shares one [`Inner`]).
@@ -122,7 +218,10 @@ impl SiteBackends {
                 query_stats,
                 handle,
                 epoch: Instant::now(),
-                open: Mutex::new(HashMap::new()),
+                slots: DashMap::new(),
+                open_count: AtomicUsize::new(0),
+                opens_total: AtomicU64::new(0),
+                last_cap_warn: AtomicU64::new(0),
             }),
         })
     }
@@ -135,8 +234,15 @@ impl SiteBackends {
 
     /// Number of databases currently held open (test/observability helper).
     #[cfg(test)]
-    async fn open_count(&self) -> usize {
-        self.inner.open.lock().await.len()
+    fn open_count(&self) -> usize {
+        self.inner.open_count.load(Ordering::Relaxed)
+    }
+
+    /// Number of database opens performed since startup (test helper): a
+    /// concurrent stampede on one cold site must add exactly one.
+    #[cfg(test)]
+    fn opens_total(&self) -> u64 {
+        self.inner.opens_total.load(Ordering::Relaxed)
     }
 
     /// Milliseconds since the registry epoch, saturating.
@@ -180,6 +286,7 @@ impl SiteBackends {
         let turso = litewire::Turso::open(path_str).await.with_context(|| {
             format!("failed to open per-site database for {site_key}: {path_str}")
         })?;
+        self.inner.opens_total.fetch_add(1, Ordering::Relaxed);
         tracing::info!(site = site_key, path = path_str, "opened per-site database (Turso engine)");
         // Screening sits innermost, against the raw engine: it must see exactly
         // the SQL the engine would run (the wire path's statements arrive here
@@ -191,8 +298,36 @@ impl SiteBackends {
         Ok(Arc::new(TrackedBackend::new(screened, self.inner.query_stats.clone())))
     }
 
-    /// Get-or-open the backend for `site_key`. Serialized under the registry
-    /// mutex (held across the open) — see the module docs, invariant 2.
+    /// The permanent slot for `site_key`, creating it on first sighting.
+    ///
+    /// A key that is not a valid site key is rejected **before** a slot is
+    /// created, so the slot map can only ever grow by real, router-approved (or
+    /// password-verified) tenants — see the module docs, invariant 1.
+    ///
+    /// # Errors
+    ///
+    /// Fails when `site_key` is not a valid site key.
+    fn slot_for(&self, site_key: &str) -> anyhow::Result<Arc<SiteSlot>> {
+        if let Some(slot) = self.inner.slots.get(site_key) {
+            return Ok(Arc::clone(slot.value()));
+        }
+        // First sighting: validate the key (which is also what derives the
+        // path) before anything is allocated for it.
+        self.db_path_for(site_key)?;
+        let now = self.now_millis();
+        let entry = self
+            .inner
+            .slots
+            .entry(Box::from(site_key))
+            .or_insert_with(|| Arc::new(SiteSlot::new(now)));
+        Ok(Arc::clone(entry.value()))
+    }
+
+    /// Get-or-open the backend for `site_key`.
+    ///
+    /// A hit takes no global lock (sharded map read + this site's read lock); a
+    /// miss serializes only against other requests for the *same* site. See the
+    /// module docs for the invariants that keeps intact.
     ///
     /// Shared by both tenant paths: the `ephpm_db_*` bridge (through
     /// [`SiteBackendResolver::resolve`]) and the multi-tenant MySQL wire
@@ -208,58 +343,134 @@ impl SiteBackends {
     /// callers treat that as "no database for this request/connection" — never
     /// as a reason to fall back to another site's.
     pub(crate) async fn get_or_open(&self, site_key: &str) -> anyhow::Result<SharedBackend> {
-        let mut open = self.inner.open.lock().await;
+        let slot = self.slot_for(site_key)?;
 
-        if let Some(entry) = open.get(site_key) {
-            entry.last_used.store(self.now_millis(), Ordering::Relaxed);
-            // Clone under the lock: eviction (which needs the same lock) can
-            // never observe `strong_count == 1` racing this clone.
-            return Ok(Arc::clone(&entry.backend));
+        // Hot path: already open. The clone happens under the read lock, so
+        // eviction (which needs the write lock) can never observe
+        // `strong_count == 1` racing it.
+        {
+            let current = slot.current.read().await;
+            if let Some(backend) = current.as_ref() {
+                slot.touch(self.now_millis());
+                return Ok(Arc::clone(backend));
+            }
         }
 
-        // Miss: derive+validate the path, then open with the lock still held so
-        // no second handle for this file can be created concurrently.
+        // Miss: open under this site's write lock. Every other site's resolve
+        // proceeds untouched; concurrent first-requests for *this* site queue
+        // here and take the branch below.
         let path = self.db_path_for(site_key)?;
+        let mut current = slot.current.write().await;
+        if let Some(backend) = current.as_ref() {
+            // Someone else opened it while we waited for the lock.
+            slot.touch(self.now_millis());
+            return Ok(Arc::clone(backend));
+        }
         let backend = self.open_backend(site_key, &path).await?;
-        open.insert(
-            Box::from(site_key),
-            Entry { backend: Arc::clone(&backend), last_used: AtomicU64::new(self.now_millis()) },
-        );
-        self.evict_over_cap(&mut open, site_key);
+        *current = Some(Arc::clone(&backend));
+        slot.open.store(true, Ordering::Relaxed);
+        slot.touch(self.now_millis());
+        let open_now = self.inner.open_count.fetch_add(1, Ordering::Relaxed) + 1;
+        drop(current);
+
+        if open_now > self.inner.max_open {
+            self.evict_over_cap(site_key);
+        }
         Ok(backend)
     }
 
-    /// Evict least-recently-used **idle** databases until the cap is met.
-    /// Runs under the held registry lock. `protect` (the site just opened) is
-    /// never evicted.
-    fn evict_over_cap(&self, open: &mut HashMap<Box<str>, Entry>, protect: &str) {
-        while open.len() > self.inner.max_open {
-            // Pick the idle (strong_count == 1) entry with the oldest last_used.
-            let victim = open
-                .iter()
-                .filter(|(k, e)| k.as_ref() != protect && Arc::strong_count(&e.backend) == 1)
-                .min_by_key(|(_, e)| e.last_used.load(Ordering::Relaxed))
-                .map(|(k, _)| k.clone());
+    /// Close least-recently-used **idle** databases until `max_open` is met
+    /// again. `protect` (the site just opened) is never a victim.
+    ///
+    /// One pass: it snapshots the open slots oldest-first and closes what it
+    /// can. A pass that frees nothing means every open database is pinned by a
+    /// live session or busy being opened — the cap is soft by design (module
+    /// docs, invariant 2), so it warns and gives up rather than spinning.
+    fn evict_over_cap(&self, protect: &str) {
+        let mut candidates: Vec<(u64, Arc<SiteSlot>)> = self
+            .inner
+            .slots
+            .iter()
+            .filter(|e| e.key().as_ref() != protect && e.value().open.load(Ordering::Relaxed))
+            .map(|e| (e.value().last_used.load(Ordering::Relaxed), Arc::clone(e.value())))
+            .collect();
+        candidates.sort_unstable_by_key(|(last_used, _)| *last_used);
 
-            match victim {
-                Some(k) => {
-                    // Removing the last reference (strong_count was 1) drops the
-                    // backend and closes the file — before any re-open can start,
-                    // because that would need this same lock.
-                    open.remove(&k);
-                    tracing::debug!(site = %k, "evicted idle per-site database (LRU, over cap)");
-                }
-                None => {
-                    tracing::warn!(
-                        open = open.len(),
-                        cap = self.inner.max_open,
-                        "all open per-site databases have live sessions — cannot evict to meet \
-                         max_open_dbs; the open-fd count is temporarily over the configured cap"
-                    );
-                    break;
-                }
+        let mut closed = 0usize;
+        for (_, slot) in candidates {
+            if self.inner.open_count.load(Ordering::Relaxed) <= self.inner.max_open {
+                break;
+            }
+            if self.close_if_idle(&slot) {
+                closed += 1;
             }
         }
+
+        if closed == 0 {
+            self.warn_cap_pinned();
+        } else {
+            tracing::debug!(closed, "evicted idle per-site databases (LRU, over cap)");
+        }
+    }
+
+    /// Warn that the cap cannot currently be met — at most once every 10s.
+    ///
+    /// Throttled because the condition is not rare: whenever `max_open_dbs` is
+    /// below the number of *concurrently active* sites, every request finds
+    /// every open database pinned, and an unthrottled warning would cost more
+    /// than the eviction pass that produced it (and would bury the log).
+    fn warn_cap_pinned(&self) {
+        const EVERY_MS: u64 = 10_000;
+        let now = self.now_millis();
+        let last = self.inner.last_cap_warn.load(Ordering::Relaxed);
+        if last != 0 && now.saturating_sub(last) < EVERY_MS {
+            return;
+        }
+        // Lose the race → someone else is emitting it right now; stay quiet.
+        if self
+            .inner
+            .last_cap_warn
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+        tracing::warn!(
+            open = self.inner.open_count.load(Ordering::Relaxed),
+            cap = self.inner.max_open,
+            "all open per-site databases have live sessions — cannot evict to meet \
+             max_open_dbs; the open-fd count is temporarily over the configured cap \
+             (further occurrences within 10s are suppressed)"
+        );
+    }
+
+    /// Close one slot's database if it is open and idle. Returns whether it
+    /// closed anything.
+    ///
+    /// `try_write` rather than `write`: a slot that is mid-open (or being read
+    /// by a resolver right now) is not a victim, and blocking here would put
+    /// the evicting request back behind exactly the serialization this registry
+    /// exists to avoid. Skipping is always safe — the cap is soft.
+    fn close_if_idle(&self, slot: &SiteSlot) -> bool {
+        let Ok(mut current) = slot.current.try_write() else {
+            return false;
+        };
+        // Idle == the slot holds the only reference. Checked under the write
+        // lock, so no resolver can be cloning it concurrently (module docs,
+        // invariant 2).
+        match current.as_ref() {
+            Some(backend) if Arc::strong_count(backend) == 1 => {}
+            _ => return false,
+        }
+        let backend = current.take();
+        slot.open.store(false, Ordering::Relaxed);
+        self.inner.open_count.fetch_sub(1, Ordering::Relaxed);
+        // Drop the last reference — which closes the file — while the write
+        // lock is still held, so no re-open of this database can begin before
+        // the old handle is gone (module docs, invariant 3).
+        drop(backend);
+        drop(current);
+        true
     }
 }
 
@@ -323,11 +534,13 @@ mod tests {
         let a1 = reg.get_or_open("site-a.test").await.expect("open");
         let a2 = reg.get_or_open("site-a.test").await.expect("open again");
         assert!(Arc::ptr_eq(&a1, &a2), "second open must reuse the cached backend");
-        assert_eq!(reg.open_count().await, 1);
+        assert_eq!(reg.open_count(), 1);
+        assert_eq!(reg.opens_total(), 1);
     }
 
     /// An invalid (traversal) site key is rejected rather than opening a file
-    /// outside `dir`.
+    /// outside `dir` — and, since a slot is the per-site open lock, it must not
+    /// leave a slot behind either (module docs, invariant 1).
     #[tokio::test]
     async fn invalid_key_is_rejected() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -335,6 +548,7 @@ mod tests {
         assert!(reg.get_or_open("../etc/passwd").await.is_err());
         assert!(reg.get_or_open("a/b").await.is_err());
         assert!(reg.get_or_open("").await.is_err());
+        assert_eq!(reg.inner.slots.len(), 0, "an invalid key must not allocate a slot");
     }
 
     /// LRU evicts an idle database when over cap, but never one pinned by a
@@ -347,23 +561,140 @@ mod tests {
         // Open A and hold a clone — simulates a live per-thread session pinning
         // A's database open.
         let a_live = reg.get_or_open("a.test").await.expect("open a");
-        assert_eq!(reg.open_count().await, 1);
+        assert_eq!(reg.open_count(), 1);
 
         // Open B: over cap, but A is pinned (strong_count > 1), so A cannot be
         // evicted — both stay open (soft bound), and a warning is logged.
         let _b = reg.get_or_open("b.test").await.expect("open b");
-        assert_eq!(reg.open_count().await, 2, "A is pinned by a live clone; cannot evict it");
+        assert_eq!(reg.open_count(), 2, "A is pinned by a live clone; cannot evict it");
 
-        // Drop the live pin; A becomes idle (strong_count == 1 in the registry).
+        // Drop the live pin; A becomes idle (only the slot holds it).
         drop(a_live);
 
         // Open C: now the LRU can evict an idle victim to meet the cap of 1.
         let _c = reg.get_or_open("c.test").await.expect("open c");
-        assert!(reg.open_count().await <= 2, "eviction should reclaim at least one idle db");
+        assert!(reg.open_count() <= 2, "eviction should reclaim at least one idle db");
 
         // Re-requesting an evicted site re-opens it correctly.
         let a_again = reg.get_or_open("a.test").await.expect("re-open a");
         let a_conn = a_again.connect().await.expect("connect re-opened a");
         a_conn.query("SELECT 1", &[]).await.expect("evicted db re-opens and works");
+    }
+
+    /// A stampede of concurrent resolves for one cold site opens the file
+    /// **once** and hands everyone the same backend — the per-site write lock
+    /// doing its job (module docs, invariant 3).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_resolve_of_one_cold_site_opens_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let reg = registry(tmp.path().to_path_buf(), 64);
+
+        let tasks: Vec<_> = (0..32)
+            .map(|_| {
+                let reg = reg.clone();
+                tokio::spawn(async move { reg.get_or_open("hot.test").await.expect("resolve") })
+            })
+            .collect();
+
+        let mut backends = Vec::new();
+        for t in tasks {
+            backends.push(t.await.expect("join"));
+        }
+
+        let first = &backends[0];
+        assert!(
+            backends.iter().all(|b| Arc::ptr_eq(b, first)),
+            "every concurrent resolve must get the one backend instance"
+        );
+        assert_eq!(reg.opens_total(), 1, "the file must have been opened exactly once");
+        assert_eq!(reg.open_count(), 1);
+    }
+
+    /// Concurrent resolves of *different* cold sites all succeed and each opens
+    /// its own file exactly once — the case a global open lock serialized.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_resolve_of_distinct_sites() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let reg = registry(tmp.path().to_path_buf(), 64);
+
+        let tasks: Vec<_> = (0..24)
+            .map(|i| {
+                let reg = reg.clone();
+                tokio::spawn(async move {
+                    let key = format!("site-{i:03}.test");
+                    let backend = reg.get_or_open(&key).await.expect("resolve");
+                    // Each handle is usable, i.e. it is a real open database.
+                    let conn = backend.connect().await.expect("connect");
+                    conn.query("SELECT 1", &[]).await.expect("query");
+                    key
+                })
+            })
+            .collect();
+
+        for t in tasks {
+            let key = t.await.expect("join");
+            assert!(tmp.path().join(format!("{key}.db")).exists());
+        }
+        assert_eq!(reg.opens_total(), 24);
+        assert_eq!(reg.open_count(), 24);
+    }
+
+    /// The cap is enforced once the pins are gone: opening `cap + 8` sites with
+    /// no live sessions leaves at most `cap` open.
+    #[tokio::test]
+    async fn cap_is_enforced_for_idle_sites() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let reg = registry(tmp.path().to_path_buf(), 4);
+
+        for i in 0..12 {
+            // Dropping the returned backend immediately makes each site idle,
+            // so the LRU always has a victim available.
+            drop(reg.get_or_open(&format!("s-{i:02}.test")).await.expect("open"));
+        }
+
+        assert!(
+            reg.open_count() <= 4,
+            "open databases ({}) must be bounded by the cap once sites are idle",
+            reg.open_count()
+        );
+        assert_eq!(reg.inner.slots.len(), 12, "slots are permanent, one per site key");
+    }
+
+    /// Eviction racing concurrent resolves of the same sites: with a tight cap
+    /// and many workers churning a small site set, every resolve must still
+    /// return a *working* database. A handle closed out from under a caller —
+    /// or a second handle opened on a file whose first handle was still alive —
+    /// would surface here as a query error.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn eviction_races_resolve_without_losing_a_database() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Cap far below the working set, so nearly every resolve triggers an
+        // open and an eviction pass.
+        let reg = registry(tmp.path().to_path_buf(), 2);
+
+        let tasks: Vec<_> = (0..16)
+            .map(|w| {
+                let reg = reg.clone();
+                tokio::spawn(async move {
+                    for round in 0..12 {
+                        let key = format!("race-{}.test", (w + round) % 8);
+                        let backend = reg.get_or_open(&key).await.expect("resolve");
+                        let conn = backend.connect().await.expect("connect");
+                        conn.query("SELECT 1", &[]).await.expect("query on a live handle");
+                    }
+                })
+            })
+            .collect();
+
+        for t in tasks {
+            t.await.expect("worker");
+        }
+
+        // Every query above ran on a handle the registry handed out while
+        // eviction was actively closing databases; that they all succeeded is
+        // the assertion. What is left must still be bounded by the working set,
+        // and every site must have been opened at least once.
+        assert!(reg.opens_total() >= 8, "each of the 8 sites must have been opened at least once");
+        assert!(reg.open_count() <= 8, "open count ({}) ran away under churn", reg.open_count());
     }
 }


### PR DESCRIPTION
## What

`SiteBackends` — the per-site (multi-tenant) database registry — guarded its open-database map with **one** `tokio::sync::Mutex`, taken on **every** resolve and held **across** the file open. That was deliberate: holding it across the open is what guaranteed "at most one Turso handle per file". It was also the throughput wall the multi-tenant scaling benchmark found, and past `max_open_dbs` it collapsed throughput ~3.6× while CPU *dropped* to ~2 of 32 cores — threads blocked, they did not work.

This replaces the map+mutex with a `DashMap` of **permanent per-site slots**, each owning its database behind its own `RwLock<Option<SharedBackend>>`:

* a **hit** is a sharded map read plus that one site's read lock — no global lock, and two different sites never contend;
* a **miss** serializes **per site**: the open happens under that slot's write lock, so opening site A no longer delays resolving site B;
* **eviction** closes the database *inside* the slot (the slot itself is never removed) under the same write lock.

## How the invariants survive

The module docs spell out three; the load-bearing one is new.

1. **One slot per site key, for the life of the process.** The slot *is* the per-site open lock, so two slots for one key would be two locks and therefore two concurrent opens of one file. `slots` is append-only — nothing removes an entry — so an `Arc<SiteSlot>` cloned out of the map is always the current slot for that key and stays valid after the map guard is dropped. That is what makes it sound to await on a slot's lock without holding a map guard. Pruning idle slots would save a few dozen bytes per site and reintroduce exactly that race; the map is bounded by the number of distinct **valid** site keys the process serves (an unknown Host resolves to no site key, the wire listener verifies the tenant password before resolving, and an invalid key is rejected *before* a slot is created — `invalid_key_is_rejected` asserts the map stays empty).

2. **Never evict a site with a live session** — unchanged in meaning (`Arc::strong_count == 1` ⇒ only the registry holds it ⇒ no live bridge session or `pdo_mysql` connection), but now checked under the slot's **write** lock. A resolver can only clone the backend under that slot's **read** lock, so the check still cannot race a clone: a resolver that got there first has already raised the count to 2 and the slot is skipped. The fd cap stays **soft** — a pinned site stays open past it.

3. **At most one open handle per file at any instant.** Every transition of `current` — `None → Some` (open) and `Some → None` (evict) — happens under that slot's write lock, with the open `await`ed and the close `drop`ped *inside* the guarded region. Invariant 1 gives exactly one such lock per file, so an open can never overlap another open or a close of the same file; invariant 2 means the taken `Arc` is the last reference, so the file is closed before any re-open can begin.

Cap accounting moves from "map length" to an atomic bumped/dropped under the owning slot's write lock, since the map no longer shrinks. The "cannot meet the cap" warning is throttled to once per 10s — with a cap below the live concurrency it fires on every request, and an unthrottled `warn!` costs more than the eviction pass that produced it.

### Bridge (`ephpm-php`), two small things

* `site_swap_target` replaces `current_site_key`: the common case (this thread's session already belongs to the request's site) no longer copies the site key into a fresh `Box<str>` on **every query** — ~90k allocations/s on the benchmark's front-page workload. The registry is still only consulted on a session swap, as before.
* `HeldSession` now declares `session` before `_backend`, so a swapped-out session drops its **connection** before it releases the pin on the site's **database**. Dropping the pin first left a (narrow) window in which the registry could see `strong_count == 1`, close the file and re-open it while that connection was still alive.

## Measured

Same box (WSL2, 32 vCPU), same binary except this change, `wp-lite`, concurrency 128, 8s warmup + 20s measured, DBs and docroot on native ext4. Three interleaved A/B pairs per point; medians below, every individual pair improved.

| point | | baseline | this PR | |
|---|---|---:|---:|---|
| **warm** — cap=4096, N=250 (every site resident) | RPS | 13,312 | **17,832** | **+34%** |
| | p50 | 8.8 ms | 6.2 ms | |
| | CPU | 16.3 cores | 21.7 cores | |
| **churn** — cap=256, N=500 (past the cap; nearly every request opens+evicts) | RPS | 1,292 | **3,163** | **+145%** |
| | p50 | 92 ms | 43 ms | |
| | CPU | 2.0 cores | 9.8 cores | |

0 errors, 100% 2xx at every point, both binaries. The CPU column is the real story on the churn point: the same work now runs on ~10 cores instead of blocking on ~2.

**fd honesty:** the cap is soft, and this version overshoots it *more* under churn — peak fds at cap=256/N=500 went 656 → 723-909 (≈258 → ≈290-385 open databases). That is not a leak: at 2.4× the throughput there are simply more in-flight sessions pinning their databases, and a pinned database is not evictable under any locking scheme. Size `RLIMIT_NOFILE` with headroom over `2 × max_open_dbs`, as the docs already say.

## Also found: the lab's "~4.7k plateau" is a harness artifact

`multitenant-scalebench`'s `run_sweep.sh` is executed from the repo checkout on `/mnt/c`, so the ephpm process inherits a **DrvFs working directory**. Same binary, same config, same provisioned state, only the server's cwd differs:

* cwd `/root/...` (ext4): **15,900 RPS**
* cwd `/mnt/c/...` (DrvFs): **4,164 RPS**

So the report's "~4.6-4.8k RPS at only ~5 of 32 cores, warm cache or not" is the 9p/DrvFs syscall cost per request, not the registry. Under that handicap this PR shows no ceiling change on the warm point (~4.0k both) — but it does remove a **bistable collapse**: across 8 baseline runs at the warm point, 3 fell into a ~1.6k/2.3-core convoy and stayed there for the whole measurement window; across 7 runs of this PR, 0 did. The churn point still improved +130% (1,244 → 2,867) even with the DrvFs wall in place. The lab harness should `cd` to a native run dir before starting the server; the sizing conclusions drawn from those numbers need re-basing.

## Tests

New in `site_backends`, all stub-mode:

* `concurrent_resolve_of_one_cold_site_opens_once` — 32-way stampede on one cold site opens the file exactly once (`opens_total == 1`) and everyone gets the same instance;
* `concurrent_resolve_of_distinct_sites` — 24 cold sites resolved concurrently, each opened once, each handle actually queryable (the case the global open lock serialized);
* `cap_is_enforced_for_idle_sites` — `cap + 8` sites opened idle leaves ≤ cap open, and the slot map keeps one entry per key;
* `eviction_races_resolve_without_losing_a_database` — 16 workers churning 8 sites under cap=2, every handed-out handle must still answer a query;
* `invalid_key_is_rejected` now also asserts no slot is allocated.

`cargo test -p ephpm-server` (350 + integration), `cargo test -p ephpm-php`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check`: clean. Full bare-process E2E (`cargo xtask e2e`) green against a php_linked 8.5 release build — including the per-site suites (`vhosts`, `security_p0`, `multitenant_hardening`, `fpm_pool`).
