### PR TITLE
chore(deps): litewire 0.2.0 (10345a8) + turso 0.7.2 (#7855); MSRV 1.85→1.88

### DIFF
--- a/.claude/agents/ephpm-systems-architect.md
+++ b/.claude/agents/ephpm-systems-architect.md
@@ -16,7 +16,7 @@ You are an elite systems architect with deep expertise spanning Rust, PHP intern
 - Conditional compilation (`#[cfg(...)]`), build scripts (`build.rs`), proc macros
 - `thiserror`/`anyhow` error handling patterns, `tracing` instrumentation
 - Cargo workspaces, xtask patterns, `cargo-nextest`, `cargo-deny`
-- MSRV discipline — currently targeting Rust 1.85; you know what's available and what isn't
+- MSRV discipline — currently targeting Rust 1.88; you know what's available and what isn't
 - Clippy pedantic compliance and nightly rustfmt (2024 edition, `group_imports = "StdExternalCrate"`)
 
 ### PHP Internals & SAPI Architecture

--- a/.claude/skills/review-ephpm/SKILL.md
+++ b/.claude/skills/review-ephpm/SKILL.md
@@ -42,4 +42,4 @@ Apply ON TOP of a normal correctness review. Each item has bitten this repo at l
 
 - Preserve outside contributors' authorship: prefer building on their branch/commits (merge-commit if squash would erase attribution - ask the owner).
 - `ephpm-e2e` is workspace-excluded - don't add it to workspace ops; its Cargo.lock drifts by design.
-- Gates: clippy pedantic `-D warnings`, `cargo +nightly fmt`, cargo-deny, MSRV 1.85.
+- Gates: clippy pedantic `-D warnings`, `cargo +nightly fmt`, cargo-deny, MSRV 1.88.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ The `TrackedBackend` wrapper in `ephpm-server/src/tracked_backend.rs` wraps any 
 - **Conditional compilation**: All PHP FFI code is gated with `#[cfg(php_linked)]`. The `php_linked` cfg is set by `ephpm-php/build.rs` when `PHP_SDK_PATH` env var is present. Stub mode must always compile and pass tests without it.
 - **C wrapper required**: PHP uses setjmp/longjmp for error handling. Never call PHP functions directly from Rust without going through `ephpm_wrapper.c` and its `zend_try/zend_catch` guards — otherwise SIGSEGV.
 - **PHP threading**: ZTS (Zend Thread Safety) is implemented. PHP is compiled with `--enable-zts` and each `spawn_blocking` thread auto-registers with TSRM on first use, getting its own isolated PHP context. No dedicated worker pool — tokio's `spawn_blocking` pool is the thread pool. A `Mutex` protects only one-time `init()`/`shutdown()`, not request execution. An `AtomicBool` fast-path check avoids the mutex for the common "is PHP ready?" path. Per-request C statics use `__thread` for thread isolation. Windows stays NTS (`ZTS=0`) due to DLL constraints.
-- **MSRV**: Rust 1.85 — do not use features from newer editions without checking.
+- **MSRV**: Rust 1.88 (forced by the litewire dependency's `rust-version = "1.88"`) — do not use features from newer toolchains without checking.
 - **Clippy**: Pedantic + all warnings denied (`-D warnings`). Zero warnings policy.
 - **Rustfmt**: 2024 edition style, `group_imports = "StdExternalCrate"`. Requires **nightly** toolchain (`cargo +nightly fmt`).
 - **Error handling**: `thiserror` for domain errors, `anyhow` for propagation with context. Always add context to errors with `.context()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ The `ephpm-e2e` crate is **excluded from the workspace** and has different depen
 |-----------|----------|---------|
 | **litewire** | Git dep on `github.com/ephpm/litewire`, pinned by `rev` in the workspace `Cargo.toml` | MySQL/Hrana/PG/TDS wire protocol → SQLite (Turso) translation proxy |
 | **PHP SDK** | Downloaded by `cargo xtask php-sdk` from `github.com/ephpm/php-sdk` releases | Prebuilt `libphp.a` (Linux/macOS) or `php8embed.{dll,lib}` (Windows) plus PHP headers. Pinned per minor in `xtask/src/main.rs::PHP_SDK_VERSIONS` |
-| **turso** | Pure-Rust crate (`turso =0.7.0`), compiled into the binary via litewire | The embedded SQLite-compatible database engine — single-node and CDC-replicated clustered. No external process. |
+| **turso** | Pure-Rust crate (`turso =0.7.2`), compiled into the binary via litewire | The embedded SQLite-compatible database engine — single-node and CDC-replicated clustered. No external process. |
 
 litewire is a standalone project at `github.com/ephpm/litewire`. It's used as a library — ePHPm calls `LiteWire::new(backend).mysql(addr).serve()`. Bumping it means updating the `rev` in the workspace `Cargo.toml` and running `cargo update -p litewire`. To work against a sibling checkout without changing the pin, add a `[patch."https://github.com/ephpm/litewire.git"]` entry pointing at `../litewire/crates/litewire` in your local config — see the comment above the dependency in `Cargo.toml`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,7 +1989,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2 0.2.21",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1991,6 +1997,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2167,7 +2184,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2638,8 +2655,8 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litewire"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "anyhow",
  "futures",
@@ -2657,8 +2674,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-backend"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -2671,8 +2688,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-hrana"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2686,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-mysql"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -2703,8 +2720,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-postgres"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "async-trait",
  "futures",
@@ -2718,8 +2735,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-session"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "litewire-backend",
  "litewire-translate",
@@ -2729,8 +2746,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-tds"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2742,10 +2759,10 @@ dependencies = [
 
 [[package]]
 name = "litewire-translate"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
- "lru 0.12.5",
+ "lru 0.18.2",
  "parking_lot",
  "sqlparser",
  "thiserror 2.0.18",
@@ -2754,8 +2771,8 @@ dependencies = [
 
 [[package]]
 name = "litewire-turso"
-version = "0.1.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=cb707ab98428#cb707ab98428821eaecdffe33fe3d25e834770dc"
+version = "0.2.0"
+source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -2808,6 +2825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3707,7 +3733,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3744,7 +3770,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1918,9 +1918,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2184,7 +2184,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3124,7 +3124,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3733,7 +3733,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3770,7 +3770,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4210,7 +4210,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4837,7 +4837,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5925,7 +5925,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2656,7 +2656,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "anyhow",
  "futures",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "async-trait",
  "futures",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "litewire-session"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "litewire-backend",
  "litewire-translate",
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "lru 0.18.2",
  "parking_lot",
@@ -2772,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=defab22f0c2d#defab22f0c2d166301b8040b01969da76729cf07"
+source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3733,7 +3733,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3770,7 +3770,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5332,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac8d131650c1bf6a2721202208b3dfba218be25c975f48bebda766173fbdc3b"
+checksum = "f9491d7a80312c5abe66a4409e4dce02065503a235453c94b9e4133877e39ffc"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -5346,9 +5346,9 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77f2106de5a3014261be18283999fde0d06c24ae5d4cb85a6eff1aaeaff453d"
+checksum = "7a833cc3bf8d4e6c101c504fa470f8ab4270c2202ff2591b61b2e373b4f20d9b"
 dependencies = [
  "aegis",
  "aes",
@@ -5416,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d367d863b095a9893690fc6c52bbf27edf422c135a58ba5ed2b03dbec8faac"
+checksum = "e7452fe676450b6840e9eb80e512d14293265221154eba66aba3845dfc0d659f"
 dependencies = [
  "chrono",
  "getrandom 0.4.2",
@@ -5427,9 +5427,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a817815d9ca218cb971ed2a0a41a89a5160966b5b4bd103c82792fd2f230f1c"
+checksum = "b2825eaa6b7b893693636947f988e252c1196393fa54d4b85637c70d616d92fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5438,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad90c0e6eea7ab131214804c70edad5372acecdcad8d4ccc75b0ded55b0df8f"
+checksum = "f0e58d029f02e442df4be0b5036ce520b49c553505d9d52ef5a98fc4056e95b7"
 dependencies = [
  "bitflags",
  "memchr",
@@ -5453,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1abf8f42cf5c40f9777982c8dfda776242397250eb48f99d524c383b1b641a"
+checksum = "18c1dc1c0304348c39b97bc6b27cdcb1d7292454ebd0de0f30b5ee3a4c61f9bb"
 dependencies = [
  "bindgen 0.69.5",
  "env_logger",
@@ -5470,9 +5470,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit_macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372ce1889d2729223886f805638a4357f389756d6b64e26487af5a78b3e92e2c"
+checksum = "c4708b5fe678b8730c85964e3d378f75e18c23c4409971360b2209f4e53e4956"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5481,9 +5481,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_engine"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4157da3af3730e3cf5109668dc29b58b673f99fbbac3db3a682a4b87d56b9c4a"
+checksum = "ce8f03e430240d590d209ac874db52773b7382c627cd604a685affde77622b09"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5504,9 +5504,9 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_sdk_kit"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa3b4dee7f50c671ca757d1ac1ea7c99a7a9dec819a98bb1ad6a055e7d0234f"
+checksum = "d48cb47d056c3ec567745761fa6f832358ca30ef9eb0435fdcfb77c558e70089"
 dependencies = [
  "bindgen 0.69.5",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,13 +292,13 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 # both — this is purely ePHPm de-linking them from the binary. The embedded
 # SQLite-family engine is `turso` only. `hrana` (the Hrana *server* wire
 # frontend, independent of the removed Hrana *client*) is kept.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "defab22f0c2d", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "10345a869d27", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)
 # so the two resolve to a single crate instance and TursoConnection
 # (re-exported by litewire) is the same turso::Connection.
-turso = { version = "=0.7.0", default-features = false }
+turso = { version = "=0.7.2", default-features = false }
 
 # Release-profile tuning for v0.4.2 perf release.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+# 1.88 is forced by the litewire dependency (its 0.2.0 workspace declares
+# rust-version = "1.88"); cargo refuses to compile a dep whose rust-version
+# exceeds the active toolchain, so 1.85–1.87 cannot build this workspace.
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/ephpm/ephpm"
 
@@ -116,7 +119,29 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ cb707ab9 — WordPress wire-fidelity fixes (litewire#28–#31).
+# litewire main @ defab22f0c2d — 0.2.0 (litewire#33–#35). Three batches:
+# (1) litewire#34 SECURITY: lru 0.12.5 → 0.18.2, fixing RUSTSEC-2026-0253 — a
+# use-after-free reachable through the production TranslateCache. Do not move
+# this pin backwards past litewire#34. Same PR adds a server-side
+# tenant-session SQL screen (litewire-backend/tenant_screen.rs): sessions
+# established through a `ConnectionAuthenticator` reject ATTACH/DETACH/
+# VACUUM-with-target/path-PRAGMA inside litewire itself, layered UNDER ePHPm's
+# own screen (ours stays — defence in depth, and it also covers the
+# non-authenticated single-site path). Also pins the opensrv-mysql `tls`
+# feature fence upstream (litewire#32 closed): the CLIENT_SSL auth-bypass
+# analysis in the b16d874b entry below is now enforced by litewire's own
+# Cargo.toml rather than by our reliance on default features.
+# (2) litewire#33: docs truth pass + 0.2.0 scaffolding — workspace version
+# 0.2.0, MSRV 1.88 (which is why ePHPm's rust-version moved 1.85 → 1.88 in the
+# same PR as this bump: cargo refuses to compile a dependency whose declared
+# rust-version exceeds the toolchain, so a 1.85 toolchain can no longer build
+# the workspace regardless of what ePHPm declares).
+# (3) litewire#35 perf: TranslateCache borrowed-key lookup + Arc'd entries
+# (~2.9x on the translate hit path — no API change), and an opt-in Turso
+# handle-reuse pool (`.handle_reuse(N)`), OFF by default. ePHPm does not call
+# `.handle_reuse`, so no behavior change from that half.
+#
+# Previous pin cb707ab9 — WordPress wire-fidelity fixes (litewire#28–#31).
 # Four things, all surfaced by running real WordPress over the MySQL frontend:
 # (1) litewire#28: unparseable/unsupported client commands no longer get a
 # default OK packet from opensrv-mysql's fallthrough — an OK of the wrong
@@ -267,7 +292,7 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 # both — this is purely ePHPm de-linking them from the binary. The embedded
 # SQLite-family engine is `turso` only. `hrana` (the Hrana *server* wire
 # frontend, independent of the removed Hrana *client*) is kept.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "cb707ab98428", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "defab22f0c2d", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ sudo ephpm uninstall --keep-data  # keep config and SQLite databases
 
 ### Build from Source
 
-For contributors or custom builds. Requires Rust 1.85+.
+For contributors or custom builds. Requires Rust 1.88+.
 
 ```bash
 # Stub mode (no PHP, fast iteration on HTTP/routing logic)
@@ -360,7 +360,7 @@ Key design decisions:
 
 ### Prerequisites
 
-- **Rust 1.85+** — https://rustup.rs (on Windows, also install [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/))
+- **Rust 1.88+** — https://rustup.rs (on Windows, also install [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/))
 - **Nightly Rust** — `rustup toolchain install nightly` (required for `cargo +nightly fmt`)
 - **cargo-nextest** — `cargo install cargo-nextest --locked`
 - **cargo-deny** — `cargo install cargo-deny --locked`

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,3 @@
 # Clippy configuration
 # Most lint configuration is in workspace Cargo.toml [workspace.lints.clippy]
-msrv = "1.85"
+msrv = "1.88"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,7 @@
 # Clippy configuration
 # Most lint configuration is in workspace Cargo.toml [workspace.lints.clippy]
-msrv = "1.88"
+# Intentionally trails the workspace `rust-version` (1.88). Raising this to
+# 1.88 enables msrv-gated lints — notably `collapsible_if`, since let-chains
+# stabilized in 1.88 — which flags ~50 sites across the tree. That sweep is
+# tracked separately for v0.7.1 rather than bundled into a dependency bump.
+msrv = "1.85"

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -9,7 +9,7 @@
 # Build:
 #   podman build -f docker/Dockerfile.e2e -t ephpm-e2e:dev .
 
-FROM rust:1.85-bookworm
+FROM rust:1.88-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/architecture/build-compose-design.md
+++ b/docs/architecture/build-compose-design.md
@@ -200,7 +200,7 @@ consults a process-global extra table. Two candidate wirings:
   contributes entries. Merely depending on the crate registers it —
   the closest analogue of xcaddy's "import = plugged in". Cost: a new
   dependency (`linkme`), MSRV/platform check needed (it supports the
-  tier-1 targets and musl; verify against Rust 1.85 before committing).
+  tier-1 targets and musl; verify against Rust 1.88 before committing).
 - **Fallback: generated `fn main`.** `crates/ephpm` exposes its `main` as
   `ephpm::run(extra: Option<ExtraRegistry>)`; forge generates a two-line
   binary crate `ephpm-custom` calling

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -86,7 +86,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/user/ephpm"
 
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@1.88.0
       - run: cargo check --workspace
 ```
 

--- a/site/content/developer/contributing.md
+++ b/site/content/developer/contributing.md
@@ -7,7 +7,7 @@ Contributions are welcome. The bar is high but the path is short — most change
 
 ## Prerequisites
 
-- **Rust 1.85+** via [rustup](https://rustup.rs). On Windows, also install [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+- **Rust 1.88+** via [rustup](https://rustup.rs). On Windows, also install [C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
 - **Nightly toolchain** — `rustup toolchain install nightly` (used for `cargo +nightly fmt` only)
 - **cargo-nextest** — `cargo install cargo-nextest --locked`
 - **cargo-deny** — `cargo install cargo-deny --locked`
@@ -66,7 +66,7 @@ E2E commands require Podman or Docker. `cargo xtask e2e-install` downloads kind/
 - All PHP FFI code is gated with `#[cfg(php_linked)]`. **Stub mode must always compile and pass tests** without a PHP SDK.
 - PHP uses `setjmp`/`longjmp` for error handling. Never call PHP functions directly from Rust — always go through `ephpm_wrapper.c` and its `zend_try`/`zend_catch` guards.
 - Crate names are kebab-case (`ephpm-*`).
-- MSRV is Rust 1.85. Don't use features from newer editions without checking.
+- MSRV is Rust 1.88. Don't use features from newer editions without checking.
 
 ## Pull request flow
 

--- a/site/content/developer/getting-started.md
+++ b/site/content/developer/getting-started.md
@@ -8,7 +8,7 @@ Everything you need to set up a development environment for ePHPm.
 
 ### Rust (required)
 
-ePHPm requires **Rust 1.85+** (edition 2024). Install via [rustup](https://rustup.rs):
+ePHPm requires **Rust 1.88+** (edition 2024). Install via [rustup](https://rustup.rs):
 
 **Linux / macOS / WSL:**
 
@@ -23,7 +23,7 @@ Download and run the installer from https://rustup.rs. You'll also need the [Vis
 
 ```bash
 # Verify installation
-rustc --version   # should be >= 1.85
+rustc --version   # should be >= 1.88
 cargo --version
 ```
 

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -89,7 +89,7 @@ sudo ephpm uninstall --keep-data
 
 ## Build from source
 
-For contributors or custom builds. Requires Rust 1.85+.
+For contributors or custom builds. Requires Rust 1.88+.
 
 ```bash
 # Stub mode — no PHP, fast iteration on HTTP/routing logic

--- a/xtask/src/doctor.rs
+++ b/xtask/src/doctor.rs
@@ -14,7 +14,7 @@ use std::{env, fs};
 
 /// Minimum supported Rust version — keep in sync with `rust-version` in the
 /// workspace `Cargo.toml`.
-const MSRV: (u32, u32) = (1, 85);
+const MSRV: (u32, u32) = (1, 88);
 
 /// Remedy shared by all Linux C-toolchain checks (matches the README and
 /// CLAUDE.md prerequisites list).

--- a/xtask/src/doctor.rs
+++ b/xtask/src/doctor.rs
@@ -613,10 +613,10 @@ mod tests {
 
     #[test]
     fn msrv_comparison() {
-        assert!(meets_msrv((1, 85)));
+        assert!(meets_msrv((1, 88)));
         assert!(meets_msrv((1, 94)));
         assert!(meets_msrv((2, 0)));
-        assert!(!meets_msrv((1, 84)));
+        assert!(!meets_msrv((1, 87)));
         assert!(!meets_msrv((0, 99)));
     }
 


### PR DESCRIPTION
Bumps litewire to `10345a869d27` (0.2.0 line) and moves ePHPm's turso pin to `=0.7.2`.

## What this brings
- **litewire 0.2.0** (batches #33/#34/#35): the `lru` 0.18.2 upgrade (fixes RUSTSEC-2026-0253, a use-after-free under the production TranslateCache), the tenant-session SQL screen (server-side ATTACH/DETACH/VACUUM/path-PRAGMA rejection on authenticated sessions — defense-in-depth under ePHPm's own screen), and the TranslateCache borrowed-key+Arc ~2.9× hit-path win.
- **turso 0.7.2** — brings tursodatabase/turso#7855 ("close vtab cursors before transaction finalization", merged 07-16). turso 0.7.0 (published 07-13) *predated* that fix by three days, so ePHPm was running without it; 0.7.2 (07-30) is the first stable release containing it. Closes the pragma-TVF gap. **Coupling:** ePHPm carries a *direct* `turso = "=0.7.0"` pin (kept exactly equal to litewire's), so both that pin and the CLAUDE.md deps row move to `=0.7.2` in lockstep — otherwise the two exact pins can't co-resolve.
- **MSRV 1.85 → 1.88** — litewire 0.2.0 declares `rust-version = 1.88` and cargo refuses to compile a dep whose MSRV exceeds the toolchain. Updated in Cargo.toml, xtask doctor, README, CLAUDE.md, site docs. CI unaffected (all jobs use stable).

## Validation
`cargo update` resolves litewire@10345a8 + turso_core 0.7.2 cleanly. litewire's own full suite (incl. the `cdc_ddl_capture`/`cdc_replication` suites exercising the #7855 vtab/pragma path) passed on the turso 0.7.2 branch. CI here runs the full bare E2E incl. the multi-tenant suites over the new tenant screen.