### PR TITLE
feat(server): native WebSockets — Rust owns the sockets, PHP runs per event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ The `ephpm-e2e` crate is **excluded from the workspace** and has different depen
 | `ephpm-db` | DB proxy — MySQL wire protocol, connection pooling, R/W splitting |
 | `ephpm-cluster` | Clustering — SWIM gossip (chitchat), hashed large-value ownership (`hash(key)` mod sorted alive nodes — not a consistent-hash ring), KV replication, SQLite primary election |
 | `ephpm-query-stats` | Query observability — SQL normalization, digest tracking, slow query logging, Prometheus metrics |
+| `ephpm-ws` | Site-scoped WebSocket connection registry — connection/channel maps, bounded per-connection outbound queues, capability-style connection IDs. Protocol-free (no framing), so both `ephpm-php` and `ephpm-server` depend on it |
 | `xtask` | Build & test tooling — `release`, `php-sdk`, `e2e` (bare-process default), `k8s-e2e`/`k8s-e2e-up`/`k8s-e2e-down` (opt-in Kind path) |
 
 ## External Dependencies
@@ -121,6 +122,8 @@ The `TrackedBackend` wrapper in `ephpm-server/src/tracked_backend.rs` wraps any 
 | `ephpm-server/src/turso_cdc.rs` | `start_clustered_turso_cdc()` — the in-process Turso CDC clustered replication path |
 | `ephpm-server/src/tracked_backend.rs` | `TrackedBackend<B>` — wraps litewire `Backend` with query stats |
 | `ephpm-server/src/router.rs` | HTTP request routing, PHP dispatch, static file serving |
+| `ephpm-server/src/websocket.rs` | Native WebSocket upgrade + per-connection session task (`[server.websocket]`, experimental) |
+| `ephpm-php/src/ws_bridge.rs` | `ephpm_ws_*` native functions — per-thread site scope + current-connection context |
 | `ephpm-config/src/lib.rs` | All config structs: `SqliteConfig`, `ReplicationConfig`, `ClusterConfig`, `DbAnalysisConfig` |
 | `ephpm-cluster/src/sqlite_election.rs` | Primary election via gossip KV (lowest ordinal wins, TTL heartbeat) |
 | `ephpm-query-stats/src/digest.rs` | SQL normalizer (state machine replacing literals with `?`) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "bytes",
  "cc",
  "ephpm-kv",
+ "ephpm-ws",
  "http",
  "libc",
  "litewire",
@@ -1451,7 +1452,9 @@ dependencies = [
  "ephpm-middleware-builtins",
  "ephpm-php",
  "ephpm-query-stats",
+ "ephpm-ws",
  "flate2",
+ "futures",
  "getrandom 0.3.4",
  "h3",
  "h3-quinn",
@@ -1484,11 +1487,26 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "turso",
+]
+
+[[package]]
+name = "ephpm-ws"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "getrandom 0.3.4",
+ "metrics",
+ "parking_lot",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4999,6 +5017,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5255,6 +5285,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "turso"
@@ -5560,6 +5608,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,12 @@ metrics-exporter-prometheus = "0.16"
 async-channel = "2"
 libloading = "0.8"
 yamux = "0.14"
+# WebSocket framing for the native `[server.websocket]` path. `tungstenite`'s
+# default features pull in a TLS stack we already have (rustls) and a URL
+# parser only a *client* needs; ePHPm is server-side only, and hyper has
+# already done the HTTP handshake by the time we hand the socket over, so the
+# codec is all we want.
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 
 # Internal crates
@@ -98,6 +104,7 @@ ephpm-middleware-builtins = { path = "crates/ephpm-middleware-builtins" }
 ephpm-php = { path = "crates/ephpm-php" }
 ephpm-query-stats = { path = "crates/ephpm-query-stats" }
 ephpm-server = { path = "crates/ephpm-server" }
+ephpm-ws = { path = "crates/ephpm-ws" }
 
 # External — litewire (embedded SQLite wire protocol proxy)
 #

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -186,6 +186,28 @@ pub struct ServerConfig {
     #[serde(default = "default_index_files")]
     pub index_files: Vec<String>,
 
+    /// Entrypoint script names to try, in order, when a WebSocket upgrade
+    /// request arrives — the `index_files` of the WebSocket path.
+    ///
+    /// Resolved against the **vhost's** document root, so each virtual host has
+    /// its own WebSocket handler (or none). The first name that exists on disk
+    /// wins and receives every event for connections upgraded on that vhost:
+    /// `connect`, `message` and `disconnect`, distinguished by
+    /// `$_SERVER['WS_EVENT']`.
+    ///
+    /// If **no** name in this list exists in the resolved document root, the
+    /// upgrade request is answered `404` — it never falls through to static
+    /// files, `index.php`, or the `[server] fallback` chain. A vhost that has
+    /// not opted into WebSockets therefore cannot accidentally serve one.
+    ///
+    /// Only consulted when `[server.websocket] enabled = true`; with the
+    /// feature off, upgrade requests are routed exactly as any other GET.
+    ///
+    /// Default: `["websocket.php"]`. Env override:
+    /// `EPHPM_SERVER__WEBSOCKET_FILES`.
+    #[serde(default = "default_websocket_files")]
+    pub websocket_files: Vec<String>,
+
     /// Fallback chain for URL resolution. Checked in order for each request.
     ///
     /// Supported variables:
@@ -280,6 +302,10 @@ pub struct ServerConfig {
     /// HTTP/3 (QUIC) settings.
     #[serde(default)]
     pub http3: Http3Config,
+
+    /// Native WebSocket support (experimental, off by default).
+    #[serde(default)]
+    pub websocket: WebSocketConfig,
 }
 
 /// Request limits configuration (`[server.request]`).
@@ -1202,6 +1228,118 @@ pub struct Http3Config {
 impl Default for Http3Config {
     fn default() -> Self {
         Self { enabled: false, listen: None, alt_svc_max_age: default_alt_svc_max_age() }
+    }
+}
+
+/// Native WebSocket configuration (`[server.websocket]`) — **experimental**.
+///
+/// ePHPm terminates WebSockets in Rust and invokes PHP **per event**, never
+/// per connection: a `connect` / `message` / `disconnect` event runs the
+/// vhost's `[server] websocket_files` entrypoint through the ordinary PHP
+/// request path and then returns. Idle connections cost reactor memory and a
+/// registry entry — no PHP thread, no worker, no process.
+///
+/// The whole feature is off unless [`WebSocketConfig::enabled`] is `true`. With
+/// it off, an upgrade request is routed exactly like any other GET (which is
+/// what ePHPm did before this section existed), so turning the section on is
+/// the only behaviour change.
+///
+/// WebSockets are negotiated over **HTTP/1.1** only. An upgrade cannot be
+/// expressed on the HTTP/2 or HTTP/3 request paths ePHPm serves (RFC 8441
+/// extended CONNECT is not implemented), and browsers open a dedicated
+/// HTTP/1.1 connection for `ws:`/`wss:` regardless — so this is not a
+/// limitation clients encounter in practice.
+#[derive(Debug, Deserialize, Clone)]
+pub struct WebSocketConfig {
+    /// Enable native WebSocket support.
+    ///
+    /// Default: `false`. Experimental and opt-in: it changes how upgrade
+    /// requests route (they resolve `[server] websocket_files` and 404 when no
+    /// entrypoint exists) and it admits long-lived connections that outlive
+    /// their HTTP request, so it is never on implicitly.
+    ///
+    /// Env override: `EPHPM_SERVER__WEBSOCKET__ENABLED`.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum concurrent WebSocket connections across every virtual host.
+    ///
+    /// Default: `10000`. `0` = unlimited. An upgrade beyond the cap is refused
+    /// with `503`, before the handshake completes.
+    ///
+    /// This is a **separate** budget from `[server.limits] max_connections`: an
+    /// upgraded socket is handed off to its own task and stops occupying an
+    /// HTTP connection slot, so the HTTP cap cannot bound it.
+    #[serde(default = "default_ws_max_connections")]
+    pub max_connections: usize,
+
+    /// Maximum concurrent WebSocket connections for any single virtual host.
+    ///
+    /// Default: `1000`. `0` = unlimited. Enforced in addition to
+    /// [`WebSocketConfig::max_connections`] so one tenant on a shared
+    /// deployment cannot consume the whole budget. Refused upgrades get `503`.
+    #[serde(default = "default_ws_max_connections_per_site")]
+    pub max_connections_per_site: usize,
+
+    /// Maximum size, in bytes, of a single inbound WebSocket **message**
+    /// (after reassembling continuation frames).
+    ///
+    /// Default: `1048576` (1 MiB). A message larger than this closes the
+    /// connection rather than allocating for it. This is the value PHP could be
+    /// asked to read as a request body, so it is deliberately independent of
+    /// `[server.request] max_body_size`.
+    #[serde(default = "default_ws_max_message_size")]
+    pub max_message_size: usize,
+
+    /// Maximum size, in bytes, of a single inbound WebSocket **frame**.
+    ///
+    /// Default: `1048576` (1 MiB). Bounds one read; `max_message_size` bounds
+    /// the reassembled total.
+    #[serde(default = "default_ws_max_frame_size")]
+    pub max_frame_size: usize,
+
+    /// Depth, in frames, of each connection's outbound queue.
+    ///
+    /// Default: `64`. When a connection's queue is full, the frame is **not**
+    /// buffered: `ephpm_ws_send` / `ephpm_ws_broadcast` return failure for that
+    /// connection and the socket is closed with WebSocket status `1013`. A slow
+    /// reader costs one connection, never the server's memory.
+    ///
+    /// `0` is not a valid depth and is normalized to `1` with a warning.
+    #[serde(default = "default_ws_send_queue")]
+    pub send_queue: usize,
+
+    /// Seconds between server-initiated WebSocket pings.
+    ///
+    /// Default: `30`. `0` disables keepalive pings. Pings are what keep an
+    /// otherwise-idle connection's [`WebSocketConfig::idle_timeout_secs`] from
+    /// expiring, so disabling them means idle connections are dropped.
+    #[serde(default = "default_ws_ping_interval_secs")]
+    pub ping_interval_secs: u64,
+
+    /// Seconds a connection may go without receiving **any** frame (including a
+    /// pong) before it is closed.
+    ///
+    /// Default: `120`. `0` disables the check. Keep this comfortably larger
+    /// than [`WebSocketConfig::ping_interval_secs`] — a client that answers
+    /// pings refreshes the timer, so the timeout only fires for a peer that has
+    /// genuinely gone away without a TCP reset.
+    #[serde(default = "default_ws_idle_timeout_secs")]
+    pub idle_timeout_secs: u64,
+}
+
+impl Default for WebSocketConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_connections: default_ws_max_connections(),
+            max_connections_per_site: default_ws_max_connections_per_site(),
+            max_message_size: default_ws_max_message_size(),
+            max_frame_size: default_ws_max_frame_size(),
+            send_queue: default_ws_send_queue(),
+            ping_interval_secs: default_ws_ping_interval_secs(),
+            idle_timeout_secs: default_ws_idle_timeout_secs(),
+        }
     }
 }
 
@@ -2441,6 +2579,40 @@ impl Config {
             )));
         }
 
+        // Native WebSockets dispatch each event through the fpm per-request
+        // path (a fresh entrypoint execution per event). Worker mode routes
+        // every request into the persistent worker's PSR-7 envelope loop
+        // instead, so the entrypoint would never run. Hard error rather than a
+        // warning: ePHPm does not come up quietly without the WebSocket support
+        // an operator asked for (the `[server.http3]` precedent).
+        //
+        // Checked BEFORE the worker-mode block below so the incompatibility is
+        // what the operator is told about, rather than a downstream complaint
+        // about the worker script.
+        if self.server.websocket.enabled && self.php.is_worker_mode() {
+            return Err(ConfigError::Validation(
+                "[server.websocket] enabled = true is not supported together with \
+                 [php] mode = \"worker\". WebSocket events are dispatched through \
+                 the fpm per-request path; in worker mode every request is served \
+                 by the persistent worker loop, so the `websocket_files` \
+                 entrypoint would never execute. Use fpm mode (the default) for \
+                 WebSockets."
+                    .to_string(),
+            ));
+        }
+
+        // An entrypoint name is what makes a vhost WebSocket-capable at all —
+        // an empty list means every upgrade request 404s, which is a silently
+        // disabled feature rather than a configuration.
+        if self.server.websocket.enabled && self.server.websocket_files.is_empty() {
+            return Err(ConfigError::Validation(
+                "[server] websocket_files is empty but [server.websocket] enabled = \
+                 true — every upgrade request would 404. Name at least one \
+                 entrypoint (default: [\"websocket.php\"])."
+                    .to_string(),
+            ));
+        }
+
         if self.php.is_worker_mode() {
             if self.server.sites_dir.is_some() {
                 return Err(ConfigError::Validation(
@@ -2597,6 +2769,7 @@ impl Default for ServerConfig {
             run_as_group: None,
             sites_domain_suffix: None,
             index_files: default_index_files(),
+            websocket_files: default_websocket_files(),
             fallback: default_fallback(),
             preview: false,
             request: RequestConfig::default(),
@@ -2612,6 +2785,7 @@ impl Default for ServerConfig {
             file_cache: FileCacheConfig::default(),
             tls: None,
             http3: Http3Config::default(),
+            websocket: WebSocketConfig::default(),
         }
     }
 }
@@ -3875,6 +4049,49 @@ fn default_index_files() -> Vec<String> {
     vec!["index.php".to_string(), "index.html".to_string()]
 }
 
+/// Default WebSocket entrypoint names — one, mirroring `index.php`'s role on
+/// the HTTP path.
+fn default_websocket_files() -> Vec<String> {
+    vec!["websocket.php".to_string()]
+}
+
+/// Global WebSocket connection ceiling. Chosen to be large enough that no
+/// ordinary deployment meets it, but finite: the whole point of terminating
+/// sockets in Rust is cheap idle connections, and "cheap" is not "free".
+fn default_ws_max_connections() -> usize {
+    10_000
+}
+
+/// Per-vhost WebSocket ceiling — a tenth of the global default, so a
+/// multi-tenant node needs ten busy tenants before the global cap is the
+/// binding constraint.
+fn default_ws_max_connections_per_site() -> usize {
+    1_000
+}
+
+fn default_ws_max_message_size() -> usize {
+    1024 * 1024 // 1 MiB
+}
+
+fn default_ws_max_frame_size() -> usize {
+    1024 * 1024 // 1 MiB
+}
+
+/// Outbound queue depth per connection. Deep enough to absorb a burst from one
+/// broadcast, shallow enough that a stalled reader is detected in frames rather
+/// than megabytes.
+fn default_ws_send_queue() -> usize {
+    64
+}
+
+fn default_ws_ping_interval_secs() -> u64 {
+    30
+}
+
+fn default_ws_idle_timeout_secs() -> u64 {
+    120
+}
+
 fn default_fallback() -> Vec<String> {
     vec!["$uri".to_string(), "$uri/".to_string(), "/index.php?$query_string".to_string()]
 }
@@ -4138,6 +4355,177 @@ alt_svc_max_age = 3600
         let _env = EnvVars::set("EPHPM_SERVER__HTTP3__ALT_SVC_MAX_AGE", "120");
         let config = Config::load(&file).unwrap();
         assert_eq!(config.server.http3.alt_svc_max_age, 120);
+    }
+
+    // ── [server.websocket] + [server] websocket_files ────────────────
+
+    /// Section absent: the feature is off and every bound resolves to its
+    /// documented default. Also guards against the `[server.security]` lesson —
+    /// a missing section must not zero the carefully chosen field defaults.
+    #[test]
+    fn websocket_section_absent_is_off_with_documented_bounds() {
+        let config = Config::default_config().expect("default config should load");
+        let ws = &config.server.websocket;
+        assert!(!ws.enabled, "native websockets must be opt-in");
+        assert_eq!(ws.max_connections, 10_000);
+        assert_eq!(ws.max_connections_per_site, 1_000);
+        assert_eq!(ws.max_message_size, 1024 * 1024);
+        assert_eq!(ws.max_frame_size, 1024 * 1024);
+        assert_eq!(ws.send_queue, 64);
+        assert_eq!(ws.ping_interval_secs, 30);
+        assert_eq!(ws.idle_timeout_secs, 120);
+        // The hand-written Default must not drift from the serde defaults.
+        let hand_written = WebSocketConfig::default();
+        assert_eq!(hand_written.max_connections, ws.max_connections);
+        assert_eq!(hand_written.send_queue, ws.send_queue);
+        assert_eq!(hand_written.idle_timeout_secs, ws.idle_timeout_secs);
+    }
+
+    /// `websocket_files` mirrors `index_files`: absent means one documented
+    /// name, and setting it replaces the list wholesale.
+    #[test]
+    fn websocket_files_defaults_to_one_entrypoint() {
+        let config = Config::default_config().expect("default config should load");
+        assert_eq!(config.server.websocket_files, vec!["websocket.php"]);
+    }
+
+    #[test]
+    fn websocket_files_is_configurable_as_an_ordered_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nwebsocket_files = [\"ws.php\", \"public/ws.php\"]\n")
+            .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.websocket_files, vec!["ws.php", "public/ws.php"]);
+    }
+
+    /// Section present but partial: the one named field takes effect and every
+    /// other bound keeps its default rather than collapsing to zero.
+    #[test]
+    fn websocket_section_partial_keeps_other_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.websocket]\nenabled = true\n").unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.websocket.enabled);
+        assert_eq!(config.server.websocket.send_queue, 64);
+        assert_eq!(config.server.websocket.max_connections, 10_000);
+        assert_eq!(config.server.websocket.idle_timeout_secs, 120);
+    }
+
+    #[test]
+    fn websocket_bounds_are_configurable() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[server.websocket]
+enabled = true
+max_connections = 50
+max_connections_per_site = 5
+max_message_size = 4096
+max_frame_size = 2048
+send_queue = 8
+ping_interval_secs = 5
+idle_timeout_secs = 15
+",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let ws = &config.server.websocket;
+        assert!(ws.enabled);
+        assert_eq!(ws.max_connections, 50);
+        assert_eq!(ws.max_connections_per_site, 5);
+        assert_eq!(ws.max_message_size, 4096);
+        assert_eq!(ws.max_frame_size, 2048);
+        assert_eq!(ws.send_queue, 8);
+        assert_eq!(ws.ping_interval_secs, 5);
+        assert_eq!(ws.idle_timeout_secs, 15);
+    }
+
+    /// Worker mode never runs the entrypoint, so the combination must fail at
+    /// startup rather than serving upgrades that silently do nothing.
+    #[test]
+    fn websockets_with_worker_mode_is_a_startup_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            "[server.websocket]\nenabled = true\n\n[php]\nmode = \"worker\"\nworker_script = \"w.php\"\n",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let err = config.validate().expect_err("worker + websocket must not validate");
+        let msg = err.to_string();
+        assert!(msg.contains("websocket"), "unhelpful error: {msg}");
+        assert!(msg.contains("worker"), "unhelpful error: {msg}");
+    }
+
+    /// An enabled feature with no entrypoint name would 404 every upgrade —
+    /// a silently disabled feature, which is exactly what the no-silent-no-op
+    /// rule forbids.
+    #[test]
+    fn websockets_enabled_with_no_entrypoint_names_is_a_startup_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            "[server]\nwebsocket_files = []\n\n[server.websocket]\nenabled = true\n",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let err = config.validate().expect_err("empty websocket_files must not validate");
+        assert!(err.to_string().contains("websocket_files"), "unhelpful error: {err}");
+    }
+
+    /// The feature being off must not make an empty list an error, and must
+    /// not make worker mode an error.
+    #[test]
+    fn websocket_validation_is_inert_when_the_feature_is_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        let script = dir.path().join("w.php");
+        std::fs::write(&script, "<?php\n").unwrap();
+        std::fs::write(
+            &file,
+            format!(
+                "[server]\ndocument_root = {:?}\nwebsocket_files = []\n\n[php]\nmode = \"worker\"\nworker_script = \"w.php\"\n",
+                dir.path().to_string_lossy(),
+            ),
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(!config.server.websocket.enabled);
+        config.validate().expect("websocket checks must not fire when the feature is off");
+    }
+
+    #[test]
+    fn test_env_var_overrides_websocket_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.websocket]\nenabled = false\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__WEBSOCKET__ENABLED", "true");
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.websocket.enabled);
+    }
+
+    #[test]
+    fn test_env_var_overrides_websocket_send_queue() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nlisten = \"0.0.0.0:8080\"\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__WEBSOCKET__SEND_QUEUE", "4");
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.websocket.send_queue, 4);
     }
 
     // ── [server.diagnostics] ─────────────────────────────────────────

--- a/crates/ephpm-e2e/Cargo.toml
+++ b/crates/ephpm-e2e/Cargo.toml
@@ -21,3 +21,10 @@ urlencoding = "2"
 brotli = "7"
 anyhow = "1"
 tempfile = "3"
+# A real WebSocket client for the `websockets` suite. `client_async` (not
+# `connect_async`) is what the suite uses: it does the RFC 6455 handshake over
+# a socket we opened ourselves, so the request can carry `Host: ws-a.test`
+# while actually connecting to 127.0.0.1 — which is how one loopback server
+# gets tested as two virtual hosts.
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
+futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }

--- a/crates/ephpm-e2e/tests/websockets.rs
+++ b/crates/ephpm-e2e/tests/websockets.rs
@@ -1,0 +1,552 @@
+//! Native WebSocket e2e tests (`[server.websocket]`).
+//!
+//! Runs against its own isolated node (`ISOLATED_CONFIG_SUITES` in
+//! `xtask/src/e2e_bare.rs`) because enabling WebSockets changes how **every**
+//! upgrade request routes. That node is multi-tenant, so this suite gets two
+//! real virtual hosts — `ws-a.test` and `ws-b.test` — on one server, which is
+//! what lets the cross-site test be an end-to-end assertion rather than a
+//! unit-level one.
+//!
+//! Environment:
+//! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://127.0.0.1:18100`)
+//! - `EPHPM_SITES_DIR` — writable sites directory on the ephpm host
+//!
+//! The suite runs single-threaded (see `suite_is_serial`): its tests share the
+//! deployed vhosts and each vhost's KV keyspace.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use ephpm_e2e::required_env;
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message;
+
+/// Vhosts this suite deploys. Both are in the isolated node's `trusted_hosts`.
+const SITE_A: &str = "ws-a.test";
+const SITE_B: &str = "ws-b.test";
+
+/// Query-string token `websocket.php` demands during `connect`. The auth-
+/// rejection test is what makes this more than decoration.
+const TOKEN: &str = "letmein";
+
+/// How long any single frame may take to arrive. Generous: a `message` event
+/// is a full PHP execution, and CI runners are not fast.
+const RECV_TIMEOUT: Duration = Duration::from_secs(15);
+
+type Ws = WebSocketStream<TcpStream>;
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+/// The WebSocket entrypoint. One script, every event — userland routes on
+/// `$_SERVER['WS_EVENT']`, which is the whole point of the design.
+const WEBSOCKET_PHP: &str = r#"<?php
+// E2E WebSocket entrypoint. Deployed to two vhosts so the suite can prove
+// site isolation with a real server.
+$event = $_SERVER['WS_EVENT'] ?? '';
+$conn  = $_SERVER['WS_CONNECTION_ID'] ?? '';
+
+if ($event === 'connect') {
+    parse_str($_SERVER['QUERY_STRING'] ?? '', $q);
+    // Authentication happens HERE — the only point at which an upgrade can
+    // still be refused. A non-2xx response means no socket is ever created.
+    if (($q['token'] ?? '') !== 'letmein') {
+        http_response_code(403);
+        echo 'denied';
+        return;
+    }
+    // The HTTP-pushes-to-socket pattern: stash the connection id under an
+    // application identity so an ordinary request handler can find it later.
+    if (!empty($q['client'])) {
+        ephpm_kv_set('ws:client:' . $q['client'], $conn);
+    }
+    http_response_code(200);
+    echo 'ok';
+    return;
+}
+
+if ($event === 'disconnect') {
+    // Best-effort cleanup. The connection is already out of the registry by
+    // the time this runs.
+    ephpm_kv_incr('ws:disconnects');
+    return;
+}
+
+if ($event === 'message') {
+    $body  = file_get_contents('php://input');
+    $parts = explode(':', $body, 3);
+    switch ($parts[0]) {
+        case 'echo':
+            // Implicit form: no connection id, acts on the connection that
+            // fired this event.
+            ephpm_ws_send('echo:' . ($parts[1] ?? ''));
+            break;
+        case 'whoami':
+            ephpm_ws_send('id:' . $conn);
+            break;
+        case 'opcode':
+            ephpm_ws_send('opcode:' . ($_SERVER['WS_OPCODE'] ?? '?'));
+            break;
+        case 'join':
+            $ok = ephpm_ws_subscribe($parts[1]);
+            ephpm_ws_send('joined:' . ($ok ? '1' : '0'));
+            break;
+        case 'leave':
+            $ok = ephpm_ws_unsubscribe($parts[1]);
+            ephpm_ws_send('left:' . ($ok ? '1' : '0'));
+            break;
+        case 'say':
+            $n = ephpm_ws_broadcast($parts[1], 'chat:' . ($parts[2] ?? ''));
+            ephpm_ws_send('sent:' . $n);
+            break;
+        case 'bye':
+            ephpm_ws_close(4001);
+            break;
+        default:
+            ephpm_ws_send('unknown');
+    }
+}
+"#;
+
+/// An ordinary HTTP handler that pushes to a live socket — the killer feature,
+/// and the exact pattern documented in `site/content/guides/websockets.md`.
+const PUSH_PHP: &str = r#"<?php
+// Look the connection up by application identity (the id `websocket.php`
+// stashed during `connect`), or take a raw id for the cross-site test.
+$id = $_GET['id'] ?? null;
+if ($id === null && isset($_GET['client'])) {
+    $id = ephpm_kv_get('ws:client:' . $_GET['client']);
+}
+if (!$id) {
+    http_response_code(404);
+    echo 'no-connection';
+    return;
+}
+$ok = ephpm_ws_connection_send($id, $_GET['msg'] ?? 'ping');
+echo $ok ? 'sent' : 'not-sent';
+"#;
+
+/// The implicit form from an ordinary HTTP request must throw, not no-op.
+const PUSH_IMPLICIT_PHP: &str = r#"<?php
+try {
+    ephpm_ws_send('this has no current connection');
+    echo 'no-exception';
+} catch (Throwable $e) {
+    echo 'threw';
+}
+"#;
+
+/// A vhost that is deliberately WebSocket-incapable: no entrypoint at all.
+const INDEX_PHP: &str = "<?php echo 'index'; ?>";
+
+fn sites_dir() -> PathBuf {
+    PathBuf::from(required_env("EPHPM_SITES_DIR"))
+}
+
+/// Deploy both vhosts. Idempotent — the suite is serial, so every test can
+/// call this and get the same state.
+async fn deploy_sites() {
+    for host in [SITE_A, SITE_B] {
+        let dir = sites_dir().join(host);
+        std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+        write(&dir, "websocket.php", WEBSOCKET_PHP);
+        write(&dir, "push.php", PUSH_PHP);
+        write(&dir, "push_implicit.php", PUSH_IMPLICIT_PHP);
+        write(&dir, "index.php", INDEX_PHP);
+    }
+    // Lazy vhost discovery has a short negative-lookup cache; poll until both
+    // hosts actually resolve rather than racing it.
+    for host in [SITE_A, SITE_B] {
+        wait_for_site(host).await;
+    }
+}
+
+fn write(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+    std::fs::write(&path, body).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+}
+
+async fn wait_for_site(host: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let resp = http_get(host, "/index.php").await;
+        if resp.0 == 200 && resp.1 == "index" {
+            return;
+        }
+        assert!(std::time::Instant::now() < deadline, "vhost {host} never became discoverable");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/// `(status, body)` for a plain HTTP request to one vhost.
+async fn http_get(host: &str, path: &str) -> (u16, String) {
+    let base = required_env("EPHPM_URL");
+    let resp = reqwest::Client::new()
+        .get(format!("{base}{path}"))
+        .header("Host", host)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {path} (Host: {host}) failed: {e}"));
+    let status = resp.status().as_u16();
+    let body = resp.text().await.unwrap_or_default();
+    (status, body)
+}
+
+/// `host:port` of the server under test, for a raw TCP connect.
+fn server_addr() -> String {
+    let base = required_env("EPHPM_URL");
+    let rest = base.strip_prefix("http://").unwrap_or(&base);
+    let authority = rest.split('/').next().unwrap_or(rest);
+    if authority.contains(':') { authority.to_string() } else { format!("{authority}:80") }
+}
+
+/// Open a WebSocket to `host`'s entrypoint.
+///
+/// Connects the TCP socket to the real server address but does the handshake
+/// with `Host: <host>` — the request names the vhost, the socket names the
+/// machine. That is what makes two virtual hosts testable on one loopback
+/// listener.
+async fn connect(host: &str, query: &str) -> Result<Ws, u16> {
+    let stream = TcpStream::connect(server_addr())
+        .await
+        .unwrap_or_else(|e| panic!("tcp connect to {}: {e}", server_addr()));
+    let url = format!("ws://{host}/chat?{query}");
+    match tokio_tungstenite::client_async(url, stream).await {
+        Ok((ws, _resp)) => Ok(ws),
+        Err(tokio_tungstenite::tungstenite::Error::Http(resp)) => Err(resp.status().as_u16()),
+        Err(e) => panic!("websocket handshake to {host} failed unexpectedly: {e}"),
+    }
+}
+
+/// Open a WebSocket that is expected to succeed.
+async fn connect_ok(host: &str, query: &str) -> Ws {
+    connect(host, query)
+        .await
+        .unwrap_or_else(|status| panic!("expected an accepted upgrade, got HTTP {status}"))
+}
+
+/// Next data frame, skipping the server's keepalive ping/pong traffic.
+async fn recv(ws: &mut Ws) -> String {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let next = tokio::time::timeout_at(deadline, ws.next())
+            .await
+            .expect("timed out waiting for a websocket frame")
+            .expect("websocket stream ended while waiting for a frame")
+            .expect("websocket read error");
+        match next {
+            Message::Text(text) => return text,
+            Message::Binary(bytes) => return String::from_utf8_lossy(&bytes).into_owned(),
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+            Message::Close(frame) => panic!("connection closed while waiting for a frame: {frame:?}"),
+        }
+    }
+}
+
+/// Assert nothing arrives within `window`. Used for the negative cases, where
+/// "no frame" is the whole assertion.
+async fn expect_silence(ws: &mut Ws, window: Duration) {
+    let deadline = tokio::time::Instant::now() + window;
+    loop {
+        match tokio::time::timeout_at(deadline, ws.next()).await {
+            // Timed out: nothing arrived, which is what we wanted.
+            Err(_) => return,
+            Ok(Some(Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)))) => {}
+            Ok(other) => panic!("expected silence, got {other:?}"),
+        }
+    }
+}
+
+async fn send(ws: &mut Ws, text: &str) {
+    ws.send(Message::Text(text.to_string())).await.expect("websocket write");
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+/// The basic loop: a frame in, one PHP execution, a frame out.
+#[tokio::test]
+async fn echo_round_trips_through_php() {
+    deploy_sites().await;
+    let mut ws = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+
+    send(&mut ws, "echo:hello").await;
+    assert_eq!(recv(&mut ws).await, "echo:hello");
+
+    // A second message on the same connection: each is its own execution, and
+    // they stay in order.
+    send(&mut ws, "echo:again").await;
+    assert_eq!(recv(&mut ws).await, "echo:again");
+}
+
+/// `WS_CONNECTION_ID` reaches PHP, and looks like the documented capability
+/// token rather than something guessable.
+#[tokio::test]
+async fn the_connection_id_is_exposed_and_unguessable_shaped() {
+    deploy_sites().await;
+    let mut first = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+    let mut second = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+
+    send(&mut first, "whoami").await;
+    send(&mut second, "whoami").await;
+    let id_a = recv(&mut first).await.strip_prefix("id:").expect("id: prefix").to_string();
+    let id_b = recv(&mut second).await.strip_prefix("id:").expect("id: prefix").to_string();
+
+    assert_eq!(id_a.len(), 32, "connection id should be 128 bits of hex: {id_a}");
+    assert!(
+        id_a.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+        "connection id should be lowercase hex: {id_a}"
+    );
+    assert_ne!(id_a, id_b);
+    let shared = id_a.chars().zip(id_b.chars()).take_while(|(x, y)| x == y).count();
+    assert!(shared < 8, "two ids share a {shared}-char prefix — not random: {id_a} / {id_b}");
+}
+
+/// `WS_OPCODE` distinguishes text from binary.
+#[tokio::test]
+async fn binary_frames_are_reported_as_binary() {
+    deploy_sites().await;
+    let mut ws = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+
+    send(&mut ws, "opcode").await;
+    assert_eq!(recv(&mut ws).await, "opcode:text");
+
+    ws.send(Message::Binary(b"opcode".to_vec())).await.expect("binary write");
+    assert_eq!(recv(&mut ws).await, "opcode:binary");
+}
+
+/// Channels: two clients, one broadcasts, the other receives.
+#[tokio::test]
+async fn a_channel_broadcast_reaches_the_other_subscriber() {
+    deploy_sites().await;
+    let mut listener = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+    let mut speaker = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+
+    send(&mut listener, "join:room").await;
+    assert_eq!(recv(&mut listener).await, "joined:1");
+    send(&mut speaker, "join:room").await;
+    assert_eq!(recv(&mut speaker).await, "joined:1");
+
+    send(&mut speaker, "say:room:hello everyone").await;
+
+    // The listener sees only the broadcast.
+    assert_eq!(recv(&mut listener).await, "chat:hello everyone");
+    // The speaker is a member too, so it sees the broadcast and then its own
+    // receipt — the broadcast is queued before the reply, so the order is
+    // deterministic.
+    assert_eq!(recv(&mut speaker).await, "chat:hello everyone");
+    assert_eq!(recv(&mut speaker).await, "sent:2");
+
+    // Leaving stops delivery.
+    send(&mut listener, "leave:room").await;
+    assert_eq!(recv(&mut listener).await, "left:1");
+    send(&mut speaker, "say:room:second").await;
+    assert_eq!(recv(&mut speaker).await, "chat:second");
+    assert_eq!(recv(&mut speaker).await, "sent:1");
+    expect_silence(&mut listener, Duration::from_secs(2)).await;
+}
+
+/// Auth at `connect`: a non-2xx response refuses the upgrade outright, and the
+/// script's own status reaches the client.
+#[tokio::test]
+async fn a_rejecting_connect_handler_refuses_the_upgrade() {
+    deploy_sites().await;
+
+    let status = connect(SITE_A, "token=wrong").await.expect_err("upgrade should be refused");
+    assert_eq!(status, 403, "the connect handler's own status must reach the client");
+
+    // And the same client with the right token still gets in — so the refusal
+    // was the handler's decision, not a broken path.
+    let mut ws = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+    send(&mut ws, "echo:ok").await;
+    assert_eq!(recv(&mut ws).await, "echo:ok");
+}
+
+/// The headline feature: an ordinary HTTP request pushes a frame to a live
+/// socket. This is the exact pattern in `guides/websockets.md` — `connect`
+/// stashes the id in the embedded KV under an application identity, and a
+/// later request looks it up and sends.
+#[tokio::test]
+async fn an_http_request_pushes_to_a_connected_socket() {
+    deploy_sites().await;
+    let mut ws = connect_ok(SITE_A, &format!("token={TOKEN}&client=alice")).await;
+
+    let (status, body) = http_get(SITE_A, "/push.php?client=alice&msg=you+have+mail").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "sent", "the HTTP handler should have found alice's connection");
+
+    assert_eq!(recv(&mut ws).await, "you have mail");
+}
+
+/// The implicit form has no current connection during an HTTP request, and
+/// must say so rather than silently doing nothing.
+#[tokio::test]
+async fn the_implicit_form_throws_from_an_http_request() {
+    deploy_sites().await;
+
+    let (status, body) = http_get(SITE_A, "/push_implicit.php").await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "threw", "ephpm_ws_send() outside an event must throw, never no-op");
+}
+
+/// Multi-tenant isolation, end to end: site B holds site A's exact connection
+/// id and still cannot reach it.
+#[tokio::test]
+async fn one_site_cannot_push_to_another_sites_connection() {
+    deploy_sites().await;
+    let mut victim = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+
+    send(&mut victim, "whoami").await;
+    let id = recv(&mut victim).await.strip_prefix("id:").expect("id: prefix").to_string();
+
+    // Site B is handed the raw id — leaked, logged, guessed; it does not
+    // matter how it got there.
+    let (status, body) = http_get(SITE_B, &format!("/push.php?id={id}&msg=pwned")).await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "not-sent", "site B must not be able to reach site A's connection");
+    expect_silence(&mut victim, Duration::from_secs(2)).await;
+
+    // ...and site A can, with the same id, so the failure above was the site
+    // boundary and not a dead connection.
+    let (status, body) = http_get(SITE_A, &format!("/push.php?id={id}&msg=legitimate")).await;
+    assert_eq!(status, 200);
+    assert_eq!(body, "sent");
+    assert_eq!(recv(&mut victim).await, "legitimate");
+}
+
+/// Channels are site-scoped too: the same channel name on two vhosts is two
+/// different channels.
+#[tokio::test]
+async fn identically_named_channels_do_not_bridge_sites() {
+    deploy_sites().await;
+    let mut on_a = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+    let mut on_b = connect_ok(SITE_B, &format!("token={TOKEN}")).await;
+
+    send(&mut on_a, "join:shared").await;
+    assert_eq!(recv(&mut on_a).await, "joined:1");
+    send(&mut on_b, "join:shared").await;
+    assert_eq!(recv(&mut on_b).await, "joined:1");
+
+    send(&mut on_b, "say:shared:from B").await;
+    assert_eq!(recv(&mut on_b).await, "chat:from B");
+    assert_eq!(recv(&mut on_b).await, "sent:1", "only B's own connection is in B's channel");
+    expect_silence(&mut on_a, Duration::from_secs(2)).await;
+}
+
+/// `ephpm_ws_close()` closes the socket with the code userland asked for.
+#[tokio::test]
+async fn userland_can_close_a_connection_with_a_code() {
+    deploy_sites().await;
+    let mut ws = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+
+    send(&mut ws, "bye").await;
+    let closed = tokio::time::timeout(RECV_TIMEOUT, async {
+        loop {
+            match ws.next().await {
+                Some(Ok(Message::Close(frame))) => return frame,
+                Some(Ok(_)) => {}
+                other => panic!("expected a close frame, got {other:?}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for the close frame");
+
+    let frame = closed.expect("close frame should carry a code");
+    assert_eq!(u16::from(frame.code), 4001);
+}
+
+/// The strict 404 rule: an upgrade to a vhost with no entrypoint is a 404 and
+/// never falls through to `index.php`, the fallback chain, or a static file.
+#[tokio::test]
+async fn an_upgrade_to_a_vhost_without_an_entrypoint_is_404() {
+    deploy_sites().await;
+    let host = "ws-a.test";
+    let entrypoint = sites_dir().join(host).join("websocket.php");
+
+    // Same vhost, entrypoint removed. `index.php` is still there and would
+    // happily answer a plain GET — the upgrade must not reach it.
+    std::fs::remove_file(&entrypoint).expect("remove the entrypoint");
+    // The router stats the entrypoint per upgrade, so no cache flush is
+    // needed; but a plain GET must still work, proving the vhost is live.
+    let (status, body) = http_get(host, "/index.php").await;
+    assert_eq!((status, body.as_str()), (200, "index"));
+
+    let status = connect(host, &format!("token={TOKEN}")).await.expect_err("should be refused");
+    assert_eq!(status, 404, "an upgrade with no entrypoint must 404, not fall through");
+
+    // Restore for whatever runs next (the suite is serial, so this is enough).
+    write(&sites_dir().join(host), "websocket.php", WEBSOCKET_PHP);
+    let mut ws = connect_ok(host, &format!("token={TOKEN}")).await;
+    send(&mut ws, "echo:restored").await;
+    assert_eq!(recv(&mut ws).await, "echo:restored");
+}
+
+/// A malformed handshake is routed to the WebSocket path (so it gets a
+/// diagnostic 400) rather than falling through to the fallback chain.
+#[tokio::test]
+async fn a_wrong_websocket_version_gets_a_400_not_a_fallthrough() {
+    deploy_sites().await;
+
+    let base = required_env("EPHPM_URL");
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/chat"))
+        .header("Host", SITE_A)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "8")
+        .header("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .send()
+        .await
+        .expect("request");
+
+    assert_eq!(resp.status().as_u16(), 400);
+    assert_eq!(
+        resp.headers().get("sec-websocket-version").and_then(|v| v.to_str().ok()),
+        Some("13"),
+        "a 400 should advertise the version we do speak"
+    );
+}
+
+/// Disconnect is dispatched: the entrypoint's `disconnect` branch bumps a KV
+/// counter, and a later HTTP request can see it.
+#[tokio::test]
+async fn closing_a_socket_dispatches_the_disconnect_event() {
+    deploy_sites().await;
+
+    // `push.php` reports 404/no-connection for a missing key, which is a
+    // convenient way to read KV without another fixture — so instead, count
+    // disconnects by connecting, closing, and polling for the increment.
+    let before = disconnect_count().await;
+
+    {
+        let mut ws = connect_ok(SITE_A, &format!("token={TOKEN}")).await;
+        send(&mut ws, "echo:bye").await;
+        assert_eq!(recv(&mut ws).await, "echo:bye");
+        ws.close(None).await.expect("client close");
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        if disconnect_count().await > before {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the disconnect event never ran (counter stayed at {before})"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Reads `ws:disconnects` out of the vhost's KV keyspace via a tiny fixture
+/// deployed on demand.
+async fn disconnect_count() -> i64 {
+    let dir = sites_dir().join(SITE_A);
+    write(&dir, "disconnects.php", "<?php echo (int)(ephpm_kv_get('ws:disconnects') ?? 0);");
+    let (status, body) = http_get(SITE_A, "/disconnects.php").await;
+    assert_eq!(status, 200, "disconnects.php should serve: {body}");
+    body.trim().parse().unwrap_or_else(|e| panic!("unparseable counter {body:?}: {e}"))
+}

--- a/crates/ephpm-e2e/tests/websockets.rs
+++ b/crates/ephpm-e2e/tests/websockets.rs
@@ -140,21 +140,35 @@ try {
 /// A vhost that is deliberately WebSocket-incapable: no entrypoint at all.
 const INDEX_PHP: &str = "<?php echo 'index'; ?>";
 
+/// Reads the `disconnect`-event counter out of this vhost's KV keyspace.
+const DISCONNECTS_PHP: &str = "<?php echo (int)(ephpm_kv_get('ws:disconnects') ?? 0);";
+
 fn sites_dir() -> PathBuf {
     PathBuf::from(required_env("EPHPM_SITES_DIR"))
 }
 
 /// Deploy both vhosts. Idempotent — the suite is serial, so every test can
 /// call this and get the same state.
+///
+/// The actual filesystem work happens **once** per test binary. Re-deploying
+/// per test is not merely wasted work — it republishes files the server may be
+/// compiling at that instant, and this node runs with OPcache timestamp
+/// validation OFF (the `serve`-mode default), so a bad compile is cached for
+/// the life of the process. See [`write`].
 async fn deploy_sites() {
-    for host in [SITE_A, SITE_B] {
-        let dir = sites_dir().join(host);
-        std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
-        write(&dir, "websocket.php", WEBSOCKET_PHP);
-        write(&dir, "push.php", PUSH_PHP);
-        write(&dir, "push_implicit.php", PUSH_IMPLICIT_PHP);
-        write(&dir, "index.php", INDEX_PHP);
-    }
+    static DEPLOYED: std::sync::Once = std::sync::Once::new();
+    DEPLOYED.call_once(|| {
+        for host in [SITE_A, SITE_B] {
+            let dir = sites_dir().join(host);
+            std::fs::create_dir_all(&dir)
+                .unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+            write(&dir, "websocket.php", WEBSOCKET_PHP);
+            write(&dir, "push.php", PUSH_PHP);
+            write(&dir, "push_implicit.php", PUSH_IMPLICIT_PHP);
+            write(&dir, "index.php", INDEX_PHP);
+            write(&dir, "disconnects.php", DISCONNECTS_PHP);
+        }
+    });
     // Lazy vhost discovery has a short negative-lookup cache; poll until both
     // hosts actually resolve rather than racing it.
     for host in [SITE_A, SITE_B] {
@@ -162,9 +176,31 @@ async fn deploy_sites() {
     }
 }
 
+/// Publish a fixture file **atomically**: write a sibling temp file, then
+/// `rename` it into place.
+///
+/// A plain `fs::write` truncates first, so there is a window in which the path
+/// exists but is empty. That window is not theoretical here: connections leak
+/// out of every test (the client just drops the socket), and the server
+/// dispatches each one's `disconnect` event asynchronously — so PHP can be
+/// compiling `websocket.php` at the exact moment the next test rewrites it.
+///
+/// With OPcache timestamp validation off (this node runs `ephpm serve`, where
+/// that is the default), compiling the empty file caches an **inert script for
+/// the rest of the process**: upgrades still succeed with 200, and no event
+/// ever emits a frame again. That is precisely how this suite failed on a
+/// loaded CI runner while passing locally — every later test that needed
+/// `websocket.php` to send something timed out, while the one test that only
+/// touches `push_implicit.php` kept passing.
+///
+/// `rename` is atomic within a filesystem, so a concurrent compile sees either
+/// the old complete file or the new complete file — never an empty one.
 fn write(dir: &Path, name: &str, body: &str) {
     let path = dir.join(name);
-    std::fs::write(&path, body).unwrap_or_else(|e| panic!("write {}: {e}", path.display()));
+    let tmp = dir.join(format!(".{name}.tmp"));
+    std::fs::write(&tmp, body).unwrap_or_else(|e| panic!("write {}: {e}", tmp.display()));
+    std::fs::rename(&tmp, &path)
+        .unwrap_or_else(|e| panic!("rename {} -> {}: {e}", tmp.display(), path.display()));
 }
 
 async fn wait_for_site(host: &str) {
@@ -541,11 +577,11 @@ async fn closing_a_socket_dispatches_the_disconnect_event() {
     }
 }
 
-/// Reads `ws:disconnects` out of the vhost's KV keyspace via a tiny fixture
-/// deployed on demand.
+/// Reads `ws:disconnects` out of the vhost's KV keyspace. The fixture is
+/// deployed once with the rest (never rewritten inside the poll loop below —
+/// republishing a script the server may be compiling is exactly the hazard
+/// [`write`] documents).
 async fn disconnect_count() -> i64 {
-    let dir = sites_dir().join(SITE_A);
-    write(&dir, "disconnects.php", "<?php echo (int)(ephpm_kv_get('ws:disconnects') ?? 0);");
     let (status, body) = http_get(SITE_A, "/disconnects.php").await;
     assert_eq!(status, 200, "disconnects.php should serve: {body}");
     body.trim().parse().unwrap_or_else(|e| panic!("unparseable counter {body:?}: {e}"))

--- a/crates/ephpm-php/Cargo.toml
+++ b/crates/ephpm-php/Cargo.toml
@@ -10,6 +10,10 @@ build = "build.rs"
 
 [dependencies]
 ephpm-kv.workspace = true
+# ws_bridge: the site-scoped WebSocket connection registry the `ephpm_ws_*`
+# native functions push into. Protocol-free, so this adds no wire-format
+# dependency to the PHP crate.
+ephpm-ws.workspace = true
 # db_bridge: per-thread litewire Session executing PHP `ephpm_db_*` calls
 # against the same backend the wire frontends serve.
 litewire.workspace = true

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -3080,6 +3080,346 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_db_execute, 0, 0, 1)
     ZEND_ARG_INFO(0, params)
 ZEND_END_ARG_INFO()
 
+/* ===================================================================
+ * WebSocket native PHP functions
+ *
+ * ePHPm owns every WebSocket socket in Rust; PHP never holds one. These
+ * functions push into a Rust-side registry (ws_bridge.rs -> ephpm-ws),
+ * which hands the frame to the target connection's session task.
+ *
+ * They are callable from ANY PHP execution, not just a websocket
+ * entrypoint event — an ordinary HTTP request handler pushing to a live
+ * socket is the point of the design.
+ *
+ * TWO FORMS. Each operation comes in an implicit and an explicit form:
+ *
+ *   ephpm_ws_send($payload)                  -> the connection that fired
+ *                                               THIS event
+ *   ephpm_ws_connection_send($id, $payload)  -> any connection in this site
+ *
+ * The implicit form reads a per-thread "current connection" the router
+ * installs for the duration of a websocket event dispatch (the same
+ * pattern as db_bridge's per-thread site session, and cleared the same
+ * way — every PHP execution sets it, to the event's connection or to
+ * nothing, so it can never leak into the next request on a reused
+ * thread). Called from an ordinary HTTP request there is no current
+ * connection, and the implicit form THROWS rather than silently doing
+ * nothing.
+ *
+ * SITE SCOPE. Every one of these is scoped to the CALLING request's
+ * virtual host, read from a Rust thread-local the router installs before
+ * PHP runs (exactly like ephpm_db_*). The scope is never taken from an
+ * argument: a connection id names a connection only within the site that
+ * created it, so site A cannot reach site B's sockets or channels even
+ * holding a valid id. A request whose Host matched no vhost has no scope
+ * and every call below throws.
+ *
+ * All state lives in Rust; g_ws_ops is written once at startup
+ * (ephpm_set_ws_ops) before any PHP thread runs, then read-only — same
+ * ZTS discipline as g_kv_ops and g_db_ops.
+ * =================================================================== */
+
+/* Bridge status codes. Non-negative is a result (0/1 for the boolean
+ * operations, a receiver count for broadcast); negative is a condition
+ * that must reach the script as an exception rather than as `false`. */
+#define EPHPM_WS_NO_CONN     (-1)
+#define EPHPM_WS_NO_SITE     (-2)
+#define EPHPM_WS_NO_REGISTRY (-3)
+
+typedef struct {
+    /* Queue one frame. `conn_id == NULL` means "the connection that
+     * fired the current event"; otherwise the id names a connection in
+     * the calling request's site. Returns 1 on success, 0 when the
+     * connection is unknown to this site, gone, or its bounded outbound
+     * queue is full (which also closes that connection with 1013), or a
+     * negative EPHPM_WS_* status. */
+    long (*send)(const char *conn_id, size_t conn_id_len,
+                 const char *payload, size_t payload_len, int binary);
+    /* Subscribe / unsubscribe a connection to a site-scoped channel.
+     * Same `conn_id == NULL` convention and same return contract. */
+    long (*subscribe)(const char *conn_id, size_t conn_id_len,
+                      const char *channel, size_t channel_len);
+    long (*unsubscribe)(const char *conn_id, size_t conn_id_len,
+                        const char *channel, size_t channel_len);
+    /* Queue one frame to every member of a site-scoped channel. Returns
+     * the number of connections it was queued to, or a negative
+     * EPHPM_WS_* status. Needs no current connection. */
+    long (*broadcast)(const char *channel, size_t channel_len,
+                      const char *payload, size_t payload_len, int binary);
+    /* Ask a connection's session task to close with `code`. Same
+     * `conn_id == NULL` convention and same return contract.
+     * Must stay LAST-appended: the layout mirrors ws_bridge.rs. */
+    long (*close)(const char *conn_id, size_t conn_id_len, int code);
+} EphpmWsOps;
+
+static EphpmWsOps g_ws_ops = {0};
+
+/* Turn a negative bridge status into a PHP exception. Returns 1 if it
+ * threw (the caller must RETURN_THROWS()), 0 otherwise.
+ *
+ * These are all misuse or misconfiguration, never an ordinary outcome —
+ * an unreachable connection is `false`, but "there is no websocket
+ * subsystem" / "this request has no tenant" / "there is no current
+ * connection here" are bugs the script must not be able to ignore. Same
+ * reasoning as ephpm_db_*'s exception on a missing backend. */
+static int ephpm_ws_threw(long rc)
+{
+    switch (rc) {
+        case EPHPM_WS_NO_REGISTRY:
+            zend_throw_exception(zend_ce_exception,
+                "ephpm_ws: native websockets are not enabled on this server "
+                "(set [server.websocket] enabled = true)", 0);
+            return 1;
+        case EPHPM_WS_NO_SITE:
+            zend_throw_exception(zend_ce_exception,
+                "ephpm_ws: no websocket context for this request — its Host "
+                "matched no virtual host, so it has no websocket capability", 0);
+            return 1;
+        case EPHPM_WS_NO_CONN:
+            zend_throw_exception(zend_ce_exception,
+                "ephpm_ws: no current websocket connection. The implicit form "
+                "is only valid inside a websocket event; from an ordinary HTTP "
+                "request use the ephpm_ws_connection_*() form with an explicit "
+                "connection id", 0);
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+/* Guard for a never-installed ops table: identical to the registry being
+ * absent, so it produces the same exception. */
+#define EPHPM_WS_REQUIRE(fn)                                   \
+    do {                                                       \
+        if (!(fn)) {                                           \
+            (void)ephpm_ws_threw(EPHPM_WS_NO_REGISTRY);        \
+            RETURN_THROWS();                                   \
+        }                                                      \
+    } while (0)
+
+/* ephpm_ws_send(string $payload, bool $binary = false): bool
+ *
+ * Push one frame to the connection that fired the current event.
+ * Returns false if that connection has gone or its outbound queue is
+ * full — the latter sheds it with WebSocket status 1013 rather than
+ * buffering. Throws outside a websocket event. */
+PHP_FUNCTION(ephpm_ws_send)
+{
+    char *payload; size_t payload_len;
+    bool binary = 0;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(payload, payload_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(binary)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.send);
+    long rc = g_ws_ops.send(NULL, 0, payload, payload_len, binary ? 1 : 0);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_connection_send(string $connection_id, string $payload,
+ *                          bool $binary = false): bool
+ *
+ * The explicit form: push to any connection in the calling request's
+ * site. This is what an ordinary HTTP handler uses after looking the id
+ * up (see the websockets guide's HTTP-pushes-to-socket pattern). */
+PHP_FUNCTION(ephpm_ws_connection_send)
+{
+    char *conn_id; size_t conn_id_len;
+    char *payload; size_t payload_len;
+    bool binary = 0;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STRING(conn_id, conn_id_len)
+        Z_PARAM_STRING(payload, payload_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(binary)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.send);
+    long rc = g_ws_ops.send(conn_id, conn_id_len, payload, payload_len,
+                            binary ? 1 : 0);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_subscribe(string $channel): bool
+ *
+ * Join the current event's connection to a channel. Channels are
+ * site-scoped: `chat` on one vhost and `chat` on another are different
+ * channels. Throws outside a websocket event. */
+PHP_FUNCTION(ephpm_ws_subscribe)
+{
+    char *channel; size_t channel_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(channel, channel_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.subscribe);
+    long rc = g_ws_ops.subscribe(NULL, 0, channel, channel_len);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_connection_subscribe(string $connection_id,
+ *                               string $channel): bool */
+PHP_FUNCTION(ephpm_ws_connection_subscribe)
+{
+    char *conn_id; size_t conn_id_len;
+    char *channel; size_t channel_len;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(conn_id, conn_id_len)
+        Z_PARAM_STRING(channel, channel_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.subscribe);
+    long rc = g_ws_ops.subscribe(conn_id, conn_id_len, channel, channel_len);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_unsubscribe(string $channel): bool */
+PHP_FUNCTION(ephpm_ws_unsubscribe)
+{
+    char *channel; size_t channel_len;
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(channel, channel_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.unsubscribe);
+    long rc = g_ws_ops.unsubscribe(NULL, 0, channel, channel_len);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_connection_unsubscribe(string $connection_id,
+ *                                 string $channel): bool */
+PHP_FUNCTION(ephpm_ws_connection_unsubscribe)
+{
+    char *conn_id; size_t conn_id_len;
+    char *channel; size_t channel_len;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(conn_id, conn_id_len)
+        Z_PARAM_STRING(channel, channel_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.unsubscribe);
+    long rc = g_ws_ops.unsubscribe(conn_id, conn_id_len, channel, channel_len);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_broadcast(string $channel, string $payload,
+ *                    bool $binary = false): int
+ *
+ * Push one frame to every member of a channel in the calling request's
+ * site. Returns the number of connections the frame was queued to;
+ * subscribers whose queue was full are not counted (and are shed).
+ *
+ * Needs no current connection, so it works identically inside a
+ * websocket event and inside an ordinary HTTP request. */
+PHP_FUNCTION(ephpm_ws_broadcast)
+{
+    char *channel; size_t channel_len;
+    char *payload; size_t payload_len;
+    bool binary = 0;
+    ZEND_PARSE_PARAMETERS_START(2, 3)
+        Z_PARAM_STRING(channel, channel_len)
+        Z_PARAM_STRING(payload, payload_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_BOOL(binary)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.broadcast);
+    long rc = g_ws_ops.broadcast(channel, channel_len, payload, payload_len,
+                                 binary ? 1 : 0);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_LONG((zend_long)rc);
+}
+
+/* ephpm_ws_close(int $code = 1000): bool
+ *
+ * Ask the current event's connection to close. Asynchronous: the socket
+ * is closed by the task that owns it, not inside this call, so any frame
+ * already queued ahead of the close is still delivered. Throws outside a
+ * websocket event. */
+PHP_FUNCTION(ephpm_ws_close)
+{
+    zend_long code = 1000;
+    ZEND_PARSE_PARAMETERS_START(0, 1)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(code)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.close);
+    long rc = g_ws_ops.close(NULL, 0, (int)code);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+/* ephpm_ws_connection_close(string $connection_id,
+ *                           int $code = 1000): bool */
+PHP_FUNCTION(ephpm_ws_connection_close)
+{
+    char *conn_id; size_t conn_id_len;
+    zend_long code = 1000;
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STRING(conn_id, conn_id_len)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_LONG(code)
+    ZEND_PARSE_PARAMETERS_END();
+
+    EPHPM_WS_REQUIRE(g_ws_ops.close);
+    long rc = g_ws_ops.close(conn_id, conn_id_len, (int)code);
+    if (ephpm_ws_threw(rc)) { RETURN_THROWS(); }
+    RETURN_BOOL(rc);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_send, 0, 0, 1)
+    ZEND_ARG_INFO(0, payload)
+    ZEND_ARG_INFO(0, binary)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_connection_send, 0, 0, 2)
+    ZEND_ARG_INFO(0, connection_id)
+    ZEND_ARG_INFO(0, payload)
+    ZEND_ARG_INFO(0, binary)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_subscribe, 0, 0, 1)
+    ZEND_ARG_INFO(0, channel)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_connection_subscribe, 0, 0, 2)
+    ZEND_ARG_INFO(0, connection_id)
+    ZEND_ARG_INFO(0, channel)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_unsubscribe, 0, 0, 1)
+    ZEND_ARG_INFO(0, channel)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_connection_unsubscribe, 0, 0, 2)
+    ZEND_ARG_INFO(0, connection_id)
+    ZEND_ARG_INFO(0, channel)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_broadcast, 0, 0, 2)
+    ZEND_ARG_INFO(0, channel)
+    ZEND_ARG_INFO(0, payload)
+    ZEND_ARG_INFO(0, binary)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_close, 0, 0, 0)
+    ZEND_ARG_INFO(0, code)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_connection_close, 0, 0, 1)
+    ZEND_ARG_INFO(0, connection_id)
+    ZEND_ARG_INFO(0, code)
+ZEND_END_ARG_INFO()
+
 /* ── Function entry table (null-terminated) ──────────────────── */
 
 static const zend_function_entry ephpm_kv_functions[] = {
@@ -3099,6 +3439,18 @@ static const zend_function_entry ephpm_kv_functions[] = {
     /* Embedded database bridge (per-thread litewire Session). */
     PHP_FE(ephpm_db_query,     arginfo_ephpm_db_query)
     PHP_FE(ephpm_db_execute,   arginfo_ephpm_db_execute)
+    /* WebSocket bridge (site-scoped connection registry). Implicit forms
+     * act on the connection that fired the current event; the
+     * ephpm_ws_connection_* forms take an explicit id. */
+    PHP_FE(ephpm_ws_send,                    arginfo_ephpm_ws_send)
+    PHP_FE(ephpm_ws_connection_send,         arginfo_ephpm_ws_connection_send)
+    PHP_FE(ephpm_ws_subscribe,               arginfo_ephpm_ws_subscribe)
+    PHP_FE(ephpm_ws_connection_subscribe,    arginfo_ephpm_ws_connection_subscribe)
+    PHP_FE(ephpm_ws_unsubscribe,             arginfo_ephpm_ws_unsubscribe)
+    PHP_FE(ephpm_ws_connection_unsubscribe,  arginfo_ephpm_ws_connection_unsubscribe)
+    PHP_FE(ephpm_ws_broadcast,               arginfo_ephpm_ws_broadcast)
+    PHP_FE(ephpm_ws_close,                   arginfo_ephpm_ws_close)
+    PHP_FE(ephpm_ws_connection_close,        arginfo_ephpm_ws_connection_close)
     PHP_FE_END
 };
 
@@ -3714,6 +4066,26 @@ void ephpm_set_db_ops(const EphpmDbOps *ops)
 {
     if (ops) {
         g_db_ops = *ops;
+    }
+}
+
+/*
+ * Set the WebSocket ops function pointer table backing ephpm_ws_send() and
+ * friends. Same timing contract as ephpm_set_kv_ops / ephpm_set_db_ops:
+ * called once at startup, before any PHP scripts execute; g_ws_ops is
+ * read-only afterwards (ZTS-safe without locking).
+ *
+ * Left NULL when [server.websocket] is disabled. The PHP functions still
+ * exist — so a script can feature-detect with function_exists() rather
+ * than fataling on an undefined function — but calling one throws
+ * "native websockets are not enabled". Deliberately an exception rather
+ * than a `false`: a silent no-op here would look exactly like a
+ * delivered frame.
+ */
+void ephpm_set_ws_ops(const EphpmWsOps *ops)
+{
+    if (ops) {
+        g_ws_ops = *ops;
     }
 }
 

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -9,6 +9,7 @@ pub mod request;
 pub mod response;
 pub mod sapi;
 pub mod worker_bridge;
+pub mod ws_bridge;
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -132,6 +133,11 @@ mod ffi {
         /// `ephpm_db_*` functions. Same timing contract as
         /// `ephpm_set_kv_ops`.
         pub fn ephpm_set_db_ops(ops: *const crate::db_bridge::EphpmDbOps);
+
+        /// Set the WebSocket ops function pointer table backing the native
+        /// `ephpm_ws_*` functions. Same timing contract as
+        /// `ephpm_set_kv_ops`.
+        pub fn ephpm_set_ws_ops(ops: *const crate::ws_bridge::EphpmWsOps);
 
         // ── Worker mode ─────────────────────────────────────────────
 
@@ -1174,6 +1180,38 @@ impl PhpRuntime {
         #[cfg(not(php_linked))]
         if registered {
             tracing::debug!("per-site db resolver registered (stub mode, no PHP wiring)");
+        }
+    }
+
+    /// Register the WebSocket connection registry backing the PHP native
+    /// `ephpm_ws_*` functions.
+    ///
+    /// Call only when `[server.websocket] enabled = true`. When never called,
+    /// the functions still **exist** (so `function_exists()` and a portable
+    /// script both behave) but every call reports failure rather than reaching
+    /// a socket.
+    ///
+    /// Must be called after [`init()`] and before any PHP request executes.
+    /// First registration wins, mirroring [`Self::set_kv_store`].
+    ///
+    /// In stub mode (no `php_linked`) the Rust-side registration still happens
+    /// (stub tests use it) but no PHP wiring occurs.
+    pub fn set_ws_registry(registry: std::sync::Arc<ephpm_ws::Registry>) {
+        let registered = ws_bridge::set_registry(registry);
+
+        #[cfg(php_linked)]
+        if registered {
+            // Safety: WS_OPS is a static with a stable address.
+            // ephpm_set_ws_ops copies the struct into the C global — the
+            // pointer only needs to be valid for the duration of this call.
+            unsafe { ffi::ephpm_set_ws_ops(&ws_bridge::WS_OPS) };
+
+            tracing::info!("websocket registry wired to PHP native functions");
+        }
+
+        #[cfg(not(php_linked))]
+        if registered {
+            tracing::debug!("websocket registry registered (stub mode, no PHP wiring)");
         }
     }
 

--- a/crates/ephpm-php/src/ws_bridge.rs
+++ b/crates/ephpm-php/src/ws_bridge.rs
@@ -1,0 +1,627 @@
+//! `ephpm_ws_*` native PHP functions → the site-scoped WebSocket registry.
+//!
+//! Mirrors [`db_bridge`](crate::db_bridge)'s ops-table shape: the C wrapper
+//! calls into an [`EphpmWsOps`] table installed once at startup, and every
+//! entry point resolves its context from thread-locals the router installs
+//! before PHP runs.
+//!
+//! # Two thread-locals, two different jobs
+//!
+//! **[`WS_CURRENT_SITE`] — which connections may be reached at all.** These
+//! functions are callable from *any* PHP execution: a WebSocket event, an
+//! ordinary HTTP request, a cron script. Pushing to a socket from a normal
+//! request handler is the point of the design, so there is no "current
+//! connection" to key security off. What there always is, is the request
+//! executing on this thread, and the router has already derived its canonical
+//! site key exactly once (`Router::resolve_site`, issue #293).
+//!
+//! So the scope is read from the thread-local, never from a parameter. A script
+//! cannot name another tenant's site any more than it can name another tenant's
+//! database, and a request with no tenant identity gets no capability at all.
+//!
+//! **[`WS_CURRENT_CONN`] — which connection the short forms mean.** During a
+//! WebSocket event dispatch the router also installs the id of the connection
+//! that fired it, so `ephpm_ws_send($payload)` needs no id. Outside an event
+//! there is no current connection and the implicit form reports
+//! [`Status::NoConnection`], which the C wrapper turns into an exception. It
+//! must never silently succeed: a no-op that looks like a delivered frame is
+//! the worst possible failure mode for a push API.
+//!
+//! Both are set on **every** PHP execution — to a value or to `None` — so
+//! neither can leak into the next request that lands on a reused thread. This
+//! is the same discipline as [`db_bridge::set_current_site`].
+//!
+//! # Split for stub mode
+//!
+//! Everything except the `unsafe extern "C"` shims and the `#[repr(C)]` table
+//! is ungated, so the scoping logic — the security-relevant half — is unit
+//! tested by a plain `cargo test` with no PHP SDK present.
+
+use std::cell::RefCell;
+use std::sync::{Arc, OnceLock};
+
+use ephpm_ws::{OutFrame, Registry};
+
+/// The process-wide registry, installed once by
+/// [`PhpRuntime::set_ws_registry`](crate::PhpRuntime::set_ws_registry).
+///
+/// Absent when `[server.websocket] enabled = false`.
+static WS_REGISTRY: OnceLock<Arc<Registry>> = OnceLock::new();
+
+/// Site scope for single-site deployments.
+///
+/// Empty string, matching [`db_bridge`](crate::db_bridge)'s `SINGLE_SITE_KEY`
+/// sentinel and safe for the same reason: a real site key is a validated
+/// vhost-directory name and can never be empty, so the sentinel cannot collide
+/// with a tenant.
+pub const SINGLE_SITE_SCOPE: &str = "";
+
+thread_local! {
+    /// The site scope for the request executing on this thread.
+    static WS_CURRENT_SITE: RefCell<Option<Box<str>>> = const { RefCell::new(None) };
+    /// The connection that fired the WebSocket event executing on this thread,
+    /// or `None` for an ordinary HTTP request.
+    static WS_CURRENT_CONN: RefCell<Option<Box<str>>> = const { RefCell::new(None) };
+}
+
+/// Outcome of a bridge call, in the encoding the C wrapper expects.
+///
+/// Non-negative values are results; negative values are conditions the script
+/// must not be able to ignore, and the wrapper converts each into a distinct
+/// exception message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// Boolean `false`, or a broadcast that reached nobody.
+    Ok(i64),
+    /// No current connection — the implicit form was used outside a WebSocket
+    /// event.
+    NoConnection,
+    /// This request has no tenant identity, so it has no WebSocket capability.
+    NoSite,
+    /// `[server.websocket]` is disabled; no registry was ever installed.
+    NoRegistry,
+}
+
+impl Status {
+    /// The wire value handed back to C.
+    #[must_use]
+    pub fn code(self) -> i64 {
+        match self {
+            Self::Ok(v) => v,
+            Self::NoConnection => -1,
+            Self::NoSite => -2,
+            Self::NoRegistry => -3,
+        }
+    }
+
+    /// Shorthand for a boolean result.
+    fn boolean(ok: bool) -> Self {
+        Self::Ok(i64::from(ok))
+    }
+}
+
+/// Install the process-wide registry. Returns `false` if one was already set.
+///
+/// Called once at startup, before any PHP thread runs.
+pub fn set_registry(registry: Arc<Registry>) -> bool {
+    WS_REGISTRY.set(registry).is_ok()
+}
+
+/// Whether a registry is installed (i.e. `[server.websocket]` is enabled).
+#[must_use]
+pub fn is_configured() -> bool {
+    WS_REGISTRY.get().is_some()
+}
+
+/// Set (or clear) the site scope for the request about to run on this thread.
+///
+/// Called by the request handler before PHP execution, alongside
+/// [`crate::db_bridge::set_current_site`]. Passing `None` clears any previous
+/// scope so a request with no tenant identity gets **no** WebSocket capability
+/// rather than inheriting the last request's.
+pub fn set_current_site(scope: Option<&str>) {
+    WS_CURRENT_SITE.with(|s| {
+        *s.borrow_mut() = scope.map(Box::from);
+    });
+}
+
+/// Set (or clear) the connection the implicit `ephpm_ws_*` forms act on.
+///
+/// Called with `Some(id)` immediately before a WebSocket event's PHP execution
+/// and with `None` before every ordinary request, so the id cannot outlive its
+/// event on a thread the pool later reuses. Clearing is not an optimisation:
+/// a stale id would make an unrelated HTTP request silently push frames to
+/// whichever socket happened to run last on that thread.
+pub fn set_current_connection(connection_id: Option<&str>) {
+    WS_CURRENT_CONN.with(|c| {
+        *c.borrow_mut() = connection_id.map(Box::from);
+    });
+}
+
+/// The site scope for this thread's request, or `None`.
+fn site_scope() -> Option<Box<str>> {
+    WS_CURRENT_SITE.with(|s| s.borrow().clone())
+}
+
+/// The current event's connection id, or `None` outside an event.
+fn current_connection() -> Option<Box<str>> {
+    WS_CURRENT_CONN.with(|c| c.borrow().clone())
+}
+
+/// Resolve the registry and this request's site scope.
+fn context() -> Result<(&'static Arc<Registry>, Box<str>), Status> {
+    let registry = WS_REGISTRY.get().ok_or(Status::NoRegistry)?;
+    let scope = site_scope().ok_or_else(|| {
+        tracing::debug!(
+            "ephpm_ws_* called with no site context — this request's Host matched no virtual \
+             host, so it has no websocket capability"
+        );
+        Status::NoSite
+    })?;
+    Ok((registry, scope))
+}
+
+/// Resolve the target connection: the explicit id when given, otherwise the
+/// current event's connection.
+fn target(explicit: Option<&[u8]>) -> Result<Box<str>, Status> {
+    match explicit {
+        Some(bytes) => {
+            // Non-UTF-8 is refused rather than lossily converted: a connection
+            // id is a hex capability token and two different byte strings must
+            // never normalize onto one.
+            let id = std::str::from_utf8(bytes).map_err(|_| Status::Ok(0))?;
+            Ok(Box::from(id))
+        }
+        None => current_connection().ok_or(Status::NoConnection),
+    }
+}
+
+/// Decode a channel name. Channel names are map keys, so the same
+/// no-lossy-conversion rule applies.
+fn channel_name(bytes: &[u8]) -> Result<&str, Status> {
+    std::str::from_utf8(bytes).map_err(|_| Status::Ok(0))
+}
+
+/// Collapse `Result<Status, Status>` — both arms are already a status.
+fn settle(result: Result<Status, Status>) -> Status {
+    match result {
+        Ok(status) | Err(status) => status,
+    }
+}
+
+// ── Core operations (ungated — unit tested in stub mode) ─────────────────
+
+/// `ephpm_ws_send()` / `ephpm_ws_connection_send()`.
+///
+/// `conn_id` is `None` for the implicit form.
+#[must_use]
+pub fn send(conn_id: Option<&[u8]>, payload: &[u8], binary: bool) -> Status {
+    settle((|| {
+        let (registry, scope) = context()?;
+        let id = target(conn_id)?;
+        let frame = OutFrame::new(bytes::Bytes::copy_from_slice(payload), binary);
+        Ok(Status::boolean(registry.send(&scope, &id, frame)))
+    })())
+}
+
+/// `ephpm_ws_subscribe()` / `ephpm_ws_connection_subscribe()`.
+#[must_use]
+pub fn subscribe(conn_id: Option<&[u8]>, channel: &[u8]) -> Status {
+    settle((|| {
+        let (registry, scope) = context()?;
+        let id = target(conn_id)?;
+        let channel = channel_name(channel)?;
+        Ok(Status::boolean(registry.subscribe(&scope, &id, channel)))
+    })())
+}
+
+/// `ephpm_ws_unsubscribe()` / `ephpm_ws_connection_unsubscribe()`.
+#[must_use]
+pub fn unsubscribe(conn_id: Option<&[u8]>, channel: &[u8]) -> Status {
+    settle((|| {
+        let (registry, scope) = context()?;
+        let id = target(conn_id)?;
+        let channel = channel_name(channel)?;
+        Ok(Status::boolean(registry.unsubscribe(&scope, &id, channel)))
+    })())
+}
+
+/// `ephpm_ws_broadcast()`. Needs no current connection.
+#[must_use]
+pub fn broadcast(channel: &[u8], payload: &[u8], binary: bool) -> Status {
+    settle((|| {
+        let (registry, scope) = context()?;
+        let channel = channel_name(channel)?;
+        let delivered =
+            registry.broadcast(&scope, channel, bytes::Bytes::copy_from_slice(payload), binary);
+        Ok(Status::Ok(i64::try_from(delivered).unwrap_or(i64::MAX)))
+    })())
+}
+
+/// `ephpm_ws_close()` / `ephpm_ws_connection_close()`.
+#[must_use]
+pub fn close(conn_id: Option<&[u8]>, code: u16) -> Status {
+    settle((|| {
+        let (registry, scope) = context()?;
+        let id = target(conn_id)?;
+        Ok(Status::boolean(registry.close(&scope, &id, code)))
+    })())
+}
+
+// ── FFI shims ───────────────────────────────────────────────────────────
+
+/// C-ABI mirror of `EphpmWsOps` in `ephpm_wrapper.c`.
+///
+/// Field order and types must match the C `typedef` exactly. New entries are
+/// **appended**, never inserted — the C side documents the same rule.
+///
+/// Every entry takes the target connection as a `(ptr, len)` pair where a NULL
+/// pointer means "the connection that fired the current event", which is what
+/// lets one op back both the implicit and the explicit PHP form.
+#[cfg(php_linked)]
+#[repr(C)]
+pub struct EphpmWsOps {
+    /// `send(conn_id|NULL, len, payload, len, binary) -> status`
+    pub send: Option<
+        unsafe extern "C" fn(
+            conn_id: *const std::os::raw::c_char,
+            conn_id_len: usize,
+            payload: *const std::os::raw::c_char,
+            payload_len: usize,
+            binary: std::os::raw::c_int,
+        ) -> std::os::raw::c_long,
+    >,
+    /// `subscribe(conn_id|NULL, len, channel, len) -> status`
+    pub subscribe: Option<
+        unsafe extern "C" fn(
+            conn_id: *const std::os::raw::c_char,
+            conn_id_len: usize,
+            channel: *const std::os::raw::c_char,
+            channel_len: usize,
+        ) -> std::os::raw::c_long,
+    >,
+    /// `unsubscribe(conn_id|NULL, len, channel, len) -> status`
+    pub unsubscribe: Option<
+        unsafe extern "C" fn(
+            conn_id: *const std::os::raw::c_char,
+            conn_id_len: usize,
+            channel: *const std::os::raw::c_char,
+            channel_len: usize,
+        ) -> std::os::raw::c_long,
+    >,
+    /// `broadcast(channel, len, payload, len, binary) -> status`
+    pub broadcast: Option<
+        unsafe extern "C" fn(
+            channel: *const std::os::raw::c_char,
+            channel_len: usize,
+            payload: *const std::os::raw::c_char,
+            payload_len: usize,
+            binary: std::os::raw::c_int,
+        ) -> std::os::raw::c_long,
+    >,
+    /// `close(conn_id|NULL, len, code) -> status`
+    pub close: Option<
+        unsafe extern "C" fn(
+            conn_id: *const std::os::raw::c_char,
+            conn_id_len: usize,
+            code: std::os::raw::c_int,
+        ) -> std::os::raw::c_long,
+    >,
+}
+
+/// Borrow a `(ptr, len)` pair from C as a byte slice.
+///
+/// # Safety
+///
+/// `ptr` must either be NULL or point to at least `len` readable bytes that
+/// stay valid for the duration of the call. PHP guarantees this for a
+/// `zend_string`'s buffer across a `PHP_FUNCTION` body: the string is a live
+/// zval argument, and none of these shims can trigger a GC pass or re-enter
+/// PHP.
+#[cfg(php_linked)]
+unsafe fn opt_slice<'a>(ptr: *const std::os::raw::c_char, len: usize) -> Option<&'a [u8]> {
+    if ptr.is_null() {
+        return None;
+    }
+    if len == 0 {
+        return Some(&[]);
+    }
+    // SAFETY: caller contract above — non-NULL `ptr` is a live zend_string
+    // buffer of at least `len` bytes, and nothing here re-enters the Zend
+    // engine.
+    Some(unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) })
+}
+
+/// Borrow a required `(ptr, len)` pair. A NULL payload is treated as empty
+/// rather than trusted.
+///
+/// # Safety
+///
+/// Same contract as [`opt_slice`].
+#[cfg(php_linked)]
+unsafe fn slice<'a>(ptr: *const std::os::raw::c_char, len: usize) -> &'a [u8] {
+    // SAFETY: caller contract above.
+    unsafe { opt_slice(ptr, len) }.unwrap_or(&[])
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn ws_send(
+    conn_id: *const std::os::raw::c_char,
+    conn_id_len: usize,
+    payload: *const std::os::raw::c_char,
+    payload_len: usize,
+    binary: std::os::raw::c_int,
+) -> std::os::raw::c_long {
+    // SAFETY: both pairs are live zend_string buffers (or NULL) for this call.
+    let (id, body) = unsafe { (opt_slice(conn_id, conn_id_len), slice(payload, payload_len)) };
+    send(id, body, binary != 0).code()
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn ws_subscribe(
+    conn_id: *const std::os::raw::c_char,
+    conn_id_len: usize,
+    channel: *const std::os::raw::c_char,
+    channel_len: usize,
+) -> std::os::raw::c_long {
+    // SAFETY: both pairs are live zend_string buffers (or NULL) for this call.
+    let (id, chan) = unsafe { (opt_slice(conn_id, conn_id_len), slice(channel, channel_len)) };
+    subscribe(id, chan).code()
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn ws_unsubscribe(
+    conn_id: *const std::os::raw::c_char,
+    conn_id_len: usize,
+    channel: *const std::os::raw::c_char,
+    channel_len: usize,
+) -> std::os::raw::c_long {
+    // SAFETY: both pairs are live zend_string buffers (or NULL) for this call.
+    let (id, chan) = unsafe { (opt_slice(conn_id, conn_id_len), slice(channel, channel_len)) };
+    unsubscribe(id, chan).code()
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn ws_broadcast(
+    channel: *const std::os::raw::c_char,
+    channel_len: usize,
+    payload: *const std::os::raw::c_char,
+    payload_len: usize,
+    binary: std::os::raw::c_int,
+) -> std::os::raw::c_long {
+    // SAFETY: both pairs are live zend_string buffers for this call.
+    let (chan, body) = unsafe { (slice(channel, channel_len), slice(payload, payload_len)) };
+    broadcast(chan, body, binary != 0).code()
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn ws_close(
+    conn_id: *const std::os::raw::c_char,
+    conn_id_len: usize,
+    code: std::os::raw::c_int,
+) -> std::os::raw::c_long {
+    // SAFETY: the pair is a live zend_string buffer (or NULL) for this call.
+    let id = unsafe { opt_slice(conn_id, conn_id_len) };
+    // PHP `int` is 64-bit; anything outside the WebSocket close-code range is
+    // clamped to "normal closure" rather than silently truncated into a
+    // different, meaningful code.
+    let code = u16::try_from(code).unwrap_or(ephpm_ws::CLOSE_NORMAL);
+    close(id, code).code()
+}
+
+/// The ops table handed to the C wrapper.
+#[cfg(php_linked)]
+pub static WS_OPS: EphpmWsOps = EphpmWsOps {
+    send: Some(ws_send),
+    subscribe: Some(ws_subscribe),
+    unsubscribe: Some(ws_unsubscribe),
+    broadcast: Some(ws_broadcast),
+    close: Some(ws_close),
+};
+
+#[cfg(test)]
+mod tests {
+    use ephpm_ws::Limits;
+
+    use super::*;
+
+    /// The scope and connection are thread-local, so every test that touches
+    /// them runs on its own thread and cannot be perturbed by a sibling.
+    fn on_thread<F: FnOnce() + Send + 'static>(f: F) {
+        std::thread::spawn(f).join().expect("test thread");
+    }
+
+    /// Install the process-wide registry exactly once for this test binary.
+    ///
+    /// `WS_REGISTRY` is a `OnceLock`, so no test may assume it is *unset* —
+    /// every assertion below holds whether this ran first or last.
+    fn shared_registry() -> &'static Arc<Registry> {
+        let registry = Arc::new(Registry::new(Limits {
+            max_connections: 0,
+            max_connections_per_site: 0,
+            send_queue: 4,
+            max_message_size: 0,
+        }));
+        let _ = set_registry(registry);
+        WS_REGISTRY.get().expect("registry installed")
+    }
+
+    #[test]
+    fn no_scope_means_no_capability() {
+        on_thread(|| {
+            let registry = shared_registry();
+            // A real, live connection under site `alpha`...
+            let conn = registry.register("alpha").expect("register");
+
+            // ...is unreachable from a request that has no tenant identity,
+            // even holding its exact id.
+            set_current_site(None);
+            set_current_connection(None);
+            assert_eq!(send(Some(conn.id.as_bytes()), b"hi", false), Status::NoSite);
+            assert_eq!(subscribe(Some(conn.id.as_bytes()), b"room"), Status::NoSite);
+            assert_eq!(unsubscribe(Some(conn.id.as_bytes()), b"room"), Status::NoSite);
+            assert_eq!(close(Some(conn.id.as_bytes()), 1000), Status::NoSite);
+            assert_eq!(broadcast(b"room", b"hi", false), Status::NoSite);
+
+            registry.unregister(&conn.id);
+        });
+    }
+
+    #[test]
+    fn the_thread_scope_is_what_gates_a_send_not_the_argument() {
+        on_thread(|| {
+            let registry = shared_registry();
+            let mut conn = registry.register("scoped-alpha").expect("register");
+
+            // Executing as another tenant: the id is valid, the scope is not.
+            set_current_site(Some("scoped-beta"));
+            assert_eq!(send(Some(conn.id.as_bytes()), b"pwned", false), Status::Ok(0));
+            assert!(conn.rx.try_recv().is_err(), "no frame may cross the site boundary");
+
+            // Executing as the owning tenant: the same call succeeds.
+            set_current_site(Some("scoped-alpha"));
+            assert_eq!(send(Some(conn.id.as_bytes()), b"hello", false), Status::Ok(1));
+            assert!(conn.rx.try_recv().is_ok());
+
+            registry.unregister(&conn.id);
+        });
+    }
+
+    /// The whole point of the implicit form: no id argument, and it must reach
+    /// exactly the connection whose event is running.
+    #[test]
+    fn the_implicit_form_targets_the_current_event_connection() {
+        on_thread(|| {
+            let registry = shared_registry();
+            let mut firing = registry.register("implicit").expect("register");
+            let mut bystander = registry.register("implicit").expect("register");
+
+            set_current_site(Some("implicit"));
+            set_current_connection(Some(&firing.id));
+
+            assert_eq!(send(None, b"echo", false), Status::Ok(1));
+            assert!(firing.rx.try_recv().is_ok(), "the firing connection receives it");
+            assert!(bystander.rx.try_recv().is_err(), "no one else does");
+
+            assert_eq!(subscribe(None, b"room"), Status::Ok(1));
+            assert_eq!(registry.channel_members("implicit", "room"), 1);
+            assert_eq!(unsubscribe(None, b"room"), Status::Ok(1));
+            assert_eq!(registry.channel_members("implicit", "room"), 0);
+
+            assert_eq!(close(None, 4000), Status::Ok(1));
+
+            registry.unregister(&firing.id);
+            registry.unregister(&bystander.id);
+        });
+    }
+
+    /// An ordinary HTTP request has no current connection. The implicit form
+    /// must say so loudly — a silent no-op looks exactly like a delivered
+    /// frame.
+    #[test]
+    fn the_implicit_form_fails_loudly_outside_an_event() {
+        on_thread(|| {
+            let _ = shared_registry();
+            set_current_site(Some("alpha"));
+            set_current_connection(None);
+
+            assert_eq!(send(None, b"hi", false), Status::NoConnection);
+            assert_eq!(subscribe(None, b"room"), Status::NoConnection);
+            assert_eq!(unsubscribe(None, b"room"), Status::NoConnection);
+            assert_eq!(close(None, 1000), Status::NoConnection);
+
+            // Broadcast needs no connection, so it stays usable from HTTP.
+            assert_eq!(broadcast(b"room", b"hi", false), Status::Ok(0));
+        });
+    }
+
+    /// The HTTP-pushes-to-socket pattern the guide documents: no current
+    /// connection, an explicit id looked up out of band.
+    #[test]
+    fn an_http_request_can_push_with_an_explicit_id() {
+        on_thread(|| {
+            let registry = shared_registry();
+            let mut conn = registry.register("push").expect("register");
+            let stashed_id = conn.id.clone();
+
+            // Simulate a later, unrelated HTTP request on this thread.
+            set_current_site(Some("push"));
+            set_current_connection(None);
+
+            assert_eq!(send(Some(stashed_id.as_bytes()), b"new comment", false), Status::Ok(1));
+            assert!(conn.rx.try_recv().is_ok());
+
+            registry.unregister(&conn.id);
+        });
+    }
+
+    #[test]
+    fn the_current_connection_does_not_leak_between_dispatches() {
+        on_thread(|| {
+            set_current_connection(Some("abc"));
+            assert_eq!(current_connection().as_deref(), Some("abc"));
+            // Next execution on this thread is an ordinary HTTP request.
+            set_current_connection(None);
+            assert_eq!(
+                current_connection(),
+                None,
+                "a cleared connection must not fall back to the last event's"
+            );
+        });
+    }
+
+    #[test]
+    fn a_scope_does_not_leak_between_requests_on_one_thread() {
+        on_thread(|| {
+            set_current_site(Some("alpha"));
+            assert_eq!(site_scope().as_deref(), Some("alpha"));
+            set_current_site(None);
+            assert_eq!(site_scope(), None, "a cleared scope must not fall back to the last one");
+        });
+    }
+
+    #[test]
+    fn scope_is_replaced_not_merged() {
+        on_thread(|| {
+            set_current_site(Some("alpha"));
+            set_current_site(Some("beta"));
+            assert_eq!(site_scope().as_deref(), Some("beta"));
+        });
+    }
+
+    #[test]
+    fn non_utf8_arguments_are_refused_without_panicking() {
+        on_thread(|| {
+            let _ = shared_registry();
+            set_current_site(Some("alpha"));
+            set_current_connection(Some("abc"));
+            assert_eq!(send(Some(b"\xff\xfe"), b"payload", false), Status::Ok(0));
+            assert_eq!(subscribe(None, b"\xff\xfe"), Status::Ok(0));
+            assert_eq!(unsubscribe(None, b"\xff\xfe"), Status::Ok(0));
+            assert_eq!(broadcast(b"\xff\xfe", b"payload", false), Status::Ok(0));
+        });
+    }
+
+    #[test]
+    fn an_unknown_connection_id_is_a_false_not_an_exception() {
+        on_thread(|| {
+            let _ = shared_registry();
+            set_current_site(Some("alpha"));
+            let unknown = b"00000000000000000000000000000000";
+            assert_eq!(send(Some(unknown), b"hi", false), Status::Ok(0));
+            assert_eq!(close(Some(unknown), 1000), Status::Ok(0));
+        });
+    }
+
+    #[test]
+    fn status_codes_match_the_c_wrapper_constants() {
+        // These three values are duplicated in ephpm_wrapper.c as
+        // EPHPM_WS_NO_CONN / NO_SITE / NO_REGISTRY. Drift here is a silent
+        // wrong-exception bug, so pin them.
+        assert_eq!(Status::NoConnection.code(), -1);
+        assert_eq!(Status::NoSite.code(), -2);
+        assert_eq!(Status::NoRegistry.code(), -3);
+        assert_eq!(Status::Ok(0).code(), 0);
+        assert_eq!(Status::Ok(7).code(), 7);
+    }
+}

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -21,6 +21,13 @@ ephpm-middleware = { workspace = true, features = ["host"] }
 ephpm-middleware-builtins.workspace = true
 ephpm-php.workspace = true
 ephpm-query-stats.workspace = true
+ephpm-ws.workspace = true
+# WebSocket framing for the upgraded socket. hyper has already done the HTTP
+# handshake, so only the codec is used (`from_raw_socket`).
+tokio-tungstenite.workspace = true
+# `StreamExt`/`SinkExt` on the WebSocket stream. Already in the graph via
+# yamux/litewire.
+futures.workspace = true
 litewire.workspace = true
 turso.workspace = true
 tokio.workspace = true

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -23,6 +23,7 @@ pub mod tls;
 pub mod tracked_backend;
 pub mod turso_cdc;
 pub mod turso_cdc_metrics;
+pub mod websocket;
 pub mod worker_pool;
 
 use std::net::SocketAddr;
@@ -650,7 +651,18 @@ async fn bind_listeners(
         None
     };
 
-    let router = Arc::new({
+    // Native WebSockets (experimental). `None` when `[server.websocket]` is
+    // disabled, which also means the PHP bridge stays unwired: `ephpm_ws_*`
+    // then throws "not enabled" instead of silently pretending to deliver.
+    let websocket = crate::websocket::WsRuntime::new(&config.server.websocket).map(Arc::new);
+    if let Some(ref runtime) = websocket {
+        ephpm_php::PhpRuntime::set_ws_registry(Arc::clone(&runtime.registry));
+    }
+
+    // `Router::share` rather than `Arc::new`: a WebSocket session outlives the
+    // request that created it and keeps dispatching PHP events through this
+    // router, so the Arc has to be reachable from the router itself.
+    let router = {
         let router = Router::new(
             config,
             kv_store,
@@ -668,6 +680,7 @@ async fn bind_listeners(
         // derived from `[cluster] node_id`.
         .with_node_id(node_id)
         .with_db_health(db_health)
+        .with_websocket(websocket)
         .with_request_log(request_log);
 
         let router = match per_site_db_wire {
@@ -680,7 +693,8 @@ async fn bind_listeners(
             Some((port, max_age)) => router.with_alt_svc(port, max_age),
             None => router,
         }
-    });
+        .share()
+    };
 
     let has_tls = !matches!(tls_mode, TlsMode::None);
 

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -99,6 +99,11 @@ const UNKNOWN_SITE_TTL: Duration = Duration::from_secs(2);
 struct SiteConfig {
     document_root: PathBuf,
     index_files: Vec<String>,
+    /// WebSocket entrypoint names for this vhost, in try-order — the
+    /// `index_files` of the upgrade path. Carried per-site for exactly the same
+    /// reason `index_files` is: the resolution has to happen against the
+    /// vhost's own document root.
+    websocket_files: Vec<String>,
     fallback: Vec<String>,
 }
 
@@ -122,6 +127,15 @@ struct SiteIdentities {
     kv: String,
     /// Key for cluster-wide OPcache invalidation (`opcache:version:<key>`).
     opcache: String,
+    /// Scope for this request's WebSocket capability — which connections and
+    /// channels `ephpm_ws_*` may reach.
+    ///
+    /// `None` on a multi-tenant node for a host that matched no vhost: such a
+    /// request gets no WebSocket capability at all, the same way it gets no
+    /// database context (issue #291). On a single-site node it is the
+    /// [`ephpm_php::ws_bridge::SINGLE_SITE_SCOPE`] sentinel, because there is
+    /// exactly one tenant and nothing to isolate it from.
+    ws: Option<String>,
 }
 
 /// A request's virtual host, resolved once: the tenant's **canonical site key**
@@ -165,6 +179,10 @@ struct ResolvedSite<'a> {
     document_root: PathBuf,
     /// Index files for this site.
     index_files: &'a [String],
+    /// WebSocket entrypoint names for this site, in try-order. Travels with the
+    /// resolved site so the upgrade path never re-reads config or re-derives a
+    /// document root.
+    websocket_files: &'a [String],
     /// Fallback chain for this site.
     fallback: &'a [String],
 }
@@ -276,6 +294,31 @@ pub struct Router {
     /// short directory names while their browser uses `*.localhost`.
     sites_domain_suffix: Option<String>,
     index_files: Vec<String>,
+    /// Default WebSocket entrypoint names (`[server] websocket_files`), used
+    /// for the default document root and for lazily-discovered vhosts.
+    websocket_files: Vec<String>,
+    /// Whether this node serves more than one tenant — `sites_dir` is set, or
+    /// static vhosts were configured.
+    ///
+    /// Decides the WebSocket registry scope: multi-tenant nodes scope by the
+    /// canonical site key (and a host that matched no vhost gets **no** scope),
+    /// single-site nodes share one sentinel scope because there is exactly one
+    /// tenant to isolate.
+    multi_site: bool,
+    /// Native WebSocket runtime, or `None` when `[server.websocket]` is
+    /// disabled — in which case an upgrade request is routed like any other
+    /// GET, exactly as before the feature existed.
+    websocket: Option<Arc<crate::websocket::WsRuntime>>,
+    /// Weak self-reference, installed by [`Router::share`].
+    ///
+    /// A WebSocket session outlives the request that created it, and every
+    /// event it dispatches goes back through this router. `Weak` rather than a
+    /// clone of the `Arc` so the router is still dropped at shutdown even with
+    /// sessions live, and `Arc::new_cyclic` rather than a post-construction
+    /// setter so it cannot be forgotten. A `Router` that was never shared (unit
+    /// tests build one on the stack) simply cannot serve an upgrade — see
+    /// [`Router::handle_websocket_upgrade`].
+    self_weak: std::sync::Weak<Router>,
     fallback: Vec<String>,
     server_port: u16,
     max_body_size: u64,
@@ -591,6 +634,7 @@ const SITE_PASSWORD_CACHE_MAX: usize = 4096;
 fn scan_sites_dir(
     sites_dir: Option<&Path>,
     default_index_files: &[String],
+    default_websocket_files: &[String],
     default_fallback: &[String],
 ) -> HashMap<String, SiteConfig> {
     let Some(dir) = sites_dir else {
@@ -621,6 +665,7 @@ fn scan_sites_dir(
             SiteConfig {
                 document_root: path,
                 index_files: default_index_files.to_vec(),
+                websocket_files: default_websocket_files.to_vec(),
                 fallback: default_fallback.to_vec(),
             },
         );
@@ -693,6 +738,7 @@ impl Router {
         let sites = scan_sites_dir(
             config.server.sites_dir.as_deref(),
             &config.server.index_files,
+            &config.server.websocket_files,
             &config.server.fallback,
         );
 
@@ -722,9 +768,18 @@ impl Router {
         let php_semaphore = (fpm_pool.is_none() && config.php.workers > 0)
             .then(|| Arc::new(tokio::sync::Semaphore::new(config.php.workers)));
 
+        // Multi-tenant iff a sites_dir is configured or vhost directories were
+        // found. Resolved once here so the WebSocket scope derivation in
+        // `site_identities` is a field read, not a re-scan.
+        let multi_site = config.server.sites_dir.is_some() || !sites.is_empty();
+
         Self {
             document_root: config.server.document_root.clone(),
             sites,
+            multi_site,
+            websocket: None,
+            self_weak: std::sync::Weak::new(),
+            websocket_files: config.server.websocket_files.clone(),
             sites_dir: config.server.sites_dir.clone(),
             sites_domain_suffix: config
                 .server
@@ -1074,6 +1129,30 @@ impl Router {
         }
     }
 
+    /// Wrap the finished router in the `Arc` the server shares across
+    /// connections, recording the weak self-reference WebSocket sessions need.
+    ///
+    /// Use this instead of `Arc::new(router)`: a session task keeps dispatching
+    /// PHP events long after the request that created it returned, so it needs
+    /// a handle on the router that does not borrow from a request.
+    /// `Arc::new_cyclic` makes that handle a construction-time guarantee rather
+    /// than a step someone can forget.
+    #[must_use]
+    pub fn share(self) -> Arc<Self> {
+        Arc::new_cyclic(|weak| Self { self_weak: weak.clone(), ..self })
+    }
+
+    /// Attach the native WebSocket runtime.
+    ///
+    /// `None` (the default) leaves the feature off: an upgrade request is then
+    /// routed exactly like any other GET, so enabling `[server.websocket]` is
+    /// the only thing that changes upgrade routing.
+    #[must_use]
+    pub fn with_websocket(mut self, websocket: Option<Arc<crate::websocket::WsRuntime>>) -> Self {
+        self.websocket = websocket;
+        self
+    }
+
     /// Override this node's `EPHPM_NODE_ID` (injected into PHP `$_SERVER`)
     /// with the effective runtime cluster identity.
     ///
@@ -1316,6 +1395,7 @@ impl Router {
                         key: Some((*key).to_string()),
                         document_root: site.document_root.clone(),
                         index_files: &site.index_files,
+                        websocket_files: &site.websocket_files,
                         fallback: &site.fallback,
                     };
                 }
@@ -1336,6 +1416,7 @@ impl Router {
                         key: Some((*key).to_string()),
                         document_root: candidate,
                         index_files: &self.index_files,
+                        websocket_files: &self.websocket_files,
                         fallback: &self.fallback,
                     };
                 }
@@ -1367,6 +1448,7 @@ impl Router {
             key: None,
             document_root: self.document_root.clone(),
             index_files: &self.index_files,
+            websocket_files: &self.websocket_files,
             fallback: &self.fallback,
         }
     }
@@ -1396,6 +1478,17 @@ impl Router {
             db: if self.per_site_db { site_key.map(str::to_owned) } else { None },
             kv: site_key.map_or_else(|| normalize_host_key(server_name), str::to_owned),
             opcache: opcache_vhost_key(site_key),
+            // Unlike `kv`, this does NOT fall back to the request host. A
+            // client-controlled scope would let anyone mint a fresh WebSocket
+            // namespace by varying `Host`, and — worse — two requests that
+            // *should* be one tenant could end up in different scopes and lose
+            // sight of each other's connections. Multi-tenant: the canonical
+            // key or nothing. Single-site: one sentinel scope for everything.
+            ws: if self.multi_site {
+                site_key.map(str::to_owned)
+            } else {
+                Some(ephpm_php::ws_bridge::SINGLE_SITE_SCOPE.to_string())
+            },
         }
     }
 
@@ -1720,7 +1813,46 @@ impl Router {
             document_root: site_root,
             index_files: site_index,
             fallback: site_fallback,
+            websocket_files: site_websocket_files,
         } = self.resolve_site(&host);
+
+        // WebSocket upgrade. Positioned deliberately:
+        //
+        // * AFTER the security gates above (trusted host, malformed host,
+        //   hidden files, blocked paths) — an upgrade is not a way around them.
+        // * AFTER `resolve_site`, because the entrypoint is resolved against
+        //   THIS vhost's document root and the connection's tenant identity is
+        //   the canonical key that resolution produced.
+        // * BEFORE `resolve_fallback`, because an upgrade request must never
+        //   fall through to a static file, `index.php`, or the fallback chain.
+        //   A vhost with no entrypoint gets a 404, full stop.
+        //
+        // With `[server.websocket]` disabled this is one `Option::is_none()`
+        // and an upgrade request routes exactly as it did before the feature
+        // existed.
+        if let Some(ref runtime) = self.websocket {
+            if crate::websocket::is_upgrade_request(&req) {
+                let mut resp = self
+                    .handle_websocket_upgrade(
+                        req,
+                        runtime,
+                        effective_addr,
+                        is_https,
+                        &site_root,
+                        site_websocket_files,
+                        site_key,
+                    )
+                    .await;
+                // Configured response headers belong on the error paths (404 /
+                // 400 / 503) but not on a 101 — a Switching Protocols response
+                // hands the socket over, and anything appended to it is bytes
+                // the client will read as WebSocket framing.
+                if resp.status() != StatusCode::SWITCHING_PROTOCOLS {
+                    self.apply_response_headers(&mut resp);
+                }
+                return Ok((resp, "websocket"));
+            }
+        }
 
         // Extract If-None-Match for ETag support before consuming the request.
         let if_none_match = if self.etag {
@@ -1781,6 +1913,7 @@ impl Router {
                                 accepts_br,
                                 site_root.clone(),
                                 site_key.clone(),
+                                None,
                             )
                             .await;
 
@@ -1852,6 +1985,7 @@ impl Router {
                             accepts_br,
                             site_root.clone(),
                             site_key.clone(),
+                            None,
                         )
                         .await,
                         "php",
@@ -1950,6 +2084,227 @@ impl Router {
     /// per-tenant value below is derived from it rather than from the `Host`
     /// header, so the database, the wire credential, the KV keyspace and the
     /// document root cannot name different tenants — see [`ResolvedSite`].
+    /// Resolve this vhost's WebSocket entrypoint — `index_files` semantics for
+    /// the upgrade path.
+    ///
+    /// Tries `[server] websocket_files` in order against the **resolved**
+    /// document root and returns the first that exists. `None` means this vhost
+    /// has not opted into WebSockets, which the caller turns into a 404.
+    ///
+    /// Each candidate is containment-checked even though the names are
+    /// operator-supplied rather than client-supplied: an entry may legitimately
+    /// contain a separator (`"public/ws.php"`), so `..` or an absolute path
+    /// must not be able to escape the vhost. A name that resolves outside the
+    /// document root is skipped with a warning rather than silently served.
+    fn resolve_websocket_script(&self, site_root: &Path, names: &[String]) -> Option<PathBuf> {
+        for name in names {
+            let candidate = site_root.join(name);
+            if !candidate.is_file() {
+                continue;
+            }
+            if !self.php_script_contained(&candidate, site_root) {
+                tracing::warn!(
+                    entry = %name,
+                    root = %site_root.display(),
+                    "ignoring a [server] websocket_files entry that resolves outside the \
+                     document root"
+                );
+                continue;
+            }
+            return Some(candidate);
+        }
+        None
+    }
+
+    /// Answer a WebSocket upgrade request.
+    ///
+    /// Order matters, and every step before the handshake is a refusal that
+    /// costs no socket:
+    ///
+    /// 1. **Entrypoint** — no `websocket_files` entry on disk ⇒ `404`, never a
+    ///    fallthrough.
+    /// 2. **Handshake** — a missing key or a `Sec-WebSocket-Version` other than
+    ///    13 ⇒ `400` advertising version 13.
+    /// 3. **Transport** — no `OnUpgrade` extension (HTTP/2, HTTP/3) ⇒ `400`.
+    /// 4. **Tenant** — no canonical site key on a multi-vhost node ⇒ `404`. A
+    ///    connection with no tenant identity would have no registry scope, so
+    ///    it is refused rather than created unreachable.
+    /// 5. **Capacity** — registry caps ⇒ `503`.
+    /// 6. **`connect`** — the entrypoint runs with the real request. Non-2xx is
+    ///    returned to the client verbatim and the reserved connection is
+    ///    released. This is the only point at which an upgrade can be refused
+    ///    by application code, which is why authentication belongs here.
+    /// 7. **`101`** — the socket is handed to a session task.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_websocket_upgrade<B>(
+        &self,
+        mut req: Request<B>,
+        runtime: &Arc<crate::websocket::WsRuntime>,
+        remote_addr: SocketAddr,
+        is_https: bool,
+        site_root: &Path,
+        websocket_files: &[String],
+        site_key: Option<String>,
+    ) -> Response<ServerBody>
+    where
+        B: RequestBody,
+    {
+        let Some(script) = self.resolve_websocket_script(site_root, websocket_files) else {
+            tracing::debug!(
+                root = %site_root.display(),
+                "websocket upgrade refused: this vhost has no [server] websocket_files entrypoint"
+            );
+            return error_response(StatusCode::NOT_FOUND, "404 Not Found");
+        };
+
+        let Some(handshake_key) = crate::websocket::handshake_key(req.headers()) else {
+            return crate::websocket::bad_handshake("handshake");
+        };
+
+        // Only the HTTP/1.1 path carries an upgrade handle. HTTP/2 and HTTP/3
+        // requests never reach here (`is_upgrade_request` requires HTTP/1.1),
+        // but the check is what makes that a fact rather than an assumption.
+        let Some(upgrade) = crate::websocket::take_upgrade(&mut req) else {
+            return crate::websocket::bad_handshake("transport");
+        };
+
+        // The router must be shared (`Router::share`) for a session to outlive
+        // this request. Unreachable in a real server; a stack-allocated router
+        // in a unit test would land here.
+        let Some(router) = self.self_weak.upgrade() else {
+            tracing::error!(
+                "websocket upgrade refused: this router was not created with Router::share()"
+            );
+            return error_response(StatusCode::SERVICE_UNAVAILABLE, "503 Service Unavailable");
+        };
+
+        let server_name = extract_server_name(&req);
+        // The registry scope comes from the SAME derivation as the database,
+        // KV and OPcache identities — one canonical site key (issue #293),
+        // pinned here and carried by the connection for its whole life.
+        let Some(site_scope) = self.site_identities(site_key.as_deref(), &server_name).ws else {
+            tracing::debug!(
+                host = %server_name,
+                "websocket upgrade refused: host matched no virtual host, so the connection \
+                 would have no tenant identity"
+            );
+            return error_response(StatusCode::NOT_FOUND, "404 Not Found");
+        };
+
+        let registered = match runtime.registry.register(&site_scope) {
+            Ok(registered) => registered,
+            Err(e) => {
+                tracing::warn!(site = %site_scope, %e, "websocket upgrade refused");
+                return crate::websocket::registry_full(e);
+            }
+        };
+
+        // Captured before `handle_php` consumes the request, and replayed on
+        // every later event so `$_SERVER` stays stable for the connection.
+        let uri = req.uri().clone();
+        let headers = req.headers().clone();
+
+        let session = crate::websocket::WsSession {
+            router,
+            site_key: site_key.clone(),
+            connection_id: registered.id.clone(),
+            script: script.clone(),
+            document_root: site_root.to_path_buf(),
+            remote_addr,
+            is_https,
+            uri,
+            headers,
+        };
+
+        // `connect` runs BEFORE the handshake completes, on the real request —
+        // so it sees the cookies, query string and headers that authentication
+        // needs. Compression is off: this response is either a refusal (small)
+        // or discarded.
+        let connect = self
+            .handle_php(
+                req,
+                remote_addr,
+                is_https,
+                script,
+                false,
+                false,
+                site_root.to_path_buf(),
+                site_key,
+                Some(crate::websocket::WsEvent {
+                    kind: crate::websocket::WsEventKind::Connect,
+                    connection_id: registered.id.clone(),
+                    opcode: None,
+                }),
+            )
+            .await;
+        counter!("ephpm_ws_events_total", "event" => "connect").increment(1);
+
+        if !connect.status().is_success() {
+            // Application-level refusal (API-Gateway `$connect` semantics).
+            // Release the reservation and hand the script's own response back
+            // to the client — status, headers and body — so a 401 with a
+            // WWW-Authenticate header works exactly as it does over HTTP.
+            runtime.registry.unregister(&registered.id);
+            counter!("ephpm_ws_connect_rejected_total").increment(1);
+            tracing::debug!(
+                status = connect.status().as_u16(),
+                "websocket upgrade refused by the connect handler"
+            );
+            return connect;
+        }
+
+        tracing::debug!(conn = %registered.id, "websocket connection established");
+        tokio::spawn(crate::websocket::run_session(
+            session,
+            upgrade,
+            Arc::clone(runtime),
+            registered.rx,
+            registered.control,
+            self.request_timeout,
+        ));
+
+        crate::websocket::switching_protocols(&handshake_key)
+    }
+
+    /// Dispatch one WebSocket lifecycle event through the ordinary PHP path.
+    ///
+    /// The entry point session tasks use. Compression is disabled (nothing
+    /// reads the response body) and the event's `$_SERVER` context rides along
+    /// in `ws_event`.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn handle_php_event(
+        &self,
+        req: Request<http_body_util::Full<Bytes>>,
+        remote_addr: SocketAddr,
+        is_https: bool,
+        script: PathBuf,
+        document_root: PathBuf,
+        site_key: Option<String>,
+        event: crate::websocket::WsEvent,
+    ) -> Response<ServerBody> {
+        self.handle_php(
+            req,
+            remote_addr,
+            is_https,
+            script,
+            false,
+            false,
+            document_root,
+            site_key,
+            Some(event),
+        )
+        .await
+    }
+
+    ///
+    /// `ws_event` marks this execution as a WebSocket lifecycle event rather
+    /// than an HTTP request. It changes exactly two things and nothing else —
+    /// the `$_SERVER` entries it contributes (`WS_EVENT`, `WS_CONNECTION_ID`,
+    /// `WS_OPCODE`) and which limit bounds the body — so a WebSocket event and
+    /// an HTTP request are the same execution in every way that affects
+    /// isolation: same per-site database session, same KV keyspace, same
+    /// `open_basedir` / temp / session sandbox, same OPcache vhost, same crash
+    /// guard, same engine.
     #[allow(clippy::too_many_arguments)]
     async fn handle_php<B>(
         &self,
@@ -1961,6 +2316,7 @@ impl Router {
         accepts_br: bool,
         document_root: PathBuf,
         site_key: Option<String>,
+        ws_event: Option<crate::websocket::WsEvent>,
     ) -> Response<ServerBody>
     where
         B: RequestBody,
@@ -2006,9 +2362,18 @@ impl Router {
             req.headers().get("content-type").and_then(|v| v.to_str().ok()).map(String::from);
         let server_name = extract_server_name(&req);
 
-        // Reject oversized request bodies before reading
-        if let Some(resp) = self.check_body_size(&req) {
-            return resp;
+        // Reject oversized request bodies before reading.
+        //
+        // Skipped for WebSocket events: their payload is a frame the codec
+        // already bounded by `[server.websocket] max_message_size`, and it is
+        // in an in-memory body we built ourselves. Applying
+        // `[server.request] max_body_size` on top would silently cap WebSocket
+        // messages at the HTTP body limit — two unrelated knobs, one of which
+        // the operator did not think they were setting.
+        if ws_event.is_none() {
+            if let Some(resp) = self.check_body_size(&req) {
+                return resp;
+            }
         }
 
         let server_port = self.server_port;
@@ -2153,8 +2518,10 @@ impl Router {
         }
 
         // fpm path buffers the whole body; cap chunked / lying clients the same
-        // way the Content-Length pre-check caps declared bodies.
-        let body = if self.max_body_size > 0 {
+        // way the Content-Length pre-check caps declared bodies. A WebSocket
+        // event's body was bounded by the codec, not by this knob (see the
+        // `check_body_size` skip above), so it takes the uncapped branch.
+        let body = if self.max_body_size > 0 && ws_event.is_none() {
             let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
             match http_body_util::Limited::new(req, cap).collect().await {
                 Ok(collected) => collected.to_bytes().to_vec(),
@@ -2184,8 +2551,12 @@ impl Router {
         // whose code is about to run (issue #290). `db` is `None` for a host
         // that matched no vhost, so `ephpm_db_*` reports "no per-site database
         // context" instead of minting `<that host>.db` (issue #291).
-        let SiteIdentities { db: db_site_key, kv: kv_site_key, opcache: vhost_name } =
-            self.site_identities(site_key.as_deref(), &server_name);
+        let SiteIdentities {
+            db: db_site_key,
+            kv: kv_site_key,
+            opcache: vhost_name,
+            ws: ws_site_scope,
+        } = self.site_identities(site_key.as_deref(), &server_name);
         // In multi-tenant mode, give this vhost its OWN temp + session
         // directories (issue #276). Resolved and created here, in the async
         // context, off the resolved (traversal-safe) document root; the paths
@@ -2215,6 +2586,17 @@ impl Router {
         if let Some(ref id) = self.node_id {
             env_vars.push(("EPHPM_NODE_ID".to_string(), id.clone()));
         }
+        // WebSocket lifecycle context. Present only for a WebSocket event, so
+        // an ordinary request can distinguish the two with
+        // `isset($_SERVER['WS_EVENT'])`.
+        if let Some(ref event) = ws_event {
+            env_vars.extend(event.server_vars());
+        }
+        // The connection the implicit `ephpm_ws_send($payload)` form acts on.
+        // `None` for an ordinary HTTP request — and it is set either way, so
+        // an event's id can never survive onto the next request that lands on
+        // this blocking thread.
+        let ws_connection_id = ws_event.as_ref().map(|event| event.connection_id.clone());
 
         // Phase-1 OPcache clustered invalidation: fast-path check outside the
         // spawn_blocking hop so a no-op costs one atomic load + one KV get and
@@ -2250,6 +2632,20 @@ impl Router {
             // backend (single-site) — and clears any stale key so per-site
             // mode never silently reuses a previous request's tenant.
             ephpm_php::db_bridge::set_current_site(db_site_key.as_deref());
+
+            // Scope `ephpm_ws_*` to this virtual host. Derived from the SAME
+            // canonical site key as the database and KV identities above, so a
+            // script cannot reach a socket belonging to a tenant whose code it
+            // is not running. `None` — a host that matched no vhost — clears
+            // the scope, leaving this thread with no WebSocket capability at
+            // all rather than the previous request's.
+            ephpm_php::ws_bridge::set_current_site(ws_site_scope.as_deref());
+
+            // And which connection the implicit `ephpm_ws_*` forms mean.
+            // Cleared (`None`) for every non-WebSocket execution, so a
+            // reused blocking thread cannot carry a previous event's
+            // connection into an unrelated request.
+            ephpm_php::ws_bridge::set_current_connection(ws_connection_id.as_deref());
 
             // Apply per-request PHP sandbox for multi-tenant isolation.
             // open_basedir varies per vhost (each site only sees its own

--- a/crates/ephpm-server/src/websocket.rs
+++ b/crates/ephpm-server/src/websocket.rs
@@ -1,0 +1,659 @@
+//! Native WebSocket termination (`[server.websocket]`) — **experimental**.
+//!
+//! # The model
+//!
+//! Rust owns every socket; PHP is invoked **per event** and never holds a
+//! connection. This is the API-Gateway / RoadRunner shape rather than the
+//! Swoole shape:
+//!
+//! | | ePHPm | Swoole / ReactPHP |
+//! |---|---|---|
+//! | who owns the socket | the Rust reactor | a PHP process |
+//! | cost of an idle connection | one registry entry + reactor memory | a PHP coroutine/process |
+//! | what runs per message | one ordinary PHP request | userland event loop callback |
+//!
+//! Thousands of idle connections therefore cost no PHP at all. A message costs
+//! exactly one PHP execution, on the same path an HTTP request takes — so
+//! `open_basedir`, the per-vhost temp/session root, the per-site database
+//! credentials, OPcache, and the crash guard all apply unchanged.
+//!
+//! # Lifecycle
+//!
+//! 1. **Upgrade.** [`Router::handle_inner`](crate::router::Router) spots an RFC
+//!    6455 upgrade, resolves the vhost's `[server] websocket_files` entrypoint
+//!    against the **already-resolved** document root, and 404s if none exists.
+//! 2. **`connect`.** The entrypoint runs with `WS_EVENT=connect` **before** the
+//!    handshake completes, using the real upgrade request — so it sees the
+//!    cookies, query string and headers auth needs. A `2xx` accepts the
+//!    upgrade; anything else is returned to the client verbatim and no socket
+//!    is ever created. This is the only point at which an upgrade can be
+//!    refused, which is why authentication belongs here.
+//! 3. **`message`.** One PHP execution per inbound data frame, with the payload
+//!    as the request body (`php://input`) and `WS_OPCODE` set to `text` or
+//!    `binary`. Executions for one connection are strictly sequential: the
+//!    socket is not read again until the handler returns.
+//! 4. **`disconnect`.** Best-effort, after the socket is gone and the
+//!    connection has already been removed from the registry — so
+//!    `ephpm_ws_send()` to the departing connection correctly fails, and a
+//!    broadcast no longer includes it. Not delivered if the process dies.
+//!
+//! # Site identity
+//!
+//! The tenant is pinned **once**, at upgrade time, from the canonical site key
+//! `Router::resolve_site` produced (issue #293). Every subsequent event for
+//! that connection carries the captured key; the `Host` header is never
+//! consulted again. A request whose host matched no vhost has no key, so it
+//! gets no registry scope and cannot open a WebSocket at all.
+//!
+//! # Transport
+//!
+//! HTTP/1.1 only, over plain TCP or TLS (both reach the same
+//! `serve_connection`, which already uses `serve_connection_with_upgrades`).
+//! HTTP/2 and HTTP/3 requests never carry the `Upgrade` mechanism this path
+//! detects — RFC 8441 extended CONNECT is not implemented — and browsers open a
+//! dedicated HTTP/1.1 connection for `ws:`/`wss:` regardless.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use ephpm_config::WebSocketConfig;
+use ephpm_ws::{Limits, Registry};
+use futures::{SinkExt, StreamExt};
+use http::{HeaderMap, Method, Request, Response, StatusCode, Uri, Version};
+use http_body_util::Full;
+use hyper::upgrade::OnUpgrade;
+use hyper_util::rt::TokioIo;
+use metrics::counter;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::protocol::{Role, WebSocketConfig as CodecConfig};
+
+use crate::body::{self, ServerBody};
+use crate::router::Router;
+
+/// WebSocket close code for "the server is going away" — used when a
+/// connection is dropped for exceeding
+/// [`WebSocketConfig::idle_timeout_secs`].
+const CLOSE_GOING_AWAY: u16 = 1001;
+
+/// WebSocket close code for an internal error — used when a `message` event's
+/// PHP execution exceeded `[server.timeouts] request`.
+const CLOSE_INTERNAL_ERROR: u16 = 1011;
+
+/// Everything the server needs to serve WebSockets, resolved once at startup.
+pub struct WsRuntime {
+    /// The site-scoped connection registry, shared with the PHP bridge.
+    pub registry: Arc<Registry>,
+    /// Codec bounds handed to every connection.
+    codec: CodecConfig,
+    /// Server-initiated ping period, or `None` when keepalive is disabled.
+    ping_interval: Option<Duration>,
+    /// How long a connection may receive nothing before it is closed, or
+    /// `None` when the check is disabled.
+    idle_timeout: Option<Duration>,
+}
+
+impl WsRuntime {
+    /// Build the runtime from `[server.websocket]`.
+    ///
+    /// Returns `None` when the feature is disabled — the `Option` is what makes
+    /// "off" cost exactly one `is_none()` on the request path, and what keeps
+    /// the registry (and therefore the PHP bridge) uninstalled.
+    #[must_use]
+    pub fn new(config: &WebSocketConfig) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+
+        let codec = CodecConfig {
+            max_message_size: Some(config.max_message_size),
+            max_frame_size: Some(config.max_frame_size),
+            // RFC 6455 requires client→server frames to be masked. Accepting
+            // unmasked ones would let a proxy-confusion payload through, and
+            // no conforming client needs it.
+            accept_unmasked_frames: false,
+            ..CodecConfig::default()
+        };
+
+        let registry = Arc::new(Registry::new(Limits {
+            max_connections: config.max_connections,
+            max_connections_per_site: config.max_connections_per_site,
+            send_queue: config.send_queue,
+            max_message_size: config.max_message_size,
+        }));
+
+        let ping_interval = non_zero_secs(config.ping_interval_secs);
+        let idle_timeout = non_zero_secs(config.idle_timeout_secs);
+        if let (Some(ping), Some(idle)) = (ping_interval, idle_timeout) {
+            if ping >= idle {
+                tracing::warn!(
+                    ping_interval_secs = config.ping_interval_secs,
+                    idle_timeout_secs = config.idle_timeout_secs,
+                    "[server.websocket] ping_interval_secs >= idle_timeout_secs — idle \
+                     connections will be closed before a ping can refresh them"
+                );
+            }
+        }
+
+        tracing::info!(
+            max_connections = config.max_connections,
+            max_connections_per_site = config.max_connections_per_site,
+            max_message_size = config.max_message_size,
+            send_queue = config.send_queue,
+            "native websocket support enabled (experimental)"
+        );
+
+        Some(Self { registry, codec, ping_interval, idle_timeout })
+    }
+}
+
+/// `0` disables a duration knob; anything else is seconds.
+fn non_zero_secs(secs: u64) -> Option<Duration> {
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// Whether this request is an RFC 6455 WebSocket upgrade.
+///
+/// Deliberately loose on the parts a client can get wrong (version, key) and
+/// strict on the parts that decide *routing*: method, HTTP version, and the
+/// `Connection: Upgrade` + `Upgrade: websocket` pair. A request that looks like
+/// an upgrade but is malformed must still be routed here — so it gets a
+/// diagnostic `400` instead of falling through and being served `index.php`.
+pub fn is_upgrade_request<B>(req: &Request<B>) -> bool {
+    if req.method() != Method::GET || req.version() != Version::HTTP_11 {
+        return false;
+    }
+    if !header_contains_token(req.headers(), http::header::CONNECTION, "upgrade") {
+        return false;
+    }
+    header_contains_token(req.headers(), http::header::UPGRADE, "websocket")
+}
+
+/// Case-insensitive comma-list token search (`Connection: keep-alive, Upgrade`).
+fn header_contains_token(headers: &HeaderMap, name: http::header::HeaderName, token: &str) -> bool {
+    headers.get_all(name).iter().any(|value| {
+        value
+            .to_str()
+            .is_ok_and(|v| v.split(',').any(|part| part.trim().eq_ignore_ascii_case(token)))
+    })
+}
+
+/// The client's `Sec-WebSocket-Key`, when the handshake is well formed.
+///
+/// Returns `None` for a missing key or a `Sec-WebSocket-Version` other than
+/// `13`, which the caller turns into a `400` carrying the version we support.
+pub(crate) fn handshake_key(headers: &HeaderMap) -> Option<String> {
+    let version = headers.get("sec-websocket-version")?.to_str().ok()?;
+    if version.trim() != "13" {
+        return None;
+    }
+    Some(headers.get("sec-websocket-key")?.to_str().ok()?.to_owned())
+}
+
+/// The `101 Switching Protocols` response completing the handshake.
+pub(crate) fn switching_protocols(key: &str) -> Response<ServerBody> {
+    let accept = tokio_tungstenite::tungstenite::handshake::derive_accept_key(key.as_bytes());
+    Response::builder()
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .header(http::header::CONNECTION, "Upgrade")
+        .header(http::header::UPGRADE, "websocket")
+        .header("sec-websocket-accept", accept)
+        .body(body::buffered(Full::new(Bytes::new())))
+        .expect("101 response builder")
+}
+
+/// A `400` that tells the client which WebSocket version we speak.
+pub(crate) fn bad_handshake(reason: &'static str) -> Response<ServerBody> {
+    counter!("ephpm_ws_handshake_rejected_total", "reason" => reason).increment(1);
+    Response::builder()
+        .status(StatusCode::BAD_REQUEST)
+        .header("sec-websocket-version", "13")
+        .header(http::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(body::buffered(Full::new(Bytes::from_static(b"400 Bad WebSocket Handshake"))))
+        .expect("400 response builder")
+}
+
+/// Which lifecycle event a PHP execution represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WsEventKind {
+    /// Runs before the handshake completes; a non-2xx response refuses it.
+    Connect,
+    /// One inbound data frame.
+    Message,
+    /// Best-effort, after the socket is gone.
+    Disconnect,
+}
+
+impl WsEventKind {
+    /// The `$_SERVER['WS_EVENT']` value.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Connect => "connect",
+            Self::Message => "message",
+            Self::Disconnect => "disconnect",
+        }
+    }
+}
+
+/// The per-event context injected into `$_SERVER`, and the marker that tells
+/// `handle_php` this execution is a WebSocket event rather than an HTTP
+/// request.
+#[derive(Debug, Clone)]
+pub struct WsEvent {
+    /// `$_SERVER['WS_EVENT']`.
+    pub kind: WsEventKind,
+    /// `$_SERVER['WS_CONNECTION_ID']` — the capability token for this socket.
+    pub connection_id: String,
+    /// `$_SERVER['WS_OPCODE']`, `"text"` or `"binary"`. Only set for
+    /// [`WsEventKind::Message`].
+    pub opcode: Option<&'static str>,
+}
+
+impl WsEvent {
+    /// The `$_SERVER` entries this event contributes.
+    #[must_use]
+    pub fn server_vars(&self) -> Vec<(String, String)> {
+        let mut vars = vec![
+            ("WS_EVENT".to_string(), self.kind.as_str().to_string()),
+            ("WS_CONNECTION_ID".to_string(), self.connection_id.clone()),
+        ];
+        if let Some(opcode) = self.opcode {
+            vars.push(("WS_OPCODE".to_string(), opcode.to_string()));
+        }
+        vars
+    }
+}
+
+/// Everything a connection's session task needs to run PHP events after the
+/// HTTP request that created it is long gone.
+///
+/// Captured once at upgrade time. In particular `site_key` and `site_scope` are
+/// snapshots of the canonical identity `Router::resolve_site` derived for the
+/// upgrade request — the session never re-derives a tenant from anything the
+/// client sends over the socket.
+pub struct WsSession {
+    pub(crate) router: Arc<Router>,
+    /// The canonical site key, pinned at upgrade time.
+    ///
+    /// This is the connection's whole tenant identity. Every event re-derives
+    /// the per-site database, KV keyspace, OPcache vhost **and** the WebSocket
+    /// registry scope from it (`Router::site_identities`), so all four keep
+    /// naming the tenant that owned the upgrade — the `Host` header is never
+    /// consulted again after the handshake.
+    pub(crate) site_key: Option<String>,
+    pub(crate) connection_id: String,
+    pub(crate) script: PathBuf,
+    pub(crate) document_root: PathBuf,
+    pub(crate) remote_addr: SocketAddr,
+    pub(crate) is_https: bool,
+    /// The upgrade request's URI, replayed on every event so `$_SERVER`
+    /// (`REQUEST_URI`, `QUERY_STRING`) is stable for the connection's life.
+    pub(crate) uri: Uri,
+    /// The upgrade request's headers, replayed on every event so cookies and
+    /// `Origin` remain visible to `message` / `disconnect` handlers.
+    pub(crate) headers: HeaderMap,
+}
+
+impl WsSession {
+    /// Build the synthetic request for one event.
+    ///
+    /// Replays the upgrade request's URI and headers, with the frame payload as
+    /// the body. The hop-by-hop upgrade headers are stripped: `$_SERVER` for a
+    /// `message` event should not claim the request is still an upgrade, and a
+    /// `Content-Length` from the original request would misdescribe this body.
+    fn event_request(
+        &self,
+        payload: Bytes,
+        content_type: Option<&'static str>,
+    ) -> Request<Full<Bytes>> {
+        let mut builder =
+            Request::builder().method(Method::GET).uri(self.uri.clone()).version(Version::HTTP_11);
+        if let Some(headers) = builder.headers_mut() {
+            headers.clone_from(&self.headers);
+            for name in [
+                http::header::CONNECTION,
+                http::header::UPGRADE,
+                http::header::CONTENT_LENGTH,
+                http::header::CONTENT_TYPE,
+            ] {
+                headers.remove(name);
+            }
+            headers.remove("sec-websocket-key");
+            headers.remove("sec-websocket-version");
+            headers.remove("sec-websocket-extensions");
+            if let Some(ct) = content_type {
+                headers.insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static(ct));
+            }
+        }
+        builder.body(Full::new(payload)).expect("websocket event request builder")
+    }
+
+    /// Run one event through the ordinary PHP request path.
+    async fn dispatch(
+        &self,
+        kind: WsEventKind,
+        payload: Bytes,
+        opcode: Option<&'static str>,
+    ) -> Response<ServerBody> {
+        let content_type = match opcode {
+            Some("binary") => Some("application/octet-stream"),
+            Some(_) => Some("text/plain; charset=utf-8"),
+            None => None,
+        };
+        let event = WsEvent { kind, connection_id: self.connection_id.clone(), opcode };
+        counter!("ephpm_ws_events_total", "event" => kind.as_str()).increment(1);
+
+        self.router
+            .handle_php_event(
+                self.event_request(payload, content_type),
+                self.remote_addr,
+                self.is_https,
+                self.script.clone(),
+                self.document_root.clone(),
+                self.site_key.clone(),
+                event,
+            )
+            .await
+    }
+}
+
+/// Refuse an upgrade whose registry admission failed.
+pub(crate) fn registry_full(err: ephpm_ws::RegisterError) -> Response<ServerBody> {
+    counter!("ephpm_ws_handshake_rejected_total", "reason" => "capacity").increment(1);
+    Response::builder()
+        .status(StatusCode::SERVICE_UNAVAILABLE)
+        .header(http::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(body::buffered(Full::new(Bytes::from(format!("503 {err}")))))
+        .expect("503 response builder")
+}
+
+/// Take the upgrade handle hyper attached to the request, if this transport
+/// has one. HTTP/2 and HTTP/3 requests never do.
+pub(crate) fn take_upgrade<B>(req: &mut Request<B>) -> Option<OnUpgrade> {
+    req.extensions_mut().remove::<OnUpgrade>()
+}
+
+/// Drive one connection's socket: outbound queue, inbound frames, keepalive.
+pub(crate) async fn run_session(
+    session: WsSession,
+    upgrade: OnUpgrade,
+    runtime: Arc<WsRuntime>,
+    mut outbound: tokio::sync::mpsc::Receiver<ephpm_ws::OutFrame>,
+    control: Arc<ephpm_ws::Control>,
+    request_timeout: Duration,
+) {
+    let upgraded = match upgrade.await {
+        Ok(upgraded) => upgraded,
+        Err(e) => {
+            tracing::debug!(%e, "websocket upgrade never completed");
+            runtime.registry.unregister(&session.connection_id);
+            return;
+        }
+    };
+
+    let mut ws =
+        WebSocketStream::from_raw_socket(TokioIo::new(upgraded), Role::Server, Some(runtime.codec))
+            .await;
+
+    // Housekeeping period: ping when keepalive is on, otherwise a half-idle
+    // tick purely to notice a peer that has gone silent. One timer serves both
+    // jobs — a ping is exactly the probe the idle check needs.
+    let tick = runtime
+        .ping_interval
+        .or_else(|| runtime.idle_timeout.map(|idle| idle / 2))
+        .unwrap_or(Duration::from_secs(3600));
+    let mut ticker = tokio::time::interval(tick);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ticker.tick().await; // the first tick completes immediately
+
+    let mut last_rx = Instant::now();
+    let mut closing: Option<u16> = None;
+
+    loop {
+        tokio::select! {
+            // Shedding and explicit closes win over anything queued behind
+            // them — a connection marked for 1013 must not first drain the
+            // very backlog that overflowed.
+            biased;
+
+            code = control.closed() => {
+                closing = Some(code);
+                break;
+            }
+
+            frame = outbound.recv() => {
+                let Some(frame) = frame else { break };
+                let message = match frame {
+                    ephpm_ws::OutFrame::Text(b) => match String::from_utf8(b.to_vec()) {
+                        Ok(text) => Message::Text(text),
+                        Err(_) => {
+                            // A text frame must carry UTF-8 (RFC 6455 §5.6).
+                            // Refusing here is better than writing a frame the
+                            // client is obliged to close the connection over.
+                            counter!("ephpm_ws_frames_rejected_total", "reason" => "invalid_utf8")
+                                .increment(1);
+                            continue;
+                        }
+                    },
+                    ephpm_ws::OutFrame::Binary(b) => Message::Binary(b.to_vec()),
+                };
+                if let Err(e) = ws.send(message).await {
+                    tracing::debug!(%e, "websocket write failed");
+                    break;
+                }
+                counter!("ephpm_ws_frames_sent_total").increment(1);
+            }
+
+            _ = ticker.tick() => {
+                if let Some(idle) = runtime.idle_timeout {
+                    if last_rx.elapsed() >= idle {
+                        tracing::debug!(
+                            conn = %session.connection_id,
+                            idle_secs = idle.as_secs(),
+                            "closing idle websocket connection"
+                        );
+                        closing = Some(CLOSE_GOING_AWAY);
+                        break;
+                    }
+                }
+                // A failed ping means the socket is already gone; stop rather
+                // than waiting for the read half to notice.
+                if runtime.ping_interval.is_some()
+                    && ws.send(Message::Ping(Vec::new())).await.is_err()
+                {
+                    break;
+                }
+            }
+
+            incoming = ws.next() => {
+                let Some(incoming) = incoming else { break };
+                let message = match incoming {
+                    Ok(message) => message,
+                    Err(e) => {
+                        tracing::debug!(%e, "websocket read failed");
+                        break;
+                    }
+                };
+                last_rx = Instant::now();
+
+                let (payload, opcode) = match message {
+                    Message::Text(text) => (Bytes::from(text.into_bytes()), "text"),
+                    Message::Binary(data) => (Bytes::from(data), "binary"),
+                    Message::Ping(_) => {
+                        // tungstenite queued the pong during the read; flush it
+                        // now rather than waiting for the next outbound frame.
+                        if ws.flush().await.is_err() {
+                            break;
+                        }
+                        continue;
+                    }
+                    // A pong only had to refresh `last_rx`, which it just did.
+                    // `Frame` is never yielded on the read path.
+                    Message::Pong(_) | Message::Frame(_) => continue,
+                    Message::Close(_) => break,
+                };
+                counter!("ephpm_ws_frames_received_total").increment(1);
+
+                // Sequential by construction: the socket is not read again
+                // until this handler returns, so one connection's messages
+                // cannot execute out of order or concurrently.
+                match tokio::time::timeout(
+                    request_timeout,
+                    session.dispatch(WsEventKind::Message, payload, Some(opcode)),
+                )
+                .await
+                {
+                    Ok(_response) => {}
+                    Err(_) => {
+                        // The blocking PHP execution cannot be cancelled, so
+                        // continuing would risk a second dispatch overlapping
+                        // the abandoned one. Close instead.
+                        counter!("ephpm_ws_event_timeouts_total").increment(1);
+                        tracing::warn!(
+                            conn = %session.connection_id,
+                            timeout_secs = request_timeout.as_secs(),
+                            "websocket message handler exceeded [server.timeouts] request"
+                        );
+                        closing = Some(CLOSE_INTERNAL_ERROR);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Best effort: the peer may already be gone.
+    let close_frame = closing.map(|code| tokio_tungstenite::tungstenite::protocol::CloseFrame {
+        code: code.into(),
+        reason: std::borrow::Cow::Borrowed(""),
+    });
+    let _ = ws.send(Message::Close(close_frame)).await;
+    let _ = ws.close(None).await;
+
+    // Unregister BEFORE the disconnect event, so a handler that calls
+    // `ephpm_ws_send($id)` on the departing connection correctly fails and a
+    // broadcast no longer reaches it.
+    runtime.registry.unregister(&session.connection_id);
+    let _ = session.dispatch(WsEventKind::Disconnect, Bytes::new(), None).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn upgrade_request() -> Request<()> {
+        Request::builder()
+            .method(Method::GET)
+            .uri("/chat")
+            .version(Version::HTTP_11)
+            .header("connection", "keep-alive, Upgrade")
+            .header("upgrade", "WebSocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(())
+            .unwrap()
+    }
+
+    #[test]
+    fn detects_an_upgrade_with_token_lists_and_mixed_case() {
+        assert!(is_upgrade_request(&upgrade_request()));
+    }
+
+    #[test]
+    fn an_ordinary_get_is_not_an_upgrade() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/index.php")
+            .version(Version::HTTP_11)
+            .body(())
+            .unwrap();
+        assert!(!is_upgrade_request(&req));
+    }
+
+    #[test]
+    fn a_post_or_http2_upgrade_is_not_routed_here() {
+        let mut req = upgrade_request();
+        *req.method_mut() = Method::POST;
+        assert!(!is_upgrade_request(&req), "only GET upgrades");
+
+        let mut req = upgrade_request();
+        *req.version_mut() = Version::HTTP_2;
+        assert!(!is_upgrade_request(&req), "HTTP/2 has no Upgrade mechanism");
+    }
+
+    #[test]
+    fn a_malformed_upgrade_still_routes_here_and_is_rejected_by_the_handshake() {
+        // Routing must not depend on the version header — otherwise a client
+        // sending version 8 would silently be served index.php.
+        let mut req = upgrade_request();
+        req.headers_mut().insert("sec-websocket-version", "8".parse().unwrap());
+        assert!(is_upgrade_request(&req));
+        assert!(handshake_key(req.headers()).is_none());
+
+        let mut req = upgrade_request();
+        req.headers_mut().remove("sec-websocket-key");
+        assert!(is_upgrade_request(&req));
+        assert!(handshake_key(req.headers()).is_none());
+    }
+
+    #[test]
+    fn accept_key_matches_rfc_6455_section_1_3() {
+        let key = handshake_key(upgrade_request().headers()).expect("well-formed handshake");
+        let resp = switching_protocols(&key);
+        assert_eq!(resp.status(), StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(
+            resp.headers().get("sec-websocket-accept").unwrap(),
+            // The worked example from RFC 6455 §1.3.
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+        );
+    }
+
+    #[test]
+    fn the_runtime_is_absent_when_the_feature_is_off() {
+        let config = WebSocketConfig::default();
+        assert!(!config.enabled);
+        assert!(WsRuntime::new(&config).is_none(), "disabled must cost an Option::is_none");
+    }
+
+    #[test]
+    fn zero_durations_disable_their_timers() {
+        let config = WebSocketConfig {
+            enabled: true,
+            ping_interval_secs: 0,
+            idle_timeout_secs: 0,
+            ..WebSocketConfig::default()
+        };
+        let runtime = WsRuntime::new(&config).expect("enabled");
+        assert!(runtime.ping_interval.is_none());
+        assert!(runtime.idle_timeout.is_none());
+    }
+
+    #[test]
+    fn event_vars_carry_the_kind_the_id_and_the_opcode() {
+        let event = WsEvent {
+            kind: WsEventKind::Message,
+            connection_id: "abc123".to_string(),
+            opcode: Some("binary"),
+        };
+        let vars = event.server_vars();
+        assert!(vars.contains(&("WS_EVENT".to_string(), "message".to_string())));
+        assert!(vars.contains(&("WS_CONNECTION_ID".to_string(), "abc123".to_string())));
+        assert!(vars.contains(&("WS_OPCODE".to_string(), "binary".to_string())));
+
+        let connect = WsEvent {
+            kind: WsEventKind::Connect,
+            connection_id: "abc123".to_string(),
+            opcode: None,
+        };
+        let vars = connect.server_vars();
+        assert!(vars.contains(&("WS_EVENT".to_string(), "connect".to_string())));
+        assert!(
+            !vars.iter().any(|(k, _)| k == "WS_OPCODE"),
+            "a connect event has no opcode to report"
+        );
+    }
+}

--- a/crates/ephpm-ws/Cargo.toml
+++ b/crates/ephpm-ws/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "ephpm-ws"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Site-scoped WebSocket connection registry for ePHPm"
+
+[dependencies]
+# Lock-free connection + channel maps. `ephpm_ws_send` is called from PHP on a
+# blocking thread while the session tasks run on the reactor, so every map is
+# touched from both worlds concurrently.
+dashmap.workspace = true
+# Guards the per-connection channel-membership set. Never held across an await
+# and never across a PHP call.
+parking_lot.workspace = true
+# Bounded per-connection outbound queue (`try_send`, never `send().await` —
+# a PHP thread must never park on a slow socket).
+tokio = { workspace = true, features = ["sync"] }
+# Frame payloads are refcounted, so a broadcast to N subscribers clones a
+# pointer N times rather than the payload.
+bytes.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+metrics.workspace = true
+# OS entropy for connection IDs. These are capability tokens — a guessable ID
+# is a cross-connection send, so this is a syscall shim, never a PRNG.
+getrandom.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
+
+[lints]
+workspace = true

--- a/crates/ephpm-ws/src/id.rs
+++ b/crates/ephpm-ws/src/id.rs
@@ -1,0 +1,84 @@
+//! Connection-ID minting.
+//!
+//! A connection ID is a **capability**, not a name. Anything that can produce a
+//! valid `(site, id)` pair can push frames to that socket, so the ID has to be
+//! unguessable by anyone who was not handed it: 128 bits from the OS CSPRNG,
+//! rendered lowercase hex.
+//!
+//! 128 bits also removes any need to check for collisions — with a per-process
+//! ceiling of a few million live connections the birthday probability is far
+//! below the noise floor of every other failure in the system.
+
+/// Length of a rendered connection ID, in ASCII characters (16 bytes as hex).
+pub const CONNECTION_ID_LEN: usize = 32;
+
+/// Raw entropy per connection ID.
+const ID_BYTES: usize = 16;
+
+/// Mint a fresh connection ID.
+///
+/// # Errors
+///
+/// Returns [`getrandom::Error`] when the OS entropy source is unavailable.
+/// Callers must treat this as fatal for the connection and refuse the upgrade —
+/// never fall back to a counter or a timestamp, which would make one tenant's
+/// IDs predictable from another's.
+pub fn new_connection_id() -> Result<String, getrandom::Error> {
+    let mut raw = [0u8; ID_BYTES];
+    getrandom::fill(&mut raw)?;
+
+    let mut out = String::with_capacity(CONNECTION_ID_LEN);
+    for byte in raw {
+        // `write!` on a String is infallible but returns a Result; the manual
+        // nibble push keeps this allocation-free and error-free.
+        out.push(hex_nibble(byte >> 4));
+        out.push(hex_nibble(byte & 0x0f));
+    }
+    Ok(out)
+}
+
+/// Map a 0..=15 nibble to its lowercase hex character.
+const fn hex_nibble(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        _ => (b'a' + (n - 10)) as char,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn ids_are_lowercase_hex_of_the_documented_length() {
+        let id = new_connection_id().expect("entropy");
+        assert_eq!(id.len(), CONNECTION_ID_LEN);
+        assert!(
+            id.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "id must be lowercase hex, got {id}"
+        );
+    }
+
+    #[test]
+    fn ids_do_not_repeat() {
+        // Not a randomness test — a smoke test that we are not handing out a
+        // constant or a counter. A duplicate here means the capability model is
+        // broken outright.
+        let mut seen = HashSet::new();
+        for _ in 0..1_000 {
+            assert!(seen.insert(new_connection_id().expect("entropy")), "duplicate connection id");
+        }
+    }
+
+    #[test]
+    fn ids_have_no_shared_prefix() {
+        // A counter or a timestamp source would show up as a long common
+        // prefix across successive IDs.
+        let a = new_connection_id().expect("entropy");
+        let b = new_connection_id().expect("entropy");
+        let shared = a.chars().zip(b.chars()).take_while(|(x, y)| x == y).count();
+        assert!(shared < 8, "successive ids share a {shared}-char prefix: {a} / {b}");
+    }
+}

--- a/crates/ephpm-ws/src/lib.rs
+++ b/crates/ephpm-ws/src/lib.rs
@@ -1,0 +1,155 @@
+//! Site-scoped WebSocket connection registry.
+//!
+//! ePHPm owns every WebSocket socket in Rust; PHP never holds one. This crate
+//! is the shared table that lets the two halves meet:
+//!
+//! * `ephpm-server` accepts the HTTP upgrade, registers the connection here,
+//!   and runs a per-connection session task that drains this connection's
+//!   outbound queue onto the socket.
+//! * `ephpm-php` exposes `ephpm_ws_send` / `ephpm_ws_broadcast` /
+//!   `ephpm_ws_subscribe` / `ephpm_ws_unsubscribe` / `ephpm_ws_close` to
+//!   userland, which resolve through this registry.
+//!
+//! It deliberately knows nothing about the WebSocket wire protocol — no
+//! framing, no masking, no handshake. [`OutFrame`] is the whole vocabulary, so
+//! this crate builds and unit-tests in stub mode (no PHP, no tungstenite).
+//!
+//! # The two invariants
+//!
+//! **1. Every lookup is site-scoped.** Connection IDs and channel names are
+//! only meaningful *within* a site. [`Registry::send`], [`Registry::broadcast`],
+//! [`Registry::subscribe`], [`Registry::unsubscribe`] and [`Registry::close`]
+//! all take the **calling** request's site scope, and a connection registered
+//! under site `a` is unreachable from site `b` even when `b` knows the exact
+//! connection ID. The scope is never taken from a function argument: the bridge
+//! reads it from the per-thread context the router installed for the request
+//! that is executing (mirroring `ephpm_db_*`), and a request with no site
+//! identity gets no scope and therefore no capability at all.
+//!
+//! A cross-site attempt is reported as "not found", identical to a stale ID —
+//! there is no oracle that tells site `b` whether an ID exists elsewhere.
+//!
+//! **2. No queue is unbounded.** Each connection gets a bounded
+//! [`tokio::sync::mpsc`] channel sized by [`Limits::send_queue`]. Producers use
+//! `try_send` only. A producer that finds the queue full does **not** block and
+//! does **not** grow a buffer: it marks the connection for shedding and returns
+//! failure, and the session task closes that socket with WebSocket status
+//! `1013 Try Again Later`. One slow reader costs one connection, never the
+//! server's memory.
+
+mod id;
+mod registry;
+
+use bytes::Bytes;
+pub use id::{CONNECTION_ID_LEN, new_connection_id};
+pub use registry::{
+    Control, MAX_CHANNEL_NAME_LEN, MAX_CHANNELS_PER_CONNECTION, Registered, Registry, RegistryStats,
+};
+
+/// WebSocket close code sent to a connection whose outbound queue overflowed.
+///
+/// `1013 Try Again Later` (RFC 6455 §7.4.1 / IANA registry) is the honest
+/// signal: the server is not at fault and the client may reconnect. It is
+/// deliberately distinct from a policy close so an operator can tell
+/// back-pressure shedding apart from an application-initiated close in logs.
+pub const CLOSE_QUEUE_OVERFLOW: u16 = 1013;
+
+/// Default close code for [`Registry::close`] when userland passes none.
+pub const CLOSE_NORMAL: u16 = 1000;
+
+/// An outbound frame queued for one connection.
+///
+/// Cheap to clone: the payload is [`Bytes`], so fanning one broadcast out to
+/// N subscribers bumps a refcount N times instead of copying N payloads.
+#[derive(Debug, Clone)]
+pub enum OutFrame {
+    /// A text frame. The payload is **not** validated as UTF-8 here; the
+    /// server-side session task rejects non-UTF-8 text before it reaches the
+    /// wire.
+    Text(Bytes),
+    /// A binary frame.
+    Binary(Bytes),
+}
+
+impl OutFrame {
+    /// Build a frame from a payload and userland's `binary` flag.
+    #[must_use]
+    pub fn new(payload: Bytes, binary: bool) -> Self {
+        if binary { Self::Binary(payload) } else { Self::Text(payload) }
+    }
+
+    /// Payload byte length, for metrics and limit checks.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Text(b) | Self::Binary(b) => b.len(),
+        }
+    }
+
+    /// Whether the payload is empty. (An empty frame is legal on the wire.)
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Resource bounds for the registry, resolved from `[server.websocket]`.
+///
+/// `0` means "no limit" for both connection caps. [`Limits::send_queue`] has no
+/// unlimited setting on purpose — an unbounded outbound queue is exactly the
+/// failure this crate exists to prevent — so `0` is normalized to `1`.
+#[derive(Debug, Clone, Copy)]
+pub struct Limits {
+    /// Maximum concurrent WebSocket connections across all sites. `0` =
+    /// unlimited.
+    pub max_connections: usize,
+    /// Maximum concurrent WebSocket connections for any single site. `0` =
+    /// unlimited. Enforced in addition to [`Limits::max_connections`], so one
+    /// tenant cannot consume a shared deployment's whole budget.
+    pub max_connections_per_site: usize,
+    /// Capacity of each connection's outbound frame queue, in frames. Overflow
+    /// closes the connection with [`CLOSE_QUEUE_OVERFLOW`].
+    pub send_queue: usize,
+    /// Maximum payload size, in bytes, of a frame PHP may push. `0` =
+    /// unlimited.
+    ///
+    /// This is the **outbound** half of `[server.websocket] max_message_size`;
+    /// the inbound half is enforced by the WebSocket codec in `ephpm-server`.
+    /// Checked here rather than at the socket so an oversized payload is
+    /// refused before it is queued — a 100 MiB frame must not be admitted into
+    /// a 64-deep queue and only discovered on write.
+    pub max_message_size: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_connections: 10_000,
+            max_connections_per_site: 1_000,
+            send_queue: 64,
+            max_message_size: 1024 * 1024,
+        }
+    }
+}
+
+/// Why [`Registry::register`] refused a new connection.
+///
+/// The server maps each variant to an HTTP status on the upgrade request, so a
+/// client learns it was shed rather than silently getting a dead socket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RegisterError {
+    /// The global [`Limits::max_connections`] cap is full.
+    #[error("websocket connection limit reached")]
+    ServerFull,
+    /// This site's [`Limits::max_connections_per_site`] cap is full.
+    #[error("websocket connection limit reached for this site")]
+    SiteFull,
+    /// The OS entropy source was unavailable, so no unguessable connection ID
+    /// could be minted.
+    ///
+    /// Deliberately fatal for the connection rather than falling back to a
+    /// counter: a predictable ID is a cross-connection send capability handed
+    /// to anyone who can count.
+    #[error("failed to draw connection-id entropy from the OS")]
+    Entropy,
+}

--- a/crates/ephpm-ws/src/registry.rs
+++ b/crates/ephpm-ws/src/registry.rs
@@ -1,0 +1,742 @@
+//! The connection + channel table.
+//!
+//! Two `DashMap`s and an atomic counter:
+//!
+//! * `conns`: connection ID → [`ConnEntry`]. Globally keyed by ID (IDs are
+//!   128-bit random, so they never collide across sites), with the owning site
+//!   stored **inside** the entry. Every scoped operation looks the ID up and
+//!   then compares the entry's site against the caller's scope — the site is a
+//!   property of the connection, never of the argument the caller supplied.
+//! * `channels`: `(site, channel)` → set of member IDs. The site is part of the
+//!   key, so `chat` under site `a` and `chat` under site `b` are different
+//!   channels that cannot see each other.
+//!
+//! # Lock discipline
+//!
+//! No `DashMap` reference is ever held across an `await`, across a PHP call, or
+//! while taking a second reference into the *same* map. `broadcast` clones the
+//! member ID list out of the channel shard and drops the reference before it
+//! sends anything, so a fan-out never pins a shard for the duration of N sends.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+
+use bytes::Bytes;
+use dashmap::DashMap;
+use metrics::{counter, gauge};
+use parking_lot::Mutex;
+use tokio::sync::{Notify, mpsc};
+
+use crate::{CLOSE_QUEUE_OVERFLOW, Limits, OutFrame, RegisterError};
+
+/// Maximum channels one connection may be subscribed to at once.
+///
+/// A fixed ceiling rather than a config knob: it exists to bound the memory a
+/// single misbehaving script can pin (one `HashSet` entry per subscription, in
+/// both directions), and no deployment has a reason to tune it. Subscribing
+/// past this returns `false`.
+pub const MAX_CHANNELS_PER_CONNECTION: usize = 64;
+
+/// Maximum channel-name length in bytes. Same rationale as
+/// [`MAX_CHANNELS_PER_CONNECTION`] — channel names come from userland and are
+/// stored twice (once per membership direction), so they are capped rather than
+/// trusted.
+pub const MAX_CHANNEL_NAME_LEN: usize = 256;
+
+/// The `(site, channel)` composite key.
+///
+/// A struct rather than a joined string: there is no separator byte to reason
+/// about, so no channel name can be crafted to collide with another site's.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ChannelKey {
+    site: Box<str>,
+    channel: Box<str>,
+}
+
+impl ChannelKey {
+    fn new(site: &str, channel: &str) -> Self {
+        Self { site: Box::from(site), channel: Box::from(channel) }
+    }
+}
+
+/// Out-of-band control for one connection: "stop, and close with this code".
+///
+/// Separate from the outbound frame queue on purpose. A close must be
+/// deliverable *precisely when the queue is full* — that is the overflow case —
+/// so it cannot travel through the queue it is reacting to.
+#[derive(Debug)]
+pub struct Control {
+    notify: Notify,
+    /// The close code to send, or `0` when no close has been requested. Only
+    /// the first request wins: an overflow shed and a userland
+    /// `ephpm_ws_close` racing each other must not produce two close frames.
+    close_code: AtomicU16,
+}
+
+impl Control {
+    fn new() -> Self {
+        Self { notify: Notify::new(), close_code: AtomicU16::new(0) }
+    }
+
+    /// Request that this connection be closed with `code`. First caller wins.
+    ///
+    /// Returns `true` if this call is the one that scheduled the close.
+    fn request_close(&self, code: u16) -> bool {
+        let won = self.close_code.compare_exchange(0, code, Ordering::SeqCst, Ordering::SeqCst);
+        // Notify regardless: if another caller won the CAS but its notification
+        // was consumed already, a second wakeup is harmless (the session task
+        // re-reads the code), whereas a missed wakeup would leak the socket.
+        self.notify.notify_one();
+        won.is_ok()
+    }
+
+    /// Wait until a close is requested, then yield the code to send.
+    ///
+    /// Cancel-safe: intended to be one arm of the session task's `select!`.
+    pub async fn closed(&self) -> u16 {
+        loop {
+            let code = self.close_code.load(Ordering::SeqCst);
+            if code != 0 {
+                return code;
+            }
+            self.notify.notified().await;
+        }
+    }
+}
+
+/// One registered connection.
+struct ConnEntry {
+    /// The site scope this connection belongs to. Set once at registration
+    /// from the upgrade request's canonical site key and never mutated — this
+    /// is the value every scoped operation compares against.
+    site: Box<str>,
+    /// Bounded outbound queue. Producers `try_send` only.
+    tx: mpsc::Sender<OutFrame>,
+    control: Arc<Control>,
+    /// Channels this connection is subscribed to, so `unregister` can clean up
+    /// the reverse index without scanning every channel.
+    channels: Mutex<HashSet<Box<str>>>,
+}
+
+/// What [`Registry::register`] hands back to the session task that will own the
+/// socket.
+#[derive(Debug)]
+pub struct Registered {
+    /// The minted, unguessable connection ID. This is the value PHP sees as
+    /// `$_SERVER['WS_CONNECTION_ID']`.
+    pub id: String,
+    /// Receiving end of this connection's bounded outbound queue.
+    pub rx: mpsc::Receiver<OutFrame>,
+    /// Out-of-band close signal.
+    pub control: Arc<Control>,
+}
+
+/// A point-in-time snapshot of registry occupancy. Used by tests and by the
+/// server's startup/shutdown logging; the live numbers are exported as metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegistryStats {
+    /// Live connections across all sites.
+    pub connections: usize,
+    /// Distinct sites with at least one live connection.
+    pub sites: usize,
+    /// Distinct `(site, channel)` pairs with at least one member.
+    pub channels: usize,
+}
+
+/// The site-scoped WebSocket connection registry.
+///
+/// Cheap to share: wrap in an `Arc` once at startup and clone the handle.
+pub struct Registry {
+    conns: DashMap<Box<str>, Arc<ConnEntry>>,
+    channels: DashMap<ChannelKey, HashSet<Box<str>>>,
+    site_counts: DashMap<Box<str>, usize>,
+    total: AtomicUsize,
+    limits: Limits,
+}
+
+impl Registry {
+    /// Build a registry with the given bounds.
+    ///
+    /// [`Limits::send_queue`] is normalized to at least 1: a zero-capacity
+    /// `mpsc` channel would make every `try_send` fail, silently turning the
+    /// feature off.
+    #[must_use]
+    pub fn new(mut limits: Limits) -> Self {
+        if limits.send_queue == 0 {
+            tracing::warn!("[server.websocket] send_queue = 0 is not a valid queue depth; using 1");
+            limits.send_queue = 1;
+        }
+        Self {
+            conns: DashMap::new(),
+            channels: DashMap::new(),
+            site_counts: DashMap::new(),
+            total: AtomicUsize::new(0),
+            limits,
+        }
+    }
+
+    /// The bounds this registry was built with.
+    #[must_use]
+    pub fn limits(&self) -> Limits {
+        self.limits
+    }
+
+    /// Admit a new connection for `site` and mint its ID.
+    ///
+    /// The caller owns the returned [`Registered`] and **must** call
+    /// [`Registry::unregister`] with the same ID when the socket ends, however
+    /// it ends.
+    ///
+    /// The ID is minted **here**, from OS entropy, rather than accepted from
+    /// the caller: that makes "every live connection has an unguessable,
+    /// unique ID" a property of this function instead of a convention every
+    /// call site has to honour.
+    ///
+    /// # Errors
+    ///
+    /// [`RegisterError::ServerFull`] or [`RegisterError::SiteFull`] when a
+    /// connection cap is reached, [`RegisterError::Entropy`] when no ID could
+    /// be drawn. The caller should refuse the upgrade rather than complete a
+    /// handshake onto a socket nothing will service.
+    pub fn register(&self, site: &str) -> Result<Registered, RegisterError> {
+        let id = crate::new_connection_id().map_err(|e| {
+            tracing::error!(%e, "refusing a websocket upgrade: OS entropy unavailable");
+            RegisterError::Entropy
+        })?;
+
+        // Reserve against the global cap first, so a per-site rejection cannot
+        // leak a global slot.
+        self.reserve_global()?;
+        if let Err(e) = self.reserve_site(site) {
+            self.total.fetch_sub(1, Ordering::SeqCst);
+            return Err(e);
+        }
+
+        let (tx, rx) = mpsc::channel(self.limits.send_queue);
+        let control = Arc::new(Control::new());
+        let entry = Arc::new(ConnEntry {
+            site: Box::from(site),
+            tx,
+            control: Arc::clone(&control),
+            channels: Mutex::new(HashSet::new()),
+        });
+        self.conns.insert(Box::from(id.as_str()), entry);
+
+        counter!("ephpm_ws_connections_total").increment(1);
+        self.publish_active();
+        Ok(Registered { id, rx, control })
+    }
+
+    /// Take a slot against the global cap.
+    fn reserve_global(&self) -> Result<(), RegisterError> {
+        if self.limits.max_connections == 0 {
+            self.total.fetch_add(1, Ordering::SeqCst);
+            return Ok(());
+        }
+        // CAS loop rather than fetch_add-then-check: an over-limit fetch_add
+        // would be briefly visible to a concurrent registration and could admit
+        // past the cap under a burst.
+        let mut current = self.total.load(Ordering::SeqCst);
+        loop {
+            if current >= self.limits.max_connections {
+                counter!("ephpm_ws_connections_rejected_total", "reason" => "server_full")
+                    .increment(1);
+                return Err(RegisterError::ServerFull);
+            }
+            match self.total.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    /// Take a slot against this site's cap.
+    fn reserve_site(&self, site: &str) -> Result<(), RegisterError> {
+        // `entry` holds the shard write lock for the whole check-and-increment,
+        // so two concurrent upgrades for one site cannot both see `n - 1`.
+        let mut slot = self.site_counts.entry(Box::from(site)).or_insert(0);
+        if self.limits.max_connections_per_site != 0
+            && *slot >= self.limits.max_connections_per_site
+        {
+            counter!("ephpm_ws_connections_rejected_total", "reason" => "site_full").increment(1);
+            return Err(RegisterError::SiteFull);
+        }
+        *slot += 1;
+        Ok(())
+    }
+
+    /// Remove a connection and every channel membership it held.
+    ///
+    /// Idempotent — a double unregister (session task teardown racing an
+    /// explicit close) is a no-op.
+    pub fn unregister(&self, id: &str) {
+        let Some((_, entry)) = self.conns.remove(id) else {
+            return;
+        };
+
+        let subscribed: Vec<Box<str>> = {
+            let mut held = entry.channels.lock();
+            held.drain().collect()
+        };
+        for channel in subscribed {
+            let key = ChannelKey { site: entry.site.clone(), channel };
+            self.remove_member(&key, id);
+        }
+
+        self.site_counts.remove_if_mut(entry.site.as_ref(), |_, count| {
+            *count = count.saturating_sub(1);
+            *count == 0
+        });
+        self.total.fetch_sub(1, Ordering::SeqCst);
+        self.publish_active();
+    }
+
+    /// Drop `id` from a channel, removing the channel entirely once empty so an
+    /// application that churns channel names cannot grow the map forever.
+    fn remove_member(&self, key: &ChannelKey, id: &str) {
+        self.channels.remove_if_mut(key, |_, members| {
+            members.remove(id);
+            members.is_empty()
+        });
+    }
+
+    /// Look up a connection **within a site scope**.
+    ///
+    /// Returns `None` both when the ID is unknown and when it belongs to a
+    /// different site: the caller cannot distinguish the two, so this is not an
+    /// existence oracle for other tenants' connection IDs.
+    fn scoped(&self, site: &str, id: &str) -> Option<Arc<ConnEntry>> {
+        let entry = self.conns.get(id)?;
+        if entry.site.as_ref() != site {
+            // Worth a counter: in a correct deployment this is always zero, so
+            // any nonzero value is either a bug or an attempt.
+            counter!("ephpm_ws_cross_site_denied_total").increment(1);
+            tracing::warn!(
+                caller_site = site,
+                owner_site = %entry.site,
+                "rejected cross-site websocket operation"
+            );
+            return None;
+        }
+        Some(Arc::clone(entry.value()))
+    }
+
+    /// Queue one frame to one connection.
+    ///
+    /// Returns `false` when the connection is unknown to this site, when its
+    /// session task has already gone, or when its outbound queue is full — the
+    /// last case also schedules the connection for a
+    /// [`CLOSE_QUEUE_OVERFLOW`] close.
+    ///
+    /// Never blocks. This runs on a PHP blocking thread; parking it on a slow
+    /// client's socket would hold a `spawn_blocking` slot hostage.
+    pub fn send(&self, site: &str, id: &str, frame: OutFrame) -> bool {
+        if !self.within_size_limit(frame.len()) {
+            return false;
+        }
+        let Some(entry) = self.scoped(site, id) else {
+            return false;
+        };
+        self.enqueue(&entry, frame)
+    }
+
+    /// Reject an oversized payload before it is queued anywhere.
+    fn within_size_limit(&self, len: usize) -> bool {
+        if self.limits.max_message_size == 0 || len <= self.limits.max_message_size {
+            return true;
+        }
+        counter!("ephpm_ws_frames_rejected_total", "reason" => "too_large").increment(1);
+        tracing::warn!(
+            len,
+            max = self.limits.max_message_size,
+            "refused an outbound websocket frame over [server.websocket] max_message_size"
+        );
+        false
+    }
+
+    /// The shared tail of [`Registry::send`] and [`Registry::broadcast`].
+    fn enqueue(&self, entry: &ConnEntry, frame: OutFrame) -> bool {
+        match entry.tx.try_send(frame) {
+            Ok(()) => {
+                counter!("ephpm_ws_frames_queued_total").increment(1);
+                true
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                counter!("ephpm_ws_send_queue_overflow_total").increment(1);
+                if entry.control.request_close(CLOSE_QUEUE_OVERFLOW) {
+                    tracing::warn!(
+                        site = %entry.site,
+                        depth = self.limits.send_queue,
+                        "websocket outbound queue full — shedding connection with 1013"
+                    );
+                }
+                false
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => false,
+        }
+    }
+
+    /// Subscribe a connection to a channel within its own site.
+    ///
+    /// Returns `false` for an unknown/foreign connection, an empty or
+    /// over-long channel name, or a connection already at
+    /// [`MAX_CHANNELS_PER_CONNECTION`].
+    pub fn subscribe(&self, site: &str, id: &str, channel: &str) -> bool {
+        if !valid_channel(channel) {
+            return false;
+        }
+        let Some(entry) = self.scoped(site, id) else {
+            return false;
+        };
+
+        {
+            let mut held = entry.channels.lock();
+            if !held.contains(channel) && held.len() >= MAX_CHANNELS_PER_CONNECTION {
+                tracing::warn!(
+                    site,
+                    max = MAX_CHANNELS_PER_CONNECTION,
+                    "websocket connection refused a subscription at the per-connection cap"
+                );
+                return false;
+            }
+            held.insert(Box::from(channel));
+        }
+
+        self.channels.entry(ChannelKey::new(site, channel)).or_default().insert(Box::from(id));
+        true
+    }
+
+    /// Remove a connection from a channel within its own site.
+    ///
+    /// Returns `false` for an unknown/foreign connection or a name that was
+    /// never subscribed.
+    pub fn unsubscribe(&self, site: &str, id: &str, channel: &str) -> bool {
+        let Some(entry) = self.scoped(site, id) else {
+            return false;
+        };
+        let was_member = entry.channels.lock().remove(channel);
+        if was_member {
+            self.remove_member(&ChannelKey::new(site, channel), id);
+        }
+        was_member
+    }
+
+    /// Queue one frame to every member of `channel` within `site`.
+    ///
+    /// Returns the number of connections the frame was **queued** to. A
+    /// subscriber whose queue was full is not counted (and is shed).
+    pub fn broadcast(&self, site: &str, channel: &str, payload: Bytes, binary: bool) -> usize {
+        if !valid_channel(channel) || !self.within_size_limit(payload.len()) {
+            return 0;
+        }
+        // Clone the membership list out and release the shard before sending:
+        // the sends below touch `conns`, and a fan-out to thousands of members
+        // must not pin this channel's shard for the whole walk.
+        let members: Vec<Box<str>> = {
+            let Some(set) = self.channels.get(&ChannelKey::new(site, channel)) else {
+                return 0;
+            };
+            set.iter().cloned().collect()
+        };
+
+        let frame = OutFrame::new(payload, binary);
+        let mut delivered = 0;
+        for id in members {
+            // Re-scope every member: membership is the reverse index, `conns`
+            // is the authority. A connection that vanished mid-broadcast, or
+            // (impossibly, but checked anyway) one whose site no longer
+            // matches, is skipped rather than trusted.
+            if let Some(entry) = self.scoped(site, &id) {
+                if self.enqueue(&entry, frame.clone()) {
+                    delivered += 1;
+                }
+            }
+        }
+        delivered
+    }
+
+    /// Ask a connection's session task to close with `code`.
+    ///
+    /// Returns `false` for an unknown/foreign connection. The socket is not
+    /// closed synchronously: the session task drains what it can and then
+    /// sends the close frame.
+    pub fn close(&self, site: &str, id: &str, code: u16) -> bool {
+        let Some(entry) = self.scoped(site, id) else {
+            return false;
+        };
+        entry.control.request_close(code);
+        true
+    }
+
+    /// Live connections in one site.
+    #[must_use]
+    pub fn site_connections(&self, site: &str) -> usize {
+        self.site_counts.get(site).map_or(0, |n| *n)
+    }
+
+    /// Members of one channel within a site.
+    #[must_use]
+    pub fn channel_members(&self, site: &str, channel: &str) -> usize {
+        self.channels.get(&ChannelKey::new(site, channel)).map_or(0, |m| m.len())
+    }
+
+    /// Occupancy snapshot.
+    #[must_use]
+    pub fn stats(&self) -> RegistryStats {
+        RegistryStats {
+            connections: self.total.load(Ordering::SeqCst),
+            sites: self.site_counts.len(),
+            channels: self.channels.len(),
+        }
+    }
+
+    /// Publish the active-connection gauge after a membership change.
+    fn publish_active(&self) {
+        #[allow(clippy::cast_precision_loss)]
+        gauge!("ephpm_ws_connections_active").set(self.total.load(Ordering::SeqCst) as f64);
+    }
+}
+
+/// Channel names are userland strings that get stored in two maps, so they are
+/// length-capped and may not be empty.
+fn valid_channel(channel: &str) -> bool {
+    !channel.is_empty() && channel.len() <= MAX_CHANNEL_NAME_LEN
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry() -> Registry {
+        Registry::new(Limits {
+            max_connections: 0,
+            max_connections_per_site: 0,
+            send_queue: 4,
+            max_message_size: 0,
+        })
+    }
+
+    fn admit(reg: &Registry, site: &str) -> Registered {
+        reg.register(site).expect("register")
+    }
+
+    fn text(s: &str) -> OutFrame {
+        OutFrame::Text(Bytes::from(s.to_owned()))
+    }
+
+    #[test]
+    fn send_reaches_a_connection_in_the_same_site() {
+        let reg = registry();
+        let mut c = admit(&reg, "alpha");
+        assert!(reg.send("alpha", &c.id, text("hi")));
+        match c.rx.try_recv().expect("frame queued") {
+            OutFrame::Text(b) => assert_eq!(&b[..], b"hi"),
+            OutFrame::Binary(_) => panic!("expected a text frame"),
+        }
+    }
+
+    #[test]
+    fn a_site_cannot_send_to_another_sites_connection_even_with_a_valid_id() {
+        // The whole point of the crate: site B holds A's exact connection ID
+        // (leaked, logged, guessed — it does not matter) and still cannot
+        // reach it.
+        let reg = registry();
+        let mut victim = admit(&reg, "alpha");
+        let leaked_id = victim.id.clone();
+
+        assert!(!reg.send("beta", &leaked_id, text("pwned")), "cross-site send must fail");
+        assert!(
+            victim.rx.try_recv().is_err(),
+            "no frame may reach a connection from outside its site"
+        );
+    }
+
+    #[test]
+    fn a_site_cannot_close_or_subscribe_another_sites_connection() {
+        let reg = registry();
+        let victim = admit(&reg, "alpha");
+
+        assert!(!reg.close("beta", &victim.id, 1000), "cross-site close must fail");
+        assert!(!reg.subscribe("beta", &victim.id, "room"), "cross-site subscribe must fail");
+        assert!(!reg.unsubscribe("beta", &victim.id, "room"), "cross-site unsubscribe must fail");
+
+        // And the victim was not scheduled for closure by the attempt.
+        assert_eq!(victim.control.close_code.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn identically_named_channels_in_two_sites_are_separate() {
+        let reg = registry();
+        let mut a = admit(&reg, "alpha");
+        let mut b = admit(&reg, "beta");
+        assert!(reg.subscribe("alpha", &a.id, "chat"));
+        assert!(reg.subscribe("beta", &b.id, "chat"));
+
+        assert_eq!(reg.broadcast("alpha", "chat", Bytes::from_static(b"a-only"), false), 1);
+        assert!(a.rx.try_recv().is_ok());
+        assert!(b.rx.try_recv().is_err(), "site beta must not see site alpha's channel traffic");
+    }
+
+    #[test]
+    fn broadcast_counts_only_connections_it_queued_to() {
+        let reg = registry();
+        let mut one = admit(&reg, "alpha");
+        let mut two = admit(&reg, "alpha");
+        let _three = admit(&reg, "alpha"); // subscribed to nothing
+        assert!(reg.subscribe("alpha", &one.id, "room"));
+        assert!(reg.subscribe("alpha", &two.id, "room"));
+
+        assert_eq!(reg.broadcast("alpha", "room", Bytes::from_static(b"hello"), false), 2);
+        assert!(one.rx.try_recv().is_ok());
+        assert!(two.rx.try_recv().is_ok());
+        assert_eq!(reg.channel_members("alpha", "room"), 2);
+        assert_eq!(reg.broadcast("alpha", "no-such-channel", Bytes::new(), false), 0);
+    }
+
+    #[test]
+    fn unsubscribe_removes_the_member_and_drops_an_empty_channel() {
+        let reg = registry();
+        let c = admit(&reg, "alpha");
+        assert!(reg.subscribe("alpha", &c.id, "room"));
+        assert_eq!(reg.stats().channels, 1);
+
+        assert!(reg.unsubscribe("alpha", &c.id, "room"));
+        assert_eq!(reg.channel_members("alpha", "room"), 0);
+        assert_eq!(reg.stats().channels, 0, "an empty channel must not linger");
+        assert!(!reg.unsubscribe("alpha", &c.id, "room"), "second unsubscribe is a no-op");
+    }
+
+    #[test]
+    fn a_full_queue_sheds_the_connection_with_1013() {
+        // send_queue = 4, and nothing is draining.
+        let reg = registry();
+        let c = admit(&reg, "alpha");
+        for i in 0..4 {
+            assert!(reg.send("alpha", &c.id, text("x")), "frame {i} should fit");
+        }
+        assert!(!reg.send("alpha", &c.id, text("overflow")), "the 5th frame must be refused");
+        assert_eq!(
+            c.control.close_code.load(Ordering::SeqCst),
+            CLOSE_QUEUE_OVERFLOW,
+            "overflow must schedule a 1013 close, not buffer"
+        );
+    }
+
+    #[test]
+    fn the_first_close_code_wins() {
+        let reg = registry();
+        let c = admit(&reg, "alpha");
+        assert!(reg.close("alpha", &c.id, 4001));
+        assert!(reg.close("alpha", &c.id, 1000));
+        assert_eq!(c.control.close_code.load(Ordering::SeqCst), 4001);
+    }
+
+    #[test]
+    fn unregister_clears_channels_and_counts() {
+        let reg = registry();
+        let c = admit(&reg, "alpha");
+        assert!(reg.subscribe("alpha", &c.id, "room"));
+        assert_eq!(reg.stats(), RegistryStats { connections: 1, sites: 1, channels: 1 });
+
+        reg.unregister(&c.id);
+        assert_eq!(reg.stats(), RegistryStats { connections: 0, sites: 0, channels: 0 });
+        assert!(!reg.send("alpha", &c.id, text("gone")));
+        reg.unregister(&c.id); // idempotent
+        assert_eq!(reg.stats().connections, 0);
+    }
+
+    #[test]
+    fn caps_are_enforced_globally_and_per_site() {
+        let reg = Registry::new(Limits {
+            max_connections: 3,
+            max_connections_per_site: 2,
+            send_queue: 4,
+            max_message_size: 0,
+        });
+        let a1 = admit(&reg, "alpha");
+        let _a2 = admit(&reg, "alpha");
+        assert_eq!(reg.register("alpha").unwrap_err(), RegisterError::SiteFull);
+        // A per-site rejection must not have consumed a global slot.
+        let _b1 = admit(&reg, "beta");
+        assert_eq!(reg.stats().connections, 3);
+        assert_eq!(reg.register("beta").unwrap_err(), RegisterError::ServerFull);
+
+        // Freeing a slot lets the next one in.
+        reg.unregister(&a1.id);
+        let _b2 = admit(&reg, "beta");
+        assert_eq!(reg.site_connections("alpha"), 1);
+        assert_eq!(reg.site_connections("beta"), 2);
+    }
+
+    #[test]
+    fn channel_names_are_validated_and_capped_per_connection() {
+        let reg = registry();
+        let c = admit(&reg, "alpha");
+        assert!(!reg.subscribe("alpha", &c.id, ""), "empty channel name");
+        assert!(
+            !reg.subscribe("alpha", &c.id, &"x".repeat(MAX_CHANNEL_NAME_LEN + 1)),
+            "over-long channel name"
+        );
+
+        for i in 0..MAX_CHANNELS_PER_CONNECTION {
+            assert!(reg.subscribe("alpha", &c.id, &format!("c{i}")), "channel {i}");
+        }
+        assert!(!reg.subscribe("alpha", &c.id, "one-too-many"));
+        // Re-subscribing to an existing channel is still allowed at the cap.
+        assert!(reg.subscribe("alpha", &c.id, "c0"));
+    }
+
+    #[test]
+    fn zero_send_queue_is_normalized_rather_than_disabling_sends() {
+        let reg = Registry::new(Limits {
+            max_connections: 0,
+            max_connections_per_site: 0,
+            send_queue: 0,
+            max_message_size: 0,
+        });
+        assert_eq!(reg.limits().send_queue, 1);
+        let mut c = admit(&reg, "alpha");
+        assert!(reg.send("alpha", &c.id, text("fits")));
+        assert!(c.rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn an_oversized_payload_is_refused_before_it_is_queued() {
+        let reg = Registry::new(Limits {
+            max_connections: 0,
+            max_connections_per_site: 0,
+            send_queue: 4,
+            max_message_size: 8,
+        });
+        let mut c = admit(&reg, "alpha");
+        assert!(reg.subscribe("alpha", &c.id, "room"));
+
+        assert!(reg.send("alpha", &c.id, text("01234567")), "8 bytes is exactly the cap");
+        assert!(c.rx.try_recv().is_ok());
+        assert!(!reg.send("alpha", &c.id, text("012345678")), "9 bytes is over the cap");
+        assert_eq!(reg.broadcast("alpha", "room", Bytes::from_static(b"0123456789"), false), 0);
+        assert!(c.rx.try_recv().is_err(), "nothing oversized may reach the queue");
+
+        // And the connection is NOT shed for it — an oversized payload is the
+        // caller's bug, not back-pressure.
+        assert_eq!(c.control.close_code.load(Ordering::SeqCst), 0);
+        assert!(reg.send("alpha", &c.id, text("ok")));
+        assert!(c.rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn closed_resolves_for_a_close_requested_before_it_is_awaited() {
+        // The session task may be mid-PHP-dispatch when a close is scheduled;
+        // the wakeup must not be lost.
+        let reg = registry();
+        let c = admit(&reg, "alpha");
+        assert!(reg.close("alpha", &c.id, 4002));
+        assert_eq!(c.control.closed().await, 4002);
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,6 +110,7 @@ COPY crates/ephpm-middleware-security-headers/Cargo.toml crates/ephpm-middleware
 COPY crates/ephpm-php/Cargo.toml          crates/ephpm-php/Cargo.toml
 COPY crates/ephpm-query-stats/Cargo.toml  crates/ephpm-query-stats/Cargo.toml
 COPY crates/ephpm-server/Cargo.toml       crates/ephpm-server/Cargo.toml
+COPY crates/ephpm-ws/Cargo.toml           crates/ephpm-ws/Cargo.toml
 
 RUN mkdir -p \
         xtask/src \
@@ -127,10 +128,11 @@ RUN mkdir -p \
         crates/ephpm-php/src \
         crates/ephpm-query-stats/src \
         crates/ephpm-server/src \
+        crates/ephpm-ws/src \
         crates/ephpm-server/examples && \
     printf 'fn main() {}\n' > xtask/src/main.rs && \
     printf 'fn main() {}\n' > crates/ephpm/src/main.rs && \
-    for d in ephpm-cluster ephpm-config ephpm-db ephpm-kv ephpm-middleware ephpm-middleware-builtins ephpm-middleware-cors ephpm-middleware-jwt ephpm-middleware-ratelimit ephpm-middleware-security-headers ephpm-php ephpm-query-stats ephpm-server; do \
+    for d in ephpm-cluster ephpm-config ephpm-db ephpm-kv ephpm-middleware ephpm-middleware-builtins ephpm-middleware-cors ephpm-middleware-jwt ephpm-middleware-ratelimit ephpm-middleware-security-headers ephpm-php ephpm-query-stats ephpm-server ephpm-ws; do \
         touch crates/$d/src/lib.rs; \
     done && \
     # ephpm-server declares three `[[example]] crate-type = ["cdylib"]` targets

--- a/site/content/guides/_index.md
+++ b/site/content/guides/_index.md
@@ -13,6 +13,7 @@ Task-oriented walkthroughs for common deployments.
 - **[Clustering Setup](clustering-setup/)** — gossip-based HA with clustered SQLite.
 - **[Database from PHP](db-from-php/)** — the in-process `ephpm_db_*` bridge, and how it relates to the `pdo_mysql` wire path.
 - **[KV from PHP](kv-from-php/)** — the `ephpm_kv_*` SAPI functions.
+- **[WebSockets](websockets/)** — *experimental*: Rust owns the sockets, PHP runs per event via `websocket.php`, and any HTTP request can push a frame.
 - **[Query Stats with Prometheus](query-stats-prometheus/)** — observability for your database queries.
 - **[Worker Mode (Write Your Own Worker)](worker-mode/)** — the engine primitives: boot once, loop on `take_request()`/`send_response()`.
 - **[Laravel Octane (Worker Mode)](laravel-octane/)** — boot Laravel once per worker with the native Octane driver.

--- a/site/content/guides/websockets.md
+++ b/site/content/guides/websockets.md
@@ -1,0 +1,236 @@
++++
+title = "WebSockets"
+weight = 18
++++
+
+> **Experimental.** Native WebSocket support is opt-in (`[server.websocket] enabled = true`, off by default) and the API may change before it stabilizes. Everything on this page is implemented and covered by tests; nothing here is aspirational.
+
+ePHPm terminates WebSockets in **Rust** and invokes PHP **per event**. PHP never holds a connection open.
+
+That is the AWS API Gateway / RoadRunner model, not the Swoole model:
+
+| | ePHPm | Swoole / ReactPHP |
+|---|---|---|
+| Who owns the socket | the Rust reactor | a PHP process |
+| Cost of an idle connection | a registry entry + reactor memory | a PHP coroutine or process |
+| What runs per message | one ordinary PHP request | a userland event-loop callback |
+| Code shape | stateless handler, like `index.php` | long-lived event loop |
+
+Ten thousand idle connections cost no PHP at all. A message costs exactly one PHP execution, on the same path an HTTP request takes — so `open_basedir`, the per-vhost temp and session directories, per-site database credentials, OPcache, and the crash guard all apply unchanged.
+
+## Enabling it
+
+```toml
+[server.websocket]
+enabled = true
+```
+
+That is the only required line; every bound has a default (see [Configuration](/reference/config/#server-websocket)).
+
+The entrypoint is `websocket.php` at the **vhost's document root** — `index.php` for WebSockets. The name is configurable, `index_files`-style:
+
+```toml
+[server]
+websocket_files = ["websocket.php"]   # default; tried in order
+```
+
+**A vhost with no entrypoint 404s every upgrade request.** It never falls through to `index.php`, a static file, or the `[server] fallback` chain. Opting a vhost into WebSockets means putting the file there.
+
+## The three events
+
+One script handles all of them. Userland routes on `$_SERVER['WS_EVENT']` — that is the point; there is no framework contract to satisfy.
+
+| `WS_EVENT` | When | Notes |
+|---|---|---|
+| `connect` | **Before** the handshake completes | Return 2xx to accept the upgrade, anything else to refuse it. **Authentication belongs here** — it is the only point at which an upgrade can still be refused. |
+| `message` | One inbound data frame | Payload is the request body (`php://input`). `WS_OPCODE` is `text` or `binary`. |
+| `disconnect` | After the socket closes | **Best-effort**, like API Gateway's `$disconnect`. Not delivered if the process dies. |
+
+Every event also gets:
+
+| `$_SERVER` key | Value |
+|---|---|
+| `WS_EVENT` | `connect`, `message`, or `disconnect` |
+| `WS_CONNECTION_ID` | 32 lowercase hex characters — 128 random bits |
+| `WS_OPCODE` | `text` or `binary`. **Only on `message` events** |
+
+The upgrade request's URI, query string, headers and cookies are replayed on every event, so `$_GET`, `$_COOKIE` and `$_SERVER['HTTP_*']` look the same in a `message` handler as they did at `connect`.
+
+Because `WS_EVENT` is only set for WebSocket events, an ordinary HTTP request can tell the difference with `isset($_SERVER['WS_EVENT'])`.
+
+## A complete minimal `websocket.php`
+
+```php
+<?php
+// public/websocket.php — a working echo + chat server.
+
+$event = $_SERVER['WS_EVENT'];
+$conn  = $_SERVER['WS_CONNECTION_ID'];
+
+switch ($event) {
+    case 'connect':
+        // Authenticate. A non-2xx response refuses the upgrade and the
+        // client sees this exact status and body.
+        $token = $_GET['token'] ?? '';
+        $userId = verify_token($token);          // your app's function
+        if ($userId === null) {
+            http_response_code(401);
+            header('WWW-Authenticate: Bearer');
+            echo 'unauthorized';
+            return;
+        }
+
+        // Remember who this socket belongs to, so an ordinary HTTP request
+        // can push to it later. See "Pushing from an HTTP request" below.
+        ephpm_kv_set("ws:user:$userId", $conn);
+        ephpm_kv_set("ws:conn:$conn", (string) $userId);
+
+        // Put them in a room. Channels are how you fan out.
+        ephpm_ws_subscribe('lobby');
+
+        http_response_code(200);
+        return;
+
+    case 'message':
+        $payload = json_decode(file_get_contents('php://input'), true);
+
+        match ($payload['type'] ?? '') {
+            // Reply to just this socket. No connection id needed — the
+            // implicit form acts on the connection that fired this event.
+            'ping' => ephpm_ws_send(json_encode(['type' => 'pong'])),
+
+            // Fan out to everyone in the room, including this socket.
+            'chat' => ephpm_ws_broadcast('lobby', json_encode([
+                'type' => 'chat',
+                'from' => ephpm_kv_get("ws:conn:$conn"),
+                'text' => $payload['text'] ?? '',
+            ])),
+
+            default => ephpm_ws_send(json_encode(['type' => 'error'])),
+        };
+        return;
+
+    case 'disconnect':
+        // Best-effort cleanup.
+        $userId = ephpm_kv_get("ws:conn:$conn");
+        if ($userId !== null) {
+            ephpm_kv_del("ws:user:$userId");
+            ephpm_kv_del("ws:conn:$conn");
+        }
+        return;
+}
+```
+
+Client side, nothing special:
+
+```js
+const ws = new WebSocket(`wss://example.com/socket?token=${token}`);
+ws.onmessage = (e) => console.log(JSON.parse(e.data));
+ws.onopen = () => ws.send(JSON.stringify({ type: 'chat', text: 'hello' }));
+```
+
+The path (`/socket`) is not routed — **any** upgrade request to the vhost runs `websocket.php`. Use the path or query string however you like; your script sees both.
+
+## Pushing from an HTTP request
+
+This is the feature that makes the model worth it: **any** PHP execution can push to a live socket, not just a WebSocket event. A normal `POST /comments` handler can notify everyone watching that post.
+
+The pattern has two halves. During `connect`, record the connection id under an identity your app already knows:
+
+```php
+// in websocket.php, connect branch
+ephpm_kv_set("ws:user:$userId", $_SERVER['WS_CONNECTION_ID']);
+```
+
+Later, from an ordinary request, look it up and send:
+
+```php
+<?php
+// POST /comments — an entirely normal HTTP handler.
+$comment = create_comment($_POST['post_id'], $_POST['body']);
+
+// Push to one specific user, if they happen to be connected.
+$connId = ephpm_kv_get("ws:user:{$comment['author_id']}");
+if ($connId !== null) {
+    ephpm_ws_connection_send($connId, json_encode([
+        'type' => 'comment.created',
+        'id'   => $comment['id'],
+    ]));
+}
+
+// Or push to everyone watching this post — no id lookup needed.
+$sent = ephpm_ws_broadcast("post:{$comment['post_id']}", json_encode([
+    'type' => 'comment.created',
+    'body' => $comment['body'],
+]));
+
+header('Content-Type: application/json');
+echo json_encode(['ok' => true, 'notified' => $sent]);
+```
+
+Note the two different functions. `ephpm_ws_send()` is the **implicit** form: it means "the connection that fired the current event", so it only works inside a WebSocket event. From an HTTP request there is no current connection, and calling it **throws** rather than silently doing nothing. Use `ephpm_ws_connection_send()` with an explicit id, or `ephpm_ws_broadcast()`, which needs no connection at all.
+
+`ephpm_kv_*` is the natural place to keep the id→identity mapping — it is in-process, so the lookup is a hash-map read, and in a cluster the mapping gossips to every node. Any store works; a database column is fine too.
+
+## Function reference
+
+Each operation has an **implicit** form (acts on the current event's connection) and an **explicit** form (`ephpm_ws_connection_*`, takes a connection id). `ephpm_ws_broadcast()` has only one form because a channel is not a connection.
+
+| Function | Returns | Notes |
+|---|---|---|
+| `ephpm_ws_send(string $payload, bool $binary = false)` | `bool` | Push to the current event's connection. Throws outside a WebSocket event. |
+| `ephpm_ws_connection_send(string $connection_id, string $payload, bool $binary = false)` | `bool` | Push to any connection in this site. |
+| `ephpm_ws_subscribe(string $channel)` | `bool` | Join the current connection to a channel. |
+| `ephpm_ws_connection_subscribe(string $connection_id, string $channel)` | `bool` | |
+| `ephpm_ws_unsubscribe(string $channel)` | `bool` | |
+| `ephpm_ws_connection_unsubscribe(string $connection_id, string $channel)` | `bool` | |
+| `ephpm_ws_broadcast(string $channel, string $payload, bool $binary = false)` | `int` | Number of connections the frame was **queued** to. Works from any PHP execution. |
+| `ephpm_ws_close(int $code = 1000)` | `bool` | Close the current connection. Throws outside a WebSocket event. |
+| `ephpm_ws_connection_close(string $connection_id, int $code = 1000)` | `bool` | |
+
+**`false` versus an exception.** A `false` return means the connection could not be reached — it is unknown to this site, it has gone, or its outbound queue is full. Those are ordinary runtime outcomes; check the return value if you care. An **exception** means the call could never have worked: WebSockets are disabled server-wide, the request has no virtual host, or the implicit form was used with no current connection. Those are bugs or misconfiguration, so they are not silently swallowed.
+
+Closing is asynchronous. `ephpm_ws_close()` asks the connection's session task to close, so frames already queued ahead of it are still delivered.
+
+## Multi-tenant isolation
+
+Connection ids and channel names are **scoped to a virtual host**. A connection opened on `a.example.com` cannot be reached from PHP running for `b.example.com`, even with the exact connection id in hand — and `chat` on one vhost is a different channel from `chat` on another.
+
+The scope is not taken from a function argument. It comes from the canonical site key the router derived for the request that is executing, the same key that selects the per-site database and KV keyspace. A request whose `Host` matches no virtual host has no tenant identity, so it gets no WebSocket capability at all: its upgrade requests 404 and its `ephpm_ws_*` calls throw.
+
+Connection ids are 128 random bits from the OS CSPRNG, rendered as 32 hex characters. Treat one as a capability: anything holding it, within the owning site, can push to that socket.
+
+## Limits and back-pressure
+
+Every connection has a **bounded** outbound queue (`[server.websocket] send_queue`, 64 frames by default). When it fills — a client that has stopped reading — the frame is **not** buffered. `ephpm_ws_send()` returns `false`, the broadcast does not count that subscriber, and the socket is closed with WebSocket status `1013 Try Again Later`. One slow reader costs one connection, never the server's memory.
+
+The other bounds:
+
+| Knob | Default | What it protects |
+|---|---|---|
+| `max_connections` | `10000` | Total sockets, all vhosts. Over the cap, upgrades get `503`. |
+| `max_connections_per_site` | `1000` | One tenant cannot consume a shared node's whole budget. |
+| `max_message_size` | 1 MiB | Largest inbound message, and largest payload PHP may push. |
+| `max_frame_size` | 1 MiB | Largest single inbound frame. |
+| `ping_interval_secs` | `30` | Server-initiated keepalive. |
+| `idle_timeout_secs` | `120` | Close a connection that has received nothing (not even a pong) for this long. |
+
+A connection is also subject to a fixed ceiling of 64 channel subscriptions and 256-byte channel names. These are not configurable — they bound what one misbehaving script can pin, and no deployment has a reason to tune them.
+
+A `message` handler that exceeds `[server.timeouts] request` closes its connection with `1011`. Unlike an HTTP request, the socket cannot simply be abandoned: the blocking PHP execution cannot be cancelled, so continuing would risk a second dispatch overlapping the abandoned one.
+
+## Metrics
+
+With `[server.metrics] enabled = true`, the WebSocket series appear at `/metrics` — see [Metrics](/reference/metrics/#websockets). The two most worth alerting on:
+
+- `ephpm_ws_send_queue_overflow_total` rising means clients are not draining, and connections are being shed.
+- `ephpm_ws_cross_site_denied_total` should be flat at zero. Anything else is a bug or an attempt.
+
+## Limitations
+
+- **HTTP/1.1 only.** WebSocket upgrades cannot be expressed on the HTTP/2 or HTTP/3 request paths ePHPm serves (RFC 8441 extended CONNECT is not implemented). Browsers open a dedicated HTTP/1.1 connection for `ws:`/`wss:` regardless, so this is not something clients encounter. TLS works normally — `wss://` is served by the same listener as `https://`.
+- **Not supported in worker mode.** `[server.websocket] enabled = true` with `[php] mode = "worker"` is a startup error: worker mode routes every request into the persistent worker's loop, so the entrypoint would never execute. Use fpm mode (the default).
+- **`disconnect` is best-effort.** A process that dies takes its in-flight `disconnect` events with it. Do not rely on it for anything that must happen exactly once; treat it as a cleanup hint, and expire the state you write at `connect`.
+- **No clustered fan-out yet.** The registry is per-process, so `ephpm_ws_broadcast()` reaches connections on **this node** only. In a multi-node cluster, a socket connected to node A is not reachable from a request served by node B. Cluster-wide fan-out is not implemented.
+- **`[server.security] allowed_php_paths` does not gate the entrypoint.** The entrypoint is selected by an operator-configured filename, not by the request path, so there is no client-driven path to allowlist. Entries are still containment-checked against the document root.
+- **Graceful shutdown does not drain WebSockets.** An upgraded socket is handed to its own task and stops counting against `[server.limits] max_connections`; shutdown does not wait for it. Clients should reconnect.

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -21,6 +21,12 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 | `fallback` | array of strings | `["$uri", "$uri/", "/index.php?$query_string"]` | URL fallback chain. Variables: `$uri`, `$query_string`. Last entry is the fallback (prefix `=` for status code, e.g. `=404`). |
 | `preview` | bool | `false` | Preview-host preset for **not-production** PR-preview instances. Adds `X-Ephpm-Preview: 1` to every response, and every `[server.limits]` knob you did not set explicitly resolves to a preview default instead of "off": `max_connections = 256`, `per_ip_max_connections = 32`, `per_ip_rate = 10.0`, `per_ip_burst = 50`, `per_site_rate = 5.0`, `per_site_burst = 20`. Explicit values always win — including explicit `0`, which disables that limit even under preview. Startup logs exactly which limits the preset supplied. Env override: `EPHPM_SERVER__PREVIEW=true`. |
 
+### `[server]` — WebSocket entrypoint
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `websocket_files` | array of strings | `["websocket.php"]` | Entrypoint script names tried, in order, when a WebSocket upgrade request arrives — the `index_files` of the WebSocket path. Resolved against the **vhost's** document root, so each virtual host has its own handler or none. The first name that exists wins and receives every event for connections upgraded on that vhost (`connect`, `message`, `disconnect`, distinguished by `$_SERVER['WS_EVENT']`). If **no** name exists in that document root, the upgrade request is answered `404` — it never falls through to static files, `index.php`, or the `[server] fallback` chain. Only consulted when `[server.websocket] enabled = true`. Env override: `EPHPM_SERVER__WEBSOCKET_FILES`. |
+
 ### `[server.request]`
 
 | Key | Type | Default | Description |
@@ -183,6 +189,25 @@ HTTP/3 runs over **UDP**, *in addition to* the TCP listeners — HTTP/1.1 and HT
 **Limitation — ACME is not supported on HTTP/3 yet.** QUIC bakes its certificate into the endpoint at bind time, whereas `rustls-acme` rotates certificates during the process lifetime. `enabled = true` together with ACME TLS is a startup error, deliberately: ePHPm refuses to come up quietly without the HTTP/3 listener you asked for. Use a static `cert`/`key` for now; ACME support is planned.
 
 **Firewalls:** QUIC is UDP. Opening TCP/443 is not enough — UDP on the same port must also be reachable, or clients will try HTTP/3, fail, and silently fall back to TCP.
+
+### `[server.websocket]`
+
+**Experimental.** Native WebSocket termination: Rust owns the sockets, PHP runs per event via the vhost's `[server] websocket_files` entrypoint. See the [WebSockets guide](/guides/websockets/).
+
+With `enabled = false` (the default) an upgrade request routes exactly like any other `GET`, so turning this section on is the only thing that changes upgrade routing.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Enable native WebSocket support. Opt-in: it changes how upgrade requests route and admits long-lived connections that outlive their HTTP request. Env override: `EPHPM_SERVER__WEBSOCKET__ENABLED`. **Startup error** when combined with `[php] mode = "worker"` (WebSocket events dispatch through the fpm per-request path), or when `[server] websocket_files` is empty. |
+| `max_connections` | usize | `10000` | Total concurrent WebSocket connections across all vhosts. `0` = unlimited. Upgrades beyond the cap get `503`. A **separate** budget from `[server.limits] max_connections`: an upgraded socket is handed to its own task and stops occupying an HTTP connection slot, so the HTTP cap cannot bound it. |
+| `max_connections_per_site` | usize | `1000` | Per-vhost cap, enforced in addition to `max_connections` so one tenant cannot consume a shared node's whole budget. `0` = unlimited. Rejected upgrades get `503`. |
+| `max_message_size` | usize (bytes) | `1048576` (1 MiB) | Largest inbound message (after reassembling continuation frames), and largest payload PHP may push with `ephpm_ws_send()` / `ephpm_ws_broadcast()`. Deliberately independent of `[server.request] max_body_size` — a WebSocket event's payload is bounded by this knob, not the HTTP body limit. |
+| `max_frame_size` | usize (bytes) | `1048576` (1 MiB) | Largest single inbound frame. `max_message_size` bounds the reassembled total. |
+| `send_queue` | usize (frames) | `64` | Depth of each connection's outbound queue. When full, the frame is **not** buffered: the send reports failure and the socket is closed with WebSocket status `1013`. A slow reader costs one connection, never the server's memory. `0` is normalized to `1` with a warning. |
+| `ping_interval_secs` | u64 | `30` | Seconds between server-initiated pings. `0` disables keepalive — which also means idle connections will be dropped, since pings are what refresh `idle_timeout_secs`. |
+| `idle_timeout_secs` | u64 | `120` | Seconds a connection may receive **nothing** (including a pong) before it is closed with `1001`. `0` disables the check. Keep comfortably larger than `ping_interval_secs`; a warning is logged if it is not. |
+
+Two ceilings are fixed rather than configurable: 64 channel subscriptions per connection and 256-byte channel names. They bound what one misbehaving script can pin.
 
 ```toml
 [server.tls]

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -50,6 +50,28 @@ Emitted only when `[server.http3] enabled = true`; the series are absent otherwi
 
 A rising `ephpm_http3_connection_errors_total{stage="handshake"}` with `ephpm_http3_connections_total` flat usually means UDP is being blocked on the path — clients are trying HTTP/3 and falling back to TCP.
 
+## WebSockets
+
+Emitted only when `[server.websocket] enabled = true`; the series are absent otherwise. See the [WebSockets guide](/guides/websockets/).
+
+The upgrade request itself also increments the `ephpm_http_*` metrics above with `handler="websocket"` — everything after the `101` is accounted for here instead, because an upgraded socket is no longer an HTTP request.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ephpm_ws_connections_total` | counter | — | Connections admitted to the registry. Counted at admission, which is *before* the `connect` handler runs — so this exceeds the number of established sockets by however many `connect` handlers refused. |
+| `ephpm_ws_connections_active` | gauge | — | Currently registered connections, across all vhosts. |
+| `ephpm_ws_connections_rejected_total` | counter | `reason` | Upgrades refused by a capacity cap. `reason="server_full"` (`max_connections`) or `reason="site_full"` (`max_connections_per_site`). |
+| `ephpm_ws_handshake_rejected_total` | counter | `reason` | Upgrades refused before any PHP ran. `reason="handshake"` (missing `Sec-WebSocket-Key`, or a `Sec-WebSocket-Version` other than 13), `reason="transport"` (no upgrade handle — not an HTTP/1.1 connection), `reason="capacity"` (the `503` companion to `ephpm_ws_connections_rejected_total`). |
+| `ephpm_ws_connect_rejected_total` | counter | — | Upgrades refused by the application's `connect` handler returning a non-2xx. This is the auth-rejection counter; a sudden rise usually means expired tokens, not an attack. |
+| `ephpm_ws_events_total` | counter | `event` | PHP executions dispatched. `event` is `connect`, `message`, or `disconnect`. |
+| `ephpm_ws_event_timeouts_total` | counter | — | `message` handlers that exceeded `[server.timeouts] request`. Each one also closes its connection with `1011`. Non-zero means a handler is blocking; the socket cannot be abandoned the way an HTTP request can. |
+| `ephpm_ws_frames_received_total` | counter | — | Inbound data frames (text and binary). Ping/pong are not counted. |
+| `ephpm_ws_frames_queued_total` | counter | — | Frames accepted into a connection's outbound queue by `ephpm_ws_send()` / `ephpm_ws_broadcast()`. A broadcast to N subscribers counts N. |
+| `ephpm_ws_frames_sent_total` | counter | — | Frames actually written to a socket. The gap between this and `ephpm_ws_frames_queued_total` is what is sitting in outbound queues (plus anything dropped by a connection that died before its queue drained). |
+| `ephpm_ws_frames_rejected_total` | counter | `reason` | Frames dropped before the wire. `reason="too_large"` (payload over `max_message_size`; the connection is **not** shed — an oversized payload is the caller's bug, not back-pressure) or `reason="invalid_utf8"` (a text frame whose payload is not valid UTF-8, which RFC 6455 §5.6 forbids). |
+| `ephpm_ws_send_queue_overflow_total` | counter | — | Sends refused because a connection's outbound queue was full. Each one also closes that connection with `1013`. **Worth alerting on**: it means clients are not draining and connections are being shed. |
+| `ephpm_ws_cross_site_denied_total` | counter | — | Attempts to reach a connection or channel belonging to a different virtual host. **Should be flat at zero.** Anything else is a bug or an attempt — the operation is refused either way, and reported to PHP as "not found" so it is not an existence oracle. |
+
 ## PHP
 
 | Metric | Type | Labels | Description |

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -147,6 +147,14 @@ const ISOLATED_DB_SUITES: &[&str] = &[
 /// requests that resolve to a site key) with the template's generous explicit
 /// per-IP limits and explicit `max_connections = 100`, which doubles as an
 /// end-to-end proof that explicit `[server.limits]` values beat the preset.
+///
+/// `websockets` needs `[server.websocket] enabled = true`, which changes how
+/// **every** upgrade request routes (they resolve `[server] websocket_files`
+/// and 404 when no entrypoint exists). That is a whole-server switch, so — like
+/// `fpm_pool` — it gets its own node rather than being bolted onto the shared
+/// template. It runs multi-tenant (`sites_dir`) so the suite can prove
+/// cross-site isolation with two real vhosts on one server, which is the
+/// property most worth an end-to-end test.
 const ISOLATED_CONFIG_SUITES: &[&str] = &[
     "opcache_invalidation",
     "rate_limit",
@@ -156,6 +164,7 @@ const ISOLATED_CONFIG_SUITES: &[&str] = &[
     "fpm_pool",
     "crash_containment",
     "preview",
+    "websockets",
 ];
 
 /// Suites that run single-threaded (a superset of the DB suites). Kept as a
@@ -181,11 +190,17 @@ fn suite_is_serial(name: &str) -> bool {
     // it probes the over-cap behaviour. Run concurrently, the burst test's
     // connections would be shed too and its "some requests succeed" half
     // could never hold.
+    //
+    // `websockets` deploys two vhost directories into `sites_dir` and shares
+    // one KV keyspace per vhost across its tests. Running serially means each
+    // test can assert on absolute connection counts and KV state instead of
+    // having to name every key uniquely and hope.
     ISOLATED_DB_SUITES.contains(&name)
         || name == "worker_mode"
         || name == "fpm_pool"
         || name == "crash_containment"
         || name == "rate_limit"
+        || name == "websockets"
 }
 
 /// Whether a suite needs its own freshly-spawned, then-torn-down single node
@@ -671,6 +686,7 @@ fn recreate_dir(path: &Path) -> io::Result<()> {
 /// empty), `{DB_SQLITE_BLOCK}` (the whole `[db.sqlite]` section — see
 /// [`SingleNodeOptions::with_sites_dir`]), `{KV_SECRET_LINE}` (a `[kv] secret`
 /// line, or empty), `{OPCACHE_BLOCK}` (an optional `[opcache]` section, or
+/// empty), `{WEBSOCKET_BLOCK}` (an optional `[server.websocket]` section, or
 /// empty), `{MIDDLEWARE_BLOCK}` (an optional `[[middleware]]` mount, or empty),
 /// `{MTH_LINE}` (the `multi_tenant_hardening = <bool>` line in
 /// `[server.security]`), `{INI_OVERRIDES_EXTRA}` (extra `[php] ini_overrides`
@@ -746,6 +762,10 @@ trusted_hosts = [
     # Consumed only by the isolated `multitenant_hardening` node (which renders
     # from this same template); inert on every other node.
     "harden.test",
+    # Consumed only by the isolated `websockets` node. Two vhosts, so the suite
+    # can prove one tenant's connections are unreachable from the other.
+    "ws-a.test",
+    "ws-b.test",
 ]
 
 [server.response]
@@ -813,6 +833,7 @@ eviction_policy = "allkeys-lru"
 enabled = true
 socket = "{KV_SOCKET}"
 {OPCACHE_BLOCK}
+{WEBSOCKET_BLOCK}
 {MIDDLEWARE_BLOCK}
 "#;
 
@@ -883,9 +904,12 @@ struct SingleNodeOptions {
     slug: String,
     /// Configure `[server] sites_dir` — i.e. run this node **multi-tenant**.
     ///
-    /// Only the long-lived shared node sets it, because only `vhosts` and
-    /// `security_p0` need it (they are the sole readers of `EPHPM_SITES_DIR`).
-    /// Every isolated node runs single-site.
+    /// Set on the long-lived shared node (for `vhosts` and `security_p0`) and
+    /// on the isolated nodes that run multi-tenant: `multitenant_hardening`
+    /// and `websockets` (whose subject *is* multi-tenancy) plus `preview`
+    /// (whose per-site rate cap only acts on requests that resolve to a site
+    /// key). Every other isolated node runs single-site. `EPHPM_SITES_DIR` is
+    /// exported to the suite exactly when this is set.
     ///
     /// This one flag decides three things at once, because the server ties them
     /// together and fails closed on the mismatched combinations:
@@ -958,6 +982,20 @@ struct SingleNodeOptions {
     /// `with_sites_dir = true`: the per-site cap only acts on requests that
     /// resolve to a site key.
     preview: bool,
+    /// Emit `[server.websocket] enabled = true` — turn on native WebSockets.
+    ///
+    /// Only the `websockets` suite sets it. Every other node leaves it `false`,
+    /// so `{WEBSOCKET_BLOCK}` renders empty and their behaviour is
+    /// byte-identical to before this knob existed. That matters more here than
+    /// for most flags: with the feature ON, **every** `Connection: Upgrade` +
+    /// `Upgrade: websocket` request stops falling through to the fallback chain
+    /// and 404s unless the vhost has a `websocket_files` entrypoint.
+    ///
+    /// Implies `with_sites_dir = true`. The suite's most valuable assertion is
+    /// that one tenant cannot reach another's sockets, which needs two real
+    /// vhosts on one server; running the whole suite multi-tenant is what makes
+    /// that a single-node test rather than a second fixture.
+    websocket: bool,
 }
 
 impl SingleNodeOptions {
@@ -982,6 +1020,7 @@ impl SingleNodeOptions {
             fpm_engine_pool: false,
             crash_containment: false,
             preview: false,
+            websocket: false,
         }
     }
 
@@ -1004,6 +1043,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
             // multitenant_hardening: the ONLY isolated node that runs
             // multi-tenant (sites_dir set) AND with the hardening preset on.
@@ -1024,6 +1064,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
             // worker_mode: persistent worker pool over tests/worker-docroot.
             // sites_dir MUST stay off — worker mode + sites_dir is rejected at
@@ -1039,6 +1080,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
             // rate_limit: small bucket, on its own node. See
             // ISOLATED_CONFIG_SUITES for why this can't share the shared node.
@@ -1053,6 +1095,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
             // middleware: mount the freshly built cors cdylib by explicit
             // path, exercising the dlopen lane in a real server.
@@ -1067,6 +1110,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
             // fpm_pool: the ONLY node on the experimental dedicated FPM thread
             // pool (`[php] fpm_engine = "pool"`). Single-site so it gets the
@@ -1088,6 +1132,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: true,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
             // crash_containment: the ONLY node with `[php] crash_containment =
             // true` (which additionally REQUIRES the pool engine — the server
@@ -1109,6 +1154,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: true,
                 crash_containment: true,
                 preview: false,
+                websocket: false,
             },
             // preview: the ONLY node with `[server] preview = true`. Runs
             // multi-tenant (sites_dir set) because the per-site PHP rate cap —
@@ -1129,6 +1175,26 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: true,
+                websocket: false,
+            },
+            // websockets: the ONLY node with `[server.websocket] enabled`.
+            // Multi-tenant (`sites_dir`) so the suite gets two real vhosts and
+            // can prove a connection opened on one is unreachable from the
+            // other — the property the whole site-scoped registry exists for.
+            // Hardening stays off: it is orthogonal here, and leaving it on
+            // would couple this suite to the preset's behaviour.
+            "websockets" => Self {
+                slug,
+                with_sites_dir: true,
+                opcache_invalidation: false,
+                tight_rate_limit: false,
+                middleware_lib: None,
+                worker: false,
+                multi_tenant_hardening: false,
+                fpm_engine_pool: false,
+                crash_containment: false,
+                preview: false,
+                websocket: true,
             },
             // DB suites: fresh DB, single-site. `sites_dir` is NOT optional
             // detail here — it would put the node in per-site database mode,
@@ -1147,6 +1213,7 @@ impl SingleNodeOptions {
                 fpm_engine_pool: false,
                 crash_containment: false,
                 preview: false,
+                websocket: false,
             },
         }
     }
@@ -1284,6 +1351,18 @@ impl SingleNodeSpawn {
         } else {
             ""
         };
+        // Native WebSockets: ON only for the `websockets` suite's node. The
+        // bounds are deliberately small so the suite can reach them cheaply —
+        // a 4-frame send queue and a 64 KiB message cap — while the ping/idle
+        // pair stays wide enough that a slow test run never trips the keepalive
+        // and produces a flake.
+        let websocket_block = if opts.websocket {
+            "\n[server.websocket]\nenabled = true\nsend_queue = 4\n\
+             max_message_size = 65536\nmax_frame_size = 65536\n\
+             ping_interval_secs = 5\nidle_timeout_secs = 120"
+        } else {
+            ""
+        };
         let limits_block = if opts.tight_rate_limit {
             "per_ip_rate = 500.0\nper_ip_burst = 100"
         } else {
@@ -1350,6 +1429,7 @@ impl SingleNodeSpawn {
             .replace("{DB_SQLITE_BLOCK}", &db_sqlite_block)
             .replace("{KV_SECRET_LINE}", &kv_secret_line)
             .replace("{OPCACHE_BLOCK}", &opcache_block)
+            .replace("{WEBSOCKET_BLOCK}", websocket_block)
             .replace("{MIDDLEWARE_BLOCK}", &middleware_block)
             .replace("{LIMITS_BLOCK}", limits_block)
             .replace("{MTH_LINE}", mth_line)


### PR DESCRIPTION
Native WebSocket support: ePHPm terminates the socket in Rust and invokes PHP **per event** through a per-vhost entrypoint. PHP never holds a connection.

**Experimental and opt-in.** `[server.websocket] enabled = false` by default; with it off an upgrade request routes exactly as it does on `main`.

## The model

| | ePHPm | Swoole / ReactPHP |
|---|---|---|
| Who owns the socket | the Rust reactor | a PHP process |
| Cost of an idle connection | a registry entry + reactor memory | a PHP coroutine/process |
| What runs per message | one ordinary PHP request | a userland event-loop callback |

This is the API Gateway (`$connect`/`$disconnect`/message to a stateless handler) / RoadRunner shape. Ten thousand idle connections cost no PHP at all.

## Upgrade and dispatch

The seam is in `handle_inner`, deliberately placed **after** the security gates and `resolve_site`, and **before** `resolve_fallback`. The connection layer already used `serve_connection_with_upgrades`, so nothing changed there.

1. **Entrypoint** - `[server] websocket_files` (default `["websocket.php"]`) resolved in order against the vhost's document root, `index_files`-style. **No entry on disk means 404**, never a fallthrough to `index.php`, a static file, or the fallback chain.
2. **Handshake** - missing key or a version other than 13 gets a 400 advertising 13. No `OnUpgrade` extension (HTTP/2, HTTP/3) gets a 400.
3. **Tenant** - no canonical site key gets a 404 (a connection with no identity would have no scope).
4. **Capacity** - registry caps give a 503.
5. **`connect`** - runs on the **real** upgrade request, before the handshake completes, so it sees the cookies and query string auth needs. 2xx accepts; anything else is returned to the client verbatim (status, headers, body, so a 401 with `WWW-Authenticate` works as it does over HTTP) and the reservation is released. This is the only point at which an upgrade can still be refused.
6. **101** - the socket goes to a session task.

Events go through **`handle_php` itself**, not a parallel path, so the per-site database session, KV keyspace, `open_basedir`/temp/session sandbox, OPcache vhost, engine selection and the #302 crash guard all apply unchanged. `ws_event` changes exactly two things: the `$_SERVER` entries it contributes, and that the body is bounded by `[server.websocket] max_message_size` instead of `[server.request] max_body_size` (two unrelated knobs; the e2e template sets the latter to 1 KiB).

`$_SERVER`: `WS_EVENT` (`connect`/`message`/`disconnect`), `WS_CONNECTION_ID`, and `WS_OPCODE` (`text`/`binary`, message events only). The upgrade request's URI and headers are replayed on every event, so `$_GET` and `$_COOKIE` stay stable for the connection's life.

Per-connection messages are strictly sequential - the socket is not read again until the handler returns. A handler exceeding `[server.timeouts] request` closes with 1011 rather than being abandoned (the blocking execution cannot be cancelled, so continuing risks overlap).

## SAPI surface

Each operation has an **implicit** form (the connection that fired this event, read from a per-thread context the router installs - the `db_bridge` session pattern) and an **explicit** form:

```php
ephpm_ws_send(string $payload, bool $binary = false): bool
ephpm_ws_connection_send(string $connection_id, string $payload, bool $binary = false): bool

ephpm_ws_subscribe(string $channel): bool
ephpm_ws_connection_subscribe(string $connection_id, string $channel): bool

ephpm_ws_unsubscribe(string $channel): bool
ephpm_ws_connection_unsubscribe(string $connection_id, string $channel): bool

ephpm_ws_broadcast(string $channel, string $payload, bool $binary = false): int   // receiver count

ephpm_ws_close(int $code = 1000): bool
ephpm_ws_connection_close(string $connection_id, int $code = 1000): bool
```

Nine PHP functions over five ops - a `NULL` connection-id pointer at the C ABI means "current connection".

**From an ordinary HTTP request the implicit form throws**, it does not no-op. A push API that silently succeeds is the worst possible failure mode. `false` means "unreachable" (unknown, gone, queue full); an **exception** means the call could never have worked (feature disabled, no tenant, no current connection) - the `ephpm_db_*` precedent.

The per-thread connection context is set on **every** PHP execution - to the event's id or to `None` - so it cannot leak onto the next request on a reused blocking thread.

## Site isolation

The registry is scoped by the **canonical site key from #293**, derived in `site_identities` alongside the database, KV and OPcache identities. It is never taken from a function argument.

- Site A cannot reach site B's connections or channels holding a valid id.
- `chat` on one vhost and `chat` on another are different channels.
- A host matching no vhost has no identity: upgrades 404, `ephpm_ws_*` throws.
- Cross-site attempts report "not found" - identical to a stale id, so there is no existence oracle. Counted as `ephpm_ws_cross_site_denied_total`, which should be flat at zero.
- Single-site nodes share one sentinel scope (the `db_bridge` `SINGLE_SITE_KEY` pattern), because there is exactly one tenant.

Connection ids are 128 bits of OS entropy as hex, minted **inside** `Registry::register` so unguessability is a property of the function rather than a convention every call site has to honour.

## Bounds - nothing unbounded

Each connection has a bounded outbound queue. On overflow the frame is **not** buffered: the send reports failure and the socket closes with `1013`. One slow reader costs one connection, never the server's memory.

`[server.websocket]`: `enabled` (false), `max_connections` (10000), `max_connections_per_site` (1000), `max_message_size` (1 MiB), `max_frame_size` (1 MiB), `send_queue` (64), `ping_interval_secs` (30), `idle_timeout_secs` (120). Plus `[server] websocket_files`. Every field follows the `add-config-knob` checklist: enforced, documented with real defaults, reference-docs rows, default plus behaviour tests, env override verified.

Two ceilings are fixed rather than knobs (64 subscriptions per connection, 256-byte channel names) - they bound what one misbehaving script can pin.

Startup **errors**, not silent no-ops: `enabled = true` with `[php] mode = "worker"` (the entrypoint would never run), and `enabled = true` with empty `websocket_files` (every upgrade would 404).

## New crate

`ephpm-ws` holds the registry. Protocol-free - no framing, no handshake, `OutFrame` is the whole vocabulary - so both `ephpm-php` and `ephpm-server` depend on it and the security-relevant half unit-tests in stub mode.

## Verification

- Stub mode: clippy `-D warnings` clean, nightly fmt clean, `cargo deny check` clean (`advisories ok, bans ok, licenses ok, sources ok`), full workspace tests green.
- Unit tests cover site isolation (site B holds A's exact id and still cannot send/close/subscribe), bounded-queue overflow closing with 1013, channel subscribe/broadcast counts and empty-channel cleanup, cap enforcement (and that a per-site rejection does not leak a global slot), id shape/uniqueness/no-shared-prefix, implicit-vs-explicit targeting, and that the C status constants match the Rust ones.
- **Fresh php_linked build** (PHP 8.5.7, WSL native ext4, no `cargo clean`, no `CARGO_TARGET_DIR` override) ran the **full bare E2E**: all 50 suites plus the 3-node cluster, ending in `All bare-process E2E suites passed`.
- New `websockets` e2e suite - 13 tests, own isolated **multi-tenant** node (`ISOLATED_CONFIG_SUITES`), real `tokio-tungstenite` client over two vhosts: echo round-trip, binary opcode, channel chat across two clients, connect-auth rejection (403 refuses the upgrade), HTTP-request-pushes-to-socket, implicit-form-throws-from-HTTP, cross-site push denied (and the same id works from the owning site), cross-site channel isolation, userland close code, the strict 404 rule, malformed-handshake 400, and disconnect dispatch.

The `e2e_bare.rs` diff is kept minimal - one `bool` on `SingleNodeOptions`, one `{WEBSOCKET_BLOCK}` placeholder, two trusted-host entries. The shared node's template is untouched (#295).

## Known flake, not from this PR

`router::tests::fpm_mode_spans_and_timeline_have_no_queue_wait` fails intermittently under parallel `cargo test` (about 1 run in 5). It snapshots a process-global tracing subscriber. Reproduced at the same rate on unmodified `main` (1 in 7); passes alone and under `--test-threads=1`. CI uses nextest (process per test) and never sees it.

## Limitations (documented, not implied)

HTTP/1.1 only (RFC 8441 extended CONNECT is not implemented; browsers use HTTP/1.1 for `ws:`/`wss:` anyway, and TLS works). No worker mode. `disconnect` is best-effort. **No clustered fan-out** - the registry is per-process, so `ephpm_ws_broadcast` reaches this node only. Graceful shutdown does not drain WebSockets. `allowed_php_paths` does not gate the entrypoint (it is operator-configured, not client-selected; it is still containment-checked).

## Docs

`site/content/guides/websockets.md` - a complete working `websocket.php`, and the HTTP-to-socket pattern as a worked example (stash the id in the embedded KV at `connect` keyed by app identity; a later request reads it and calls the explicit-id send). The e2e suite follows that exact pattern, so the guide's example is pinned by a test. Plus reference rows for every knob and a metrics section for every emitted series.
