### PR TITLE
test(e2e): revive bare_process_smoke and de-flake etag_cache (#239, #246)

### DIFF
--- a/crates/ephpm-e2e/Cargo.lock
+++ b/crates/ephpm-e2e/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +94,41 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -97,11 +147,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "brotli",
+ "futures-util",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
  "urlencoding",
 ]
 
@@ -146,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,9 +216,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -468,6 +548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +579,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "reqwest"
@@ -604,6 +723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,10 +809,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -720,6 +870,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -793,6 +955,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,10 +1003,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -944,6 +1142,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/ephpm-e2e/src/lib.rs
+++ b/crates/ephpm-e2e/src/lib.rs
@@ -18,10 +18,11 @@
 //!   skip gracefully when it is unset so the whole crate still compile-checks
 //!   without a built binary.
 
+use std::collections::BTreeSet;
+use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::fs;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -124,6 +125,20 @@ impl Drop for SingleNodeFixture {
     }
 }
 
+/// How long each cluster node gets to answer `/_ephpm/health`.
+///
+/// Sized against measured cold-start, not guessed: two ephpm processes
+/// starting at once take ~18-25s from `spawn` to first 200 on a Windows host
+/// (a ~120 MB binary to page in, plus PHP runtime init), and the previous 20s
+/// sat inside that spread — which showed up as intermittent "never healthy"
+/// with an *empty* stderr, i.e. a node that was fine and merely slow.
+///
+/// A generous deadline costs nothing on a healthy node (the poll returns as
+/// soon as it gets a 200) and nothing on a genuinely broken one either:
+/// [`wait_for_health`] returns immediately when the child exits, which is how
+/// a bind clash reports. Only the "hung but alive" case waits this long.
+const CLUSTER_HEALTH_TIMEOUT: Duration = Duration::from_secs(90);
+
 /// A cluster of ephpm processes on 127.0.0.1 (each on its own port set).
 pub struct ClusterFixture {
     nodes: Vec<ClusterFixtureNode>,
@@ -146,15 +161,7 @@ impl ClusterFixture {
         }
 
         // Reserve all port sets before spawning so overlap is impossible.
-        let mut port_sets = Vec::with_capacity(size);
-        for _ in 0..size {
-            port_sets.push(ClusterPorts {
-                http: reserve_loopback_port().await?,
-                mysql: reserve_loopback_port().await?,
-                gossip: reserve_loopback_port().await?,
-                kv_data: reserve_loopback_port().await?,
-            });
-        }
+        let port_sets = reserve_cluster_ports(size).await?;
 
         let join_addrs: Vec<String> =
             port_sets.iter().map(|p| format!("127.0.0.1:{}", p.gossip)).collect();
@@ -219,9 +226,20 @@ impl ClusterFixture {
                 .and_then(|s| s.parse().ok())
                 .ok_or_else(|| anyhow!("could not parse port from {}", node.base_url))?;
             let child = node.child.as_mut().ok_or_else(|| anyhow!("node {i} has no child"))?;
-            wait_for_health(child, port, Duration::from_secs(20))
-                .await
-                .with_context(|| format!("cluster node {i} never healthy"))?;
+            if let Err(e) = wait_for_health(child, port, CLUSTER_HEALTH_TIMEOUT).await {
+                // Inline the child's stderr rather than pointing at it: the
+                // tempdir is deleted when this `Err` unwinds the fixture, so a
+                // path in the message would name a file the reader can never
+                // open. A bind clash — the failure mode this fixture is most
+                // prone to, see `GOSSIP_PORT_SPAN` — says so in one line.
+                let log = tmp.path().join(format!("node-{i}")).join("stderr.log");
+                let detail = fs::read_to_string(&log)
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_else(|e| format!("(stderr.log unreadable: {e})"));
+                return Err(e.context(format!(
+                    "cluster node {i} (http {port}) never healthy; its stderr said: {detail}"
+                )));
+            }
         }
 
         Ok(Self { nodes, _tempdir: tmp })
@@ -271,6 +289,119 @@ async fn reserve_loopback_port() -> Result<u16> {
     let port = listener.local_addr().context("local_addr")?.port();
     drop(listener);
     Ok(port)
+}
+
+/// Ports past `[cluster] bind` that a node claims without anyone reserving
+/// them.
+///
+/// `ephpm-cluster` derives the cluster-channel listener from the gossip bind
+/// address as `gossip_socket_addr().port() + 2` (see `cluster_channel.rs`), so
+/// a node with gossip on `G` also owns `G + 2`. Reserving `G..=G + 2` keeps
+/// that derived port out of every other node's port set.
+///
+/// This is what made `bare_process_smoke` fail the first time it ever ran
+/// (issue #239): the kernel hands out ephemeral ports consecutively, so node
+/// 0's gossip `G` put its channel on `G + 2` — which had already been handed
+/// to node 1 as its HTTP port. Node 1 then died with "failed to bind ...
+/// (os error 10048 / EADDRINUSE)" and the fixture reported "never healthy".
+const CLUSTER_CHANNEL_PORT_OFFSET: u16 = 2;
+
+/// Size of the port window a gossip port claims: the bind port itself through
+/// its derived cluster-channel port inclusive.
+const GOSSIP_PORT_SPAN: u16 = CLUSTER_CHANNEL_PORT_OFFSET + 1;
+
+/// Probe sockets held open while a port plan is being assembled.
+///
+/// Holding them is load-bearing: dropping a probe returns its port to the
+/// ephemeral pool, and the kernel walks that pool in order, so an early
+/// release is exactly how a rejected port comes back as the answer to the
+/// next request.
+#[derive(Default)]
+struct PortProbes {
+    tcp: Vec<tokio::net::TcpListener>,
+    udp: Vec<tokio::net::UdpSocket>,
+}
+
+/// Reserve a non-overlapping port set per node.
+///
+/// Two things here are easy to get wrong, and both did (issue #239):
+///
+/// - **Protocol.** Gossip is **UDP**; every other listener is TCP. A port that
+///   accepts a TCP bind can still refuse a UDP one — on Windows, Hyper-V/WinNAT
+///   reserve large UDP-only ranges and the bind fails with `WSAEACCES`. So the
+///   gossip port is probed with a real UDP socket.
+/// - **Derived ports.** The cluster channel is never configured, only derived
+///   (`gossip + 2`), so it has to be probed and claimed explicitly or a sibling
+///   node gets handed it.
+async fn reserve_cluster_ports(size: usize) -> Result<Vec<ClusterPorts>> {
+    let mut probes = PortProbes::default();
+    let mut claimed: BTreeSet<u16> = BTreeSet::new();
+    let mut sets = Vec::with_capacity(size);
+
+    for _ in 0..size {
+        let http = claim_tcp_port(&mut probes, &mut claimed).await?;
+        let mysql = claim_tcp_port(&mut probes, &mut claimed).await?;
+        let kv_data = claim_tcp_port(&mut probes, &mut claimed).await?;
+        let gossip = claim_gossip_port(&mut probes, &mut claimed).await?;
+        sets.push(ClusterPorts { http, mysql, gossip, kv_data });
+    }
+
+    // Release every probe now that the assignment is fixed; the children bind
+    // these ports themselves a moment later.
+    drop(probes);
+    Ok(sets)
+}
+
+/// Number of attempts any single port claim gets before giving up.
+const MAX_PORT_ATTEMPTS: usize = 64;
+
+/// Claim one unclaimed loopback TCP port.
+async fn claim_tcp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
+    for _ in 0..MAX_PORT_ATTEMPTS {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.context("bind :0")?;
+        let port = listener.local_addr().context("local_addr")?.port();
+        probes.tcp.push(listener);
+        if claimed.insert(port) {
+            return Ok(port);
+        }
+    }
+    Err(anyhow!("could not reserve a free loopback TCP port in {MAX_PORT_ATTEMPTS} attempts"))
+}
+
+/// Claim a gossip port `G` that is genuinely bindable as **UDP**, and whose
+/// derived cluster-channel port `G + 2` is genuinely bindable as **TCP**.
+///
+/// Claims the whole `G..G + GOSSIP_PORT_SPAN` window so no other node can be
+/// handed the channel port.
+async fn claim_gossip_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
+    for _ in 0..MAX_PORT_ATTEMPTS {
+        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.context("bind udp :0")?;
+        let port = socket.local_addr().context("local_addr")?.port();
+        probes.udp.push(socket);
+
+        let span: Vec<u16> = match (0..GOSSIP_PORT_SPAN)
+            .map(|off| port.checked_add(off))
+            .collect::<Option<Vec<_>>>()
+        {
+            Some(ports) if !ports.iter().any(|p| claimed.contains(p)) => ports,
+            _ => continue,
+        };
+
+        // The channel port is TCP and nobody probes it but us. If it is taken
+        // (or excluded), this whole gossip port is unusable — try another.
+        let channel = port + CLUSTER_CHANNEL_PORT_OFFSET;
+        let Ok(listener) = tokio::net::TcpListener::bind(("127.0.0.1", channel)).await else {
+            continue;
+        };
+        probes.tcp.push(listener);
+
+        claimed.extend(span);
+        return Ok(port);
+    }
+    Err(anyhow!(
+        "could not reserve a loopback UDP gossip port with a free TCP channel port \
+         (gossip + {CLUSTER_CHANNEL_PORT_OFFSET}) in {MAX_PORT_ATTEMPTS} attempts"
+    ))
 }
 
 /// Poll `child`'s health endpoint until it answers 200, the child exits, or

--- a/crates/ephpm-e2e/tests/bare_process_smoke.rs
+++ b/crates/ephpm-e2e/tests/bare_process_smoke.rs
@@ -1,35 +1,85 @@
 //! Bare-process fixture smoke test.
 //!
-//! Exercises `ClusterFixture` directly: spawns a 2-node ephpm cluster on
-//! 127.0.0.1 and asserts both nodes serve `/index.php`. Skips gracefully
-//! when `EPHPM_BINARY` is unset so `cargo test --no-run` still succeeds on
-//! machines without a built release binary.
+//! Exercises [`ClusterFixture`] directly: spawns a 2-node ephpm cluster on
+//! 127.0.0.1 and asserts both nodes serve `/index.php`. This is the only
+//! coverage `ClusterFixture` has — the harness's own cluster fixture lives in
+//! `xtask`, so without this suite the library one is compiled and never run.
+//!
+//! # How it is wired (issue #239)
+//!
+//! This suite manages its own topology, so `cargo xtask e2e` lists it in
+//! `SELF_MANAGED_SUITES`: the harness spawns **no** node for it and hands it
+//! `EPHPM_BINARY` plus `EPHPM_DOCROOT`. [`ClusterFixture`] reserves its own
+//! loopback ports and writes its own config template, so it cannot collide
+//! with — or perturb — the fixed-port fixtures the harness spawns later. That
+//! is the same contract `turso_cdc` runs under, and the reason neither suite
+//! touches the harness's shared node template (the #288/#295 lesson).
+//!
+//! Two bugs kept this dormant and broken before that:
+//!
+//! 1. Nothing set `EPHPM_BINARY` for it, so it silently `return`ed and
+//!    reported `ok` — it had never once run.
+//! 2. It derived its docroot from `CARGO_MANIFEST_DIR`. The harness execs
+//!    **pre-built** test binaries, which inherit *xtask's* environment, so
+//!    that resolved to `xtask/tests/docroot` — a path that does not exist.
+//!    The docroot now comes from `EPHPM_DOCROOT`, with a fallback (below)
+//!    for a direct `cargo test` run where no harness is involved.
 
 use std::path::PathBuf;
 
 use ephpm_e2e::{ClusterFixture, ephpm_binary_env};
 
+/// Resolve the document root to serve.
+///
+/// Prefers `EPHPM_DOCROOT`, which `cargo xtask e2e` sets to the canonicalized
+/// `tests/docroot`. Falls back to deriving it from `CARGO_MANIFEST_DIR` for a
+/// direct `cargo test --manifest-path crates/ephpm-e2e/Cargo.toml` run, where
+/// cargo sets that variable to *this* crate's directory and the workspace root
+/// is two levels up. Under the harness the fallback is never used — and must
+/// never be relied on, because there `CARGO_MANIFEST_DIR` belongs to xtask.
+fn resolve_docroot() -> PathBuf {
+    if let Some(dir) = std::env::var_os("EPHPM_DOCROOT") {
+        return PathBuf::from(dir);
+    }
+    let manifest_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    // crates/ephpm-e2e -> crates -> <workspace root>
+    manifest_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("ephpm-e2e manifest dir has a workspace root two levels up")
+        .join("tests")
+        .join("docroot")
+}
+
 #[tokio::test]
 async fn two_node_cluster_serves_php() {
     let Some(binary) = ephpm_binary_env() else {
-        eprintln!("EPHPM_BINARY not set — skipping bare-process cluster smoke test");
+        // Deliberate, and the only skip left: a bare `cargo test` on a
+        // checkout with no release build cannot spawn anything. `cargo xtask
+        // e2e` always sets this, so a skip in CI means the harness wiring
+        // regressed — hence the loud marker rather than a quiet `return`.
+        eprintln!(
+            "SKIP two_node_cluster_serves_php: EPHPM_BINARY is unset. \
+             Under `cargo xtask e2e` this must never happen — check that \
+             `bare_process_smoke` is still in SELF_MANAGED_SUITES."
+        );
         return;
     };
 
-    // The docroot lives next to this test file; walk up from the manifest dir.
-    let manifest_dir =
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
-    let docroot = manifest_dir.join("tests").join("docroot");
-    assert!(docroot.exists(), "docroot missing at {}", docroot.display());
+    let docroot = resolve_docroot();
+    assert!(
+        docroot.join("index.php").is_file(),
+        "docroot {} has no index.php — set EPHPM_DOCROOT to the tests/docroot to serve",
+        docroot.display()
+    );
 
     let fixture = ClusterFixture::start(&binary, &docroot, 2)
         .await
         .unwrap_or_else(|e| panic!("failed to start cluster fixture: {e}"));
 
-    let client = reqwest::Client::builder()
-        .pool_max_idle_per_host(0)
-        .build()
-        .expect("reqwest client");
+    let client =
+        reqwest::Client::builder().pool_max_idle_per_host(0).build().expect("reqwest client");
 
     for (i, base_url) in fixture.base_urls().iter().enumerate() {
         let url = format!("{base_url}/index.php");
@@ -38,16 +88,8 @@ async fn two_node_cluster_serves_php() {
             .send()
             .await
             .unwrap_or_else(|e| panic!("GET {url} on node {i} failed: {e}"));
-        assert_eq!(
-            resp.status().as_u16(),
-            200,
-            "node {i} ({base_url}) returned {}",
-            resp.status()
-        );
+        assert_eq!(resp.status().as_u16(), 200, "node {i} ({base_url}) returned {}", resp.status());
         let body = resp.text().await.expect("body");
-        assert!(
-            body.contains("ePHPm"),
-            "node {i} response missing 'ePHPm' marker, got: {body}"
-        );
+        assert!(body.contains("ePHPm"), "node {i} response missing 'ePHPm' marker, got: {body}");
     }
 }

--- a/crates/ephpm-e2e/tests/etag_cache.rs
+++ b/crates/ephpm-e2e/tests/etag_cache.rs
@@ -12,13 +12,59 @@
 //! - `EPHPM_URL` — base URL of the ephpm instance (e.g. `http://ephpm:8080`)
 //!
 //! Requires `server.php_etag_cache.enabled = true` in the ephpm configuration.
+//!
+//! # Why every test builds its own URL (issue #246)
+//!
+//! The server keys its PHP `ETag` cache by `{prefix}{method}:{path}?{query}`
+//! (`php_etag_cache_key` in `ephpm-server/src/router.rs`) in the **KV store**,
+//! which lives as long as the server process — not as long as one test binary
+//! run. When every test hit the same bare `/etag_test.php`, all six shared one
+//! cache entry, which made this suite both:
+//!
+//! - **order-dependent** — with `--test-threads=4` the six tests interleave
+//!   arbitrarily on one key, so what a test observes depends on which sibling
+//!   touched the entry last; and
+//! - **history-dependent** — `php_etag_different_query_strings_independent`
+//!   asserts that `?v=2` is *not* cached, but its own previous run left exactly
+//!   that entry behind. Against a server that outlives one suite run it fails
+//!   from the second run onward (measured: 39/40 runs against a warm server;
+//!   0/40 against a fresh one).
+//!
+//! The fix is isolation, not serialization: [`etag_url`] gives each test a
+//! query string unique to that test *and* to this process, so each test owns a
+//! private cache key that no sibling and no earlier run can reach. The PHP
+//! fixture ignores the query string, so the `ETag` value is unchanged.
+
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use ephpm_e2e::required_env;
 
+/// Identifier unique to this test-binary process.
+///
+/// Combines the pid with the wall-clock nanosecond it was first read, so two
+/// runs against the same long-lived server cannot collide even if the OS
+/// recycles the pid.
+fn run_id() -> &'static str {
+    static RUN_ID: OnceLock<String> = OnceLock::new();
+    RUN_ID.get_or_init(|| {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_nanos());
+        format!("{}-{nanos}", std::process::id())
+    })
+}
+
+/// URL of the ETag fixture with a cache key private to `case`.
+///
+/// `case` names the test; the run id makes the key unique per process. See the
+/// module docs for why this matters.
+fn etag_url(case: &str) -> String {
+    let base_url = required_env("EPHPM_URL");
+    format!("{base_url}/etag_test.php?case={case}.{}", run_id())
+}
+
 #[tokio::test]
 async fn php_etag_first_request_returns_200_with_etag() {
-    let base_url = required_env("EPHPM_URL");
-    let url = format!("{base_url}/etag_test.php");
+    let url = etag_url("first_request");
 
     let resp = reqwest::get(&url)
         .await
@@ -49,8 +95,7 @@ async fn php_etag_first_request_returns_200_with_etag() {
 
 #[tokio::test]
 async fn php_etag_matching_returns_304() {
-    let base_url = required_env("EPHPM_URL");
-    let url = format!("{base_url}/etag_test.php");
+    let url = etag_url("matching_304");
     let client = reqwest::Client::new();
 
     // First request — get the ETag
@@ -92,8 +137,7 @@ async fn php_etag_matching_returns_304() {
 
 #[tokio::test]
 async fn php_etag_mismatched_returns_200() {
-    let base_url = required_env("EPHPM_URL");
-    let url = format!("{base_url}/etag_test.php");
+    let url = etag_url("mismatched");
     let client = reqwest::Client::new();
 
     // Prime the cache
@@ -123,8 +167,7 @@ async fn php_etag_mismatched_returns_200() {
 
 #[tokio::test]
 async fn php_etag_post_requests_not_cached() {
-    let base_url = required_env("EPHPM_URL");
-    let url = format!("{base_url}/etag_test.php");
+    let url = etag_url("post_not_cached");
     let client = reqwest::Client::new();
 
     // Prime the cache with a GET
@@ -160,8 +203,7 @@ async fn php_etag_post_requests_not_cached() {
 
 #[tokio::test]
 async fn php_etag_no_if_none_match_returns_200() {
-    let base_url = required_env("EPHPM_URL");
-    let url = format!("{base_url}/etag_test.php");
+    let url = etag_url("no_inm");
     let client = reqwest::Client::new();
 
     // Prime the cache
@@ -184,11 +226,12 @@ async fn php_etag_no_if_none_match_returns_200() {
 
 #[tokio::test]
 async fn php_etag_different_query_strings_independent() {
-    let base_url = required_env("EPHPM_URL");
     let client = reqwest::Client::new();
 
-    // GET with ?v=1 — cache the ETag
-    let url_v1 = format!("{base_url}/etag_test.php?v=1");
+    // Two query strings that differ only in `v`, both private to this run —
+    // `v=2` must be an unseen cache key, which is the whole point of the test
+    // and exactly what a shared `?v=2` could not guarantee (see module docs).
+    let url_v1 = format!("{}&v=1", etag_url("query_independent"));
     let resp = client.get(&url_v1).send().await.unwrap();
     assert_eq!(resp.status().as_u16(), 200);
     let etag_v1 = resp
@@ -199,7 +242,7 @@ async fn php_etag_different_query_strings_independent() {
         .to_owned();
 
     // Same ETag against a different query string — must NOT match
-    let url_v2 = format!("{base_url}/etag_test.php?v=2");
+    let url_v2 = format!("{}&v=2", etag_url("query_independent"));
     let resp = client
         .get(&url_v2)
         .header("If-None-Match", &etag_v1)

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -243,11 +243,10 @@ fn suite_needs_fresh_node(name: &str) -> bool {
 /// suite that only ever runs a subprocess. So these run first, before any
 /// port is claimed, with just `EPHPM_CLI_BINARY` in the environment.
 ///
-/// Note this is the ONLY place the binary path is handed to a suite that
-/// doesn't mount middleware; it deliberately uses a distinct variable name
-/// rather than `EPHPM_BINARY`, which `ephpm-e2e`'s self-managed fixtures treat
-/// as an opt-in switch (see `SingleNodeSpawn::env` for why exporting that one
-/// broadly breaks `bare_process_smoke`).
+/// It deliberately uses a distinct variable name rather than `EPHPM_BINARY`,
+/// which `ephpm-e2e`'s self-managed fixtures treat as an opt-in switch to
+/// spawn their own topology (see `SELF_MANAGED_SUITES`). A `cli` suite that
+/// saw `EPHPM_BINARY` would gain that behaviour for free, which it must not.
 const NO_NODE_SUITES: &[&str] = &["cli"];
 
 /// Suites that manage their own ephpm topology entirely — the harness starts
@@ -264,10 +263,21 @@ const NO_NODE_SUITES: &[&str] = &["cli"];
 /// `hrana_listen` config must live in the suite's own template, not the
 /// shared one.
 ///
+/// `bare_process_smoke` is here because it is the only coverage `ephpm-e2e`'s
+/// own [`ClusterFixture`](../../crates/ephpm-e2e/src/lib.rs) has: it spawns a
+/// 2-node cluster from the library fixture and asserts both nodes serve PHP.
+/// That fixture writes its own config template and reserves its own loopback
+/// ports, so — exactly like `turso_cdc` — it needs no node from the harness
+/// and cannot collide with the fixed-port fixtures spawned later. Until #239
+/// it was dormant (nothing set `EPHPM_BINARY`, so it self-skipped and reported
+/// `ok`) *and* broken (it derived its docroot from `CARGO_MANIFEST_DIR`, which
+/// is xtask's under this harness). `EPHPM_DOCROOT` below fixes the second half.
+///
 /// NOTE: `EPHPM_BINARY` goes to exactly these suites and the `middleware`
-/// node — see the warning in [`SingleNodeSpawn::env`] about why it must not
-/// be exported globally (`bare_process_smoke` wakes up and fails).
-const SELF_MANAGED_SUITES: &[&str] = &["turso_cdc"];
+/// node — see the note in [`SingleNodeSpawn::env`]. It stays scoped rather
+/// than global because it is an opt-in switch for `ephpm-e2e`'s self-managed
+/// fixtures, and a suite that gets it starts spawning real processes.
+const SELF_MANAGED_SUITES: &[&str] = &["turso_cdc", "bare_process_smoke"];
 
 /// Test suites that must be excluded from bare-process runs entirely.
 ///
@@ -450,8 +460,15 @@ pub fn run(args: &[String]) -> ExitCode {
             "==> Running {} self-managed suite(s), each spawning its own ephpm topology...",
             self_managed_suites.len()
         );
+        // `EPHPM_DOCROOT` is the harness-supplied document root for suites
+        // that spawn their own nodes. It exists because a pre-built test
+        // binary exec'd from here inherits *xtask's* `CARGO_MANIFEST_DIR`, so
+        // a suite cannot derive the repo's `tests/docroot` for itself (#239).
+        // `turso_cdc` ignores it and builds a throwaway docroot in its own
+        // tempdir; `bare_process_smoke` serves this one.
         let env = vec![
             ("EPHPM_BINARY".to_string(), ephpm_bin.to_string_lossy().into_owned()),
+            ("EPHPM_DOCROOT".to_string(), docroot.to_string_lossy().into_owned()),
             ("EXPECTED_PHP_VERSION".to_string(), php_version.clone()),
         ];
         for (name, path) in &self_managed_suites {
@@ -1675,14 +1692,13 @@ impl SingleNodeSpawn {
         //
         // Do NOT hoist `EPHPM_BINARY` out of this branch and set it for every
         // suite. `ephpm-e2e`'s self-managed fixtures treat it as an opt-in
-        // switch -- `bare_process_smoke` reads it and, when present, spawns its
-        // own 2-node cluster. Exporting it globally woke that suite up for the
-        // first time ever, and it failed immediately: it derives its docroot
-        // from `CARGO_MANIFEST_DIR`, which under `cargo xtask e2e` is *xtask's*
-        // manifest dir (the harness execs pre-built test binaries, which
-        // inherit xtask's environment), so it looked for `xtask/tests/docroot`.
-        // That suite is dormant *and* broken under this harness; un-dormanting
-        // it is separate work.
+        // switch -- a suite that sees it starts spawning real ephpm processes.
+        // `bare_process_smoke` is the one that does; since #239 it gets the
+        // variable deliberately, via SELF_MANAGED_SUITES, together with the
+        // `EPHPM_DOCROOT` it needs (it cannot derive the docroot itself --
+        // pre-built test binaries inherit *xtask's* `CARGO_MANIFEST_DIR`).
+        // Setting `EPHPM_BINARY` globally would hand that switch to every
+        // suite instead, including ones that share this node.
         if let Some(lib) = &self.middleware_lib {
             env.push(("EPHPM_BINARY".to_string(), self.binary.to_string_lossy().into_owned()));
             env.push(("EPHPM_MIDDLEWARE_LIB".to_string(), lib.to_string_lossy().into_owned()));


### PR DESCRIPTION
Fixes #239. Fixes #246.

Both issues were reproduced on current `main` before any change, and both fixes are proven by re-running — for the flake, repeatedly.

## #246 — `etag_cache` flake

**It is not a request/response asynchrony race.** The ETag is stored synchronously, before the response is returned (`router.rs`, post-store block), so "the write hasn't landed yet" was never possible.

The real defect is **shared cache-key state**. All six tests hit one bare `/etag_test.php`, and the server keys its PHP ETag cache by `{method}:{path}?{query}` in the **KV store — which outlives a test-binary run**. That made the suite:

- **order-dependent** — six tests interleaving on one key at `--test-threads=4`; and
- **history-dependent** — `php_etag_different_query_strings_independent` asserts `?v=2` is *not* cached, but its own previous run left exactly that entry behind.

Measured on a single long-lived node, `--test-threads=4`:

| fixture | result |
|---|---|
| one long-lived server, repeated suite runs | **39 / 40 runs failed** |
| fresh server per run (what CI does) | **0 / 100 failed** |

Failure text, deterministic from run 2 onward:

```
php_etag_different_query_strings_independent ... FAILED
assertion `left == right` failed: ETag from ?v=1 must not match cache for ?v=2, got 304 Not Modified
  left: 304
 right: 200
```

**Fix — isolation, not suppression.** Each test derives a query string unique to that test *and* to the process (pid + nanos), so each owns a private cache key that no sibling and no earlier run can reach. `--test-threads` stays at **4**; no sleeps, no retries, no serialization.

**Proof:** same warm server, same reproducer: **39/40 failures → 0/60**, plus 0/40 and 0/25 on later re-runs, and 0/100 fresh-node.

## #239 — `bare_process_smoke` dormant AND broken

The issue lists two bugs. There were **three** — the third only became visible once the suite ran for the first time.

1. **Dormant.** Nothing set `EPHPM_BINARY`, so it self-skipped and reported `ok`. Now in `SELF_MANAGED_SUITES` — the same contract `turso_cdc` runs under (harness spawns no node, hands over the binary path). The skip remains only for a bare `cargo test` with no release build, and now prints a loud marker naming the wiring that must have regressed.
2. **Wrong docroot.** It derived one from `CARGO_MANIFEST_DIR`, which under the harness is **xtask's** manifest dir (pre-built test binaries inherit xtask's environment). xtask now exports `EPHPM_DOCROOT`; the fallback for a direct `cargo test` walks up from the e2e crate rather than assuming a `tests/docroot` beside it.
3. **`ClusterFixture` could not start a cluster at all** — which is precisely why nobody noticed it had zero coverage. It reserved 4 TCP ports per node, but a node claims a **fifth, derived** port: the cluster channel binds `gossip + 2` (`cluster_channel.rs`). Ephemeral ports are handed out consecutively, so node 0's channel landed on node 1's HTTP port:

   ```
   INFO cluster_channel: listener bound  listen_addr=127.0.0.1:21204   <- node 0, gossip 21202 + 2
   error: failed to bind to 127.0.0.1:21204 ... (os error 10048)       <- node 1's HTTP port
   ```

   Gossip is also **UDP**, and a TCP probe says nothing about a UDP port — that surfaced as `WSAEACCES` against a WinNAT-excluded range.

   Reservation now probes gossip over **UDP**, probes the derived channel port over **TCP**, claims the whole `gossip..gossip+2` window, and holds every probe socket until the plan is settled (releasing one early lets the kernel hand it straight back).

Two supporting changes:

- **Health budget 20s → 90s.** Two cold ephpm processes take ~18–25s to first `200` (a ~120 MB binary to page in plus PHP init), so the old 20s sat *inside* that spread and a healthy-but-slow node read as a failure. This is a deadline, not a sleep: a healthy node returns immediately, and `wait_for_health` still returns the moment the child exits — which is how a bind clash reports, so this cannot mask bug 3.
- **Health failures inline the child's stderr.** The tempdir is deleted as the error unwinds, so a path in the message would name a file the reader can never open. This is what turned "never healthy" into the one-line bind diagnosis above.

**Proof:** 0/25 and 0/8 repeated runs.

## Shared node template

**Not touched.** Both suites are self-managed and own their fixtures, per the #288/#295 lesson. The only harness changes are: `bare_process_smoke` added to `SELF_MANAGED_SUITES`, and `EPHPM_DOCROOT` added to the env handed to *self-managed suites only* (`turso_cdc` ignores it — it builds a throwaway docroot in its own tempdir). No shared-node config, no fixed-port fixture, and no other suite's environment changes.

## Cargo.lock

Regenerated. `tokio-tungstenite` has been declared in `crates/ephpm-e2e/Cargo.toml` since the websockets suite landed but was never committed to the lockfile, so every `cargo xtask e2e` dirtied the tree.

## Checks

- `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- `cargo clippy` on the touched e2e targets (`--lib --test etag_cache --test bare_process_smoke`) — clean
- `cargo +nightly fmt --all -- --check` — clean

`ephpm-e2e` is workspace-excluded, so it has never been covered by CI clippy/fmt and carries pervasive pre-existing drift in files this PR does not touch (`sqlite`, `security_p0`, `worker_mode`, …). Deliberately not reformatted here — that is its own cleanup.

## Out of scope, worth separate issues

- **`cargo xtask e2e` cannot run on Windows.** The harness canonicalizes the docroot, and `Path::canonicalize()` on Windows returns a `\\?\` verbatim path, which PHP's `open_basedir` does not recognise — every script 500s with "not within the allowed path(s)". Confirmed pre-existing and not specific to these suites: `cargo xtask e2e --tests basic` fails identically. Harmless in CI (Linux `canonicalize()` returns a plain path).
- **The PHP ETag cache key has no site component** (`etag:GET:/path`), so on a multi-tenant node two vhosts share one entry. Not touched here — flagging it because it is a tenancy-isolation question, not a test one.
