### PR TITLE
ci(e2e): cap fleet pile-up with a concurrency group; the red E2E legs were runner deaths, not #317

### DIFF
--- a/.claude/skills/triage-ci/SKILL.md
+++ b/.claude/skills/triage-ci/SKILL.md
@@ -7,6 +7,22 @@ description: Diagnose a failing ephpm CI run (E2E, unit, deny, release). Use whe
 
 Work the ladder top-down. Each step either identifies the failure class or rules it out.
 
+## 0. No logs? Read the job's *annotation* before assuming a test failed
+
+The fleet regularly returns `BlobNotFound` / `log not found` for a failed job. That absence is itself a signal, and there is a second channel that still works:
+
+```bash
+gh api repos/ephpm/ephpm/actions/runs/<RUN_ID>/jobs \
+  --jq '.jobs[] | .name, ([.steps[] | "  \(.number). \(.name) => \(.conclusion//"null")"] | join("\n"))'
+gh api repos/ephpm/ephpm/check-runs/<JOB_ID>/annotations --jq '.[] | "\(.annotation_level): \(.message)"'
+```
+
+**A step with `conclusion: null` and `completed_at: null` did not fail — it never finished.** GitHub only records a step conclusion when the runner reports one, so a null conclusion on the step that was executing means the runner process died underneath it. A genuine test failure always leaves `conclusion: failure` on that step plus a completed `Complete job` step.
+
+- **Known signature — runner death**: annotation reads `The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.` This is **infra, not your commit.** Missing logs follow from it: the runner never lived to upload them.
+- Corroborate before believing it — the cheap checks, in order: does the same tree pass on other matrix legs? Did the PR's own run of the identical tree pass? How many heavy jobs were on the fleet in that window (`gh run list --workflow=e2e.yml --limit 15` and compare `created_at`)? Precedent (2026-08-19): four commits landed on main in 74 seconds, twelve E2E legs hit the fleet at once, and the last run's 8.3/8.5 legs died this way on two attempts while its 8.4 leg and all nine earlier legs passed. The commit was innocent; `.github/workflows/e2e.yml` now carries a concurrency group to cap the pile-up.
+- Do **not** start bisecting a commit until this step rules runner death out. "Deterministic across re-runs" is not evidence of a code bug when the fleet stays saturated or degraded between attempts.
+
 ## 1. Read the failure summary FIRST (bottom of the E2E job log)
 
 Default path is `cargo xtask e2e` (bare-process). On failure it dumps each node's stderr file and prints a `==== FAILED E2E SUITES (bare-process) ====` block with the per-suite names.
@@ -47,7 +63,8 @@ The Windows/Linux runners are **ephemerd** JIT runners on Luther's box; macOS ru
 ## 4. Rerun rules
 
 - `gh run rerun <RUN_ID> --failed` is refused while any job in the run is still running/queued. **Cancel first, then rerun-failed** - completed-successful jobs (Linux legs, Docker) are preserved, only failed/cancelled legs re-execute. This also applies to release runs: never re-tag to retry.
-- E2E runs are serialized repo-wide via a concurrency group - "pending" E2E often just means another run holds the lock.
+- E2E runs are serialized **per ref** via a concurrency group (`ephpm-e2e-${{ github.ref }}`) - "pending" E2E often just means an earlier run on that same ref holds the lock. Pushes to main queue (every commit keeps its own result, so CI history stays bisectable); pull-request runs cancel in progress when superseded.
+- A re-run that dies the same way is not automatically a code bug. If step 0 said "lost communication", check the fleet box before re-running again - a host left short on memory or disk by an earlier burst will kill the next runner too. `.github/workflows/fleet-maintenance.yml` purges docker build cache/images on a node.
 
 ## 5. Repo-wide sudden failures
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,8 +44,8 @@ on:
 # both died mid-step with "The self-hosted runner lost communication with the
 # server" — on two separate attempts, with no logs uploaded — while its 8.4 leg
 # and all nine legs of the three earlier runs passed. Nothing about the commit
-# was at fault: that same tree is green locally on 8.3/8.4/8.5, and its own PR
-# run passed all three legs.
+# was at fault: that exact tree is green locally on 8.3/8.4/8.5, and every file
+# it changed is byte-identical to its PR head, whose own run passed all three.
 #
 # Grouping by ref means a burst of merges to main queues instead of piling up.
 # `cancel-in-progress` stays false on push so every commit on main still gets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,15 +28,49 @@ on:
       - "docs/**"
       - "**.md"
 
-# NOTE: no `concurrency` group. Bare-process runs are independent - each job
-# spawns ephpm processes on high, per-run loopback ports and cleans up on exit.
-# Multiple E2E runs can share the runner without stepping on each other, and
-# the matrix legs can run in parallel.
+# Cap how many of these land on the ephemerd fleet at once.
+#
+# Bare-process runs are independent *of each other* — each job spawns ephpm on
+# high, per-run loopback ports and cleans up on exit, so there is no port or
+# state collision. That was the original reason this workflow had no
+# `concurrency` group at all. What that reasoning missed is the host: every leg
+# does a full `lto = "fat"`, `codegen-units = 1` release build of the whole
+# workspace plus a statically linked PHP (~2.3 GB peak RSS in the final rustc
+# invocation alone, on top of `-j$(nproc)` parallel rustc before it) into a
+# fresh ephemeral runner workspace.
+#
+# On 2026-08-19 four commits landed on main inside 74 seconds. That put twelve
+# of these legs on the fleet simultaneously; the last run's 8.3 and 8.5 legs
+# both died mid-step with "The self-hosted runner lost communication with the
+# server" — on two separate attempts, with no logs uploaded — while its 8.4 leg
+# and all nine legs of the three earlier runs passed. Nothing about the commit
+# was at fault: that same tree is green locally on 8.3/8.4/8.5, and its own PR
+# run passed all three legs.
+#
+# Grouping by ref means a burst of merges to main queues instead of piling up.
+# `cancel-in-progress` stays false on push so every commit on main still gets
+# its own E2E result — that per-commit signal is what makes `git bisect` over CI
+# history possible, and it is how the 2026-08-19 incident was localized in the
+# first place. Pull requests do cancel superseded runs: only the head commit of
+# a PR needs to be green, and a force-push otherwise leaves a doomed run holding
+# three runners.
+#
+# Sibling precedent for capping fleet load: `build-memory.yml` and
+# `k8s-e2e.yml` both serialize repo-wide, and `nightly.yml` caps its macOS
+# matrix at 2 "to leave headroom on the Apple Silicon host".
+concurrency:
+  group: ephpm-e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e-bare:
     name: E2E bare-process (PHP ${{ matrix.php }})
     runs-on: [self-hosted, linux, x64]
+    # A healthy leg is 10-20 minutes (cold cache, full release build included).
+    # The GitHub default is 360, which turns a wedged runner into a six-hour
+    # hold on a fleet slot. Generous enough not to fire on a slow-but-working
+    # run, tight enough that a stuck one frees the runner the same hour.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/site/content/developer/testing.md
+++ b/site/content/developer/testing.md
@@ -386,18 +386,23 @@ CONTAINER_ENGINE=docker cargo xtask e2e --php-version 8.4
 
 ## GitHub Actions
 
-The E2E workflow (`.github/workflows/e2e.yml`) runs a matrix of PHP 8.4 and 8.5:
+The E2E workflow (`.github/workflows/e2e.yml`) runs a matrix of PHP 8.3, 8.4 and 8.5:
 
 ```yaml
+concurrency:
+  group: ephpm-e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 strategy:
+  fail-fast: false
   matrix:
-    php: ["8.4", "8.5"]
+    php: ["8.3", "8.5", "8.4"]
 steps:
-  - cargo xtask e2e-install
   - cargo xtask e2e --php-version ${{ matrix.php }}
 ```
 
-Each job builds ephpm with the specified PHP version, deploys it to a Kind cluster, and validates that `/index.php` reports the correct PHP version and embedded SAPI.
+Each job builds ephpm with the specified PHP version, spawns it as a bare process on 127.0.0.1, and runs the `ephpm-e2e` suites against it. No Kind cluster is involved — that path is opt-in via `cargo xtask k8s-e2e` and `.github/workflows/k8s-e2e.yml`.
+
+The concurrency group caps how many of these land on the self-hosted fleet at once: each leg is a full `lto = "fat"` release build with PHP statically linked, so a burst of merges could otherwise put a dozen of them on the box simultaneously and starve the runners. Pushes to main queue rather than cancel, so every commit keeps its own E2E result.
 
 ---
 


### PR DESCRIPTION
## The E2E legs on main did not fail a test — the runners died

`E2E Tests` on `1b64706` (#317) bisected cleanly and looked damning: 8.3 and 8.5 red, 8.4 green, identical on a re-run. That pattern reads exactly like a PHP-version-dependent assertion in the `cli` suite #317 added.

It isn't. Logs came back `BlobNotFound`, but the job metadata survived, and it says something different:

```console
$ gh api repos/ephpm/ephpm/actions/runs/32299454696/jobs --jq '...'
E2E bare-process (PHP 8.3)
  4. Run dtolnay/rust-toolchain@stable => success
  5. Run bare-process E2E          => null      # <- never finished
  10. Post Run actions/checkout@v4 => null

$ gh api repos/ephpm/ephpm/check-runs/96231004190/annotations
failure: The self-hosted runner lost communication with the server. Verify the
machine is running and has a healthy network connection. Anything in your
workflow that terminates the runner process, starves it for CPU/Memory, or
blocks its network access can cause this error.
```

A step with `conclusion: null` and `completed_at: null` did not fail — the runner process died underneath it. Same annotation on both legs, on **both** attempts. The missing logs follow from it: the runner never lived to upload them.

## The commit is innocent

Built PHP-linked at `1b64706` (unmodified) and ran the full bare-process suite locally on every matrix leg, including both CI called red:

| leg | binary | result |
|---|---|---|
| PHP 8.3.31 | `ephpm php -v` → `PHP 8.3.31 (cli) (ZTS)` | `==> All bare-process E2E suites passed` |
| PHP 8.4.23 | `ephpm php -v` → `PHP 8.4.23 (cli) (ZTS)` | `==> All bare-process E2E suites passed` |
| PHP 8.5.7 | `ephpm php -v` → `PHP 8.5.7 (cli) (ZTS)` | `==> All bare-process E2E suites passed` |

The `cli` suite specifically — the prime suspect, since it asserts on PHP error text:

```console
==> Running 1 server-less suite(s) directly against the binary...
==> Running suite: cli (--test-threads=4)
test result: ok. 9 passed; 0 failed; ... finished in 0.14s
```

9/9 on all three, in 0.14 s, at 35 MB peak RSS per `ephpm php` invocation. It cannot starve a runner and its assertions are already version-tolerant — the messages it matches (`Uncaught Exception: boom`, `Call to undefined function nosuchfunc()`, `Parse error`, `Undefined variable`, the `Command line code` / `Standard input code` labels) are byte-identical across 8.3, 8.4 and 8.5.

**It also still earns its keep.** Run unmodified against the published v0.7.0 artifact it fails 6 of 9, naming both halves of #321 independently:

```console
$ EPHPM_CLI_BINARY=/root/v070/ephpm cli-39404f886b179afe --test-threads=4
panicked: -r undefined function: no diagnostic at all (issue #321 regression — the fatal was swallowed). exit=0
panicked: script file fatal: expected php-cli's fatal exit status 255, got 0
test result: FAILED. 3 passed; 6 failed;
```

So **no test changes here.** Weakening that suite would have been the wrong fix to the wrong problem.

## What actually happened, and what this PR does

Four commits landed on main inside 74 seconds (#311, #312, #323, #317). That put **twelve** E2E legs on the ephemerd fleet simultaneously. Every leg is a full `lto = "fat"`, `codegen-units = 1` release build of the workspace with PHP statically linked — measured at ~2.3 GB peak RSS in the final rustc invocation alone, on top of `-j$(nproc)` parallel rustc before it, into a fresh ephemeral runner workspace. The last run to get runners lost two of its three legs. Its 8.4 leg and all nine legs of the three earlier runs passed, and #317's own PR run (`32217089205`) had passed all three legs; every file #317 touched is byte-identical between the two (`cli.rs`, `ephpm_wrapper.c`, `ephpm/src/main.rs`, `e2e_bare.rs`), the merge commit additionally carrying #311/#312/#323, which each passed E2E on main independently.

`e2e.yml` was the only heavy self-hosted workflow with no cap at all — `build-memory.yml` and `k8s-e2e.yml` serialize repo-wide, `nightly.yml` caps its macOS matrix at 2 "to leave headroom on the Apple Silicon host". This adds:

```yaml
concurrency:
  group: ephpm-e2e-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Grouping by ref makes a burst of merges to main **queue** instead of pile up. `cancel-in-progress` stays false on push so every commit on main keeps its own E2E result — that per-commit signal is what makes CI history bisectable, and it is how this incident got localized to #317 in the first place. Pull requests do cancel superseded runs: only the head commit needs to be green, and a force-push otherwise leaves a doomed run holding three runners.

Plus `timeout-minutes: 60` on the job (a healthy leg is 10–20 min; the GitHub default of 360 turns a wedged runner into a six-hour hold on a fleet slot).

The old `# NOTE: no concurrency group` comment is replaced rather than deleted — its reasoning was about ports and state, which is still correct and still not the constraint that bit us.

## Also

- **`triage-ci` skill** gains step 0: when logs come back `BlobNotFound`, read the job annotation, and treat a null step conclusion as runner death rather than a test failure. This is the rung whose absence sent this investigation after a phantom version-dependent assertion. It also warns that "deterministic across re-runs" is not evidence of a code bug when the fleet stays saturated or degraded between attempts.
- Corrects the skill's stale claim that E2E is serialized repo-wide (per-ref now), and `site/content/developer/testing.md`'s stale E2E section (claimed a 8.4/8.5 matrix deployed to a Kind cluster via `cargo xtask e2e-install`; it is 8.3/8.4/8.5, bare-process).

## Unblocking v0.7.1

`gh run rerun 32299454696 --failed` has been kicked off on main. If it dies the same way again, the fleet box itself needs attention before another retry — a host left short on memory or disk by the twelve-leg burst will kill the next runner too (`fleet-maintenance.yml` purges docker cache/images on a node).

## Verification

- Full `cargo xtask e2e` at `1b64706`, green on 8.3.31 / 8.4.23 / 8.5.7 (all built from the pinned SDKs, binary identity asserted via `ephpm php -v` in each run).
- `cli` suite fails 6/9 against the published `ephpm-v0.7.0+php8.5.7-linux-x86_64` artifact — the #321 regression cover is intact.
- No Rust changed, so `cargo +nightly fmt` / `cargo clippy` are unaffected; YAML re-parsed and asserted (`concurrency`, `timeout-minutes`, matrix).
