### PR TITLE
fix(tls): one rustls crypto provider — converge on aws-lc-rs (#241)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3748,6 +3748,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4045,7 +4046,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
@@ -4238,7 +4238,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,38 @@ brotli = "7"
 zstd = "0.13"
 ipnet = "2"
 tracing-appender = "0.2"
-rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+# ONE rustls crypto provider for the whole tree: aws-lc-rs (issue #241).
+#
+# rustls only auto-selects a provider when EXACTLY ONE of its `ring` /
+# `aws_lc_rs` features is enabled; with both on, `from_crate_features()`
+# returns `None` and every bare `ServerConfig::builder()` /
+# `ClientConfig::builder()` panics at runtime with "Could not automatically
+# determine the process-level CryptoProvider". That is what broke static
+# `[server.tls]` startup in every release from v0.1.0 to v0.6.1 (#243).
+#
+# aws-lc-rs rather than ring, because ring cannot be the sink:
+#   - `ephpm-db` needs RSA-OAEP for the caching_sha2_password full-auth
+#     handshake and ring has no public-key *encryption* at all (see the
+#     aws-lc-rs pin below);
+#   - `rustls-acme` + `rcgen` (ACME/TLS-ALPN-01) and `pgwire` (via litewire)
+#     enable aws-lc-rs unconditionally.
+# So aws-lc-rs is compiled in no matter what we choose, and picking ring
+# would leave BOTH providers linked. Choosing aws-lc-rs costs no new build
+# toolchain either: it is already built in every release lane (Linux gnu,
+# macOS, Windows MSVC) as a direct dependency of ephpm-db.
+#
+# Cargo features are additive and cannot be turned off from here, so the
+# only way to keep this true is to keep every rustls consumer off `ring`.
+# The guard is `crates/ephpm-server/tests/tls_single_crypto_provider.rs`,
+# which fails the moment anything re-introduces `rustls/ring`.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
 tokio-rustls = "0.26"
 rustls-pemfile = "2"
-# HTTP/3 (QUIC). The rustls-ring feature keeps QUIC on the SAME rustls
-# crypto provider the TCP TLS path installs as the process default (see
-# the rustls pin above) - mixing providers is a runtime panic risk.
-quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring", "log"] }
+# HTTP/3 (QUIC). `rustls-aws-lc-rs` keeps QUIC on the SAME rustls crypto
+# provider the TCP TLS path uses (see the rustls pin above) - mixing
+# providers is a runtime panic risk. It also keeps quinn-proto's own
+# packet-protection crypto on aws-lc-rs instead of dragging `ring` back in.
+quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs", "log"] }
 h3 = "0.0.8"
 h3-quinn = "0.0.10"
 rustls-acme = { version = "0.15", default-features = false, features = ["tokio", "aws-lc-rs", "tls12", "webpki-roots"] }
@@ -78,6 +103,11 @@ md5 = "0.8"
 # rustls-acme and rcgen, so this pulls in nothing new — and it lets us avoid the
 # pure-Rust `rsa` crate, which still carries the unpatched RUSTSEC-2023-0071
 # (Marvin timing sidechannel).
+#
+# This is also why `ring` cannot be the workspace's single crypto provider:
+# ring exposes RSA *signing* and verification but no public-key encryption,
+# so there is no ring equivalent of `aws_lc_rs::rsa::OaepPublicEncryptingKey`.
+# See the rustls pin above (issue #241).
 aws-lc-rs = "1.16"
 base64ct = { version = "1", features = ["alloc"] }
 redis = { version = "0.27", default-features = false, features = ["tokio-comp"] }

--- a/crates/ephpm-server/src/http3.rs
+++ b/crates/ephpm-server/src/http3.rs
@@ -642,11 +642,13 @@ mod tests {
 
     /// The single-crypto-provider invariant, asserted rather than assumed.
     ///
-    /// `ring` and `aws-lc-rs` are both compiled into this binary, so "which
-    /// provider does TLS use?" has a real answer that could differ per
-    /// transport. `tls::build_server_config` hands out one cached `Arc`, so
-    /// pointer identity is a genuine check that HTTP/3 and HTTPS-over-TCP got
-    /// the *same* provider instance — not merely two equivalent ones.
+    /// Since #241 the tree carries a single rustls provider (aws-lc-rs), so
+    /// the two transports can no longer disagree by crate feature. They could
+    /// still disagree by *code* — one of them naming a provider directly
+    /// instead of going through `tls::build_server_config`. That function
+    /// hands out one cached `Arc`, so pointer identity is a genuine check
+    /// that HTTP/3 and HTTPS-over-TCP got the *same* provider instance, not
+    /// merely two equivalent ones.
     #[test]
     fn http3_and_tcp_tls_share_one_crypto_provider() {
         crate::tls::tests_support::init_crypto();

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -79,6 +79,15 @@ pub const OTEL_TRACE_TARGET: &str = "ephpm_otel";
 ///
 /// Returns an error if the listen address is invalid or binding fails.
 pub async fn serve(config: Config, dev_mode: bool) -> anyhow::Result<()> {
+    // Install the process-wide rustls crypto provider before anything can
+    // build a TLS config. ePHPm's own listeners name the provider explicitly
+    // and do not need this, but third-party rustls users in the tree
+    // (hyper-rustls behind the Prometheus push gateway, for one) call the
+    // bare `builder()` and consult the process default. Installing it here,
+    // deliberately and once, is what keeps every TLS config in the process on
+    // the same provider. Idempotent — see `tls::install_default_crypto_provider`.
+    tls::install_default_crypto_provider();
+
     // Install Prometheus recorder if metrics are enabled.
     let metrics_handle = if config.server.metrics.enabled {
         Some(metrics::init().context("failed to initialize metrics")?)

--- a/crates/ephpm-server/src/tls.rs
+++ b/crates/ephpm-server/src/tls.rs
@@ -62,23 +62,53 @@ pub fn build_server_config(
     Ok(config)
 }
 
-/// The rustls crypto provider this server uses.
+/// Install this process's rustls crypto provider, exactly once.
 ///
-/// **This must be named explicitly, and `ServerConfig::builder()` must never
-/// be called.** Both `ring` and `aws-lc-rs` end up compiled in: the workspace
-/// pins `rustls` to `ring`, while `rustls-acme`, `rcgen` and `hyper-rustls`
-/// (via `metrics-exporter-prometheus`) enable `aws-lc-rs`, and Cargo unions
-/// features. With both features on, rustls' `from_crate_features()` returns
-/// `None` — it does not pick one — so the bare builder panics at runtime:
+/// Call this once at startup, before anything can build a rustls config.
+/// It is idempotent and never panics: `install_default` returns `Err` when a
+/// provider is already installed, and that is a normal outcome (a test
+/// harness, an embedding host, or a second call), not a failure.
+///
+/// ePHPm's own configs do not depend on this — they name the provider
+/// explicitly through `crypto_provider()`. It exists for the *third-party*
+/// rustls users in the tree that call the bare `builder()` and therefore
+/// consult the process default: `hyper-rustls` behind
+/// `metrics-exporter-prometheus`, and `reqwest` in the integration tests.
+/// Installing deliberately means those all land on the same provider ePHPm's
+/// listeners use, instead of whichever one a crate feature happened to pick.
+pub fn install_default_crypto_provider() {
+    // `install_default` consumes a `CryptoProvider`; clone out of the shared
+    // `Arc` so the installed default and `crypto_provider()` are the same
+    // configuration.
+    let _ = crypto_provider().as_ref().clone().install_default();
+}
+
+/// The rustls crypto provider this server uses: **aws-lc-rs**.
+///
+/// The provider is named explicitly here and `ServerConfig::builder()` is
+/// never called. Why both halves of that matter:
+///
+/// rustls picks a provider from its crate features only when *exactly one*
+/// of `ring` / `aws_lc_rs` is enabled. Cargo unions features across the whole
+/// graph, so for a long time this binary had both on; in that state
+/// `from_crate_features()` returns `None` rather than choosing, and the bare
+/// builder panics at runtime:
 ///
 /// > Could not automatically determine the process-level CryptoProvider from
 /// > Rustls crate features.
 ///
-/// That is not hypothetical: it made every `[server.tls]` static-certificate
-/// startup abort with exit 101. See `tests/tls_provider_independence.rs`.
+/// That is not hypothetical — it made every `[server.tls]` static-certificate
+/// startup abort with exit 101, in every release from v0.1.0 through v0.6.1,
+/// while the ACME path kept working because `rustls-acme` names its provider.
+/// #243 fixed the call site; **#241 removed the ambiguity itself** by
+/// converging the tree on aws-lc-rs (see the `rustls` pin in the workspace
+/// `Cargo.toml` for why aws-lc-rs and not ring).
 ///
-/// `ring` is chosen to match the workspace `rustls` pin. Consolidating the
-/// stack on a single provider is tracked in issue #241.
+/// Naming the provider is kept anyway, as defence in depth: it is a one-line
+/// dependency change to re-introduce `rustls/ring`, and if that happens the
+/// explicit name is the difference between a lint-visible duplicate and a
+/// startup panic. `tests/tls_single_crypto_provider.rs` guards the feature
+/// state; `tests/tls_provider_independence.rs` guards the call sites.
 ///
 /// The `OnceLock` means every config built here shares one `Arc`, so "the
 /// whole server uses one provider" is checkable by pointer identity — which
@@ -87,7 +117,7 @@ pub fn build_server_config(
 fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     static PROVIDER: std::sync::OnceLock<Arc<rustls::crypto::CryptoProvider>> =
         std::sync::OnceLock::new();
-    Arc::clone(PROVIDER.get_or_init(|| Arc::new(rustls::crypto::ring::default_provider())))
+    Arc::clone(PROVIDER.get_or_init(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider())))
 }
 
 /// Load PEM-encoded certificates from a file.
@@ -132,14 +162,12 @@ pub(crate) mod tests_support {
 
     /// Install the process-wide rustls crypto provider exactly once.
     ///
-    /// Both `ring` and `aws-lc-rs` are compiled into this binary (the TLS pin
-    /// selects ring; `rustls-acme` pulls aws-lc-rs), so rustls refuses to pick
-    /// one implicitly in some configurations. Tests pin it explicitly and
-    /// ignore an `Err` — another test module may have won the race.
+    /// Goes through the same entry point production startup uses, so a test
+    /// can never install a *different* provider than the server would. The
+    /// `Once` is belt-and-braces: `install_default_crypto_provider` is itself
+    /// idempotent.
     pub(crate) fn init_crypto() {
-        CRYPTO_INIT.call_once(|| {
-            let _ = rustls::crypto::ring::default_provider().install_default();
-        });
+        CRYPTO_INIT.call_once(super::install_default_crypto_provider);
     }
 
     /// Generate a self-signed RSA cert+key pair using rcgen.

--- a/crates/ephpm-server/tests/http3_e2e.rs
+++ b/crates/ephpm-server/tests/http3_e2e.rs
@@ -73,13 +73,12 @@ fn issue_certs() -> TestCa {
     }
 }
 
-/// Install the process-wide rustls provider. Both `ring` and `aws-lc-rs` are
-/// linked into this binary, so pin one rather than letting rustls guess.
+/// Install the process-wide rustls provider through the same entry point the
+/// server uses, so the QUIC client in these tests cannot end up on a
+/// different provider than the endpoint it is dialling.
 fn init_crypto() {
     static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
+    ONCE.call_once(ephpm_server::tls::install_default_crypto_provider);
 }
 
 fn test_config(document_root: &std::path::Path, max_body_size: u64) -> Config {

--- a/crates/ephpm-server/tests/tls_provider_independence.rs
+++ b/crates/ephpm-server/tests/tls_provider_independence.rs
@@ -3,20 +3,19 @@
 //! **This file must live in its own integration-test binary and must never
 //! call `CryptoProvider::install_default()`.** That is the entire point.
 //!
-//! Both `ring` and `aws-lc-rs` end up compiled in — the workspace pins
-//! `rustls` to `ring`, while `rustls-acme`, `rcgen` and `hyper-rustls` (via
-//! `metrics-exporter-prometheus`) enable `aws-lc-rs`, and Cargo unions
-//! features. In that configuration rustls' `from_crate_features()` returns
-//! `None` rather than picking one, so `rustls::ServerConfig::builder()`
-//! panics unless something already installed a provider:
+//! Historically both `ring` and `aws-lc-rs` were compiled in, because Cargo
+//! unions features across the graph. In that state rustls'
+//! `from_crate_features()` returns `None` rather than picking one, so
+//! `rustls::ServerConfig::builder()` panics unless something already
+//! installed a provider:
 //!
 //! > Could not automatically determine the process-level CryptoProvider from
 //! > Rustls crate features.
 //!
-//! `crates/ephpm-server/src/tls.rs` did exactly that, so every server
-//! configured with a static `[server.tls]` cert/key aborted at startup with
-//! exit 101 — reproduced on v0.6.1 and on main. It survived review and CI
-//! because:
+//! `crates/ephpm-server/src/tls.rs` called exactly that builder, so every
+//! server configured with a static `[server.tls]` cert/key aborted at startup
+//! with exit 101 — reproduced on v0.6.1 and on main. It survived review and
+//! CI because:
 //!
 //! - `rustls-acme` always calls `builder_with_provider`, so the ACME path was
 //!   unaffected and kept working; and
@@ -27,7 +26,18 @@
 //! `install_default()` call anywhere in this binary, or folding these tests
 //! into one that has such a call, silently disarms them.
 //!
-//! Provider consolidation is tracked in issue #241.
+//! # Relationship to `tls_single_crypto_provider.rs`
+//!
+//! #241 removed the ambiguity at its source: the tree now compiles exactly
+//! one provider (aws-lc-rs), and `tests/tls_single_crypto_provider.rs` fails
+//! if that ever stops being true. So these tests are no longer the *primary*
+//! guard — with one provider, even a bare `builder()` would pass here.
+//!
+//! They are kept because the two failures are independent. Re-introducing
+//! `rustls/ring` is a one-line dependency change that any PR could make, and
+//! on the day it happens these tests are what decide whether static-cert
+//! HTTPS still starts. Keeping the call sites provider-independent is what
+//! makes that a duplicate-dependency nuisance instead of a startup panic.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/ephpm-server/tests/tls_single_crypto_provider.rs
+++ b/crates/ephpm-server/tests/tls_single_crypto_provider.rs
@@ -1,0 +1,84 @@
+//! Exactly one rustls crypto provider may be compiled into this tree (#241).
+//!
+//! **This file must contain exactly one test, and it must live in its own
+//! integration-test binary.** Both constraints are load-bearing — see
+//! "Why it is alone in here" below.
+//!
+//! # What is being pinned
+//!
+//! `rustls` selects a provider from its crate features via
+//! `CryptoProvider::from_crate_features()`, which returns `Some` only when
+//! *exactly one* of `ring` / `aws_lc_rs` is enabled. With both on it returns
+//! `None` — it does not pick a winner — and every bare
+//! `ServerConfig::builder()` / `ClientConfig::builder()` in the process
+//! panics:
+//!
+//! > Could not automatically determine the process-level CryptoProvider from
+//! > Rustls crate features.
+//!
+//! Cargo unions features across the entire graph, so a single new dependency
+//! (or one feature flip on an existing one) is enough to put the tree back in
+//! that state. When it happened before, it made static-certificate
+//! `[server.tls]` startup abort with exit 101 in every release from v0.1.0
+//! through v0.6.1, and nothing caught it for thirteen tags.
+//!
+//! This test converts that from a runtime surprise into a test failure.
+//!
+//! # Why it is alone in here
+//!
+//! `ServerConfig::builder()` does not merely *read* the crate-feature
+//! provider — on success it **installs it as the process default**. Any test
+//! that runs afterwards in the same binary then sees a provider already
+//! installed, which is exactly the state
+//! `tests/tls_provider_independence.rs` exists to rule out. Adding a second
+//! test here, or folding this one into another file, silently disarms
+//! whatever shares the binary with it.
+//!
+//! # If this test fails
+//!
+//! Do not "fix" it by installing a provider first — that hides the problem
+//! rather than reporting it. Find the new `rustls/ring` edge and remove it:
+//!
+//! ```text
+//! cargo tree -i rustls@0.23 -e features | grep -n 'rustls feature "ring"' -A6
+//! ```
+//!
+//! As of #241 the three edges that had to be steered were the workspace
+//! `rustls` pin, the workspace `quinn` pin (`rustls-ring` →
+//! `rustls-aws-lc-rs`), and `reqwest`'s `rustls-tls` dev-dependency feature
+//! on `crates/ephpm`. `ring` still appears in `Cargo.lock` behind
+//! `opensrv-mysql 0.7.0` → `tokio-rustls 0.25` → `rustls 0.22`, which is a
+//! separate stack ePHPm cannot reach from here (litewire owns that edge, and
+//! opensrv-mysql has had no release since 2024-02).
+
+use rustls::crypto::CryptoProvider;
+
+/// `from_crate_features()` must be able to pick a provider on its own.
+///
+/// Asserted through the public builder rather than the (private)
+/// `from_crate_features` so this tests the real path a third-party crate
+/// takes.
+#[test]
+fn exactly_one_crypto_provider_is_compiled_in() {
+    assert!(
+        CryptoProvider::get_default().is_none(),
+        "nothing in this test binary may install a provider before this \
+         assertion runs — see the module docs; the check below is meaningless \
+         once a process default exists"
+    );
+
+    // Panics with "Could not automatically determine the process-level
+    // CryptoProvider" if both `ring` and `aws_lc_rs` are enabled on rustls.
+    let _ = rustls::ServerConfig::builder();
+
+    // The provider it settled on is the one the rest of the tree names
+    // explicitly. If these ever diverge, ePHPm's listeners and its
+    // third-party rustls users (hyper-rustls, reqwest) are on different
+    // crypto — which is the failure mode #241 set out to make impossible.
+    let installed = CryptoProvider::get_default().expect("the builder installs what it selected");
+    let expected = rustls::crypto::aws_lc_rs::default_provider();
+    assert_eq!(
+        installed.cipher_suites, expected.cipher_suites,
+        "the crate-feature provider must be aws-lc-rs (see the workspace rustls pin)"
+    );
+}

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -69,7 +69,18 @@ windows-sys = { version = "0.59", features = [
 ] }
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# `rustls-tls-webpki-roots-no-provider`, NOT `rustls-tls`: the latter implies
+# reqwest's `__rustls-ring`, which enables `rustls/ring` and would put a second
+# crypto provider back into the graph (issue #241). The `-no-provider` variant
+# builds its `ClientConfig` from `CryptoProvider::get_default()` instead, so
+# these tests exercise the outbound TLS client on the *same* provider the
+# server uses — but they must call
+# `ephpm_server::tls::install_default_crypto_provider()` first, because reqwest
+# panics with "No provider set" if none is installed.
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "rustls-tls-webpki-roots-no-provider",
+] }
 serde_json = "1"
 tokio = { workspace = true, features = ["macros", "rt"] }
 

--- a/crates/ephpm/tests/kv_sapi_integration.rs
+++ b/crates/ephpm/tests/kv_sapi_integration.rs
@@ -26,8 +26,21 @@ fn wait_for_port(port: u16, timeout_secs: u64) -> bool {
     }
 }
 
+/// Install the rustls crypto provider reqwest will look for.
+///
+/// The dev-dependency uses `rustls-tls-webpki-roots-no-provider` so it cannot
+/// drag a second crypto provider into the graph (#241); the cost is that
+/// reqwest panics with "No provider set" unless a process default exists. Go
+/// through the server's own entry point rather than naming a provider here,
+/// so the test client and the server can never disagree.
+fn init_crypto() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(ephpm_server::tls::install_default_crypto_provider);
+}
+
 /// Helper to make HTTP GET request and parse JSON response.
 async fn get_json(url: &str) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    init_crypto();
     let resp = reqwest::get(url).await?;
     let status = resp.status();
     let body = resp.text().await?;

--- a/crates/ephpm/tests/vhost_routing.rs
+++ b/crates/ephpm/tests/vhost_routing.rs
@@ -123,6 +123,14 @@ impl Drop for ServerGuard {
 /// client because the rest of the test is synchronous and we don't need a
 /// tokio runtime just for three GETs.
 fn get_with_host(url: &str, host: &str) -> (u16, String) {
+    // The reqwest dev-dependency is built with
+    // `rustls-tls-webpki-roots-no-provider` so it cannot pull a second crypto
+    // provider into the graph (#241); in exchange it panics with "No provider
+    // set" unless a process default is installed. Use the server's own entry
+    // point so the client and the server can never disagree on the provider.
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(ephpm_server::tls::install_default_crypto_provider);
+
     let rt =
         tokio::runtime::Builder::new_current_thread().enable_all().build().expect("tokio runtime");
     rt.block_on(async {


### PR DESCRIPTION
Converges the tree on **one rustls crypto provider (aws-lc-rs)** and makes the
process default explicit and non-panicking.

Closes #241.

## The problem

Cargo unions features, so `rustls 0.23` had **both** `ring` and `aws_lc_rs`
enabled. In that state `CryptoProvider::from_crate_features()` returns `None`
rather than picking one, and every bare `ServerConfig::builder()` /
`ClientConfig::builder()` in the process panics:

> Could not automatically determine the process-level CryptoProvider from
> Rustls crate features.

#243 fixed the call site in `tls.rs` — the one that made static-cert
`[server.tls]` startup abort with exit 101 in **every release from v0.1.0
through v0.6.1**. This PR removes the ambiguity itself, so the next crate that
calls the bare builder cannot re-trigger it.

## Dependency map (before)

Three edges enabled `rustls/ring`, and all three were ours:

| Edge | Source |
|---|---|
| `rustls` `features = ["ring", …]` | workspace `Cargo.toml` |
| `quinn` `rustls-ring` | workspace `Cargo.toml` — also put quinn-proto's own packet-protection crypto on ring |
| `reqwest` `rustls-tls` ⇒ `__rustls-ring` | **dev**-dependency of `crates/ephpm` |

Everything else was already on aws-lc-rs: `rustls-acme`, `rcgen`,
`hyper-rustls` (via `metrics-exporter-prometheus`), `tokio-rustls` 0.26
defaults, and `pgwire` (via litewire).

## Why aws-lc-rs and not ring

ring cannot be the sink:

- `ephpm-db` needs **RSA-OAEP** for the `caching_sha2_password` full-auth
  handshake (#236). ring has RSA *signing* but no public-key **encryption** at
  all — there is no ring equivalent of
  `aws_lc_rs::rsa::OaepPublicEncryptingKey`.
- `rustls-acme` + `rcgen` (ACME/TLS-ALPN-01) and `pgwire` enable aws-lc-rs
  unconditionally.

So aws-lc-rs is linked no matter what we choose; picking ring would have left
**both** providers in the binary. Choosing aws-lc-rs also costs **no new build
toolchain** — it is already compiled in every release lane (Linux gnu, macOS,
Windows MSVC) as a direct dependency of `ephpm-db`, so the C/CMake build the
issue worried about is a cost we have been paying since #236. No musl lane
exists (Linux targets `-gnu`).

## Explicit, non-panicking installation

`tls::install_default_crypto_provider()` runs once at the top of `serve()` and
ignores the `Err` that means "already installed".

ePHPm's own configs do not depend on it — they still name the provider through
`builder_with_provider`. It exists for the **third-party** rustls users that
call the bare builder and consult the process default (hyper-rustls behind the
Prometheus push gateway; reqwest in the integration tests), so they cannot land
on a different provider than the listeners. The test helpers and `http3_e2e`
now route through this same function instead of naming a provider themselves.

## What is left, and why it is not ours to fix

`ring` is still in the graph, reachable by exactly one path:

```
ring 0.17.14
├── rustls 0.22.4        <- tokio-rustls 0.25 <- opensrv-mysql 0.7.0 <- litewire-mysql
└── rustls-webpki 0.102.8 <- rustls 0.22.4
```

`opensrv-mysql 0.7.0` is the **latest release** (2024-02-21) and it pins
`tokio-rustls 0.25`. We cannot steer it from here, and we must not:
`default-features = false` would drop its `tls` feature, which compiles out the
`CLIENT_SSL` handshake re-parse and turns litewire's MySQL frontend auth into a
bypass (litewire#32 pins that feature upstream for exactly this reason).

**Lifting it requires a litewire-side change** — either upstream opensrv-mysql
bumps tokio-rustls, or litewire forks/replaces it. I did not touch the litewire
pin. This is already the documented justification for the `rustls-webpki`
0.102.8 advisory ignores in `deny.toml`, which therefore still apply unchanged.

## Verification

Not a lockfile diff — the binary was run.

- **Real HTTPS, static cert.** `ephpm serve` with `[server.tls] cert`/`key`:
  reached `TLS enabled (manual)` → `HTTPS listening`, and
  `curl -sk https://127.0.0.1:19443/index.html` returned **200** with the body
  and `alt-svc: h3=":19443"`. This is the path that panicked for 13 tags.
- **Real outbound TLS.** An ACME staging run completed a genuine TLS handshake
  to Let's Encrypt (`ACME certificate event event=AccountCacheStore`), then got
  a legitimate HTTP 400 about my deliberately-bogus contact address — i.e. the
  outbound client worked and the server rejected the email, not the crypto.
- **QUIC.** `HTTP/3 (QUIC) listening on UDP` binds, and `http3_e2e` (6 tests)
  does a full in-process QUIC handshake on aws-lc-rs.
- **Negative test.** Re-adding `rustls/ring` makes the new guard fail with the
  original panic text, verbatim. Reverted.
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt
  --all -- --check`: clean.
- `cargo test -p ephpm-server`: 379 unit + 35 integration, all pass.
  `cargo test -p ephpm`: pass (`vhost_routing` exercises the re-featured reqwest
  for real).

## Regression guard

`crates/ephpm-server/tests/tls_single_crypto_provider.rs` — a **single-test**
binary that never installs a provider and asserts the bare builder can select
one on its own. Both properties are load-bearing: the builder *installs* what
it selects, so a second test in that file would silently disarm it (and would
disarm `tls_provider_independence.rs` if merged in).

This had to be a runtime assertion. `cargo tree -d` could never have caught the
original bug — `ring` and `aws-lc-rs` are *different crates*, each at a single
version, so a duplicate-version lint sees nothing wrong.

`tls_provider_independence.rs` is kept as defence in depth: re-introducing
`rustls/ring` is a one-line dependency change, and keeping the call sites
provider-independent is what makes that a duplicate-dependency nuisance instead
of a startup panic.

## Notes

- **No binary-size win, and the issue's expectation should be corrected.** Zero
  packages are added or removed (the whole `Cargo.lock` delta is 1 insertion /
  2 deletions inside existing dependency lists). `ring` still compiles for
  rustls 0.22, so the fat-LTO size delta is at best whatever `--gc-sections`
  reclaims from now-unreferenced ring code. The real size and audit-surface win
  is gated on removing the opensrv-mysql rustls 0.22 stack.
- **Adjacent, not fixed here:** under `--features otlp`, `opentelemetry-otlp`
  pulls `reqwest` with **no TLS feature at all**, so an `https://` OTLP endpoint
  cannot work. Pre-existing and out of scope — worth its own issue.
