### PR TITLE
ci: compile PHP-linked ephpm-php on Windows for pull requests (#319)

### DIFF
--- a/.github/workflows/windows-php-check.yml
+++ b/.github/workflows/windows-php-check.yml
@@ -1,0 +1,178 @@
+# Windows PHP-linked compile check — the PR gate for LLP64 width bugs (#319).
+#
+# `php_linked` is only set by crates/ephpm-php/build.rs when PHP_SDK_PATH is
+# present, so regular PR CI (stub mode, Linux/macOS) never type-checks the FFI
+# code on Windows. Before this workflow, the only Windows PHP-linked compile
+# was release.yml's build-windows leg — which runs exclusively on a `v*` tag
+# push, so a Windows-only compile error (c_long is 32-bit on LLP64, 64-bit on
+# LP64) could not surface until a release was already tagged and parked on it.
+# That cost the v0.7.0 tag two cut cycles: 5x E0308 in ws_bridge (#318) and an
+# E0277 on `c_long::from(u32)` (#320).
+#
+# `cargo check -p ephpm-php` with PHP_SDK_PATH set is sufficient to catch that
+# class: it runs ephpm-php's build.rs for real (cl.exe compiles
+# ephpm_wrapper.c, bindgen parses the SDK headers) and type-checks every
+# #[cfg(php_linked)] path in the crate. No final-binary link, no LTO, no
+# release profile — the expensive parts of the release leg that a type error
+# never reaches anyway.
+#
+# Cost note: the ephemerd Windows runners are ephemeral and bare, so the VS
+# Build Tools install alone can take up to 20 minutes (the same install block
+# release.yml uses). The `paths:` filter below keeps that tax off every PR
+# that cannot introduce this bug class — only the FFI crate itself, the binary
+# crate's build.rs (it probes the same SDK), the SDK-download tooling, and
+# this workflow can.
+#
+# One PHP minor is enough: the LLP64 width-bug class is PHP-version-
+# independent, and 8.3 matches the first pin in xtask::PHP_SDK_VERSIONS and
+# the release matrix.
+
+name: Windows PHP Check
+
+on:
+  pull_request:
+    # `main` plus long-lived feature branches that other PRs stack onto — see
+    # the matching note in ci.yml.
+    branches: [main, "feat/**"]
+    # Everything OUTSIDE these paths skips the job entirely (no run, not a
+    # skipped-but-green run) — the 20-minute toolchain install is only paid
+    # when the change could actually break the Windows PHP-linked build.
+    paths:
+      - "crates/ephpm-php/**"
+      - "crates/ephpm/build.rs"
+      - "xtask/**"
+      - ".github/workflows/windows-php-check.yml"
+  # Manual escape hatch: exercise the job without opening a PR that touches a
+  # filtered path — e.g. to validate this workflow itself or a change to the
+  # Windows runner fleet.
+  workflow_dispatch:
+
+# Cap fleet pile-up per ref — same shape as e2e.yml (#324) and release.yml
+# (#325). Only a PR's head commit needs this signal, so a superseded PR run
+# cancels instead of holding the (small) Windows pool; a manual dispatch runs
+# on its own ref and is never cancelled by PR traffic.
+concurrency:
+  group: ephpm-windows-php-check-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-windows:
+    name: PHP-linked cargo check (PHP 8.3, windows-x86_64)
+    runs-on: [self-hosted, windows, x64]
+    # Toolchain provisioning dominates (up to ~20 min for VS Build Tools on a
+    # bare runner); the check itself is single-digit minutes. The GitHub
+    # default of 360 would turn a wedged runner into a six-hour hold on the
+    # only Windows pool.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      # ---- Toolchain provisioning ----------------------------------------
+      # The three steps below are copied from release.yml's build-windows job
+      # — keep them in sync with it. They stay separate, named steps on
+      # purpose: a red "Install ..." / "Enter ..." step is a runner or infra
+      # problem; only a red "cargo check" step is a real compile error in the
+      # change under test.
+
+      - name: Install Rust toolchain
+        shell: powershell
+        run: |
+          $cargoBin = "$env:USERPROFILE\.cargo\bin"
+          if (-not (Test-Path "$cargoBin\rustup.exe")) {
+            Write-Host "Installing rustup..."
+            Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+            .\rustup-init.exe -y --default-toolchain stable --profile minimal
+            Remove-Item rustup-init.exe
+          }
+          $env:PATH = "$cargoBin;$env:PATH"
+          $cargoBin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & "$cargoBin\rustup.exe" show
+
+      - name: Install Visual Studio Build Tools
+        shell: powershell
+        # Mirrors php-sdk's install block; runner image is bare so each
+        # job installs VS Build Tools fresh via the official bootstrapper.
+        run: |
+          $installPath = "C:\BuildTools"
+          $msbuild = "$installPath\MSBuild\Current\Bin\MSBuild.exe"
+          if (Test-Path $msbuild) {
+            Write-Host "VS Build Tools already present at $installPath"
+          } else {
+            Write-Host "Downloading VS Build Tools bootstrapper..."
+            Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile vs_buildtools.exe
+            $proc = Start-Process -FilePath .\vs_buildtools.exe `
+              -ArgumentList @(
+                '--quiet', '--wait', '--norestart', '--nocache',
+                '--installPath', $installPath,
+                '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--add', 'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
+                '--includeRecommended'
+              ) -Wait -PassThru -NoNewWindow
+            Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
+            Remove-Item vs_buildtools.exe
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while (-not (Test-Path $msbuild) -and $sw.Elapsed.TotalMinutes -lt 20) {
+              Start-Sleep -Seconds 30
+              Write-Host ("  ...waiting for VS install ({0:F0}s)" -f $sw.Elapsed.TotalSeconds)
+            }
+            if (-not (Test-Path $msbuild)) {
+              Write-Host "::error::VS install timed out - $msbuild never appeared"
+              exit 1
+            }
+            Write-Host ("MSBuild.exe found after {0:F0}s" -f $sw.Elapsed.TotalSeconds)
+          }
+
+      - name: Enter MSVC developer environment
+        shell: powershell
+        run: |
+          $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { Write-Error "vcvars64.bat not found"; exit 1 }
+          $envBefore = @{}
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+            $envBefore[$e.Key] = $e.Value
+          }
+          $cmdLine = 'call "' + $vcvars + '" >NUL & set'
+          $output = & cmd /c $cmdLine
+          foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              if ($envBefore[$matches[1]] -ne $matches[2]) {
+                "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+              }
+            }
+          }
+          $libclangDir = "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+          if (Test-Path "$libclangDir\libclang.dll") {
+            "LIBCLANG_PATH=$libclangDir" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          } else {
+            Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
+          }
+
+      # ---- PHP SDK ---------------------------------------------------------
+      # Separate step for the same reason as the toolchain ones: a download
+      # failure (github.com/ephpm/php-sdk release missing, network) must not
+      # read as a compile failure.
+      - name: Download PHP SDK (8.3)
+        shell: powershell
+        run: cargo xtask php-sdk 8.3
+
+      # ---- The actual gate ---------------------------------------------------
+      - name: cargo check -p ephpm-php (PHP-linked)
+        shell: powershell
+        env:
+          # xtask's cache layout is php-sdk/<full-version>-<os>-<arch>/ with no
+          # libc suffix on Windows (php_sdk_dir_for in xtask/src/main.rs). The
+          # full version must match xtask::PHP_SDK_VERSIONS["8.3"] — same
+          # keep-in-sync rule as the release.yml matrix pins.
+          PHP_SDK_PATH: ${{ github.workspace }}\php-sdk\8.3.31-windows-x86_64
+          # sqlparser (a turso dependency, in this crate's graph via litewire)
+          # has deeply recursive AST types that overflow the Windows
+          # toolchain's default rustc thread stack in release.yml's build
+          # (STATUS_STACK_OVERFLOW, 0xc00000fd). A dev-profile check has not
+          # been observed to hit it, but the env var costs nothing and keeps
+          # this job's environment aligned with the release leg it stands in
+          # for.
+          RUST_MIN_STACK: "33554432"
+        run: cargo check -p ephpm-php

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ The `TrackedBackend` wrapper in `ephpm-server/src/tracked_backend.rs` wraps any 
 
 ## CI Pipeline
 
-Runs on push/PR to main: fmt check → clippy → test → cargo-deny. Release builds triggered by `v*` tags across PHP 8.3/8.4/8.5 × linux-x64/linux-arm64/macos/windows, plus the Docker image; `Create Release` publishes only after all build legs succeed.
+Runs on push/PR to main: fmt check → clippy → test → cargo-deny. PRs touching `crates/ephpm-php/**`, `crates/ephpm/build.rs`, `xtask/**`, or `windows-php-check.yml` additionally get a Windows PHP-linked `cargo check -p ephpm-php` (`.github/workflows/windows-php-check.yml`, PHP 8.3 SDK) — the LLP64 compile gate that stub-mode CI can't provide (#318/#320/#319). Release builds triggered by `v*` tags across PHP 8.3/8.4/8.5 × linux-x64/linux-arm64/macos/windows, plus the Docker image; `Create Release` publishes only after all build legs succeed.
 
 ## Truthfulness: Docs Must Match Code
 

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -20,6 +20,7 @@ ephpm/
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml              # Lint, test, deny
+│       ├── windows-php-check.yml # PR-gated Windows PHP-linked cargo check
 │       └── release.yml         # Build matrix (PHP 8.3/8.4 × linux/mac/windows)
 ├── crates/
 │   ├── ephpm/                  # Binary crate (main entry point)
@@ -252,6 +253,26 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       - run: cargo check --workspace
 ```
+
+### GitHub Actions: windows-php-check.yml
+
+Regular CI builds in stub mode (no `PHP_SDK_PATH`), so nothing above compiles
+the `#[cfg(php_linked)]` FFI code — and `c_long` width bugs (32-bit on
+Windows LLP64, 64-bit on Linux/macOS LP64) used to surface only in the
+release build matrix, after a tag was already pushed (#318, #320, tracked as
+#319).
+
+`windows-php-check.yml` closes that gap: on pull requests that touch
+`crates/ephpm-php/**`, `crates/ephpm/build.rs`, `xtask/**`, or the workflow
+itself, it runs `cargo check -p ephpm-php` on a `[self-hosted, windows, x64]`
+runner with `PHP_SDK_PATH` pointing at the PHP 8.3 SDK (downloaded via
+`cargo xtask php-sdk 8.3`). That runs the crate's `build.rs` for real —
+cl.exe compiles `ephpm_wrapper.c`, bindgen parses the SDK headers — and
+type-checks every PHP-linked code path, without the release build's linking
+or LTO cost. PRs not touching those paths skip the job entirely (the bare
+ephemeral Windows runners pay up to ~20 minutes of VS Build Tools install per
+job, so the filter matters). One PHP minor suffices: the LLP64 width-bug
+class is PHP-version-independent.
 
 ### GitHub Actions: release.yml
 


### PR DESCRIPTION
Closes #319. Targeting v0.7.2.

## The gap

`php_linked` is only set when `PHP_SDK_PATH` is present. PR CI builds stub mode only, so the first — and only — thing that compiled the Windows PHP-linked configuration was `release.yml`'s `build-windows` leg, on an already-pushed `v*` tag. Three Windows-only bugs shipped undetected this way; #318 (5x E0308, ws_bridge `c_long`) and #320 (E0277, `c_long::from(u32)`) each cost the v0.7.0 tag a cut cycle.

## What this adds

`.github/workflows/windows-php-check.yml` — one job, `cargo check -p ephpm-php` with `PHP_SDK_PATH` set, on `[self-hosted, windows, x64]`:

- **`cargo check` is sufficient** for the E0308/E0277 width-bug class: it runs `ephpm-php`'s `build.rs` for real (cl.exe compiles `ephpm_wrapper.c`, bindgen parses the SDK headers) and type-checks every `#[cfg(php_linked)]` path — no final-binary link, no LTO, no release profile.
- **Toolchain steps copied verbatim from `release.yml`'s `build-windows`** (rustup install, VS Build Tools bootstrapper, vcvars64 env capture + `LIBCLANG_PATH`) — kept as separate named steps so a toolchain-install failure is clearly distinguishable from a compile failure.
- **Path-filtered trigger** so the up-to-20-min bare-runner toolchain tax is only paid when the change can matter: `crates/ephpm-php/**`, `crates/ephpm/build.rs`, `xtask/**`, and the workflow file itself. Everything else skips the job entirely. Plus `workflow_dispatch` as a manual escape hatch (useful for the first live run).
- **One PHP minor (8.3)** — matches the `xtask::PHP_SDK_VERSIONS` pin; the LLP64 bug class is PHP-version-independent.
- **Per-ref concurrency group, cancel-in-progress on PRs** (`e2e.yml` #324 / `release.yml` #325 precedent) and `timeout-minutes: 45`.

Docs: `CLAUDE.md` CI Pipeline section and `site/content/developer/architecture-overview.md` updated in the same PR.

## Proof it catches the historical bug

Run locally on Windows (MSVC Build Tools + the 8.3.31 windows-x86_64 SDK), using the exact command/env from the workflow:

**(a) current `main` (0339ee3) — clean:**

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 51.94s
CHECK_EXIT=0
```

**(b) `main` with #320's fix reverted (`git revert --no-commit c84e3c6`) — the exact E0277 that parked the v0.7.0 tag:**

```
error[E0277]: the trait bound `i32: From<u32>` is not satisfied
   --> crates\ephpm-php\src\lib.rs:750:56
    |
750 |             unsafe { ffi::ephpm_set_max_execution_time(::std::os::raw::c_long::from(secs)) };
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `From<u32>` is not implemented for `i32`
error: could not compile `ephpm-php` (lib) due to 1 previous error
CHECK_EXIT=101
```

`actionlint` passes on the workflow.

## Caveat

The first PR run on the fleet is the live test of the job itself (it cannot be exercised from a workstation), and the Windows ephemerd fleet has been down since 2026-08-11 — until it's back this check will queue. The job is structured so an infra failure (Install/Enter steps) reads differently from a real compile failure (`cargo check` step), and `workflow_dispatch` allows a manual shakedown without a dummy PR.
