### PR TITLE
feat(build): Windows TAILCALL offering - clang SDK variant + non-gating release leg (#329)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -22,7 +22,7 @@ The `v*` push triggers `.github/workflows/release.yml`. `EPHPM_RELEASE_VERSION` 
 
 ## 3. What the matrix produces
 
-- Binaries: `ephpm-vX.Y.Z+php<FULL>-<os>-<arch>.tar.gz` for linux-x86_64, linux-aarch64, macos-aarch64, windows-x86_64 x PHP pins (see `matrix.php` in release.yml; keep in sync with `xtask::PHP_SDK_VERSIONS`). Plus `SHA256SUMS`.
+- Binaries: `ephpm-vX.Y.Z+php<FULL>-<os>-<arch>.tar.gz` for linux-x86_64, linux-aarch64, macos-aarch64, windows-x86_64 x PHP pins (see `matrix.php` in release.yml; keep in sync with `xtask::PHP_SDK_VERSIONS`). Plus `SHA256SUMS`. Optionally `ephpm-vX.Y.Z+php8.5.7-windows-x86_64-tailcall.tar.gz` from the experimental non-gating `build-windows-tailcall` leg — its absence never blocks or fails a release, and when its leg finishes after Create Release it self-attaches (and updates SHA256SUMS) best-effort.
 - Docker: `ephpm/ephpm:vX.Y.Z-php<FULL>`, `:vX.Y.Z-php<MINOR>`, `:<MINOR>`, `:vX.Y.Z`, `:latest` (rolling tags skip pre-releases; a `-` in the tag = prerelease, marked so on GitHub).
 - `Create Release` publishes ONLY after build-linux + build-linux-arm64 + build-macos + build-windows + docker-image all succeed. (arm64 is the leg that historically parks a release — OOM on the self-hosted runner — so when publish never fires, check it first.)
 
@@ -39,7 +39,7 @@ Known leg-specific failures: see `triage-ci` (macOS llvm@17/libclang, Windows ep
 ## 5. Verify the release (always, before announcing)
 
 ```bash
-gh release view vX.Y.Z --json isDraft,isPrerelease,assets   # expect 13 assets (12 tarballs + SHA256SUMS)
+gh release view vX.Y.Z --json isDraft,isPrerelease,assets   # expect 13 assets (12 tarballs + SHA256SUMS); 14 if the non-gating windows-tailcall leg landed its archive
 gh release download vX.Y.Z --pattern "*php<DEFAULT_PHP>-linux-x86_64.tar.gz" --pattern "*windows-x86_64.tar.gz"
 ```
 Smoke each downloaded binary: `ephpm --version` reports the tag; serve a one-line `<?php echo "PHPOK ".PHP_VERSION;` docroot and curl it (Linux binary is glibc-dynamic with a glibc >= 2.39 floor - run it in `debian:13-slim` via podman, NOT alpine and NOT debian:12; Windows runs natively). Expect HTTP 200 + `PHPOK <php-version>`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ name: Release
 #       ephpm-vX.Y.Z+php<PHP_FULL>-<os>-<arch>.tar.gz   (one per PHP minor x OS/arch)
 #       SHA256SUMS                                       (covers all archives)
 #
+#   * EXPERIMENTAL, may be absent from a given release (its leg is
+#     non-gating -- see build-windows-tailcall):
+#       ephpm-vX.Y.Z+php8.5.7-windows-x86_64-tailcall.tar.gz
+#         (PHP 8.5 built with clang-cl: the TAILCALL VM instead of MSVC's
+#          CALL VM -- 1.6-1.7x faster on CPU-bound PHP)
+#
 #   * Docker images pushed to Docker Hub at docker.io/ephpm/ephpm:
 #       :vX.Y.Z-php<PHP_FULL>     pinned ephpm release x pinned PHP patch
 #       :vX.Y.Z-php<PHP_MINOR>    pinned ephpm release x rolling PHP minor
@@ -455,6 +461,253 @@ jobs:
           name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-windows-x86_64
           path: ${{ steps.pkg.outputs.archive }}
 
+  # -- Windows TAILCALL binary (EXPERIMENTAL, NON-GATING) ---------------------
+  # PHP 8.5 built with clang-cl so the interpreter is the TAILCALL VM
+  # ([[clang::musttail]] + preserve_none) instead of the slow CALL VM every
+  # MSVC-built PHP falls back to -- measured 1.6-1.7x faster on CPU-bound PHP
+  # through ePHPm, ~3% on the Symfony demo (issue #329). PHP 8.5 only: the
+  # TAILCALL VM does not exist in 8.3/8.4.
+  #
+  # NON-GATING BY DESIGN: the `release` job does NOT `needs:` this job, and
+  # `continue-on-error: true` keeps a red leg from failing the run -- the
+  # release publishes with or without this artifact. Two ways the tarball
+  # reaches the release page:
+  #   1. This job finishes before `Create Release` collects artifacts -> the
+  #      REST collect script picks it up like any other archive and it lands
+  #      in SHA256SUMS.
+  #   2. (The common case -- this job starts only after all three MSVC legs
+  #      finish, which is usually the release's critical path.) The release is
+  #      already published; the final step here attaches the tarball to it and
+  #      appends its hash to SHA256SUMS, best-effort.
+  # If the -clang SDK asset is missing from the php-sdk release, or anything
+  # else fails, the leg goes red and nothing downstream notices.
+  build-windows-tailcall:
+    name: Build (PHP ${{ matrix.php_full }}, windows-x86_64, TAILCALL)
+    if: github.event_name == 'push'
+    # Serialized behind the MSVC Windows legs: one release build per Windows
+    # worker at a time (the v0.5.1 run's concurrent legs took the pool down).
+    # Side effect: if build-windows fails this leg is skipped -- fine, the
+    # release is not publishing in that case anyway.
+    needs: build-windows
+    runs-on: [self-hosted, windows, x64]
+    continue-on-error: true
+    # VS Build Tools install (~20 min on a cold ephemerd VM) + a full
+    # PHP-linked release build. Generous ceiling so a slow fleet day does not
+    # kill an otherwise-good leg; depends on the self-hosted Windows
+    # (ephemerd) fleet being up, same as build-windows.
+    timeout-minutes: 200
+    permissions:
+      # For the best-effort late attach of the tarball to the GitHub release.
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - php_minor: "8.5"
+            php_full: "8.5.7"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        shell: powershell
+        run: |
+          $cargoBin = "$env:USERPROFILE\.cargo\bin"
+          if (-not (Test-Path "$cargoBin\rustup.exe")) {
+            Write-Host "Installing rustup..."
+            Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+            .\rustup-init.exe -y --default-toolchain stable --profile minimal
+            Remove-Item rustup-init.exe
+          }
+          $env:PATH = "$cargoBin;$env:PATH"
+          $cargoBin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & "$cargoBin\rustup.exe" show
+
+      - name: Install Visual Studio Build Tools
+        shell: powershell
+        # Same fresh-VM install as build-windows. The MSVC toolset is still
+        # what links ephpm.exe; only the PHP SDK inside is clang-built
+        # (clang-cl is MSVC-ABI-compatible, so nothing else changes).
+        run: |
+          $installPath = "C:\BuildTools"
+          $msbuild = "$installPath\MSBuild\Current\Bin\MSBuild.exe"
+          if (Test-Path $msbuild) {
+            Write-Host "VS Build Tools already present at $installPath"
+          } else {
+            Write-Host "Downloading VS Build Tools bootstrapper..."
+            Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile vs_buildtools.exe
+            $proc = Start-Process -FilePath .\vs_buildtools.exe `
+              -ArgumentList @(
+                '--quiet', '--wait', '--norestart', '--nocache',
+                '--installPath', $installPath,
+                '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--add', 'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
+                '--includeRecommended'
+              ) -Wait -PassThru -NoNewWindow
+            Write-Host "Bootstrapper exit code: $($proc.ExitCode)"
+            Remove-Item vs_buildtools.exe
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while (-not (Test-Path $msbuild) -and $sw.Elapsed.TotalMinutes -lt 20) {
+              Start-Sleep -Seconds 30
+              Write-Host ("  ...waiting for VS install ({0:F0}s)" -f $sw.Elapsed.TotalSeconds)
+            }
+            if (-not (Test-Path $msbuild)) {
+              Write-Host "::error::VS install timed out - $msbuild never appeared"
+              exit 1
+            }
+            Write-Host ("MSBuild.exe found after {0:F0}s" -f $sw.Elapsed.TotalSeconds)
+          }
+
+      - name: Enter MSVC developer environment
+        shell: powershell
+        run: |
+          $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { Write-Error "vcvars64.bat not found"; exit 1 }
+          $envBefore = @{}
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+            $envBefore[$e.Key] = $e.Value
+          }
+          $cmdLine = 'call "' + $vcvars + '" >NUL & set'
+          $output = & cmd /c $cmdLine
+          foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              if ($envBefore[$matches[1]] -ne $matches[2]) {
+                "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+              }
+            }
+          }
+          $libclangDir = "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+          if (Test-Path "$libclangDir\libclang.dll") {
+            "LIBCLANG_PATH=$libclangDir" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          } else {
+            Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
+          }
+
+      - name: Compute release version
+        # See build-linux for rationale; strips leading "v" from the git ref.
+        shell: powershell
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          $version = $env:REF_NAME -replace '^v',''
+          "EPHPM_RELEASE_VERSION=$version" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+
+      - name: Build ephpm.exe (clang/TAILCALL SDK)
+        shell: powershell
+        env:
+          # Same LTO/stack settings as build-windows -- see its comments.
+          CARGO_PROFILE_RELEASE_LTO: "off"
+          RUST_MIN_STACK: "33554432"
+        # --variant clang downloads php-sdk-<ver>-windows-x86_64-clang.tar.gz
+        # and hard-gates on the SDK's VM kind: xtask disassembles
+        # zend_vm_kind() out of php8embed.lib and requires mov eax,5
+        # (ZEND_VM_KIND_TAILCALL) before linking. A mislabeled CALL-VM SDK
+        # fails the build here rather than shipping under a -tailcall name.
+        run: cargo xtask release ${{ matrix.php_minor }} --target windows --variant clang
+
+      - name: Assert the produced binary is the TAILCALL build
+        shell: powershell
+        env:
+          PHP_FULL: ${{ matrix.php_full }}
+        # Belt over the xtask gate's suspenders, this time on the built exe:
+        # the embedded PHP must report the exact pinned version + ZTS, and the
+        # clang SDK cache dir must be the one the build populated. (The VM
+        # kind itself was proven by the xtask disassembly gate above.)
+        run: |
+          $exe = "target\x86_64-pc-windows-msvc\release\ephpm.exe"
+          if (-not (Test-Path $exe)) { Write-Host "::error::$exe not found"; exit 1 }
+          $v = (& $exe php -v) -join "`n"
+          Write-Host $v
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::ephpm php -v exited $LASTEXITCODE"; exit 1 }
+          if ($v -notmatch [regex]::Escape("PHP $env:PHP_FULL")) {
+            Write-Host "::error::embedded PHP is not $env:PHP_FULL"; exit 1
+          }
+          if ($v -notmatch 'ZTS') { Write-Host "::error::embedded PHP is not a ZTS build"; exit 1 }
+          $clangLib = "php-sdk\$env:PHP_FULL-windows-x86_64-clang\lib\php8embed.lib"
+          if (-not (Test-Path $clangLib)) {
+            Write-Host "::error::clang SDK cache $clangLib missing -- wrong SDK linked?"; exit 1
+          }
+          Write-Host "==> TAILCALL build asserted: PHP $env:PHP_FULL ZTS, clang SDK cache present"
+
+      - name: Package archive
+        id: pkg
+        shell: powershell
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php_full }}
+        # The artifact name says what the binary IS (-tailcall: the TAILCALL
+        # VM), not how it is built (clang) -- consumers care about the former.
+        run: |
+          $name = "ephpm-$env:VERSION+php$env:PHP_FULL-windows-x86_64-tailcall"
+          $stage = "dist\$name"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item target\x86_64-pc-windows-msvc\release\ephpm.exe "$stage\ephpm.exe"
+          Copy-Item LICENSE "$stage\LICENSE"
+          Copy-Item .github\release-readme.txt "$stage\README.txt"
+          tar -C dist -czf "dist\$name.tar.gz" $name
+          Remove-Item -Recurse -Force $stage
+          "archive=dist/$name.tar.gz" | Out-File -Append -FilePath $env:GITHUB_OUTPUT -Encoding utf8
+          "archive_name=$name.tar.gz" | Out-File -Append -FilePath $env:GITHUB_OUTPUT -Encoding utf8
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-windows-x86_64-tailcall
+          path: ${{ steps.pkg.outputs.archive }}
+
+      - name: Attach to the GitHub release if it already exists (best effort)
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          ARCHIVE: ${{ steps.pkg.outputs.archive }}
+          ARCHIVE_NAME: ${{ steps.pkg.outputs.archive_name }}
+        # This leg usually finishes AFTER `Create Release` (it queues behind
+        # all three MSVC legs on the same serialized worker pool), so the
+        # normal artifact-collect path misses it. If the release for this tag
+        # is already published, attach the tarball and append its hash to
+        # SHA256SUMS via the REST API. If the release does not exist yet, do
+        # nothing: we finished early enough that the collect script will pick
+        # the workflow artifact up. Never fails the job -- the artifact also
+        # remains downloadable from the workflow run either way.
+        run: |
+          $headers = @{ Authorization = "Bearer $env:GH_TOKEN"; Accept = "application/vnd.github+json" }
+          try {
+            $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$env:REPO/releases/tags/$env:TAG" -Headers $headers
+          } catch {
+            Write-Host "==> Release for $env:TAG not published yet -- the Create Release job will collect the workflow artifact instead."
+            exit 0
+          }
+          try {
+            # Drop any stale same-named asset (e.g. a rerun of this leg).
+            $rel.assets | Where-Object { $_.name -eq $env:ARCHIVE_NAME } | ForEach-Object {
+              Invoke-RestMethod -Method Delete -Uri "https://api.github.com/repos/$env:REPO/releases/assets/$($_.id)" -Headers $headers | Out-Null
+            }
+            $uploadUrl = ($rel.upload_url -replace '\{.*\}$','') + "?name=$([uri]::EscapeDataString($env:ARCHIVE_NAME))"
+            Invoke-RestMethod -Method Post -Uri $uploadUrl -Headers ($headers + @{ "Content-Type" = "application/gzip" }) -InFile $env:ARCHIVE | Out-Null
+            Write-Host "==> Attached $env:ARCHIVE_NAME to release $env:TAG"
+
+            # Append our line to SHA256SUMS (same `<sha256>  <name>` shape as
+            # `sha256sum`, sorted) and replace the asset.
+            $hash = (Get-FileHash -Algorithm SHA256 $env:ARCHIVE).Hash.ToLower()
+            $sums = $rel.assets | Where-Object { $_.name -eq 'SHA256SUMS' } | Select-Object -First 1
+            $lines = @()
+            if ($sums) {
+              $raw = Invoke-RestMethod -Uri "https://api.github.com/repos/$env:REPO/releases/assets/$($sums.id)" -Headers @{ Authorization = "Bearer $env:GH_TOKEN"; Accept = "application/octet-stream" }
+              $lines = ($raw -split "`n") | Where-Object { $_.Trim() -ne '' -and ($_ -notmatch [regex]::Escape($env:ARCHIVE_NAME)) }
+              Invoke-RestMethod -Method Delete -Uri "https://api.github.com/repos/$env:REPO/releases/assets/$($sums.id)" -Headers $headers | Out-Null
+            }
+            $lines += "$hash  $env:ARCHIVE_NAME"
+            $content = (($lines | Sort-Object) -join "`n") + "`n"
+            $tmp = "SHA256SUMS.tailcall"
+            [System.IO.File]::WriteAllText("$PWD\$tmp", $content)
+            $sumsUrl = ($rel.upload_url -replace '\{.*\}$','') + "?name=SHA256SUMS"
+            Invoke-RestMethod -Method Post -Uri $sumsUrl -Headers ($headers + @{ "Content-Type" = "text/plain" }) -InFile "$PWD\$tmp" | Out-Null
+            Write-Host "==> SHA256SUMS updated with $hash  $env:ARCHIVE_NAME"
+          } catch {
+            Write-Host "::warning::best-effort release attach failed: $($_.Exception.Message)"
+            exit 0
+          }
+
   # -- Docker images on Docker Hub --------------------------------------------
   docker-image:
     name: Docker (PHP ${{ matrix.php_full }})
@@ -555,7 +808,9 @@ jobs:
       # Side benefit: the classic path produces no ".dockerbuild" build-record
       # artifact at all, so the DOCKER_BUILD_RECORD_UPLOAD/DOCKER_BUILD_SUMMARY
       # opt-outs this step used to carry are moot -- the Create Release job's
-      # artifact download stays at the 12 binary archives it expects.
+      # artifact download stays at just the binary archives it expects (the 12
+      # gating ones, plus the optional windows-tailcall archive if that leg
+      # finished in time).
       - name: Build and push image
         env:
           TAGS: ${{ steps.tags.outputs.tags }}
@@ -624,6 +879,11 @@ jobs:
   # -- Release: gather archives, hash them, attach to the GitHub release ------
   release:
     name: Create Release
+    # build-windows-tailcall is deliberately ABSENT from `needs`: it is an
+    # experimental, non-gating leg and the release must publish with or
+    # without its artifact (which self-attaches late when it lands after
+    # this job -- see that job's comments). Do not add it here until the
+    # TAILCALL artifact is promoted to a supported, gating deliverable.
     needs: [build-linux, build-linux-arm64, build-macos, build-windows, docker-image]
     # `!cancelled()` overrides the default "skip when a dependency was skipped"
     # so the republish path (where the four binary legs are intentionally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Key files:
 - `crates/ephpm-php/ephpm_wrapper.c` — C bridge for all PHP FFI calls (required for setjmp/longjmp safety)
 - `crates/ephpm-php/build.rs` — bindgen configuration and link flags
 - `.github/workflows/ci.yml` — Lint, test, deny checks on every PR
-- `.github/workflows/release.yml` — Tag-triggered release build matrix (PHP 8.4/8.5 × linux-x86_64/macos-aarch64/windows-x86_64), produces tarballs + Docker Hub images
+- `.github/workflows/release.yml` — Tag-triggered release build matrix (PHP 8.4/8.5 × linux-x86_64/macos-aarch64/windows-x86_64), produces tarballs + Docker Hub images, plus an experimental non-gating `build-windows-tailcall` leg (PHP 8.5, clang/TAILCALL VM, `-tailcall` tarball)
 - `.github/workflows/nightly.yml` — Scheduled comprehensive build with the same matrix plus fuzz, E2E, smoke, audit jobs
 
 ## Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,18 @@ cargo xtask release 8.4       # → target/release/ephpm (PHP 8.4)
 # The cargo-xwin cross-compile-from-WSL path was REMOVED; `cargo xtask
 # release --target windows` errors out on a non-Windows host.
 cargo xtask release --target windows       # → target/x86_64-pc-windows-msvc/release/ephpm.exe
+
+# Experimental TAILCALL Windows build (PHP 8.5 only): links the clang-cl-built
+# SDK (php-sdk-<ver>-windows-x86_64-clang.tar.gz) whose interpreter is the
+# TAILCALL VM — 1.6-1.7x faster on CPU-bound PHP than the MSVC CALL VM.
+# xtask hard-gates on the SDK's VM kind (disassembles zend_vm_kind, requires
+# ZEND_VM_KIND_TAILCALL) before linking. Same output path as the MSVC exe.
+cargo xtask release --target windows --variant clang
 ```
 
 Prerequisites for `cargo xtask release`: git, curl, tar, `build-essential`, `pkg-config`, and `libclang-dev` (for bindgen). On Linux the build targets the host-default `<arch>-unknown-linux-gnu` triple against the glibc-linked (`-gnu`) `libphp.a` — the resulting binary is a single glibc-dynamic file that can `dlopen()` shared PHP extensions and middleware; no musl toolchain is involved. The xtask downloads only the PHP SDK from `github.com/ephpm/php-sdk` releases — no PHP CLI, Composer, static-php-cli, or sqld binary needed (the Turso engine is a pure-Rust crate compiled into the binary).
 
-The PHP SDK is cached at `php-sdk/<version>-<os>-<arch>[-gnu]/` (the `-gnu` libc suffix applies on Linux, e.g. `php-sdk/8.5.7-linux-x86_64-gnu/`). Delete that directory to force a re-download.
+The PHP SDK is cached at `php-sdk/<version>-<os>-<arch>[-gnu][-clang]/` (the `-gnu` libc suffix applies on Linux, e.g. `php-sdk/8.5.7-linux-x86_64-gnu/`; the `-clang` variant suffix applies to the experimental Windows TAILCALL SDK, e.g. `php-sdk/8.5.7-windows-x86_64-clang/`). Delete that directory to force a re-download.
 
 ## Testing
 

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -2014,8 +2014,6 @@ mod disable_functions_tests {
 
 #[cfg(test)]
 mod cli_tests {
-    use clap::Parser as _;
-
     use super::*;
 
     #[test]

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -56,6 +56,28 @@ Installs to `C:\Program Files\ephpm\`, adds the directory to the system `PATH`, 
 
 > Single-node SQLite (the in-process Turso engine), the MySQL/Postgres proxy, and everything else work normally on Windows. Clustered SQLite (Turso CDC replication) is untested on Windows.
 
+### TAILCALL build — experimental, PHP 8.5 only
+
+A release may additionally carry a second Windows archive:
+
+```text
+ephpm-vX.Y.Z+php8.5.7-windows-x86_64-tailcall.tar.gz
+```
+
+Every PHP built with MSVC — including the default ePHPm Windows binary — falls back to the interpreter's slow `CALL` VM. The `-tailcall` archive contains the same `ephpm.exe`, but with PHP 8.5 compiled by clang-cl so the interpreter is the new TAILCALL VM (`[[clang::musttail]]` + `preserve_none`), which recovers roughly the performance of the HYBRID VM that Linux/macOS builds have always had.
+
+Measured against the default MSVC Windows binary, end-to-end through ePHPm (Ryzen 9 5950X):
+
+- **1.6–1.7x faster on CPU-bound PHP** (reference loop 2.73 ms vs 4.43 ms).
+- **~3% on the Symfony demo app** — real applications are dominated by the filesystem tier, matching upstream's ~5.5% Symfony figure for the VM-kind delta. If your workload is I/O-bound, expect the small number, not the big one.
+
+Status and caveats:
+
+- **Experimental.** Its release-CI leg is non-gating, so a given release can ship without this archive. The MSVC binary remains the default and supported Windows build.
+- **PHP 8.5 only** — the TAILCALL VM does not exist in PHP 8.3/8.4.
+- Install is identical: extract and run `.\ephpm.exe install`.
+- The build pipeline hard-gates on the VM kind (it disassembles `zend_vm_kind()` out of the PHP static lib and requires `ZEND_VM_KIND_TAILCALL`), so an archive named `-tailcall` cannot silently contain the CALL VM.
+
 ## Manage the service
 
 After `install`, the same commands work on every platform — they wrap systemd / launchd / the Windows service controller:
@@ -132,6 +154,14 @@ cargo xtask release --target windows   # → target\x86_64-pc-windows-msvc\relea
 ```
 
 The SDK download is the same php-sdk release, with a prebuilt static `php8embed.lib` for Windows. It links statically, so `ephpm.exe` is a single self-contained binary — there is no DLL to deploy alongside it.
+
+To build the experimental [TAILCALL variant](#tailcall-build--experimental-php-85-only) from source (PHP 8.5 only):
+
+```powershell
+cargo xtask release --target windows --variant clang
+```
+
+This downloads the clang-cl-built SDK asset (`php-sdk-<ver>-windows-x86_64-clang.tar.gz`, cached at `php-sdk/<ver>-windows-x86_64-clang/` next to the default SDK) and verifies the SDK's interpreter is the TAILCALL VM before linking. `cargo xtask php-sdk 8.5 --target windows --variant clang` fetches the SDK alone.
 
 A binary built from source can also self-install:
 

--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -4,10 +4,11 @@
 //! that must stay in lockstep:
 //!
 //! 1. `xtask/src/main.rs` — the `PHP_SDK_VERSIONS` table (source of truth)
-//! 2. `.github/workflows/release.yml` — 5 matrix sites, one entry per minor
+//! 2. `.github/workflows/release.yml` — matrix sites, one entry per minor
 //!    in each: two inline-map matrices (`build-linux`, `build-linux-arm64`)
 //!    and three `php_minor`/`php_full` include blocks (`build-macos`,
-//!    `build-windows`, `docker-image`)
+//!    `build-windows`, `docker-image`); minors in `TAILCALL_MINORS`
+//!    additionally appear in the `build-windows-tailcall` include block
 //! 3. `docker/Dockerfile` — `ARG PHP_SDK_VERSION` default (+ its inline
 //!    example), only for the default minor
 //! 4. `site/content/developer/architecture-overview.md` — the support table
@@ -22,6 +23,11 @@ use std::fs;
 use std::process::ExitCode;
 
 use crate::{DEFAULT_PHP_MINOR, PHP_SDK_VERSIONS, workspace_root};
+
+/// Minors that also appear in release.yml's experimental
+/// `build-windows-tailcall` job (one extra `php_full:` include-block pin
+/// site each). 8.5-only today: the TAILCALL VM does not exist in 8.3/8.4.
+const TAILCALL_MINORS: &[&str] = &["8.5"];
 
 /// One exact-substring substitution in one file, with a required match count.
 struct Substitution {
@@ -65,11 +71,12 @@ fn substitutions(minor: &str, old_full: &str, new_full: &str) -> Vec<Substitutio
         // docker-image:
         //   - php_minor: "8.3"
         //     php_full: "8.3.31"
+        // TAILCALL minors also pin the build-windows-tailcall include block.
         Substitution {
             path: ".github/workflows/release.yml",
             needle: format!("php_full: \"{old_full}\""),
             replacement: format!("php_full: \"{new_full}\""),
-            expected: 3,
+            expected: if TAILCALL_MINORS.contains(&minor) { 4 } else { 3 },
         },
         // The PHP support table ("Supported — in CI (pinned X.Y.Z)").
         Substitution {
@@ -343,6 +350,22 @@ mod tests {
         let err = apply(fixture, inline).unwrap_err();
         assert!(err.contains("expected exactly 2"), "unexpected message: {err}");
         assert!(err.contains("found 3"), "unexpected message: {err}");
+    }
+
+    /// TAILCALL minors carry one extra `php_full:` include-block pin site
+    /// (the build-windows-tailcall job); every other minor keeps three.
+    #[test]
+    fn tailcall_minor_expects_extra_windows_include_site() {
+        let php_full_expected = |minor: &str, full: &str| {
+            substitutions(minor, full, full)
+                .iter()
+                .find(|s| s.path.ends_with("release.yml") && s.needle.starts_with("php_full"))
+                .unwrap()
+                .expected
+        };
+        assert_eq!(php_full_expected("8.5", "8.5.7"), 4, "8.5 pins build-windows-tailcall too");
+        assert_eq!(php_full_expected("8.4", "8.4.23"), 3);
+        assert_eq!(php_full_expected("8.3", "8.3.31"), 3);
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,6 +60,7 @@ Usage: cargo xtask <command> [options]
 Commands:
   release [8.5] [--target windows]  Build ephpm with PHP linked (default: 8.5)
   php-sdk [8.5]                     Download the PHP SDK (libphp.a + headers) for the current platform
+                                    (--target windows: fetch the Windows SDK from any host)
   e2e [--php-version 8.5]           Run bare-process E2E tests (spawns ephpm on 127.0.0.1, no Kind/Tilt)
   cli-conformance --php <path>      Diff `ephpm php` against an upstream php CLI over tests/cli-conformance/
   k8s-e2e [--php-version 8.5]       Run K8s E2E tests (opt-in; creates Kind cluster, builds images, tilt ci)
@@ -76,7 +77,12 @@ shorthand (e.g. \"8.5\") to use the pinned patch release, or a full version
 
 Windows builds:
   --target windows    Build a native Windows .exe (must run on Windows; MSVC build tools required).
-                      Downloads the same prebuilt SDK as Linux/macOS, but for windows-x86_64."
+                      Downloads the same prebuilt SDK as Linux/macOS, but for windows-x86_64.
+  --variant clang     (with --target windows, PHP 8.5 only) Use the clang-cl-built PHP SDK whose
+                      interpreter is the TAILCALL VM — 1.6-1.7x faster on CPU-bound PHP than the
+                      default MSVC build's CALL VM. Experimental. The SDK asset is
+                      php-sdk-<ver>-windows-x86_64-clang.tar.gz, cached side-by-side with the
+                      default; the produced ephpm.exe is verified to contain the TAILCALL VM."
     );
 }
 
@@ -102,12 +108,13 @@ fn parse_target(args: &[String]) -> Option<&str> {
     None
 }
 
-/// Extract the PHP version from release args, skipping `--target` and its value.
-/// Falls back to "8.5" if no positional version argument is found.
+/// Extract the positional PHP version from `release`/`php-sdk` args, skipping
+/// the value-taking flags (`--target`, `--variant`) and their values.
+/// Falls back to the default minor if no positional argument is found.
 fn parse_release_php_version(args: &[String]) -> &str {
     let mut i = 0;
     while i < args.len() {
-        if args[i] == "--target" {
+        if args[i] == "--target" || args[i] == "--variant" {
             i += 2; // skip flag and its value
             continue;
         }
@@ -116,7 +123,51 @@ fn parse_release_php_version(args: &[String]) -> &str {
         }
         i += 1;
     }
-    "8.5"
+    DEFAULT_PHP_MINOR
+}
+
+/// Parse `--variant <value>` from args. `None` when the flag is absent.
+///
+/// The value is validated at the use sites via `validate_variant` so each
+/// command can hard-error in its own context (release vs. download).
+fn parse_variant(args: &[String]) -> Option<&str> {
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "--variant" {
+            return args.get(i + 1).map(String::as_str);
+        }
+    }
+    None
+}
+
+/// Validate a `--variant` request against the SDK platform and PHP version.
+///
+/// The only SDK build variant besides the default toolchain is `clang`: PHP
+/// built with clang-cl (MSVC-ABI-compatible) so the interpreter is PHP 8.5's
+/// TAILCALL VM (`[[clang::musttail]]` + `preserve_none`) instead of the slow
+/// `ZEND_VM_KIND_CALL` interpreter every MSVC-built PHP falls back to. The
+/// artifact only exists for windows-x86_64 and PHP 8.5 — the TAILCALL VM does
+/// not exist in PHP 8.3/8.4, so those minors hard-error here with an
+/// explanation instead of a confusing 404 at download time (issue #329).
+fn validate_variant(variant: &str, version: &str, os: &str, arch: &str) -> Result<(), ()> {
+    if variant != "clang" {
+        eprintln!("error: unsupported --variant '{variant}' (supported: clang)");
+        eprintln!("       omit --variant for the default-toolchain SDK");
+        return Err(());
+    }
+    if os != "windows" || arch != "x86_64" {
+        eprintln!("error: --variant clang is only published for windows-x86_64");
+        eprintln!(
+            "       (Linux/macOS SDKs already ship the fast HYBRID VM — there is no clang variant)"
+        );
+        return Err(());
+    }
+    if !version.starts_with("8.5.") {
+        eprintln!("error: --variant clang requires PHP 8.5 (got {version})");
+        eprintln!("       The TAILCALL VM does not exist in PHP 8.3/8.4; those minors ship");
+        eprintln!("       only the default MSVC (CALL VM) Windows build.");
+        return Err(());
+    }
+    Ok(())
 }
 
 /// Dispatch release builds based on `--target` flag.
@@ -126,7 +177,14 @@ fn parse_release_php_version(args: &[String]) -> &str {
 /// path applies its own host guard.
 fn release(args: &[String]) -> ExitCode {
     match parse_target(args) {
-        None => require_unix(|| release_native(args)),
+        None => {
+            if parse_variant(args).is_some() {
+                eprintln!("error: --variant is only supported with --target windows");
+                eprintln!("       (the clang/TAILCALL SDK variant is a Windows-only artifact)");
+                return ExitCode::FAILURE;
+            }
+            require_unix(|| release_native(args))
+        }
         Some("windows") => release_windows(args),
         Some(other) => {
             eprintln!("error: unsupported target '{other}' (supported: windows)");
@@ -254,10 +312,29 @@ fn release_windows(args: &[String]) -> ExitCode {
     };
     let target = "x86_64-pc-windows-msvc";
 
-    if ensure_php_sdk_for(&php_version, "windows", "x86_64").is_err() {
+    // Optional `--variant clang`: link against the clang-cl / TAILCALL SDK
+    // instead of the default MSVC one. Same Rust target, same MSVC link step
+    // — clang-cl is MSVC-ABI-compatible, so the only difference is which
+    // php8embed.lib PHP_SDK_PATH points at.
+    let variant = parse_variant(args);
+    if let Some(v) = variant
+        && validate_variant(v, &php_version, "windows", "x86_64").is_err()
+    {
         return ExitCode::FAILURE;
     }
-    let sdk_dir = php_sdk_dir_for(&php_version, "windows", "x86_64");
+
+    if ensure_php_sdk_variant(&php_version, "windows", "x86_64", variant).is_err() {
+        return ExitCode::FAILURE;
+    }
+    let sdk_dir = php_sdk_dir_variant(&php_version, "windows", "x86_64", variant);
+
+    // Hard gate for the clang variant: prove the SDK's php8embed.lib really
+    // contains the TAILCALL interpreter BEFORE linking it into ephpm.exe. An
+    // artifact advertised as TAILCALL that silently ships the CALL VM is the
+    // exact failure this build path exists to prevent.
+    if variant.is_some() && verify_tailcall_vm(&sdk_dir).is_err() {
+        return ExitCode::FAILURE;
+    }
 
     eprintln!("==> Ensuring Rust target {target} is installed...");
     let status = Command::new("rustup").args(["target", "add", target]).status();
@@ -337,26 +414,48 @@ fn resolve_php_version(input: &str) -> Option<String> {
 
 /// Download the prebuilt PHP SDK for the host platform.
 ///
-/// `cargo xtask php-sdk [version]` — pulls `libphp.a` (Linux/macOS) or
-/// `php8embed.{dll,lib}` (Windows) plus the PHP headers from
-/// github.com/ephpm/php-sdk releases and extracts them into
-/// `<workspace>/php-sdk/<full-version>/`.
+/// `cargo xtask php-sdk [version] [--target windows] [--variant clang]` —
+/// pulls `libphp.a` (Linux/macOS) or `php8embed.lib` (Windows) plus the PHP
+/// headers from github.com/ephpm/php-sdk releases and extracts them into
+/// `<workspace>/php-sdk/<full-version>-<os>-<arch>[suffix]/`.
+///
+/// `--target windows` overrides host detection so any host with curl + tar
+/// can prefetch the Windows SDK (the download itself is platform-neutral).
+/// `--variant clang` selects the clang-cl / TAILCALL Windows SDK
+/// (PHP 8.5 only — see `validate_variant`).
 fn php_sdk(args: &[String]) -> ExitCode {
-    let input = args.first().map_or(DEFAULT_PHP_MINOR, String::as_str);
-    let Some(version) = resolve_php_version(input) else {
+    let Some(version) = resolve_php_version(parse_release_php_version(args)) else {
         return ExitCode::FAILURE;
     };
 
-    let (os, arch) = match host_php_sdk_platform() {
-        Some(p) => p,
-        None => return ExitCode::FAILURE,
+    let (os, arch) = match parse_target(args) {
+        None => match host_php_sdk_platform() {
+            Some(p) => p,
+            None => return ExitCode::FAILURE,
+        },
+        Some("windows") => ("windows", "x86_64"),
+        Some(other) => {
+            eprintln!("error: unsupported target '{other}' (supported: windows)");
+            eprintln!("       omit --target to download the SDK for the current platform");
+            return ExitCode::FAILURE;
+        }
     };
 
-    if ensure_php_sdk_for(&version, os, arch).is_err() {
+    let variant = parse_variant(args);
+    if let Some(v) = variant
+        && validate_variant(v, &version, os, arch).is_err()
+    {
         return ExitCode::FAILURE;
     }
 
-    eprintln!("==> PHP SDK ready at {}", php_sdk_dir_for(&version, os, arch).display());
+    if ensure_php_sdk_variant(&version, os, arch, variant).is_err() {
+        return ExitCode::FAILURE;
+    }
+
+    eprintln!(
+        "==> PHP SDK ready at {}",
+        php_sdk_dir_variant(&version, os, arch, variant).display()
+    );
     ExitCode::SUCCESS
 }
 
@@ -409,7 +508,19 @@ fn ensure_php_sdk(version: &str) -> Result<(), ()> {
 /// The cache is keyed by `(version, os, arch)` so cross-compiled builds can
 /// hold multiple SDKs side-by-side without trampling each other.
 fn ensure_php_sdk_for(version: &str, os: &str, arch: &str) -> Result<(), ()> {
-    let dest = php_sdk_dir_for(version, os, arch);
+    ensure_php_sdk_variant(version, os, arch, None)
+}
+
+/// Variant-aware form of `ensure_php_sdk_for`. `variant = Some("clang")`
+/// selects the clang-cl / TAILCALL Windows SDK; `None` is the default
+/// toolchain and behaves exactly like `ensure_php_sdk_for` always has.
+fn ensure_php_sdk_variant(
+    version: &str,
+    os: &str,
+    arch: &str,
+    variant: Option<&str>,
+) -> Result<(), ()> {
+    let dest = php_sdk_dir_variant(version, os, arch, variant);
 
     // Layout we expect inside `dest/`:
     //   lib/libphp.a            (Linux + macOS)
@@ -423,7 +534,8 @@ fn ensure_php_sdk_for(version: &str, os: &str, arch: &str) -> Result<(), ()> {
 
     if already_present {
         eprintln!(
-            "==> PHP SDK {version} ({os}-{arch}) already cached at {} — skipping download",
+            "==> PHP SDK {version} ({os}-{arch}{}) already cached at {} — skipping download",
+            php_sdk_variant_suffix(variant),
             dest.display()
         );
         return Ok(());
@@ -433,15 +545,26 @@ fn ensure_php_sdk_for(version: &str, os: &str, arch: &str) -> Result<(), ()> {
         eprintln!("error: failed to create {}: {e}", dest.display());
     })?;
 
-    let suffix = php_sdk_libc_suffix(os);
+    let suffix = format!("{}{}", php_sdk_libc_suffix(os), php_sdk_variant_suffix(variant));
     let asset = format!("php-sdk-{version}-{os}-{arch}{suffix}.tar.gz");
     let url = format!("https://github.com/ephpm/php-sdk/releases/download/v{version}/{asset}");
 
     eprintln!("==> Downloading {asset}...");
     if !download_and_extract_full_tarball(&url, &dest) {
+        // Drop whatever partially extracted so nothing half-populated
+        // lingers in the cache directory.
+        let _ = fs::remove_dir_all(&dest);
         eprintln!("error: failed to download or extract PHP SDK from {url}");
         eprintln!("       Verify that release v{version} exists at:");
         eprintln!("         https://github.com/ephpm/php-sdk/releases/tag/v{version}");
+        if variant.is_some() {
+            eprintln!(
+                "       The -clang (TAILCALL) asset is experimental and may not be attached to"
+            );
+            eprintln!(
+                "       every SDK release yet — the default MSVC SDK (omit --variant) always is."
+            );
+        }
         return Err(());
     }
 
@@ -459,9 +582,27 @@ fn php_sdk_libc_suffix(os: &str) -> &'static str {
     if os == "linux" { "-gnu" } else { "" }
 }
 
+/// Toolchain-variant suffix used in SDK release-asset and cache-directory
+/// names. The default toolchain (MSVC on Windows, gcc/clang elsewhere) has no
+/// suffix; the clang-cl / TAILCALL Windows SDK is published as `-clang` and
+/// cached under its own directory so the two variants never trample each
+/// other (the cache-hit check is just "does `lib/php8embed.lib` exist").
+fn php_sdk_variant_suffix(variant: Option<&str>) -> &'static str {
+    match variant {
+        Some("clang") => "-clang",
+        _ => "",
+    }
+}
+
 /// Workspace-relative cache path for a PHP SDK pinned to `(version, os, arch)`.
 fn php_sdk_dir_for(version: &str, os: &str, arch: &str) -> PathBuf {
-    let suffix = php_sdk_libc_suffix(os);
+    php_sdk_dir_variant(version, os, arch, None)
+}
+
+/// Variant-aware form of `php_sdk_dir_for` (e.g. the clang/TAILCALL Windows
+/// SDK caches at `php-sdk/<version>-windows-x86_64-clang/`).
+fn php_sdk_dir_variant(version: &str, os: &str, arch: &str, variant: Option<&str>) -> PathBuf {
+    let suffix = format!("{}{}", php_sdk_libc_suffix(os), php_sdk_variant_suffix(variant));
     workspace_root().join("php-sdk").join(format!("{version}-{os}-{arch}{suffix}"))
 }
 
@@ -477,19 +618,140 @@ fn php_sdk_dir(version: &str) -> PathBuf {
 ///
 /// Uses `tar --strip-components=1` if the archive nests under a top-level
 /// directory (the php-sdk archives use `./lib/...`, so strip is harmless).
+///
+/// Both pipeline stages are checked: tar alone is not enough, because
+/// Windows bsdtar exits 0 on empty stdin, which used to turn a curl 404
+/// (missing release asset) into a phantom "SDK ready" success.
 fn download_and_extract_full_tarball(url: &str, dest: &Path) -> bool {
     let curl =
         Command::new("curl").args(["-fSL", url]).stdout(std::process::Stdio::piped()).spawn();
 
-    let Ok(curl) = curl else {
+    let Ok(mut curl) = curl else {
         eprintln!("error: failed to spawn curl");
         return false;
     };
 
-    let status =
-        Command::new("tar").args(["xz", "-C"]).arg(dest).stdin(curl.stdout.unwrap()).status();
+    let stdout = curl.stdout.take().expect("curl stdout was piped");
+    let tar_status = Command::new("tar").args(["xz", "-C"]).arg(dest).stdin(stdout).status();
+    let curl_status = curl.wait();
 
-    ran_ok(&status)
+    ran_ok(&tar_status) && matches!(curl_status, Ok(s) if s.success())
+}
+
+/// Hard gate for the clang/TAILCALL Windows SDK: prove `php8embed.lib`
+/// actually contains the TAILCALL interpreter before linking it into
+/// `ephpm.exe`.
+///
+/// `zend_vm_kind()` compiles to a constant return, so its disassembly is a
+/// truthful, dependency-free witness of which interpreter was generated:
+/// `mov eax,5` is `ZEND_VM_KIND_TAILCALL`, `mov eax,1` is the slow MSVC
+/// `ZEND_VM_KIND_CALL`. The function lives in `Zend/zend_execute.obj`
+/// (`zend_vm_execute.h` is `#include`d by `zend_execute.c` — there is no
+/// separate `zend_vm_execute.obj`), so: list the lib's members, extract that
+/// object, disassemble it, and require `mov eax,5` in the `zend_vm_kind`
+/// body. This is the same gate the php-sdk clang lane runs before
+/// publishing, repeated on the consumer side so an ephpm artifact named
+/// "-tailcall" can never silently ship the CALL VM even if a mislabeled SDK
+/// tarball slips through. Costs ~3 s and ~11 MB of scratch disassembly.
+///
+/// Requires `lib.exe` and `dumpbin.exe` on PATH — part of the same MSVC
+/// developer environment `cargo xtask release --target windows` already
+/// requires for the build itself.
+fn verify_tailcall_vm(sdk_dir: &Path) -> Result<(), ()> {
+    let lib_path = sdk_dir.join("lib").join("php8embed.lib");
+    if !lib_path.exists() {
+        eprintln!("error: {} not found — SDK cache is incomplete", lib_path.display());
+        return Err(());
+    }
+
+    eprintln!("==> Verifying the SDK's interpreter is the TAILCALL VM...");
+
+    // 1. Find the archive member that defines zend_vm_kind. Member names are
+    //    full paths from the SDK build tree, so match on the trailing
+    //    `Zend\zend_execute.obj` (never `zend_execute_API.obj`).
+    let list = Command::new("lib").args(["/nologo", "/list"]).arg(&lib_path).output();
+    let Ok(list) = list else {
+        eprintln!("error: failed to run lib.exe — is the MSVC developer environment active?");
+        return Err(());
+    };
+    if !list.status.success() {
+        eprintln!("error: lib /list failed on {}", lib_path.display());
+        return Err(());
+    }
+    let members = String::from_utf8_lossy(&list.stdout);
+    let member = members.lines().map(str::trim).find(|line| {
+        let norm = line.replace('/', "\\").to_ascii_lowercase();
+        norm.ends_with("zend\\zend_execute.obj")
+    });
+    let Some(member) = member else {
+        eprintln!(
+            "error: Zend\\zend_execute.obj not found among the members of {}",
+            lib_path.display()
+        );
+        return Err(());
+    };
+
+    // 2. Extract it and disassemble to a scratch file (the full disasm of
+    //    the VM object is ~11 MB — stream it from disk, don't buffer stdout).
+    let scratch = env::temp_dir().join(format!("ephpm-vm-kind-probe-{}", std::process::id()));
+    let obj = scratch.with_extension("obj");
+    let txt = scratch.with_extension("txt");
+    let cleanup = || {
+        let _ = fs::remove_file(&obj);
+        let _ = fs::remove_file(&txt);
+    };
+
+    let status = Command::new("lib")
+        .arg("/nologo")
+        .arg(format!("/extract:{member}"))
+        .arg(format!("/out:{}", obj.display()))
+        .arg(&lib_path)
+        .status();
+    if !ran_ok(&status) || !obj.exists() {
+        eprintln!("error: lib /extract:{member} failed");
+        cleanup();
+        return Err(());
+    }
+
+    let status = Command::new("dumpbin")
+        .args(["/nologo", "/disasm:nobytes"])
+        .arg(&obj)
+        .arg(format!("/out:{}", txt.display()))
+        .status();
+    if !ran_ok(&status) {
+        eprintln!("error: dumpbin /disasm failed on the extracted zend_execute.obj");
+        cleanup();
+        return Err(());
+    }
+
+    // 3. Find the `zend_vm_kind:` label and require `mov eax,5` right after.
+    let Ok(disasm) = fs::read_to_string(&txt) else {
+        eprintln!("error: failed to read the dumpbin disassembly at {}", txt.display());
+        cleanup();
+        return Err(());
+    };
+    cleanup();
+
+    let mut lines = disasm.lines();
+    let found = lines.by_ref().any(|l| l.trim() == "zend_vm_kind:");
+    if !found {
+        eprintln!("error: zend_vm_kind not found in the disassembly — cannot verify VM kind");
+        return Err(());
+    }
+    let body: Vec<&str> = lines.by_ref().take(4).collect();
+    let is_tailcall = body.iter().any(|l| l.replace(' ', "").ends_with("moveax,5"));
+    if is_tailcall {
+        eprintln!("==> VM kind verified: ZEND_VM_KIND_TAILCALL (5)");
+        Ok(())
+    } else {
+        eprintln!("error: the SDK's VM kind is NOT TAILCALL. zend_vm_kind() disassembles to:");
+        for l in &body {
+            eprintln!("         {l}");
+        }
+        eprintln!("       (mov eax,1 = the MSVC CALL VM — a mislabeled default SDK.)");
+        eprintln!("       Refusing to build a '-tailcall' binary from it.");
+        Err(())
+    }
 }
 
 // ── K8s E2E testing (Kind + Tilt) — opt-in only ──────────────────────────────


### PR DESCRIPTION
Part of #329 (item 4: ePHPm integration). Consumes the php-sdk `windows-x86_64-clang` platform (php-sdk#45) and turns it into the experimental **`-tailcall` Windows artifact**.

## What

Every MSVC-built PHP gets the interpreter's slow `ZEND_VM_KIND_CALL` VM. PHP 8.5's TAILCALL VM (`[[clang::musttail]]` + `preserve_none`, compiled with clang-cl) recovers HYBRID-class performance and links into the unchanged MSVC Rust pipeline with zero source changes. Measured end-to-end through ePHPm: **1.6-1.7x on CPU-bound PHP** (ref loop 2.73 ms vs 4.43 ms), **~3% on the Symfony demo** (real apps are filesystem-bound).

## Changes

### `xtask`: `--variant clang` (additive, default path untouched)

- `cargo xtask php-sdk 8.5 --target windows --variant clang` downloads `php-sdk-<ver>-windows-x86_64-clang.tar.gz` from the same php-sdk release, cached at `php-sdk/<ver>-windows-x86_64-clang/` beside the default. `--target windows` on `php-sdk` also works from any host now (pure curl+tar prefetch).
- `cargo xtask release 8.5 --target windows --variant clang` builds `ephpm.exe` against the clang SDK. Same Rust target (`x86_64-pc-windows-msvc`), same link step - clang-cl is MSVC-ABI-compatible.
- **8.5-only, fail-closed**: `--variant clang` with 8.3/8.4 is a hard error explaining that the TAILCALL VM doesn't exist there; non-Windows and unknown variant values also hard-error.
- **VM-kind hard gate in xtask** (ported from the php-sdk lane): before linking, `zend_vm_kind()` is disassembled out of the SDK's `php8embed.lib` (`lib /list` -> `/extract` of `Zend\zend_execute.obj` -> `dumpbin /disasm`) and must be `mov eax,5` (`ZEND_VM_KIND_TAILCALL`). A mislabeled CALL-VM SDK fails the build instead of shipping under a `-tailcall` name. Verified locally on both libs: clang SDK -> `mov eax,5` (pass), MSVC SDK -> `mov eax,1` (correctly refused). Costs ~2.5 s.
- Fixed a latent download bug the failure path exposed: the curl|tar pipeline only checked **tar**'s exit status, and Windows bsdtar exits 0 on empty stdin - so a curl 404 (missing release asset) printed `==> PHP SDK ready` and exited 0. Both stages are checked now, and a partial extract is removed so the cache can't be poisoned.

### `release.yml`: `build-windows-tailcall` (experimental, NON-GATING)

- Modeled on `build-windows`; single matrix entry (PHP 8.5 only), `continue-on-error: true`, `timeout-minutes: 200` (VS install ~20 min + full PHP-linked build; depends on the self-hosted ephemerd Windows fleet), `needs: build-windows` so the serialized Windows pool never runs two release builds at once.
- Produces + uploads `ephpm-vX.Y.Z+php8.5.7-windows-x86_64-tailcall.tar.gz` (the name says what it IS - tailcall - not how it's built).
- Post-build assertion: `ephpm.exe php -v` must report the pinned 8.5.x + ZTS and the `-clang` SDK cache must be the one populated (the VM kind itself is proven by the xtask disassembly gate during the build).
- **`Create Release` does NOT `needs:` it** (comment added there to keep it that way) and tolerates its absence in both directions:
  - Leg fails / SDK asset missing from the php-sdk release -> job red but `continue-on-error` keeps the run green; the collect script simply finds no tailcall artifact; the release publishes exactly as today.
  - Leg finishes **after** `Create Release` (the common case - it queues behind all three MSVC legs, usually the critical path): a final best-effort step attaches the tarball to the already-published release and appends its hash to `SHA256SUMS` via the REST API. Any failure there is a warning, never a red.
  - Leg finishes before: the existing all-attempts REST collect picks the archive up like any other and it lands in the generated `SHA256SUMS`.
- `bump-php-pin` learned the new pin site: the 8.5 `php_full:` count in release.yml is now 4 (was 3); `--check` passes, and a unit test pins the per-minor counts.

## Docs

- `site/content/getting-started/install.md`: "TAILCALL build" section - what it is, both honest numbers (1.6-1.7x CPU-bound / ~3% Symfony), experimental + non-gating + may be absent from a release, 8.5-only, MSVC remains the default; plus the `--variant clang` build-from-source recipe.
- `CLAUDE.md` build commands + SDK cache naming, `AGENTS.md` release.yml row, release skill (asset count 13 -> optionally 14, verification note).

## Verification (local, no fleet dependency)

- clang SDK staged into the cache path (`php-sdk/8.5.7-windows-x86_64-clang/` junction to the locally-built SDK); `cargo xtask release 8.5 --target windows --variant clang` end to end: VM gate passed (`==> VM kind verified: ZEND_VM_KIND_TAILCALL (5)`), exe built, `--version` / `php -v` (8.5.7 ZTS) OK, CPU ref loop **2.858 ms vs 4.982 ms** on the MSVC reference build (**1.74x**, and parity with the reference clang exe at 2.879 ms), serve-mode HTTP 200 with PHP executing (`PHPOK 8.5.7 ZTS=1`).
- Download-failure path exercised for real (empty cache -> curl 404 -> exit 1 with a clang-specific hint, no leftover cache dir).
- Default MSVC path proven unchanged: `cargo xtask php-sdk 8.3 --target windows` / `8.5 --target windows` hit the existing caches with identical naming; stub `cargo check`/clippy/fmt clean on Windows and Linux; all 32 xtask tests pass on both.
- release.yml validated with PyYAML + structural asserts (needs-absence, continue-on-error, timeout, single 8.5 matrix entry).

**Do not merge before** php-sdk#45 lands and one green clang-lane dispatch publishes the `-clang` asset (issue #329 items 1-3) - until then the CI leg fails its SDK download and, by design, nothing else notices.
