### PR TITLE
docs: point lab links at github.com/ephpm/lab

### DIFF
--- a/site/content/benchmarking/methodology.md
+++ b/site/content/benchmarking/methodology.md
@@ -13,7 +13,7 @@ Two complementary setups are used:
 - **Local single-node** (podman/Docker): one container per runtime, a load
   generator container on the same network, fixtures mounted read-only.
   Fast to iterate; used for A/B comparisons between ePHPm versions and
-  against php-fpm. The [ePHPm-lab](https://github.com/tinfoyle/ePHPm-lab)
+  against php-fpm. The [ePHPm lab](https://github.com/ephpm/lab)
   `RUNTIMES-BENCH` recipe is the reference form.
 - **Kubernetes (LKE)**: the lab's k6 suites for realistic app workloads
   (Krayin CRM, Laravel, WordPress/WooCommerce). Not locally reproducible;

--- a/site/content/guides/opcache-cluster-invalidation.md
+++ b/site/content/guides/opcache-cluster-invalidation.md
@@ -174,7 +174,7 @@ kubectl exec app-0 -- ephpm deploy --site blog
 ```
 
 A complete, tested manifest pair (demo + php-fpm comparison benchmark)
-lives in the [ePHPm-lab repository](https://github.com/tinfoyle/ePHPm-lab)
+lives in the [ePHPm-lab repository](https://github.com/ephpm/lab)
 under `k8s/opcache-cluster.yaml`.
 
 ## Why not rely on `opcache.validate_timestamps`?

--- a/site/content/roadmap/worker-dispatch-fastpath.md
+++ b/site/content/roadmap/worker-dispatch-fastpath.md
@@ -107,7 +107,7 @@ because the Rust edge (TLS/ACME, static files, security filtering,
 clustering, KV) is the product. The design ceiling is roughly 1.5–2× on
 empty-request microbenchmarks — and on any request doing ≥1 ms of real
 PHP work, the residual boundary cost is under 5%. The [rate-160
-pressure result](https://github.com/tinfoyle/ePHPm-lab) (worker mode
+pressure result](https://github.com/ephpm/lab) (worker mode
 holding 159/160 req/s while fpm+Redis collapsed to 100) is what the
 fast path is defending and extending.
 


### PR DESCRIPTION
The benchmark lab moved from the `tinfoyle/ePHPm-lab` personal fork to the `ephpm/lab` org repo. This fixes the stale URL in `site/content/benchmarking/methodology.md` (the audit item) plus the two other site pages that carried the same dead link (`roadmap/worker-dispatch-fastpath.md`, `guides/opcache-cluster-invalidation.md`), per the repo's fix-every-hit rule. No content changes beyond the URLs and one link label.