### PR TITLE
fix(cli): shutdown functions, destructors, and exit-in-shutdown status under ephpm php (#334)

### DIFF
--- a/crates/ephpm-e2e/tests/cli.rs
+++ b/crates/ephpm-e2e/tests/cli.rs
@@ -1,6 +1,7 @@
 //! `ephpm php` CLI conformance — fatal-error reporting, exit statuses,
-//! startup-time `-d` (OPcache/JIT activation, issue #331) and the cli-SAPI
-//! process-title functions (issue #316).
+//! startup-time `-d` (OPcache/JIT activation, issue #331), the cli-SAPI
+//! process-title functions (issue #316), and the end-of-request lifecycle
+//! (shutdown functions / destructors / exit-status-from-shutdown, issue #334).
 //!
 //! Regression cover for **issue #321**: on v0.7.0 a fatal error or an uncaught
 //! exception under `ephpm php -r` produced **no output at all and exit 0**,
@@ -417,6 +418,185 @@ fn process_title_round_trips_and_reaches_proc_cmdline() {
          --- stdout ---\n{}\n--- stderr ---\n{}",
         run.stdout, run.stderr
     );
+    assert_eq!(run.code, 0);
+}
+
+// ─── Issue #334: shutdown functions and end-of-script destructors ─────────
+//
+// The observable defect: `ephpm php` never ran php_request_shutdown() while
+// its stdout writer was installed — the request was left for
+// php_embed_shutdown() at process exit, after the exit code was captured and
+// the CLI output path was torn down. So register_shutdown_function()
+// callbacks and destructors of objects alive at script end ran invisibly
+// (output into a discarded buffer), and exit() inside a shutdown function
+// could not set the exit status. Every expectation below is verified
+// byte-identical against real php-cli (8.5.4 and 8.3).
+
+/// php-cli's end-of-request order, in one script: shutdown functions in
+/// registration order (including one registered *during* shutdown), THEN
+/// destructors of objects still alive at script end — with every byte
+/// reaching stdout. Asserted as one exact stdout string so an ordering
+/// regression (destructors before shutdown functions, missing nested
+/// registration, dropped output) cannot pass.
+#[test]
+fn shutdown_functions_then_destructors_run_in_php_cli_order() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[],
+        "<?php\n\
+         class D { public function __construct(private string $n) {}\n\
+                   public function __destruct() { echo \"destruct {$this->n}\\n\"; } }\n\
+         register_shutdown_function(function () { echo \"shutdown 1\\n\"; });\n\
+         register_shutdown_function(function () {\n\
+             echo \"shutdown 2\\n\";\n\
+             register_shutdown_function(function () { echo \"shutdown nested\\n\"; });\n\
+         });\n\
+         $global = new D('global');\n\
+         $a = new D('a');\n\
+         $b = new D('b');\n\
+         unset($a);\n\
+         echo \"end of script\\n\";\n",
+    );
+    assert_eq!(
+        run.stdout,
+        "destruct a\nend of script\nshutdown 1\nshutdown 2\nshutdown nested\n\
+         destruct b\ndestruct global\n",
+        "shutdown/destructor order diverges from php-cli (issue #334)\n\
+         --- stderr ---\n{}",
+        run.stderr
+    );
+    assert_eq!(run.code, 0, "unexpected exit {}", run.code);
+}
+
+/// `exit(7)` inside a shutdown function must both print (output during
+/// shutdown reaches stdout) and set the process exit status — the second
+/// observable half of #334.
+#[test]
+fn exit_in_shutdown_function_sets_exit_status() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[],
+        "<?php\n\
+         register_shutdown_function(function () { echo \"in shutdown\\n\"; exit(7); });\n\
+         echo \"main\\n\";\n",
+    );
+    assert_eq!(run.stdout, "main\nin shutdown\n", "stderr: {}", run.stderr);
+    assert_eq!(run.code, 7, "exit() in a shutdown function must set the exit status");
+}
+
+/// The status read after request shutdown wins over the script's own exit()
+/// — php-cli's do_cli returns EG(exit_status) *after* php_request_shutdown.
+/// Both directions verified against real php-cli: exit(1)→exit(7) exits 7,
+/// and exit(3)→exit(0) exits 0 (a shutdown function can clear the status).
+#[test]
+fn exit_in_shutdown_overrides_script_exit_status() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let seven = run_php(
+        &bin,
+        &[],
+        "<?php\n\
+         register_shutdown_function(function () { echo \"in shutdown\\n\"; exit(7); });\n\
+         echo \"main\\n\";\nexit(1);\n",
+    );
+    assert_eq!(seven.stdout, "main\nin shutdown\n", "stderr: {}", seven.stderr);
+    assert_eq!(seven.code, 7, "shutdown exit(7) must override the script's exit(1)");
+
+    let zero = run_php(
+        &bin,
+        &[],
+        "<?php\n\
+         register_shutdown_function(function () { echo \"s1\\n\"; exit(0); });\n\
+         echo \"main\\n\";\nexit(3);\n",
+    );
+    assert_eq!(zero.stdout, "main\ns1\n", "stderr: {}", zero.stderr);
+    assert_eq!(zero.code, 0, "shutdown exit(0) must clear the script's exit(3), like php-cli");
+}
+
+/// After an uncaught exception php-cli still runs shutdown functions and
+/// destructors (WordPress' fatal handler and most loggers rely on this),
+/// and the exit status stays 255.
+#[test]
+fn shutdown_and_destructors_run_after_uncaught_exception() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[],
+        "<?php\n\
+         register_shutdown_function(function () { echo \"shutdown after exception\\n\"; });\n\
+         class D { public function __destruct() { echo \"destruct\\n\"; } }\n\
+         $d = new D();\n\
+         throw new RuntimeException('boom');\n",
+    );
+    assert_fatal(&run, "Uncaught RuntimeException: boom", "uncaught exception before shutdown");
+    assert!(
+        run.stdout.contains("shutdown after exception"),
+        "shutdown function did not run after the uncaught exception:\n--- stdout ---\n{}\n\
+         --- stderr ---\n{}",
+        run.stdout,
+        run.stderr
+    );
+    assert!(
+        run.stdout.contains("destruct"),
+        "destructor did not run after the uncaught exception:\n--- stdout ---\n{}",
+        run.stdout
+    );
+}
+
+/// A fatal *inside* a shutdown function: the diagnostic is reported, the
+/// remaining shutdown functions are skipped, destructors still run, and the
+/// exit status is 255 — verified identical on real php-cli 8.5 and 8.3.
+#[test]
+fn fatal_inside_shutdown_function_matches_php_cli() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &[],
+        "<?php\n\
+         register_shutdown_function(function () { echo \"sf1\\n\"; nosuchfunc(); });\n\
+         register_shutdown_function(function () { echo \"sf2\\n\"; });\n\
+         class D { public function __destruct() { echo \"destruct\\n\"; } }\n\
+         $d = new D();\n\
+         echo \"main\\n\";\n",
+    );
+    assert_fatal(&run, "Call to undefined function nosuchfunc()", "fatal in shutdown function");
+    assert!(run.stdout.contains("sf1"), "first shutdown function did not run:\n{}", run.stdout);
+    assert!(
+        !run.output().contains("sf2"),
+        "php-cli skips the remaining shutdown functions after a fatal in one:\n{}",
+        run.output()
+    );
+    assert!(
+        run.stdout.contains("destruct"),
+        "destructors must still run after a fatal in a shutdown function:\n{}",
+        run.stdout
+    );
+}
+
+/// `-r` code goes through a different execute path (zend_eval_string_ex, not
+/// php_execute_script); its shutdown functions must fire too.
+#[test]
+fn shutdown_functions_run_for_r_code() {
+    let Some(bin) = cli_binary() else {
+        return;
+    };
+    let run = run_php(
+        &bin,
+        &["-r", "register_shutdown_function(function () { echo 'SD'; }); echo 'M';"],
+        "",
+    );
+    assert_eq!(run.stdout, "MSD", "-r shutdown function output (stderr: {})", run.stderr);
     assert_eq!(run.code, 0);
 }
 

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -5031,6 +5031,79 @@ static int cli_process_stdin_lines(
     return result;
 }
 
+/*
+ * End the CLI request exactly as php-cli's do_cli() does at its `out:` label
+ * (sapi/cli/php_cli.c): run php_request_shutdown() while the CLI stdout
+ * ub_write is still installed, and (re)read the exit status from
+ * EG(exit_status) AFTERWARDS.
+ *
+ * php_request_shutdown() is what fires PHP's end-of-request userland
+ * machinery, in its documented order: registered shutdown functions first
+ * (registration order, including ones registered during shutdown), then
+ * end-of-script object destructors (zend_call_destructors), then the output
+ * flush. This CLI used to skip the call entirely and leave the request for
+ * php_embed_shutdown() at process exit — by which point cli_end() had
+ * restored the HTTP capture ub_write and the exit code had been captured, so
+ * shutdown functions and destructors ran invisibly and exit() inside a
+ * shutdown function could not set the status (issue #334).
+ *
+ * exit() inside a shutdown function throws/longjmps again (a nested
+ * bailout). php_request_shutdown() guards each phase with its own zend_try
+ * internally, but a bailout must never escape into the CLI teardown with the
+ * request half torn down, so the call carries a guard of its own — the role
+ * php-cli's zend_first_try in main() plays.
+ *
+ * Exit-status contract (verified against php-cli 8.5.4): do_cli returns
+ * EG(exit_status) read after request shutdown, so exit(N) in a shutdown
+ * function overrides even the script's own exit() — including exit(0)
+ * clearing a nonzero status. When shutdown did NOT change EG(exit_status),
+ * the pre-shutdown `result` is kept; that preserves the two statuses that
+ * live outside EG(exit_status) in this CLI: the lint-failure 255 from
+ * cli_scan_protected and the bailed-with-status-0 → 1 fallback (#317/#321).
+ * (php-cli 8.5 keeps those inside EG(exit_status), so the pre/post
+ * comparison is observably identical to its unconditional read.)
+ *
+ * Finally, the embed lifecycle expects one active request when
+ * php_embed_shutdown() runs (it unconditionally calls php_request_shutdown),
+ * so a fresh, empty request is started before returning — the same
+ * shutdown→startup pairing ephpm_execute_request uses per HTTP request.
+ * $argv/$argc in SG(request_info) are cleared first so nothing in the
+ * throwaway request (or its eventual teardown, which outlives the caller's
+ * argv memory) ever reads the CLI argv pointers again. It runs no user code
+ * and produces no output; the capture ub_write restored by cli_end() would
+ * swallow anything it did produce.
+ */
+static int cli_shutdown_request(int result)
+{
+    int pre_status = (int)EG(exit_status);
+
+    zend_try {
+        php_request_shutdown(NULL);
+    } zend_catch {
+        /* A bailout escaped php_request_shutdown's internal phase guards;
+         * the request is as torn down as it will get — carry on so the
+         * exit status is still captured and cli_end() still runs. */
+    } zend_end_try();
+
+    int post_status = (int)EG(exit_status);
+    if (post_status != pre_status) {
+        result = post_status;
+    }
+
+    /* Restore the embed invariant: one active request left open for
+     * php_embed_shutdown() to close at process exit. If startup fails
+     * there is nothing to recover — the process is about to exit. */
+    SG(request_info).argc = 0;
+    SG(request_info).argv = NULL;
+    if (php_request_startup() == SUCCESS) {
+        SG(headers_sent) = 1;
+        SG(request_info).no_headers = 1;
+        EG(max_allowed_stack_size) = 0;
+    }
+
+    return result;
+}
+
 /* PHP CLI option table — matches the real PHP CLI SAPI options.
  * Used by php_getopt() to parse argc/argv. */
 static const opt_struct cli_options[] = {
@@ -5390,33 +5463,32 @@ int ephpm_cli_main(int argc, char **argv)
     CG(skip_shebang) = 1;
 
     /* Execute based on mode */
+    cli_begin(&orig_ub_write);
     if (want_lines) {
         /* -B/-R/-F/-E awk-like stdin line processor */
-        cli_begin(&orig_ub_write);
         result = cli_process_stdin_lines(begin_code, line_code, line_file, end_code);
-        php_output_end_all();
-        cli_end(orig_ub_write);
     } else if (mode == 'r' && exec_direct) {
         /* -r "code" */
-        cli_begin(&orig_ub_write);
         result = cli_eval_protected(exec_direct, "Command line code");
-        cli_end(orig_ub_write);
     } else if (mode == 'l' || mode == 'w' || mode == 's') {
         /* -l (lint), -w (strip), -s (highlight): a named file, or the
          * program on stdin when none was named. */
-        cli_begin(&orig_ub_write);
         result = cli_scan_protected(mode, script_file, php_self);
-        php_output_end_all();
-        cli_end(orig_ub_write);
     } else {
         /* Standard mode: execute a named script, or the program read from
          * stdin (`ephpm php < file.php`, `… | ephpm php`). Both compile from
          * a FILE*-backed handle, so `<?php` tags, $argv[0] and file
          * semantics match php-cli — unlike -r, which is raw code. */
-        cli_begin(&orig_ub_write);
         result = cli_execute_script_protected(script_file);
-        cli_end(orig_ub_write);
     }
+
+    /* php-cli parity (#334): request shutdown — user shutdown functions,
+     * then destructors, then the output flush (which also ends any output
+     * buffers the mode left open) — runs BEFORE the stdout ub_write is torn
+     * down, and the exit status is re-read afterwards so exit() inside a
+     * shutdown function sets it. See cli_shutdown_request. */
+    result = cli_shutdown_request(result);
+    cli_end(orig_ub_write);
 
     return result;
 }

--- a/site/content/reference/cli/php.md
+++ b/site/content/reference/cli/php.md
@@ -130,6 +130,24 @@ error yields `255`; a syntax error under `-l` yields `255` (with
 > never reported and never set the exit status. Both halves are now pinned by
 > the `cli` E2E suite.
 
+### End of script
+
+Script teardown follows php-cli's end-of-request order: callbacks registered
+with `register_shutdown_function()` run first (in registration order,
+including callbacks registered *during* shutdown), then destructors of
+objects still alive at script end, then output is flushed. Shutdown functions
+run even after an uncaught exception or fatal error, exactly as in php-cli.
+`exit(N)` inside a shutdown function sets the process exit status and
+overrides the script's own `exit()` — including `exit(0)` clearing a nonzero
+status.
+
+> **Fixed in v0.7.2.** Up to and including v0.7.1, `ephpm php` skipped its
+> end-of-request teardown while the CLI output path was live
+> ([#334](https://github.com/ephpm/ephpm/issues/334)): shutdown functions and
+> end-of-script destructors ran invisibly at process exit, and `exit()` inside
+> a shutdown function could not set the exit status. Pinned by the `cli` E2E
+> suite and the CLI conformance corpus (cases 021/036).
+
 ### Not supported
 
 - `-a` (interactive shell) — the PHP interactive shell is part of the standalone


### PR DESCRIPTION
Fixes #334 for v0.7.2: `ephpm php` now runs `register_shutdown_function()` callbacks and end-of-script object destructors, and `exit()` inside a shutdown function sets the process exit status — byte-identical to php-cli.

**Stacked on #341** (`fix/cli-opcache-proctitle`) — merge #341 first. This branch touches the same region of `ephpm_cli_main` that #341 reworked, so it is based on that branch to avoid a three-way conflict; once #341 merges (with `--delete-branch`), GitHub retargets this PR to `main` and the diff stays exactly the two commits here.

## Root cause

`ephpm_cli_main` never ended the request it ran the script in. The mode helpers captured `EG(exit_status)`, `cli_end()` restored the HTTP-capture `ub_write` (`ephpm_sapi_ub_write`, which appends to the per-request response buffer) and flushed stdout — and the request was left for `php_embed_shutdown()` at process exit (`run_php` → `PhpRuntime::shutdown`). So the userland teardown that lives in `php_request_shutdown()` — shutdown functions (step 1), then `zend_call_destructors` (step 2), then the output flush (step 3) — **did** eventually run, but:

- its output went into the HTTP capture buffer that nothing ever reads on the CLI path → shutdown functions and destructors were observably silent, i.e. "never ran";
- `exit(N)` inside a shutdown function set `EG(exit_status)` *after* the process exit code had already been captured → the status was lost.

php-cli's contract (verified against php-src 8.5 `sapi/cli/php_cli.c`): `do_cli()`'s `out:` label runs `php_request_shutdown((void*)0)` and returns `EG(exit_status)` **read after** the shutdown — that's why `exit(7)` in a shutdown function overrides even the script's own `exit(1)`, and `exit(0)` clears a nonzero status (both confirmed against real php-cli 8.5.4 before writing a line of the fix).

## Fix (`crates/ephpm-php/ephpm_wrapper.c`)

New `cli_shutdown_request()`, called after the mode executes and **before** `cli_end()`:

1. `php_request_shutdown(NULL)` runs while the CLI stdout `ub_write` is still installed, inside a `zend_try`/`zend_catch` guard of its own — `exit()` in a shutdown function longjmps again (nested bailout), and while `php_request_shutdown` guards each phase internally, a bailout must never escape into the CLI teardown half-way (the role php-cli's `zend_first_try` in `main()` plays).
2. The exit status is re-read from `EG(exit_status)` afterwards. A pre/post comparison keeps the pre-shutdown `result` when shutdown didn't touch the status — preserving the two codes that live outside `EG(exit_status)` in this CLI (lint-failure 255, and #317's bailed-with-status-0 → 1 fallback) while being observably identical to php-cli's unconditional read everywhere reachable.
3. A fresh empty request is started (with `SG(request_info).argv/argc` cleared so nothing ever re-reads the caller's argv memory), restoring the embed invariant that `php_embed_shutdown()` closes exactly one active request — the same shutdown→startup pairing `ephpm_execute_request` uses per HTTP request.

The premature `php_output_end_all()` calls in the `-B/-R/-F/-E` and `-l/-w/-s` branches are gone: the flush now happens inside `php_request_shutdown` in php-cli's canonical order (shutdown functions **before** the flush, so an `ob_start()` buffer still open at script end behaves identically).

## Verified byte-identical to real php-cli

Nine probe scripts diffed against real php-cli 8.5.4 (`php -n`), all byte-identical on **Linux (WSL, ephpm PHP 8.5.7)** and matching on **Windows (MSVC local build, ephpm PHP 8.3.31)**:

| Case | php-cli / ephpm (after) |
|---|---|
| shutdown fns (registration order) + one registered during shutdown, then destructors of survivors | `destruct a`, `end of script`, `shutdown 1`, `shutdown 2`, `shutdown nested`, `destruct b`, `destruct global`, exit 0 |
| `exit(7)` in shutdown fn | prints, exit **7** |
| script `exit(1)` + shutdown `exit(7)` | exit **7** (post-shutdown status wins) |
| script `exit(3)` + shutdown `exit(0)` | exit **0** (can clear a nonzero status) |
| `exit(7)` in shutdown fn #1 | fn #2 skipped, destructors still run, exit 7 |
| fatal inside shutdown fn | diagnostic, remaining fns skipped, destructors run, exit 255 |
| uncaught exception in script | diagnostic, then shutdown fn + destructor still run, exit 255 |
| fatal in script | diagnostic, then shutdown fn + destructor still run, exit 255 |
| `-r` code registering a shutdown fn | fires, output on stdout |

Before (v0.7.1 lineage, pre-fix): each of these printed nothing after end-of-script and kept the pre-shutdown status (the #334 repro).

## Conformance harness (#342)

Ran `cargo xtask cli-conformance` (from #342's branch merged into a throwaway local branch) against this build on Linux vs upstream php-cli 8.5.4:

- **`021-shutdown-destruct` and `036-exit-in-shutdown` XPASS** — and PASS byte-for-byte with their `xfail` markers removed.
- **0 unexplained mismatches across the whole corpus** — no regression in any other case (incl. the lint/line-processor/`-w`/`-s` cases whose flush path this touches).
- Coordination: the two `.meta` marker files live on #342's branch, not this one, so **whichever of this PR / #342 merges second must delete `tests/cli-conformance/021-shutdown-destruct.meta` and `036-exit-in-shutdown.meta`** (XPASS fails the nightly by design). Same situation as #341's `134`/`135`/`138` markers, which also XPASS against this stacked build.

## Tests

`crates/ephpm-e2e/tests/cli.rs`: six new real-binary cases (`shutdown_functions_then_destructors_run_in_php_cli_order` asserts the full ordering as one exact stdout string, `exit_in_shutdown_function_sets_exit_status`, `exit_in_shutdown_overrides_script_exit_status` both directions, `shutdown_and_destructors_run_after_uncaught_exception`, `fatal_inside_shutdown_function_matches_php_cli`, `shutdown_functions_run_for_r_code`).

- Linux (`cargo xtask e2e --tests cli`): **22/22 pass** (all 16 pre-existing #321/#331/#316 tests stay green).
- Windows (same suite against the MSVC binary): **21/21 pass** (the 22nd is the Linux-only `/proc/self/cmdline` title test).
- `http` e2e suite re-run as an HTTP-path smoke: green (the change is unreachable from the server path).
- `cargo clippy --workspace --all-targets -- -D warnings` (Linux) and `cargo +nightly fmt --all -- --check`: clean.

Docs: new "End of script" section in `site/content/reference/cli/php.md` documenting the lifecycle and the v0.7.2 fix.

Closes #334.
