### PR TITLE
docs(windows): JIT closes the TAILCALL interpreter gap; clarify what the TAILCALL VM is

### DIFF
--- a/site/content/analysis/php-on-windows.md
+++ b/site/content/analysis/php-on-windows.md
@@ -217,6 +217,49 @@ build/link/flag differences explain Windows-vs-Windows.** The 22% spread is
 empirical proof that ~20%-scale build effects are real while remaining far
 too small to bridge the 2x to Linux.
 
+### 2.5 How the TAILCALL VM works — three clarifications [VERIFIED]
+
+TAILCALL comes up often enough that three points are worth stating plainly,
+because each is a common misconception:
+
+1. **The VM kind is chosen at *compile time*, not by a runtime setting.** The
+   selection above (`ZEND_VM_KIND_CALL` / `HYBRID` / `TAILCALL` / …) is
+   resolved by the C preprocessor when php-src is built — from
+   [`Zend/zend_vm_opcodes.h`](https://github.com/php/php-src/blob/PHP-8.5/Zend/zend_vm_opcodes.h)
+   and the
+   [`Zend/zend_vm_gen.php`](https://github.com/php/php-src/blob/PHP-8.5/Zend/zend_vm_gen.php)
+   generator. There is **no `opcache.vm_kind`, no `php.ini` toggle, and no
+   CLI flag** that switches it: which VM a binary runs is baked in by *how it
+   was compiled*. That is exactly why ePHPm ships a **separate** `-tailcall`
+   Windows binary (built with clang-cl) rather than a config option — you
+   cannot turn TAILCALL "on" in a running MSVC build. [VERIFIED — the §2.1
+   selection logic is preprocessor-only]
+
+2. **TAILCALL is shipped, not a future feature — but only in PHP 8.5, only
+   under Clang.** It landed in PHP 8.5
+   ([PR #17849](https://github.com/php/php-src/pull/17849)) and requires
+   Clang's `[[clang::musttail]]` (`HAVE_MUSTTAIL`) plus the `preserve_none`
+   calling convention (`HAVE_PRESERVE_NONE`) on x86-64/aarch64. It **does not
+   exist in PHP 8.3 or 8.4**, and it never compiles under MSVC or GCC. So
+   ePHPm's `-tailcall` artifact is PHP-8.5-only by construction, not by
+   policy. [VERIFIED]
+
+3. **Every platform already runs the fastest interpreter its compiler can
+   emit — TAILCALL is how *Clang* platforms reach that bar, not a
+   project-wide switch.** On Linux, GCC produces HYBRID, and HYBRID is
+   already as fast as TAILCALL: upstream's own `bench.php` has them within
+   noise, HYBRID marginally *ahead* (**1.006 s HYBRID vs 1.017 s TAILCALL**,
+   [PR #17849](https://github.com/php/php-src/pull/17849)). Switching Linux
+   to TAILCALL would therefore gain nothing and cost the GCC toolchain
+   (HYBRID's register pinning is GCC-only) — there is no "make everything
+   TAILCALL for cohesion" upside. TAILCALL exists for the platforms GCC
+   cannot serve: Clang-only targets, where the fallback is the slow CALL VM.
+   Windows/MSVC is exactly such a platform, which is why the `-tailcall`
+   (clang-cl) build is a Windows artifact and not a Linux one. (macOS builds
+   with Clang and already picks up a fast VM on 8.5, so no separate macOS
+   variant is published either.) [VERIFIED bench; JUDGEMENT on the toolchain
+   trade-off]
+
 ---
 
 ## 3. The filesystem half: why metadata ops cost ~10x
@@ -321,35 +364,49 @@ exclusion.
 
 ## 5. What closes the gap, and by how much [MEASURED]
 
-The interpreter half has two real fixes, and we measured both end-to-end
-through ePHPm (serve mode, c=1, same CPU loop as §1 — a separate run from
-the §1 matrix, hence the ±0.01 ms wobble on the baseline):
+The interpreter half has two real fixes — the TAILCALL VM (§2.5) and the
+JIT — and after v0.7.3 shipped we re-measured both end-to-end through the
+**released** Windows binaries (serve mode, c=1, matched opcache ini, quiet
+box, 100% HTTP 200). The result is more nuanced than a flat "TAILCALL is
+~1.7x". (The v0.7.3 release notes quote the JIT-off interpreter figure,
+~1.7x; the JIT-on picture below is the fuller story.)
 
-| Arm | Time | vs MSVC baseline |
-|---|---|---|
-| MSVC build, CALL VM (baseline) | 5.56 ms | — |
-| clang build, TAILCALL VM | 3.14 ms | **1.77x faster** |
-| MSVC build + JIT (`opcache.jit=tracing`) | 2.33 ms | **2.39x faster** |
-| clang build + JIT | 2.53 ms | 2.20x faster |
-| Linux, HYBRID interpreter (reference) | 2.55 ms | — |
+| Arm (released v0.7.3 binaries) | MSVC (CALL) | TAILCALL | TAILCALL vs MSVC |
+|---|---|---|---|
+| Interpreter only, JIT **off** — CPU loop | 4.795 ms | 2.791 ms | **1.72x faster** |
+| Warm hot loop, JIT **on** (`opcache.jit=tracing`) | 1.835 ms | 1.976 ms | gap closed — MSVC edges ahead |
+| Cold / short code, JIT on (`cpu.php`, c=1) | 5.33 ms | 3.44 ms | **1.55x faster** |
 
-- **The TAILCALL VM** (PHP 8.5's Clang-only dispatch, §2.1) recovers almost
-  exactly the 1.77x upstream measured — because clang-cl targets the MSVC
-  ABI, the clang-built `php8embed.lib` links into ePHPm's unchanged MSVC
-  Rust pipeline with zero source changes. ePHPm v0.7.3 ships this as an
-  **experimental** `-tailcall` Windows artifact (PHP 8.5 only — TAILCALL
-  does not exist in 8.3/8.4). See
-  [the guide](/guides/windows-performance/#the-tailcall-build) for status
-  and caveats.
-- **The JIT** sidesteps the dispatch question entirely: JIT-emitted native
-  code doesn't run on the C-compiled VM at all, so the MSVC penalty
-  dissolves where the JIT lands. With `opcache.jit=tracing`, the *MSVC*
-  build beats the Linux HYBRID *interpreter* on this loop.
-- **Neither moves a filesystem-bound app much.** On the Symfony demo (dev
-  mode, c=16) TAILCALL was worth **+3%** and the JIT **~0%** — the workload
-  is metadata-bound, exactly as §2.3's calibration predicts. The levers for
-  real apps are the filesystem levers (§3.3, and the
-  [guide](/guides/windows-performance/)).
+Read those three rows as one story:
+
+- **JIT off → TAILCALL's 1.72x is the full, durable win.** This is the pure
+  interpreter number, and it is exactly what runs whenever the JIT is off:
+  in ePHPm's **multi-tenant serve** mode (where the JIT is disabled by
+  default — per-vhost `opcache_invalidate` never reclaims JIT buffer, #350),
+  in worker mode, in dev, and anywhere an operator sets
+  `opcache_jit = "disable"`. **Multi-tenant serve is TAILCALL's best
+  real-world case**: there the interpreter is the whole game, so the ~1.72x
+  lands in full.
+- **JIT on, warm hot path → the gap essentially closes.** With
+  `opcache.jit=tracing` (ePHPm's **single-site serve** default since v0.7.3,
+  #350) hot code is compiled to native machine code that never touches the
+  C interpreter's dispatch — so the host VM's dispatch quality stops
+  mattering, and MSVC+JIT and TAILCALL+JIT land on top of each other (MSVC
+  even edges ahead, and both beat the ~2.5 ms Linux HYBRID *interpreter*
+  from §1). **Do not read the 1.6–1.7x as a JIT-on single-site hot-path
+  number** — it is the *interpreter* number.
+- **JIT on, cold/short code → TAILCALL still wins (~1.55x).** The JIT only
+  helps code it has already traced and compiled; first-request paths,
+  framework bootstrap, and short-lived scripts run the interpreter even with
+  the JIT enabled, and there TAILCALL keeps a real edge (cold `cpu.php`:
+  3.44 ms vs 5.33 ms). TAILCALL's marginal value in a JIT-on single-site
+  deployment is this cold-path latency, not steady-state throughput.
+- **Neither moves a filesystem-bound app much.** On the Symfony demo (JIT
+  off) TAILCALL was worth **+4.9%** on `/en` and **+3.1%** on `/en/blog`,
+  and the app is filesystem-bound either way — ~80 req/s on Windows vs ~580
+  on Linux ext4, a 5–7x gap that holds regardless of VM, exactly as §2.3's
+  calibration predicts. The levers for real apps are the filesystem levers
+  (§3.3, and the [guide](/guides/windows-performance/)).
 
 What does **not** work: MinGW-GCC (the only compiler that yields HYBRID) is
 explicitly unsupported by PHP's Windows build system, and MSYS2 ships no PHP

--- a/site/content/guides/windows-performance.md
+++ b/site/content/guides/windows-performance.md
@@ -20,13 +20,15 @@ see the [analysis page](/analysis/php-on-windows/) for setup):
 
 | Your workload | Windows penalty | What helps | Measured effect |
 |---|---|---|---|
-| CPU-bound PHP (loops, crypto, image math, parsers) | ~2.0–2.2x | TAILCALL build, JIT | **1.77x / 2.39x** on our CPU loop |
+| CPU-bound PHP (loops, crypto, image math, parsers) | ~2.0–2.2x | JIT (on by default single-site), TAILCALL build | JIT **~2.4x**; TAILCALL **1.72x** interpreter-only (JIT off), **~1.55x** on cold code with JIT on, ≈0 marginal on the JIT-on hot path |
 | Typical web app (framework, autoloader, templates) | mixed, mostly filesystem | serve-mode defaults, fewer file ops | single digits from runtime levers; the win is cutting file operations |
 | File-metadata-heavy (dev mode, deep `vendor/`, cache-miss storms) | ~10x on the metadata itself | fewer `stat`s: prod opcache settings, classmaps, Dev Drive | eliminates *repeat* cost; first touch stays expensive |
 
-For calibration: on the Symfony demo (dev mode, c=16) the TAILCALL build was
-worth **+3%** end-to-end and the JIT **~0%** — real apps are
-filesystem-bound on Windows, and no interpreter lever changes that.
+For calibration: on the Symfony demo the TAILCALL build was worth **+3–5%**
+end-to-end (+4.9% on `/en`, +3.1% on `/en/blog`, JIT off) and the JIT ~0% —
+real apps are filesystem-bound on Windows (~80 req/s vs ~580 on Linux ext4,
+a 5–7x gap that holds regardless of VM), and no interpreter lever changes
+that.
 
 ---
 
@@ -47,9 +49,31 @@ and compiles under clang-cl — which is MSVC-ABI-compatible, so a clang-built
 `php8embed.lib` links into ePHPm's unchanged Rust pipeline.
 ([Full mechanism.](/analysis/php-on-windows/#2-the-interpreter-half-msvc-gets-a-slower-virtual-machine))
 
-Measured end-to-end through ePHPm on Windows: **1.6–1.7x faster on
-CPU-bound PHP** than the MSVC artifact (serve-mode CPU loop: 3.14 ms vs
-5.56 ms; reference loops in #329 agree).
+Measured end-to-end through ePHPm on Windows: **1.72x faster on the pure
+interpreter** than the MSVC artifact (CPU loop, JIT off: 2.79 ms vs 4.80 ms;
+reference loops in #329 agree). Read that number precisely — it is the
+*interpreter* win, and it lands in full exactly where the interpreter does
+the work:
+
+- **Multi-tenant serve**, where ePHPm ships the JIT off by default (see
+  [The JIT](#the-jit)) — the interpreter is the whole game, so the ~1.72x is
+  the entire benefit. This is TAILCALL's strongest real-world case.
+- **Cold / short / first-request code** — framework bootstrap, first hits,
+  short scripts — which run the interpreter even when the JIT is enabled
+  (~1.55x there).
+
+Where it is a *smaller* win: a **single-site** serve deployment, which since
+v0.7.3 runs the tracing JIT **on** by default. JIT-compiled hot code
+sidesteps the interpreter's dispatch entirely, so on a warm hot loop
+MSVC+JIT and TAILCALL+JIT are neck-and-neck (see §5 of the
+[analysis](/analysis/php-on-windows/)) — TAILCALL's remaining edge there is
+cold-path latency, not steady-state throughput. Don't expect 1.72x on a
+JIT-on single-site hot path.
+
+And note *why* it is a separate binary rather than a config flag: the Zend VM
+kind is fixed when PHP is compiled — there is no `opcache.vm_kind` or
+`php.ini` toggle
+([how the TAILCALL VM works, §2.5](/analysis/php-on-windows/#2-the-interpreter-half-msvc-gets-a-slower-virtual-machine)).
 
 - It ships as a separate, suffixed download:
   `ephpm-vX.Y.Z+php8.5.7-windows-x86_64-tailcall.tar.gz` alongside the
@@ -67,38 +91,51 @@ CPU-bound PHP** than the MSVC artifact (serve-mode CPU loop: 3.14 ms vs
 
 The opcache JIT compiles hot code to native machine code, which doesn't run
 on the C-compiled interpreter loop at all — so the MSVC dispatch penalty
-dissolves wherever the JIT lands. On our CPU loop it was the single biggest
-lever: **2.39x** (5.56 ms → 2.33 ms), faster than Linux's HYBRID
-*interpreter* on the same workload.
+dissolves wherever the JIT lands. On our CPU loop it is the single biggest
+lever: **~2.4x**, faster than Linux's HYBRID *interpreter* on the same
+workload. Because it emits its own machine code, the JIT also makes the
+choice of interpreter (CALL vs TAILCALL) largely moot on hot paths — see
+[the TAILCALL section](#the-tailcall-build) above.
 
-PHP leaves the JIT off by default (`opcache.jit=disable`), and so does ePHPm
-— it helps CPU-bound work and can regress the I/O-bound request path typical
-of web apps, so it is a deliberate opt-in. Enable it through
-`[php] ini_overrides`:
+Since v0.7.3, ePHPm's JIT default is **shaped by mode** (#350), not a blanket
+off:
+
+| Mode | `[php] opcache_jit` unset → | Why |
+|---|---|---|
+| Single-site `ephpm serve` | **`tracing` (on)** | measured ~2.4x on CPU-bound PHP; single-process embed avoids the multi-process SHM JIT bugs |
+| Multi-tenant (`[server] sites_dir`) | `disable` | per-vhost `opcache_invalidate` never reclaims JIT buffer, so deploy churn would silently exhaust it |
+| Worker mode (`[php] mode = "worker"`) | `disable` | JIT works there but the recycle lifecycle isn't soaked — opt in explicitly |
+| Dev | `disable` | PHP's own default |
+
+So on a single-site box you already get the JIT with no config change. To
+pin it explicitly in any mode, set the `[php] opcache_jit` knob — an explicit
+value wins everywhere, and a dedicated startup line always states the
+effective JIT state and why:
 
 ```toml
 [php]
-ini_overrides = [["opcache.jit", "tracing"]]
+opcache_jit = "tracing"   # "tracing" | "function" | "disable"
+                          # env override: EPHPM_PHP__OPCACHE_JIT
 
-# Optional: pin the JIT code buffer (MB). When unset, ePHPm pre-sizes a
-# buffer automatically in serve mode (~1/64 of the memory budget, clamped
-# 32–64 MB), so enabling JIT needs no other config change.
+# Optional: pin the JIT code buffer (MB). When unset, ePHPm auto-sizes it in
+# serve mode (~1/64 of the memory budget, clamped 32–64 MB), so an enabled
+# JIT is never silently bufferless.
 opcache_jit_buffer_size = 128
 ```
 
-`ini_overrides` is a list of `[directive, value]` pairs applied after
-`ini_file` (if set), so it wins over both. Two caveats, both measured or
-verified:
+See the [config reference](/reference/config/#opcache-jit) for the full
+shaped-default table. Two caveats, both measured or verified:
 
-- **Expect ~0% on filesystem-bound apps.** Symfony demo, dev mode, c=16:
-  no measurable change. The JIT is a CPU lever, not a web-app lever.
-- **Multi-tenant deploys never reclaim JIT buffer.** In multi-site mode,
-  a per-vhost `ephpm deploy` / `opcache_invalidate()` invalidates the
-  opcode cache entries but the JIT'd code they produced stays resident —
-  the JIT buffer only grows until process restart (measured). On a
-  many-tenant box with frequent deploys, either size
-  `opcache_jit_buffer_size` for the accumulation and restart on a schedule,
-  or leave the JIT off.
+- **Expect ~0% on filesystem-bound apps.** Symfony demo: no measurable
+  change. The JIT is a CPU lever, not a web-app lever.
+- **Multi-tenant deploys never reclaim JIT buffer — which is why the
+  multi-tenant default is off.** A per-vhost `ephpm deploy` /
+  `opcache_invalidate()` invalidates the opcode cache entries but the JIT'd
+  code they produced stays resident — the JIT buffer only grows until
+  process restart (measured). If you override the default and enable the JIT
+  on a many-tenant box, watch the `ephpm_opcache_jit_buffer_free_bytes`
+  gauge for exhaustion, size `opcache_jit_buffer_size` for the accumulation,
+  and restart on a schedule.
 
 ---
 
@@ -238,8 +275,9 @@ request = 60          # the only runaway-request ceiling on Windows
 # intent survives someone running the same config under `ephpm dev`:
 opcache_validate_timestamps = false
 
-# Opt-in JIT — only if your workload is CPU-bound (see caveats above):
-# ini_overrides = [["opcache.jit", "tracing"]]
+# Single-site serve already runs the tracing JIT by default (since v0.7.3).
+# Turn it off with:   opcache_jit = "disable"
+# Or pin it on:       opcache_jit = "tracing"
 ```
 
 Run it with `ephpm serve --config ephpm.toml`, deploy code with


### PR DESCRIPTION
Docs-only follow-up to the v0.7.3 Windows-performance pages (#329), correcting two things measured/clarified after the release shipped. No code changes.

## What changed

### `analysis/php-on-windows.md`
- **New §2.5 "How the TAILCALL VM works — three clarifications"** — answers the three misconceptions that keep coming up:
  1. The Zend VM kind is selected at **compile time** (preprocessor in `zend_vm_opcodes.h` + the `zend_vm_gen.php` generator) — there is **no `opcache.vm_kind` / `php.ini` / CLI toggle**. That is *why* ePHPm ships a separate `-tailcall` binary rather than a config flag.
  2. TAILCALL is **shipped in PHP 8.5 only, clang-only** (`[[clang::musttail]]` + `preserve_none`); it does not exist in 8.3/8.4 and never compiles under MSVC or GCC.
  3. **Every platform already runs the fastest interpreter its compiler can emit** — Linux/GCC = HYBRID, which upstream `bench.php` puts marginally *ahead* of TAILCALL (1.006 vs 1.017 s). So there is no "make everything TAILCALL for cohesion" upside; TAILCALL lifts clang-only platforms (Windows/MSVC → clang-cl) to parity.
- **§5 rewritten** around the fresh released-v0.7.3 numbers and the corrected synthesis: JIT **off** → TAILCALL's **1.72x** interpreter win is the full benefit (multi-tenant serve, where the JIT is off by default, is its best real-world case); JIT **on, warm hot loop** → the gap closes and MSVC even edges ahead (1.835 vs 1.976 ms); JIT **on, cold/short code** → TAILCALL still **~1.55x** (`cpu.php` 3.44 vs 5.33 ms). The 1.6–1.7x is explicitly framed as the JIT-off interpreter figure, not the JIT-on single-site hot path.

### `guides/windows-performance.md`
- Qualified the TAILCALL claim as the **JIT-off interpreter** number and spelled out where it does/doesn't land; added a link to the §2.5 clarification and the "why a separate binary, not a flag" point.
- **Corrected the now-stale JIT section**: v0.7.3 (#350) shipped a **mode-shaped `opcache.jit` default** — `tracing` on in single-site serve, `disable` in multi-tenant/worker/dev — via the `[php] opcache_jit` knob. The old text ("PHP leaves the JIT off by default, and so does ePHPm … opt in via `[php] ini_overrides`") described pre-#350 behavior and is replaced.
- Updated the triage table, the calibration line, and the tuned production-config block.

## Verification (per the Truthfulness rules)
- VM-kind selection / compile-time / 8.5-only / clang-only / HYBRID-vs-TAILCALL 1.006 vs 1.017 s — verified against the research draft and its php-src citations (`Zend/zend_vm_opcodes.h`, PR #17849).
- Shaped `opcache.jit` default, `[php] opcache_jit` values, `EPHPM_PHP__OPCACHE_JIT`, buffer autotune, `ephpm_opcache_jit_buffer_free_bytes` gauge — verified against `crates/ephpm-config/src/lib.rs` and `site/content/reference/config.md`; consistent with the shipped v0.7.3 release notes.
- Benchmark numbers are the fresh released-v0.7.3 measurements provided for this change (labeled measured-by-us).

## Deliberately NOT done
- The published v0.7.3 GitHub release notes were **not** altered (they quote the JIT-off ~1.74x interpreter figure); the JIT-on nuance now lives in these docs, which the §5 intro notes.
- **macOS was not asserted as "HYBRID".** ePHPm's own `xtask` builds the macOS SDK with **Homebrew clang** on `aarch64-apple-darwin`, which cannot produce HYBRID (an existing `xtask` comment calling it "HYBRID" looks inaccurate). The docs frame macOS only as "clang-built, already gets a fast VM on 8.5, no separate variant published" and anchor the parity argument on Linux (GCC/HYBRID) + Windows (MSVC/CALL → clang-cl/TAILCALL), which are fully verifiable. Flagged for a maintainer to reconcile the xtask comment separately.

Do not merge yet — for review.