### PR TITLE
fix(ws): narrow Status::code to c_long at the FFI boundary (unblocks v0.7.0 Windows build)

### DIFF
--- a/crates/ephpm-php/src/ws_bridge.rs
+++ b/crates/ephpm-php/src/ws_bridge.rs
@@ -94,6 +94,29 @@ impl Status {
         }
     }
 
+    /// The wire value narrowed to the C ABI's `long`, as the ops table
+    /// declares it (`long (*send)(...)` etc. in `ephpm_wrapper.c`).
+    ///
+    /// `long` is 64-bit on LP64 (Linux, macOS) but **32-bit on Windows**
+    /// (LLP64), so [`Status::code`]'s `i64` has to narrow at the boundary —
+    /// without this the Windows build fails to compile (and it did: the
+    /// v0.7.0 release's `build-windows` leg was the first thing to ever
+    /// type-check this code, because `php_linked` is only set when
+    /// `PHP_SDK_PATH` is present, which PR CI never does).
+    ///
+    /// The narrowing cannot lose information: the error variants are
+    /// `-1..=-3`, and `Ok(v)` carries either a boolean or a count of
+    /// connections a frame was queued to, which the registry's per-site and
+    /// global connection caps bound far below `i32::MAX`.
+    #[cfg(php_linked)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "every reachable value fits in 32 bits; see doc comment"
+    )]
+    fn code_c(self) -> std::os::raw::c_long {
+        self.code() as std::os::raw::c_long
+    }
+
     /// Shorthand for a boolean result.
     fn boolean(ok: bool) -> Self {
         Self::Ok(i64::from(ok))
@@ -354,7 +377,7 @@ unsafe extern "C" fn ws_send(
 ) -> std::os::raw::c_long {
     // SAFETY: both pairs are live zend_string buffers (or NULL) for this call.
     let (id, body) = unsafe { (opt_slice(conn_id, conn_id_len), slice(payload, payload_len)) };
-    send(id, body, binary != 0).code()
+    send(id, body, binary != 0).code_c()
 }
 
 #[cfg(php_linked)]
@@ -366,7 +389,7 @@ unsafe extern "C" fn ws_subscribe(
 ) -> std::os::raw::c_long {
     // SAFETY: both pairs are live zend_string buffers (or NULL) for this call.
     let (id, chan) = unsafe { (opt_slice(conn_id, conn_id_len), slice(channel, channel_len)) };
-    subscribe(id, chan).code()
+    subscribe(id, chan).code_c()
 }
 
 #[cfg(php_linked)]
@@ -378,7 +401,7 @@ unsafe extern "C" fn ws_unsubscribe(
 ) -> std::os::raw::c_long {
     // SAFETY: both pairs are live zend_string buffers (or NULL) for this call.
     let (id, chan) = unsafe { (opt_slice(conn_id, conn_id_len), slice(channel, channel_len)) };
-    unsubscribe(id, chan).code()
+    unsubscribe(id, chan).code_c()
 }
 
 #[cfg(php_linked)]
@@ -391,7 +414,7 @@ unsafe extern "C" fn ws_broadcast(
 ) -> std::os::raw::c_long {
     // SAFETY: both pairs are live zend_string buffers for this call.
     let (chan, body) = unsafe { (slice(channel, channel_len), slice(payload, payload_len)) };
-    broadcast(chan, body, binary != 0).code()
+    broadcast(chan, body, binary != 0).code_c()
 }
 
 #[cfg(php_linked)]
@@ -406,7 +429,7 @@ unsafe extern "C" fn ws_close(
     // clamped to "normal closure" rather than silently truncated into a
     // different, meaningful code.
     let code = u16::try_from(code).unwrap_or(ephpm_ws::CLOSE_NORMAL);
-    close(id, code).code()
+    close(id, code).code_c()
 }
 
 /// The ops table handed to the C wrapper.


### PR DESCRIPTION
The v0.7.0 release's `Build (PHP 8.3.31, windows-x86_64)` leg failed with 5x `E0308: mismatched types` in `crates/ephpm-php/src/ws_bridge.rs`.

**Cause.** The `EphpmWsOps` table declares its entries as C `long` (`long (*send)(...)` in `ephpm_wrapper.c`), and the Rust shims correspondingly return `std::os::raw::c_long`. But they returned `Status::code()`, which is `i64`. `c_long` is 64-bit on LP64 (Linux, macOS) and **32-bit on Windows** (LLP64), so the code only ever type-checked on Unix.

**Why CI never caught it.** These shims are gated `#[cfg(php_linked)]`, and `php_linked` is only set by `ephpm-php/build.rs` when `PHP_SDK_PATH` is present. PR CI builds in stub mode, so the Windows PHP-linked compile happens for the first time in the release matrix. The native WebSocket bridge (#304) has therefore never compiled on Windows.

**Fix.** A `Status::code_c()` that narrows explicitly at the boundary, documented as to why the narrowing is lossless (error variants are -1..=-3; `Ok(v)` is a boolean or a connection count bounded well below `i32::MAX` by the registry's caps).

**Verification.** Stub-mode clippy `-D warnings` and tests are clean, but note that **stub mode does not compile `code_c` at all** - the real proof is a Windows release build, which is the next step. The rest of the FFI surface was audited: `db_bridge`/`kv_bridge` use `c_longlong` for 64-bit values and only put provably-small values (`c_long::from(bool)`) into `c_long`, so `ws_bridge` was the only site with this defect.

**Follow-up (not in this PR):** CI should compile PHP-linked on Windows so this class of bug is caught on PRs rather than at tag time.