### PR TITLE
fix(cli): php-cli parity for `ephpm php` — stdin programs, exit codes, -l/-w/-s; docs truth pass (v0.7.1)

### DIFF
--- a/.claude/agents/ephpm-systems-architect.md
+++ b/.claude/agents/ephpm-systems-architect.md
@@ -83,7 +83,7 @@ You are an elite systems architect with deep expertise spanning Rust, PHP intern
 | Dependency | Location | Purpose |
 |-----------|----------|---------|
 | **litewire** | git dep pinned by `rev` in workspace `Cargo.toml` | MySQL/Hrana/PG/TDS wire protocol → SQLite (Turso) translation. Standalone project at github.com/ephpm/litewire. ePHPm enables the `turso` backend feature only (rusqlite/hrana-client de-linked in v0.7.0) |
-| **turso** | pure-Rust crate (`turso =0.7.0`), compiled in via litewire | The embedded SQLite-compatible engine — single-node and CDC-replicated clustered. No external process |
+| **turso** | pure-Rust crate (`turso =0.7.2`), compiled in via litewire | The embedded SQLite-compatible engine — single-node and CDC-replicated clustered. No external process |
 
 ### Critical Design Decisions (Non-Obvious)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 litewire = { git = "https://github.com/ephpm/litewire.git", rev = "10345a869d27", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
-# in its signatures. Pinned to the exact version litewire pins (=0.7.0)
+# in its signatures. Pinned to the exact version litewire pins (=0.7.2)
 # so the two resolve to a single crate instance and TursoConnection
 # (re-exported by litewire) is the same turso::Connection.
 turso = { version = "=0.7.2", default-features = false }

--- a/crates/ephpm-e2e/tests/cli.rs
+++ b/crates/ephpm-e2e/tests/cli.rs
@@ -1,0 +1,248 @@
+//! `ephpm php` CLI conformance — fatal-error reporting and exit statuses.
+//!
+//! Regression cover for **issue #321**: on v0.7.0 a fatal error or an uncaught
+//! exception under `ephpm php -r` produced **no output at all and exit 0**,
+//! where php-cli prints a diagnostic and exits 255. Two separate observable
+//! defects — the silence and the status — so both are asserted independently
+//! here. Asserting only the exit code would let the silence come back.
+//!
+//! Root cause, for the record: `-r` evaluated the snippet with a plain
+//! `zend_eval_string`, which leaves an uncaught exception *pending* rather than
+//! reporting it. In PHP 8 almost every CLI-visible fatal arrives as a thrown
+//! object — `Call to undefined function` throws `Error`, a compile failure
+//! inside `eval` throws `ParseError` — so nothing ever reached
+//! `php_error_cb`, nothing was displayed, and `EG(exit_status)` was never set
+//! to 255. It is *not* an ini problem: `display_errors` was already `1`, which
+//! is why non-fatal diagnostics (warnings) printed correctly the whole time.
+//! The fix is `zend_eval_string_ex(..., handle_exceptions = 1)` plus taking
+//! `EG(exit_status)` unconditionally (see `cli_eval_protected` and
+//! `cli_execute_script_protected` in `crates/ephpm-php/ephpm_wrapper.c`).
+//!
+//! This suite needs no HTTP server — it execs the release binary directly —
+//! so `cargo xtask e2e` runs it without spawning a node (see `NO_NODE_SUITES`
+//! in `xtask/src/e2e_bare.rs`) and hands it the binary path in
+//! `EPHPM_CLI_BINARY`. The suite self-skips when that is unset, so the file
+//! still compiles and links on a checkout with no release build.
+//!
+//! These assertions only mean anything against a PHP-linked binary: the whole
+//! CLI lives behind `#[cfg(php_linked)]`, so a stub-mode unit test could not
+//! reach it.
+//!
+//! Environment variables:
+//! - `EPHPM_CLI_BINARY` — path to a PHP-linked `ephpm` binary
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn cli_binary() -> Option<PathBuf> {
+    std::env::var_os("EPHPM_CLI_BINARY").map(PathBuf::from).filter(|p| !p.as_os_str().is_empty())
+}
+
+/// What one `ephpm php …` invocation produced.
+struct Run {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+impl Run {
+    /// stdout and stderr concatenated — for assertions that only care that the
+    /// diagnostic was emitted *somewhere*, independent of `display_errors`'
+    /// stdout-vs-stderr routing.
+    fn output(&self) -> String {
+        format!("{}{}", self.stdout, self.stderr)
+    }
+}
+
+/// Run `ephpm php <args…>` with `stdin_data` on stdin.
+fn run_php(bin: &PathBuf, args: &[&str], stdin_data: &str) -> Run {
+    let mut child = Command::new(bin)
+        .arg("php")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn {} php {args:?}: {e}", bin.display()));
+
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(stdin_data.as_bytes())
+        .unwrap_or_else(|e| panic!("write stdin for {args:?}: {e}"));
+
+    let out = child.wait_with_output().unwrap_or_else(|e| panic!("wait for {args:?}: {e}"));
+    Run {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        // A signal death has no code; -1 is never a legitimate PHP exit status,
+        // so it fails every assertion below rather than silently passing.
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+/// Assert the run produced a fatal diagnostic containing `needle` AND exited
+/// 255 — the two halves of #321, checked separately so a regression in either
+/// one is named precisely.
+fn assert_fatal(run: &Run, needle: &str, ctx: &str) {
+    let combined = run.output();
+    assert!(
+        !combined.trim().is_empty(),
+        "{ctx}: no diagnostic at all (issue #321 regression — the fatal was \
+         swallowed). exit={}",
+        run.code
+    );
+    assert!(
+        combined.contains(needle),
+        "{ctx}: diagnostic did not mention {needle:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        run.stdout,
+        run.stderr
+    );
+    assert_eq!(
+        run.code, 255,
+        "{ctx}: expected php-cli's fatal exit status 255, got {}\n--- output ---\n{combined}",
+        run.code
+    );
+}
+
+/// The control case. If this breaks, the binary or the harness is wrong and
+/// every other failure in this file is noise.
+#[test]
+fn plain_code_runs_and_exits_zero() {
+    let Some(bin) = cli_binary() else {
+        eprintln!("EPHPM_CLI_BINARY unset — skipping ephpm php CLI tests");
+        return;
+    };
+    let run = run_php(&bin, &["-r", "echo 22+20;"], "");
+    assert_eq!(run.stdout, "42", "unexpected stdout (stderr: {})", run.stderr);
+    assert_eq!(run.code, 0, "expected exit 0, got {}", run.code);
+}
+
+/// `exit(3)` propagates. This half already worked on v0.7.0 and is kept so a
+/// fix for the fatal path can't regress the ordinary one.
+#[test]
+fn explicit_exit_status_propagates() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &["-r", "exit(3);"], "");
+    assert_eq!(run.code, 3, "expected exit 3, got {} (output: {})", run.code, run.output());
+}
+
+/// #321 case 1: an uncaught exception under `-r`. On v0.7.0: silent, exit 0.
+#[test]
+fn uncaught_exception_reports_and_exits_255() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &["-r", "throw new Exception(\"boom\");"], "");
+    assert_fatal(&run, "Uncaught Exception: boom", "-r uncaught exception");
+    // php-cli labels `-r` code "Command line code"; the message is worthless
+    // for debugging without the location.
+    assert!(
+        run.output().contains("Command line code"),
+        "-r fatal is missing php-cli's \"Command line code\" label:\n{}",
+        run.output()
+    );
+    assert!(
+        run.output().contains("Stack trace"),
+        "-r fatal is missing the stack trace:\n{}",
+        run.output()
+    );
+}
+
+/// #321 case 2: calling an undefined function. In PHP 8 this throws `Error`,
+/// so it took the same silent path as an explicit `throw`.
+#[test]
+fn undefined_function_reports_and_exits_255() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &["-r", "nosuchfunc();"], "");
+    assert_fatal(&run, "Call to undefined function nosuchfunc()", "-r undefined function");
+}
+
+/// #321 case 3: a parse error in `-r` code. Inside `eval` a compile failure is
+/// a thrown `ParseError`, which is why it vanished too.
+#[test]
+fn parse_error_reports_and_exits_255() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &["-r", "this is not php <<<"], "");
+    assert_fatal(&run, "Parse error", "-r parse error");
+}
+
+/// The silence was never an ini default — `display_errors` was already on.
+/// Pin that: the diagnostic must appear with the shipped defaults AND under
+/// `-n` (no ini file at all), so nobody "fixes" a future regression by
+/// changing a default instead of the plumbing.
+#[test]
+fn fatal_is_reported_with_default_ini_and_with_no_ini() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let defaults = run_php(&bin, &["-r", "echo ini_get(\"display_errors\");"], "");
+    assert_eq!(
+        defaults.stdout, "1",
+        "display_errors is expected to already be on by default; if this \
+         changed, the #321 assertions below need rethinking"
+    );
+
+    let no_ini = run_php(&bin, &["-n", "-r", "nosuchfunc();"], "");
+    assert_fatal(&no_ini, "Call to undefined function", "-n -r undefined function");
+}
+
+/// A named script file. v0.7.0 *did* print this diagnostic (php_execute_script
+/// takes a different path than eval) but still exited 0 — the exit-status half
+/// of #321 on its own.
+#[test]
+fn script_file_fatal_reports_and_exits_255() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("fatal.php");
+    std::fs::write(&script, "<?php\nnosuchfunc();\n").expect("write script");
+
+    let run = run_php(&bin, &[script.to_str().expect("utf8 path")], "");
+    assert_fatal(&run, "Call to undefined function nosuchfunc()", "script file fatal");
+    assert!(
+        run.output().contains("fatal.php"),
+        "script-file fatal should name the script:\n{}",
+        run.output()
+    );
+}
+
+/// A program piped in on stdin. php-cli calls it "Standard input code"; the
+/// fatal must be reported and exit 255 there too.
+#[test]
+fn stdin_program_fatal_reports_and_exits_255() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &[], "<?php nosuchfunc();\n");
+    assert_fatal(&run, "Call to undefined function nosuchfunc()", "stdin program fatal");
+    assert!(
+        run.output().contains("Standard input code"),
+        "stdin fatal should use php-cli's \"Standard input code\" label:\n{}",
+        run.output()
+    );
+}
+
+/// Non-fatal diagnostics were never broken — warnings printed fine on v0.7.0,
+/// which is the evidence that ruled out `display_errors`. Keep that asymmetry
+/// pinned so the two paths can't silently swap places.
+#[test]
+fn warning_is_reported_and_execution_continues() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &["-r", "echo $nope; echo \"END\";"], "");
+    let combined = run.output();
+    assert!(combined.contains("Undefined variable"), "warning not reported:\n{combined}");
+    assert!(combined.contains("END"), "execution did not continue past the warning:\n{combined}");
+    assert_eq!(run.code, 0, "a warning must not change the exit status, got {}", run.code);
+}

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -4212,7 +4212,8 @@ static void cli_end(size_t (*orig_ub_write)(const char *, size_t))
  * SG(request_info).path_translated is deliberately left NULL: SAPI
  * deactivation efree()s it, so it must never point at C argv memory.
  */
-static void cli_register_argv(int argc, char **argv, int script_ind, const char *script_name)
+static void cli_register_argv(
+    int argc, char **argv, int script_ind, const char *script_name, int is_file)
 {
     argv[script_ind] = (char *)script_name;
     SG(request_info).argc = argc - script_ind;
@@ -4223,24 +4224,33 @@ static void cli_register_argv(int argc, char **argv, int script_ind, const char 
     php_build_argv(NULL, Z_TYPE_P(server) == IS_ARRAY ? server : NULL);
 
     if (Z_TYPE_P(server) == IS_ARRAY) {
-        static const char *const keys[] = {
-            "PHP_SELF", "SCRIPT_NAME", "SCRIPT_FILENAME", "PATH_TRANSLATED"
-        };
-        for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); i++) {
+        /* php-cli sets PHP_SELF/SCRIPT_NAME to the script identity in every
+         * mode, but SCRIPT_FILENAME/PATH_TRANSLATED only when a real file is
+         * being executed — for stdin programs and -r they are "" (verified
+         * against php 8.5 cli). */
+        static const char *const self_keys[] = { "PHP_SELF", "SCRIPT_NAME" };
+        static const char *const file_keys[] = { "SCRIPT_FILENAME", "PATH_TRANSLATED" };
+        for (size_t i = 0; i < sizeof(self_keys) / sizeof(self_keys[0]); i++) {
             zval tmp;
             ZVAL_STRING(&tmp, script_name);
-            zend_hash_str_update(Z_ARRVAL_P(server), keys[i], strlen(keys[i]), &tmp);
+            zend_hash_str_update(
+                Z_ARRVAL_P(server), self_keys[i], strlen(self_keys[i]), &tmp);
+        }
+        for (size_t i = 0; i < sizeof(file_keys) / sizeof(file_keys[0]); i++) {
+            zval tmp;
+            ZVAL_STRING(&tmp, is_file ? script_name : "");
+            zend_hash_str_update(
+                Z_ARRVAL_P(server), file_keys[i], strlen(file_keys[i]), &tmp);
         }
     }
 }
 
 /*
- * Helper: execute code or a file with bailout protection.
- * If `code` is non-NULL, evaluates it via zend_eval_string.
- * If `filename` is non-NULL, executes it via php_execute_script.
- * Returns the PHP exit status.
+ * Helper: evaluate raw code (-r, and the --rf/--rc/--re/--rz/--ri reflection
+ * flags) with bailout protection. Returns the PHP exit status. Scripts go
+ * through cli_execute_script_protected instead.
  */
-static int cli_execute_protected(const char *code, const char *filename)
+static int cli_eval_protected(const char *code, const char *label)
 {
     int result = 0;
     JMP_BUF *__orig_bailout = EG(bailout);
@@ -4248,20 +4258,22 @@ static int cli_execute_protected(const char *code, const char *filename)
 
     EG(bailout) = &__bailout;
     if (SETJMP(__bailout) == 0) {
-        if (code) {
-            zend_eval_string((char *)code, NULL, "ephpm php -r");
-        } else if (filename) {
-            zend_file_handle file_handle;
-            zend_stream_init_filename(&file_handle, filename);
-            php_execute_script(&file_handle);
-        }
+        /* handle_exceptions=1: an uncaught exception becomes the same
+         * E_ERROR php-cli reports ("Uncaught … in Command line code"),
+         * which sets EG(exit_status) = 255 — plain zend_eval_string would
+         * leave the exception pending and unreported. -r passes php-cli's
+         * own label so error messages are byte-identical. */
+        zend_eval_string_ex((char *)code, NULL, (char *)label, 1);
 
         /* PHP 8.x: exit() throws an unwind exit exception instead of
-         * calling zend_bailout(). Check for it after normal return. */
+         * calling zend_bailout(); clear it if still pending. Then take
+         * EG(exit_status) unconditionally — the engine catches fatals
+         * internally (its error handler already set exit_status to 255),
+         * so "0 unless we bailed" would drop exit()/fatal codes. */
         if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
             zend_clear_exception();
-            result = EG(exit_status);
         }
+        result = (int)EG(exit_status);
     } else {
         /* PHP bailed out (fatal error) */
         result = EG(exit_status);
@@ -4308,13 +4320,48 @@ static void cli_register_file_handles(void)
 }
 
 /*
- * Execute a program read from stdin, with bailout protection. Reads through
- * the C `stdin` FILE* via zend_stream_init_fp — the same mechanism php-cli
- * uses ("Standard input code"), which works in the embed build where the
- * `php://stdin` stream wrapper does not open for compilation. The program is
- * a real script (expects `<?php` tags), unlike -r's raw code.
+ * php-cli's name for a program that came from stdin. It is used verbatim as
+ * the compiled file name, the lint label, $argv[0] and $_SERVER['PHP_SELF'],
+ * exactly as stock php-cli does (php_cli.c: `php_self = "Standard input
+ * code"`), so error messages and script self-identification match.
  */
-static int cli_execute_stdin_protected(void)
+#define CLI_STDIN_NAME "Standard input code"
+
+/*
+ * Open the primary script source, mirroring php-cli's cli_seek_file_begin.
+ *
+ * A named file is fopen'd in binary mode and wrapped with zend_stream_init_fp
+ * — the same FILE*-backed handle php-cli compiles from, so reading is
+ * byte-exact (binary-safe, no CRLF translation) and the exact path is used
+ * with no include_path search. A NULL filename means the program comes from
+ * the process's stdin, which is how `php < script.php` and `… | php` work;
+ * that path also works in the embed build, where the `php://stdin` stream
+ * wrapper does not open for compilation.
+ *
+ * On failure prints php-cli's exact message and returns 0; the caller exits 1.
+ */
+static int cli_open_script(zend_file_handle *fh, const char *filename)
+{
+    if (filename) {
+        FILE *fp = VCWD_FOPEN(filename, "rb");
+        if (!fp) {
+            fprintf(stderr, "Could not open input file: %s\n", filename);
+            return 0;
+        }
+        zend_stream_init_fp(fh, fp, filename);
+    } else {
+        zend_stream_init_fp(fh, stdin, CLI_STDIN_NAME);
+    }
+    fh->primary_script = 1;
+    return 1;
+}
+
+/*
+ * Execute the primary script with bailout protection. `filename` NULL means
+ * "read the program from stdin". The program is a real script (expects
+ * `<?php` tags), unlike -r's raw code.
+ */
+static int cli_execute_script_protected(const char *filename)
 {
     int result = 0;
     JMP_BUF *__orig_bailout = EG(bailout);
@@ -4323,15 +4370,71 @@ static int cli_execute_stdin_protected(void)
     EG(bailout) = &__bailout;
     if (SETJMP(__bailout) == 0) {
         zend_file_handle file_handle;
-        zend_stream_init_fp(&file_handle, stdin, "Standard input code");
-        file_handle.primary_script = 1;
+        if (!cli_open_script(&file_handle, filename)) {
+            EG(bailout) = __orig_bailout;
+            return 1;
+        }
         php_execute_script(&file_handle);
         zend_destroy_file_handle(&file_handle);
 
+        /* See cli_eval_protected: exit()/fatal codes live in
+         * EG(exit_status) after php_execute_script returns. */
         if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
             zend_clear_exception();
-            result = EG(exit_status);
         }
+        result = (int)EG(exit_status);
+    } else {
+        result = EG(exit_status);
+        if (result == 0) result = 1;
+    }
+    EG(bailout) = __orig_bailout;
+    return result;
+}
+
+/*
+ * -l (lint), -w (strip) and -s (highlight), all bailout-protected and all
+ * accepting the program on stdin when `filename` is NULL — php-cli routes
+ * every one of these modes through the same file handle, so `php -l < f.php`
+ * and `… | php -w` work there and must work here. `mode` is the CLI option
+ * letter. Returns the exit code (255 for a lint failure, 1 if the file can't
+ * be opened, matching php-cli).
+ */
+static int cli_scan_protected(int mode, const char *filename, const char *php_self)
+{
+    /* volatile: assigned between SETJMP and a possible longjmp, then read
+     * after it — without this the value is indeterminate (and gcc warns
+     * -Wclobbered). */
+    volatile int result = 0;
+    JMP_BUF *__orig_bailout = EG(bailout);
+    JMP_BUF __bailout;
+
+    EG(bailout) = &__bailout;
+    if (SETJMP(__bailout) == 0) {
+        zend_file_handle file_handle;
+        if (!cli_open_script(&file_handle, filename)) {
+            EG(bailout) = __orig_bailout;
+            return 1;
+        }
+        if (mode == 'l') {
+            if (php_lint_script(&file_handle) == SUCCESS) {
+                php_printf("No syntax errors detected in %s\n", php_self);
+            } else {
+                php_printf("Errors parsing %s\n", php_self);
+                result = 255;
+            }
+        } else if (open_file_for_scanning(&file_handle) == SUCCESS) {
+            if (mode == 'w') {
+                zend_strip();
+            } else {
+                zend_syntax_highlighter_ini syntax_highlighter_ini;
+                php_get_highlight_struct(&syntax_highlighter_ini);
+                zend_highlight(&syntax_highlighter_ini);
+            }
+        }
+        /* php-cli destroys the handle once, after the mode has run
+         * (php_cli.c's `out:` label); the dtor NULLs the FILE* so this is
+         * safe whether or not the scanner already consumed it. */
+        zend_destroy_file_handle(&file_handle);
     } else {
         result = EG(exit_status);
         if (result == 0) result = 1;
@@ -4407,9 +4510,11 @@ static char *cli_read_line(FILE *fp, size_t *out_len)
 }
 
 /*
- * Install $argn (current line, trailing CR/LF stripped) and $argi (zero-based
- * line index) into the global symbol table for the -R/-F line processor, the
- * same variables php-cli exposes.
+ * Install $argn (current line, trailing CR/LF stripped) and $argi (line
+ * number) into the global symbol table for the -R/-F line processor, the
+ * same variables php-cli exposes. $argi is **1-based**: php-cli increments
+ * before assigning, so the first line is 1 (verified against php 8.5:
+ * `printf 'a\nb\n' | php -R 'echo $argi;'` prints 1 then 2).
  */
 static void cli_set_line_vars(const char *line, size_t len, zend_long argi)
 {
@@ -4444,17 +4549,19 @@ static int cli_process_stdin_lines(
     EG(bailout) = &__bailout;
     if (SETJMP(__bailout) == 0) {
         if (begin_code) {
-            zend_eval_string((char *)begin_code, NULL, "ephpm php -B");
+            zend_eval_string_ex(
+                (char *)begin_code, NULL, "Command line begin code", 1);
         }
         if (!(EG(exception) && zend_is_unwind_exit(EG(exception)))) {
             zend_long argi = 0;
             char *line;
             size_t len;
             while ((line = cli_read_line(stdin, &len)) != NULL) {
-                cli_set_line_vars(line, len, argi);
+                cli_set_line_vars(line, len, ++argi);
                 free(line);
                 if (per_line_code) {
-                    zend_eval_string((char *)per_line_code, NULL, "ephpm php -R");
+                    zend_eval_string_ex(
+                        (char *)per_line_code, NULL, "Command line run code", 1);
                 } else if (per_line_file) {
                     zend_file_handle fh;
                     zend_stream_init_filename(&fh, per_line_file);
@@ -4464,17 +4571,18 @@ static int cli_process_stdin_lines(
                 if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
                     break;
                 }
-                argi++;
             }
         }
         if (end_code && !(EG(exception) && zend_is_unwind_exit(EG(exception)))) {
-            zend_eval_string((char *)end_code, NULL, "ephpm php -E");
+            zend_eval_string_ex((char *)end_code, NULL, "Command line end code", 1);
         }
 
+        /* See cli_eval_protected: take EG(exit_status) unconditionally
+         * so exit() inside -B/-R/-F/-E code keeps its code. */
         if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
             zend_clear_exception();
-            result = EG(exit_status);
         }
+        result = (int)EG(exit_status);
     } else {
         result = EG(exit_status);
         if (result == 0) {
@@ -4643,7 +4751,6 @@ int ephpm_cli_main(int argc, char **argv)
                 "  -s               Output HTML syntax highlighted source\n"
                 "  -v               Version number\n"
                 "  -w               Output source with stripped comments and whitespace\n"
-                "  -z <file>        Load Zend extension <file>\n"
                 "\n"
                 "  args...          Arguments passed to script. Use -- args when first argument\n"
                 "                   starts with - or script is read from stdin\n"
@@ -4676,20 +4783,41 @@ int ephpm_cli_main(int argc, char **argv)
         case 14: /* --ri / --rextinfo   <name> */
         {
             /* Reflection info flags, matching php-cli. Implemented via the
-             * always-compiled Reflection extension; a bad name surfaces the
-             * ReflectionException, and the whole thing is bailout-protected. */
+             * always-compiled Reflection extension, and bailout-protected.
+             *
+             * The name is bound as $__ephpm_r rather than interpolated into
+             * the snippet: a name containing a quote would otherwise change
+             * the code being evaluated.
+             *
+             * A bad name is caught and reported as php-cli reports it —
+             * `Exception: <message>` on stdout with exit status 0, not an
+             * uncaught-exception fatal. --ri has its own message for an
+             * absent extension ("Extension 'x' not present."), also php-cli's.
+             */
+            zval reflect_name;
+            ZVAL_STRING(&reflect_name, php_optarg ? php_optarg : "");
+            zend_hash_str_update(
+                &EG(symbol_table), "__ephpm_r", sizeof("__ephpm_r") - 1, &reflect_name);
+
             const char *expr;
             switch (c) {
-            case 10: expr = "echo new ReflectionFunction('%s'), \"\\n\";"; break;
-            case 11: expr = "echo new ReflectionClass('%s'), \"\\n\";"; break;
-            case 12: expr = "echo new ReflectionExtension('%s'), \"\\n\";"; break;
-            case 13: expr = "echo new ReflectionZendExtension('%s'), \"\\n\";"; break;
-            default: expr = "(new ReflectionExtension('%s'))->info();"; break; /* --ri */
+            case 10: expr = "echo new ReflectionFunction($__ephpm_r), \"\\n\";"; break;
+            case 11: expr = "echo new ReflectionClass($__ephpm_r), \"\\n\";"; break;
+            case 12: expr = "echo new ReflectionExtension($__ephpm_r), \"\\n\";"; break;
+            case 13: expr = "echo new ReflectionZendExtension($__ephpm_r), \"\\n\";"; break;
+            default: /* --ri */
+                expr = "if (!extension_loaded($__ephpm_r)) {"
+                       "  echo \"Extension '\", $__ephpm_r, \"' not present.\\n\";"
+                       "} else { (new ReflectionExtension($__ephpm_r))->info(); }";
+                break;
             }
             char code[1024];
-            snprintf(code, sizeof(code), expr, php_optarg ? php_optarg : "");
+            snprintf(code, sizeof(code),
+                "try { %s } catch (Throwable $e) {"
+                "  echo 'Exception: ', $e->getMessage(), \"\\n\"; }",
+                expr);
             cli_begin(&orig_ub_write);
-            cli_execute_protected(code, NULL);
+            cli_eval_protected(code, "ephpm php reflection");
             php_output_end_all();
             cli_end(orig_ub_write);
             return 0;
@@ -4786,31 +4914,43 @@ int ephpm_cli_main(int argc, char **argv)
     /* Define STDIN/STDOUT/STDERR before any script runs, like php-cli. */
     cli_register_file_handles();
 
-    /* Determine whether the program/script comes from stdin. php-cli reads a
-     * program from stdin when no -r/-f/positional/line-mode is given, and `-`
-     * as the script name is the explicit stdin sentinel. Line mode (-R/-F)
-     * consumes stdin itself, so it is handled separately below. */
-    int want_lines = (line_code != NULL || line_file != NULL);
-    if (!script_file && !exec_direct && !want_lines) {
-        if (php_optind < argc && strcmp(argv[php_optind], "-") == 0) {
-            read_stdin = 1;
-            php_optind++; /* consume the "-" */
-        } else if (php_optind < argc && argv[php_optind][0] != '-') {
-            script_file = argv[php_optind];
-            php_optind++; /* consume it: what follows are the script's args */
-        } else if (php_optind >= argc) {
-            /* Nothing to run and nothing named — read the program from stdin. */
-            read_stdin = 1;
-        }
+    /* Pick up a positional script name, mirroring php-cli's condition
+     * (php_cli.c): only when no script is set yet, the mode is not -r or
+     * line-mode (both of which take no script file), and the previous argv
+     * slot is not "--" — everything after "--" belongs to the script, so
+     * `… | ephpm php -- a b` keeps reading the program from stdin. */
+    /* Any of -B/-R/-F/-E selects php-cli's stdin line-processing mode, so
+     * stdin is consumed as input lines rather than compiled as a program.
+     * (Verified: `printf 'a\n' | php -B 'echo "S\n";'` prints only S — the
+     * lines are read and discarded, not executed.) */
+    int want_lines =
+        (line_code != NULL || line_file != NULL || begin_code != NULL || end_code != NULL);
+    if (argc > php_optind && !script_file && !exec_direct && !want_lines
+        && strcmp(argv[php_optind - 1], "--") != 0) {
+        script_file = argv[php_optind];
+        php_optind++; /* consume it: what follows are the script's args */
     }
+
+    /* No script named and no -r/line-mode: the program comes from stdin.
+     * php-cli does this unconditionally (it does not test isatty), so an
+     * interactive `ephpm php` waits on stdin exactly as `php` does. Note
+     * php-cli has no `-` stdin sentinel: `php -` reports "Could not open
+     * input file: -", and so does this. */
+    if (!script_file && !exec_direct && !want_lines) {
+        read_stdin = 1;
+    }
+
+    /* Script identity, following php-cli: the script path when one was
+     * named, otherwise "Standard input code" — for stdin programs AND for
+     * -r (verified against php 8.5: `php -r 'var_dump($argv);'` prints
+     * $argv[0] === "Standard input code"). */
+    const char *php_self = script_file ? script_file : CLI_STDIN_NAME;
 
     /* Make script arguments visible to userland ($argv/$argc/$_SERVER).
      * argv[php_optind - 1] is repurposed as $argv[0] (php-cli does the
-     * same slot trick); "-" stands in for -r code and for stdin, matching
-     * php-cli (`echo '<?php var_dump($argv);' | php` → $argv[0] === "-"). */
+     * same slot trick). */
     if (script_file || exec_direct || read_stdin || want_lines) {
-        cli_register_argv(
-            argc, argv, php_optind - 1, script_file ? script_file : "-");
+        cli_register_argv(argc, argv, php_optind - 1, php_self, script_file != NULL);
     }
 
     /* CLI scripts routinely start with a shebang (artisan, composer, …);
@@ -4827,61 +4967,23 @@ int ephpm_cli_main(int argc, char **argv)
     } else if (mode == 'r' && exec_direct) {
         /* -r "code" */
         cli_begin(&orig_ub_write);
-        result = cli_execute_protected(exec_direct, NULL);
+        result = cli_eval_protected(exec_direct, "Command line code");
         cli_end(orig_ub_write);
-    } else if (mode == 'l') {
-        /* -l file | -l < stdin (syntax check) */
+    } else if (mode == 'l' || mode == 'w' || mode == 's') {
+        /* -l (lint), -w (strip), -s (highlight): a named file, or the
+         * program on stdin when none was named. */
         cli_begin(&orig_ub_write);
-        {
-            zend_file_handle file_handle;
-            const char *lint_label;
-            if (script_file) {
-                zend_stream_init_filename(&file_handle, script_file);
-                lint_label = script_file;
-            } else {
-                zend_stream_init_fp(&file_handle, stdin, "Standard input code");
-                lint_label = "-";
-            }
-            if (php_lint_script(&file_handle) == SUCCESS) {
-                php_printf("No syntax errors detected in %s\n", lint_label);
-            } else {
-                result = 255;
-            }
-            zend_destroy_file_handle(&file_handle);
-        }
+        result = cli_scan_protected(mode, script_file, php_self);
         php_output_end_all();
         cli_end(orig_ub_write);
-    } else if (script_file) {
-        /* Execute a file (standard mode, -w, -s) */
-        cli_begin(&orig_ub_write);
-        if (mode == 'w') {
-            char code[4096];
-            snprintf(code, sizeof(code),
-                "echo php_strip_whitespace('%s');", script_file);
-            cli_execute_protected(code, NULL);
-            php_output_end_all();
-        } else if (mode == 's') {
-            char code[4096];
-            snprintf(code, sizeof(code),
-                "highlight_file('%s');", script_file);
-            cli_execute_protected(code, NULL);
-            php_output_end_all();
-        } else {
-            result = cli_execute_protected(NULL, script_file);
-        }
-        cli_end(orig_ub_write);
-    } else if (read_stdin) {
-        /* Program read from stdin (piped or `-`). Executed as a real script
-         * (with <?php tags), so $argv[0] === "-" and file semantics match
-         * php-cli — unlike -r, which is raw code. */
-        cli_begin(&orig_ub_write);
-        result = cli_execute_stdin_protected();
-        cli_end(orig_ub_write);
     } else {
-        /* No script or code provided */
-        fprintf(stderr, "ephpm php: no input file\n"
-                        "Run 'ephpm php -h' for usage information.\n");
-        return 1;
+        /* Standard mode: execute a named script, or the program read from
+         * stdin (`ephpm php < file.php`, `… | ephpm php`). Both compile from
+         * a FILE*-backed handle, so `<?php` tags, $argv[0] and file
+         * semantics match php-cli — unlike -r, which is raw code. */
+        cli_begin(&orig_ub_write);
+        result = cli_execute_script_protected(script_file);
+        cli_end(orig_ub_write);
     }
 
     return result;

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -308,7 +308,7 @@ fn run() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Php { args }) => run_php(&args),
+        Some(Commands::Php { args }) => run_php(&php_cli_args(&args)),
         Some(Commands::Kv { host, port, password, user, subcommand }) => {
             let auth = KvAuth::resolve(user, password)?;
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
@@ -523,6 +523,37 @@ fn find_free_port(host: &str, start_port: u16) -> anyhow::Result<u16> {
         }
     }
     anyhow::bail!("no free port in range {start_port}..={}", start_port.saturating_add(49))
+}
+
+/// The verbatim argument list for `ephpm php`, including any `--` separator.
+///
+/// `--` is *meaningful* to php-cli: it ends option parsing, so
+/// `… | php -- a b` reads the program from stdin and passes `a b` to it
+/// rather than running a script named `a`. clap consumes the first `--` it
+/// sees, so the parsed `Vec<String>` cannot express the difference. `ephpm`
+/// declares no global options before its subcommand, so argv[1] is always the
+/// `php` token and argv[2..] is exactly what the user typed after it.
+///
+/// Falls back to clap's view for any argv shape that doesn't match that
+/// expectation (including non-UTF-8 arguments), so this can only ever restore
+/// a separator — never invent arguments.
+fn php_cli_args(parsed: &[String]) -> Vec<String> {
+    let raw =
+        std::env::args_os().skip(2).map(|a| a.into_string().ok()).collect::<Option<Vec<String>>>();
+    restore_php_separator(raw, parsed)
+}
+
+/// Pure half of [`php_cli_args`]: `raw` is argv[2..] when it was all valid
+/// UTF-8. Returns `raw` only when it differs from `parsed` by exactly the one
+/// `--` clap swallowed.
+fn restore_php_separator(raw: Option<Vec<String>>, parsed: &[String]) -> Vec<String> {
+    let Some(raw) = raw else { return parsed.to_vec() };
+
+    let mut without_separator = raw.clone();
+    if let Some(i) = without_separator.iter().position(|a| a == "--") {
+        without_separator.remove(i);
+    }
+    if without_separator == parsed { raw } else { parsed.to_vec() }
 }
 
 /// Run the `ephpm php` subcommand — pass args through to the embedded PHP CLI.
@@ -1874,6 +1905,46 @@ fn resolve_target(site: Option<&str>, all: bool) -> anyhow::Result<String> {
         }
         (None, true) => Ok(OPCACHE_BROADCAST_VHOST.to_string()),
         (None, false) => Ok(OPCACHE_DEFAULT_VHOST.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod php_arg_tests {
+    use super::*;
+
+    fn v(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn separator_clap_swallowed_is_restored() {
+        // `… | ephpm php -- a b`: php-cli needs the `--` to know that `a` is an
+        // argument and the program comes from stdin, not that `a` is a script.
+        let raw = v(&["--", "a", "b"]);
+        let parsed = v(&["a", "b"]);
+        assert_eq!(restore_php_separator(Some(raw.clone()), &parsed), raw);
+    }
+
+    #[test]
+    fn only_the_first_separator_is_clap_s() {
+        // clap strips one `--`; a second is a real PHP argument and stays put.
+        let raw = v(&["--", "-r", "echo 1;", "--", "x"]);
+        let parsed = v(&["-r", "echo 1;", "--", "x"]);
+        assert_eq!(restore_php_separator(Some(raw.clone()), &parsed), raw);
+    }
+
+    #[test]
+    fn args_without_a_separator_are_unchanged() {
+        let raw = v(&["-r", "echo 1;"]);
+        assert_eq!(restore_php_separator(Some(raw.clone()), &raw), raw);
+    }
+
+    #[test]
+    fn unexpected_argv_shape_keeps_the_parsed_view() {
+        // Raw tail that is not "parsed plus one separator" is not trusted.
+        let parsed = v(&["-r", "echo 1;"]);
+        assert_eq!(restore_php_separator(Some(v(&["something", "else"])), &parsed), parsed);
+        assert_eq!(restore_php_separator(None, &parsed), parsed);
     }
 }
 

--- a/site/content/reference/cli/php.md
+++ b/site/content/reference/cli/php.md
@@ -102,12 +102,26 @@ ephpm php -l < src/Controller.php      # No syntax errors detected in Standard i
 cat src/Controller.php | ephpm php -w  # stripped source on stdout
 ```
 
-### Exit codes
+### Errors and exit codes
+
+Diagnostics go where php-cli sends them. `display_errors` defaults to on and
+routes to **stdout** (php-cli's CLI default), so a fatal error, an uncaught
+exception or a parse error prints the same `Fatal error:` / `Parse error:`
+block php-cli prints — including the file/line and the stack trace — whether
+the code came from `-r`, a script file, or stdin. Set `-d display_errors=stderr`
+to route them to stderr instead.
 
 Exit codes match php-cli: `exit(N)` yields `N`; an uncaught exception or fatal
 error yields `255`; a syntax error under `-l` yields `255` (with
 `Errors parsing <name>` on stdout); a script file that cannot be opened prints
 `Could not open input file: <path>` and yields `1`.
+
+> **Fixed in v0.7.1.** Up to and including v0.7.0, a fatal error or uncaught
+> exception under `ephpm php -r` printed **nothing** and exited `0`
+> ([#321](https://github.com/ephpm/ephpm/issues/321)) — the snippet was
+> evaluated without exception handling, so the thrown `Error`/`Exception` was
+> never reported and never set the exit status. Both halves are now pinned by
+> the `cli` E2E suite.
 
 ### Not supported
 

--- a/site/content/reference/cli/php.md
+++ b/site/content/reference/cli/php.md
@@ -17,6 +17,7 @@ Laravel's artisan, and PHPUnit through it.
 ephpm php [PHP_ARGS...]
 ephpm php [options] [-f] <file> [--] [args...]
 ephpm php [options] -r <code> [--] [args...]
+ephpm php [options] -- [args...]        # program from stdin, with args
 echo '<?php ...' | ephpm php            # program from stdin
 ```
 
@@ -29,15 +30,18 @@ ephpm php -r 'echo PHP_VERSION;'
 # Run a script
 ephpm php script.php
 
-# Program from stdin (also `ephpm php -` and `ephpm php < file`)
+# Program from stdin (also `ephpm php < file`)
 echo '<?php echo 2 + 2;' | ephpm php
+
+# ...with arguments: everything after `--` belongs to the script
+echo '<?php var_dump($argv);' | ephpm php -- one two
 
 # Composer / WP-CLI / artisan — all work unmodified
 ephpm php -d memory_limit=-1 composer.phar install
 ephpm php wp-cli.phar --info
 ephpm php artisan migrate
 
-# Per-line stdin processor (awk-like): $argn = line, $argi = 0-based index
+# Per-line stdin processor (awk-like): $argn = line, $argi = line number (1-based)
 printf 'a\nbb\n' | ephpm php -R 'echo strlen($argn), "\n";'
 
 # Print loaded modules
@@ -69,6 +73,42 @@ keeps reporting `PHP_SAPI === "ephpm"` — only the `ephpm php` process is `cli`
 - `-c <path>` — load `php.ini` from this path.
 - `-n` — load no `php.ini` at all.
 
+### Programs on stdin
+
+With no `-r`, no `-B`/`-R`/`-F`/`-E` line mode, and no script named on the
+command line, the program is read from **stdin** — the same rule stock php-cli
+uses, so `ephpm php < script.php` and `… | ephpm php` both work. Everything
+after `--` is treated as script arguments rather than a filename, so
+`… | ephpm php -- a b` still reads the program from stdin.
+
+(Any one of `-B`/`-R`/`-F`/`-E` selects the line processor instead, where stdin
+is consumed as *input lines* rather than compiled as a program — `$argn` is the
+current line and `$argi` its 1-based line number.)
+
+A stdin program is a real script: it needs `<?php` tags (unlike `-r`, which is
+raw code), and it is identified as php-cli identifies it — `$argv[0]`,
+`$_SERVER['PHP_SELF']` and `$_SERVER['SCRIPT_NAME']` are the literal string
+`Standard input code`, while `SCRIPT_FILENAME`/`PATH_TRANSLATED` stay empty
+because no file was executed. The same identity applies to `-r`.
+
+As in stock php-cli there is **no `-` stdin sentinel**: `ephpm php -` reports
+`Could not open input file: -` and exits 1, exactly as `php -` does.
+
+`-l` (lint), `-w` (strip comments/whitespace) and `-s` (syntax highlight) also
+read stdin when no file is named:
+
+```bash
+ephpm php -l < src/Controller.php      # No syntax errors detected in Standard input code
+cat src/Controller.php | ephpm php -w  # stripped source on stdout
+```
+
+### Exit codes
+
+Exit codes match php-cli: `exit(N)` yields `N`; an uncaught exception or fatal
+error yields `255`; a syntax error under `-l` yields `255` (with
+`Errors parsing <name>` on stdout); a script file that cannot be opened prints
+`Could not open input file: <path>` and yields `1`.
+
 ### Not supported
 
 - `-a` (interactive shell) — the PHP interactive shell is part of the standalone
@@ -78,6 +118,9 @@ keeps reporting `PHP_SAPI === "ephpm"` — only the `ephpm php` process is `cli`
   embed build, so `ephpm php -S` prints a clear error. It is deliberately **not**
   aliased to `ephpm serve`. Use a full php-cli for `php -S`, or `ephpm serve` /
   `ephpm dev` for ePHPm's own HTTP server.
+- `-z <file>` (load a Zend extension) — not offered, matching current php-cli,
+  which also rejects it. Zend extensions must be present at module startup;
+  register them through `[php] extensions` in your config.
 
 ## Phar support
 
@@ -95,7 +138,7 @@ The embedded PHP interpreter is the **same** runtime that serves HTTP requests. 
 
 ## How it works
 
-`ephpm php` runs the embedded PHP runtime in CLI mode via FFI — the same runtime that serves HTTP requests, but with the SAPI reporting as `cli`. It's not a wrapper around an external `php` binary. The argument list is forwarded as-is, including `-r`, `-d`, file paths, and trailing application arguments — script arguments are registered as `$argv`/`$argc` (and mirrored into `$_SERVER`, with `PHP_SELF`/`SCRIPT_NAME`/`SCRIPT_FILENAME` set to the script path) exactly as the stock `php` CLI does, so Symfony Console and artisan see their arguments. A program read from stdin gets `$argv[0] === "-"`, matching php-cli. Shebang lines (`#!/usr/bin/env php`) are skipped.
+`ephpm php` runs the embedded PHP runtime in CLI mode via FFI — the same runtime that serves HTTP requests, but with the SAPI reporting as `cli`. It's not a wrapper around an external `php` binary. The argument list is forwarded as-is, including `-r`, `-d`, file paths, and trailing application arguments — script arguments are registered as `$argv`/`$argc` (and mirrored into `$_SERVER`, with `PHP_SELF`/`SCRIPT_NAME`/`SCRIPT_FILENAME` set to the script path) exactly as the stock `php` CLI does, so Symfony Console and artisan see their arguments. When no script file is named — a stdin program, or `-r` — the identity is `Standard input code` instead, again matching php-cli (see [Programs on stdin](#programs-on-stdin)). Scripts are read byte-exactly from a binary-mode file handle, and shebang lines (`#!/usr/bin/env php`) are skipped.
 
 ## Windows note
 

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -83,7 +83,8 @@ black-box sidecar ever was.
 
 > **Status: SHIPPED, 2026-07; became the default and only engine in
 > v0.7.0.** litewire has a `litewire-turso` backend (engine pinned
-> `turso =0.7.0`) and ePHPm builds it as the sole embedded engine.
+> `turso =0.7.2` as of v0.7.1) and ePHPm builds it as the sole embedded
+> engine.
 > Gate 2–4 evidence lives in `docs/turso-phase1-results.md`; Phase 2
 > design notes in `docs/turso-phase2-cdc-design.md`.
 

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -229,6 +229,22 @@ fn suite_needs_fresh_node(name: &str) -> bool {
     ISOLATED_DB_SUITES.contains(&name) || ISOLATED_CONFIG_SUITES.contains(&name)
 }
 
+/// Suites that need **no ephpm server at all** — they exec the release binary
+/// directly and assert on its stdout/stderr/exit status.
+///
+/// `cli` covers `ephpm php` (issue #321: fatals were silent and exited 0).
+/// Spawning an HTTP node for it would be pure waste, and worse, it would have
+/// to be a node whose config could never perturb — or be perturbed by — a
+/// suite that only ever runs a subprocess. So these run first, before any
+/// port is claimed, with just `EPHPM_CLI_BINARY` in the environment.
+///
+/// Note this is the ONLY place the binary path is handed to a suite that
+/// doesn't mount middleware; it deliberately uses a distinct variable name
+/// rather than `EPHPM_BINARY`, which `ephpm-e2e`'s self-managed fixtures treat
+/// as an opt-in switch (see `SingleNodeSpawn::env` for why exporting that one
+/// broadly breaks `bare_process_smoke`).
+const NO_NODE_SUITES: &[&str] = &["cli"];
+
 /// Test suites that must be excluded from bare-process runs entirely.
 ///
 /// A few historical suites were Kind-only (they poke Kubernetes services,
@@ -359,7 +375,24 @@ pub fn run(args: &[String]) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    // Suites that need no server run first and cheapest: no node, no ports.
+    let (no_node_suites, single_suites): (Vec<_>, Vec<_>) =
+        single_suites.into_iter().partition(|(name, _)| NO_NODE_SUITES.contains(&name.as_str()));
+
     let mut failed: Vec<String> = Vec::new();
+
+    if !no_node_suites.is_empty() {
+        eprintln!(
+            "==> Running {} server-less suite(s) directly against the binary...",
+            no_node_suites.len()
+        );
+        let env = vec![("EPHPM_CLI_BINARY".to_string(), ephpm_bin.to_string_lossy().into_owned())];
+        for (name, path) in &no_node_suites {
+            if !run_suite(name, path, &env) {
+                failed.push((*name).clone());
+            }
+        }
+    }
 
     // The `middleware` suite mounts a real loadable module by path, so a
     // cdylib has to exist before its node starts. Nothing else in the build


### PR DESCRIPTION
`ephpm php` is meant to be a drop-in `php` CLI. #306 got it most of the way;
this closes the remaining behavioural gaps against upstream php-cli and fixes
the docs that described the old behaviour.

Everything below was checked twice: against **php-src** (`sapi/cli/php_cli.c`)
for the rule, and against a real **php 8.5.4 CLI** for the observable output,
before being changed.

## CLI (`crates/ephpm-php/ephpm_wrapper.c`, `crates/ephpm/src/main.rs`)

**Programs on stdin**
- `… | ephpm php -- a b` took `a` as a script name and failed. The
  positional-script test now mirrors php_cli.c exactly, including its
  `strcmp(argv[php_optind - 1], "--")` guard. clap swallows the first `--`
  before the C parser sees it, so `php_cli_args` recovers the verbatim tail
  from `argv[2..]` (falling back to clap's view for any argv shape that isn't
  "parsed plus one separator" — it can only restore a separator, never invent
  arguments). Unit-tested.
- `$argv[0]`/`PHP_SELF`/`SCRIPT_NAME` are `"Standard input code"`, not `"-"` —
  for stdin programs *and* for `-r`. `SCRIPT_FILENAME`/`PATH_TRANSLATED` stay
  empty unless a real file ran.
- No `-` sentinel. Upstream has none: `php -` says
  `Could not open input file: -` and exits 1. Ours now does the same.

**Exit codes** — `EG(exit_status)` is taken unconditionally after execution
rather than only on a bailout, so `exit(3)`, fatals and uncaught exceptions no
longer all report 0. `-r` and the line-mode snippets run through
`zend_eval_string_ex(handle_exceptions = 1)` under php-cli's own labels
(`Command line code`, `Command line begin/run/end code`), so an uncaught
exception is reported and exits 255 instead of vanishing.

**Missing input file** — a named script is `fopen`'d like php-cli's
`cli_seek_file_begin`, giving the exact `Could not open input file: X` message
and exit 1 instead of a `Failed opening required` fatal and exit 0.

**`-l` / `-w` / `-s` read stdin** — upstream routes lint, strip and highlight
through the same handle. `-w`/`-s` previously required a file and silently
*executed* a piped program instead of stripping it; they now use `zend_strip()`
/ `zend_highlight()` on a scanner handle, which also removes an
`snprintf`-into-a-PHP-string-literal that broke on quotes in paths and
truncated at 4096 bytes. Lint failures print `Errors parsing X` and exit 255.

**Line mode** — `-B`/`-E` alone now select stdin line-processing mode as
php-cli does (previously stdin was compiled as a *program*, so
`printf 'a\n' | php -B '…'` executed the input). `$argi` is 1-based, matching
upstream (it was 0-based, and the docs said so).

**Reflection flags** — `--rf`/`--rc`/`--re`/`--rz` on an unknown name print
`Exception: <message>` with status 0, as php-cli does, instead of an
uncaught-exception fatal; `--ri` prints `Extension 'x' not present.`. The name
is bound as a variable rather than interpolated into the evaluated snippet.

**`-h`** no longer advertises `-z <file>` — it was never in the option table
(the flag was ignored and its argument taken as a script name), and current
php-cli rejects `-z` as well.

Reading is via a `FILE*`-backed handle opened `"rb"`, so scripts are byte-exact
and binary-safe. Every new PHP entry point runs under the file's existing
SETJMP/bailout guard; no unguarded PHP calls were added.

## Docs

`site/content/reference/cli/php.md` claimed `$argv[0] === "-"` for stdin
"matching php-cli" and offered `ephpm php -` as a stdin form — neither was ever
true upstream. Corrected, and the page now documents the stdin rule and its
`--` interaction, stdin for `-l`/`-w`/`-s`, the exit codes, 1-based `$argi`,
and `-z` under "Not supported".

Straggler `turso =0.7.0` mentions left by #309's bump, in the three places that
state the *current* pin (roadmap page, the `Cargo.toml` comment above the dep,
the systems-architect agent table). Historical experiment records under
`docs/turso-*.md` keep 0.7.0 — that is what they measured.

Re-verified against source and already correct (no change needed): MSRV 1.88;
Turso-only with legacy `engine = "sqlite"`/`"rusqlite"` a hard startup error;
`[db.sqlite] dir` required fail-closed in multi-site mode;
`multi_tenant_hardening`/`disable_shell_exec`/`open_basedir` defaulting to true
when `[server.security]` is present or `sites_dir` is set, and inert (with a
startup warning) in single-site mode; `disable_functions` composed as a union
with operator `ini_overrides`; `max_execution_time = 30` natively enforced only
on builds with per-thread timers.

## Verification

A throwaway harness diffed `ephpm php` against the system `php` 8.5.4 —
stdout+stderr and exit status — over 55 cases (stdin programs, `--` handling,
`$argv`/`$argc`/`$_SERVER` identity, exit codes for `exit()`/fatal/parse
error/uncaught exception, `-l`/`-w`/`-s` with a file and on stdin, missing
files, `-B`/`-R`/`-F`/`-E`, `$argn`/`$argi`, `-d`, shebangs, reflection flags,
binary-safe and CRLF input, phar-free `-f`).

Two residual diffs are **php.ini artifacts, not behaviour**: the distro php.ini
sets `log_errors=On`, so `php` prints `PHP Parse error: …` on stderr where
ephpm prints the `display_errors` copy. Under `-n` (no ini) the two are
byte-identical, which the harness confirms.

Built and run on Linux (PHP 8.5.7, ZTS). Stub mode: `cargo clippy --workspace
--all-targets -- -D warnings` clean and `cargo test -p ephpm` green (56 unit
tests including the new `php_arg_tests`). `cargo +nightly fmt --all --check`
clean. Not exercised on Windows/macOS — the Windows host used for this work has
no MSVC linker installed, so the Windows leg is CI's first look.
