### PR TITLE
docs: v0.7.0 release pass — version pins + truth sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ enabled = true
 # enable switch — there is no `enabled` key.
 [db.sqlite]
 path = "/var/lib/ephpm/app.db"
-# engine = "turso"   # experimental Turso Database engine (Beta upstream)
+# engine = "turso"   # the default and only engine as of v0.7.0 — the Turso Database engine (Beta upstream); may be omitted
 ```
 
 Any TOML key can be overridden with an `EPHPM_` prefixed environment variable — e.g. `EPHPM_SERVER__LISTEN=0.0.0.0:9090`, `EPHPM_PHP__MEMORY_LIMIT=256M`. Nesting uses `__`. Arrays use JSON syntax: `EPHPM_CLUSTER__JOIN='["a:7946","b:7946"]'`. See [Environment Variables](https://ephpm.dev/reference/environment-variables/) for the full mapping rules.
@@ -347,7 +347,7 @@ crates/
 ├── ephpm-config/    Configuration — figment, TOML + env var overrides
 ├── ephpm-kv/        Embedded KV store — DashMap, RESP2 protocol, TTL/expiry, compression
 ├── ephpm-db/        DB proxy — MySQL wire protocol, connection pooling
-└── ephpm-cluster/   Clustering — SWIM gossip (chitchat), consistent hash ring, SQLite election
+└── ephpm-cluster/   Clustering — SWIM gossip (chitchat), hashed key ownership, SQLite election
 ```
 
 Key design decisions:
@@ -424,7 +424,7 @@ The default `cargo xtask e2e` spawns bare ephpm processes on 127.0.0.1 — no co
 - [Implementation guide](https://ephpm.dev/architecture/implementation/) — Build system, CI, MVP spec
 - [CLI design](https://ephpm.dev/architecture/cli/) — Command structure, UX principles
 - [Security model](https://ephpm.dev/architecture/security/) — Threat model, FFI safety, trust boundaries
-- [Clustering](https://ephpm.dev/architecture/clustering/) — SWIM gossip, consistent hash ring, two-tier KV
+- [Clustering](https://ephpm.dev/architecture/clustering/) — SWIM gossip, hashed key ownership, two-tier KV
 - [DB proxy](https://ephpm.dev/architecture/db-proxy/) — MySQL wire protocol, connection pooling, query analysis
 - [Kubernetes deployment](https://ephpm.dev/architecture/kubernetes/) — Helm chart, StatefulSet, gossip DNS
 - [Observability](https://ephpm.dev/architecture/metrics/) — Prometheus metrics, histogram buckets, phased rollout

--- a/docs/guides/wordpress.md
+++ b/docs/guides/wordpress.md
@@ -110,7 +110,7 @@ define( 'WP_CACHE', true );
 # 'Failed to open stream' on subdirectory requests.
 ephpm dev --port 8088 --document-root "$(pwd)/wordpress"
 
-#   ePHPm 0.2.0 — dev server
+#   ePHPm 0.7.0 — dev server
 #     serving:  /path/to/wordpress
 #     url:      http://127.0.0.1:8088
 #     php:      8.5.7
@@ -377,7 +377,7 @@ spec:
               mountPath: /etc/ephpm
 
         - name: wordpress-install
-          image: ephpm/ephpm:v0.6.3-php8.5.7
+          image: ephpm/ephpm:v0.7.0-php8.5.7
           command:
             - sh
             - -c
@@ -405,7 +405,7 @@ spec:
 
       containers:
         - name: ephpm
-          image: ephpm/ephpm:v0.6.3-php8.5.7
+          image: ephpm/ephpm:v0.7.0-php8.5.7
           command: [ephpm, serve, --config, /etc/ephpm/ephpm.toml]
           ports:
             - name: http

--- a/examples/wordpress-compose/compose.yaml
+++ b/examples/wordpress-compose/compose.yaml
@@ -78,7 +78,7 @@ services:
     # includes the fix for the MySQL 8 backend handshake; older images
     # ("Bad handshake" against MySQL 8.x) won't work for this demo.
     # Use ephpm/ephpm:8.5 to track the rolling latest-release / PHP 8.5.
-    image: ephpm/ephpm:v0.6.3-php8.5.7
+    image: ephpm/ephpm:v0.7.0-php8.5.7
     depends_on:
       init:
         condition: service_completed_successfully

--- a/site/content/architecture/database/engines.md
+++ b/site/content/architecture/database/engines.md
@@ -61,9 +61,9 @@ Because the engine is Beta upstream, take its limits literally:
 
 The Turso engine opens existing SQLite3/rusqlite-created `.db` files **in
 place** for cleanly-shut-down databases — both WAL and rollback-journal modes.
-Verified this session: `PRAGMA integrity_check` returns `ok` and rows are
-intact. So the normal 0.6.x → 0.7.0 upgrade of a stopped node is seamless:
-**no dump/reload is required.**
+This was verified during the v0.7.0 engine swap: `PRAGMA integrity_check`
+returns `ok` and rows are intact. So the normal 0.6.x → 0.7.0 upgrade of a
+stopped node is seamless: **no dump/reload is required.**
 
 Two honest caveats:
 

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -961,7 +961,7 @@ This is the hardest crate and the core of the project.
 | Milestone | Key Features | Status |
 |-----------|-------------|--------|
 | **v0.2: ZTS + Workers** | Thread-safe PHP, multiple concurrent requests | **Implemented** (ZTS via `spawn_blocking` + TSRM) |
-| **v0.3: TLS** | Automatic HTTPS via `rustls-acme`, Let's Encrypt | Planned |
+| **v0.3: TLS** | Automatic HTTPS via `rustls-acme`, Let's Encrypt | **Implemented** — see [TLS & ACME](/guides/tls-acme/) |
 | **v0.4: DB Proxy** | **Implemented (partial)**: MySQL transparent proxy, connection pooling, reset strategy; **Missing**: read/write splitting, replication, slow query analysis | Ahead of schedule |
 | **v0.5: KV Store** | **Implemented**: Single-node RESP2 server, strings + hashes, TTL/expiry, eviction policies (`noeviction`/`allkeys-lru`/`volatile-lru`/`allkeys-random`) with memory-limit enforcement, compression, SAPI bridge for direct PHP access, clustering; **Missing**: lists/sets/sorted sets, persistence | Shipped |
 | **Future: Admin UI** | Embedded web dashboard, request inspector | Planned |

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -75,6 +75,25 @@ To run the server in the foreground without registering a service (useful for de
 sudo ephpm serve --config /etc/ephpm/ephpm.toml
 ```
 
+## Upgrading from 0.6.x
+
+v0.7.0 replaced the embedded SQLite engine: the rusqlite (SQLite C engine)
+backend and the sqld sidecar were removed, and the in-process
+[Turso engine](/architecture/database/engines/) is now the only embedded
+engine. For an upgrading node:
+
+- **Your `.db` files open in place** — a cleanly-shut-down 0.6.x database
+  (WAL or rollback journal) needs no dump/reload. **Stop the old node cleanly
+  before upgrading**: a hot `-wal` left by a hard crash was not verified to
+  replay through Turso.
+- **`[db.sqlite] engine = "sqlite"` (or `"rusqlite"`) is now a hard startup
+  error** with a migration message — remove the `engine` key or set it to
+  `"turso"`. The removed `[db.sqlite.sqld]` block and `cdc_experimental` flag
+  log deprecation warnings and have no effect.
+
+Details and caveats (including non-UTF-8 `TEXT`):
+[Database Engines → Opening existing `.db` files](/architecture/database/engines/#opening-existing-sqlite--rusqlite-db-files).
+
 ## Uninstall
 
 ```bash

--- a/site/content/guides/diagnosing-crashes.md
+++ b/site/content/guides/diagnosing-crashes.md
@@ -9,8 +9,16 @@ can fault in ways no amount of Rust safety prevents. When that happens the
 whole process dies: there is one address space, and the Zend memory manager,
 the glibc heap and the OPcache shared memory are shared by every thread in it.
 
-ePHPm cannot recover from that, and does not try. What it does is **tell you
-what happened** before it goes.
+ePHPm cannot recover from that in general, and does not try. What it does is
+**tell you what happened** before it goes.
+
+There is one narrow, opt-in exception as of v0.7.0: with
+[`[php] crash_containment = true`](/reference/config/#php) (which requires
+`fpm_engine = "pool"`), a PHP **C-stack overflow** — and only that fault
+class — is contained instead of fatal: the offending request is answered
+`500` and the pool thread that ran it is retired and replaced. Heap
+corruption and wild writes still kill the process exactly as described on
+this page.
 
 ## What you get
 
@@ -114,6 +122,12 @@ The backtrace for this case is honest but not very useful: every captured frame
 is the same recursing function, so you get its name and a repeat count and
 nothing about the caller. `backtrace(3)` unwinds inward-out and stops at 64
 frames, which a runaway recursion consumes entirely.
+
+If PHP request code (a deep object-graph free) is what overflows the stack, you
+can opt in to surviving it instead of dying: `[php] crash_containment = true`
+with `fpm_engine = "pool"` answers that request `500` and retires the poisoned
+thread. See the note at the top of this page and the
+[configuration reference](/reference/config/#php) for the costs.
 
 ## Exit status is unchanged
 

--- a/site/content/guides/kv-from-php.md
+++ b/site/content/guides/kv-from-php.md
@@ -5,10 +5,10 @@ weight = 6
 
 ePHPm's built-in KV store is reachable two ways from PHP:
 
-1. **SAPI functions** — `ephpm_kv_*` calls into the embedded store directly. ~100 ns per op, zero serialization.
-2. **RESP protocol** — any Redis client (Predis, phpredis) connects to the embedded RESP listener. ~10–100 µs per op.
+1. **SAPI functions** — `ephpm_kv_*` calls into the embedded store directly: an in-process function call with no socket and no serialization. Measured: **~100–220 ns per op for small values** (64 B `get` ≈ 116 ns, `set` ≈ 160 ns, `incr` ≈ 162 ns), rising to ~1–2 µs at 64 KB where the value copy dominates.
+2. **RESP protocol** — any Redis client (Predis, phpredis) connects to the embedded RESP listener: one loopback TCP round trip per operation. Measured: **~80–110 µs per round trip** (c=1, raw socket), nearly independent of value size — client libraries add their own overhead on top, and bare-metal loopback can be faster than the bench box.
 
-The store is the same in both cases. Use SAPI for hot paths; use RESP when you need portability or Redis-style commands.
+The store is the same in both cases; only the path differs — by roughly **500×**, because the SAPI path skips the network stack entirely. The numbers are medians from the lab's `kv-micro` suite ([ephpm/lab](https://github.com/ephpm/lab), `kv/`, results in `docs/kv-micro-v070.md`), measured 2026-08-17 against a from-source v0.7.0 build (PHP 8.5 ZTS, WSL2, compression off). Use SAPI for hot paths; use RESP when you need portability or Redis-style commands.
 
 ## SAPI functions
 

--- a/site/content/guides/wordpress.md
+++ b/site/content/guides/wordpress.md
@@ -113,7 +113,7 @@ define( 'WP_CACHE', true );
 # 'Failed to open stream' on subdirectory requests.
 ephpm dev --port 8088 --document-root "$(pwd)/wordpress"
 
-#   ePHPm 0.2.0 — dev server
+#   ePHPm 0.7.0 — dev server
 #     serving:  /path/to/wordpress
 #     url:      http://127.0.0.1:8088
 #     php:      8.5.7
@@ -380,7 +380,7 @@ spec:
               mountPath: /etc/ephpm
 
         - name: wordpress-install
-          image: ephpm/ephpm:v0.6.3-php8.5
+          image: ephpm/ephpm:v0.7.0-php8.5
           command:
             - sh
             - -c
@@ -408,7 +408,7 @@ spec:
 
       containers:
         - name: ephpm
-          image: ephpm/ephpm:v0.6.3-php8.5
+          image: ephpm/ephpm:v0.7.0-php8.5
           command: [ephpm, serve, --config, /etc/ephpm/ephpm.toml]
           ports:
             - name: http

--- a/site/content/roadmap/_index.md
+++ b/site/content/roadmap/_index.md
@@ -16,7 +16,7 @@ These pages describe targets, not currently-shipped behavior. For what works tod
 - **[Benchmarks as a Release Artifact](benchmarks/)** — in-tree bench recipes, per-release numbers, and a regression gate.
 - **[NTS Prefork Mode](nts-prefork/)** — trading features for pure per-request PHP speed, gated on a post-PGO measurement.
 - **[The Deploy Story](deploy-warmup/)** — post-invalidation warmup, `ephpm doctor <framework>`, `cache status`, thin deploy hooks.
-- **[Preview Deployments](preview/)** — instant per-PR preview URLs via a GitHub bot.
+- **[Preview Deployments](preview/)** — instant per-PR preview URLs via a GitHub bot. The runtime half (per-site databases, the `[server] preview` limits preset) **shipped in v0.7.0**; the bot remains design.
 - **[OPcache Clustering & Per-Vhost Preload](opcache-clustering/)** — Phase 1 (cluster-wide invalidation) shipped in 0.4.0; per-vhost preload and worker-mode invalidation remain.
 - **[Symfony Runtime Adapter](symfony-runtime-driver/)** — native `ephpm` adapter under `symfony/runtime`, on top of the shipped worker-mode engine.
 - **[Kubernetes Operator](kubernetes/)** — first-class K8s deployment.

--- a/site/content/roadmap/preview.md
+++ b/site/content/roadmap/preview.md
@@ -1,11 +1,18 @@
 # Preview Deployments
 
-> **Status: DESIGN — not implemented in this repository.** Nothing on this
-> page ships with the `ephpm` binary. The webhook handler it describes
-> (**switchboard**) is a separate project, not part of ePHPm, and no code in
-> this repository references it. In particular, the per-pull-request database
-> isolation described below is a design goal, not a property ePHPm provides
-> today. Treat the whole page as a sketch of an intended product.
+> **Status: DESIGN — the bot is not implemented in this repository.** The
+> webhook handler this page describes (**switchboard**) is a separate
+> project, not part of ePHPm, and no code in this repository references it.
+> Treat the bot workflow below as a sketch of an intended product.
+>
+> The **runtime side has shipped**, though: as of v0.7.0 ePHPm provides
+> per-site database isolation (each vhost gets its own Turso database file —
+> [`[db.sqlite] dir`](/reference/config/#dbsqlite)) and a preview-host preset
+> ([`[server] preview = true`](/reference/config/#server)) that applies safe
+> per-IP/per-site rate and connection limits, load shedding, and an
+> `X-Ephpm-Preview: 1` marker header. What is still design-only is
+> everything switchboard would do: webhooks, cloning, framework detection,
+> PR comments, and teardown.
 
 The design: preview deployments for PHP applications driven by a GitHub bot, where every pull request would get a live preview URL with its own database — deployed in seconds, torn down on merge.
 

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -296,8 +296,14 @@ below for exactly what is and isn't closed.
    round-trip (Turso surfaces TEXT as `String` — an upstream limitation).
 4. Crash-recovery soak clean. **Open** — this is why single-node Turso
    ships "eyes open" rather than declared GA.
-5. WordPress + Laravel e2e suites green on the Turso backend. WordPress
-   front-page + drop-in passed; **automate in CI and confirm Laravel**.
+5. WordPress + Laravel e2e suites green on the Turso backend. **Open as
+   an automated gate**, but WordPress-on-Turso now has real informal
+   validation beyond the original front-page + drop-in pass: the live
+   WooCommerce demo store runs WordPress + WooCommerce on the per-site
+   Turso path, and the lab's `wp-real` workload drives full WordPress
+   installs against per-site Turso databases. Those are demos and
+   benchmarks, not an e2e suite — **automate in CI and confirm Laravel**
+   before calling this gate met.
 
 v0.7.0 shipped Turso-only despite gates 1 and 4 remaining open, because
 removing rusqlite removes the cross-tenant `ATTACH` RCE primitive from


### PR DESCRIPTION
v0.7.0 docs release pass: version pins bumped on main first (per the release convention — the tag does not exist yet), plus a claims-vs-code truth sweep of the v0.7.0 feature docs using the `audit-docs` method. Docs-only; no code changes.

## Workstream A — version pins (v0.6.x → v0.7.0)

| File | Change |
|---|---|
| `examples/wordpress-compose/compose.yaml:81` | `ephpm/ephpm:v0.6.3-php8.5.7` → `v0.7.0-php8.5.7` |
| `docs/guides/wordpress.md:380,408` | same image pin, both K8s manifests |
| `site/content/guides/wordpress.md:383,411` | `v0.6.3-php8.5` → `v0.7.0-php8.5` |
| `site/content/guides/wordpress.md:116` / `docs/guides/wordpress.md:113` | `ePHPm 0.2.0 — dev server` banner in sample output → `0.7.0` |

Tag shape verified against `.github/workflows/release.yml:516-522` (tags keep the leading `v`; PHP full pin is still 8.5.7 per the matrix at `release.yml:223-224` and `xtask/src/main.rs:16`).

**Deliberately not bumped** (historical/errata/compatibility floors): `site/content/benchmarking/results.md` + `findings.md` (versions that produced numbers), `guides/tls-acme.md` + `reference/config.md:160` ("fixed in v0.6.2" errata), all "Requires v0.6.3 or newer" floors (`guides/db-from-php.md:26`, `reference/php-packages.md:53`), `developer/testing.md` stub-mode transcript.

## Workstream B — truth sweep, grouped by feature

### 1. KV guide — invented latency numbers (the audit finding)
`site/content/guides/kv-from-php.md:8-11`: the published "~100 ns per op" / "~10–100 µs per op" figures had never been measured. The lab's new `kv-micro` suite landed results mid-pass (ephpm/lab `docs/kv-micro-v070.md`, 2026-08-17, from-source build of main @ `180d0ac`), so the numbers were **replaced with measured ones + provenance** (option a): small-value SAPI ~100–220 ns (get ≈ 116 ns / set ≈ 160 ns at 64 B, ~1–2 µs at 64 KB, copy-bound), RESP ~80–110 µs per loopback round trip, ~500× between paths. Also spot-verified while in the file: the 13 `ephpm_kv_*` functions exist in `crates/ephpm-php/ephpm_wrapper.c:3462-3474`, the RESP command table matches `crates/ephpm-kv/src/command.rs` (incl. `FLUSHALL` at `:330`, no `SCAN`), and the `[kv] secret` HMAC multi-tenant description matches `crates/ephpm-kv/src/auth.rs:37` + `crates/ephpm-server/src/router.rs:1304-1342`.

### 2. WebSockets guide (#304) — verified clean, no edits
`site/content/guides/websockets.md` + `reference/config.md:193-210` + `reference/metrics.md:53-73` all match code: all 9 `ephpm_ws_*` signatures/arities (`ephpm_wrapper.c:3415-3456`: send 1–2, connection_send 2–3, broadcast 2–3, close 0–1, connection_close 1–2, sub/unsub 1 / connection forms 2); `[server.websocket]` defaults (`ephpm-config/src/lib.rs:4177-4208`: 10000/1000/1 MiB/1 MiB/64/30/120); `websocket_files` default `["websocket.php"]` (`lib.rs:4170`); worker-mode startup error + empty-files error (`lib.rs:2697-2716`); 1013 overflow shed (`ephpm-ws/src/lib.rs:55`, `registry.rs:371-376`); 1001 idle close (`ephpm-server/src/websocket.rs:80`); fixed 64-subscription/256-byte ceilings (`ephpm-ws/src/registry.rs:39,45`); both headline metrics recorded (`registry.rs:319,371`). Experimental labeling and the single-node-broadcast limitation are present (`websockets.md:6,234`).

### 3. Preview / limits / engine knobs (#296 #298 #302 #305) — verified, one gap fixed
`reference/config.md` rows match `ephpm-config/src/lib.rs`: preview preset values (`config.md:22` vs `lib.rs:998-1007`), `per_site_rate`/`per_site_burst` defaults 0.0/20 (`config.md:142-143` vs `lib.rs:943,951`), `fpm_engine` (`config.md:243` vs `lib.rs:2380-2394`), `crash_containment` requires pool (`config.md:244` vs `lib.rs:2419-2428`), `overload_policy` unset≠wait + workers=0 inert WARN (`config.md:245` vs `lib.rs:2437-2461`), `shed_after_ms` default 0 (`config.md:246` vs `lib.rs:2477-2478,3824`), `ephpm_php_shed_total` really recorded (`ephpm-server/src/router.rs:3903`). Gap fixed: `guides/diagnosing-crashes.md:12` claimed unconditionally "ePHPm cannot recover from that, and does not try" — now notes the opt-in `crash_containment` exception (stack-overflow-only, pool engine), with a cross-ref from the Stack overflows section.

### 4. `ephpm php` CLI (#306) — doc exists, verified clean
`site/content/reference/cli/php.md` (added by #306) checked against `crates/ephpm/src/main.rs:94-97,311,528-558` (clap passthrough + `-d extension=` warn) and the wrapper's CLI (`ephpm_wrapper.c:4410-4790`): the honest `-a` unsupported error (`:4755-4762`) and the `-S` never-aliased stance (`:4770`) are exactly as documented, `-R`/`$argn`/`$argi` line mode exists (`:4410-4430`). No changes needed; `reference/cli/_index.md:87-119` also already covers it.

### 5. Roadmap hygiene
- `site/content/roadmap/turso-engine.md:299-306` (gate 5): now states WP-on-Turso has **informal** validation — the live WooCommerce demo store and the lab's `wp-real` per-site-Turso workload — while keeping the automated-CI + Laravel gate **open** (demos ≠ e2e suite). Gate 3 was already MET; gates 1/4 open; clustered stays experimental throughout.
- `site/content/roadmap/preview.md:3-16`: banner no longer denies per-PR database isolation outright — the runtime half (per-site Turso DBs, `[server] preview` preset) shipped in v0.7.0; switchboard (the bot) remains design-only. Mirrored one-liner in `roadmap/_index.md:19`.
- `site/content/developer/architecture-overview.md:964`: v0.3 TLS milestone still said "Planned" — TLS/ACME shipped (see `guides/tls-acme.md`). Marked Implemented.

### 6. Migration notes (engine hard error + 0.6.x→0.7.0 upgrade)
Already well covered in `architecture/database/engines.md:24-33,60-76` and `reference/config.md:370`, but nothing sat where an *upgrading* user starts — added an "Upgrading from 0.6.x" section to `site/content/getting-started/install.md:78-96` (in-place `.db` open, clean-shutdown/hot-`-wal` caveat, `engine = "sqlite"` hard error, deprecated `sqld`/`cdc_experimental` warn-and-ignore), linking to the engines page. Also fixed `engines.md:64` "Verified this session" (meaningless self-reference in published docs).

### Bonus fixes found by the sweep (README)
- `README.md:132`: config example called `engine = "turso"` "experimental" — it is the default and only engine in v0.7.0.
- `README.md:350,427`: "consistent hash ring" — the cluster uses `hash(key)` mod the sorted alive-node list, explicitly *not* a ring (`site/content/architecture/clustering.md:613` and `ephpm-cluster` docs agree); corrected to "hashed key ownership".

## Notes
- Site build not verified: no Hugo toolchain on this Windows box (xtask would download it); markdown-level correctness only.
- No overlap with the in-flight litewire pin bump (Cargo.toml only) or the release-notes draft (scratchpad only).
