### PR TITLE
fix(cli): v0.7.2 CLI fidelity — -d applies at startup (opcache/JIT, #331); cli_set/get_process_title (#316)

### DIFF
--- a/crates/ephpm-e2e/tests/cli.rs
+++ b/crates/ephpm-e2e/tests/cli.rs
@@ -1,4 +1,6 @@
-//! `ephpm php` CLI conformance — fatal-error reporting and exit statuses.
+//! `ephpm php` CLI conformance — fatal-error reporting, exit statuses,
+//! startup-time `-d` (OPcache/JIT activation, issue #331) and the cli-SAPI
+//! process-title functions (issue #316).
 //!
 //! Regression cover for **issue #321**: on v0.7.0 a fatal error or an uncaught
 //! exception under `ephpm php -r` produced **no output at all and exit 0**,
@@ -230,6 +232,192 @@ fn stdin_program_fatal_reports_and_exits_255() {
         "stdin fatal should use php-cli's \"Standard input code\" label:\n{}",
         run.output()
     );
+}
+
+// ─── Issue #331: `-d` must apply at module startup (OPcache / JIT) ────────
+//
+// The observable defect: `-d opcache.enable_cli=1` made `ini_get()` report 1
+// while `opcache_get_status()` stayed `false`, because OPcache decides once —
+// in its MINIT-time startup hook — whether it will ever activate, and `-d`
+// used to be applied after init. The JIT (which lives in OPcache SHM) was
+// silently dead the same way. These assert the *activation*, not the ini
+// value, so the old failure mode cannot pass.
+
+/// `-d opcache.enable_cli=1` must actually activate OPcache, as in php-cli.
+#[test]
+fn opcache_activates_with_enable_cli() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[
+            "-d",
+            "opcache.enable_cli=1",
+            "-r",
+            // `?? false` so an inactive opcache (status === false) prints
+            // bool(false) instead of a bool-offset warning.
+            "var_dump(opcache_get_status(false)['opcache_enabled'] ?? false);",
+        ],
+        "",
+    );
+    assert_eq!(run.code, 0, "unexpected exit {} (output: {})", run.code, run.output());
+    assert_eq!(
+        run.stdout, "bool(true)\n",
+        "OPcache did not activate under -d opcache.enable_cli=1 (issue #331)\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        run.stdout, run.stderr
+    );
+}
+
+/// Without the flag OPcache must stay inactive — the php-cli default. Pins
+/// that the fix didn't force opcache on unconditionally.
+#[test]
+fn opcache_stays_inactive_without_enable_cli() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(&bin, &["-r", "var_dump(opcache_get_status(false));"], "");
+    assert_eq!(run.code, 0, "unexpected exit {} (output: {})", run.code, run.output());
+    assert_eq!(
+        run.stdout, "bool(false)\n",
+        "OPcache should be inactive without opcache.enable_cli, like php-cli\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        run.stdout, run.stderr
+    );
+}
+
+/// The JIT flags must reach OPcache's startup: `jit.on === true` and a
+/// non-zero buffer. This is the "CLI benchmarks vs real php are unfair" half
+/// of #331 — before the fix these flags silently no-oped.
+#[test]
+fn jit_activates_with_tracing_flags() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[
+            "-d",
+            "opcache.enable_cli=1",
+            "-d",
+            "opcache.jit=tracing",
+            "-d",
+            "opcache.jit_buffer_size=64M",
+            "-r",
+            "$s = opcache_get_status(false); \
+             var_dump($s['jit']['on'] ?? false, ($s['jit']['buffer_size'] ?? 0) > 0);",
+        ],
+        "",
+    );
+    assert_eq!(run.code, 0, "unexpected exit {} (output: {})", run.code, run.output());
+    assert_eq!(
+        run.stdout,
+        "bool(true)\nbool(true)\n",
+        "JIT did not come up under -d opcache.jit=tracing (issue #331)\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        run.stdout, run.stderr
+    );
+}
+
+/// `-d` must override the embed SAPI's HARDCODED_INI defaults (the merge
+/// order pin: defines are spliced *after* the hardcoded block). The embed
+/// hardcodes max_execution_time=0, so a `-d` for it only wins if the order
+/// is right.
+#[test]
+fn ini_define_overrides_embed_hardcoded_defaults() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &["-d", "max_execution_time=17", "-r", "var_dump(ini_get('max_execution_time'));"],
+        "",
+    );
+    assert_eq!(
+        run.stdout,
+        "string(2) \"17\"\n",
+        "-d must beat the embed SAPI's hardcoded ini defaults\n--- output ---\n{}",
+        run.output()
+    );
+    assert_eq!(run.code, 0);
+}
+
+/// A value starting with a non-alphanumeric goes through php-cli's
+/// quote-wrapping path (php_ini_builder_define); a path value is the
+/// canonical case.
+#[test]
+fn ini_define_quotes_non_alnum_values_like_php_cli() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run =
+        run_php(&bin, &["-d", "include_path=/e2e/one", "-r", "echo ini_get('include_path');"], "");
+    assert_eq!(
+        run.stdout,
+        "/e2e/one",
+        "quoted -d value did not round-trip\n--- output ---\n{}",
+        run.output()
+    );
+    assert_eq!(run.code, 0);
+}
+
+// ─── Issue #316: cli_set_process_title / cli_get_process_title ────────────
+
+/// The functions must exist under `ephpm php` on every platform — the `cli`
+/// SAPI identity promises them (PsySH calls cli_set_process_title, so
+/// `artisan tinker <file>` fataled while they were missing).
+#[test]
+fn process_title_functions_exist() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[
+            "-r",
+            "var_dump(function_exists('cli_set_process_title'), \
+             function_exists('cli_get_process_title'));",
+        ],
+        "",
+    );
+    assert_eq!(
+        run.stdout,
+        "bool(true)\nbool(true)\n",
+        "cli process-title functions missing (issue #316)\n--- output ---\n{}",
+        run.output()
+    );
+    assert_eq!(run.code, 0);
+}
+
+/// On Linux the title must genuinely change: set → true, get round-trips,
+/// and /proc/self/cmdline (what `ps` shows) begins with the new title —
+/// php-src's PS_USE_CLOBBER_ARGV behavior, not a stored-string fake.
+#[cfg(target_os = "linux")]
+#[test]
+fn process_title_round_trips_and_reaches_proc_cmdline() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[
+            "-r",
+            "$t = 'ephpm-e2e-title-316'; \
+             var_dump(cli_set_process_title($t)); \
+             var_dump(cli_get_process_title() === $t); \
+             var_dump(strpos(file_get_contents('/proc/self/cmdline'), $t) === 0);",
+        ],
+        "",
+    );
+    assert_eq!(
+        run.stdout,
+        "bool(true)\nbool(true)\nbool(true)\n",
+        "process title did not set / round-trip / reach /proc/self/cmdline\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        run.stdout, run.stderr
+    );
+    assert_eq!(run.code, 0);
 }
 
 /// Non-fatal diagnostics were never broken — warnings printed fine on v0.7.0,

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
+#include <ctype.h>
 
 /* MSVC has no POSIX strtok_r; its strtok_s has the same 3-arg semantics. */
 #ifdef _MSC_VER
@@ -3456,39 +3457,378 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_ws_connection_close, 0, 0, 1)
     ZEND_ARG_INFO(0, code)
 ZEND_END_ARG_INFO()
 
+/* ===================================================================
+ * CLI process title — cli_set_process_title() / cli_get_process_title()
+ *
+ * php-src registers these two functions from the cli SAPI (sapi/cli/
+ * php_cli_process_title.c on top of ps_title.c, itself lifted from
+ * PostgreSQL's ps_status.c). The embed SAPI never registers them, so
+ * `ephpm php` — which deliberately reports PHP_SAPI === "cli" — fataled
+ * on code that keys on the SAPI name instead of function_exists()
+ * (PsySH calls cli_set_process_title(), so `artisan tinker <file>`
+ * died with "Call to undefined function"). Issue #316.
+ *
+ * This is a condensed port of ps_title.c for the platforms ePHPm ships:
+ *
+ *   Linux (glibc)  — PS_USE_CLOBBER_ARGV: overwrite the original argv
+ *                    (+ contiguous environ) area so /proc/self/cmdline
+ *                    and `ps` show the title. php-cli captures argv in
+ *                    main(); our main() is Rust, so a glibc `.init_array`
+ *                    constructor (which glibc calls with main's argc/
+ *                    argv/envp) captures it instead, and the environment
+ *                    is deep-copied out of the clobber area there —
+ *                    single-threaded, pre-main, exactly when php-cli's
+ *                    save_ps_args() would run. Unlike save_ps_args() we
+ *                    do NOT rewrite the argv[i] pointer slots or hand
+ *                    out an argv copy: Rust (clap, std::env::args) still
+ *                    reads the original argv, which stays intact until
+ *                    the first cli_set_process_title() call. After that
+ *                    call std::env::args() would read the title — the
+ *                    same property php-cli itself has for anything
+ *                    reading its clobbered argv — and the CLI parses its
+ *                    arguments long before any PHP script runs.
+ *   Windows        — PS_USE_WIN32: SetConsoleTitleW / GetConsoleTitleW
+ *                    with UTF-8 <-> UTF-16 conversion (php-src converts
+ *                    via php_win32_cp_any_to_w; the runtime codepage is
+ *                    UTF-8 in these builds). Fails honestly (false /
+ *                    "Windows error code: N") when no console exists.
+ *   elsewhere      — PS_TITLE_NOT_AVAILABLE, reported exactly as php's
+ *                    ps_title.c reports an unsupported OS ("Not
+ *                    available on this OS"): warning + false/NULL, never
+ *                    fake success. (macOS could adopt the clobber path +
+ *                    _NSGetArgv fix later; it is left honest-unsupported
+ *                    rather than shipped unverified.)
+ *
+ * Return-value contract matches php_cli_process_title.c byte for byte:
+ * set → true, or E_WARNING "cli_set_process_title had an error: <why>"
+ * + false; get → the stored title, or the same-shaped warning + null.
+ * PHP 8.5 changed set() to reject an over-long title ("Too long")
+ * instead of truncating; mirrored under PHP_VERSION_ID.
+ * =================================================================== */
+
+/* Status codes, mirroring sapi/cli/ps_title.h. */
+#define EPHPM_PS_TITLE_SUCCESS         0
+#define EPHPM_PS_TITLE_NOT_AVAILABLE   1
+#define EPHPM_PS_TITLE_NOT_INITIALIZED 2
+#define EPHPM_PS_TITLE_WINDOWS_ERROR   4
+#define EPHPM_PS_TITLE_TOO_LONG        5
+
+#if defined(__linux__) && defined(__GLIBC__)
+#define EPHPM_PS_USE_CLOBBER_ARGV 1
+
+extern char **environ;
+
+static char *g_ps_buffer = NULL;      /* the original argv area */
+static size_t g_ps_buffer_size = 0;   /* clobberable bytes at g_ps_buffer */
+static size_t g_ps_buffer_cur_len = 0;
+static int g_ps_args_saved = 0;
+
+/*
+ * Capture the process argv area before Rust's main() runs. glibc invokes
+ * `.init_array` constructors with (argc, argv, envp), which is the only way
+ * to reach the REAL argv from a program whose main() is Rust. Gated to the
+ * `ephpm php` invocation (argv[1] == "php"): only the CLI registers the
+ * title functions, and the serve-mode process should not have its
+ * environment relocated behind Rust's back. If the gate or the contiguity
+ * check misses, the functions degrade to php's honest "Not initialized
+ * correctly" failure instead of guessing at memory layout.
+ *
+ * The environ deep-copy-and-swap is verbatim save_ps_args() logic: the
+ * kernel places environ strings directly after argv strings, so clobbering
+ * a long title into the area would corrupt the environment unless it has
+ * been moved first. Copying here is safe — pre-main is single-threaded, and
+ * both glibc (getenv/setenv) and Rust std::env read the live `environ`
+ * global rather than caching the startup block. The copies are process-
+ * lifetime by design (php frees its own only for valgrind's benefit, from
+ * a cleanup hook we don't have).
+ */
+__attribute__((constructor)) static void ephpm_ps_capture_argv(
+    int argc, char **argv, char **envp)
+{
+    (void)envp;
+    if (argc < 2 || !argv || !argv[0] || !argv[1] || strcmp(argv[1], "php") != 0) {
+        return;
+    }
+
+    /* Contiguity check over argv, exactly as save_ps_args(). */
+    char *end_of_area = NULL;
+    for (int i = 0; i < argc; i++) {
+        if (!argv[i] || (i != 0 && end_of_area + 1 != argv[i])) {
+            return; /* unexpected layout — leave the title unsupported */
+        }
+        end_of_area = argv[i] + strlen(argv[i]);
+    }
+
+    /* Extend the clobber area over contiguous environ strings, then move
+     * the environment out of it. */
+    int n = 0;
+    while (environ[n] != NULL) {
+        n++;
+    }
+    char **new_environ = (char **)malloc(((size_t)n + 1) * sizeof(char *));
+    if (!new_environ) {
+        return;
+    }
+    for (int i = 0; i < n; i++) {
+        if (end_of_area + 1 == environ[i]) {
+            end_of_area = environ[i] + strlen(environ[i]);
+        }
+        new_environ[i] = strdup(environ[i]);
+        if (!new_environ[i]) {
+            for (int j = 0; j < i; j++) {
+                free(new_environ[j]);
+            }
+            free(new_environ);
+            return;
+        }
+    }
+    new_environ[n] = NULL;
+    environ = new_environ;
+
+    g_ps_buffer = argv[0];
+    g_ps_buffer_size = (size_t)(end_of_area - argv[0]);
+    g_ps_buffer_cur_len = 0;
+    g_ps_args_saved = 1;
+}
+
+#elif defined(_WIN32)
+#define EPHPM_PS_USE_WIN32 1
+
+/* UTF-8 rendering of the console title; MAX_PATH UTF-16 units can need up
+ * to 3 bytes each. Mirrors ps_title.c's MAX_PATH-sized ps_buffer. */
+static char g_ps_buffer[MAX_PATH * 3];
+static size_t g_ps_buffer_cur_len = 0;
+static char g_ps_windows_error[64];
+#endif
+
+/* is_ps_title_available(), condensed. */
+static int ephpm_ps_title_available(void)
+{
+#if defined(EPHPM_PS_USE_CLOBBER_ARGV)
+    return g_ps_args_saved ? EPHPM_PS_TITLE_SUCCESS : EPHPM_PS_TITLE_NOT_INITIALIZED;
+#elif defined(EPHPM_PS_USE_WIN32)
+    /* php-cli's save_ps_args() runs unconditionally in main(), so Windows
+     * is always "initialized" there; the CLI-mode flag is our equivalent. */
+    return g_cli_mode ? EPHPM_PS_TITLE_SUCCESS : EPHPM_PS_TITLE_NOT_INITIALIZED;
+#else
+    return EPHPM_PS_TITLE_NOT_AVAILABLE;
+#endif
+}
+
+/* ps_title_errno(), same strings as sapi/cli/ps_title.c. */
+static const char *ephpm_ps_title_errno(int rc)
+{
+    switch (rc) {
+    case EPHPM_PS_TITLE_SUCCESS:
+        return "Success";
+    case EPHPM_PS_TITLE_NOT_AVAILABLE:
+        return "Not available on this OS";
+    case EPHPM_PS_TITLE_NOT_INITIALIZED:
+        return "Not initialized correctly";
+    case EPHPM_PS_TITLE_TOO_LONG:
+        return "Too long";
+#ifdef EPHPM_PS_USE_WIN32
+    case EPHPM_PS_TITLE_WINDOWS_ERROR:
+        snprintf(g_ps_windows_error, sizeof(g_ps_windows_error),
+                 "Windows error code: %lu", GetLastError());
+        return g_ps_windows_error;
+#endif
+    default:
+        break;
+    }
+    return "Unknown error code";
+}
+
+/* set_ps_title(). PHP 8.5 rejects an over-long title; earlier truncate. */
+static int ephpm_set_ps_title(const char *title, size_t title_len)
+{
+    int rc = ephpm_ps_title_available();
+    if (rc != EPHPM_PS_TITLE_SUCCESS) {
+        return rc;
+    }
+
+#if defined(EPHPM_PS_USE_CLOBBER_ARGV)
+#if PHP_VERSION_ID >= 80500
+    if (title_len >= g_ps_buffer_size) {
+        return EPHPM_PS_TITLE_TOO_LONG;
+    }
+    /* Includes the final NUL: zend strings are NUL-terminated. */
+    memcpy(g_ps_buffer, title, title_len + 1);
+    g_ps_buffer_cur_len = title_len;
+#else
+    strncpy(g_ps_buffer, title, g_ps_buffer_size);
+    g_ps_buffer[g_ps_buffer_size - 1] = '\0';
+    g_ps_buffer_cur_len = strlen(g_ps_buffer);
+    (void)title_len;
+#endif
+    /* Pad the rest of the area with NULs (PS_PADDING on Linux) so stale
+     * argv/environ bytes never leak into /proc/self/cmdline. */
+    if (g_ps_buffer_cur_len < g_ps_buffer_size) {
+        memset(g_ps_buffer + g_ps_buffer_cur_len, '\0',
+               g_ps_buffer_size - g_ps_buffer_cur_len);
+    }
+    return EPHPM_PS_TITLE_SUCCESS;
+#elif defined(EPHPM_PS_USE_WIN32)
+#if PHP_VERSION_ID >= 80500
+    if (title_len >= sizeof(g_ps_buffer)) {
+        return EPHPM_PS_TITLE_TOO_LONG;
+    }
+#else
+    if (title_len >= sizeof(g_ps_buffer)) {
+        title_len = sizeof(g_ps_buffer) - 1; /* pre-8.5: truncate like strncpy */
+    }
+#endif
+    {
+        wchar_t wide[MAX_PATH];
+        char truncated[sizeof(g_ps_buffer)];
+        memcpy(truncated, title, title_len);
+        truncated[title_len] = '\0';
+        int wlen = MultiByteToWideChar(CP_UTF8, 0, truncated, -1, wide, MAX_PATH);
+        if (wlen == 0 || !SetConsoleTitleW(wide)) {
+            return EPHPM_PS_TITLE_WINDOWS_ERROR;
+        }
+        memcpy(g_ps_buffer, truncated, title_len + 1);
+        g_ps_buffer_cur_len = title_len;
+    }
+    return EPHPM_PS_TITLE_SUCCESS;
+#else
+    (void)title;
+    (void)title_len;
+    return EPHPM_PS_TITLE_NOT_AVAILABLE; /* unreachable: available() failed */
+#endif
+}
+
+/* get_ps_title(). On Windows the console is re-queried, as php-src does. */
+static int ephpm_get_ps_title(size_t *displen, const char **string)
+{
+    int rc = ephpm_ps_title_available();
+    if (rc != EPHPM_PS_TITLE_SUCCESS) {
+        return rc;
+    }
+
+#if defined(EPHPM_PS_USE_WIN32)
+    {
+        wchar_t wide[MAX_PATH];
+        if (!GetConsoleTitleW(wide, MAX_PATH)) {
+            return EPHPM_PS_TITLE_WINDOWS_ERROR;
+        }
+        int bytes = WideCharToMultiByte(
+            CP_UTF8, 0, wide, -1, g_ps_buffer, (int)sizeof(g_ps_buffer), NULL, NULL);
+        if (bytes == 0) {
+            return EPHPM_PS_TITLE_WINDOWS_ERROR;
+        }
+        g_ps_buffer_cur_len = (size_t)bytes - 1; /* bytes includes the NUL */
+    }
+#endif
+#if defined(EPHPM_PS_USE_CLOBBER_ARGV) || defined(EPHPM_PS_USE_WIN32)
+    *displen = g_ps_buffer_cur_len;
+    *string = g_ps_buffer;
+    return EPHPM_PS_TITLE_SUCCESS;
+#else
+    (void)displen;
+    (void)string;
+    return EPHPM_PS_TITLE_NOT_AVAILABLE; /* unreachable: available() failed */
+#endif
+}
+
+/* PHP_FUNCTION bodies: verbatim php_cli_process_title.c semantics. */
+PHP_FUNCTION(cli_set_process_title)
+{
+    char *title = NULL;
+    size_t title_len;
+    int rc;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &title, &title_len) == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    rc = ephpm_set_ps_title(title, title_len);
+    if (rc == EPHPM_PS_TITLE_SUCCESS) {
+        RETURN_TRUE;
+    }
+
+    php_error_docref(NULL, E_WARNING, "cli_set_process_title had an error: %s",
+                     ephpm_ps_title_errno(rc));
+    RETURN_FALSE;
+}
+
+PHP_FUNCTION(cli_get_process_title)
+{
+    size_t length = 0;
+    const char *title = NULL;
+    int rc;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        RETURN_THROWS();
+    }
+
+    rc = ephpm_get_ps_title(&length, &title);
+    if (rc != EPHPM_PS_TITLE_SUCCESS) {
+        php_error_docref(NULL, E_WARNING, "cli_get_process_title had an error: %s",
+                         ephpm_ps_title_errno(rc));
+        RETURN_NULL();
+    }
+
+    RETURN_STRINGL(title, length);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_cli_set_process_title, 0, 0, 1)
+    ZEND_ARG_INFO(0, title)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_cli_get_process_title, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 /* ── Function entry table (null-terminated) ──────────────────── */
 
-static const zend_function_entry ephpm_kv_functions[] = {
-    PHP_FE(ephpm_kv_get,       arginfo_ephpm_kv_get)
-    PHP_FE(ephpm_kv_set,       arginfo_ephpm_kv_set)
-    PHP_FE(ephpm_kv_setnx,     arginfo_ephpm_kv_setnx)
-    PHP_FE(ephpm_kv_del,       arginfo_ephpm_kv_del)
-    PHP_FE(ephpm_kv_exists,    arginfo_ephpm_kv_exists)
-    PHP_FE(ephpm_kv_incr,      arginfo_ephpm_kv_incr)
-    PHP_FE(ephpm_kv_decr,      arginfo_ephpm_kv_decr)
-    PHP_FE(ephpm_kv_incr_by,   arginfo_ephpm_kv_incr_by)
-    PHP_FE(ephpm_kv_expire,    arginfo_ephpm_kv_expire)
-    PHP_FE(ephpm_kv_ttl,       arginfo_ephpm_kv_ttl)
-    PHP_FE(ephpm_kv_pttl,      arginfo_ephpm_kv_pttl)
-    PHP_FE(ephpm_kv_flush_all, arginfo_ephpm_kv_flush_all)
-    PHP_FE(ephpm_kv_wait,      arginfo_ephpm_kv_wait)
-    /* Embedded database bridge (per-thread litewire Session). */
-    PHP_FE(ephpm_db_query,     arginfo_ephpm_db_query)
-    PHP_FE(ephpm_db_execute,   arginfo_ephpm_db_execute)
-    /* WebSocket bridge (site-scoped connection registry). Implicit forms
-     * act on the connection that fired the current event; the
-     * ephpm_ws_connection_* forms take an explicit id. */
-    PHP_FE(ephpm_ws_send,                    arginfo_ephpm_ws_send)
-    PHP_FE(ephpm_ws_connection_send,         arginfo_ephpm_ws_connection_send)
-    PHP_FE(ephpm_ws_subscribe,               arginfo_ephpm_ws_subscribe)
-    PHP_FE(ephpm_ws_connection_subscribe,    arginfo_ephpm_ws_connection_subscribe)
-    PHP_FE(ephpm_ws_unsubscribe,             arginfo_ephpm_ws_unsubscribe)
-    PHP_FE(ephpm_ws_connection_unsubscribe,  arginfo_ephpm_ws_connection_unsubscribe)
-    PHP_FE(ephpm_ws_broadcast,               arginfo_ephpm_ws_broadcast)
-    PHP_FE(ephpm_ws_close,                   arginfo_ephpm_ws_close)
+/* The entries every mode gets. Kept as a macro so the serve-mode table and
+ * the CLI table (which adds the cli-SAPI-only functions) share one list —
+ * a new native function added here lands in both automatically. */
+#define EPHPM_COMMON_FUNCTION_ENTRIES \
+    PHP_FE(ephpm_kv_get,       arginfo_ephpm_kv_get) \
+    PHP_FE(ephpm_kv_set,       arginfo_ephpm_kv_set) \
+    PHP_FE(ephpm_kv_setnx,     arginfo_ephpm_kv_setnx) \
+    PHP_FE(ephpm_kv_del,       arginfo_ephpm_kv_del) \
+    PHP_FE(ephpm_kv_exists,    arginfo_ephpm_kv_exists) \
+    PHP_FE(ephpm_kv_incr,      arginfo_ephpm_kv_incr) \
+    PHP_FE(ephpm_kv_decr,      arginfo_ephpm_kv_decr) \
+    PHP_FE(ephpm_kv_incr_by,   arginfo_ephpm_kv_incr_by) \
+    PHP_FE(ephpm_kv_expire,    arginfo_ephpm_kv_expire) \
+    PHP_FE(ephpm_kv_ttl,       arginfo_ephpm_kv_ttl) \
+    PHP_FE(ephpm_kv_pttl,      arginfo_ephpm_kv_pttl) \
+    PHP_FE(ephpm_kv_flush_all, arginfo_ephpm_kv_flush_all) \
+    PHP_FE(ephpm_kv_wait,      arginfo_ephpm_kv_wait) \
+    /* Embedded database bridge (per-thread litewire Session). */ \
+    PHP_FE(ephpm_db_query,     arginfo_ephpm_db_query) \
+    PHP_FE(ephpm_db_execute,   arginfo_ephpm_db_execute) \
+    /* WebSocket bridge (site-scoped connection registry). Implicit forms \
+     * act on the connection that fired the current event; the \
+     * ephpm_ws_connection_* forms take an explicit id. */ \
+    PHP_FE(ephpm_ws_send,                    arginfo_ephpm_ws_send) \
+    PHP_FE(ephpm_ws_connection_send,         arginfo_ephpm_ws_connection_send) \
+    PHP_FE(ephpm_ws_subscribe,               arginfo_ephpm_ws_subscribe) \
+    PHP_FE(ephpm_ws_connection_subscribe,    arginfo_ephpm_ws_connection_subscribe) \
+    PHP_FE(ephpm_ws_unsubscribe,             arginfo_ephpm_ws_unsubscribe) \
+    PHP_FE(ephpm_ws_connection_unsubscribe,  arginfo_ephpm_ws_connection_unsubscribe) \
+    PHP_FE(ephpm_ws_broadcast,               arginfo_ephpm_ws_broadcast) \
+    PHP_FE(ephpm_ws_close,                   arginfo_ephpm_ws_close) \
     PHP_FE(ephpm_ws_connection_close,        arginfo_ephpm_ws_connection_close)
+
+static const zend_function_entry ephpm_kv_functions[] = {
+    EPHPM_COMMON_FUNCTION_ENTRIES
     PHP_FE_END
 };
+
+/* CLI-mode table: everything above plus the functions the cli SAPI itself
+ * registers in php-src (issue #316). Selected by ephpm_module_startup()
+ * when g_cli_mode is set, so a web request never sees them. */
+static const zend_function_entry ephpm_cli_functions[] = {
+    EPHPM_COMMON_FUNCTION_ENTRIES
+    PHP_FE(cli_set_process_title, arginfo_cli_set_process_title)
+    PHP_FE(cli_get_process_title, arginfo_cli_get_process_title)
+    PHP_FE_END
+};
+
 
 /* ===================================================================
  * Native session save handler — `session.save_handler = ephpm`.
@@ -4009,6 +4349,100 @@ void ephpm_cli_set_no_ini(void)
     php_embed_module.php_ini_ignore_cwd = 1;
 }
 
+/* ===== CLI `-d` directives (startup-time, issue #331) =====
+ *
+ * php-cli applies `-d name[=value]` by appending "name=value\n" lines to
+ * sapi_module.ini_entries BEFORE php_module_startup(), so the values are in
+ * the configuration hash when every extension's MINIT runs. That timing is
+ * load-bearing: OPcache decides once, in accel_startup() (a MINIT-time hook),
+ * whether it will ever be active — on 8.3/8.4 accel_find_sapi() requires
+ * `opcache.enable_cli=1` for the "cli" SAPI, and 8.5 keeps the same
+ * enable_cli-at-startup check without the allowlist. The JIT is likewise
+ * wired up at startup (its buffer lives in OPcache SHM). Applying `-d` after
+ * php_embed_init() — the pre-#331 behavior — changed the ini entry (visible
+ * to ini_get()) but could never re-run that decision, so
+ * `-d opcache.enable_cli=1` reported 1 while opcache_get_status() stayed
+ * false and `-d opcache.jit=…` silently did nothing.
+ *
+ * The buffer below accumulates directives in exactly the format php-cli's
+ * php_ini_builder_define() produces (value double-quoted when it starts with
+ * a non-alphanumeric that isn't already a quote; bare `-d name` = "name=1").
+ * ephpm_module_startup() splices it AFTER the embed SAPI's HARDCODED_INI so
+ * `-d` wins over those defaults, exactly as php-cli's `-d` wins over its
+ * ini_defaults. Because the whole string is parsed during php_init_config()
+ * this also restores php-cli's `-d extension=…` / `-d zend_extension=…`
+ * behavior: the ini parser routes those to the extension lists that
+ * php_ini_register_extensions() loads during module startup.
+ *
+ * Not implemented with PHP's own php_ini_builder API on purpose: these
+ * helpers run BEFORE php_embed_init(), and keeping them libc-only avoids
+ * depending on PHPAPI symbol export differences across the per-platform SDK
+ * builds. The buffer intentionally lives for the process lifetime (php-cli
+ * frees its builder only at exit; ours is handed to sapi_module.ini_entries).
+ */
+static char *g_cli_ini_defines = NULL;
+static size_t g_cli_ini_defines_len = 0;
+static size_t g_cli_ini_defines_cap = 0;
+
+/* Append `len` bytes to the define buffer, growing it as needed. Returns 0
+ * on allocation failure (the directive is then dropped — matching the spirit
+ * of php-cli, where a failed realloc aborts; we degrade instead because this
+ * runs before PHP's own error machinery exists). */
+static int cli_ini_defines_append(const char *src, size_t len)
+{
+    if (g_cli_ini_defines_len + len + 1 > g_cli_ini_defines_cap) {
+        size_t ncap = g_cli_ini_defines_cap ? g_cli_ini_defines_cap : 256;
+        while (g_cli_ini_defines_len + len + 1 > ncap) {
+            ncap *= 2;
+        }
+        char *nbuf = (char *)realloc(g_cli_ini_defines, ncap);
+        if (!nbuf) {
+            return 0;
+        }
+        g_cli_ini_defines = nbuf;
+        g_cli_ini_defines_cap = ncap;
+    }
+    memcpy(g_cli_ini_defines + g_cli_ini_defines_len, src, len);
+    g_cli_ini_defines_len += len;
+    g_cli_ini_defines[g_cli_ini_defines_len] = '\0';
+    return 1;
+}
+
+/*
+ * Record one CLI `-d name[=value]` directive for startup-time application.
+ * Must be called BEFORE php_embed_init() — driven from the Rust CLI pre-scan
+ * alongside ephpm_enable_cli_mode()/-c/-n. The string is copied immediately;
+ * the caller's pointer need not outlive the call.
+ *
+ * Quoting mirrors php-cli's php_ini_builder_define() exactly: a value whose
+ * first character is non-alphanumeric and not already a quote is wrapped in
+ * double quotes (so `-d error_reporting=E_ALL & ~E_NOTICE` parses as one
+ * value), and a bare `-d name` becomes `name=1`.
+ */
+void ephpm_cli_add_ini_define(const char *def)
+{
+    if (!def || !*def) {
+        return;
+    }
+    size_t len = strlen(def);
+    const char *val = strchr(def, '=');
+
+    if (val != NULL) {
+        val++;
+        if (!isalnum((unsigned char)*val) && *val != '"' && *val != '\'' && *val != '\0') {
+            /* name= + "value" + \n */
+            (void)(cli_ini_defines_append(def, (size_t)(val - def))
+                && cli_ini_defines_append("\"", 1)
+                && cli_ini_defines_append(val, len - (size_t)(val - def))
+                && cli_ini_defines_append("\"\n", 2));
+        } else {
+            (void)(cli_ini_defines_append(def, len) && cli_ini_defines_append("\n", 1));
+        }
+    } else {
+        (void)(cli_ini_defines_append(def, len) && cli_ini_defines_append("=1\n", 3));
+    }
+}
+
 /*
  * Custom startup callback installed in place of php_embed_module.startup.
  *
@@ -4038,7 +4472,33 @@ void ephpm_cli_set_no_ini(void)
  */
 static int ephpm_module_startup(sapi_module_struct *sm)
 {
-    sm->additional_functions = ephpm_kv_functions;
+    /* In CLI mode the table additionally carries the cli-SAPI-only functions
+     * (cli_set_process_title / cli_get_process_title, issue #316) — the `cli`
+     * SAPI identity promises them, but a web request must never see them
+     * (php-fpm has its own fastcgi_* equivalents; ours reports "ephpm"). */
+    sm->additional_functions = g_cli_mode ? ephpm_cli_functions : ephpm_kv_functions;
+
+    /* Splice CLI `-d` directives into the SAPI's startup ini (issue #331).
+     * php_embed_init() has just set sm->ini_entries to the embed SAPI's
+     * HARDCODED_INI; php_module_startup() re-copies *sm into sapi_module and
+     * php_init_config() parses ini_entries LAST (after any php.ini), so this
+     * is the exact window php-cli's `-d` handling occupies. Our entries go
+     * AFTER the hardcoded ones so `-d` overrides them, and after-the-file
+     * parsing means `-d` overrides php.ini — both php-cli behaviors. The
+     * merged buffer must outlive module startup; like php-cli's ini string it
+     * is left to the process teardown. */
+    if (g_cli_ini_defines) {
+        size_t base_len = sm->ini_entries ? strlen(sm->ini_entries) : 0;
+        char *merged = (char *)malloc(base_len + g_cli_ini_defines_len + 1);
+        if (merged) {
+            if (base_len) {
+                memcpy(merged, sm->ini_entries, base_len);
+            }
+            memcpy(merged + base_len, g_cli_ini_defines, g_cli_ini_defines_len);
+            merged[base_len + g_cli_ini_defines_len] = '\0';
+            sm->ini_entries = merged;
+        }
+    }
     /* Register the worker module as php_module_startup's `additional_module` so
      * its functions (Ephpm\Worker\take_request/send_response) and its MINIT
      * (the Envelope class) land in CG(function_table)/CG(class_table) DURING
@@ -4444,31 +4904,6 @@ static int cli_scan_protected(int mode, const char *filename, const char *php_se
 }
 
 /*
- * Apply a single `-d name[=value]` ini directive, matching php-cli semantics:
- * a bare `-d name` sets it to "1". Applied after startup via
- * zend_alter_ini_entry_chars at SYSTEM/ACTIVATE privilege so PHP_INI_ALL and
- * PHP_INI_SYSTEM-at-activate entries (memory_limit, error_reporting,
- * disable_functions, …) take effect for the executed script. Entries that are
- * only settable at MINIT (e.g. most opcache.* / extension=) cannot be changed
- * post-startup in the embed model — the same limitation the `-d extension=`
- * warning in the Rust layer documents.
- */
-static void cli_apply_ini_define(const char *def)
-{
-    const char *eq = strchr(def, '=');
-    size_t name_len = eq ? (size_t)(eq - def) : strlen(def);
-    const char *value = eq ? eq + 1 : "1";
-    size_t value_len = strlen(value);
-    if (name_len == 0) {
-        return;
-    }
-    zend_string *key = zend_string_init(def, name_len, 0);
-    zend_alter_ini_entry_chars(
-        key, (char *)value, value_len, ZEND_INI_SYSTEM, ZEND_INI_STAGE_ACTIVATE);
-    zend_string_release(key);
-}
-
-/*
  * Portable line reader for the -R/-F/-B/-E stdin line processor and REPL-free
  * stdin execution. Reads one line (including any trailing newline) from `fp`
  * into a malloc'd buffer. Returns the buffer (caller frees) and sets *out_len,
@@ -4679,12 +5114,6 @@ int ephpm_cli_main(int argc, char **argv)
     int want_interactive = 0;   /* -a */
     int read_stdin = 0;         /* script/program comes from stdin */
 
-    /* Collected -d name[=value] directives (applied after startup). Bounded;
-     * a CLI invocation with hundreds of -d is pathological, and extra ones are
-     * silently dropped rather than risk an unbounded stack array. */
-    const char *ini_defines[128];
-    int n_ini_defines = 0;
-
     /* First pass: handle flags that print info and exit immediately */
     while ((c = php_getopt(argc, argv, cli_options, &php_optarg, &php_optind, 0, 2)) != -1) {
         switch (c) {
@@ -4850,9 +5279,13 @@ int ephpm_cli_main(int argc, char **argv)
             mode = 's';
             break;
         case 'd':
-            if (n_ini_defines < (int)(sizeof(ini_defines) / sizeof(ini_defines[0]))) {
-                ini_defines[n_ini_defines++] = php_optarg;
-            }
+            /* Already applied. `-d` must take effect at module startup (the
+             * OPcache/JIT decision is made in MINIT — issue #331), so the
+             * Rust pre-scan collected these and ephpm_cli_add_ini_define()
+             * spliced them into sapi_module.ini_entries before
+             * php_module_startup(), exactly as php-cli does. php_getopt still
+             * consumes the argument here so positional detection stays
+             * correct. */
             break;
         case 'B':
             begin_code = php_optarg;
@@ -4872,9 +5305,10 @@ int ephpm_cli_main(int argc, char **argv)
         case 'S':
             server_addr = php_optarg;
             break;
-        /* -c and -n are init-time (which ini to load) and are handled by the
-         * Rust pre-scan before php_embed_init; php_getopt still consumes their
-         * arguments here so positional detection stays correct. */
+        /* -c, -n and -d are init-time (which ini to load, and startup ini
+         * overrides) and are handled by the Rust pre-scan before
+         * php_embed_init; php_getopt still consumes their arguments here so
+         * positional detection stays correct. */
         default:
             break;
         }
@@ -4904,11 +5338,6 @@ int ephpm_cli_main(int argc, char **argv)
             "Use a full php-cli for `php -S`, or run `ephpm serve` / `ephpm dev` for\n"
             "ePHPm's own HTTP server.\n");
         return 1;
-    }
-
-    /* Apply -d directives now that the runtime is up (see cli_apply_ini_define). */
-    for (int i = 0; i < n_ini_defines; i++) {
-        cli_apply_ini_define(ini_defines[i]);
     }
 
     /* Define STDIN/STDOUT/STDERR before any script runs, like php-cli. */

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -3561,6 +3561,9 @@ __attribute__((constructor)) static void ephpm_ps_capture_argv(
 
     /* Extend the clobber area over contiguous environ strings, then move
      * the environment out of it. */
+    if (!environ) {
+        return;
+    }
     int n = 0;
     while (environ[n] != NULL) {
         n++;

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -127,6 +127,16 @@ mod ffi {
         /// `php_embed_init()` (the ini search happens during module startup).
         pub fn ephpm_cli_set_no_ini();
 
+        /// CLI `-d name[=value]` — record one ini directive for startup-time
+        /// application (spliced into `sapi_module.ini_entries` before
+        /// `php_module_startup()`, exactly as php-cli applies `-d`). Must be
+        /// called BEFORE `php_embed_init()`: MINIT-time consumers (OPcache's
+        /// enable/enable_cli/JIT decision, `extension=` loading) read the
+        /// value during module startup and never again (issue #331). The
+        /// string is copied immediately; the pointer need not outlive the
+        /// call.
+        pub fn ephpm_cli_add_ini_define(def: *const ::std::os::raw::c_char);
+
         /// Set the configured `max_execution_time` (seconds) the request paths
         /// use to arm PHP's per-thread execution timer. Necessary because the
         /// embed SAPI resets the `max_execution_time` ini entry to `0`
@@ -436,26 +446,33 @@ pub struct PhpRuntime {
     initialized: bool,
 }
 
-/// Pre-scan `ephpm php` arguments for the two ini-loading flags that must be
-/// decided *before* `php_embed_init()` runs: `-c <path>` (use this php.ini) and
-/// `-n` (load no ini at all). The C option parser (`php_getopt`) only runs
-/// after init, which is too late to influence which ini PHP loads at module
-/// startup — so this lightweight, `php_getopt`-aware scan mirrors its short-
-/// option semantics (bundled flags, attached-or-separate arguments) closely
-/// enough to locate `-c`/`-n` without ever mistaking an option *argument* (e.g.
-/// the code after `-r`) for one of them.
+/// Pre-scan `ephpm php` arguments for the ini flags that must be decided
+/// *before* `php_embed_init()` runs: `-c <path>` (use this php.ini), `-n`
+/// (load no ini at all), and every `-d name[=value]` directive. The C option
+/// parser (`php_getopt`) only runs after init, which is too late to influence
+/// which ini PHP loads — or which values MINIT-time consumers see: OPcache
+/// decides at module startup whether it will ever activate
+/// (`opcache.enable_cli`, the JIT knobs) and `extension=` lines load there
+/// too, so `-d` has to reach `sapi_module.ini_entries` before startup exactly
+/// as it does in php-cli (issue #331). This lightweight, `php_getopt`-aware
+/// scan mirrors its short-option semantics (bundled flags,
+/// attached-or-separate arguments) closely enough to locate them without ever
+/// mistaking an option *argument* (e.g. the code after `-r`) for one of them.
 ///
-/// Returns `(ini_path, no_ini)`. `-n` takes precedence over `-c`, matching
-/// php-cli. Scanning stops at the first positional (the script), at `--`, or at
-/// the `-` stdin sentinel — everything after those is script arguments, not
+/// Returns `(ini_path, no_ini, ini_defines)`. `-n` takes precedence over
+/// `-c`, matching php-cli (but does not suppress `-d`, also matching).
+/// Scanning stops at the first positional (the script), at `--`, or at the
+/// `-` stdin sentinel — everything after those is script arguments, not
 /// interpreter options.
 #[cfg(any(php_linked, test))]
-fn precscan_cli_ini_flags(args: &[String]) -> (Option<String>, bool) {
+#[allow(clippy::too_many_lines)]
+fn precscan_cli_ini_flags(args: &[String]) -> (Option<String>, bool, Vec<String>) {
     /// Short options that consume a following argument (from `cli_options`).
     const TAKES_ARG: &[char] = &['B', 'c', 'd', 'E', 'F', 'f', 'R', 'r', 'S', 't'];
 
     let mut ini_path: Option<String> = None;
     let mut no_ini = false;
+    let mut ini_defines: Vec<String> = Vec::new();
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
@@ -511,6 +528,21 @@ fn precscan_cli_ini_flags(args: &[String]) -> (Option<String>, bool) {
                     }
                     break;
                 }
+                if ch == 'd' {
+                    // Same value shapes as `-c`: attached (`-dfoo=1`) or the
+                    // next token (`-d foo=1`). Order is preserved — a later
+                    // `-d` for the same key wins, as in php-cli.
+                    let rest: String = chars[j + 1..].iter().collect();
+                    if rest.is_empty() {
+                        if let Some(next) = args.get(i + 1) {
+                            ini_defines.push(next.clone());
+                            consumed_next = true;
+                        }
+                    } else {
+                        ini_defines.push(rest);
+                    }
+                    break;
+                }
                 if TAKES_ARG.contains(&ch) {
                     // Some other arg-taking option (r, f, d, …). Its argument is
                     // the rest of this token, or the next token — skip it so its
@@ -532,7 +564,8 @@ fn precscan_cli_ini_flags(args: &[String]) -> (Option<String>, bool) {
         break;
     }
     // `-n` (ignore all ini) subsumes `-c` (choose an ini), matching php-cli.
-    (if no_ini { None } else { ini_path }, no_ini)
+    // `-d` directives survive `-n` — `php -n -d x=y` applies them there too.
+    (if no_ini { None } else { ini_path }, no_ini, ini_defines)
 }
 
 /// Whether the PHP module has been initialized (set once by `init()`).
@@ -809,11 +842,14 @@ impl PhpRuntime {
     /// Returns `PhpError::LockPoisoned` or `PhpError::InitFailed` on failure.
     pub fn cli_main(args: &[String]) -> Result<i32, PhpError> {
         // Init-time CLI decisions that must be settled BEFORE php_embed_init()
-        // runs (inside `Self::init()`): the SAPI identity ("cli"), and which
-        // php.ini to load (`-c <path>` / `-n`). Parsed from a lightweight,
-        // php_getopt-aware pre-scan because the C option parser only runs
-        // afterwards. The `-c` path CString is bound for the rest of this
-        // function so its pointer stays valid until init completes.
+        // runs (inside `Self::init()`): the SAPI identity ("cli"), which
+        // php.ini to load (`-c <path>` / `-n`), and the `-d` ini directives —
+        // those must be in `sapi_module.ini_entries` when module startup runs
+        // so MINIT-time consumers (OPcache/JIT activation, `extension=`) see
+        // them, exactly as php-cli applies them (issue #331). Parsed from a
+        // lightweight, php_getopt-aware pre-scan because the C option parser
+        // only runs afterwards. The `-c` path CString is bound for the rest of
+        // this function so its pointer stays valid until init completes.
         #[cfg(php_linked)]
         let _cli_ini_path_cstring = {
             use std::ffi::CString;
@@ -823,7 +859,19 @@ impl PhpRuntime {
             // startup; no PHP runtime state exists yet.
             unsafe { ffi::ephpm_enable_cli_mode() };
 
-            let (ini_override, no_ini) = precscan_cli_ini_flags(args);
+            let (ini_override, no_ini, ini_defines) = precscan_cli_ini_flags(args);
+
+            for define in &ini_defines {
+                // A `-d` value containing a NUL cannot be a valid ini
+                // directive; skip it rather than truncate it silently.
+                if let Ok(cstr) = CString::new(define.as_str()) {
+                    // SAFETY: before-init timing contract as above. The C side
+                    // copies the string immediately, so the CString may drop
+                    // at the end of this iteration.
+                    unsafe { ffi::ephpm_cli_add_ini_define(cstr.as_ptr()) };
+                }
+            }
+
             if no_ini {
                 // SAFETY: same before-init timing contract.
                 unsafe { ffi::ephpm_cli_set_no_ini() };
@@ -1640,23 +1688,30 @@ mod tests {
     use super::*;
 
     /// Convenience: build the `Vec<String>` `precscan_cli_ini_flags` expects.
-    fn scan(args: &[&str]) -> (Option<String>, bool) {
+    fn scan(args: &[&str]) -> (Option<String>, bool, Vec<String>) {
         let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
         precscan_cli_ini_flags(&owned)
     }
 
+    /// Convenience for the `-d` collection assertions.
+    fn defines(args: &[&str]) -> Vec<String> {
+        scan(args).2
+    }
+
+    const NO_DEFINES: Vec<String> = Vec::new();
+
     #[test]
     fn precscan_no_ini_flags() {
-        assert_eq!(scan(&["-r", "echo 1;"]), (None, false));
-        assert_eq!(scan(&["script.php", "arg"]), (None, false));
-        assert_eq!(scan(&[]), (None, false));
+        assert_eq!(scan(&["-r", "echo 1;"]), (None, false, NO_DEFINES));
+        assert_eq!(scan(&["script.php", "arg"]), (None, false, NO_DEFINES));
+        assert_eq!(scan(&[]), (None, false, NO_DEFINES));
     }
 
     #[test]
     fn precscan_finds_no_ini() {
-        assert_eq!(scan(&["-n", "script.php"]), (None, true));
+        assert_eq!(scan(&["-n", "script.php"]), (None, true, NO_DEFINES));
         // Bundled with another no-arg flag.
-        assert_eq!(scan(&["-nl", "script.php"]), (None, true));
+        assert_eq!(scan(&["-nl", "script.php"]), (None, true, NO_DEFINES));
     }
 
     #[test]
@@ -1668,37 +1723,67 @@ mod tests {
     #[test]
     fn precscan_n_beats_c() {
         // `-n` wins regardless of `-c` also being present, matching php-cli.
-        assert_eq!(scan(&["-c", "/etc/alt.ini", "-n", "s.php"]), (None, true));
+        assert_eq!(scan(&["-c", "/etc/alt.ini", "-n", "s.php"]), (None, true, NO_DEFINES));
     }
 
     #[test]
     fn precscan_does_not_read_option_arguments() {
         // The `-n`/`-c` inside -r code or -d value must NOT be treated as flags.
-        assert_eq!(scan(&["-r", "-n"]), (None, false));
-        assert_eq!(scan(&["-r", "echo '-c x';", "arg"]), (None, false));
-        assert_eq!(scan(&["-d", "auto_prepend_file=-n", "s.php"]), (None, false));
+        assert_eq!(scan(&["-r", "-n"]), (None, false, NO_DEFINES));
+        assert_eq!(scan(&["-r", "echo '-c x';", "arg"]), (None, false, NO_DEFINES));
+        let run = scan(&["-d", "auto_prepend_file=-n", "s.php"]);
+        assert_eq!((run.0, run.1), (None, false));
+        assert_eq!(run.2, vec!["auto_prepend_file=-n".to_string()]);
     }
 
     #[test]
     fn precscan_stops_at_positional_and_dashes() {
         // A `-n` that appears after the script name is a script argument.
-        assert_eq!(scan(&["script.php", "-n"]), (None, false));
-        assert_eq!(scan(&["--", "-n"]), (None, false));
-        assert_eq!(scan(&["-", "-n"]), (None, false));
+        assert_eq!(scan(&["script.php", "-n"]), (None, false, NO_DEFINES));
+        assert_eq!(scan(&["--", "-n"]), (None, false, NO_DEFINES));
+        assert_eq!(scan(&["-", "-n"]), (None, false, NO_DEFINES));
+        // Same for a `-d`: after the script it belongs to the script.
+        assert_eq!(defines(&["script.php", "-d", "foo=1"]), NO_DEFINES);
     }
 
     #[test]
     fn precscan_composer_invocation() {
-        // The canonical composer form must be seen as "no ini flags".
-        assert_eq!(scan(&["-d", "memory_limit=-1", "composer.phar", "--version"]), (None, false));
+        // The canonical composer form: memory_limit collected, no ini flags.
+        assert_eq!(
+            scan(&["-d", "memory_limit=-1", "composer.phar", "--version"]),
+            (None, false, vec!["memory_limit=-1".to_string()])
+        );
     }
 
     #[test]
     fn precscan_skips_long_reflection_arg() {
         // `--rf name` takes a separate arg; a trailing `-n` after it is not
         // reached because the reflection arg is the terminal token here.
-        assert_eq!(scan(&["--rf", "strlen"]), (None, false));
-        assert_eq!(scan(&["--ini", "-n", "s.php"]), (None, true));
+        assert_eq!(scan(&["--rf", "strlen"]), (None, false, NO_DEFINES));
+        assert_eq!(scan(&["--ini", "-n", "s.php"]), (None, true, NO_DEFINES));
+    }
+
+    #[test]
+    fn precscan_collects_defines_separate_attached_and_ordered() {
+        // Separate and attached forms, order preserved (later `-d` for the
+        // same key must stay later — php-cli lets it win at parse time).
+        assert_eq!(
+            defines(&["-d", "opcache.enable_cli=1", "-dopcache.jit=tracing", "-r", "echo 1;"]),
+            vec!["opcache.enable_cli=1".to_string(), "opcache.jit=tracing".to_string()]
+        );
+        // Bare `-d name` (value defaults to 1 on the C side) and bundling
+        // after no-arg flags (`-qd foo`).
+        assert_eq!(defines(&["-d", "opcache.enable_cli", "s.php"]), vec!["opcache.enable_cli"]);
+        assert_eq!(defines(&["-qd", "foo=bar", "s.php"]), vec!["foo=bar"]);
+    }
+
+    #[test]
+    fn precscan_defines_survive_no_ini() {
+        // `php -n -d x=y` still applies the define, matching php-cli.
+        assert_eq!(
+            scan(&["-n", "-d", "memory_limit=64M", "s.php"]),
+            (None, true, vec!["memory_limit=64M".to_string()])
+        );
     }
 
     fn make_test_request() -> PhpRequest {

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -557,41 +557,15 @@ fn restore_php_separator(raw: Option<Vec<String>>, parsed: &[String]) -> Vec<Str
 }
 
 /// Run the `ephpm php` subcommand — pass args through to the embedded PHP CLI.
+///
+/// `-d` directives (including `-d extension=`) are applied at module startup
+/// by the CLI pre-scan in `ephpm_php::PhpRuntime::cli_main`, matching php-cli
+/// — the former "runtime `-d extension=` is ignored" warning is gone because
+/// the limitation is gone (issue #331).
 fn run_php(args: &[String]) -> anyhow::Result<ExitCode> {
-    warn_if_runtime_extension_flag(args);
     let exit_code = ephpm_php::PhpRuntime::cli_main(args).context("PHP CLI failed")?;
     let _ = ephpm_php::PhpRuntime::shutdown();
     Ok(exit_code_from(exit_code))
-}
-
-/// Warn when a runtime `-d extension=` is passed to `ephpm php`.
-///
-/// The embedded PHP runtime initialises before it parses `-d` directives, so
-/// `-d extension=…` is silently ignored (extensions must be registered at
-/// startup). Rather than let the knob be a silent no-op, warn once and point
-/// the user at the config equivalent.
-fn warn_if_runtime_extension_flag(args: &[String]) {
-    // Match `-d extension=…` (split), `-dextension=…`, and `-d=extension=…`.
-    let mut prev_was_d = false;
-    for arg in args {
-        let is_ext_directive = if prev_was_d {
-            arg.starts_with("extension=")
-        } else if let Some(rest) = arg.strip_prefix("-d") {
-            // `-dextension=…` or `-d=extension=…`
-            rest.strip_prefix('=').unwrap_or(rest).starts_with("extension=")
-        } else {
-            false
-        };
-        if is_ext_directive {
-            tracing::warn!(
-                "`-d extension=` is ignored by `ephpm php` — the embedded PHP \
-                 runtime loads extensions before parsing `-d`. Register shared \
-                 extensions via `[php] extensions` in ephpm.toml instead."
-            );
-            return;
-        }
-        prev_was_d = arg == "-d";
-    }
 }
 
 /// Startup diagnostics for `[php] max_execution_time`.

--- a/docs/architecture/dynamic-baseline-design.md
+++ b/docs/architecture/dynamic-baseline-design.md
@@ -138,13 +138,14 @@ With `[php] extensions = ["/mw/pivot_ping.so"]`:
 - CLI: `PHPRC=/mw/cli-php.ini ephpm php -r 'var_dump(pivot_ping());'` →
   same string.
 
-Caveat found: `ephpm php -d extension=...` does **not** load the
-extension — PHP is initialized before CLI args are parsed, and
-`extension=` only takes effect at MINIT. `ephpm php` now **warns** when a
-runtime `-d extension=` is passed (rather than silently ignoring it) and
-points at `[php] extensions`. The CLI does not read `ephpm.toml` either;
-for a CLI-only load use `PHPRC` pointing at an ini with the `extension=`
-line.
+Caveat found at the time: `ephpm php -d extension=...` did **not** load
+the extension — PHP was initialized before CLI args were parsed, and
+`extension=` only takes effect at MINIT. **Resolved by #331** (v0.7.2):
+the CLI pre-scan now splices `-d` directives into
+`sapi_module.ini_entries` before module startup, exactly as php-cli
+does, so `-d extension=` loads for real and the interim warning was
+removed. The CLI still does not read `ephpm.toml`; `PHPRC` pointing at
+an ini with the `extension=` line also remains an option.
 
 ### 3.3 ABI rules
 
@@ -243,5 +244,5 @@ consecutive requests return `boot #1, request #N` with N climbing
    validated" rows in §6.
 5. **macOS runner group** — bring macos-arm64 release validation onto
    the native runner pool.
-6. **CLI ergonomics** — `ephpm php -d extension=` now warns rather than
-   silently ignoring the flag (§3.2).
+6. **CLI ergonomics** — resolved: `ephpm php -d extension=` loads the
+   extension at module startup since #331 (§3.2).

--- a/site/content/reference/cli/php.md
+++ b/site/content/reference/cli/php.md
@@ -58,6 +58,12 @@ tools that gate on the SAPI name run normally:
 - **WP-CLI** (`wp-cli.phar`) — runs; `STDIN`/`STDOUT`/`STDERR` are defined.
 - **Laravel artisan** / any Symfony Console app — `$argv`/`$argc` are
   registered, so subcommands and options are parsed.
+- **cli-SAPI-only functions** — `cli_set_process_title()` /
+  `cli_get_process_title()` exist (PsySH calls them, so `artisan tinker`
+  works). The title genuinely changes on Linux (`/proc/self/cmdline`, `ps`)
+  and sets the console title on Windows, mirroring php-src's `ps_title.c`; on
+  other platforms the functions exist but honestly return `false`/`null` with
+  php's own "Not available on this OS" warning.
 
 The server (`ephpm serve` / `ephpm dev`) is a separate process invocation and
 keeps reporting `PHP_SAPI === "ephpm"` — only the `ephpm php` process is `cli`.
@@ -65,13 +71,14 @@ keeps reporting `PHP_SAPI === "ephpm"` — only the `ephpm php` process is `cli`
 ### Ini flags
 
 - `-d key[=value]` — set an ini directive for this run (`-d key` means
-  `key=1`). Applied after startup, so `PHP_INI_ALL`/`PHP_INI_SYSTEM` directives
-  such as `memory_limit`, `error_reporting`, and `disable_functions` take
-  effect. Directives that only apply at module startup (most `opcache.*`, and
-  `-d extension=`) cannot be set this way — register extensions via `[php]
-  extensions` in your config instead.
+  `key=1`). Applied at module startup exactly as php-cli applies it, so it
+  overrides `php.ini` and works for startup-only directives too:
+  `-d opcache.enable_cli=1` activates OPcache, the `opcache.jit*` knobs enable
+  the JIT, and `-d extension=` / `-d zend_extension=` load extensions — in
+  addition to the runtime-changeable directives (`memory_limit`,
+  `error_reporting`, `disable_functions`, …).
 - `-c <path>` — load `php.ini` from this path.
-- `-n` — load no `php.ini` at all.
+- `-n` — load no `php.ini` at all (`-d` still applies, as in php-cli).
 
 ### Programs on stdin
 


### PR DESCRIPTION
Two `ephpm php` CLI-fidelity fixes for v0.7.2, both in `ephpm_cli_main`'s orbit in `crates/ephpm-php/ephpm_wrapper.c`.

## #331 — opcache/JIT never activated in the one-shot CLI

**Root cause.** OPcache decides *once*, at MINIT time, whether it will ever be active: `accel_startup()` reads `ZCG(accel_directives).enable_cli` during module startup and permanently declines when it is 0 (8.3/8.4 via `accel_find_sapi()`'s `enable_cli && sapi=="cli"` arm; 8.5 dropped the allowlist but kept the same startup-time `!enable_cli && accel_sapi_is_cli()` check — verified in php-src for all three branches). The JIT is wired up in the same startup phase (its buffer lives in OPcache SHM). php-cli passes `-d` to `sapi_module.ini_entries` **before** `php_module_startup()`; our CLI applied `-d` **after** `php_embed_init()` via `zend_alter_ini_entry_chars` — which is why `ini_get('opcache.enable_cli')` showed 1 (the entry was altered) while `opcache_get_status()` stayed `false` (the decision had already been made). The SAPI *name* was not the problem — it has been "cli" since #306.

**Fix.** The Rust CLI pre-scan (which already handles `-c`/`-n`) now also collects every `-d` and hands each to a new pre-init hook `ephpm_cli_add_ini_define()`, which accumulates them in exactly php-cli's `php_ini_builder_define()` format (same value-quoting rule, bare `-d name` → `name=1`). `ephpm_module_startup()` — our existing startup shim, which runs after `php_embed_init()` sets `ini_entries = HARDCODED_INI` and before `php_module_startup()` reads it — splices them in after the hardcoded block, so `-d` overrides both the embed defaults and php.ini, php-cli's exact precedence. The old post-startup `zend_alter_ini_entry_chars` loop is gone; `-d` now takes effect at the same point in the lifecycle as php-cli.

Free consequence: `-d extension=` / `-d zend_extension=` now genuinely load (the ini parser routes them to `php_ini_register_extensions()`), so the "`-d extension=` is ignored" warning in `main.rs` and its doc claims were removed/updated.

## #316 — `cli_set_process_title()` / `cli_get_process_title()` missing

**Root cause.** php-src registers these from the cli SAPI (`sapi/cli/php_cli_process_title.c` + `ps_title.c`); the embed SAPI never does. `ephpm php` deliberately reports `PHP_SAPI === "cli"`, so code that keys on the SAPI name (PsySH → `artisan tinker <file>`) fataled.

**Fix.** A condensed `ps_title.c` port in the wrapper, registered via a CLI-only function table (the startup shim picks `ephpm_cli_functions` when `g_cli_mode` is set; web requests never see them; the shared entries live in one macro so future natives land in both tables):

- **Linux (glibc)** — `PS_USE_CLOBBER_ARGV`, php's real mechanism: the original argv area is overwritten so `/proc/self/cmdline` and `ps` show the title. php-cli captures argv in `main()`; our `main()` is Rust, so a glibc `.init_array` constructor (called with argc/argv/envp) captures it, gated to `argv[1] == "php"`, and deep-copies environ out of the clobber area exactly as `save_ps_args()` does. Unlike php we do **not** rewrite the `argv[i]` pointer slots — clap/std still parse the untouched argv, which only gets clobbered when a script actually sets a title.
- **Windows** — `PS_USE_WIN32`, php's real mechanism there: `SetConsoleTitleW`/`GetConsoleTitleW` with UTF-8↔UTF-16 conversion; fails honestly (warning + `false`) when there is no console.
- **elsewhere (macOS)** — honest `PS_TITLE_NOT_AVAILABLE` ("Not available on this OS" warning + `false`/`null`), never fake success. macOS could adopt the clobber path + `_NSGetArgv` later; not shipped unverified.

Return-value contract and warning strings match `php_cli_process_title.c` byte for byte, including PHP 8.5's "Too long" rejection (pre-8.5 truncates), and `cli_get_process_title()` before any set returns `""` — verified identical to real php-cli 8.5.4.

## Evidence (real binaries)

**Before** (both bugs reproduced on real pre-fix binaries):
- Linux, the released **v0.7.0** binary (`PHP 8.5.7 (cli)`): `-d opcache.enable_cli=1` → `ini_get` reports `"1"` but `opcache_get_status(false)` → `bool(false)`; with the JIT flags, status stays `false`; `function_exists('cli_set_process_title')` → `bool(false)`.
- Windows, a main-built `ephpm.exe` (8.5.7): identical shape — `ini_get('opcache.enable_cli')` → `"1"`, `opcache_get_status(false)` → `bool(false)`, `function_exists('cli_set_process_title')` → `bool(false)`.

**After:**

| Case | Linux (PHP 8.5.7, WSL) | Windows (PHP 8.3.31, MSVC) |
|---|---|---|
| `-d opcache.enable_cli=1` → `opcache_enabled` | `bool(true)` | `bool(true)` |
| no flag → `opcache_get_status(false)` | `bool(false)` | `bool(false)` |
| `-d opcache.jit=tracing -d opcache.jit_buffer_size=64M` → `jit.on`, buffer | `bool(true)`, 67108848 | `bool(true)`, 67108848 |
| `-d max_execution_time=17` beats embed HARDCODED_INI | `"17"` | `"17"` |
| quoted value (`-d include_path=/e2e/one`) | `/e2e/one` | `/e2e/one` |
| `cli_set_process_title` exists / set / get | true / true / round-trips | true / true / round-trips |
| title reaches the OS | `/proc/self/cmdline` + `ps -o args=` show it | console title (GetConsoleTitleW round-trip) |
| get before set | `string(0) ""` (= php-cli) | — |

Gold check (`/root/laravel-gate/app`, Laravel + PsySH): `v0.7.0: ephpm php artisan tinker <file>` → `Error  Call to undefined function cli_set_process_title().`; fixed binary → the include runs (`tinker-ran: 4`) and tinker exits cleanly at EOF.

## Tests

New e2e coverage in `crates/ephpm-e2e/tests/cli.rs` (execs the real binary — the only kind of test that can cover this): `opcache_activates_with_enable_cli`, `opcache_stays_inactive_without_enable_cli`, `jit_activates_with_tracing_flags`, `ini_define_overrides_embed_hardcoded_defaults`, `ini_define_quotes_non_alnum_values_like_php_cli`, `process_title_functions_exist`, `process_title_round_trips_and_reaches_proc_cmdline` (Linux). Full `cli` suite (incl. the #321 regression tests) green via `cargo xtask e2e --tests cli` on Linux; the new tests also pass against the Windows binary. Prescan unit tests extended for `-d` collection (stub-mode safe).

Docs updated in the same PR: `site/content/reference/cli/php.md` (ini flags + drop-in surface), `docs/architecture/dynamic-baseline-design.md` (`-d extension=` caveat resolved).

Closes #331. Closes #316.
