### PR TITLE
fix(otlp): enable TLS for the OTLP exporter so https:// endpoints work (#370)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,8 +1476,10 @@ dependencies = [
  "opentelemetry_sdk",
  "quinn",
  "rcgen",
+ "reqwest",
  "rustls 0.23.37",
  "rustls-acme",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1495,6 +1497,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "turso",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,20 @@ opentelemetry = { version = "0.31", default-features = false, features = ["trace
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
 tracing-opentelemetry = { version = "0.32", default-features = false }
+# The OTLP exporter's HTTP client, so an `https://` collector endpoint works
+# (without these features reqwest is built with no TLS backend at all and
+# every https:// export fails at connect time).
+#
+# `rustls-tls-manual-roots-no-provider` is the ONLY correct feature here.
+# Every other `rustls-tls-*` feature ALSO enables reqwest's `__rustls-ring`,
+# which links `ring` and reintroduces the multi-provider bug tracked in #241
+# (see `ephpm-server/src/tls.rs::crypto_provider`). "manual roots" +
+# "no provider" means reqwest supplies neither a crypto provider nor a root
+# store; `otlp.rs` hands it a fully-built `rustls::ClientConfig` instead.
+# That is also why the roots are our own dependencies below.
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls-manual-roots-no-provider"] }
+rustls-native-certs = "0.8"
+webpki-roots = "0.26"
 thiserror = "2"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -68,6 +68,13 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
+# The exporter's HTTP client and its trust anchors. We build the
+# `rustls::ClientConfig` ourselves (see src/otlp.rs) so the exporter uses the
+# same crypto provider as the rest of the server; reqwest is therefore
+# compiled with no provider and no root store of its own.
+reqwest = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
+webpki-roots = { workspace = true, optional = true }
 
 # Privilege drop ([server] run_as_user/run_as_group): setgroups/setgid/setuid
 # and getpwnam/getgrnam name resolution live behind libc on Unix. No-op on
@@ -86,6 +93,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
     "dep:tracing-subscriber",
+    "dep:reqwest",
+    "dep:rustls-native-certs",
+    "dep:webpki-roots",
 ]
 
 [dev-dependencies]

--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -23,6 +23,31 @@
 //! tokio runtime: the tracing subscriber (and therefore this layer) is
 //! initialized in `main` *before* the runtime exists, because PHP must be
 //! initialized single-threaded.
+//!
+//! # TLS
+//!
+//! Both `http://` and `https://` endpoints work. Plaintext to a collector on
+//! localhost stays the common, zero-config case — nothing here forces TLS or
+//! changes how an `http://` endpoint behaves.
+//!
+//! The client is built by [`build_http_client`] rather than left to
+//! `opentelemetry-otlp`'s default, for two reasons:
+//!
+//! 1. **Crypto provider.** reqwest is compiled with
+//!    `rustls-tls-manual-roots-no-provider` — the only `rustls-tls-*` feature
+//!    that does not also enable reqwest's `__rustls-ring` and link `ring`
+//!    (issue #241). With no provider feature, reqwest's own TLS path calls
+//!    `CryptoProvider::get_default()` and panics with "No provider set" when
+//!    nothing has installed one — which is exactly the situation here, since
+//!    the exporter is built in `main` before any listener starts. Handing it
+//!    a preconfigured [`rustls::ClientConfig`] built from
+//!    [`crate::tls::crypto_provider`] fixes the ordering *and* guarantees the
+//!    exporter cannot drift onto a different provider than the HTTPS
+//!    listener.
+//! 2. **Root store.** reqwest supplies no roots in this configuration, so we
+//!    choose them explicitly — see [`build_http_client`].
+
+use std::time::Duration;
 
 use anyhow::Context as _;
 use opentelemetry::trace::TracerProvider as _;
@@ -48,6 +73,100 @@ impl Drop for OtlpGuard {
     }
 }
 
+/// The OTLP spec's default export timeout when no env var overrides it
+/// (the spec states it as 10000ms; `opentelemetry-otlp` uses the same value).
+const DEFAULT_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Resolve the export timeout from the standard OTLP env vars.
+///
+/// `opentelemetry-otlp` applies this itself, but only to the client *it*
+/// builds — we supply our own (see [`build_http_client`]), so the same
+/// precedence is reproduced here. Both variables are in milliseconds.
+fn export_timeout() -> Duration {
+    ["OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "OTEL_EXPORTER_OTLP_TIMEOUT"]
+        .iter()
+        .find_map(|var| std::env::var(var).ok()?.parse::<u64>().ok())
+        .map_or(DEFAULT_EXPORT_TIMEOUT, Duration::from_millis)
+}
+
+/// Build the exporter's HTTP client, with TLS wired up so that an `https://`
+/// collector endpoint works.
+///
+/// `http://` endpoints are unaffected: reqwest only consults this TLS
+/// configuration for `https://` URLs, so a plaintext collector on localhost
+/// behaves exactly as it did before TLS was available.
+///
+/// # Trust anchors
+///
+/// The root store is the **union of the OS trust store and the bundled
+/// Mozilla set**:
+///
+/// - **OS trust store** (`rustls-native-certs`) is what makes the realistic
+///   HTTPS case work at all. A collector reached over TLS is usually an
+///   internal one behind a corporate or private CA, and that CA exists *only*
+///   in the platform trust store — a bundled-roots-only build could never
+///   talk to it. `rustls-native-certs` also honours `SSL_CERT_FILE` /
+///   `SSL_CERT_DIR`, which is why no ePHPm-specific trust-store setting is
+///   introduced here: operators already have a standard way to point at a
+///   private bundle. A `[server.diagnostics]` knob (a CA path, or pinning)
+///   is the natural place to go if per-endpoint control is ever wanted.
+/// - **Bundled Mozilla set** (`webpki-roots`) is added as a fallback so a
+///   publicly trusted SaaS collector still works from a `scratch`/distroless
+///   image that ships no CA bundle at all — a real deployment shape for a
+///   single-binary server, and one where the OS store is simply empty.
+///
+/// Neither crate is new to the build; both are already in the dependency
+/// graph, so this adds no packages and no second TLS stack.
+///
+/// The returned `String` describes the trust store for the caller to log —
+/// like [`init_layer`], this runs before the tracing subscriber is installed
+/// and so cannot log anything itself.
+///
+/// # Errors
+///
+/// Returns an error when the crypto provider rejects the default TLS
+/// versions, or when the client cannot be constructed.
+fn build_http_client() -> anyhow::Result<(reqwest::blocking::Client, String)> {
+    let mut roots = rustls::RootCertStore::empty();
+
+    // `errors` here are per-certificate parse/read failures on an otherwise
+    // usable store; an empty store is the case actually worth reporting, and
+    // that shows up in the description below.
+    let native = rustls_native_certs::load_native_certs();
+    let (native_added, _native_ignored) = roots.add_parsable_certificates(native.certs);
+
+    let bundled = webpki_roots::TLS_SERVER_ROOTS.len();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    // Naming the provider explicitly is mandatory, not stylistic — see the
+    // module docs and `crate::tls::crypto_provider`.
+    let tls = rustls::ClientConfig::builder_with_provider(crate::tls::crypto_provider())
+        .with_safe_default_protocol_versions()
+        .context("crypto provider does not support the default TLS versions")?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    let timeout = export_timeout();
+
+    // `reqwest::blocking` panics if constructed inside a tokio runtime.
+    // `init_layer` runs before the runtime exists, but building on a plain
+    // thread keeps that a local guarantee rather than a caller obligation —
+    // it is also what the exporter's own default client does.
+    let client = std::thread::spawn(move || {
+        reqwest::blocking::Client::builder().timeout(timeout).use_preconfigured_tls(tls).build()
+    })
+    .join()
+    .map_err(|_| anyhow::anyhow!("the OTLP HTTP client builder thread panicked"))?
+    .context("failed to build the OTLP exporter's HTTP client")?;
+
+    let description = format!(
+        "TLS trust anchors: {native_added} from the OS store + {bundled} bundled; \
+         timeout {}ms",
+        timeout.as_millis()
+    );
+    Ok((client, description))
+}
+
 /// Resolve the endpoint and build the OTLP tracing layer.
 ///
 /// `config_endpoint` is `[server.diagnostics] otlp_endpoint`. The standard
@@ -66,7 +185,8 @@ impl Drop for OtlpGuard {
 ///
 /// # Errors
 ///
-/// Returns an error when the exporter cannot be built (malformed endpoint).
+/// Returns an error when the exporter cannot be built (malformed endpoint),
+/// or when its HTTP client cannot be built (see [`build_http_client`]).
 pub fn init_layer<S>(
     config_endpoint: Option<&str>,
 ) -> anyhow::Result<Option<(impl Layer<S>, OtlpGuard, String)>>
@@ -77,8 +197,18 @@ where
         .iter()
         .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()));
 
+    // Resolve the endpoint before building the client: when nothing is
+    // configured we return early and never touch the OS trust store.
+    if env_endpoint.is_none() && config_endpoint.is_none() {
+        return Ok(None);
+    }
+
+    use opentelemetry_otlp::WithHttpConfig as _;
+    let (http_client, tls_description) = build_http_client()?;
+
     let builder = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
+        .with_http_client(http_client)
         .with_protocol(opentelemetry_otlp::Protocol::HttpBinary);
 
     let (builder, endpoint_source) = if let Some(ref env_ep) = env_endpoint {
@@ -95,6 +225,8 @@ where
         };
         (builder.with_endpoint(&url), format!("config: {url}"))
     } else {
+        // Unreachable: the guard above already returned for "no endpoint
+        // configured anywhere". Kept so the arm structure stays total.
         return Ok(None);
     };
 
@@ -125,7 +257,8 @@ where
             .with_target(crate::OTEL_TRACE_TARGET, tracing::level_filters::LevelFilter::DEBUG),
     );
 
-    let description = format!("{endpoint_source} (service.name = {service_name})");
+    let description =
+        format!("{endpoint_source} (service.name = {service_name}; {tls_description})");
     Ok(Some((layer, OtlpGuard { provider }, description)))
 }
 
@@ -163,5 +296,70 @@ pub(crate) fn set_span_parent_from_headers(span: &tracing::Span, headers: &hyper
         // A span the subscriber never enabled (or a malformed header) is not
         // worth more than a debug line on a per-request path.
         tracing::debug!(error = %e, "failed to parent request span to incoming traceparent");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read as _, Write as _};
+
+    use super::*;
+
+    /// The client must speak plaintext exactly as before TLS was added.
+    ///
+    /// Enabling a reqwest TLS feature is the kind of change that can quietly
+    /// alter the default scheme handling, and `http://` to a collector on
+    /// localhost is the dominant real-world configuration — so it gets an
+    /// offline test rather than being assumed.
+    #[test]
+    fn plain_http_endpoint_still_works() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+
+        let server = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).expect("read request");
+            sock.write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n")
+                .expect("write response");
+        });
+
+        let (client, description) = build_http_client().expect("build client");
+        let response = client
+            .post(format!("http://{addr}/v1/traces"))
+            .body(vec![0u8; 8])
+            .send()
+            .expect("plaintext POST must reach the listener");
+
+        assert_eq!(response.status(), 200);
+        server.join().expect("server thread");
+
+        // The trust store is irrelevant to plaintext, but it must have been
+        // built without error for the client to exist at all.
+        assert!(description.contains("trust anchors"), "unexpected description: {description}");
+    }
+
+    /// A real TLS handshake against a public HTTPS endpoint.
+    ///
+    /// This is the whole point of the change: before it, reqwest was compiled
+    /// with no TLS backend and every `https://` export failed at connect
+    /// time. The assertion is deliberately about *reaching* HTTP semantics —
+    /// any status code proves the handshake and certificate validation
+    /// completed. A 4xx from a server that does not speak OTLP is a pass.
+    ///
+    /// Ignored by default: it needs outbound network access.
+    #[test]
+    #[ignore = "requires outbound network access"]
+    fn https_endpoint_completes_a_real_tls_handshake() {
+        let (client, description) = build_http_client().expect("build client");
+
+        let response = client
+            .post("https://example.com/v1/traces")
+            .header("content-type", "application/x-protobuf")
+            .body(vec![0u8; 8])
+            .send()
+            .expect("TLS handshake to a public HTTPS endpoint must succeed");
+
+        println!("handshake OK: status {} ({description})", response.status());
     }
 }

--- a/crates/ephpm-server/src/tls.rs
+++ b/crates/ephpm-server/src/tls.rs
@@ -84,7 +84,14 @@ pub fn build_server_config(
 /// whole server uses one provider" is checkable by pointer identity — which
 /// is exactly how the HTTP/3 tests assert that QUIC and HTTPS-over-TCP did
 /// not diverge.
-fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+///
+/// The OTLP exporter's HTTPS client ([`crate::otlp`]) calls this too. It has
+/// to: reqwest is compiled with no crypto-provider feature, so its own path
+/// would call `CryptoProvider::get_default()` and `panic!("No provider set")`
+/// — the exporter is built in `main`, before anything installs a process
+/// default. Naming the provider here sidesteps both that panic and the
+/// ambiguity described above.
+pub(crate) fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     static PROVIDER: std::sync::OnceLock<Arc<rustls::crypto::CryptoProvider>> =
         std::sync::OnceLock::new();
     Arc::clone(PROVIDER.get_or_init(|| Arc::new(rustls::crypto::ring::default_provider())))

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -124,7 +124,24 @@ ini_overrides = [
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `request_log` | bool | (mode default) | Per-request timeline: the last 256 completed requests (method, path, status, total/queue-wait/PHP durations in ms, response bytes, timestamp) served as JSON at `GET /_ephpm/requests`, newest first. Unset resolves per mode: **on** under `ephpm dev` / bare `ephpm`, **off** under `ephpm serve`. `queue_wait_ms` is `null` outside worker mode (there is no dispatch queue on the fpm path); in worker mode `php_ms` includes the queue wait, matching `ephpm_php_execution_duration_seconds`. Requests to `/_ephpm/*` and the metrics path are not recorded. When off, `/_ephpm/requests` is not registered and the path falls through to normal routing. Env override: `EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG`. |
-| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"` (OTLP **http/protobuf**; `/v1/traces` is appended when missing). Exports one `http.request` span per request (attrs: method, path, status) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. Requires a binary built with the `otlp` cargo feature — without it, a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs. |
+| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"` (OTLP **http/protobuf**; `/v1/traces` is appended when missing). Exports one `http.request` span per request (attrs: method, path, status) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. Requires a binary built with the `otlp` cargo feature — without it, a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs. Both `http://` and `https://` endpoints are supported — see the note below. |
+
+**OTLP over HTTPS.** An `https://` endpoint works with no extra configuration.
+TLS is rustls (the same crypto provider the HTTPS listener uses — never
+OpenSSL or a second TLS stack), and the exporter trusts the **union of the
+operating system's trust store and the bundled Mozilla root set**. The OS
+store is what lets ePHPm reach an internal collector fronted by a corporate or
+private CA; the bundled set is a fallback so a publicly trusted endpoint still
+works from a `scratch`/distroless image that ships no CA bundle. To trust a
+private CA that is not installed system-wide, point the standard
+`SSL_CERT_FILE` (a PEM bundle) or `SSL_CERT_DIR` environment variable at it —
+there is no ePHPm-specific trust-store setting. Note that setting either
+variable *replaces* the OS trust store rather than adding to it (the bundled
+Mozilla set is still trusted), so such a bundle must contain every CA the
+exporter needs. `http://` endpoints are
+unaffected and remain the zero-config default for a collector on localhost.
+Export timeout follows the standard `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` /
+`OTEL_EXPORTER_OTLP_TIMEOUT` variables (milliseconds, default `10000`).
 
 ### `[server.limits]`
 


### PR DESCRIPTION
Fixes #370. Target: v0.7.4.

## The gap

Under `--features otlp`, an `https://` OTLP endpoint **cannot work**. `opentelemetry-otlp` is pinned with `http-proto` + `reqwest-blocking-client`, and nothing in the workspace enabled a TLS feature on `reqwest` — so it was compiled with no TLS backend at all.

Pre-existing, not a regression. Found while consolidating TLS providers for #241 / #368.

**Transport check first** — the original observation named reqwest, and that is correct: ePHPm uses OTLP/**HTTP**, not gRPC. `otlp.rs` builds `SpanExporter::builder().with_http().with_protocol(Protocol::HttpBinary)`. `tonic` is in the graph via an unrelated path, so this is reqwest's TLS story, not tonic's.

**Dependency graph, before:**

```
$ cargo tree -e features,no-dev -i reqwest --features otlp -p ephpm
└── reqwest feature "blocking"
```

Worth flagging for reviewers: plain `cargo tree -e features -i reqwest` is **misleading** here — it shows `rustls-tls`, but only via the `ephpm` crate's `reqwest` *dev*-dependency, which resolver v2/v3 does not unify into the binary build. `-e features,no-dev` is the graph that ships.

**Runtime, before** (reproduced by reverting only the feature line):

```
reqwest::Error { kind: Request, url: "https://example.com/v1/traces",
  source: ...Error(Connect, ConnectError("invalid URL, scheme is not http")) }
```

## What this does

Enables TLS on the exporter's HTTP client. **HTTPS becomes possible, not mandatory** — `http://` to a collector on localhost is the dominant deployment and is completely untouched.

### Why the feature choice is forced

`rustls-tls`, `rustls-tls-webpki-roots` and `rustls-tls-native-roots` **all** also enable reqwest's `__rustls-ring`, which links `ring` — reintroducing exactly the multi-provider bug #368 is fixing, and tripping its guard. Only `rustls-tls-manual-roots-no-provider` avoids it.

But `-no-provider` has its own trap: reqwest then resolves the provider through `CryptoProvider::get_default()` and

```rust
#[cfg(not(feature = "__rustls-ring"))]
panic!("No provider set");
```

…which is precisely this situation — the OTLP layer is built in `main`, before any listener installs a provider (PHP must init single-threaded, so the subscriber precedes the tokio runtime).

So the client is built explicitly with a preconfigured `rustls::ClientConfig` from the server's own `tls::crypto_provider()`. That kills the ordering hazard **and** makes it structurally impossible for the exporter to drift onto a different provider than the HTTPS listener.

### Interaction with #368

**This is provider-agnostic by construction and needs no rebase.** It routes through `tls::crypto_provider()`, so when #368 flips that from ring to aws-lc-rs the exporter follows automatically, with no change to this code. Reqwest is *not* an inbound edge to `ring` either before or after:

```
$ cargo tree -e no-dev -i ring --features otlp -p ephpm
ring v0.17.14
├── quinn-proto  ├── rustls v0.22.4 (opensrv-mysql)  ├── rustls v0.23.37
```

Merge order is not load-bearing, though landing #368 first is tidier.

### Root store: OS trust store ∪ bundled Mozilla set

Deliberate, and the reasoning is in the code:

- **OS store** (`rustls-native-certs`) is what makes the realistic case work at all. A collector reached over TLS is usually internal, behind a corporate or private CA that exists *only* in the platform store. A webpki-roots-only build could never talk to it, and there'd be no knob to work around that.
- **Bundled Mozilla set** (`webpki-roots`) as fallback, so a publicly trusted SaaS endpoint still works from a `scratch`/distroless image with no CA bundle — a real shape for a single-binary server, and one where the OS store is simply empty.

**Configurable?** Not yet, deliberately. `rustls-native-certs` honours `SSL_CERT_FILE` / `SSL_CERT_DIR` on **every** platform (checked before the platform store, in `lib.rs` not a platform module), so operators already have a standard escape hatch for a private bundle. A `[server.diagnostics]` CA-path or pinning knob is the natural next step if per-endpoint control is ever wanted; the doc comment says so.

## Cost

**Zero new packages.** `reqwest`, `rustls-native-certs` and `webpki-roots` were all already in the graph. The lockfile grows by exactly three lines — all of them edges, no new package entries:

```
+ "reqwest",
+ "rustls-native-certs",
+ "webpki-roots 0.26.11",
```

No second TLS stack: no `native-tls`, no `openssl` (both absent from the lock entirely).

## Verification — actually exercised, not just a feature diff

Two tests in `otlp.rs`, both run against the real `build_http_client()`:

- `plain_http_endpoint_still_works` — offline, loopback listener; asserts plaintext POST returns 200. Runs in CI (with the feature on).
- `https_endpoint_completes_a_real_tls_handshake` — `#[ignore]`d (needs network). **A real handshake:**

```
test otlp::tests::plain_http_endpoint_still_works ... ok
handshake OK: status 405 Method Not Allowed
  (TLS trust anchors: 27 from the OS store + 136 bundled; timeout 10000ms)
test otlp::tests::https_endpoint_completes_a_real_tls_handshake ... ok
```

The 405 is the pass: an endpoint that doesn't speak OTLP still had to complete TLS + certificate validation to answer at all — same standard as #368 accepting a 400 from Let's Encrypt staging.

**Negative control:** reverting *only* the reqwest feature line and restoring the default client reproduces `ConnectError("invalid URL, scheme is not http")` on the same test, while the `http://` test still passes. So the tests genuinely discriminate.

Gates: `cargo clippy --workspace --all-targets -- -D warnings` clean **with and without** `--features otlp`; `cargo +nightly fmt --all -- --check` clean; `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`.

## Docs

`site/content/reference/config.md` (`[server.diagnostics] otlp_endpoint`) now states that `https://` is supported, names the trust store, documents the `SSL_CERT_FILE`/`SSL_CERT_DIR` escape hatch — including that it *replaces* rather than augments the OS store — and records the export-timeout env vars.

## Note for a follow-up (not done here)

`crates/ephpm/Cargo.toml`'s dev-dependency `reqwest = { features = ["json", "rustls-tls"] }` pulls `__rustls-ring` into **test** builds. It doesn't affect the shipped binary or #368's runtime guard, so it's left alone to avoid conflicting with #368 — but it's the remaining ring edge in the test graph.
