### PR TITLE
docs: correct false "macOS ships HYBRID VM" claim

### DIFF
--- a/site/content/analysis/php-on-windows.md
+++ b/site/content/analysis/php-on-windows.md
@@ -256,9 +256,11 @@ because each is a common misconception:
    cannot serve: Clang-only targets, where the fallback is the slow CALL VM.
    Windows/MSVC is exactly such a platform, which is why the `-tailcall`
    (clang-cl) build is a Windows artifact and not a Linux one. (macOS builds
-   with Clang and already picks up a fast VM on 8.5, so no separate macOS
-   variant is published either.) [VERIFIED bench; JUDGEMENT on the toolchain
-   trade-off]
+   with Clang too: on PHP 8.5 it already picks up TAILCALL, so a variant would
+   add nothing; on 8.3/8.4 it falls back to the same slow CALL VM as MSVC —
+   clang cannot emit HYBRID and TAILCALL does not exist there — so no faster
+   macOS variant is possible to publish. Use macOS 8.5 for CPU-bound work.)
+   [VERIFIED bench; JUDGEMENT on the toolchain trade-off]
 
 ---
 

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -64,7 +64,7 @@ A release may additionally carry a second Windows archive:
 ephpm-vX.Y.Z+php8.5.7-windows-x86_64-tailcall.tar.gz
 ```
 
-Every PHP built with MSVC — including the default ePHPm Windows binary — falls back to the interpreter's slow `CALL` VM. The `-tailcall` archive contains the same `ephpm.exe`, but with PHP 8.5 compiled by clang-cl so the interpreter is the new TAILCALL VM (`[[clang::musttail]]` + `preserve_none`), which recovers roughly the performance of the HYBRID VM that Linux/macOS builds have always had.
+Every PHP built with MSVC — including the default ePHPm Windows binary — falls back to the interpreter's slow `CALL` VM. The `-tailcall` archive contains the same `ephpm.exe`, but with PHP 8.5 compiled by clang-cl so the interpreter is the new TAILCALL VM (`[[clang::musttail]]` + `preserve_none`), which recovers roughly the performance of the HYBRID VM that Linux (GCC) builds get. macOS is a clang build, not GCC, so it never gets HYBRID: PHP 8.5 there runs the TAILCALL VM, while 8.3/8.4 fall back to the same slow `CALL` VM.
 
 Measured against the default MSVC Windows binary, end-to-end through ePHPm (Ryzen 9 5950X):
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -156,9 +156,9 @@ fn validate_variant(variant: &str, version: &str, os: &str, arch: &str) -> Resul
     }
     if os != "windows" || arch != "x86_64" {
         eprintln!("error: --variant clang is only published for windows-x86_64");
-        eprintln!(
-            "       (Linux/macOS SDKs already ship the fast HYBRID VM — there is no clang variant)"
-        );
+        eprintln!("       only Windows's default SDK is the slow MSVC CALL VM, so only Windows");
+        eprintln!("       needs a clang/TAILCALL variant. Linux builds with GCC (HYBRID VM);");
+        eprintln!("       macOS is already clang - 8.5 gets TAILCALL, but 8.3/8.4 fall to CALL.");
         return Err(());
     }
     if !version.starts_with("8.5.") {


### PR DESCRIPTION
macOS SDKs are clang-built and never ship the HYBRID VM. PHP 8.5 gets TAILCALL; 8.3/8.4 fall back to the slowest `CALL` VM — clang defines `__GNUC__` but fails PHP's `HAVE_GCC_GLOBAL_REGS` check (no HYBRID), and TAILCALL does not exist before 8.5. Verified by disassembling `zend_vm_kind` from the shipped `libphp.a` (8.5 → 5/TAILCALL, 8.4/8.3 → 1/CALL).

Fixes every hit of the false "macOS ... HYBRID" claim:

- `xtask/src/main.rs` (`validate_variant`): the `--variant` error said "Linux/macOS SDKs already ship the fast HYBRID VM". Only Linux (GCC) is HYBRID; macOS is a clang build. Reworded to explain why the clang/TAILCALL variant is Windows-only.
- `site/content/getting-started/install.md`: "the HYBRID VM that Linux/macOS builds have always had" → Linux (GCC) only, with macOS 8.5=TAILCALL / 8.3-8.4=CALL noted.
- `site/content/analysis/php-on-windows.md`: the macOS parenthetical implied macOS reaches the fast VM bar generally; made explicit that 8.3/8.4 macOS runs the slow CALL VM.

Linux=HYBRID wording is kept because Linux builds with GCC (`gcc-toolset-13`), the mechanism PHP uses to select HYBRID; not re-verified by disassembly this session, so phrased by toolchain, not asserted as freshly measured.

rustfmt clean (`cargo +nightly fmt -p xtask -- --check`).