### PR TITLE
fix(build): pin PHP 8.3 to 8.3.33 — Windows OPcache was silently off (php-sdk#47)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - { minor: "8.3", full: "8.3.31" }
+          - { minor: "8.3", full: "8.3.33" }
           - { minor: "8.4", full: "8.4.23" }
           - { minor: "8.5", full: "8.5.7" }
         arch:
@@ -177,7 +177,7 @@ jobs:
       max-parallel: 1
       matrix:
         php:
-          - { minor: "8.3", full: "8.3.31" }
+          - { minor: "8.3", full: "8.3.33" }
           - { minor: "8.4", full: "8.4.23" }
           - { minor: "8.5", full: "8.5.7" }
     steps:
@@ -244,7 +244,7 @@ jobs:
       matrix:
         include:
           - php_minor: "8.3"
-            php_full: "8.3.31"
+            php_full: "8.3.33"
           - php_minor: "8.4"
             php_full: "8.4.23"
           - php_minor: "8.5"
@@ -324,7 +324,7 @@ jobs:
       matrix:
         include:
           - php_minor: "8.3"
-            php_full: "8.3.31"
+            php_full: "8.3.33"
           - php_minor: "8.4"
             php_full: "8.4.23"
           - php_minor: "8.5"
@@ -719,7 +719,7 @@ jobs:
       matrix:
         include:
           - php_minor: "8.3"
-            php_full: "8.3.31"
+            php_full: "8.3.33"
           - php_minor: "8.4"
             php_full: "8.4.23"
             default: false

--- a/.github/workflows/windows-php-check.yml
+++ b/.github/workflows/windows-php-check.yml
@@ -166,7 +166,7 @@ jobs:
           # libc suffix on Windows (php_sdk_dir_for in xtask/src/main.rs). The
           # full version must match xtask::PHP_SDK_VERSIONS["8.3"] — same
           # keep-in-sync rule as the release.yml matrix pins.
-          PHP_SDK_PATH: ${{ github.workspace }}\php-sdk\8.3.31-windows-x86_64
+          PHP_SDK_PATH: ${{ github.workspace }}\php-sdk\8.3.33-windows-x86_64
           # sqlparser (a turso dependency, in this crate's graph via litewire)
           # has deeply recursive AST types that overflow the Windows
           # toolchain's default rustc thread stack in release.yml's build

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -819,7 +819,7 @@ This is the same approach FrankenPHP uses.
 |-------------|----------------------------|---------------|
 | PHP 8.1 | EOL (December 2025) | Not supported |
 | PHP 8.2 | Security-only (until Dec 2026) | Best-effort |
-| PHP 8.3 | Active support (until Dec 2026) | **Supported — in CI (pinned 8.3.31)** |
+| PHP 8.3 | Active support (until Dec 2026) | **Supported — in CI (pinned 8.3.33)** |
 | PHP 8.4 | Active support (until Dec 2027) | **Supported — in CI (pinned 8.4.23)** |
 | PHP 8.5 | Active support | **Supported — in CI (pinned 8.5.7)** |
 

--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -13,6 +13,9 @@
 //!    example), only for the default minor
 //! 4. `site/content/developer/architecture-overview.md` — the support table
 //!    listing the CI-pinned full versions
+//! 5. `.github/workflows/windows-php-check.yml` — the `PHP_SDK_PATH` cache
+//!    path for the Windows PHP-linked compile gate, only for
+//!    `WINDOWS_CHECK_MINOR`
 //!
 //! A missed pin site has broken a release before, so every substitution
 //! asserts its exact expected match count and the command refuses to write
@@ -28,6 +31,15 @@ use crate::{DEFAULT_PHP_MINOR, PHP_SDK_VERSIONS, workspace_root};
 /// `build-windows-tailcall` job (one extra `php_full:` include-block pin
 /// site each). 8.5-only today: the TAILCALL VM does not exist in 8.3/8.4.
 const TAILCALL_MINORS: &[&str] = &["8.5"];
+
+/// The PHP minor pinned by `.github/workflows/windows-php-check.yml`.
+///
+/// That workflow spells one SDK cache path out in full
+/// (`php-sdk\<full>-windows-x86_64`) instead of deriving it from
+/// `PHP_SDK_VERSIONS`, so it is a pin site for exactly this minor and drifts
+/// silently when the minor moves. Keep in sync with the `cargo xtask php-sdk
+/// <minor>` argument in that workflow.
+const WINDOWS_CHECK_MINOR: &str = "8.3";
 
 /// One exact-substring substitution in one file, with a required match count.
 struct Substitution {
@@ -86,6 +98,17 @@ fn substitutions(minor: &str, old_full: &str, new_full: &str) -> Vec<Substitutio
             expected: 1,
         },
     ];
+    // The Windows PHP-linked compile gate hardcodes one SDK cache path for
+    // WINDOWS_CHECK_MINOR. Missing this site left that job checking against a
+    // stale SDK after a bump — see the module docs on why that matters.
+    if minor == WINDOWS_CHECK_MINOR {
+        subs.push(Substitution {
+            path: ".github/workflows/windows-php-check.yml",
+            needle: format!("php-sdk\\{old_full}-windows-x86_64"),
+            replacement: format!("php-sdk\\{new_full}-windows-x86_64"),
+            expected: 1,
+        });
+    }
     // The Dockerfile only pins the default minor: once as the ARG default
     // and once in the comment example right above it ("e.g., v8.5.7").
     if minor == DEFAULT_PHP_MINOR {
@@ -115,6 +138,41 @@ fn apply(contents: &str, sub: &Substitution) -> Result<String, String> {
             sub.path, sub.expected, sub.needle, found
         ))
     }
+}
+
+/// Apply every substitution, composing the ones that target the same file.
+///
+/// `read` yields a file's on-disk contents by workspace-relative path; keeping
+/// I/O in the caller's closure makes the composition rule unit-testable.
+///
+/// Several substitutions can name one file — release.yml carries two distinct
+/// pin shapes. Each must be applied *on top of* the previous result. Reading
+/// the file fresh per substitution and staging each as its own pending write
+/// makes the last write win and silently discards the earlier substitution:
+/// a partial bump, which is the exact failure this command exists to prevent.
+///
+/// Returns one staged write per file, or every error encountered (all-or-
+/// nothing: the caller writes only when this returns `Ok`).
+fn apply_all(
+    subs: &[Substitution],
+    read: impl Fn(&str) -> Result<String, String>,
+) -> Result<Vec<(&'static str, String)>, Vec<String>> {
+    let mut staged: Vec<(&'static str, String)> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    for sub in subs {
+        let current = match staged.iter().find(|(path, _)| *path == sub.path) {
+            Some((_, pending)) => Ok(pending.clone()),
+            None => read(sub.path),
+        };
+        match current.and_then(|contents| apply(&contents, sub)) {
+            Ok(updated) => match staged.iter_mut().find(|(path, _)| *path == sub.path) {
+                Some((_, pending)) => *pending = updated,
+                None => staged.push((sub.path, updated)),
+            },
+            Err(e) => errors.push(e),
+        }
+    }
+    if errors.is_empty() { Ok(staged) } else { Err(errors) }
 }
 
 /// Validate that `full` is a plausible patch release of `minor`
@@ -180,27 +238,21 @@ pub fn bump_php_pin(args: &[String]) -> ExitCode {
     // matched. A partial bump (some files moved, some not) is exactly the
     // broken state this command exists to prevent.
     let root = workspace_root();
-    let mut staged: Vec<(std::path::PathBuf, &'static str, String)> = Vec::new();
-    let mut errors: Vec<String> = Vec::new();
-    for sub in substitutions(minor, old_full, new_full) {
-        let path = root.join(sub.path);
-        match fs::read_to_string(&path) {
-            Ok(contents) => match apply(&contents, &sub) {
-                Ok(updated) => staged.push((path, sub.path, updated)),
-                Err(e) => errors.push(e),
-            },
-            Err(e) => errors.push(format!("{}: cannot read: {e}", sub.path)),
+    let subs = substitutions(minor, old_full, new_full);
+    let staged = match apply_all(&subs, |rel| {
+        fs::read_to_string(root.join(rel)).map_err(|e| format!("{rel}: cannot read: {e}"))
+    }) {
+        Ok(staged) => staged,
+        Err(errors) => {
+            eprintln!("error: refusing to bump — no files were modified:");
+            for e in &errors {
+                eprintln!("  - {e}");
+            }
+            return ExitCode::FAILURE;
         }
-    }
-    if !errors.is_empty() {
-        eprintln!("error: refusing to bump — no files were modified:");
-        for e in &errors {
-            eprintln!("  - {e}");
-        }
-        return ExitCode::FAILURE;
-    }
-    for (path, rel, contents) in staged {
-        if let Err(e) = fs::write(&path, contents) {
+    };
+    for (rel, contents) in staged {
+        if let Err(e) = fs::write(root.join(rel), contents) {
             eprintln!("error: failed to write {rel}: {e}");
             return ExitCode::FAILURE;
         }
@@ -258,6 +310,76 @@ mod tests {
         };
         let input = "a: \"1.2.3\"\nb: \"1.2.3\"\n";
         assert_eq!(apply(input, &sub).unwrap(), "a: \"1.2.4\"\nb: \"1.2.4\"\n");
+    }
+
+    /// Regression: two substitutions naming the same file must compose.
+    ///
+    /// The bug this pins: each substitution was applied to a fresh read of the
+    /// file and staged as its own write, so the last write won and the first
+    /// substitution vanished. Live effect — `bump-php-pin 8.3 8.3.33` moved
+    /// release.yml's three `php_full:` sites but silently left both
+    /// `{ minor: "8.3", full: "8.3.31" }` inline-map sites behind, so the two
+    /// Linux release legs kept building the old SDK. `--check` then failed on
+    /// the tool's own output.
+    #[test]
+    fn apply_all_composes_substitutions_targeting_one_file() {
+        let subs = substitutions("8.3", "8.3.31", "8.3.33");
+        let release: Vec<&Substitution> =
+            subs.iter().filter(|s| s.path == ".github/workflows/release.yml").collect();
+        assert_eq!(release.len(), 2, "release.yml should carry both pin shapes");
+
+        let file = concat!(
+            "          - { minor: \"8.3\", full: \"8.3.31\" }\n",
+            "          - { minor: \"8.3\", full: \"8.3.31\" }\n",
+            "            php_full: \"8.3.31\"\n",
+            "            php_full: \"8.3.31\"\n",
+            "            php_full: \"8.3.31\"\n",
+        );
+        let staged = apply_all(&subs, |path| {
+            if path == ".github/workflows/release.yml" {
+                Ok(file.to_string())
+            } else {
+                // Every other pin site: a minimal body carrying its own needle.
+                Ok(subs
+                    .iter()
+                    .filter(|s| s.path == path)
+                    .map(|s| s.needle.repeat(s.expected))
+                    .collect::<String>())
+            }
+        })
+        .expect("all sites should match");
+
+        let (_, out) = staged
+            .iter()
+            .find(|(path, _)| *path == ".github/workflows/release.yml")
+            .expect("release.yml must be staged");
+        assert!(!out.contains("8.3.31"), "no 8.3.31 may survive, got:\n{out}");
+        assert_eq!(out.matches("{ minor: \"8.3\", full: \"8.3.33\" }").count(), 2);
+        assert_eq!(out.matches("php_full: \"8.3.33\"").count(), 3);
+        assert_eq!(
+            staged.iter().filter(|(path, _)| *path == ".github/workflows/release.yml").count(),
+            1,
+            "one file must stage exactly one write"
+        );
+    }
+
+    /// The Windows PHP-linked compile gate is a pin site for its own minor.
+    #[test]
+    fn windows_php_check_path_is_a_pin_site() {
+        let subs = substitutions(WINDOWS_CHECK_MINOR, "8.3.31", "8.3.33");
+        let sub = subs
+            .iter()
+            .find(|s| s.path == ".github/workflows/windows-php-check.yml")
+            .expect("windows-php-check.yml must be a pin site for WINDOWS_CHECK_MINOR");
+        assert_eq!(sub.needle, r"php-sdk\8.3.31-windows-x86_64");
+        assert_eq!(sub.replacement, r"php-sdk\8.3.33-windows-x86_64");
+
+        // ...and only for that minor.
+        assert!(
+            substitutions("8.5", "8.5.7", "8.5.9")
+                .iter()
+                .all(|s| s.path != ".github/workflows/windows-php-check.yml"),
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,7 +14,7 @@ mod e2e_bare;
 /// shorthand (e.g. "8.5") to the specific patch release we publish SDKs for.
 /// Users may also pass a full version explicitly (e.g. "8.5.6") and the
 /// resolver will accept it as-is.
-const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.31"), ("8.4", "8.4.23"), ("8.5", "8.5.7")];
+const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.33"), ("8.4", "8.4.23"), ("8.5", "8.5.7")];
 
 /// Default PHP minor when no version is specified on the command line.
 const DEFAULT_PHP_MINOR: &str = "8.5";


### PR DESCRIPTION
Windows ePHPm builds on **PHP 8.3 have been running with no opcode caching at all**. `opcache_get_status()` returns `false` in serve mode: the pinned SDK's `php8embed.lib` predates the OPcache `supported_sapis` allowlist patch, so OPcache declines to activate for the unknown `ephpm` SAPI at MINIT. The extension loads — it just never engages. PHP 8.5 is unaffected (upstream removed the allowlist entirely).

## What was actually wrong

Not what ephpm/php-sdk#47 assumed. The SDK build pipeline is fine and needs no change; **we were pinning a stale SDK**, and only for 8.3.

Verified against the shipped artifacts — searching `php8embed.lib` for the injected SAPI name, with `fuzzer`/`frankenphp` as positive controls proving we're reading the right string table:

| Windows SDK | `ephpm` in `supported_sapis` | controls |
|---|---|---|
| **8.3.31** ← what we pinned | **MISSING** | both present |
| 8.3.33 | present | both present |
| **8.4.23** ← what we pin | **present** | both present |
| 8.4.24 | present | both present |

So **8.4 was never broken** (issue #47 claimed 8.3/8.4; the original evidence was a symbol grep of 8.3.31 only, and the empirical follow-up only tested 8.3 and 8.5). 8.3.33 has carried the patch since 2026-08-02.

This changes one pin: **8.3.31 → 8.3.33**. 8.4 is deliberately left at 8.4.23 — it is already correct, and bumping it would drag an unrelated PHP version change into an OPcache fix.

## Why it sat broken for three weeks

The nightly **SDK Bump** workflow has been trying to land exactly this bump every night since 8.3.33 shipped, and failing at the push step:

```
! [remote rejected] bump/php-8.3.33 (refusing to allow a GitHub App to create or
  update workflow `.github/workflows/release.yml` without `workflows` permission)
```

`GITHUB_TOKEN` cannot modify files under `.github/workflows/`, and `release.yml` is one. Nobody saw it because the failure is in a scheduled workflow. **Not fixed here** — it needs a credential with workflow scope, which is a separate decision. Follow-up filed.

## Two bugs in the bump tool, both found by using it

**1. Substitutions targeting the same file clobbered each other.**

Each substitution was applied to a *fresh read* of the file and staged as its own pending write, so the last write won. Running `bump-php-pin 8.3 8.3.33` moved release.yml's three `php_full:` sites but **silently dropped both `{ minor: "8.3", full: "8.3.31" }` inline-map sites** — leaving the two Linux release legs building the old SDK. That is precisely the partial bump the command's two-phase design exists to prevent, and its docstring warns "a missed pin site has broken a release before."

The tool's own `--check` caught its own output as drift, which is how this surfaced. The CI run confirms it is not a local artifact — the nightly bump produced the identical incomplete diff (`3 files changed, 5 insertions(+), 5 deletions(-)`).

Substitutions now compose per file. The staging step is extracted as a pure function (`apply_all`) taking a read callback, so the composition rule is unit-tested without disk I/O. Every existing test exercised single-substitution inputs — which is exactly why this was invisible.

**2. `windows-php-check.yml` was not a known pin site.**

It spells out `PHP_SDK_PATH: ...\php-sdk\8.3.31-windows-x86_64` rather than deriving it from `PHP_SDK_VERSIONS`. After any 8.3 bump, the Windows PHP-linked compile gate would keep checking against the *previous* SDK. Added to the substitution table and to `--check`.

## Verification

- `cargo xtask bump-php-pin --check` — green across all three minors. **It was not green before this change.**
- `cargo test -p xtask bump` — 12 passed, including two new tests. `apply_all_composes_substitutions_targeting_one_file` fails against the old staging logic.
- clippy (`-D warnings`) and nightly fmt clean.
- release.yml now moves 5 pin sites (10 lines) rather than 3.

Closes ephpm/php-sdk#47.
