### PR TITLE
fix(cluster): reject claim-mine primary reclaim when CDC log identity changed (#344)

### DIFF
--- a/crates/ephpm-cluster/src/sqlite_election.rs
+++ b/crates/ephpm-cluster/src/sqlite_election.rs
@@ -33,6 +33,27 @@
 //!    only triggers when two nodes genuinely elected concurrently (e.g.
 //!    a symmetric partition heal), where either database is as good as
 //!    the other and determinism is what matters.
+//!
+//! # Data-identity guard on the fast reclaim (issue #344)
+//!
+//! Rule 1 deliberately lets a *restarting incumbent* reclaim primary
+//! immediately when its own claim is still unexpired in gossip (TTL ~10s),
+//! so a fast restart does not bounce the role. But "same node id" is not
+//! "same data": if the node's database was wiped or replaced between stop
+//! and start (a redeploy onto an empty volume), it comes back with an
+//! **empty database and a fresh CDC log identity** yet the same node id,
+//! wins that fast-reclaim inside the TTL window, and re-roots the cluster
+//! onto the empty database — #314's blast radius through a narrower door.
+//!
+//! The fix stamps the primary's **CDC log identity** (`__ephpm_cdc_log_id`,
+//! issue #315 — a stable per-database-file fingerprint) into the claim and
+//! requires the fast reclaim to match on **both** node id and log id. When
+//! the node id matches but the log id does not, the claim describes data
+//! this node no longer holds: it refuses the fast path, stops refreshing
+//! the stale claim (letting it expire), and falls through to the normal
+//! startup grace + election so a node that still has the data can win. When
+//! the data identity is unchanged the deliberate fast-restart behaviour is
+//! preserved unchanged.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -77,22 +98,46 @@ pub enum ElectedRole {
 
 /// Value stored in gossip KV for the primary claim.
 ///
-/// Format: `"{node_id}|{grpc_addr}"`.
+/// Format: `"{node_id}|{grpc_addr}|{log_id}"`.
+///
+/// `log_id` is the primary's CDC log identity (`__ephpm_cdc_log_id`, issue
+/// #315) — a stable per-database-file fingerprint. It is what distinguishes
+/// "the same node restarting with the same data" from "the same node id
+/// coming back with a *different* (wiped/replaced) database" (issue #344).
+/// The `grpc_addr` and `log_id` fields never contain a `|` (an address has
+/// none, and the log id is 32 hex chars), so a plain three-way split is
+/// unambiguous.
 #[derive(Debug, Clone)]
 struct PrimaryClaim {
     node_id: String,
     grpc_addr: String,
+    /// CDC log identity of the primary's database (issue #315/#344). Empty
+    /// when decoded from a legacy two-field claim written by an older node
+    /// mid-rolling-upgrade; an empty local/claimed log id never matches a
+    /// real one, so the reclaim guard errs safe (defers to election).
+    log_id: String,
 }
 
 impl PrimaryClaim {
     fn encode(&self) -> Vec<u8> {
-        format!("{}|{}", self.node_id, self.grpc_addr).into_bytes()
+        format!("{}|{}|{}", self.node_id, self.grpc_addr, self.log_id).into_bytes()
     }
 
     fn decode(bytes: &[u8]) -> Option<Self> {
         let s = std::str::from_utf8(bytes).ok()?;
-        let (node_id, grpc_addr) = s.split_once('|')?;
-        Some(Self { node_id: node_id.to_string(), grpc_addr: grpc_addr.to_string() })
+        // `node_id|grpc_addr|log_id`. Tolerate a legacy two-field claim
+        // (`node_id|grpc_addr`) from a node that has not yet upgraded: the
+        // missing log id decodes as empty, which fails the #344 identity
+        // match and so defers to election rather than fast-reclaiming.
+        let mut parts = s.splitn(3, '|');
+        let node_id = parts.next()?;
+        let grpc_addr = parts.next()?;
+        let log_id = parts.next().unwrap_or("");
+        Some(Self {
+            node_id: node_id.to_string(),
+            grpc_addr: grpc_addr.to_string(),
+            log_id: log_id.to_string(),
+        })
     }
 }
 
@@ -103,6 +148,11 @@ impl PrimaryClaim {
 pub struct SqliteElection {
     cluster: Arc<ClusterHandle>,
     grpc_listen: String,
+    /// This node's CDC log identity (`__ephpm_cdc_log_id`, issue #315) — a
+    /// stable fingerprint of the database file this node currently holds.
+    /// Stamped into every published claim and compared against a surviving
+    /// claim's log id before the fast-restart reclaim (issue #344).
+    log_id: String,
     role_tx: watch::Sender<ElectedRole>,
     role_rx: watch::Receiver<ElectedRole>,
     /// When this election manager was created. Gates the first
@@ -114,14 +164,17 @@ impl SqliteElection {
     /// Create a new election manager.
     ///
     /// `grpc_listen` is this node's sqld gRPC address that replicas will
-    /// connect to if this node becomes primary.
+    /// connect to if this node becomes primary. `log_id` is this node's CDC
+    /// log identity (issue #315) — the fingerprint of the database this node
+    /// currently holds, used to reject a fast reclaim after the data was
+    /// wiped/replaced (issue #344).
     #[must_use]
-    pub fn new(cluster: Arc<ClusterHandle>, grpc_listen: String) -> Self {
+    pub fn new(cluster: Arc<ClusterHandle>, grpc_listen: String, log_id: String) -> Self {
         // Start as replica with empty URL — will be resolved on first tick.
         let (role_tx, role_rx) =
             watch::channel(ElectedRole::Replica { primary_grpc_url: String::new() });
 
-        Self { cluster, grpc_listen, role_tx, role_rx, boot: tokio::time::Instant::now() }
+        Self { cluster, grpc_listen, log_id, role_tx, role_rx, boot: tokio::time::Instant::now() }
     }
 
     /// Get a receiver for role changes.
@@ -160,20 +213,45 @@ impl SqliteElection {
         if let Some(bytes) = self.cluster.gossip_get(PRIMARY_KEY).await
             && let Some(claim) = PrimaryClaim::decode(&bytes)
         {
-            if claim.node_id == self.cluster.self_node().id {
-                // Our own (unexpired) claim survived a restart —
-                // reclaiming is not a theft; refresh and carry on.
-                self.publish_claim().await;
-                tracing::info!("SQLite election: reclaiming our own surviving primary claim");
-                return ElectedRole::Primary;
+            match classify_claim(&claim, &self.cluster.self_node().id, &self.log_id) {
+                ClaimKind::OwnFresh => {
+                    // Our own (unexpired) claim survived a restart AND the
+                    // database it describes is the one we still hold —
+                    // reclaiming is not a theft; refresh and carry on.
+                    self.publish_claim().await;
+                    tracing::info!("SQLite election: reclaiming our own surviving primary claim");
+                    return ElectedRole::Primary;
+                }
+                ClaimKind::OwnStale => {
+                    // Same node id, DIFFERENT CDC log identity: this node
+                    // came back with a wiped/replaced database (empty volume
+                    // on redeploy) inside the claim TTL. The surviving claim
+                    // describes data we no longer have, so fast-reclaiming
+                    // would re-root the cluster onto an empty database
+                    // (issue #344 — #314's blast radius through a narrower
+                    // door). Refuse the fast path: do not reclaim; return
+                    // unresolved so the election loop applies the startup
+                    // grace + election and a node that still holds the data
+                    // can win.
+                    tracing::warn!(
+                        claimed_log = %claim.log_id,
+                        local_log = %self.log_id,
+                        "SQLite election: a surviving primary claim names this node but its CDC \
+                         log identity does not match our current database (wiped/replaced across \
+                         restart, issue #344); refusing the fast reclaim and deferring to election"
+                    );
+                    return ElectedRole::Replica { primary_grpc_url: String::new() };
+                }
+                ClaimKind::Foreign => {
+                    if let Some(url) = self.replica_url_for(&claim).await {
+                        return ElectedRole::Replica { primary_grpc_url: url };
+                    }
+                    // Claim points at a host that is not a known member.
+                    // Refuse to dial it (defense in depth against a forged
+                    // gossip claim) and wait for a valid one.
+                    return ElectedRole::Replica { primary_grpc_url: String::new() };
+                }
             }
-            if let Some(url) = self.replica_url_for(&claim).await {
-                return ElectedRole::Replica { primary_grpc_url: url };
-            }
-            // Claim points at a host that is not a known member.
-            // Refuse to dial it (defense in depth against a forged
-            // gossip claim) and wait for a valid one.
-            return ElectedRole::Replica { primary_grpc_url: String::new() };
         }
 
         // No valid claim visible. That means either the cluster genuinely
@@ -223,57 +301,80 @@ impl SqliteElection {
         if let Some(bytes) = self.cluster.gossip_get(PRIMARY_KEY).await
             && let Some(claim) = PrimaryClaim::decode(&bytes)
         {
-            if claim.node_id == self_node.id {
-                // We are the primary — refresh heartbeat.
-                self.publish_claim().await;
-                return ElectedRole::Primary;
-            }
-
-            // Someone else claims primary -- check if they're alive AND
-            // that the advertised gRPC address belongs to a known member
-            // (defense in depth: a forged claim from a plaintext gossip
-            // injection must not make us dial an arbitrary host).
-            let nodes = self.cluster.nodes().await;
-            let primary_alive =
-                nodes.iter().any(|n| n.id == claim.node_id && n.state == NodeState::Alive);
-
-            if primary_alive {
-                // Conflict: we hold the primary role, yet a live peer
-                // claims it too (gossip KV is last-write-wins, so its
-                // newer write shadows ours). Do not yield
-                // unconditionally — that is how a joining node stole
-                // the role from a healthy incumbent. Break the tie by
-                // the documented rule: lowest node id wins.
-                if matches!(current, ElectedRole::Primary) {
-                    if incumbent_wins_tie(&self_node.id, &claim.node_id) {
-                        tracing::warn!(
-                            claimant = %claim.node_id,
-                            "SQLite election: live conflicting primary claim from a \
-                             higher-ordinal node; keeping the primary role and \
-                             re-asserting our claim (lowest node id wins)"
-                        );
-                        self.publish_claim().await;
-                        return ElectedRole::Primary;
-                    }
+            match classify_claim(&claim, &self_node.id, &self.log_id) {
+                ClaimKind::OwnFresh => {
+                    // We are the primary and the claim describes the database
+                    // we still hold — refresh heartbeat.
+                    self.publish_claim().await;
+                    return ElectedRole::Primary;
+                }
+                ClaimKind::OwnStale => {
+                    // Same node id, DIFFERENT CDC log identity (issue #344): a
+                    // stale claim from a previous incarnation whose database
+                    // is gone. Do NOT reclaim and do NOT refresh it — that is
+                    // what re-roots the cluster onto an empty database. Treat
+                    // it as absent and fall through to the startup grace +
+                    // election tail below (the grace still gates a first
+                    // self-election while current != Primary), letting the
+                    // claim expire so a node that still holds the data can win.
                     tracing::warn!(
-                        claimant = %claim.node_id,
-                        "SQLite election: live conflicting primary claim from a \
-                         lower-ordinal node; stepping down (lowest node id wins)"
+                        claimed_log = %claim.log_id,
+                        local_log = %self.log_id,
+                        "SQLite election: surviving primary claim names this node but its CDC log \
+                         identity no longer matches our database (wiped/replaced, issue #344); not \
+                         reclaiming — deferring to election"
                     );
                 }
-                if let Some(url) = self.replica_url_for(&claim).await {
-                    return ElectedRole::Replica { primary_grpc_url: url };
-                }
-                // Alive primary but the gRPC host is not a known member --
-                // refuse to dial it and wait for a valid claim.
-                return ElectedRole::Replica { primary_grpc_url: String::new() };
-            }
+                ClaimKind::Foreign => {
+                    // Someone else claims primary -- check if they're alive
+                    // AND that the advertised gRPC address belongs to a known
+                    // member (defense in depth: a forged claim from a
+                    // plaintext gossip injection must not make us dial an
+                    // arbitrary host).
+                    let nodes = self.cluster.nodes().await;
+                    let primary_alive =
+                        nodes.iter().any(|n| n.id == claim.node_id && n.state == NodeState::Alive);
 
-            // Primary is dead — fall through to re-election.
-            tracing::warn!(
-                dead_primary = %claim.node_id,
-                "primary node is dead, triggering re-election"
-            );
+                    if primary_alive {
+                        // Conflict: we hold the primary role, yet a live peer
+                        // claims it too (gossip KV is last-write-wins, so its
+                        // newer write shadows ours). Do not yield
+                        // unconditionally — that is how a joining node stole
+                        // the role from a healthy incumbent. Break the tie by
+                        // the documented rule: lowest node id wins.
+                        if matches!(current, ElectedRole::Primary) {
+                            if incumbent_wins_tie(&self_node.id, &claim.node_id) {
+                                tracing::warn!(
+                                    claimant = %claim.node_id,
+                                    "SQLite election: live conflicting primary claim from a \
+                                     higher-ordinal node; keeping the primary role and \
+                                     re-asserting our claim (lowest node id wins)"
+                                );
+                                self.publish_claim().await;
+                                return ElectedRole::Primary;
+                            }
+                            tracing::warn!(
+                                claimant = %claim.node_id,
+                                "SQLite election: live conflicting primary claim from a \
+                                 lower-ordinal node; stepping down (lowest node id wins)"
+                            );
+                        }
+                        if let Some(url) = self.replica_url_for(&claim).await {
+                            return ElectedRole::Replica { primary_grpc_url: url };
+                        }
+                        // Alive primary but the gRPC host is not a known
+                        // member -- refuse to dial it and wait for a valid
+                        // claim.
+                        return ElectedRole::Replica { primary_grpc_url: String::new() };
+                    }
+
+                    // Primary is dead — fall through to re-election.
+                    tracing::warn!(
+                        dead_primary = %claim.node_id,
+                        "primary node is dead, triggering re-election"
+                    );
+                }
+            }
         }
 
         // No valid primary claim visible. If this node started recently,
@@ -352,8 +453,43 @@ impl SqliteElection {
         let claim = PrimaryClaim {
             node_id: self.cluster.self_node().id.clone(),
             grpc_addr: self.grpc_listen.clone(),
+            log_id: self.log_id.clone(),
         };
         self.cluster.gossip_set(PRIMARY_KEY, &claim.encode(), Some(PRIMARY_TTL)).await;
+    }
+}
+
+/// How a surviving primary claim relates to *this* node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimKind {
+    /// Names this node AND describes the database this node still holds
+    /// (node id and CDC log identity both match). Eligible for the
+    /// fast-restart reclaim.
+    OwnFresh,
+    /// Names this node but with a *different* CDC log identity — a stale
+    /// claim from a previous incarnation whose database was wiped/replaced
+    /// (issue #344). Must NOT be fast-reclaimed; defer to grace + election.
+    OwnStale,
+    /// Names a different node.
+    Foreign,
+}
+
+/// Classify a surviving primary claim against this node's identity.
+///
+/// The fast-restart reclaim (issue #314) must fire only for
+/// [`ClaimKind::OwnFresh`]: a matching node id is not enough, because a
+/// redeploy onto an empty volume brings the same node id back with a
+/// *different* database and a fresh CDC log identity. Requiring the log id
+/// to match too is what closes the issue #344 window — the same node
+/// returning with wiped data classifies as [`ClaimKind::OwnStale`] and is
+/// denied the fast path.
+fn classify_claim(claim: &PrimaryClaim, self_id: &str, self_log_id: &str) -> ClaimKind {
+    if claim.node_id != self_id {
+        ClaimKind::Foreign
+    } else if claim.log_id == self_log_id {
+        ClaimKind::OwnFresh
+    } else {
+        ClaimKind::OwnStale
     }
 }
 
@@ -395,11 +531,16 @@ mod tests {
 
     #[test]
     fn primary_claim_roundtrip() {
-        let claim = PrimaryClaim { node_id: "ephpm-0".into(), grpc_addr: "10.0.1.2:5001".into() };
+        let claim = PrimaryClaim {
+            node_id: "ephpm-0".into(),
+            grpc_addr: "10.0.1.2:5001".into(),
+            log_id: "0123456789abcdef0123456789abcdef".into(),
+        };
         let encoded = claim.encode();
         let decoded = PrimaryClaim::decode(&encoded).unwrap();
         assert_eq!(decoded.node_id, "ephpm-0");
         assert_eq!(decoded.grpc_addr, "10.0.1.2:5001");
+        assert_eq!(decoded.log_id, "0123456789abcdef0123456789abcdef");
     }
 
     #[test]
@@ -410,9 +551,25 @@ mod tests {
 
     #[test]
     fn primary_claim_encode_format() {
-        let claim = PrimaryClaim { node_id: "node-1".into(), grpc_addr: "0.0.0.0:5001".into() };
+        let claim = PrimaryClaim {
+            node_id: "node-1".into(),
+            grpc_addr: "0.0.0.0:5001".into(),
+            log_id: "cafef00d".into(),
+        };
         let bytes = claim.encode();
-        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "node-1|0.0.0.0:5001");
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "node-1|0.0.0.0:5001|cafef00d");
+    }
+
+    /// A legacy two-field claim (`node_id|grpc_addr`, no log id) written by
+    /// a node that has not yet upgraded must still decode — with an empty
+    /// log id, which the #344 reclaim guard treats as "does not match" and
+    /// so safely defers to election.
+    #[test]
+    fn primary_claim_decode_legacy_two_field() {
+        let decoded = PrimaryClaim::decode(b"ephpm-0|10.0.1.2:5001").unwrap();
+        assert_eq!(decoded.node_id, "ephpm-0");
+        assert_eq!(decoded.grpc_addr, "10.0.1.2:5001");
+        assert_eq!(decoded.log_id, "");
     }
 
     #[test]
@@ -438,27 +595,39 @@ mod tests {
 
     #[test]
     fn primary_claim_with_ipv6() {
-        let claim = PrimaryClaim { node_id: "node-v6".into(), grpc_addr: "[::1]:5001".into() };
+        let claim = PrimaryClaim {
+            node_id: "node-v6".into(),
+            grpc_addr: "[::1]:5001".into(),
+            log_id: "deadbeef".into(),
+        };
         let encoded = claim.encode();
         let decoded = PrimaryClaim::decode(&encoded).unwrap();
         assert_eq!(decoded.node_id, "node-v6");
         assert_eq!(decoded.grpc_addr, "[::1]:5001");
+        assert_eq!(decoded.log_id, "deadbeef");
     }
 
     #[test]
-    fn primary_claim_decode_multiple_pipes() {
-        // Only the first pipe is the separator.
-        let decoded = PrimaryClaim::decode(b"a|b|c").unwrap();
+    fn primary_claim_decode_three_fields() {
+        // node_id | grpc_addr | log_id — a plain three-way split (neither an
+        // address nor a hex log id contains a pipe).
+        let decoded = PrimaryClaim::decode(b"a|10.0.1.2:5001|abc123").unwrap();
         assert_eq!(decoded.node_id, "a");
-        assert_eq!(decoded.grpc_addr, "b|c");
+        assert_eq!(decoded.grpc_addr, "10.0.1.2:5001");
+        assert_eq!(decoded.log_id, "abc123");
     }
 
     #[test]
     fn primary_claim_with_long_node_id() {
         let long_id = "ephpm-".to_string() + &"x".repeat(200);
-        let claim = PrimaryClaim { node_id: long_id.clone(), grpc_addr: "10.0.1.2:5001".into() };
+        let claim = PrimaryClaim {
+            node_id: long_id.clone(),
+            grpc_addr: "10.0.1.2:5001".into(),
+            log_id: "abcdef".into(),
+        };
         let roundtripped = PrimaryClaim::decode(&claim.encode()).unwrap();
         assert_eq!(roundtripped.node_id, long_id);
+        assert_eq!(roundtripped.log_id, "abcdef");
     }
 
     /// Verify that lowest-ordinal wins: when comparing node IDs
@@ -571,5 +740,84 @@ mod tests {
         // but the tie-break must not let an equal id "win" as incumbent
         // AND as claimant on two nodes at once.
         assert!(!incumbent_wins_tie("cdc-node-1", "cdc-node-1"));
+    }
+
+    fn claim_with_log(node_id: &str, log_id: &str) -> PrimaryClaim {
+        PrimaryClaim {
+            node_id: node_id.into(),
+            grpc_addr: "10.0.1.2:5001".into(),
+            log_id: log_id.into(),
+        }
+    }
+
+    /// The issue #344 window: node N was primary with CDC log identity A and
+    /// published a claim; N is redeployed onto an empty volume and restarts
+    /// within the claim TTL, now holding a *fresh, empty* database with log
+    /// identity B. Its own surviving claim (node N, log A) is still in
+    /// gossip. The claim-mine fast reclaim must NOT fire — the claim names
+    /// data N no longer has, and reclaiming would re-root the cluster onto
+    /// the empty database. It must classify as `OwnStale` (defer to
+    /// election), not `OwnFresh` (fast reclaim).
+    #[test]
+    fn wiped_restart_does_not_take_fast_reclaim() {
+        let self_id = "ephpm-0";
+        let log_before_wipe = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let log_after_wipe = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        let surviving_claim = claim_with_log(self_id, log_before_wipe);
+
+        // Same node id, different (fresh) log identity → stale, must defer.
+        assert_eq!(
+            classify_claim(&surviving_claim, self_id, log_after_wipe),
+            ClaimKind::OwnStale,
+            "a wiped-DB restart must not be eligible for the fast reclaim"
+        );
+    }
+
+    /// The deliberate fast-restart behaviour (issue #314) is preserved when
+    /// the data identity is unchanged: same node id AND same CDC log
+    /// identity classifies as `OwnFresh`, so a genuine fast restart still
+    /// reclaims immediately without bouncing the role.
+    #[test]
+    fn genuine_fast_restart_still_reclaims() {
+        let self_id = "ephpm-0";
+        let log = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let surviving_claim = claim_with_log(self_id, log);
+        assert_eq!(
+            classify_claim(&surviving_claim, self_id, log),
+            ClaimKind::OwnFresh,
+            "an unchanged-data fast restart must still reclaim"
+        );
+    }
+
+    /// A claim naming a different node is `Foreign` regardless of log id —
+    /// the log-identity guard only gates our *own* claim's fast reclaim.
+    #[test]
+    fn foreign_claim_is_foreign_regardless_of_log_id() {
+        let claim = claim_with_log("ephpm-1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        // Even if the log ids happened to collide, a different node id is
+        // always foreign.
+        assert_eq!(
+            classify_claim(&claim, "ephpm-0", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            ClaimKind::Foreign
+        );
+        assert_eq!(
+            classify_claim(&claim, "ephpm-0", "cccccccccccccccccccccccccccccccc"),
+            ClaimKind::Foreign
+        );
+    }
+
+    /// A legacy two-field claim (empty log id after decode) from a node that
+    /// has not yet upgraded must never satisfy the fast reclaim against a
+    /// node holding a real (non-empty) log id — it classifies as `OwnStale`
+    /// and defers, which is the safe direction during a rolling upgrade.
+    #[test]
+    fn legacy_empty_log_claim_defers() {
+        let legacy = PrimaryClaim::decode(b"ephpm-0|10.0.1.2:5001").unwrap();
+        assert_eq!(legacy.log_id, "");
+        assert_eq!(
+            classify_claim(&legacy, "ephpm-0", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            ClaimKind::OwnStale
+        );
     }
 }

--- a/crates/ephpm-server/src/turso_cdc.rs
+++ b/crates/ephpm-server/src/turso_cdc.rs
@@ -488,7 +488,40 @@ pub async fn start_clustered_turso_cdc(
          \"10.0.1.5:7946\"), or set [cluster.channel] listen to a specific \
          host:port explicitly.",
     )?;
-    let (initial_role, role_rx) = determine_role(sqlite_config, cluster, channel_advertise).await?;
+
+    // Mgmt factory: used by the per-subscriber tailers and the snapshot
+    // dumper on the primary, and by the apply loop on the replica. Never
+    // opts into CDC-on-connect — the tailer reads turso_cdc explicitly,
+    // and the applier's writes must NOT be re-captured (that would make
+    // a replica echo the primary's changes into its own CDC log).
+    //
+    // Opened BEFORE the election (moved up from below) so this node's CDC
+    // log identity is available to the election: the primary claim carries
+    // that identity, and the fast-restart reclaim must match on it (issue
+    // #344).
+    let mgmt_factory = Arc::new(
+        Turso::open(db_path)
+            .await
+            .with_context(|| format!("failed to open mgmt Turso factory at {db_path}"))?,
+    );
+
+    // Establish this database's persistent CDC log identity (issue #315)
+    // BEFORE the election runs. Done on EVERY node, not just the primary:
+    // any node can be promoted later, and the identity must already exist
+    // when the first subscriber dials in. Written through the mgmt
+    // connection so it is never captured into the CDC log itself. Passing it
+    // to the election is what lets a node whose database was wiped/replaced
+    // across a restart (fresh identity) refuse to fast-reclaim its own stale
+    // primary claim (issue #344).
+    let local_log_id = {
+        let conn =
+            mgmt_factory.raw_connection().context("CDC: open mgmt connection for log identity")?;
+        ensure_log_id(&conn).await.context("CDC: establish local log identity")?
+    };
+    tracing::info!(log_id = %local_log_id, "CDC: local log identity established");
+
+    let (initial_role, role_rx) =
+        determine_role(sqlite_config, cluster, channel_advertise, local_log_id.clone()).await?;
 
     // In auto mode the initial role is deliberately unresolved until the
     // election has actually seen the cluster (issue #314: deciding
@@ -527,30 +560,11 @@ pub async fn start_clustered_turso_cdc(
         .await
         .with_context(|| format!("failed to open wire Turso factory at {db_path}"))?;
 
-    // Mgmt factory: used by the per-subscriber tailers and the snapshot
-    // dumper on the primary, and by the apply loop on the replica. Never
-    // opts into CDC-on-connect — the tailer reads turso_cdc explicitly,
-    // and the applier's writes must NOT be re-captured (that would make
-    // a replica echo the primary's changes into its own CDC log).
-    let mgmt_factory = Arc::new(
-        Turso::open(db_path)
-            .await
-            .with_context(|| format!("failed to open mgmt Turso factory at {db_path}"))?,
-    );
+    // Mgmt factory and this node's CDC log identity are established above,
+    // before the election, so the primary claim can carry the identity
+    // (issue #344).
 
     let max_snapshot_bytes = sqlite_config.replication.max_snapshot_bytes;
-
-    // Establish this database's persistent CDC log identity (issue #315).
-    // Done on EVERY node, not just the primary: any node can be promoted
-    // later, and the identity must already exist when the first subscriber
-    // dials in. Written through the mgmt connection so it is never
-    // captured into the CDC log itself.
-    let local_log_id = {
-        let conn =
-            mgmt_factory.raw_connection().context("CDC: open mgmt connection for log identity")?;
-        ensure_log_id(&conn).await.context("CDC: establish local log identity")?
-    };
-    tracing::info!(log_id = %local_log_id, "CDC: local log identity established");
 
     // Seed the zero-valued CDC series before anything can record. An
     // operator scraping a freshly booted node must be able to tell
@@ -801,6 +815,7 @@ async fn determine_role(
     sqlite_config: &SqliteConfig,
     cluster: &Arc<ephpm_cluster::ClusterHandle>,
     channel_advertise: SocketAddr,
+    local_log_id: String,
 ) -> anyhow::Result<(Role, Option<tokio::sync::watch::Receiver<ephpm_cluster::ElectedRole>>)> {
     match sqlite_config.replication.role.as_str() {
         "primary" => Ok((Role::Primary, None)),
@@ -836,6 +851,7 @@ async fn determine_role(
             let election = ephpm_cluster::SqliteElection::new(
                 Arc::clone(cluster),
                 channel_advertise.to_string(),
+                local_log_id,
             );
             let initial = election.determine_initial_role().await;
             let rx = election.watch_role();

--- a/crates/ephpm-server/tests/turso_cdc_cluster_integration.rs
+++ b/crates/ephpm-server/tests/turso_cdc_cluster_integration.rs
@@ -186,7 +186,12 @@ async fn bring_up_node(node_id: &str, seed: Option<&str>) -> Node {
     // the channel's `advertise_addr()` — not `listen_addr()` — which
     // is Bug 2's fix on the caller side.
     let advertise = channel.advertise_addr().expect("advertise resolved (loopback bind)");
-    let election = SqliteElection::new(Arc::clone(&cluster), advertise.to_string());
+    // A stable synthetic CDC log identity per node — this test does not
+    // wipe a database mid-flight, so each node keeps one identity for its
+    // lifetime (the #344 log-identity reclaim guard is unit-tested in
+    // ephpm-cluster::sqlite_election).
+    let log_id = format!("logid-{node_id}");
+    let election = SqliteElection::new(Arc::clone(&cluster), advertise.to_string(), log_id);
 
     Node { cluster, channel, election, _gossip_port: gossip_port }
 }

--- a/site/content/architecture/database/_index.md
+++ b/site/content/architecture/database/_index.md
@@ -198,12 +198,13 @@ Clustered mode replicates in-process — there is no separate database server bi
 ePHPm uses its gossip clustering (SWIM protocol via chitchat) to elect the primary:
 
 1. On cluster formation, the lowest-ordinal alive node becomes primary — after a short startup grace (~15s, longer than claim TTL + heartbeat), so a node joining an *existing* cluster always observes the incumbent's claim before it may elect itself (a joining node used to steal the role — issue #314)
-2. The primary's identity is stored in gossip KV (`kv:sqlite:primary`)
+2. The primary's identity is stored in gossip KV (`kv:sqlite:primary`) — the claim carries the node id, the cluster-channel address peers dial, and the node's **CDC log identity** (the per-database fingerprint from issue #315)
 3. The primary heartbeats this key every 5s with a 10s TTL
 4. If the primary dies, gossip detects it (phi-accrual failure detector)
 5. Next lowest-ordinal node promotes itself and begins publishing its CDC stream
 6. Replicas detect the KV change and reconnect to the new primary's cluster channel address, re-scoping their replication cursor to the new primary's CDC log identity (`change_id` is per-database, not cluster-global — issue #315)
 7. If two live nodes ever claim simultaneously (e.g. a partition heal), the conflict resolves deterministically to the lowest node id
+8. A restarting incumbent whose own claim is still unexpired reclaims the primary role immediately (avoiding a role bounce) — but *only* if its CDC log identity still matches the claim. A node that restarted with a wiped/replaced database (empty volume) presents a fresh log identity, fails this match, and defers to the normal grace + election rather than re-rooting the cluster onto its empty database (issue #344)
 
 ### Failover
 

--- a/site/content/guides/clustering-setup.md
+++ b/site/content/guides/clustering-setup.md
@@ -117,6 +117,7 @@ Prometheus metrics on `/metrics` cover HTTP, PHP, DB, and KV behaviour. Cluster-
 - **Network partition** — gossip detects partitions in seconds. The minority side will see itself as a smaller cluster; the majority retains the SQLite primary.
 - **Primary crash** — replicas detect via gossip TTL expiry on `kv:sqlite:primary`, and the next-lowest-ordinal node promotes itself and begins publishing its CDC stream. Window is ~10s.
 - **Brief Replica-with-empty-URL window** — between primary death and re-election, `evaluate_role` returns `Replica` with an empty primary URL for one tick. The role watcher sees two transitions (Replica-empty → Primary). Harmless, but logs are loud.
+- **Primary restart with a wiped/replaced database** — a fast restart of the incumbent normally reclaims the primary role immediately (its own claim on `kv:sqlite:primary` is still unexpired within the ~10s TTL), which avoids bouncing the role. If that restart also *replaced the database* — a redeploy onto an empty volume — the node comes back with an empty database and a fresh CDC log identity. The primary claim carries the node's CDC log identity, and the fast reclaim requires it to match, so the wiped node **refuses** the reclaim and defers to the normal grace + election instead of re-rooting the cluster onto its empty database (issue #344). You will see a `WARN` naming the mismatched log identity. Persist the SQLite data directory across restarts (a `StatefulSet` volume claim) so a legitimate restart keeps its data and reclaims fast.
 
 ## See also
 

--- a/site/content/roadmap/turso-engine.md
+++ b/site/content/roadmap/turso-engine.md
@@ -223,6 +223,20 @@ path is a **single ordered stream** with no schema-sync side channel.
   deterministically to the lowest node id instead of the last writer.
   The cost: a genuinely fresh cluster elects its first primary ~15–20s
   after boot instead of immediately.
+- **Data-identity guard on the fast reclaim (issue #344).** The startup
+  grace deliberately exempts a *restarting incumbent* whose own claim is
+  still unexpired in gossip (TTL ~10s), so a fast restart does not bounce
+  the role. But "same node id" is not "same data": a redeploy onto an
+  empty volume brings the same node back with an empty database and a
+  fresh CDC log identity, and it would win that fast reclaim inside the
+  TTL window — re-rooting the cluster onto the empty database (#314's
+  blast radius through a narrower door). The primary claim now carries the
+  node's **CDC log identity** (the same per-database fingerprint from the
+  log-identity fix above), and the fast reclaim requires *both* the node
+  id and the log id to match. A node that comes back with a different log
+  identity refuses the reclaim and falls through to the normal grace +
+  election; a genuine fast restart with unchanged data still reclaims
+  immediately.
 - Prometheus instrumentation for the whole path — batches and rows
   shipped and applied, subscriber count, the applied watermark, apply and
   tail-poll errors, reconnects by outcome, snapshot bytes and outcome,


### PR DESCRIPTION
## The window (#344)

`SqliteElection`'s primary claim on `kv:sqlite:primary` identified the primary by **node id only**. On restart, `determine_initial_role`'s claim-mine fast path lets a node reclaim primary immediately if its own claim is still unexpired in gossip (TTL ~10s) — deliberate, so a fast restart does not bounce the role.

But **"same node id" is not "same data"**: if the node's database was wiped/replaced between stop and start (a redeploy onto an empty volume), it comes back with an **empty database and a fresh CDC log identity**, wins the fast reclaim inside the TTL window, and re-roots the cluster onto the empty database — the same blast radius as #314 through a narrower door.

The #315 log-identity machinery already *detects* the log change replica-side (replicas re-seed to cursor 0 for the fresh log id). Detection was correct; the **election outcome** was wrong. A node with no data must not win the claim-mine fast path.

## The fix (approach: log-id-in-claim)

I chose **recording the CDC log identity in the claim** over the local-epoch alternative, because the log identity (`__ephpm_cdc_log_id`, the per-database fingerprint from #315) is cheaply available at election time — it just needed to be established a few lines earlier — and putting it in the claim keeps the decision self-describing rather than relying on separate local persistence.

- `PrimaryClaim` gains a `log_id` field; wire format `node_id|grpc_addr|log_id`. Decode tolerates a **legacy two-field claim** (empty log id) during a rolling upgrade.
- A pure `classify_claim(claim, self_id, self_log_id) -> ClaimKind` helper returns `OwnFresh` / `OwnStale` / `Foreign`. Both the initial-role path and the election loop (`evaluate_role`) consume it, so the guard lives in exactly one place.
- The fast reclaim fires **only** for `OwnFresh` (node id **and** log id match). `OwnStale` (node id matches, log id differs) refuses the reclaim, stops refreshing the stale claim, and defers to the normal startup grace + election — so a node that still holds the data can win. The deliberate fast-restart behavior is preserved unchanged when the data identity matches.
- In `start_clustered_turso_cdc`, the log identity is now established (via `ensure_log_id`) **before** the election and threaded through `determine_role` into `SqliteElection::new`.

A wiped node therefore boots as an unresolved replica (`is_primary = false`), so it also won't serve stale/empty CDC to peers while its old claim expires.

## Test

Pure unit tests in `ephpm-cluster::sqlite_election` (matching the crate's existing sync test style) reproduce the window:

- `wiped_restart_does_not_take_fast_reclaim` — claim by node N with log-id A, then N presenting log-id B (wiped DB) classifies as `OwnStale` (defers to election), **not** `OwnFresh`.
- `genuine_fast_restart_still_reclaims` — unchanged data (same log id) stays `OwnFresh` (reclaims immediately).
- `foreign_claim_is_foreign_regardless_of_log_id` and `legacy_empty_log_claim_defers` cover the other arms and rolling-upgrade safety.
- Plus updated `PrimaryClaim` encode/decode tests for the new three-field format.

`cargo test -p ephpm-cluster --lib sqlite_election::` — 24 passed. `cargo clippy -p ephpm-cluster` and `-p ephpm-server` (all-targets, `-D warnings`) clean. `cargo +nightly fmt --all --check` clean.

## Docs (same PR)

Updated the turso-engine roadmap, the clustering-setup failure-modes guide, and the database architecture election list to describe the log-identity reclaim guard.

Clustered mode is experimental, so this is low-risk.
