### PR TITLE
perf(db): litewire 344d2c23 - end the 1 MiB memset per MySQL packet (#322)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2184,7 +2184,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2656,7 +2656,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "anyhow",
  "futures",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "async-trait",
  "futures",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "litewire-session"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "litewire-backend",
  "litewire-translate",
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "lru 0.18.2",
  "parking_lot",
@@ -2772,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
+source = "git+https://github.com/ephpm/litewire.git?rev=ce52816ff842#ce52816ff8424b2d020213ec4d43842fab4ef1a2"
 dependencies = [
  "async-trait",
  "litewire-backend",
@@ -3124,7 +3124,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3733,7 +3733,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3770,7 +3770,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4210,7 +4210,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4837,7 +4837,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5925,7 +5925,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 [[package]]
 name = "litewire"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "anyhow",
  "futures",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "litewire-backend"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "litewire-hrana"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "litewire-mysql"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "async-trait",
  "getrandom 0.3.4",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "litewire-postgres"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "async-trait",
  "futures",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "litewire-session"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "litewire-backend",
  "litewire-translate",
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "litewire-tds"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "bytes",
  "litewire-backend",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "litewire-translate"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "lru 0.18.2",
  "parking_lot",
@@ -2772,7 +2772,7 @@ dependencies = [
 [[package]]
 name = "litewire-turso"
 version = "0.2.0"
-source = "git+https://github.com/ephpm/litewire.git?rev=10345a869d27#10345a869d27b4256ebe6e97d7789ea3db873c5a"
+source = "git+https://github.com/ephpm/litewire.git?rev=344d2c23bf4e#344d2c23bf4eb8e7050fc9e059146cfdbea18d78"
 dependencies = [
  "async-trait",
  "litewire-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,7 +314,7 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 # both — this is purely ePHPm de-linking them from the binary. The embedded
 # SQLite-family engine is `turso` only. `hrana` (the Hrana *server* wire
 # frontend, independent of the removed Hrana *client*) is kept.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "344d2c23bf4e", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "ce52816ff842", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,29 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 #
 #   [patch."https://github.com/ephpm/litewire.git"]
 #   litewire = { path = "../litewire/crates/litewire" }
-# litewire main @ defab22f0c2d — 0.2.0 (litewire#33–#35). Three batches:
+# litewire @ 344d2c23bf4e — PERF: the MySQL command filter now hands
+# opensrv-mysql a whole command packet per `poll_read` (litewire#37, ePHPm #322).
+#
+# The filter added in litewire#28 (pin cb707ab9) returned the four-byte packet
+# header plus the command byte on their own and made opensrv-mysql poll again
+# for the body. `PacketReader::next_async` loops until a packet parses and
+# escalates its scratch buffer from 4 KiB to 1 MiB on the SECOND iteration, so
+# splitting the header off guaranteed a `Vec::resize(1_048_576, 0)` — a 1 MiB
+# zeroing memset — for every command packet. That is the whole of the v0.7.0
+# wire regression measured in #322: 12.8% of cycles in
+# `__memset_avx2_unaligned_erms`, and −15.7% on a fresh-connection +
+# ten-point-SELECT wire benchmark, recovered to −0.5% of the v0.6.3 shape by
+# this pin. The in-process `ephpm_db_*` bridge never touches the MySQL frontend,
+# which is why the bridge half of the lab suite stayed flat throughout.
+#
+# Do not move this pin backwards past litewire#37 without re-measuring the wire
+# path: every pin from cb707ab9 to 10345a869d27 carries the 1 MiB memset.
+#
+# Previous pin 10345a869d27 — turso 0.7.0 → 0.7.2 (litewire#36). Code-identical
+# to defab22f0c2d; the only change is the engine pin. Measured neutral for the
+# wire path (±1% on the same benchmark), so it is NOT the #322 regression.
+#
+# Previous pin defab22f0c2d — 0.2.0 (litewire#33–#35). Three batches:
 # (1) litewire#34 SECURITY: lru 0.12.5 → 0.18.2, fixing RUSTSEC-2026-0253 — a
 # use-after-free reachable through the production TranslateCache. Do not move
 # this pin backwards past litewire#34. Same PR adds a server-side
@@ -292,7 +314,7 @@ ephpm-ws = { path = "crates/ephpm-ws" }
 # both — this is purely ePHPm de-linking them from the binary. The embedded
 # SQLite-family engine is `turso` only. `hrana` (the Hrana *server* wire
 # frontend, independent of the removed Hrana *client*) is kept.
-litewire = { git = "https://github.com/ephpm/litewire.git", rev = "10345a869d27", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
+litewire = { git = "https://github.com/ephpm/litewire.git", rev = "344d2c23bf4e", default-features = false, features = ["mysql", "postgres", "tds", "hrana", "turso"] }
 # Direct dependency on the same turso the pinned litewire uses, so the
 # snapshot-bootstrap dump code (Phase 2.1) can name turso::{Row, Value}
 # in its signatures. Pinned to the exact version litewire pins (=0.7.0)


### PR DESCRIPTION
Fixes #322.

## Attribution: litewire, not turso

v0.7.0 moved two pins at once — litewire `e34c6392` → `10345a86` and turso
`0.7.0` → `0.7.2`. They were separated at a fixed ePHPm commit by building a
wire-path microbenchmark (litewire's MySQL frontend over the Turso backend,
one fresh connection + ten sequential point SELECTs per iteration — the shape
of the lab's `db.php` fixture) against all four combinations. n=600 per rep,
three reps, interleaved, two pinned cores.

| arm | litewire | turso | rep1 | rep2 | rep3 |
|---|---|---|---:|---:|---:|
| A | `10345a86` | 0.7.2 | 529.1 | 543.5 | 543.3 |
| B | `e34c6392` | 0.7.0 | 623.2 | 641.0 | 638.6 |
| C | `e34c6392` | **0.7.2** | 629.9 | 629.6 | 644.0 |
| D | `10345a86` | **0.7.0** | 537.1 | 546.4 | 563.3 |

C tracks B and D tracks A: **turso 0.7.0 vs 0.7.2 is a no-op** for this
workload. Confirmed independently at the engine level — a microbenchmark of
`db.connect()` + session setup + ten cold `prepare_cached` + `query` measured
128.4/125.6/140.1 µs on 0.7.0 against 129.9/131.4/137.3 µs on 0.7.2, i.e.
inside the rep-to-rep spread.

## Mechanism: a 1 MiB memset per MySQL command packet

Peeling the new frontend apart one layer at a time on `10345a86` localised it
to `CommandFilter` alone — the `Arc<TcpStream>`/`SocketHandle` plumbing and
the 8 KiB `BufReader` introduced in the same PR are free:

| variant | req/s |
|---|---:|
| new plumbing + filter (as shipped) | 494–542 |
| new plumbing, filter removed | 637–643 |
| old `into_split()` plumbing, filter removed | 643–646 |

The filter returned the four-byte packet header plus the command byte on
their own and made `opensrv-mysql` poll again for the body. That is a legal
`AsyncRead` and pathological for the one reader that consumes it:

```rust
// opensrv_mysql::PacketReader::next_async
let mut buffer_size = PACKET_BUFFER_SIZE;      // 4 KiB
loop {
    ...                                        // parse attempt
    if self.bytes.len() - end < buffer_size {
        self.bytes.resize(max(buffer_size, end * 2), 0);   // <- memset
    }
    let read = self.r.read(&mut self.bytes[end..]).await?;
    buffer_size = PACKET_LARGE_BUFFER_SIZE;    // 1 MiB
}
```

Handing back a header with no body **guarantees** the second iteration, and
with it a `Vec::resize(1_048_576, 0)` for every command. `perf` on the
regressed build puts **12.8%** of cycles in `__memset_avx2_unaligned_erms`;
that symbol is absent from the pre-filter build and from the fixed one, and
total cycles for the same work drop 5.35e9 → 4.50e9.

Fixed upstream in **ephpm/litewire#37**: the filter now falls through from
header to body inside a single `poll_read`, exactly as an unfiltered socket
delivered them, with the "never park holding bytes" corollary enforced and
both properties pinned by tests.

## End-to-end verification

Two real ePHPm binaries built from the same commit (`c84e3c6`) with the
litewire pin as the only difference. Server pinned to one core (the lab's
`--cpus 1`), load generator on separate cores, 8s unrecorded warmup then a
recorded 15s cell, gates verified before every pass, two passes. Every cell
100% HTTP 200 **and** body-checked against the fixture's expected value, so a
run that started erroring could not be reported as a win.

| cell | c | `10345a86` (pass 1 / 2) | `344d2c23` (pass 1 / 2) | Δ |
|---|---:|---:|---:|---:|
| wire-point | 1 | 807.5 / 813.8 | 933.7 / 933.3 | **+15.1%** |
| wire-point | 16 | 820.0 / 852.6 | 1142.1 / 1142.9 | **+36.7%** |
| wire-wide | 1 | 1339.5 / 1343.0 | 1411.7 / 1411.8 | **+5.3%** |
| wire-wide | 16 | 1448.0 / 1499.6 | 1959.9 / 1965.0 | **+33.1%** |
| wire-write | 1 | 1702.3 / 1718.5 | 1815.0 / 1819.2 | **+6.2%** |
| wire-write | 16 | 1946.0 / 1989.6 | 2857.5 / 2884.9 | **+45.8%** |
| bridge-point | 1 | 3062.6 / 3074.8 | 3067.0 / 3046.3 | −0.4% |
| bridge-point | 16 | 6553.8 / 6728.8 | 6606.4 / 6742.5 | +0.5% |

The bridge cells are the control. `ephpm_db_*` shares the same backend object
in the same process but never touches the MySQL frontend, and it does not
move — the same signature #322 reported, inverted. The c=16 gains exceed the
originally reported c=16 losses, which is what a per-packet 1 MiB memset
should do once it stops evicting everything else from cache.

Box: 32-core Ryzen under WSL2 Ubuntu, load average 0.8–2.8, nothing else
building during any measurement (all builds were sequenced before the runs).

## Scope

Cargo.toml pin + the nine matching Cargo.lock source lines. No ePHPm source
changes. `cargo clippy --workspace --all-targets -- -D warnings` and
`cargo +nightly fmt --all -- --check` clean; a php-linked release build
succeeds and serves the fixtures (that is where the numbers above come from).

## Before merging

The pin `344d2c23bf4e` is the head of litewire#37's branch. **Re-pin to the
squash-merge commit on litewire `main` once litewire#37 lands**, then
`cargo update -p litewire`. Merging this first would pin a commit that is not
on litewire's default branch.
