### PR TITLE
test: eliminate the bind-drop-rebind port race in test harnesses

### DIFF
--- a/crates/ephpm-db/tests/caching_sha2_auth.rs
+++ b/crates/ephpm-db/tests/caching_sha2_auth.rs
@@ -33,6 +33,7 @@
 //! Set `MYSQL_SHA2_TEST_URL` to an admin connection string against a stock
 //! `MySQL` 8 (e.g. `mysql://root:secret@127.0.0.1:3306/mysql`) to enable these.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
@@ -61,13 +62,21 @@ fn test_pool_config() -> PoolConfig {
 
 /// Boot a [`MySqlProxy`] against `backend_url` on an OS-assigned port.
 ///
-/// Returns `Err` with the proxy's own error text when the backend handshake
-/// fails, so a test can assert on an auth failure instead of hanging.
+/// The listener is bound exactly once and handed to [`MySqlProxy::run_on`]
+/// — never dropped and rebound. The old bind-drop-rebind dance raced other
+/// test processes binding `127.0.0.1:0`: a stolen port made the proxy's
+/// rebind fail while the ready-check connected to the *other* test's proxy,
+/// so the session died mid-stream with `ConnectionReset` (the intermittent
+/// `DB Integration` CI failure).
+///
+/// Panics with the proxy's own error text when the backend handshake fails
+/// (`MySqlProxy::new` dials the backend), so a test fails fast instead of
+/// hanging. No readiness poll is needed: the listener is live before this
+/// function returns, and early clients queue in the kernel accept backlog
+/// until `run_on` starts accepting.
 async fn start_proxy(backend_url: &str) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let listen_addr = listener.local_addr().unwrap().to_string();
-    drop(listener);
-    tokio::time::sleep(Duration::from_millis(50)).await;
 
     let proxy = MySqlProxy::new(
         backend_url,
@@ -83,18 +92,12 @@ async fn start_proxy(backend_url: &str) -> String {
     .expect("MySqlProxy::new failed — backend handshake did not complete");
 
     tokio::spawn(async move {
-        if let Err(e) = proxy.run().await {
+        if let Err(e) = proxy.run_on(Arc::new(listener)).await {
             eprintln!("proxy stopped: {e}");
         }
     });
 
-    for _ in 0..100 {
-        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
-            return listen_addr;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    panic!("proxy did not become ready at {listen_addr}");
+    listen_addr
 }
 
 /// `mysql_async` opts pointed at the proxy. The proxy accepts any client

--- a/crates/ephpm-db/tests/deferred_startup.rs
+++ b/crates/ephpm-db/tests/deferred_startup.rs
@@ -92,6 +92,23 @@ fn handshake_response() -> Vec<u8> {
 /// Reserve a loopback port and release it, so a backend can be bound there
 /// later. Between the release and the late `start_mock_backend_on`, the
 /// address is exactly what the bug needs: routable but refusing connections.
+///
+/// This is a deliberate bind-drop pattern, unlike the rebind race fixed in
+/// the proxy integration tests (`run_on` with a held listener): these tests
+/// *require* an address with nothing listening, and a held listener would
+/// accept connections into its backlog. There is no portable way to reserve
+/// a TCP port as "refusing". The residual cross-process TOCTOU — another
+/// test binding `:0` could be issued this port before the late rebind —
+/// fails closed on both rebind paths: `spawn_deferred` refuses to start on
+/// an occupied listen port (see `bind_failure_is_an_error_not_a_warning`)
+/// and `start_mock_backend_on` panics if its bind fails, so neither silently
+/// proceeds against another test's socket. What remains is a theoretical
+/// assertion flake — a stranger binding a reserved *upstream* port and
+/// speaking MySQL could flip `ever_connected` early — which the kernel's
+/// aversion to immediate ephemeral-port reuse makes vanishingly rare, and
+/// which cannot reproduce the wrong-backend mid-session failure mode the
+/// proxy tests had: nothing here ever exchanges application traffic with a
+/// socket it did not bind or verify by handshake.
 async fn reserve_addr() -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("reserve port");
     let addr = listener.local_addr().expect("reserved addr");

--- a/crates/ephpm-db/tests/pg_proxy_integration.rs
+++ b/crates/ephpm-db/tests/pg_proxy_integration.rs
@@ -30,6 +30,7 @@
 //!     cargo test -p ephpm-db --test pg_proxy_integration -- --ignored
 //! ```
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ephpm_db::ResetStrategy;
@@ -58,14 +59,20 @@ fn test_pool_config() -> PoolConfig {
 
 /// Boot a [`PgProxy`] on a random OS-assigned port and return the listen
 /// address (e.g. `127.0.0.1:XXXXX`).
+///
+/// The listener is bound exactly once and handed to [`PgProxy::run_on`] —
+/// never dropped and rebound. Dropping a `:0` listener and rebinding its port
+/// races other test processes doing the same, and the old ready-poll would
+/// then happily connect to *their* proxy (see `caching_sha2_auth.rs`). No
+/// readiness poll is needed: the listener is live before this function
+/// returns; early clients queue in the kernel accept backlog.
 async fn start_proxy(
     backend_url: &str,
     pool_config: PoolConfig,
     reset_strategy: ResetStrategy,
 ) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let listen_addr = addr.to_string();
+    let listen_addr = listener.local_addr().unwrap().to_string();
 
     let proxy = PgProxy::new(
         backend_url,
@@ -81,22 +88,13 @@ async fn start_proxy(
     .await
     .expect("failed to create PgProxy — backend handshake failed");
 
-    drop(listener);
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
     tokio::spawn(async move {
-        if let Err(e) = proxy.run().await {
+        if let Err(e) = proxy.run_on(Arc::new(listener)).await {
             eprintln!("proxy stopped: {e}");
         }
     });
 
-    for _ in 0..50 {
-        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
-            return listen_addr;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    panic!("proxy did not become ready at {listen_addr}");
+    listen_addr
 }
 
 /// Build a `tokio_postgres` config that routes through the proxy.

--- a/crates/ephpm-db/tests/proxy_integration.rs
+++ b/crates/ephpm-db/tests/proxy_integration.rs
@@ -9,6 +9,7 @@
 //! Locally an unset `MYSQL_TEST_URL` skips; in CI it is a failure. See
 //! `tests/common/mod.rs` for why.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ephpm_db::ResetStrategy;
@@ -37,6 +38,13 @@ fn test_pool_config() -> PoolConfig {
 
 /// Boot a [`MySqlProxy`] on a random OS-assigned port and return the listen
 /// address (e.g. `127.0.0.1:XXXXX`).
+///
+/// The listener is bound exactly once and handed to [`MySqlProxy::run_on`] —
+/// never dropped and rebound. Dropping a `:0` listener and rebinding its port
+/// races other test processes doing the same, and the old ready-poll would
+/// then happily connect to *their* proxy (see `caching_sha2_auth.rs`). No
+/// readiness poll is needed: the listener is live before this function
+/// returns; early clients queue in the kernel accept backlog.
 async fn start_proxy(
     backend_url: &str,
     pool_config: PoolConfig,
@@ -44,8 +52,7 @@ async fn start_proxy(
 ) -> String {
     // Bind to port 0 so the OS assigns a free port.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let listen_addr = addr.to_string();
+    let listen_addr = listener.local_addr().unwrap().to_string();
 
     // Build the proxy pointed at the real backend.
     let proxy = MySqlProxy::new(
@@ -63,27 +70,14 @@ async fn start_proxy(
     .await
     .expect("failed to create MySqlProxy");
 
-    // Drop the listener we used for port discovery — the proxy will re-bind.
-    drop(listener);
-
-    // Give the OS a moment to release the port before the proxy re-binds.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Run the proxy in the background.
+    // Run the proxy in the background on the listener bound above.
     tokio::spawn(async move {
-        if let Err(e) = proxy.run().await {
+        if let Err(e) = proxy.run_on(Arc::new(listener)).await {
             eprintln!("proxy stopped: {e}");
         }
     });
 
-    // Wait for the proxy listener to be ready.
-    for _ in 0..50 {
-        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
-            return listen_addr;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    panic!("proxy did not become ready at {listen_addr}");
+    listen_addr
 }
 
 /// Boot a [`MySqlProxy`] with read/write splitting enabled and one replica
@@ -113,22 +107,14 @@ async fn start_proxy_rw_split(
     .await
     .expect("failed to create MySqlProxy");
 
-    drop(listener);
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
+    // Same single-bind pattern as `start_proxy` — see the comment there.
     tokio::spawn(async move {
-        if let Err(e) = proxy.run().await {
+        if let Err(e) = proxy.run_on(Arc::new(listener)).await {
             eprintln!("proxy stopped: {e}");
         }
     });
 
-    for _ in 0..50 {
-        if tokio::net::TcpStream::connect(&listen_addr).await.is_ok() {
-            return listen_addr;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    panic!("proxy did not become ready at {listen_addr}");
+    listen_addr
 }
 
 /// Build a `mysql_async` connection opts that route through the proxy.

--- a/crates/ephpm-e2e/src/lib.rs
+++ b/crates/ephpm-e2e/src/lib.rs
@@ -87,7 +87,7 @@ impl SingleNodeFixture {
         let stdout = fs::File::create(tmp.path().join("stdout.log")).context("open stdout log")?;
         let stderr = fs::File::create(tmp.path().join("stderr.log")).context("open stderr log")?;
 
-        let child = Command::new(ephpm_binary)
+        let mut child = Command::new(ephpm_binary)
             .args(["serve", "--config"])
             .arg(&config_path)
             .stdout(Stdio::from(stdout))
@@ -95,7 +95,7 @@ impl SingleNodeFixture {
             .spawn()
             .with_context(|| format!("spawn ephpm ({})", ephpm_binary.display()))?;
 
-        wait_for_health(http_port, Duration::from_secs(15)).await.with_context(|| {
+        wait_for_health(&mut child, http_port, Duration::from_secs(15)).await.with_context(|| {
             format!(
                 "ephpm on 127.0.0.1:{http_port} never healthy — check {}",
                 tmp.path().join("stderr.log").display()
@@ -211,14 +211,15 @@ impl ClusterFixture {
             });
         }
 
-        for (i, node) in nodes.iter().enumerate() {
+        for (i, node) in nodes.iter_mut().enumerate() {
             let port: u16 = node
                 .base_url
                 .rsplit(':')
                 .next()
                 .and_then(|s| s.parse().ok())
                 .ok_or_else(|| anyhow!("could not parse port from {}", node.base_url))?;
-            wait_for_health(port, Duration::from_secs(20))
+            let child = node.child.as_mut().ok_or_else(|| anyhow!("node {i} has no child"))?;
+            wait_for_health(child, port, Duration::from_secs(20))
                 .await
                 .with_context(|| format!("cluster node {i} never healthy"))?;
         }
@@ -256,8 +257,15 @@ struct ClusterPorts {
 /// then dropping the listener.
 ///
 /// There is an inherent TOCTOU here — the port may be re-issued before ephpm
-/// binds it — but for a test fixture that only ever runs one topology at a
-/// time this is acceptable in practice.
+/// binds it — and unlike the in-process proxy tests (which now bind once and
+/// hand the live listener to `run_on`) it cannot be engineered away: the
+/// ports cross a process boundary through a generated config file, and
+/// `ephpm serve` has no way to inherit an already-bound socket. The race
+/// fails closed rather than cross-wired: a stolen port makes the child's own
+/// bind fail and the child exit, which `wait_for_health` detects and reports
+/// immediately instead of health-probing a port someone else may now own.
+/// For a fixture that runs one topology at a time this is acceptable in
+/// practice.
 async fn reserve_loopback_port() -> Result<u16> {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.context("bind :0")?;
     let port = listener.local_addr().context("local_addr")?.port();
@@ -265,10 +273,23 @@ async fn reserve_loopback_port() -> Result<u16> {
     Ok(port)
 }
 
-async fn wait_for_health(port: u16, timeout: Duration) -> Result<()> {
+/// Poll `child`'s health endpoint until it answers 200, the child exits, or
+/// `timeout` elapses.
+///
+/// The child-exit check is load-bearing for the reserved-port TOCTOU (see
+/// [`reserve_loopback_port`]): a stolen port makes the child fail its bind
+/// and exit, and without the check the poll could get a 200 from whatever
+/// *else* is listening there and hand the test a stranger's server.
+async fn wait_for_health(child: &mut Child, port: u16, timeout: Duration) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let mut last_err = String::from("no attempts made");
     while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().context("try_wait on ephpm child")? {
+            return Err(anyhow!(
+                "ephpm exited ({status}) before reporting healthy — \
+                 possibly its reserved port was taken; check its stderr log"
+            ));
+        }
         match tokio::task::spawn_blocking(move || tcp_get(port, "/_ephpm/health"))
             .await
             .map_err(|e| anyhow!("join error: {e}"))?

--- a/crates/ephpm/tests/vhost_routing.rs
+++ b/crates/ephpm/tests/vhost_routing.rs
@@ -24,6 +24,15 @@ const BIN: &str = env!("CARGO_BIN_EXE_ephpm");
 
 /// Pick a free port on 127.0.0.1 by binding to port 0 and reading back the
 /// kernel-assigned port. Mirrors what `ephpm dev` does internally.
+///
+/// This is only a *starting hint* for `ephpm dev`'s own free-port scan, not
+/// a reservation: another process may grab the port between the drop here
+/// and the server's bind, in which case `run_dev`'s `find_free_port` moves
+/// on to the next free port. That is why `spawn_dev` reports back the port
+/// the server actually bound (parsed from its `HTTP listening` log line)
+/// instead of trusting this one — the bind-drop-rebind race can shift the
+/// server onto a neighboring port, but it can no longer point the test's
+/// requests at a stranger's socket.
 fn pick_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind 127.0.0.1:0");
     let port = listener.local_addr().expect("local_addr").port();
@@ -31,12 +40,25 @@ fn pick_port() -> u16 {
     port
 }
 
+/// Extract the bound port from an `HTTP listening` log line, e.g.
+/// `... HTTP listening addr=127.0.0.1:43121`. Parses the digits after the
+/// literal `127.0.0.1:` — matching on the value rather than `addr=` so that
+/// ANSI styling around the field name cannot break the parse.
+fn parse_listening_port(line: &str) -> Option<u16> {
+    let tail = &line[line.rfind("127.0.0.1:")? + "127.0.0.1:".len()..];
+    let digits: String = tail.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
 /// Spawn `ephpm dev --sites <sites> --document-root <doc_root> --port <port>`
-/// and block until it logs `HTTP listening` (or 15 seconds elapse).
+/// and block until it logs `HTTP listening` (or 15 seconds elapse), returning
+/// the child and the port the server **actually** bound — which is `port`
+/// unless something else claimed it first, in which case the dev server's
+/// free-port scan picked a nearby one.
 ///
 /// Both stdout (banner) and stderr (tracing) must be drained — otherwise a
 /// piped child blocks on its first write past the pipe buffer.
-fn spawn_dev(sites: &PathBuf, doc_root: &PathBuf, port: u16) -> Child {
+fn spawn_dev(sites: &PathBuf, doc_root: &PathBuf, port: u16) -> (Child, u16) {
     let mut cmd = Command::new(BIN);
     cmd.arg("dev")
         .arg("--sites")
@@ -49,14 +71,14 @@ fn spawn_dev(sites: &PathBuf, doc_root: &PathBuf, port: u16) -> Child {
         .stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("spawn ephpm dev");
 
-    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    let (tx, rx) = std::sync::mpsc::channel::<Option<u16>>();
     let tx_stdout = tx.clone();
     let stdout = child.stdout.take().expect("stdout piped");
     std::thread::spawn(move || {
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
             eprintln!("ephpm[out]: {line}");
             if line.contains("HTTP listening") {
-                let _ = tx_stdout.send(());
+                let _ = tx_stdout.send(parse_listening_port(&line));
             }
         }
     });
@@ -66,15 +88,20 @@ fn spawn_dev(sites: &PathBuf, doc_root: &PathBuf, port: u16) -> Child {
         for line in BufReader::new(stderr).lines().map_while(Result::ok) {
             eprintln!("ephpm[err]: {line}");
             if line.contains("HTTP listening") {
-                let _ = tx.send(());
+                let _ = tx.send(parse_listening_port(&line));
             }
         }
     });
 
     let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
-        if rx.try_recv().is_ok() {
-            return child;
+        if let Ok(parsed) = rx.try_recv() {
+            let Some(bound_port) = parsed else {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("'HTTP listening' was logged but no 127.0.0.1:<port> could be parsed");
+            };
+            return (child, bound_port);
         }
         std::thread::sleep(Duration::from_millis(50));
     }
@@ -126,8 +153,8 @@ fn dev_sites_routes_localhost_subdomains() {
     std::fs::create_dir_all(&doc_root).expect("mkdir doc_root");
     std::fs::write(doc_root.join("index.html"), "<h1>fallback</h1>").expect("write fallback");
 
-    let port = pick_port();
-    let _server = ServerGuard(spawn_dev(&sites, &doc_root, port));
+    let (child, port) = spawn_dev(&sites, &doc_root, pick_port());
+    let _server = ServerGuard(child);
     let base = format!("http://127.0.0.1:{port}/");
 
     // Each named vhost serves its own content.


### PR DESCRIPTION
## Problem

`DB Integration` on main fails intermittently: `fast_auth_still_works_once_the_cache_is_warm` (caching_sha2_auth.rs) dies with `ConnectionReset` and `proxy stopped: I/O error: Address already in use (os error 98)` on stderr.

Root cause is a systemic **bind-drop-rebind race** in test helpers: bind `127.0.0.1:0` to discover a free port, drop the listener, then have the proxy re-bind the same address. Under nextest's process-per-test parallelism another test doing the same dance can steal the port between drop and rebind. The failure is worse than a failed bind: the ready-check `TcpStream::connect` succeeds against the *other* test's proxy, so the test proceeds against the wrong backend and dies mid-session.

## Fix

`MySqlProxy::run_on` / `PgProxy::run_on` already accept an existing listener. Bind once, never drop, hand the same listener to the proxy. The listener is live before the helper returns (early clients queue in the kernel accept backlog), so the 50 ms sleep and the connect ready-poll are removed as unnecessary — `MySqlProxy::new` / `PgProxy::new` already complete the backend handshake before the helper returns, so there is nothing left to poll for.

Per site:

| Site | Action |
|------|--------|
| `crates/ephpm-db/tests/caching_sha2_auth.rs` (the CI flake) | fixed with `run_on`; sleep + ready-poll removed |
| `crates/ephpm-db/tests/proxy_integration.rs` (both helpers) | fixed with `run_on`; sleep + ready-poll removed |
| `crates/ephpm-db/tests/pg_proxy_integration.rs` | fixed with `PgProxy::run_on` (API already existed); sleep + ready-poll removed |
| `crates/ephpm-db/tests/deferred_startup.rs` | **left intentional** — those tests *require* a routable-but-refusing address (a held listener would accept into its backlog). Both late-rebind paths fail closed (`spawn_deferred` errors on an occupied port; the mock backend panics on bind failure), so the residual TOCTOU cannot produce the wrong-backend mode. Documented on `reserve_addr`. |
| `crates/ephpm/tests/vhost_routing.rs` | fixed differently — the port crosses a process boundary (`ephpm dev --port N`), so a listener cannot be handed over. Worse, a stolen port made `run_dev`'s `find_free_port` silently shift the server to `N+1` while the test kept GETting the stolen port. The test now parses the port the server **actually bound** from its `HTTP listening addr=127.0.0.1:PORT` log line and uses that, so a shifted port is followed and a stranger's socket is never queried. |
| `crates/ephpm/src/main.rs` `find_free_port` (production) | **benign, untouched** — dev-mode-only probe; a stolen port makes the subsequent real bind fail loudly with the OS error (it is the server binding, not connecting, so no wrong-backend mode exists). Already documented at the definition. |
| `crates/ephpm-e2e/src/lib.rs` | ports cross a process boundary through a generated config, so the reservation TOCTOU is inherent. Hardened instead: `wait_for_health` now takes the child and detects child exit — a stolen port kills the child at bind, and previously the health poll could receive a 200 from whatever *else* owned the port and hand the fixture a stranger's server. Documented on `reserve_loopback_port`. No change to the xtask shared node template. |

## Verification

All on this branch, Linux (WSL):

- `cargo test -p ephpm-db` — full crate suite green.
- Real databases (podman: `mysql:8.0` ×2 — separate server for the sha2 suite as its doc requires — and `postgres:17`): `proxy_integration`, `pg_proxy_integration`, `caching_sha2_auth` each run 20× sequentially with `-- --ignored`, then 5 rounds of all three test binaries **concurrently** for cross-process port pressure. Zero failures, including `fast_auth_still_works_once_the_cache_is_warm`.
- `cargo test -p ephpm --test vhost_routing` — green (this also validates the log-line port parse: the test can only pass if the parsed port reaches the right server).
- `cargo test -p ephpm-db --test deferred_startup` ×20 — green.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check` — clean.
- `crates/ephpm-e2e`: `cargo check` — compiles (workspace-excluded crate; its fixtures are exercised by `cargo xtask e2e`, not run here).
