### PR TITLE
fix(php): saturate max_execution_time into c_long (second Windows LLP64 blocker)

### DIFF
--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -744,10 +744,17 @@ impl PhpRuntime {
     pub fn set_max_execution_time(secs: u32) {
         #[cfg(php_linked)]
         {
+            // `c_long` is 64-bit on LP64 (Linux, macOS) but 32-bit on Windows
+            // (LLP64), so `u32` has no infallible conversion on every target —
+            // `i32: From<u32>` does not exist. Saturate instead: a configured
+            // limit above `c_long::MAX` seconds is ~68 years at 32-bit, which
+            // is indistinguishable from "no limit" for a request timeout.
+            let secs =
+                ::std::os::raw::c_long::try_from(secs).unwrap_or(::std::os::raw::c_long::MAX);
             // SAFETY: ephpm_set_max_execution_time only stores the value into a
             // C static; it touches no PHP runtime state and is safe to call from
             // the single-threaded startup path before the tokio runtime exists.
-            unsafe { ffi::ephpm_set_max_execution_time(::std::os::raw::c_long::from(secs)) };
+            unsafe { ffi::ephpm_set_max_execution_time(secs) };
         }
         #[cfg(not(php_linked))]
         {


### PR DESCRIPTION
Second LLP64 defect blocking the v0.7.0 Windows build, found after #318 cleared the first.

`crates/ephpm-php/src/lib.rs:750` called `c_long::from(secs)` with `secs: u32`. On LP64 that resolves to `i64: From<u32>` and compiles; on Windows `c_long` is `i32` and `i32: From<u32>` does not exist (a `u32` does not fit). Fixed with a saturating `try_from` - a configured limit above `c_long::MAX` seconds is ~68 years at 32-bit, indistinguishable from 'no limit' for a request timeout.

**Notable:** this code predates the native WebSockets work, so Windows PHP-linked builds were broken by **at least two independent defects**, not one regression. That is the cost of #319 - nothing compiles `php_linked` on Windows until a release tag exists.

**Audit performed.** I swept every `c_long` site under `ephpm-php` rather than fix one error per 30-minute Windows build:

| Site | Verdict |
|---|---|
| `ws_bridge.rs` (5 shims) | fixed in #318 |
| `lib.rs:750` `from(secs: u32)` | **this PR** |
| `kv_bridge.rs:273` `from(bool)` | safe - `i32: From<bool>` and `i64: From<bool>` both exist |
| `lib.rs:1557` opcache count | safe - only `< 0` and `-1/-2/-3` matches, width-agnostic |
| extern decls / fn-ptr types | safe - both sides are `c_long`/`long` |

Everything else in `db_bridge`/`kv_bridge` uses `c_longlong` for 64-bit values, which is correct.

**Verification:** fmt clean, clippy `-D warnings` clean in WSL. As with #318, stub mode does **not** compile this line (`#[cfg(php_linked)]`), so the Windows release leg remains the only real proof.