### PR TITLE
fix(xtask): match release.yml pin sites by shape - the arm64 job split added a 5th site

### DIFF
--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -4,8 +4,10 @@
 //! that must stay in lockstep:
 //!
 //! 1. `xtask/src/main.rs` — the `PHP_SDK_VERSIONS` table (source of truth)
-//! 2. `.github/workflows/release.yml` — 4 matrix sites (linux / macos /
-//!    windows / docker), one entry per minor in each
+//! 2. `.github/workflows/release.yml` — 5 matrix sites, one entry per minor
+//!    in each: two inline-map matrices (`build-linux`, `build-linux-arm64`)
+//!    and three `php_minor`/`php_full` include blocks (`build-macos`,
+//!    `build-windows`, `docker-image`)
 //! 3. `docker/Dockerfile` — `ARG PHP_SDK_VERSION` default (+ its inline
 //!    example), only for the default minor
 //! 4. `site/content/developer/architecture-overview.md` — the support table
@@ -45,15 +47,29 @@ fn substitutions(minor: &str, old_full: &str, new_full: &str) -> Vec<Substitutio
             replacement: format!("(\"{minor}\", \"{new_full}\")"),
             expected: 1,
         },
-        // The 4 release matrix sites (build-linux inline map, build-macos,
-        // build-windows, docker-image). Matching the bare quoted version is
-        // unambiguous — a full version string can only belong to one minor —
-        // and the count assert catches any structural change to the matrix.
+        // The 5 release matrix sites, matched by their structured pin keys
+        // rather than the bare quoted version so that prose (a comment or a
+        // step name that happens to mention a version) can never be counted
+        // as — or rewritten like — a pin. The count asserts still catch any
+        // structural change to the matrices (a job added or removed).
+        //
+        // Shape 1: the inline-map matrices in build-linux and build-linux-arm64:
+        //   - { minor: "8.3", full: "8.3.31" }
         Substitution {
             path: ".github/workflows/release.yml",
-            needle: format!("\"{old_full}\""),
-            replacement: format!("\"{new_full}\""),
-            expected: 4,
+            needle: format!("{{ minor: \"{minor}\", full: \"{old_full}\" }}"),
+            replacement: format!("{{ minor: \"{minor}\", full: \"{new_full}\" }}"),
+            expected: 2,
+        },
+        // Shape 2: the `include:` blocks in build-macos, build-windows and
+        // docker-image:
+        //   - php_minor: "8.3"
+        //     php_full: "8.3.31"
+        Substitution {
+            path: ".github/workflows/release.yml",
+            needle: format!("php_full: \"{old_full}\""),
+            replacement: format!("php_full: \"{new_full}\""),
+            expected: 3,
         },
         // The PHP support table ("Supported — in CI (pinned X.Y.Z)").
         Substitution {
@@ -276,22 +292,57 @@ mod tests {
         assert_eq!(apply(input, &sub).unwrap(), input);
     }
 
+    /// Mirrors the current release.yml shape: two inline-map matrices
+    /// (build-linux, build-linux-arm64) plus three `php_minor`/`php_full`
+    /// include blocks (build-macos, build-windows, docker-image), and a prose
+    /// comment that mentions a full version — which must NOT count as a pin.
     #[test]
-    fn release_yml_fixture_hits_all_four_matrix_sites() {
+    fn release_yml_fixture_hits_all_five_matrix_sites() {
         let fixture = r#"
+          - { minor: "8.4", full: "8.4.23" }
           - { minor: "8.4", full: "8.4.23" }
           - php_minor: "8.4"
             php_full: "8.4.23"
+          # PHP SDK 8.4.23 macOS objects are built with a newer Xcode that
           - php_minor: "8.4"
             php_full: "8.4.23"
           - php_minor: "8.4"
             php_full: "8.4.23"
+            default: true
 "#;
         let subs = substitutions("8.4", "8.4.23", "8.4.30");
-        let yml = subs.iter().find(|s| s.path.ends_with("release.yml")).unwrap();
-        let out = apply(fixture, yml).unwrap();
-        assert_eq!(out.matches("\"8.4.30\"").count(), 4);
-        assert!(!out.contains("8.4.23"));
+        let yml_subs: Vec<_> = subs.iter().filter(|s| s.path.ends_with("release.yml")).collect();
+        assert_eq!(yml_subs.len(), 2, "inline-map + php_full shapes");
+        let mut out = fixture.to_string();
+        for sub in yml_subs {
+            out = apply(&out, sub).unwrap();
+        }
+        assert_eq!(out.matches("\"8.4.30\"").count(), 5);
+        // The comment is prose, not a pin site — it must survive untouched
+        // and must not have been counted toward either expected total.
+        assert!(out.contains("# PHP SDK 8.4.23 macOS objects"));
+        assert!(!out.contains("\"8.4.23\""));
+    }
+
+    /// A structural change to the matrices (a job added or removed) must be
+    /// refused, not silently half-applied — the fail-safe that caught the
+    /// build-linux-arm64 job split in the first place.
+    #[test]
+    fn release_yml_shape_change_is_refused() {
+        // One extra inline-map job (3 instead of the expected 2).
+        let fixture = r#"
+          - { minor: "8.4", full: "8.4.23" }
+          - { minor: "8.4", full: "8.4.23" }
+          - { minor: "8.4", full: "8.4.23" }
+"#;
+        let subs = substitutions("8.4", "8.4.23", "8.4.30");
+        let inline = subs
+            .iter()
+            .find(|s| s.path.ends_with("release.yml") && s.needle.contains("{ minor:"))
+            .unwrap();
+        let err = apply(fixture, inline).unwrap_err();
+        assert!(err.contains("expected exactly 2"), "unexpected message: {err}");
+        assert!(err.contains("found 3"), "unexpected message: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The nightly `SDK Bump` workflow has failed every night with:

```
error: refusing to bump — no files were modified:
  .github/workflows/release.yml: expected exactly 4 occurrence(s) of "8.3.31", found 5
  — pin sites changed shape; update xtask/src/bump.rs to match
```

This is the fail-safe working as designed: `bump-php-pin` counted raw quoted `"x.y.z"` strings in `release.yml` and required exactly 4. When the arm64 matrix was split out of `build-linux` into its own `build-linux-arm64` job, each minor gained a 5th pin site, so the count mismatched and the command (correctly) refused to write anything — including the pending 8.3.33 bump.

## Fix

Rather than bumping the raw count to 5, the matcher now targets the two structured shapes the pins actually take in `release.yml`:

| Shape | Needle | Jobs | Expected |
|---|---|---|---|
| Inline-map matrix | `{ minor: "X.Y", full: "X.Y.Z" }` | `build-linux`, `build-linux-arm64` | 2 |
| Include block | `php_full: "X.Y.Z"` | `build-macos`, `build-windows`, `docker-image` | 3 |

This is strictly more precise than the raw count: prose that merely mentions a version — e.g. the `# PHP SDK 8.5.7 macOS objects are built with a newer Xcode...` comment in `build-macos` (unquoted today, but one edit away from tripping a raw count) — can never be counted as, or rewritten like, a pin. The fail-safe property is unchanged: adding or removing a matrix job still mismatches an expected count and the command refuses all-or-nothing.

The module docs now describe the real 5-site shape, the `release_yml_fixture_hits_all_four_matrix_sites` fixture test is updated to mirror current `release.yml` (five pin sites + a version-mentioning comment that must survive untouched), and a new `release_yml_shape_change_is_refused` test pins the refusal behavior.

## Not in this PR

No pins are bumped here (still 8.3.31 / 8.4.23 / 8.5.7). Once this merges, the nightly workflow should open the 8.3.33 bump on its own.

## Verification

- `cargo test -p xtask` — 17 passed, 0 failed (includes the two new/updated shape tests)
- `cargo xtask bump-php-pin --check` against the live tree — all pin sites agree (8.3 → 8.3.31, 8.4 → 8.4.23, 8.5 → 8.5.7)
- `cargo clippy -p xtask --all-targets -- -D warnings` clean; `cargo +nightly fmt --all -- --check` clean
