### PR TITLE
test: fix three process-global test-state races (whole-suite flakes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "serial_test",
  "sha1",
  "sha2 0.10.9",
  "tempfile",

--- a/crates/ephpm-php/src/db_bridge.rs
+++ b/crates/ephpm-php/src/db_bridge.rs
@@ -1681,9 +1681,13 @@ mod tests {
     }
 
     #[test]
+    // Its own assertions are thread-local and would not need serializing, but
+    // `on_request_end()` also drains the process-global session graveyard —
+    // which would steal the sessions `teardown_tests` is asserting on. See the
+    // invariant documented above `mod teardown_tests`.
+    #[serial]
     fn request_end_without_a_session_is_a_noop() {
         // This test's thread never ran a query, so no session exists.
-        // (Thread-locals are per-test-thread; no #[serial] needed.)
         assert_eq!(thread_in_transaction(), None);
         on_request_end();
         assert_eq!(thread_in_transaction(), None);
@@ -2069,6 +2073,8 @@ mod screen_tests {
 mod per_site_tests {
     use std::collections::HashMap;
 
+    use serial_test::serial;
+
     use super::tests::TEST_RT;
     use super::*;
 
@@ -2115,7 +2121,12 @@ mod per_site_tests {
 
     /// The issue-#274 / pentest-C1 exploit, at the bridge level: site A writes
     /// a secret; site B must NOT be able to read it.
+    ///
+    /// Serialized because it calls `on_request_end()`, which drains the
+    /// process-global session graveyard `teardown_tests` asserts on — see the
+    /// invariant documented above `mod teardown_tests`.
     #[test]
+    #[serial]
     fn cross_tenant_read_is_impossible() {
         let dir = tempfile::tempdir().expect("tempdir");
         let a = open_turso(&dir.path().join("site-a.db"));
@@ -2209,10 +2220,40 @@ mod per_site_tests {
 //
 // These run against a real Turso backend on purpose: a mock connection has no
 // engine buffers to drop and would pass no matter what.
+//
+// ── Why every drain-touching test here is `#[serial]` ──────────────────
+//
+// The graveyard ([`PARKED_SESSIONS`]) and its accounting ([`PARKED_TOTAL`],
+// [`DRAINED_TOTAL`]) are **process-global by design**: any thread's request-end
+// must be able to reclaim any *other* retired thread's session, whatever bridge
+// it came from. `cargo test` runs the whole crate's tests as threads inside one
+// process, so a sibling test calling `on_request_end()` drains this test's
+// parked sessions first; this test's own drain then finds an empty graveyard
+// and its `DRAINED_TOTAL` delta stays at zero. That is a shared-state race, not
+// timing noise — it reproduced at ~32% of full-suite runs, and it is invisible
+// under `cargo nextest` (process per test) and `--test-threads=1`, which is why
+// CI mostly escaped it.
+//
+// Injecting a per-test graveyard was considered and rejected: the park path
+// runs *inside a TLS destructor*, where touching any Rust thread-local is
+// precisely the abort (#300) this machinery exists to prevent — so the
+// graveyard cannot be selected from thread-local state — and parks also
+// originate on libtest's own threads, which a test cannot instrument. Making
+// the graveyard per-bridge instead would break the global-reclaim property
+// that is the whole point of the design.
+//
+// So the exclusion is explicit instead. **Invariant: every test in this crate
+// that calls `on_request_end()` or `drain_parked_sessions()` must be
+// `#[serial]`** — a non-serial drainer anywhere in the crate re-opens this race.
+// Note that `#[serial]` is only needed against *drains*; a sibling thread
+// merely *parking* a session can never make these assertions fail, because
+// parks only ever add.
 #[cfg(test)]
 mod teardown_tests {
     use std::collections::HashMap;
     use std::sync::atomic::AtomicBool;
+
+    use serial_test::serial;
 
     use super::per_site_tests::{open_turso, per_site_bridge};
     use super::*;
@@ -2247,6 +2288,7 @@ mod teardown_tests {
     /// test binary aborts with `fatal runtime error: thread local panicked on
     /// drop`, which is exactly the production failure.
     #[test]
+    #[serial]
     fn retiring_thread_parks_its_session_instead_of_dropping_it() {
         let dir = tempfile::tempdir().expect("tempdir");
         let bridge = one_site_bridge(dir.path(), "park.test");
@@ -2296,6 +2338,7 @@ mod teardown_tests {
     /// row is precisely the tokio blocking-pool reaping pattern that produced
     /// the abort under load.
     #[test]
+    #[serial]
     fn thread_churn_is_reclaimed_by_request_end() {
         let dir = tempfile::tempdir().expect("tempdir");
         let bridge = one_site_bridge(dir.path(), "churn.test");
@@ -2331,14 +2374,32 @@ mod teardown_tests {
     }
 
     /// Draining an empty graveyard is a cheap no-op, and repeated drains are
-    /// idempotent — it sits on the per-request path.
+    /// idempotent — it sits on the per-request path, so a back-to-back drain
+    /// must neither panic, deadlock, nor invent accounting.
+    ///
+    /// Asserted as the cumulative invariant (`drained <= parked`) rather than a
+    /// per-window delta. `#[serial]` excludes concurrent *drains*, but it
+    /// cannot stop an unrelated test's thread from retiring and *parking*
+    /// mid-test, and such a session can be counted as parked before this
+    /// window while being reclaimed inside it — which is correct behavior that
+    /// a delta assertion reads as a violation. (That is not theoretical: the
+    /// delta form failed 1 run in 150.) The cumulative form has no such window:
+    /// every drained session was parked first, and both totals only grow, so
+    /// reading `drained` before `parked` can never observe an inversion.
     #[test]
+    #[serial]
     fn draining_nothing_is_a_noop() {
         drain_parked_sessions();
-        let drained_before = drained_total();
         drain_parked_sessions();
         drain_parked_sessions();
-        assert_eq!(drained_total(), drained_before, "empty drains must not account anything");
+        // Read order matters: `drained` first, so a park+drain racing between
+        // the two loads can only widen the gap, never invert it.
+        let drained = drained_total();
+        let parked = parked_total();
+        assert!(
+            drained <= parked,
+            "a drain accounted a session that was never parked ({drained} drained > {parked} parked)"
+        );
     }
 
     // ── The platform behavior that makes #300 possible ──────────────────

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -100,6 +100,12 @@ rcgen.workspace = true
 sha1.workspace = true
 # Paused-clock (`start_paused`) support for the idle-timeout watchdog tests.
 tokio = { workspace = true, features = ["test-util"] }
+# Excludes the CDC-metrics tests from running alongside anything else that
+# mutates the process-global subscriber registry (turso_cdc_metrics::REGISTRY).
+# Already a workspace dependency (ephpm-php uses it), so this adds no new crate
+# to the tree. Works on `#[tokio::test]`, which a bare Mutex guard held across
+# an await does not.
+serial_test.workspace = true
 # Real MySQL client for the handle-reuse experiment: PHP's `pdo_mysql` opens a
 # connection per request, and the only way to observe what that does to
 # litewire's session-worker free-list is to drive the wire frontend with a

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -4813,6 +4813,46 @@ mod tests {
         }
     }
 
+    /// Makes the router's span callsites enabled **process-wide**, so a span
+    /// test's thread-local collector can actually see them.
+    ///
+    /// Without this, the span tests are order-dependent flakes. `tracing`
+    /// caches each callsite's `Interest` **globally and once**, at the callsite's
+    /// first hit: `DefaultCallsite::register` asks `DISPATCHERS.rebuilder()`,
+    /// which — with no global dispatcher installed — takes the `JustOne` path
+    /// and consults `dispatcher::get_default`, i.e. *whatever subscriber was
+    /// current on the thread that happened to hit the callsite first*. In this
+    /// crate's test binary that is almost always a plain router test with no
+    /// subscriber at all, whose `NoSubscriber` answers `Interest::never()` — and
+    /// that verdict is then cached for every thread, forever. A span test that
+    /// later installs a collector with `set_default` records nothing, and its
+    /// `spans` snapshot comes back empty.
+    ///
+    /// `set_default` alone does not fix it. It does trigger a full interest
+    /// rebuild (via `Dispatch::new` → `callsite::register_dispatch`), which
+    /// repairs callsites already registered by then — which is why the common
+    /// `http.request` callsite usually survives. But `php.execute` and
+    /// `worker.queue_wait` are hit by only a handful of tests, so they are
+    /// frequently *still unregistered* at that moment, and a concurrent
+    /// no-subscriber thread can register them — latching `never` — in the window
+    /// between the rebuild and the span test's own request.
+    ///
+    /// Installing a global default closes the window from both ends: the
+    /// `set_global_default` call rebuilds the cache (repairing anything already
+    /// latched `never`), and from then on the `JustOne` path resolves to this
+    /// `Registry` — which enables everything — no matter which thread registers
+    /// a callsite first. Collection stays per-test and thread-local; this
+    /// subscriber only exists to keep the callsites alive.
+    fn enable_span_callsites() {
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            // A plain `Registry` enables every callsite and collects nothing.
+            // The error case (a global default already set) is not reachable
+            // here, and would be harmless anyway.
+            let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+        });
+    }
+
     impl<S> tracing_subscriber::Layer<S> for SpanTree
     where
         S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
@@ -4917,6 +4957,7 @@ mod tests {
     /// the dispatch but never answers, so the inner worker timeout fires.
     #[tokio::test(start_paused = true)]
     async fn worker_mode_records_queue_wait_and_emits_span_tree() {
+        enable_span_callsites();
         let tree = SpanTree::default();
         let subscriber = tracing_subscriber::registry().with(tree.clone());
         let _guard = tracing::subscriber::set_default(subscriber);
@@ -4992,6 +5033,7 @@ mod tests {
     /// the measurement points are identical.
     #[tokio::test]
     async fn fpm_mode_spans_and_timeline_have_no_queue_wait() {
+        enable_span_callsites();
         let tree = SpanTree::default();
         let subscriber = tracing_subscriber::registry().with(tree.clone());
         let _guard = tracing::subscriber::set_default(subscriber);
@@ -5046,6 +5088,7 @@ mod tests {
     async fn fpm_pool_engine_dispatches_php_request() {
         ephpm_php::PhpRuntime::init().expect("stub runtime init");
 
+        enable_span_callsites();
         let tree = SpanTree::default();
         let subscriber = tracing_subscriber::registry().with(tree.clone());
         let _guard = tracing::subscriber::set_default(subscriber);

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -1963,7 +1963,16 @@ mod tests {
     ///
     /// The assertion is two-part on purpose: staying alive is not enough,
     /// the subscriber must still deliver the first real batch afterwards.
+    ///
+    /// `#[serial(cdc_registry)]` because this drives the production
+    /// `serve_subscriber`, which attaches to the process-global subscriber
+    /// registry in `turso_cdc_metrics`. Left concurrent, its subscriber
+    /// (attached at change_id 0) pulls that registry's `shipped` cursor to 0
+    /// and adds a `cursors` row underneath the gauge tests asserting on both —
+    /// the crate's dominant flake at 13/100 full-suite runs. See the group's
+    /// invariant documented on `turso_cdc_metrics::tests`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial_test::serial(cdc_registry)]
     async fn cold_primary_holds_subscriber_open_until_first_write() {
         let db = tempfile::NamedTempFile::new().unwrap();
         let path = db.path().to_str().unwrap().to_string();

--- a/crates/ephpm-server/src/turso_cdc_metrics.rs
+++ b/crates/ephpm-server/src/turso_cdc_metrics.rs
@@ -370,6 +370,8 @@ pub fn init() {
 
 #[cfg(test)]
 mod tests {
+    use serial_test::serial;
+
     use super::*;
 
     /// The registry is process-global, so these tests must not run
@@ -377,6 +379,26 @@ mod tests {
     /// the gauges (which is deterministic) rather than on recorded metric
     /// values (which need an installed recorder — that coverage lives in
     /// `tests/turso_cdc_metrics_e2e.rs`, where a real scrape is parsed).
+    ///
+    /// ── Why `#[serial(cdc_registry)]` and not a module-local `Mutex` ──
+    ///
+    /// A module-local lock only excluded these four tests from *each other*,
+    /// which is not the whole population: `turso_cdc::tests::
+    /// cold_primary_holds_subscriber_open_until_first_write` drives the
+    /// **production** `serve_subscriber`, which calls `attach_subscriber` on
+    /// this same global registry. Its subscriber attaching at change_id 0
+    /// concurrently pulls `shipped` down to 0 and adds a row to `cursors` —
+    /// which is exactly what the `shipped`/`cursors.len()` assertions below
+    /// read. That was the crate's dominant test flake: 13 of 100 full-suite
+    /// runs of `cargo test -p ephpm-server` failed here, spread across three
+    /// of these tests, while each passed in isolation every time.
+    ///
+    /// The named `cdc_registry` group therefore has to include that test too —
+    /// it is tagged at its own definition in `turso_cdc.rs`. **Invariant: any
+    /// test that attaches a CDC subscriber, samples the head, or resets the
+    /// registry must join this group.** A named key (rather than the default)
+    /// keeps unrelated future `#[serial]` tests in this crate from being
+    /// serialized against CDC work for no reason.
     fn reset() {
         REGISTRY.cursors.clear();
         REGISTRY.head.store(0, Ordering::Relaxed);
@@ -387,8 +409,8 @@ mod tests {
     /// Lag is head minus the *slowest* subscriber, not the fastest: one
     /// caught-up replica must not mask another that is far behind.
     #[test]
+    #[serial(cdc_registry)]
     fn lag_tracks_the_slowest_subscriber() {
-        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         reset();
 
         let fast = attach_subscriber(0);
@@ -411,8 +433,8 @@ mod tests {
     /// shipped cursor is *retained* so lag keeps growing against a dead
     /// replica rather than freezing or resetting to zero.
     #[test]
+    #[serial(cdc_registry)]
     fn detached_subscriber_retains_cursor_so_lag_keeps_growing() {
-        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         reset();
 
         {
@@ -435,8 +457,8 @@ mod tests {
     /// (the sampler reads `0` when `turso_cdc` does not exist yet) must
     /// never walk the head backwards and invent negative lag.
     #[test]
+    #[serial(cdc_registry)]
     fn head_is_monotonic_and_lag_never_negative() {
-        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         reset();
 
         let sub = attach_subscriber(0);
@@ -455,8 +477,8 @@ mod tests {
     /// shipped cursor — its backlog is real, and reporting the caught-up
     /// replica's position instead would hide it.
     #[test]
+    #[serial(cdc_registry)]
     fn a_new_cold_subscriber_lowers_the_shipped_cursor() {
-        let _s = LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         reset();
 
         let warm = attach_subscriber(0);
@@ -470,6 +492,4 @@ mod tests {
         // ...and once it leaves, the remaining replica's position stands.
         assert_eq!(REGISTRY.shipped.load(Ordering::Relaxed), 1000);
     }
-
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 }


### PR DESCRIPTION
**v0.7.1 — P0: CI & release reliability. Do not merge until after the v0.7.0 tag.**

Three tests failed intermittently under `cargo test` while passing in isolation every single time. All three turned out to be the same bug: an assertion on **process-global state that a concurrently-running sibling test mutates**. None of them is timing noise.

Measured on a loop of each crate's full test binary, before and after:

| crate | before | after |
|---|---|---|
| `ephpm-php` | **32 / 100** runs failed | **0 / 200** |
| `ephpm-server` | **13 / 100** runs failed | **0 / 150** |

CI mostly escapes these because `cargo nextest run --workspace` uses a process per test. Plain `cargo test` — what you run locally — trips them regularly.

## 1. `db_bridge::teardown_tests` — the #300 session graveyard

`thread_churn_is_reclaimed_by_request_end` and `retiring_thread_parks_its_session_instead_of_dropping_it` assert on `PARKED_TOTAL` / `DRAINED_TOTAL`, which back a **process-global** graveyard. That globality is deliberate: any thread's request-end must be able to reclaim any *other* retired thread's session. So a sibling test calling `on_request_end()` drains this test's parked sessions first, and the test's own drain then finds nothing — the counter never moves and the assertion fails.

Fixed by serializing every test in the crate that drains the graveyard, which is the exclusion the shared design actually requires. Five tests joined the group; the invariant is documented on the module so a future drainer does not silently re-open the race.

**Injection was considered and rejected.** The park path runs inside a TLS destructor, where touching a thread-local is the exact abort (#300) this machinery exists to prevent — so the graveyard cannot be selected from thread-local state — and parks also originate on libtest's own threads, which a test cannot instrument. Making the graveyard per-bridge would break the global-reclaim property outright. The reasoning is written into the module comment rather than left for the next reader to re-derive.

`draining_nothing_is_a_noop` additionally moved from a delta assertion to the cumulative `drained <= parked` invariant. `#[serial]` excludes concurrent *drains* but cannot stop an unrelated test's thread from *parking* mid-test, and such a session can be counted parked before the window and reclaimed inside it. The delta form still failed 1 run in 150; the cumulative form has no such window.

## 2. `turso_cdc_metrics::tests` — the CDC subscriber registry

These four already took a module-local `Mutex` — but that only excluded them from *each other*. `turso_cdc::tests::cold_primary_holds_subscriber_open_until_first_write` drives the **production** `serve_subscriber`, which attaches to the same global registry: its subscriber (at `change_id` 0) pulls `shipped` down to 0 and adds a `cursors` row underneath the assertions reading exactly those two fields. This was the dominant `ephpm-server` flake — all 13 failures, spread across three of the four tests.

Replaced the local `Mutex` with `#[serial(cdc_registry)]` and put the production-driving test in the same named group. `serial_test` was already a workspace dependency (`ephpm-php` uses it), so no new crate enters the tree — and unlike a `Mutex` guard, it works on `#[tokio::test]` without holding a lock across an await.

## 3. `router::tests` span tests — the tracing callsite-interest cache

This one is worth reading carefully, because `set_default` looks like it should be sufficient and is not.

`tracing` caches each callsite's `Interest` **globally, and once**, at that callsite's first hit: `DefaultCallsite::register` consults `DISPATCHERS.rebuilder()`, which — with no global dispatcher installed — takes the `Rebuilder::JustOne` path and asks `dispatcher::get_default`, i.e. *whatever subscriber happened to be current on the thread that got there first* (tracing-core 0.1.36, `callsite.rs`). In this test binary that is almost always a plain router test with no subscriber at all, whose `NoSubscriber` answers `Interest::never()` — and that verdict is then cached for every thread, for the life of the process. A span test that later installs a collector via `set_default` records nothing and snapshots an empty span list.

`set_default` does trigger a full interest rebuild, via `Dispatch::new` → `callsite::register_dispatch`, which repairs callsites *already registered* by then. That is why the very common `http.request` callsite usually survives. But `php.execute` and `worker.queue_wait` are hit by only a handful of tests, so they are frequently **still unregistered** at that moment — leaving a window for a no-subscriber thread to register them, and latch them `never`, between the rebuild and the span test's own request. That is precisely why the two PHP-span tests are the ones that flake.

Fixed by installing a plain `Registry` as the global default once. That closes the window from both ends: the `set_global_default` call rebuilds the cache (repairing anything already latched `never`), and from then on the `JustOne` path resolves to a subscriber that enables everything, no matter which thread registers a callsite first. Per-test collection is unchanged — each test still installs its own `SpanTree` and reads only what it collected.

## Verification

- `ephpm-php` full test binary, 200 consecutive runs: **0 failures** (baseline 32/100 on the same box).
- `ephpm-server` full test binary, 150 consecutive runs: **0 failures** (baseline 13/100).
- Root cause for (3) established by reading the tracing-core 0.1.36 source (`callsite.rs` `Rebuilder::JustOne` / `rebuild_callsite_interest`, `dispatcher.rs` `Dispatch::new`), not inferred from symptoms. Being an order race with a narrow window, it did not reproduce locally in 100 full-suite runs or 200 targeted runs — the fix makes the failure mode unreachable by construction rather than merely less likely, which is why it is included.
- Stub mode throughout (no PHP SDK).

No production code paths changed — the diff is test attributes, test helpers, one dev-dependency, and comments.