### PR TITLE
chore(lint): track the workspace MSRV in clippy.toml and collapse to let-chains

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,12 @@
 # Clippy configuration
 # Most lint configuration is in workspace Cargo.toml [workspace.lints.clippy]
-# Intentionally trails the workspace `rust-version` (1.88). Raising this to
-# 1.88 enables msrv-gated lints — notably `collapsible_if`, since let-chains
-# stabilized in 1.88 — which flags ~50 sites across the tree. That sweep is
-# tracked separately for v0.7.1 rather than bundled into a dependency bump.
-msrv = "1.85"
+#
+# Tracks the workspace `rust-version` exactly. Keeping it lower used to suppress
+# msrv-gated lints — notably `collapsible_if`, which only fires once let-chains
+# are available (stabilized in 1.88) — so clippy was not checking the tree
+# against the toolchain features it is actually allowed to use. Raising it to
+# 1.88 closed that gap; the resulting let-chain collapse landed as its own
+# sweep for v0.7.1, separate from the dependency bump that moved the MSRV.
+#
+# Keep this in lockstep with `rust-version` in the workspace Cargo.toml.
+msrv = "1.88"

--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -995,10 +995,10 @@ pub async fn start_gossip_applier(
 /// and subsequent v1 echoes for the same key are skipped, which is the
 /// desired behavior.
 fn should_apply(applied: &AppliedWriteMap, key: &str, write_ms: u64) -> bool {
-    if let Some(prev) = applied.get(key) {
-        if write_ms <= *prev {
-            return false;
-        }
+    if let Some(prev) = applied.get(key)
+        && write_ms <= *prev
+    {
+        return false;
     }
     applied.insert(key.to_string(), write_ms);
     true

--- a/crates/ephpm-cluster/src/gossip_kv.rs
+++ b/crates/ephpm-cluster/src/gossip_kv.rs
@@ -203,10 +203,10 @@ impl ClusterHandle {
                 }
                 return;
             }
-            if let Some((value, write_ms)) = decode_value_with_write_ms(encoded) {
-                if best.as_ref().is_none_or(|(seen, _)| write_ms > *seen) {
-                    *best = Some((write_ms, Some(value)));
-                }
+            if let Some((value, write_ms)) = decode_value_with_write_ms(encoded)
+                && best.as_ref().is_none_or(|(seen, _)| write_ms > *seen)
+            {
+                *best = Some((write_ms, Some(value)));
             }
         };
 
@@ -214,10 +214,10 @@ impl ClusterHandle {
             consider(encoded, &mut best);
         }
         for node_id in guard.live_nodes().cloned().collect::<Vec<_>>() {
-            if let Some(state) = guard.node_state(&node_id) {
-                if let Some(encoded) = state.get(&chitchat_key) {
-                    consider(encoded, &mut best);
-                }
+            if let Some(state) = guard.node_state(&node_id)
+                && let Some(encoded) = state.get(&chitchat_key)
+            {
+                consider(encoded, &mut best);
             }
         }
         best.and_then(|(_, value)| value)
@@ -286,10 +286,10 @@ impl ClusterHandle {
             consider(encoded, &mut best);
         }
         for node_id in guard.live_nodes().cloned().collect::<Vec<_>>() {
-            if let Some(state) = guard.node_state(&node_id) {
-                if let Some(encoded) = state.get(&chitchat_key) {
-                    consider(encoded, &mut best);
-                }
+            if let Some(state) = guard.node_state(&node_id)
+                && let Some(encoded) = state.get(&chitchat_key)
+            {
+                consider(encoded, &mut best);
             }
         }
         best.and_then(|(_, ttl)| ttl)

--- a/crates/ephpm-cluster/src/sqlite_election.rs
+++ b/crates/ephpm-cluster/src/sqlite_election.rs
@@ -157,23 +157,23 @@ impl SqliteElection {
 
     async fn initial_role_inner(&self) -> ElectedRole {
         // Check if there's already a primary claim in gossip.
-        if let Some(bytes) = self.cluster.gossip_get(PRIMARY_KEY).await {
-            if let Some(claim) = PrimaryClaim::decode(&bytes) {
-                if claim.node_id == self.cluster.self_node().id {
-                    // Our own (unexpired) claim survived a restart —
-                    // reclaiming is not a theft; refresh and carry on.
-                    self.publish_claim().await;
-                    tracing::info!("SQLite election: reclaiming our own surviving primary claim");
-                    return ElectedRole::Primary;
-                }
-                if let Some(url) = self.replica_url_for(&claim).await {
-                    return ElectedRole::Replica { primary_grpc_url: url };
-                }
-                // Claim points at a host that is not a known member.
-                // Refuse to dial it (defense in depth against a forged
-                // gossip claim) and wait for a valid one.
-                return ElectedRole::Replica { primary_grpc_url: String::new() };
+        if let Some(bytes) = self.cluster.gossip_get(PRIMARY_KEY).await
+            && let Some(claim) = PrimaryClaim::decode(&bytes)
+        {
+            if claim.node_id == self.cluster.self_node().id {
+                // Our own (unexpired) claim survived a restart —
+                // reclaiming is not a theft; refresh and carry on.
+                self.publish_claim().await;
+                tracing::info!("SQLite election: reclaiming our own surviving primary claim");
+                return ElectedRole::Primary;
             }
+            if let Some(url) = self.replica_url_for(&claim).await {
+                return ElectedRole::Replica { primary_grpc_url: url };
+            }
+            // Claim points at a host that is not a known member.
+            // Refuse to dial it (defense in depth against a forged
+            // gossip claim) and wait for a valid one.
+            return ElectedRole::Replica { primary_grpc_url: String::new() };
         }
 
         // No valid claim visible. That means either the cluster genuinely
@@ -220,60 +220,60 @@ impl SqliteElection {
         let self_node = self.cluster.self_node();
 
         // Check existing primary claim.
-        if let Some(bytes) = self.cluster.gossip_get(PRIMARY_KEY).await {
-            if let Some(claim) = PrimaryClaim::decode(&bytes) {
-                if claim.node_id == self_node.id {
-                    // We are the primary — refresh heartbeat.
-                    self.publish_claim().await;
-                    return ElectedRole::Primary;
-                }
+        if let Some(bytes) = self.cluster.gossip_get(PRIMARY_KEY).await
+            && let Some(claim) = PrimaryClaim::decode(&bytes)
+        {
+            if claim.node_id == self_node.id {
+                // We are the primary — refresh heartbeat.
+                self.publish_claim().await;
+                return ElectedRole::Primary;
+            }
 
-                // Someone else claims primary -- check if they're alive AND
-                // that the advertised gRPC address belongs to a known member
-                // (defense in depth: a forged claim from a plaintext gossip
-                // injection must not make us dial an arbitrary host).
-                let nodes = self.cluster.nodes().await;
-                let primary_alive =
-                    nodes.iter().any(|n| n.id == claim.node_id && n.state == NodeState::Alive);
+            // Someone else claims primary -- check if they're alive AND
+            // that the advertised gRPC address belongs to a known member
+            // (defense in depth: a forged claim from a plaintext gossip
+            // injection must not make us dial an arbitrary host).
+            let nodes = self.cluster.nodes().await;
+            let primary_alive =
+                nodes.iter().any(|n| n.id == claim.node_id && n.state == NodeState::Alive);
 
-                if primary_alive {
-                    // Conflict: we hold the primary role, yet a live peer
-                    // claims it too (gossip KV is last-write-wins, so its
-                    // newer write shadows ours). Do not yield
-                    // unconditionally — that is how a joining node stole
-                    // the role from a healthy incumbent. Break the tie by
-                    // the documented rule: lowest node id wins.
-                    if matches!(current, ElectedRole::Primary) {
-                        if incumbent_wins_tie(&self_node.id, &claim.node_id) {
-                            tracing::warn!(
-                                claimant = %claim.node_id,
-                                "SQLite election: live conflicting primary claim from a \
-                                 higher-ordinal node; keeping the primary role and \
-                                 re-asserting our claim (lowest node id wins)"
-                            );
-                            self.publish_claim().await;
-                            return ElectedRole::Primary;
-                        }
+            if primary_alive {
+                // Conflict: we hold the primary role, yet a live peer
+                // claims it too (gossip KV is last-write-wins, so its
+                // newer write shadows ours). Do not yield
+                // unconditionally — that is how a joining node stole
+                // the role from a healthy incumbent. Break the tie by
+                // the documented rule: lowest node id wins.
+                if matches!(current, ElectedRole::Primary) {
+                    if incumbent_wins_tie(&self_node.id, &claim.node_id) {
                         tracing::warn!(
                             claimant = %claim.node_id,
                             "SQLite election: live conflicting primary claim from a \
-                             lower-ordinal node; stepping down (lowest node id wins)"
+                             higher-ordinal node; keeping the primary role and \
+                             re-asserting our claim (lowest node id wins)"
                         );
+                        self.publish_claim().await;
+                        return ElectedRole::Primary;
                     }
-                    if let Some(url) = self.replica_url_for(&claim).await {
-                        return ElectedRole::Replica { primary_grpc_url: url };
-                    }
-                    // Alive primary but the gRPC host is not a known member --
-                    // refuse to dial it and wait for a valid claim.
-                    return ElectedRole::Replica { primary_grpc_url: String::new() };
+                    tracing::warn!(
+                        claimant = %claim.node_id,
+                        "SQLite election: live conflicting primary claim from a \
+                         lower-ordinal node; stepping down (lowest node id wins)"
+                    );
                 }
-
-                // Primary is dead — fall through to re-election.
-                tracing::warn!(
-                    dead_primary = %claim.node_id,
-                    "primary node is dead, triggering re-election"
-                );
+                if let Some(url) = self.replica_url_for(&claim).await {
+                    return ElectedRole::Replica { primary_grpc_url: url };
+                }
+                // Alive primary but the gRPC host is not a known member --
+                // refuse to dial it and wait for a valid claim.
+                return ElectedRole::Replica { primary_grpc_url: String::new() };
             }
+
+            // Primary is dead — fall through to re-election.
+            tracing::warn!(
+                dead_primary = %claim.node_id,
+                "primary node is dead, triggering re-election"
+            );
         }
 
         // No valid primary claim visible. If this node started recently,

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -2854,14 +2854,14 @@ impl Config {
         }
 
         // Enforce containment under document_root when the root itself exists.
-        if let Ok(canon_root) = doc_root.canonicalize() {
-            if !canon_script.starts_with(&canon_root) {
-                return Err(ConfigError::Validation(format!(
-                    "[php] worker_script {} resolves outside document_root {}",
-                    canon_script.display(),
-                    canon_root.display(),
-                )));
-            }
+        if let Ok(canon_root) = doc_root.canonicalize()
+            && !canon_script.starts_with(&canon_root)
+        {
+            return Err(ConfigError::Validation(format!(
+                "[php] worker_script {} resolves outside document_root {}",
+                canon_script.display(),
+                canon_root.display(),
+            )));
         }
 
         // On Windows, `canonicalize()` returns an extended-length *verbatim*

--- a/crates/ephpm-db/src/mysql.rs
+++ b/crates/ephpm-db/src/mysql.rs
@@ -748,11 +748,11 @@ fn build_handshake_response(
     // Lenenc-encoded auth response.
     encode_lenenc_bytes(&mut buf, &auth_response);
 
-    if let Some(db) = database {
-        if !db.is_empty() {
-            buf.extend_from_slice(db.as_bytes());
-            buf.push(0);
-        }
+    if let Some(db) = database
+        && !db.is_empty()
+    {
+        buf.extend_from_slice(db.as_bytes());
+        buf.push(0);
     }
 
     let plugin_name = if use_caching_sha2 {
@@ -1824,10 +1824,10 @@ fn select_pool<'a>(
     }
 
     // Sticky after write: check if still in sticky window.
-    if let Some(sticky_until) = state.sticky_until {
-        if std::time::Instant::now() < sticky_until {
-            return primary;
-        }
+    if let Some(sticky_until) = state.sticky_until
+        && std::time::Instant::now() < sticky_until
+    {
+        return primary;
     }
 
     // Read queries can use replicas via round-robin.
@@ -2075,12 +2075,11 @@ async fn proxy_routing_loop(
                 stmt_pool_map.insert(stmt_id, PreparedStmt { target: pool_target, sql });
                 debug!(stmt_id, ?pool_target, "prepared statement registered");
             }
-        } else if cmd == COM_STMT_CLOSE {
-            if let Some(stmt_id) = parse_stmt_id(&payload) {
-                if let Some(removed) = stmt_pool_map.remove(&stmt_id) {
-                    debug!(stmt_id, ?removed, "prepared statement closed");
-                }
-            }
+        } else if cmd == COM_STMT_CLOSE
+            && let Some(stmt_id) = parse_stmt_id(&payload)
+            && let Some(removed) = stmt_pool_map.remove(&stmt_id)
+        {
+            debug!(stmt_id, ?removed, "prepared statement closed");
         }
 
         // Record after the statement-id map is up to date, so a
@@ -2089,10 +2088,9 @@ async fn proxy_routing_loop(
         // which is a recordable execution.
         if let (Some(collector), Some(started), Some(outcome)) =
             (recorder, started, relayed.response)
+            && let Some(sql) = routing_recordable_sql(&payload, &stmt_pool_map)
         {
-            if let Some(sql) = routing_recordable_sql(&payload, &stmt_pool_map) {
-                collector.record(sql, started.elapsed(), outcome.ok, outcome.rows);
-            }
+            collector.record(sql, started.elapsed(), outcome.ok, outcome.rows);
         }
 
         // Return backend to pool.

--- a/crates/ephpm-db/src/postgres.rs
+++ b/crates/ephpm-db/src/postgres.rs
@@ -1259,15 +1259,15 @@ async fn pg_proxy_bidirectional_sniff(
                         // turn carries no SQL but still owns this
                         // `ReadyForQuery`, and leaving its entry behind would
                         // misattribute every later statement on the session.
-                        if let Some(turn) = turns.lock().pop_front() {
-                            if let Some(sql) = turn.sql {
-                                collector.record(
-                                    &sql,
-                                    turn.started.elapsed(),
-                                    outcome.ok,
-                                    outcome.rows,
-                                );
-                            }
+                        if let Some(turn) = turns.lock().pop_front()
+                            && let Some(sql) = turn.sql
+                        {
+                            collector.record(
+                                &sql,
+                                turn.started.elapsed(),
+                                outcome.ok,
+                                outcome.rows,
+                            );
                         }
                     }
                     outcome = ResponseOutcome { ok: true, rows: 0 };
@@ -1374,10 +1374,10 @@ fn pg_select_pool<'a>(
     if state.in_transaction {
         return primary;
     }
-    if let Some(sticky_until) = state.sticky_until {
-        if std::time::Instant::now() < sticky_until {
-            return primary;
-        }
+    if let Some(sticky_until) = state.sticky_until
+        && std::time::Instant::now() < sticky_until
+    {
+        return primary;
     }
     if matches!(kind, PgQueryKind::Read) {
         let idx = replica_rr.fetch_add(1, Ordering::Relaxed) % replicas.len();

--- a/crates/ephpm-e2e/tests/cluster.rs
+++ b/crates/ephpm-e2e/tests/cluster.rs
@@ -196,16 +196,14 @@ async fn cluster_nodes_discover_each_other() {
                 l.contains("ephpm_cluster_nodes") && !l.starts_with('#')
             }) {
                 // Parse the gauge value (last token on the line).
-                if let Some(val_str) = line.split_whitespace().last() {
-                    if let Ok(count) = val_str.parse::<f64>() {
-                        if (count as usize) < expected {
-                            last_error = format!(
-                                "node {i}: ephpm_cluster_nodes = {count}, want >= {expected}"
-                            );
-                            all_converged = false;
-                            break;
-                        }
-                    }
+                if let Some(val_str) = line.split_whitespace().last()
+                    && let Ok(count) = val_str.parse::<f64>()
+                    && (count as usize) < expected
+                {
+                    last_error =
+                        format!("node {i}: ephpm_cluster_nodes = {count}, want >= {expected}");
+                    all_converged = false;
+                    break;
                 }
             }
         }

--- a/crates/ephpm-kv/src/command.rs
+++ b/crates/ephpm-kv/src/command.rs
@@ -132,7 +132,7 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
             Frame::Array(results)
         }
         "MSET" => {
-            if argv.len() < 2 || argv.len() % 2 != 0 {
+            if argv.len() < 2 || !argv.len().is_multiple_of(2) {
                 return Frame::error("ERR wrong number of arguments for 'mset' command");
             }
             for pair in argv.chunks(2) {
@@ -334,7 +334,7 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
 
         // ── Hash operations ──────────────────────────────────────
         "HSET" => {
-            if argv.len() < 3 || argv.len() % 2 == 0 {
+            if argv.len() < 3 || argv.len().is_multiple_of(2) {
                 return Frame::error("ERR wrong number of arguments for 'hset' command");
             }
             let key = str_from(argv[0]);
@@ -441,10 +441,10 @@ fn cmd_set(store: &Arc<Store>, argv: &[&[u8]]) -> Frame {
                 if i + 1 >= argv.len() {
                     return Frame::error("ERR syntax error");
                 }
-                if let Ok(sec) = parse_i64(argv[i + 1]) {
-                    if sec > 0 {
-                        ttl = Some(Duration::from_secs(u64::try_from(sec).unwrap_or(u64::MAX)));
-                    }
+                if let Ok(sec) = parse_i64(argv[i + 1])
+                    && sec > 0
+                {
+                    ttl = Some(Duration::from_secs(u64::try_from(sec).unwrap_or(u64::MAX)));
                 }
                 i += 2;
             }
@@ -452,10 +452,10 @@ fn cmd_set(store: &Arc<Store>, argv: &[&[u8]]) -> Frame {
                 if i + 1 >= argv.len() {
                     return Frame::error("ERR syntax error");
                 }
-                if let Ok(ms) = parse_i64(argv[i + 1]) {
-                    if ms > 0 {
-                        ttl = Some(Duration::from_millis(u64::try_from(ms).unwrap_or(u64::MAX)));
-                    }
+                if let Ok(ms) = parse_i64(argv[i + 1])
+                    && ms > 0
+                {
+                    ttl = Some(Duration::from_millis(u64::try_from(ms).unwrap_or(u64::MAX)));
                 }
                 i += 2;
             }

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -613,10 +613,10 @@ impl Store {
         // entry() lock below is fine — the locked check below catches
         // it; the peek just saves an unnecessary `ensure_memory` call
         // for the common "already taken" case.
-        if let Some(existing) = self.data.get(&key) {
-            if !existing.is_expired() {
-                return false;
-            }
+        if let Some(existing) = self.data.get(&key)
+            && !existing.is_expired()
+        {
+            return false;
         }
 
         // Build the candidate entry first so we can compute its size

--- a/crates/ephpm-middleware-builtins/src/jwt.rs
+++ b/crates/ephpm-middleware-builtins/src/jwt.rs
@@ -42,10 +42,11 @@ pub struct Jwt {
 /// with nothing after it yields the empty string (= missing token).
 fn strip_bearer(value: &str) -> &str {
     let trimmed = value.trim();
-    if let (Some(scheme), Some(rest)) = (trimmed.get(..6), trimmed.get(6..)) {
-        if scheme.eq_ignore_ascii_case("bearer") && (rest.is_empty() || rest.starts_with(' ')) {
-            return rest.trim_start();
-        }
+    if let (Some(scheme), Some(rest)) = (trimmed.get(..6), trimmed.get(6..))
+        && scheme.eq_ignore_ascii_case("bearer")
+        && (rest.is_empty() || rest.starts_with(' '))
+    {
+        return rest.trim_start();
     }
     trimmed
 }
@@ -87,15 +88,15 @@ impl Jwt {
         if exp <= now {
             return None;
         }
-        if let Some(nbf) = claims.get("nbf") {
-            if numeric_date(nbf)? > now {
-                return None;
-            }
+        if let Some(nbf) = claims.get("nbf")
+            && numeric_date(nbf)? > now
+        {
+            return None;
         }
-        if let Some(expected) = &self.issuer {
-            if claims.get("iss").and_then(serde_json::Value::as_str) != Some(expected.as_str()) {
-                return None;
-            }
+        if let Some(expected) = &self.issuer
+            && claims.get("iss").and_then(serde_json::Value::as_str) != Some(expected.as_str())
+        {
+            return None;
         }
         if let Some(expected) = &self.audience {
             let ok = match claims.get("aud") {

--- a/crates/ephpm-php/build.rs
+++ b/crates/ephpm-php/build.rs
@@ -633,13 +633,13 @@ fn generate_bindings(include_dir: &Path, target_os: &str) {
 /// install locations on Debian/Ubuntu.
 fn find_clang_resource_include() -> Option<PathBuf> {
     // Try clang --print-resource-dir
-    if let Ok(output) = Command::new("clang").arg("--print-resource-dir").output() {
-        if output.status.success() {
-            let dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let include = PathBuf::from(&dir).join("include");
-            if include.join("stddef.h").exists() {
-                return Some(include);
-            }
+    if let Ok(output) = Command::new("clang").arg("--print-resource-dir").output()
+        && output.status.success()
+    {
+        let dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let include = PathBuf::from(&dir).join("include");
+        if include.join("stddef.h").exists() {
+            return Some(include);
         }
     }
 

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1492,10 +1492,9 @@ async fn serve_http_redirect(stream: TcpStream, remote_addr: SocketAddr, setting
         .timer(hyper_util::rt::TokioTimer::new())
         .serve_connection(io, service)
         .await
+        && !err.is_incomplete_message()
     {
-        if !err.is_incomplete_message() {
-            tracing::debug!(%remote_addr, %err, "redirect connection error");
-        }
+        tracing::debug!(%remote_addr, %err, "redirect connection error");
     }
 }
 
@@ -1989,15 +1988,16 @@ fn wire_per_site_db(
 ) -> anyhow::Result<Option<site_wire_auth::SiteWireAuth>> {
     // A multi-site + clustered SQLite config cannot get per-site isolation
     // yet: warn rather than silently pretend it is isolated.
-    if let Some(sqlite) = &config.db.sqlite {
-        if config.server.sites_dir.is_some() && is_clustered_sqlite(sqlite, cluster_enabled) {
-            tracing::warn!(
-                "[db.sqlite] multi-site mode ([server] sites_dir) combined with clustered \
+    if let Some(sqlite) = &config.db.sqlite
+        && config.server.sites_dir.is_some()
+        && is_clustered_sqlite(sqlite, cluster_enabled)
+    {
+        tracing::warn!(
+            "[db.sqlite] multi-site mode ([server] sites_dir) combined with clustered \
                  replication does NOT get per-site database isolation — all virtual hosts share \
                  the clustered database. Per-site isolation is single-node only. Run single-node \
                  for isolated per-tenant databases, or accept a shared database in clustered mode."
-            );
-        }
+        );
     }
 
     if !is_per_site_sqlite(config, cluster_enabled) {

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -201,10 +201,10 @@ impl MiddlewareChain {
         let mut response_headers: Vec<(String, String)> = Vec::new();
 
         for module in &self.modules {
-            if let Some(pattern) = &module.match_pattern {
-                if !path_matches(pattern, path) {
-                    continue;
-                }
+            if let Some(pattern) = &module.match_pattern
+                && !path_matches(pattern, path)
+            {
+                continue;
             }
 
             let verdict = match &module.backend {
@@ -389,10 +389,10 @@ fn resolve_library(library: &str) -> anyhow::Result<PathBuf> {
     ];
 
     let mut dirs = vec![PathBuf::from(".")];
-    if let Ok(dir) = std::env::var("EPHPM_MIDDLEWARE_DIR") {
-        if !dir.is_empty() {
-            dirs.push(PathBuf::from(dir));
-        }
+    if let Ok(dir) = std::env::var("EPHPM_MIDDLEWARE_DIR")
+        && !dir.is_empty()
+    {
+        dirs.push(PathBuf::from(dir));
     }
     dirs.push(PathBuf::from("/usr/local/lib/ephpm/middleware"));
 

--- a/crates/ephpm-server/src/privdrop.rs
+++ b/crates/ephpm-server/src/privdrop.rs
@@ -196,16 +196,16 @@ fn chown_runtime_dirs(config: &Config, uid: u32, gid: u32) -> anyhow::Result<()>
     }
 
     // ACME certificate cache: rustls-acme writes renewed certs here at runtime.
-    if let Some(tls) = config.server.tls.as_ref() {
-        if tls.is_acme() {
-            let dir = &tls.cache_dir;
-            // start_acme already created it during bind; create_dir_all is a
-            // harmless idempotent guard.
-            std::fs::create_dir_all(dir)
-                .with_context(|| format!("failed to create ACME cache dir {}", dir.display()))?;
-            chown_tree(dir, uid, gid)
-                .with_context(|| format!("failed to chown ACME cache dir {}", dir.display()))?;
-        }
+    if let Some(tls) = config.server.tls.as_ref()
+        && tls.is_acme()
+    {
+        let dir = &tls.cache_dir;
+        // start_acme already created it during bind; create_dir_all is a
+        // harmless idempotent guard.
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create ACME cache dir {}", dir.display()))?;
+        chown_tree(dir, uid, gid)
+            .with_context(|| format!("failed to chown ACME cache dir {}", dir.display()))?;
     }
 
     Ok(())

--- a/crates/ephpm-server/src/rate_limit.rs
+++ b/crates/ephpm-server/src/rate_limit.rs
@@ -172,10 +172,10 @@ pub struct ConnectionGuard {
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         self.limiter.global_connections.fetch_sub(1, Ordering::Relaxed);
-        if self.counted {
-            if let Some(state) = self.limiter.per_ip.get(&self.ip) {
-                state.connections.fetch_sub(1, Ordering::Relaxed);
-            }
+        if self.counted
+            && let Some(state) = self.limiter.per_ip.get(&self.ip)
+        {
+            state.connections.fetch_sub(1, Ordering::Relaxed);
         }
     }
 }

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -574,10 +574,9 @@ fn build_ingest_strip_headers(mounts: &[MiddlewareMount]) -> Vec<String> {
             .as_ref()
             .and_then(|c| c.get("claims_header"))
             .and_then(serde_json::Value::as_str)
+            && !name.is_empty()
         {
-            if !name.is_empty() {
-                names.push(name.to_ascii_lowercase());
-            }
+            names.push(name.to_ascii_lowercase());
         }
     }
     names.sort_unstable();
@@ -1401,16 +1400,16 @@ impl Router {
         // Check the startup-scanned registry first for each candidate key.
         // Verify the directory still exists — it may have been removed (teardown).
         for key in lookup_keys {
-            if let Some(site) = self.sites.get(*key) {
-                if site.document_root.is_dir() {
-                    return ResolvedSite {
-                        key: Some((*key).to_string()),
-                        document_root: site.document_root.clone(),
-                        index_files: &site.index_files,
-                        websocket_files: &site.websocket_files,
-                        fallback: &site.fallback,
-                    };
-                }
+            if let Some(site) = self.sites.get(*key)
+                && site.document_root.is_dir()
+            {
+                return ResolvedSite {
+                    key: Some((*key).to_string()),
+                    document_root: site.document_root.clone(),
+                    index_files: &site.index_files,
+                    websocket_files: &site.websocket_files,
+                    fallback: &site.fallback,
+                };
             }
         }
 
@@ -1745,10 +1744,10 @@ impl Router {
         // raw IP, so a `Host`-gated probe would 421 and the pod would never
         // become ready.
         if method_ref == hyper::Method::GET {
-            if let Some(ref handle) = self.metrics_handle {
-                if uri_path == self.metrics_path {
-                    return Ok((metrics::render(handle), "metrics"));
-                }
+            if let Some(ref handle) = self.metrics_handle
+                && uri_path == self.metrics_path
+            {
+                return Ok((metrics::render(handle), "metrics"));
             }
 
             // Liveness probe — always 200 if the server is running.
@@ -1765,10 +1764,10 @@ impl Router {
             // the ring buffer as JSON, newest first. Only mounted when the
             // timeline is enabled — when disabled, the path deliberately
             // falls through and behaves like any other unknown /_ephpm/ path.
-            if uri_path == "/_ephpm/requests" {
-                if let Some(ref log) = self.request_log {
-                    return Ok((json_response_owned(StatusCode::OK, log.to_json()), "diagnostics"));
-                }
+            if uri_path == "/_ephpm/requests"
+                && let Some(ref log) = self.request_log
+            {
+                return Ok((json_response_owned(StatusCode::OK, log.to_json()), "diagnostics"));
             }
         }
 
@@ -1842,28 +1841,28 @@ impl Router {
         // With `[server.websocket]` disabled this is one `Option::is_none()`
         // and an upgrade request routes exactly as it did before the feature
         // existed.
-        if let Some(ref runtime) = self.websocket {
-            if crate::websocket::is_upgrade_request(&req) {
-                let mut resp = self
-                    .handle_websocket_upgrade(
-                        req,
-                        runtime,
-                        effective_addr,
-                        is_https,
-                        &site_root,
-                        site_websocket_files,
-                        site_key,
-                    )
-                    .await;
-                // Configured response headers belong on the error paths (404 /
-                // 400 / 503) but not on a 101 — a Switching Protocols response
-                // hands the socket over, and anything appended to it is bytes
-                // the client will read as WebSocket framing.
-                if resp.status() != StatusCode::SWITCHING_PROTOCOLS {
-                    self.apply_response_headers(&mut resp);
-                }
-                return Ok((resp, "websocket"));
+        if let Some(ref runtime) = self.websocket
+            && crate::websocket::is_upgrade_request(&req)
+        {
+            let mut resp = self
+                .handle_websocket_upgrade(
+                    req,
+                    runtime,
+                    effective_addr,
+                    is_https,
+                    &site_root,
+                    site_websocket_files,
+                    site_key,
+                )
+                .await;
+            // Configured response headers belong on the error paths (404 /
+            // 400 / 503) but not on a 101 — a Switching Protocols response
+            // hands the socket over, and anything appended to it is bytes
+            // the client will read as WebSocket framing.
+            if resp.status() != StatusCode::SWITCHING_PROTOCOLS {
+                self.apply_response_headers(&mut resp);
             }
+            return Ok((resp, "websocket"));
         }
 
         // Extract If-None-Match for ETag support before consuming the request.
@@ -1890,26 +1889,24 @@ impl Router {
                             && self.php_etag_cache_config.enabled;
 
                         // Pre-check: bypass PHP if client's ETag matches stored value.
-                        if is_cacheable {
-                            if let Some(client_tag) = &if_none_match {
-                                let key = php_etag_cache_key(
-                                    &self.php_etag_cache_config.key_prefix,
-                                    method,
-                                    &uri_path,
-                                    &query_string,
-                                );
-                                if let Some(stored) = self.store.get(&key) {
-                                    let stored_etag = String::from_utf8_lossy(&stored);
-                                    if etag_matches_value(&stored_etag, client_tag) {
-                                        return Ok((
-                                            Response::builder()
-                                                .status(StatusCode::NOT_MODIFIED)
-                                                .header("etag", stored_etag.as_ref())
-                                                .body(body::buffered(Full::new(Bytes::new())))
-                                                .expect("304 builder"),
-                                            "php",
-                                        ));
-                                    }
+                        if is_cacheable && let Some(client_tag) = &if_none_match {
+                            let key = php_etag_cache_key(
+                                &self.php_etag_cache_config.key_prefix,
+                                method,
+                                &uri_path,
+                                &query_string,
+                            );
+                            if let Some(stored) = self.store.get(&key) {
+                                let stored_etag = String::from_utf8_lossy(&stored);
+                                if etag_matches_value(&stored_etag, client_tag) {
+                                    return Ok((
+                                        Response::builder()
+                                            .status(StatusCode::NOT_MODIFIED)
+                                            .header("etag", stored_etag.as_ref())
+                                            .body(body::buffered(Full::new(Bytes::new())))
+                                            .expect("304 builder"),
+                                        "php",
+                                    ));
                                 }
                             }
                         }
@@ -1930,26 +1927,25 @@ impl Router {
                             .await;
 
                         // Post-store: cache any ETag PHP set in the response.
-                        if is_cacheable {
-                            if let Some(etag_val) =
+                        if is_cacheable
+                            && let Some(etag_val) =
                                 resp.headers().get("etag").and_then(|v| v.to_str().ok())
-                            {
-                                let key = php_etag_cache_key(
-                                    &self.php_etag_cache_config.key_prefix,
-                                    method,
-                                    &uri_path,
-                                    &query_string,
-                                );
-                                #[allow(clippy::cast_sign_loss)]
-                                let ttl = if self.php_etag_cache_config.ttl_secs > 0 {
-                                    Some(Duration::from_secs(
-                                        self.php_etag_cache_config.ttl_secs as u64,
-                                    ))
-                                } else {
-                                    None
-                                };
-                                self.store.set(key, etag_val.as_bytes().to_vec(), ttl);
-                            }
+                        {
+                            let key = php_etag_cache_key(
+                                &self.php_etag_cache_config.key_prefix,
+                                method,
+                                &uri_path,
+                                &query_string,
+                            );
+                            #[allow(clippy::cast_sign_loss)]
+                            let ttl = if self.php_etag_cache_config.ttl_secs > 0 {
+                                Some(Duration::from_secs(
+                                    self.php_etag_cache_config.ttl_secs as u64,
+                                ))
+                            } else {
+                                None
+                            };
+                            self.store.set(key, etag_val.as_bytes().to_vec(), ttl);
                         }
 
                         (resp, "php")
@@ -2344,17 +2340,16 @@ impl Router {
         // Keyed by the canonical site key `resolve_site` returned, NEVER
         // re-derived from the Host header (issues #290/#291). No key
         // (unmatched host, or single-site mode) = no per-site cap.
-        if let (Some(limiter), Some(key)) = (self.limiter.as_deref(), site_key.as_deref()) {
-            if !limiter.check_site_rate(key) {
-                counter!("ephpm_site_rate_limited_total").increment(1);
-                let retry_after = limiter.site_retry_after_secs();
-                let mut resp =
-                    error_response(StatusCode::TOO_MANY_REQUESTS, "429 Too Many Requests");
-                if let Ok(value) = hyper::header::HeaderValue::from_str(&retry_after.to_string()) {
-                    resp.headers_mut().insert(hyper::header::RETRY_AFTER, value);
-                }
-                return resp;
+        if let (Some(limiter), Some(key)) = (self.limiter.as_deref(), site_key.as_deref())
+            && !limiter.check_site_rate(key)
+        {
+            counter!("ephpm_site_rate_limited_total").increment(1);
+            let retry_after = limiter.site_retry_after_secs();
+            let mut resp = error_response(StatusCode::TOO_MANY_REQUESTS, "429 Too Many Requests");
+            if let Ok(value) = hyper::header::HeaderValue::from_str(&retry_after.to_string()) {
+                resp.headers_mut().insert(hyper::header::RETRY_AFTER, value);
             }
+            return resp;
         }
 
         let method = req.method().to_string();
@@ -2382,10 +2377,10 @@ impl Router {
         // `[server.request] max_body_size` on top would silently cap WebSocket
         // messages at the HTTP body limit — two unrelated knobs, one of which
         // the operator did not think they were setting.
-        if ws_event.is_none() {
-            if let Some(resp) = self.check_body_size(&req) {
-                return resp;
-            }
+        if ws_event.is_none()
+            && let Some(resp) = self.check_body_size(&req)
+        {
+            return resp;
         }
 
         let server_port = self.server_port;
@@ -2518,13 +2513,13 @@ impl Router {
             // the truncated body, the request as sent was over the limit — the
             // client gets a 413, exactly as the Content-Length pre-check would
             // have produced.
-            if let Some(flag) = body_overflow {
-                if flag.load(std::sync::atomic::Ordering::Acquire) {
-                    return apply_response_headers(
-                        error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large"),
-                        &mw_response_headers,
-                    );
-                }
+            if let Some(flag) = body_overflow
+                && flag.load(std::sync::atomic::Ordering::Acquire)
+            {
+                return apply_response_headers(
+                    error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large"),
+                    &mw_response_headers,
+                );
             }
             return apply_response_headers(resp, &mw_response_headers);
         }
@@ -3250,13 +3245,13 @@ impl Router {
         // Worker mode: not ready until at least one worker has booted its
         // framework and reached take_request() — prevents load balancers from
         // routing before the framework is up (design §4.5).
-        if let Some(pool) = &self.worker_pool {
-            if pool.ready_count() == 0 {
-                return json_response(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    r#"{"status":"not_ready","reason":"no worker has finished booting"}"#,
-                );
-            }
+        if let Some(pool) = &self.worker_pool
+            && pool.ready_count() == 0
+        {
+            return json_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                r#"{"status":"not_ready","reason":"no worker has finished booting"}"#,
+            );
         }
         // A configured SQL proxy that has never reached its upstream cannot
         // serve a single query — the process must stay out of rotation and a
@@ -3310,10 +3305,10 @@ impl Router {
     /// the (typically 1-3 element) proxy chain on this per-request path.
     fn resolve_xff(&self, xff: &str) -> Option<IpAddr> {
         for ip_str in xff.rsplit(',') {
-            if let Ok(ip) = ip_str.trim().parse::<IpAddr>() {
-                if !self.is_trusted_proxy(ip) {
-                    return Some(ip);
-                }
+            if let Ok(ip) = ip_str.trim().parse::<IpAddr>()
+                && !self.is_trusted_proxy(ip)
+            {
+                return Some(ip);
             }
         }
         // All IPs in the chain are trusted (or unparseable) — use the leftmost.
@@ -3737,17 +3732,17 @@ struct PerSiteDbWire {
 /// pointing at the proxy listener. PHP frameworks auto-discover these.
 fn build_db_env_vars(config: &Config) -> Vec<(String, String)> {
     // MySQL takes precedence (most common for PHP).
-    if let Some(ref mysql) = config.db.mysql {
-        if mysql.inject_env {
-            let listen = mysql.listen.as_deref().unwrap_or("127.0.0.1:3306");
-            return db_env_from_url(listen, &mysql.url, "mysql");
-        }
+    if let Some(ref mysql) = config.db.mysql
+        && mysql.inject_env
+    {
+        let listen = mysql.listen.as_deref().unwrap_or("127.0.0.1:3306");
+        return db_env_from_url(listen, &mysql.url, "mysql");
     }
-    if let Some(ref pg) = config.db.postgres {
-        if pg.inject_env {
-            let listen = pg.listen.as_deref().unwrap_or("127.0.0.1:5432");
-            return db_env_from_url(listen, &pg.url, "pgsql");
-        }
+    if let Some(ref pg) = config.db.postgres
+        && pg.inject_env
+    {
+        let listen = pg.listen.as_deref().unwrap_or("127.0.0.1:5432");
+        return db_env_from_url(listen, &pg.url, "pgsql");
     }
     Vec::new()
 }

--- a/crates/ephpm-server/src/static_files.rs
+++ b/crates/ephpm-server/src/static_files.rs
@@ -50,14 +50,11 @@ pub async fn serve_file(
 
     // Try the file cache first. Returns `None` for metadata-only entries
     // (large files without inlined content) so we fall through to streaming.
-    if let Some(cache) = file_cache {
-        if let Some(entry) = cache.lookup(&canonical_file).await {
-            if let Some(resp) =
-                serve_cached_entry(entry, accepts_gzip, cache_control, if_none_match)
-            {
-                return resp;
-            }
-        }
+    if let Some(cache) = file_cache
+        && let Some(entry) = cache.lookup(&canonical_file).await
+        && let Some(resp) = serve_cached_entry(entry, accepts_gzip, cache_control, if_none_match)
+    {
+        return resp;
     }
 
     // Check file size — stream large files instead of reading into memory.
@@ -83,72 +80,70 @@ pub async fn serve_file(
 
     // Insert into cache if enabled. For small files (which are inlined),
     // serve directly from the cache entry.
-    if let Some(cache) = file_cache {
-        if let Ok(mtime) = metadata.modified() {
-            let entry = cache.insert(&canonical_file, &content, mtime, mime, compression);
-            if let Some(resp) =
-                serve_cached_entry(entry, accepts_gzip, cache_control, if_none_match)
-            {
-                return resp;
-            }
+    if let Some(cache) = file_cache
+        && let Ok(mtime) = metadata.modified()
+    {
+        let entry = cache.insert(&canonical_file, &content, mtime, mime, compression);
+        if let Some(resp) = serve_cached_entry(entry, accepts_gzip, cache_control, if_none_match) {
+            return resp;
         }
     }
 
     // Uncached path — compute ETag from content hash.
     let etag_value = if etag { Some(compute_etag(&content)) } else { None };
 
-    if let (Some(tag), Some(client_tag)) = (&etag_value, if_none_match) {
-        if etag_matches(tag, client_tag) {
-            let mut builder = Response::builder().status(StatusCode::NOT_MODIFIED);
-            builder = builder.header("ETag", tag.as_str());
-            if !cache_control.is_empty() {
-                builder = builder.header("Cache-Control", cache_control);
-            }
-            return builder
-                .body(body::buffered(Full::new(Bytes::new())))
-                .unwrap_or_else(|_| internal_error());
+    if let (Some(tag), Some(client_tag)) = (&etag_value, if_none_match)
+        && etag_matches(tag, client_tag)
+    {
+        let mut builder = Response::builder().status(StatusCode::NOT_MODIFIED);
+        builder = builder.header("ETag", tag.as_str());
+        if !cache_control.is_empty() {
+            builder = builder.header("Cache-Control", cache_control);
         }
+        return builder
+            .body(body::buffered(Full::new(Bytes::new())))
+            .unwrap_or_else(|_| internal_error());
     }
 
     // Prefer Brotli over gzip — better compression ratio for text assets.
-    if accepts_br {
-        if let Some(compressed) = crate::router::brotli_compress(&content, mime, compression) {
-            let mut builder = Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", mime)
-                .header("Content-Length", compressed.len())
-                .header("Content-Encoding", "br")
-                .header("Vary", "Accept-Encoding");
-            if !cache_control.is_empty() {
-                builder = builder.header("Cache-Control", cache_control);
-            }
-            if let Some(ref tag) = etag_value {
-                builder = builder.header("ETag", tag.as_str());
-            }
-            return builder
-                .body(body::buffered(Full::new(Bytes::from(compressed))))
-                .unwrap_or_else(|_| internal_error());
+    if accepts_br
+        && let Some(compressed) = crate::router::brotli_compress(&content, mime, compression)
+    {
+        let mut builder = Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", mime)
+            .header("Content-Length", compressed.len())
+            .header("Content-Encoding", "br")
+            .header("Vary", "Accept-Encoding");
+        if !cache_control.is_empty() {
+            builder = builder.header("Cache-Control", cache_control);
         }
+        if let Some(ref tag) = etag_value {
+            builder = builder.header("ETag", tag.as_str());
+        }
+        return builder
+            .body(body::buffered(Full::new(Bytes::from(compressed))))
+            .unwrap_or_else(|_| internal_error());
     }
 
-    if accepts_gzip {
-        if let Some(compressed) = crate::router::gzip_compress(&content, mime, compression) {
-            let mut builder = Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", mime)
-                .header("Content-Length", compressed.len())
-                .header("Content-Encoding", "gzip")
-                .header("Vary", "Accept-Encoding");
-            if !cache_control.is_empty() {
-                builder = builder.header("Cache-Control", cache_control);
-            }
-            if let Some(ref tag) = etag_value {
-                builder = builder.header("ETag", tag.as_str());
-            }
-            return builder
-                .body(body::buffered(Full::new(Bytes::from(compressed))))
-                .unwrap_or_else(|_| internal_error());
+    if accepts_gzip
+        && let Some(compressed) = crate::router::gzip_compress(&content, mime, compression)
+    {
+        let mut builder = Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", mime)
+            .header("Content-Length", compressed.len())
+            .header("Content-Encoding", "gzip")
+            .header("Vary", "Accept-Encoding");
+        if !cache_control.is_empty() {
+            builder = builder.header("Cache-Control", cache_control);
         }
+        if let Some(ref tag) = etag_value {
+            builder = builder.header("ETag", tag.as_str());
+        }
+        return builder
+            .body(body::buffered(Full::new(Bytes::from(compressed))))
+            .unwrap_or_else(|_| internal_error());
     }
 
     let mut builder = Response::builder()
@@ -178,40 +173,38 @@ fn serve_cached_entry(
     if_none_match: Option<&str>,
 ) -> Option<Response<ServerBody>> {
     // ETag check — works even for metadata-only entries.
-    if let Some(client_tag) = if_none_match {
-        if etag_matches(&entry.etag, client_tag) {
-            let mut builder = Response::builder().status(StatusCode::NOT_MODIFIED);
-            builder = builder.header("ETag", entry.etag.as_str());
-            if !cache_control.is_empty() {
-                builder = builder.header("Cache-Control", cache_control);
-            }
-            return Some(
-                builder
-                    .body(body::buffered(Full::new(Bytes::new())))
-                    .unwrap_or_else(|_| internal_error()),
-            );
+    if let Some(client_tag) = if_none_match
+        && etag_matches(&entry.etag, client_tag)
+    {
+        let mut builder = Response::builder().status(StatusCode::NOT_MODIFIED);
+        builder = builder.header("ETag", entry.etag.as_str());
+        if !cache_control.is_empty() {
+            builder = builder.header("Cache-Control", cache_control);
         }
+        return Some(
+            builder
+                .body(body::buffered(Full::new(Bytes::new())))
+                .unwrap_or_else(|_| internal_error()),
+        );
     }
 
     // Serve pre-compressed gzip variant if available.
-    if accepts_gzip {
-        if let Some(ref gzip) = entry.gzip_content {
-            let mut builder = Response::builder()
-                .status(StatusCode::OK)
-                .header("Content-Type", entry.mime.as_str())
-                .header("Content-Length", gzip.len())
-                .header("Content-Encoding", "gzip")
-                .header("Vary", "Accept-Encoding")
-                .header("ETag", entry.etag.as_str());
-            if !cache_control.is_empty() {
-                builder = builder.header("Cache-Control", cache_control);
-            }
-            return Some(
-                builder
-                    .body(body::buffered(Full::new(gzip.clone())))
-                    .unwrap_or_else(|_| internal_error()),
-            );
+    if accepts_gzip && let Some(ref gzip) = entry.gzip_content {
+        let mut builder = Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", entry.mime.as_str())
+            .header("Content-Length", gzip.len())
+            .header("Content-Encoding", "gzip")
+            .header("Vary", "Accept-Encoding")
+            .header("ETag", entry.etag.as_str());
+        if !cache_control.is_empty() {
+            builder = builder.header("Cache-Control", cache_control);
         }
+        return Some(
+            builder
+                .body(body::buffered(Full::new(gzip.clone())))
+                .unwrap_or_else(|_| internal_error()),
+        );
     }
 
     // Serve from cached content if inlined.
@@ -260,17 +253,17 @@ async fn serve_streamed(
     });
 
     // ETag check.
-    if let (Some(tag), Some(client_tag)) = (&etag_value, if_none_match) {
-        if etag_matches(tag, client_tag) {
-            let mut builder = Response::builder().status(StatusCode::NOT_MODIFIED);
-            builder = builder.header("ETag", tag.as_str());
-            if !cache_control.is_empty() {
-                builder = builder.header("Cache-Control", cache_control);
-            }
-            return builder
-                .body(body::buffered(Full::new(Bytes::new())))
-                .unwrap_or_else(|_| internal_error());
+    if let (Some(tag), Some(client_tag)) = (&etag_value, if_none_match)
+        && etag_matches(tag, client_tag)
+    {
+        let mut builder = Response::builder().status(StatusCode::NOT_MODIFIED);
+        builder = builder.header("ETag", tag.as_str());
+        if !cache_control.is_empty() {
+            builder = builder.header("Cache-Control", cache_control);
         }
+        return builder
+            .body(body::buffered(Full::new(Bytes::new())))
+            .unwrap_or_else(|_| internal_error());
     }
 
     let Ok(file) = tokio::fs::File::open(path).await else {

--- a/crates/ephpm-server/src/websocket.rs
+++ b/crates/ephpm-server/src/websocket.rs
@@ -127,15 +127,15 @@ impl WsRuntime {
 
         let ping_interval = non_zero_secs(config.ping_interval_secs);
         let idle_timeout = non_zero_secs(config.idle_timeout_secs);
-        if let (Some(ping), Some(idle)) = (ping_interval, idle_timeout) {
-            if ping >= idle {
-                tracing::warn!(
-                    ping_interval_secs = config.ping_interval_secs,
-                    idle_timeout_secs = config.idle_timeout_secs,
-                    "[server.websocket] ping_interval_secs >= idle_timeout_secs — idle \
+        if let (Some(ping), Some(idle)) = (ping_interval, idle_timeout)
+            && ping >= idle
+        {
+            tracing::warn!(
+                ping_interval_secs = config.ping_interval_secs,
+                idle_timeout_secs = config.idle_timeout_secs,
+                "[server.websocket] ping_interval_secs >= idle_timeout_secs — idle \
                      connections will be closed before a ping can refresh them"
-                );
-            }
+            );
         }
 
         tracing::info!(
@@ -449,16 +449,16 @@ pub(crate) async fn run_session(
             }
 
             _ = ticker.tick() => {
-                if let Some(idle) = runtime.idle_timeout {
-                    if last_rx.elapsed() >= idle {
-                        tracing::debug!(
-                            conn = %session.connection_id,
-                            idle_secs = idle.as_secs(),
-                            "closing idle websocket connection"
-                        );
-                        closing = Some(CLOSE_GOING_AWAY);
-                        break;
-                    }
+                if let Some(idle) = runtime.idle_timeout
+                    && last_rx.elapsed() >= idle
+                {
+                    tracing::debug!(
+                        conn = %session.connection_id,
+                        idle_secs = idle.as_secs(),
+                        "closing idle websocket connection"
+                    );
+                    closing = Some(CLOSE_GOING_AWAY);
+                    break;
                 }
                 // A failed ping means the socket is already gone; stop rather
                 // than waiting for the read half to notice.

--- a/crates/ephpm-server/tests/turso_cdc_cluster_integration.rs
+++ b/crates/ephpm-server/tests/turso_cdc_cluster_integration.rs
@@ -248,10 +248,10 @@ async fn wait_for_non_empty_replica_url(
     loop {
         {
             let role = rx.borrow().clone();
-            if let ElectedRole::Replica { primary_grpc_url } = &role {
-                if !primary_grpc_url.is_empty() {
-                    return Some(primary_grpc_url.clone());
-                }
+            if let ElectedRole::Replica { primary_grpc_url } = &role
+                && !primary_grpc_url.is_empty()
+            {
+                return Some(primary_grpc_url.clone());
             }
         }
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/crates/ephpm-ws/src/registry.rs
+++ b/crates/ephpm-ws/src/registry.rs
@@ -452,10 +452,10 @@ impl Registry {
             // is the authority. A connection that vanished mid-broadcast, or
             // (impossibly, but checked anyway) one whose site no longer
             // matches, is skipped rather than trusted.
-            if let Some(entry) = self.scoped(site, &id) {
-                if self.enqueue(&entry, frame.clone()) {
-                    delivered += 1;
-                }
+            if let Some(entry) = self.scoped(site, &id)
+                && self.enqueue(&entry, frame.clone())
+            {
+                delivered += 1;
             }
         }
         delivered

--- a/crates/ephpm/build.rs
+++ b/crates/ephpm/build.rs
@@ -130,19 +130,19 @@ fn main() {
         // Ask the active Apple clang for its resource dir and link the
         // builtins archive explicitly. Harmless when no object references
         // the symbol (8.3/8.4 SDKs) — ld64 dead-strips it.
-        if let Ok(out) = Command::new("cc").arg("--print-resource-dir").output() {
-            if out.status.success() {
-                let resource_dir = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                let builtins = Path::new(&resource_dir).join("lib/darwin/libclang_rt.osx.a");
-                if builtins.exists() {
-                    println!("cargo::rustc-link-arg={}", builtins.display());
-                } else {
-                    println!(
-                        "cargo::warning=libclang_rt.osx.a not found under {resource_dir}; \
+        if let Ok(out) = Command::new("cc").arg("--print-resource-dir").output()
+            && out.status.success()
+        {
+            let resource_dir = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let builtins = Path::new(&resource_dir).join("lib/darwin/libclang_rt.osx.a");
+            if builtins.exists() {
+                println!("cargo::rustc-link-arg={}", builtins.display());
+            } else {
+                println!(
+                    "cargo::warning=libclang_rt.osx.a not found under {resource_dir}; \
                          linking may fail with undefined __isPlatformVersionAtLeast \
                          (PHP 8.5 SDK sqlite @available guards)"
-                    );
-                }
+                );
             }
         }
         return;

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -458,13 +458,11 @@ fn read_listen_address(config: &Path) -> Option<String> {
             in_server = rest.starts_with("server]");
             continue;
         }
-        if in_server {
-            if let Some(value) = trimmed.strip_prefix("listen") {
-                let value = value.trim_start().trim_start_matches('=').trim();
-                let value = value.trim_matches('"').trim_matches('\'');
-                if !value.is_empty() {
-                    return Some(value.to_string());
-                }
+        if in_server && let Some(value) = trimmed.strip_prefix("listen") {
+            let value = value.trim_start().trim_start_matches('=').trim();
+            let value = value.trim_matches('"').trim_matches('\'');
+            if !value.is_empty() {
+                return Some(value.to_string());
             }
         }
     }

--- a/xtask/src/cli_conformance.rs
+++ b/xtask/src/cli_conformance.rs
@@ -561,22 +561,23 @@ fn strip_versions(input: &[u8]) -> Vec<u8> {
     let mut i = 0;
     while i < input.len() {
         // `(built: Jul 16 2026 18:56:38)` — replace the payload.
-        if input[i..].starts_with(b"(built: ") {
-            if let Some(close) = input[i..].iter().position(|&b| b == b')') {
-                out.extend_from_slice(b"(built: <DATE>)");
-                i += close + 1;
-                continue;
-            }
+        if input[i..].starts_with(b"(built: ")
+            && let Some(close) = input[i..].iter().position(|&b| b == b')')
+        {
+            out.extend_from_slice(b"(built: <DATE>)");
+            i += close + 1;
+            continue;
         }
         // A version token must not start mid-number: letters before it are
         // fine (`Zend Engine v4.5.7`), digits or dots are not.
         let at_boundary = i == 0 || (!input[i - 1].is_ascii_digit() && input[i - 1] != b'.');
-        if at_boundary && input[i].is_ascii_digit() {
-            if let Some(len) = match_version(&input[i..]) {
-                out.extend_from_slice(b"<VERSION>");
-                i += len;
-                continue;
-            }
+        if at_boundary
+            && input[i].is_ascii_digit()
+            && let Some(len) = match_version(&input[i..])
+        {
+            out.extend_from_slice(b"<VERSION>");
+            i += len;
+            continue;
         }
         out.push(input[i]);
         i += 1;

--- a/xtask/src/doctor.rs
+++ b/xtask/src/doctor.rs
@@ -347,10 +347,11 @@ fn libclang_check_linux() -> Check {
         return check;
     }
     // Best-effort: ldconfig cache, then the Debian/Ubuntu llvm layout.
-    if let Ok(out) = Command::new("ldconfig").arg("-p").output() {
-        if out.status.success() && String::from_utf8_lossy(&out.stdout).contains("libclang") {
-            return Check::new("libclang", Status::Ok, "found via ldconfig -p");
-        }
+    if let Ok(out) = Command::new("ldconfig").arg("-p").output()
+        && out.status.success()
+        && String::from_utf8_lossy(&out.stdout).contains("libclang")
+    {
+        return Check::new("libclang", Status::Ok, "found via ldconfig -p");
     }
     if let Some(dir) = find_llvm_lib_dir() {
         return Check::new("libclang", Status::Ok, dir.display().to_string());

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -379,10 +379,10 @@ pub fn run(args: &[String]) -> ExitCode {
         if SKIP_SUITES.contains(&name.as_str()) {
             continue;
         }
-        if let Some(only) = only_suite.as_deref() {
-            if name != only {
-                continue;
-            }
+        if let Some(only) = only_suite.as_deref()
+            && name != only
+        {
+            continue;
         }
         if CLUSTER_SUITES.contains(&name.as_str()) {
             cluster_suites.push((name, path));

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -83,10 +83,10 @@ Windows builds:
 /// Parse `--php-version <ver>` from args, defaulting to "8.5".
 fn parse_php_version(args: &[String]) -> &str {
     for (i, arg) in args.iter().enumerate() {
-        if arg == "--php-version" {
-            if let Some(ver) = args.get(i + 1) {
-                return ver;
-            }
+        if arg == "--php-version"
+            && let Some(ver) = args.get(i + 1)
+        {
+            return ver;
         }
     }
     "8.5"
@@ -1069,14 +1069,14 @@ PREV_REASON:.status.containerStatuses[*].lastState.terminated.reason",
     if let Ok(o) = out {
         let codes = String::from_utf8_lossy(&o.stdout);
         for tok in codes.split_whitespace() {
-            if let Ok(code) = tok.parse::<i64>() {
-                if let Some(sig) = decode_fatal_signal(code) {
-                    eprintln!(
-                        "!!! ephpm container exited {code} = {sig} — the SERVER UNDER TEST \
+            if let Ok(code) = tok.parse::<i64>()
+                && let Some(sig) = decode_fatal_signal(code)
+            {
+                eprintln!(
+                    "!!! ephpm container exited {code} = {sig} — the SERVER UNDER TEST \
 crashed; this is a server bug, not a test/infra flake. Check the 'previous \
 container' logs above for the last output before death."
-                    );
-                }
+                );
             }
         }
     }


### PR DESCRIPTION
**v0.7.1 — P0. Do not merge until after the v0.7.0 tag.** Deliberately split out of #309 (the dependency bump that moved the MSRV) because it is a large mechanical refactor through security-sensitive code and deserves its own review.

`clippy.toml` pinned `msrv = "1.85"` while the workspace `rust-version` is `1.88`. That gap is not cosmetic — clippy suppresses msrv-gated lints, so it was checking the tree against an older feature set than the toolchain is actually allowed to use. `collapsible_if` is the significant one: it only fires once let-chains are available, which happened in 1.88.

Raising `msrv` to 1.88 surfaced **61 sites — 59 `collapsible_if` and 2 `manual_is_multiple_of`** — across `xtask`, `ephpm-kv`, `ephpm-db`, `ephpm-cluster`, `ephpm-server`, `ephpm-middleware-builtins`, `ephpm-ws`, `ephpm-config`, `ephpm-php`, `ephpm`, and both `build.rs` files. All are collapsed here. `clippy.toml` now carries a note to keep the two versions in lockstep so the gap cannot silently reopen.

## Why this is safe

Every collapse is the same shape:

```rust
if let P = e { if c { B } }   ->   if let P = e && c { B }
```

`&&` short-circuits, so `c` is still only evaluated when the pattern matched, and in every case the inner `if` was the last statement in its block with **no `else`** — so the fall-through behavior is identical.

The transformations were produced by `cargo clippy --fix` (machine-applicable suggestions only), then `cargo +nightly fmt --all`, then **read hunk by hunk**. Two got individual scrutiny:

- **`ephpm-db/src/mysql.rs`, COM_STMT_CLOSE** — the collapsed condition calls `stmt_pool_map.remove()`, which has a *side effect*. Verified it still runs under exactly the same conditions: the `else if` arm has no trailing `else`, so a failed pattern falls through either way, and the removal happens whenever the command is `COM_STMT_CLOSE` and the id parses, as before.
- **`ephpm-middleware-builtins/src/jwt.rs`, `nbf`** — `numeric_date(nbf)?` now sits inside the let-chain. As before, a malformed `nbf` propagates `None` out of the function and **rejects** the token rather than skipping the check.

The security-sensitive paths named in review guidance were read rather than pattern-matched:

- `privdrop.rs` — the ACME cache chown still happens only for an ACME TLS config.
- `jwt.rs` — `nbf` / `iss` validation keeps its exact guard order and reject-on-failure semantics.
- `router.rs` — the per-site rate-limit 429 still requires limiter **and** site key **and** a failed check; `check_body_size` is still called only when `ws_event.is_none()` (short-circuit preserved).
- `sqlite_election.rs` — the "alive primary, but the advertised gRPC host is not a known member → refuse to dial" defense-in-depth branch is bit-for-bit equivalent, including the fall-through to re-election when the primary is dead.

One hunk (`websocket.rs`, inside a `tokio::select!` arm) had to be re-indented by hand: rustfmt does not format macro bodies.

## `ephpm-e2e`

Checked separately, as it is excluded from the workspace and CI therefore never lints it. It *does* still inherit the root `clippy.toml`, so the bump surfaces 2 sites in `tests/cluster.rs` — collapsed those too (confirmed: 0 warnings under 1.85, 2 under 1.88, 0 after the fix). Its pre-existing rustfmt drift is deliberately left alone; CI does not format that crate and reformatting it here would bury this diff.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — **clean** (exit 0).
- `cargo +nightly fmt --all -- --check` — **clean**.
- `cargo test --workspace` — **green**, all 44 test binaries, 0 failures.
- `cargo clippy` inside `crates/ephpm-e2e` — no remaining `collapsible_if`.

Stub mode throughout (no PHP SDK). No behavior changes, no public API changes.

> **Heads-up on overlap:** this touches `xtask/src/e2e_bare.rs` (one collapse), which the in-flight E2E-hardening work also edits. Trivial to resolve either way, but worth sequencing.