### PR TITLE
docs(middleware): worked Rust middleware example — api-gate, verified on the dlopen lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephpm-middleware-example"
+version = "0.1.0"
+dependencies = [
+ "ephpm-kv",
+ "ephpm-middleware",
+ "libloading",
+ "serde_json",
+]
+
+[[package]]
 name = "ephpm-middleware-jwt"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/*", "xtask"]
+# `examples/rust-middleware` is the worked example for the native-middleware
+# C ABI. It is a workspace member so `cargo clippy --workspace` and
+# `cargo +nightly fmt --all` keep it compiling against the current ABI — an
+# example that has drifted out of tree is worse than no example. It is kept
+# OUT of `default-members` so a plain `cargo build` does not pay for it.
+members = ["crates/*", "examples/rust-middleware", "xtask"]
 default-members = ["crates/*"]
 exclude = ["crates/ephpm-e2e"]
 resolver = "3"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -146,6 +146,11 @@ COPY crates/ephpm-php/Cargo.toml          crates/ephpm-php/Cargo.toml
 COPY crates/ephpm-query-stats/Cargo.toml  crates/ephpm-query-stats/Cargo.toml
 COPY crates/ephpm-server/Cargo.toml       crates/ephpm-server/Cargo.toml
 COPY crates/ephpm-ws/Cargo.toml           crates/ephpm-ws/Cargo.toml
+# `examples/rust-middleware` is a workspace member (see the root Cargo.toml),
+# so `cargo fetch` below loads its manifest. It declares an explicit `[lib]`,
+# which cargo hard-errors on if src/lib.rs is missing — copy the manifest and
+# stub the lib source below, exactly like the crates above.
+COPY examples/rust-middleware/Cargo.toml  examples/rust-middleware/Cargo.toml
 
 RUN mkdir -p \
         xtask/src \
@@ -164,12 +169,18 @@ RUN mkdir -p \
         crates/ephpm-query-stats/src \
         crates/ephpm-server/src \
         crates/ephpm-ws/src \
-        crates/ephpm-server/examples && \
+        crates/ephpm-server/examples \
+        examples/rust-middleware/src && \
     printf 'fn main() {}\n' > xtask/src/main.rs && \
     printf 'fn main() {}\n' > crates/ephpm/src/main.rs && \
     for d in ephpm-cluster ephpm-config ephpm-db ephpm-kv ephpm-middleware ephpm-middleware-builtins ephpm-middleware-cors ephpm-middleware-jwt ephpm-middleware-ratelimit ephpm-middleware-security-headers ephpm-php ephpm-query-stats ephpm-server ephpm-ws; do \
         touch crates/$d/src/lib.rs; \
     done && \
+    # examples/rust-middleware declares an explicit [lib] (name = "api_gate");
+    # cargo errors during `cargo fetch` below if src/lib.rs is absent. Its
+    # examples/abi_probe.rs is auto-discovered (no [[example]] block) so it is
+    # NOT needed here — only the lib source is.
+    touch examples/rust-middleware/src/lib.rs && \
     # ephpm-server declares several `[[example]] crate-type = ["cdylib"]`
     # targets (the middleware-ABI probes added in #230, plus the response-phase
     # proof modules). A named [[example]] must exist as a file or cargo

--- a/examples/rust-middleware/Cargo.toml
+++ b/examples/rust-middleware/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "ephpm-middleware-example"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "Worked example: an ePHPm native middleware written in Rust — API-key gate with a cluster-wide rate limiter, loaded through the dlopen lane"
+
+[lib]
+# `name` decides the artifact name: libapi_gate.so / libapi_gate.dylib /
+# api_gate.dll. Mount that file in `[[middleware]] library = "..."`.
+name = "api_gate"
+# cdylib = the loadable module. The rlib is only so `cargo test` can link the
+# unit tests below against the same code; a real module needs cdylib alone.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ephpm-middleware.workspace = true
+serde_json.workspace = true
+
+# The `host` feature pulls in the host-side request context and callback table
+# so the unit tests can build a `Request` and a real KV store without a running
+# server. A shipped module never enables it.
+[dev-dependencies]
+ephpm-middleware = { workspace = true, features = ["host"] }
+ephpm-kv.workspace = true
+# Used only by `examples/abi_probe.rs`, which dlopens the built cdylib the way
+# the ePHPm loader does.
+libloading.workspace = true
+
+[lints]
+workspace = true

--- a/examples/rust-middleware/README.md
+++ b/examples/rust-middleware/README.md
@@ -1,0 +1,395 @@
+# `api-gate` — a native ePHPm middleware in Rust
+
+A complete, loadable middleware module: an **API-key gate with a cluster-wide
+rate limiter**, built as a `cdylib`, `dlopen`ed by a stock ePHPm binary, and
+deciding real HTTP requests before PHP runs.
+
+It is the counterpart to
+[`ephpm/elephc-middleware-example`](https://github.com/ephpm/elephc-middleware-example),
+which compiles PHP to a native module and needs ~180 lines of hand-written C
+shim to bridge elephc's output to the ABI. **This example needs no shim.** In
+Rust the ABI is used as designed: one `declare!` line generates the four
+exported C symbols, the version handshake, config parsing, panic containment
+and the response marshaling. There is not a single `unsafe` block in
+[`src/lib.rs`](src/lib.rs) outside the unit tests.
+
+Everything below was verified end to end — see
+[Verified transcript](#verified-transcript).
+
+---
+
+## What it does
+
+| Request | Verdict | Result |
+|---|---|---|
+| `GET /health.php` | `ACTION_CONTINUE` | PHP runs untouched; `X-Api-Gate: bypass` appended |
+| `GET /api/v1/users` (no key) | `ACTION_RESPOND` | `401` JSON, PHP never runs |
+| `GET /api/v1/users` (revoked key) | `ACTION_RESPOND` | `403` JSON, PHP never runs |
+| `GET /api/v1/users` (over budget) | `ACTION_RESPOND` | `429` + `Retry-After`, PHP never runs |
+| `GET /api/v1/users` (valid key) | `ACTION_REWRITE` | `REQUEST_URI` → `/users`, `X-Api-Tenant` injected, PHP runs |
+
+Host callbacks used: **`kv_incr_ttl`** (the fixed-window counter — one atomic
+call; cluster-wide with no code change once KV replication is on),
+**`kv_get`** (runtime revocation), and **`log`** (module diagnostics into
+ePHPm's `tracing` stream).
+
+---
+
+## The ABI in one page
+
+A middleware module is a shared library exporting four C symbols. The
+canonical definition is
+[`crates/ephpm-middleware/src/abi.rs`](../../crates/ephpm-middleware/src/abi.rs);
+this is the summary.
+
+```c
+int32_t     ephpm_middleware_init(uint32_t abi_version,
+                                  const char* config_json,
+                                  const ephpm_host_v1* host);
+int32_t     ephpm_middleware_invoke(const ephpm_request_t* request,
+                                    ephpm_response_t* response_out);
+void        ephpm_middleware_shutdown(void);
+const char* ephpm_middleware_describe(void);   /* optional, nullable */
+```
+
+**The host table is passed by pointer**, not `dlsym`'d out of the host
+executable. Exporting symbols from an executable needs `-rdynamic` on Linux
+and has no clean Windows analogue; a table pointer is portable everywhere
+`dlopen`/`LoadLibrary` is. The pointer is valid for the process lifetime.
+
+**Request data comes from accessor function pointers on that table**, not a
+flat struct, so fields can be added without an ABI break: additions append to
+the end of the table under the same major version. `kv_incr_ttl` is itself
+such an append — it sits after `log`, and a module built before it existed
+simply never reads that far.
+
+### Two rules you must honour
+
+1. **Refuse a newer host major.** `ABI_V1` is `0x01_00_00_00`; the top byte
+   gates compatibility. If `abi_version >> 24` exceeds what you were built
+   for, return non-zero from `init` and do not load. A struct-layout
+   disagreement that loads anyway is memory corruption, not a warning.
+   `declare!` does this check and returns `-1`.
+
+2. **Keep response pointers alive until `invoke` returns.** Everything you
+   write into `EphpmResponse` — body, rewrite path, header names and values —
+   must still be valid when `invoke` returns; the host copies before
+   unwinding. You may not point at a temporary. `declare!` parks the marshaled
+   buffers in a thread-local that lives until the next `invoke` on that
+   thread, so returning an owned `Response` is always correct.
+
+Both rules are also why the C example needs a shim and this one does not.
+
+### The three verdicts
+
+| Verdict | Meaning | `Response::header()` means | `Response::path()` |
+|---|---|---|---|
+| `ACTION_CONTINUE` | run the rest of the chain, then PHP | — (use `response_header()`) | ignored |
+| `ACTION_REWRITE` | mutate the request, then continue | **request**-header override | rewrites `REQUEST_URI` |
+| `ACTION_RESPOND` | short-circuit; PHP never runs | **response** header | ignored |
+
+`RESPOND` stops the chain immediately. `REWRITE` accumulates: the path
+override is last-writer-wins and header overrides apply in chain order, and
+the router applies them **after** the whole chain has run — so a later module
+still sees the original request, not an earlier module's rewrite.
+
+**`REWRITE` semantics worth knowing before you design around it:** in fpm mode
+the script has already been resolved by the time the chain runs, so a path
+rewrite changes `REQUEST_URI` (what a front controller routes on) and **not**
+which file executes. In worker mode every request goes through PHP and the
+booted framework routes on the rewritten `REQUEST_URI`. This example is built
+around a front controller precisely so the rewrite is meaningful in both.
+
+---
+
+## Build
+
+The crate declares `crate-type = ["cdylib", "rlib"]`; the `cdylib` is the
+module. The `rlib` exists only so `cargo test` can link the unit tests.
+
+```bash
+cargo build --release -p ephpm-middleware-example
+```
+
+| Platform | Artifact |
+|---|---|
+| Linux | `target/release/libapi_gate.so` |
+| macOS | `target/release/libapi_gate.dylib` |
+| Windows | `target/release/api_gate.dll` |
+
+Add `--target <triple>` if you need a specific triple; the artifact then lands
+under `target/<triple>/release/`. The module and the ePHPm binary loading it
+must be built for the same platform and the same ABI major.
+
+Run the unit tests (they build a `Request` against a real in-memory KV store,
+no server needed — the `host` feature of `ephpm-middleware` is a dev-dependency
+for exactly this):
+
+```bash
+cargo test -p ephpm-middleware-example
+```
+
+There is also a standalone probe that `dlopen`s the built module the way the
+ePHPm loader does and checks the handshake — useful when bringing up your own
+module, because it tells you whether the host will accept it without standing
+up a server. Build both with the same flags:
+
+```bash
+cargo build --release -p ephpm-middleware-example
+cargo run   --release -p ephpm-middleware-example --example abi_probe
+```
+
+---
+
+## Mount it
+
+```toml
+[[middleware]]
+library = "/abs/path/target/release/libapi_gate.so"
+order = 10
+config = { keys = { k-alpha = "alpha", k-beta = "beta" }, prefix = "/api/", strip_prefix = "/api/v1", requests_per_window = 5 }
+```
+
+`library` resolves in this order:
+
+1. **A builtin name** (`jwt`, `cors`, `ratelimit`, `security-headers`) — the
+   compiled-in static registry, no `dlopen` at all.
+2. **A bare name** — resolved through the middleware search path with a
+   platform suffix, e.g. `auth-jwt` → `auth-jwt.linux-x86_64.so`.
+3. **An explicit path** — any value containing a path separator or a file
+   extension is used as-is.
+
+**Use an explicit path when you want to be sure you are testing the dlopen
+lane.** A bare name is checked against the builtin registry first, so a
+collision would quietly run something else.
+
+`order` sets chain position (lower first). An optional `match = "/api/*"` glob
+restricts the mount to matching paths. `config` is serialised to JSON and
+handed to `init`; a mount whose `init` fails **aborts server startup** rather
+than silently not running — which is the only safe default for an auth module.
+
+### Config keys for this module
+
+| key | default | meaning |
+|---|---|---|
+| `keys` (object) | **required**, non-empty | `"api key" -> "tenant"` |
+| `prefix` (string) | `"/api/"` | only paths with this prefix are gated |
+| `strip_prefix` (string) | unset | removed from the front of the path on `REWRITE` |
+| `requests_per_window` (integer) | `100` | budget per tenant per 10-second window |
+
+---
+
+## Run the demo
+
+[`demo/`](demo) is a complete, self-contained site: a front controller, a
+health endpoint outside the gate, and a page that revokes a tenant from PHP.
+
+```bash
+cargo build --release -p ephpm-middleware-example
+cd examples/rust-middleware/demo
+# edit the `library` path in ephpm.toml for your platform first
+ephpm serve --config ephpm.toml
+```
+
+Then, against `http://127.0.0.1:8099`:
+
+```bash
+# CONTINUE — outside the gate
+curl -i /health.php                                    # 200, X-Api-Gate: bypass
+
+# RESPOND — no key
+curl -i /api/v1/users                                  # 401 + WWW-Authenticate
+
+# REWRITE — valid key
+curl -i -H 'X-Api-Key: k-alpha' /api/v1/users          # 200, REQUEST_URI=/users, tenant=alpha
+
+# RESPOND — over budget (budget is 5/10s in the demo config)
+for i in $(seq 1 8); do curl -s -o /dev/null -w '%{http_code} ' \
+  -H 'X-Api-Key: k-alpha' /api/v1/users; done          # 200×5 then 429
+
+# RESPOND — revoked from PHP, enforced in native code
+curl -s '/revoke.php?tenant=beta'                      # PHP writes the KV marker
+curl -i -H 'X-Api-Key: k-beta' /api/v1/users           # 403
+curl -s '/revoke.php?tenant=beta&restore=1'            # back to 200
+```
+
+`revoke.php` is the interesting one: PHP calls `ephpm_kv_set()`, the module
+reads the same literal key through the host table's `kv_get`, and the next
+request is rejected in native code with no restart and no config reload. TTL
+is in **seconds** on both surfaces.
+
+> **Single-site only.** With `[server] sites_dir` set, PHP is rebound per
+> request to a per-vhost KV store while the middleware host table holds one
+> process-wide store, so PHP and middleware would no longer meet on the same
+> key. The rate limiter is unaffected (it only talks to the middleware side);
+> the PHP-driven revocation demo is what would break.
+
+> `revoke.php` has no authentication. It is a demo, not a pattern.
+
+---
+
+## Verified transcript
+
+Run against a freshly built PHP-linked `ephpm.exe` (PHP 8.5.7) on
+**Windows 11 / x86_64-pc-windows-msvc**, mounting the `api_gate.dll` built from
+this crate. The server confirms the dlopen at startup:
+
+```text
+INFO ephpm_server::middleware: middleware initialised
+     module=…\release\api_gate.dll describe=api-gate 0.1.0 (rust middleware example)
+INFO ephpm_server: middleware chain loaded count=1 modules=["…\release\api_gate.dll"]
+```
+
+**CONTINUE** — outside the gate; PHP runs and the gate only appends a header:
+
+```text
+$ curl -sS -D- http://127.0.0.1:8099/health.php
+HTTP/1.1 200 OK
+x-powered-by: PHP/8.5.7
+content-type: application/json
+x-api-gate: bypass
+
+{ "status": "ok", "gated": false, "tenant": null }
+```
+
+**RESPOND 401** — gated path, no key. No `x-powered-by`: PHP never ran.
+
+```text
+$ curl -sS -D- http://127.0.0.1:8099/api/v1/users
+HTTP/1.1 401 Unauthorized
+content-type: application/json
+x-api-gate: reject
+www-authenticate: ApiKey realm="api-gate"
+
+{"error":"missing or unknown X-Api-Key"}
+```
+
+An unknown key (`X-Api-Key: nope`) returns `401` the same way.
+
+**REWRITE** — valid key. `REQUEST_URI` was rewritten from `/api/v1/users?limit=5`
+to `/users?limit=5`, the tenant was injected as a request header, and the
+front controller still executed:
+
+```text
+$ curl -sS -D- -H 'X-Api-Key: k-alpha' 'http://127.0.0.1:8099/api/v1/users?limit=5'
+HTTP/1.1 200 OK
+x-powered-by: PHP/8.5.7
+x-api-gate: allow
+x-ratelimit-limit: 5
+x-ratelimit-remaining: 4
+
+{ "script": "index.php", "request_uri": "/users?limit=5", "tenant": "alpha" }
+```
+
+**RESPOND 429** — budget is 5 per 10-second window; the 6th request trips it:
+
+```text
+$ for i in 1..8: curl -o /dev/null -w '%{http_code}' -H 'X-Api-Key: k-gamma' …/api/v1/x
+200 200 200 200 200 429 429 429
+
+HTTP/1.1 429 Too Many Requests
+retry-after: 7
+x-ratelimit-limit: 5
+x-ratelimit-remaining: 0
+
+{"error":"rate limit exceeded"}
+```
+
+**RESPOND 403** — PHP and the native module on one KV store:
+
+```text
+$ curl -o NUL -w 'before=%{http_code}' -H 'X-Api-Key: k-beta' …/api/v1/x
+before=200
+
+$ curl -sS 'http://127.0.0.1:8099/revoke.php?tenant=beta'      # PHP: ephpm_kv_set()
+{"tenant":"beta","revoked":true,"key":"apigate:revoked:beta","ttl":300}
+
+$ curl -sS -D- -H 'X-Api-Key: k-beta' …/api/v1/x
+HTTP/1.1 403 Forbidden
+{"error":"api key revoked"}
+
+$ curl -sS 'http://127.0.0.1:8099/revoke.php?tenant=beta&restore=1'
+$ curl -o NUL -w 'after_restore=%{http_code}' -H 'X-Api-Key: k-beta' …/api/v1/x
+after_restore=200
+```
+
+The module's own `log` callback surfaced in ePHPm's `tracing` output during
+that sequence, correctly levelled and targeted:
+
+```text
+INFO ephpm_middleware: api-gate: rejecting revoked tenant `beta`
+```
+
+**ABI handshake** — `cargo run -p ephpm-middleware-example --example abi_probe`,
+against the same `api_gate.dll`:
+
+```text
+module:  …\release\api_gate.dll
+symbols: init, invoke, shutdown, describe — all resolved
+describe: api-gate 0.1.0 (rust middleware example)
+handshake: host major 2 refused (rc = -1)
+handshake: null host table refused (rc = -1)
+handshake: config without `keys` refused (rc = -3)
+handshake: ABI_V1 + valid config accepted (rc = 0)
+invoke:  /health.php -> ACTION_CONTINUE
+invoke:  /api/v1/users -> ACTION_RESPOND 401 "{\"error\":\"missing or unknown X-Api-Key\"}" (3 header(s))
+shutdown: ok
+```
+
+The refusals are asserted **before** the accepted call on purpose: `declare!`
+stashes the host table and instance in `OnceLock`s, so a successful `init`
+first would make the refusal unfalsifiable.
+
+Plus `cargo test -p ephpm-middleware-example` — 8 unit tests covering config
+validation, all three verdicts, per-tenant budget isolation and revocation.
+
+### Not verified here
+
+* **Linux and macOS.** The module is platform-agnostic Rust with no
+  conditional compilation, and the loader path is the same `libloading` call,
+  but this transcript is Windows only — treat `.so`/`.dylib` as **unverified**
+  until someone runs it. (`cargo xtask e2e` cannot complete on Windows —
+  issue #367 — so the in-tree E2E suite was not the harness used here; the
+  server above was driven directly.)
+* **Clustered KV.** The rate limiter is cluster-wide *by construction* (one
+  `kv_incr_ttl` against a replicated store), but this run was a single node.
+  The cross-node behaviour is **unverified**.
+
+---
+
+## The honest caveats
+
+* **A fully static binary cannot `dlopen`.** If you build a statically linked
+  ePHPm (musl, no dynamic loader), this lane does not exist — not because of
+  anything ePHPm does, but because there is no runtime linker to call. That is
+  precisely why the **builtin lane** exists: a module compiled into the binary
+  and dispatched through the static registry, same `Middleware` trait, same
+  code, no FFI. The stock Linux release is glibc-dynamic, so `dlopen` works
+  there; the four in-tree modules ship on the builtin lane so they work
+  everywhere.
+
+* **The chain only sees PHP-dispatched requests in fpm mode.** Static files
+  and router-generated 403/404s do not pass through middleware. Worker mode
+  routes everything through PHP, so there the chain sees everything.
+
+* **The request body is not available in v1.** `request_body` returns length
+  0. The chain deliberately runs *before* the body is read — rejecting before
+  paying for the transfer is the point — so body inspection would defeat it.
+  Reserved for a future buffered-body option.
+
+* **Loading a module runs its initialisers with the server's privileges.**
+  This is the documented v1 trust model: a middleware module is trusted code,
+  the same as a PHP extension. There is no sandbox.
+
+* **Failure posture is a choice, and this module makes both.**
+  Authentication is fail-closed (unknown key rejected; a panic in `invoke` is
+  converted by `declare!` to a 500). Rate limiting is fail-open (KV
+  unavailable ⇒ allow, with a warning) — dropping all traffic because the
+  counter tier hiccuped turns a soft protection into a hard outage.
+
+## See also
+
+* [`crates/ephpm-middleware/src/abi.rs`](../../crates/ephpm-middleware/src/abi.rs) — the ABI, with the design rationale in the module docs
+* [`crates/ephpm-middleware/src/lib.rs`](../../crates/ephpm-middleware/src/lib.rs) — the `Middleware` trait, `Response` builder, `Host` services and the `declare!` macro
+* [`crates/ephpm-middleware-builtins/src/`](../../crates/ephpm-middleware-builtins/src) — the four shipped modules, written against the same trait
+* [`crates/ephpm-server/tests/middleware_dlopen.rs`](../../crates/ephpm-server/tests/middleware_dlopen.rs) — loader coverage: symbol resolution, version handshake, failure modes

--- a/examples/rust-middleware/demo/ephpm.toml
+++ b/examples/rust-middleware/demo/ephpm.toml
@@ -1,0 +1,36 @@
+# Demo config for the api-gate native middleware example.
+#
+# Run from this directory:
+#   ephpm serve --config ephpm.toml
+#
+# `document_root` and the `library` path below are relative to your shell's
+# working directory, so either run from here or make them absolute.
+
+[server]
+listen = "127.0.0.1:8099"
+document_root = "public"
+
+# Left at the default on purpose:
+#   fallback = ["$uri", "$uri/", "/index.php?$query_string"]
+# That is what routes /api/v1/users (no such file) to the front controller
+# public/index.php, which is the request the REWRITE verdict acts on.
+
+[php]
+mode = "fpm"
+
+# ── the middleware mount ──────────────────────────────────────────────────
+#
+# `library` is an explicit PATH here, which is what forces the dlopen lane:
+# the loader checks bare names against the compiled-in builtin registry first,
+# so a bare name would silently test something else.
+#
+# Adjust the path for your platform after `cargo build --release -p
+# ephpm-middleware-example`:
+#   Linux   ../../../target/release/libapi_gate.so
+#   macOS   ../../../target/release/libapi_gate.dylib
+#   Windows ../../../target/release/api_gate.dll
+# (add /<triple> after target/ if you built with --target)
+[[middleware]]
+library = "../../../target/release/libapi_gate.so"
+order = 10
+config = { keys = { k-alpha = "alpha", k-beta = "beta", k-gamma = "gamma" }, prefix = "/api/", strip_prefix = "/api/v1", requests_per_window = 5 }

--- a/examples/rust-middleware/demo/public/health.php
+++ b/examples/rust-middleware/demo/public/health.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * The CONTINUE lane: this path is outside the gate's `prefix`, so the module
+ * returns ACTION_CONTINUE and PHP runs exactly as it would with no middleware
+ * mounted. The only trace the gate leaves is the `X-Api-Gate: bypass`
+ * response header it appended.
+ */
+
+header('Content-Type: application/json');
+
+echo json_encode([
+    'status' => 'ok',
+    'gated'  => false,
+    'tenant' => $_SERVER['HTTP_X_API_TENANT'] ?? null, // always null here
+], JSON_PRETTY_PRINT), "\n";

--- a/examples/rust-middleware/demo/public/index.php
+++ b/examples/rust-middleware/demo/public/index.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Front controller for the api-gate demo.
+ *
+ * Requests to /api/... do not exist as files, so ePHPm's default `fallback`
+ * chain (["$uri", "$uri/", "/index.php?$query_string"]) resolves them here.
+ * That is what makes the middleware's REWRITE verdict meaningful: the gate
+ * rewrites REQUEST_URI, and this front controller is what routes on it.
+ */
+
+header('Content-Type: application/json');
+
+echo json_encode([
+    // Which file actually executed. In fpm mode this is decided before the
+    // middleware chain runs, so a REWRITE never changes it.
+    'script'      => basename($_SERVER['SCRIPT_NAME'] ?? __FILE__),
+    // What the REWRITE verdict rewrote. Compare with the URL you requested.
+    'request_uri' => $_SERVER['REQUEST_URI'] ?? null,
+    // Injected by the middleware as a request-header override.
+    'tenant'      => $_SERVER['HTTP_X_API_TENANT'] ?? null,
+], JSON_PRETTY_PRINT), "\n";

--- a/examples/rust-middleware/demo/public/revoke.php
+++ b/examples/rust-middleware/demo/public/revoke.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Revoke (or restore) a tenant from PHP, to show that the native middleware
+ * and PHP share ONE embedded KV store under the same literal key names.
+ *
+ * `ephpm_kv_set()` here writes exactly the key the module reads with the host
+ * table's `kv_get` callback, so the very next request through the gate is
+ * rejected with 403 — in native code, with no restart and no config reload.
+ * When clustering is enabled the marker gossips to every node.
+ *
+ * NOTE — demo only. This endpoint has no authentication of its own. It sits
+ * outside the gate's `prefix` on purpose (so you can still un-revoke a tenant
+ * after revoking it), which also means nothing is guarding it. Do not copy
+ * this file into anything real.
+ *
+ * NOTE — single-site only. With `[server] sites_dir` set, PHP is rebound to a
+ * per-vhost store per request while the middleware host table keeps one
+ * process-wide store, so the two would no longer meet on the same key.
+ */
+
+header('Content-Type: application/json');
+
+if (!function_exists('ephpm_kv_set')) {
+    http_response_code(501);
+    echo json_encode(['error' => 'not running under ePHPm — ephpm_kv_* unavailable']), "\n";
+    return;
+}
+
+$tenant = $_GET['tenant'] ?? '';
+if ($tenant === '' || !preg_match('/^[A-Za-z0-9_-]+$/', $tenant)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'pass ?tenant=<name>']), "\n";
+    return;
+}
+
+// Must match ApiGate::revocation_key() in src/lib.rs.
+$key = "apigate:revoked:{$tenant}";
+
+if (isset($_GET['restore'])) {
+    ephpm_kv_del($key);
+    echo json_encode(['tenant' => $tenant, 'revoked' => false, 'key' => $key]), "\n";
+    return;
+}
+
+// TTL is in SECONDS on both surfaces: PHP's ephpm_kv_set() and the middleware
+// host table agree. Any value at all means "revoked"; the module only checks
+// for presence.
+ephpm_kv_set($key, '1', 300);
+echo json_encode(['tenant' => $tenant, 'revoked' => true, 'key' => $key, 'ttl' => 300]), "\n";

--- a/examples/rust-middleware/examples/abi_probe.rs
+++ b/examples/rust-middleware/examples/abi_probe.rs
@@ -1,0 +1,153 @@
+//! Loads the built `api-gate` cdylib exactly the way ePHPm's loader does and
+//! exercises the parts of the C ABI a unit test cannot reach: the four
+//! exported symbols, the version handshake, and one `invoke` marshaled back
+//! out of module memory through the raw `EphpmResponse` struct.
+//!
+//! This is a debugging aid for module authors — point it at your own module
+//! and it tells you whether the host will accept it, without standing up a
+//! server.
+//!
+//! ```text
+//! cargo build --release -p ephpm-middleware-example
+//! cargo run --release -p ephpm-middleware-example --example abi_probe
+//! ```
+//!
+//! It resolves the library next to its own binary, so build both with the
+//! same `--release`/`--target` flags.
+#![allow(unsafe_code)] // The whole point: call a C ABI by hand.
+
+use std::ffi::{CStr, CString};
+use std::path::{Path, PathBuf};
+
+use ephpm_middleware::abi::{
+    self, ACTION_CONTINUE, ACTION_RESPOND, EphpmResponse, InitFn, InvokeFn, ShutdownFn,
+};
+use ephpm_middleware::host::{RequestCtx, host_table, set_kv_store};
+
+/// The cdylib sits one directory up from `.../examples/abi_probe`.
+fn library_path() -> PathBuf {
+    let exe = std::env::current_exe().expect("probe has a path");
+    let dir = exe.parent().and_then(Path::parent).expect("<profile>/examples/<bin>");
+    dir.join(format!("{}api_gate{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_SUFFIX))
+}
+
+/// A config the module accepts.
+fn good_config() -> CString {
+    CString::new(r#"{"keys":{"k-alpha":"alpha"},"prefix":"/api/","requests_per_window":1}"#)
+        .expect("no interior NUL")
+}
+
+fn main() {
+    // The module's KV callbacks need a store behind them, exactly as the
+    // server wires one up before loading any middleware.
+    set_kv_store(&ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default()));
+
+    let path = library_path();
+    assert!(
+        path.is_file(),
+        "module not built at {} — run `cargo build -p ephpm-middleware-example` with the same \
+         --release/--target flags as this probe",
+        path.display()
+    );
+    println!("module:  {}", path.display());
+
+    // SAFETY: loading a middleware module runs its initialisers with this
+    // process's privileges — the documented v1 trust model. This artifact is
+    // built from this workspace.
+    let lib = unsafe { libloading::Library::new(&path) }.expect("dlopen the module");
+
+    // ── 1. all four symbols resolve ───────────────────────────────────────
+    // SAFETY: each symbol is declared with the ABI signature `declare!` emits.
+    let init: InitFn = *unsafe { lib.get(abi::SYM_INIT) }.expect("ephpm_middleware_init");
+    // SAFETY: as above.
+    let invoke: InvokeFn = *unsafe { lib.get(abi::SYM_INVOKE) }.expect("ephpm_middleware_invoke");
+    // SAFETY: as above.
+    let shutdown: ShutdownFn =
+        *unsafe { lib.get(abi::SYM_SHUTDOWN) }.expect("ephpm_middleware_shutdown");
+    // SAFETY: as above; `describe` is optional but this module exports it.
+    let describe: abi::DescribeFn =
+        *unsafe { lib.get(abi::SYM_DESCRIBE) }.expect("ephpm_middleware_describe");
+    println!("symbols: init, invoke, shutdown, describe — all resolved");
+
+    // SAFETY: the module returns a 'static NUL-terminated string.
+    let name = unsafe { CStr::from_ptr(describe()) }.to_string_lossy().into_owned();
+    println!("describe: {name}");
+
+    let host = std::ptr::from_ref(host_table());
+    let config = good_config();
+
+    // ── 2. version handshake ──────────────────────────────────────────────
+    // Refusals are asserted BEFORE the accepted call: `declare!` stashes the
+    // host table and instance in `OnceLock`s, so a successful init first would
+    // make the refusal unfalsifiable.
+    let future_major = abi::ABI_V1 + (1 << 24);
+    // SAFETY: `config` outlives the call; the host table is 'static.
+    let rc = unsafe { init(future_major, config.as_ptr(), host) };
+    assert_ne!(rc, 0, "a module built for ABI major 1 must refuse an ABI major 2 host");
+    println!("handshake: host major 2 refused (rc = {rc})");
+
+    // SAFETY: as above; a null host table is an explicitly handled input.
+    let rc = unsafe { init(abi::ABI_V1, config.as_ptr(), std::ptr::null()) };
+    assert_ne!(rc, 0, "a null host table must be refused");
+    println!("handshake: null host table refused (rc = {rc})");
+
+    let bad = CString::new(r#"{"prefix":"/api/"}"#).expect("no interior NUL");
+    // SAFETY: as above.
+    let rc = unsafe { init(abi::ABI_V1, bad.as_ptr(), host) };
+    assert_ne!(rc, 0, "a config with no `keys` must be refused");
+    println!("handshake: config without `keys` refused (rc = {rc})");
+
+    // Negative control: without this, a module that refused *everything*
+    // would look identical to a working version gate.
+    // SAFETY: as above.
+    let rc = unsafe { init(abi::ABI_V1, config.as_ptr(), host) };
+    assert_eq!(rc, 0, "the host's own ABI major with a valid config must be accepted");
+    println!("handshake: ABI_V1 + valid config accepted (rc = 0)");
+
+    // ── 3. one CONTINUE and one RESPOND, read back through the raw struct ─
+    let ctx = RequestCtx::new("GET", "/health.php", "", "198.51.100.4", "probe", &[]);
+    let mut out = zeroed_response();
+    // SAFETY: `ctx` outlives the call; `out` is a valid, caller-owned struct.
+    let rc = unsafe { invoke(ctx.as_abi(), &raw mut out) };
+    assert_eq!(rc, 0);
+    assert_eq!(out.action, ACTION_CONTINUE, "an un-gated path must CONTINUE");
+    println!("invoke:  /health.php -> ACTION_CONTINUE");
+
+    let ctx = RequestCtx::new("GET", "/api/v1/users", "", "198.51.100.4", "probe", &[]);
+    let mut out = zeroed_response();
+    // SAFETY: as above.
+    let rc = unsafe { invoke(ctx.as_abi(), &raw mut out) };
+    assert_eq!(rc, 0);
+    assert_eq!(out.action, ACTION_RESPOND, "a gated path with no key must RESPOND");
+    assert_eq!(out.status, 401);
+    // The pointer-lifetime rule in practice: these are still valid here,
+    // before `invoke` is called again on this thread.
+    // SAFETY: `body`/`body_len` were written by the module and remain valid.
+    let body = unsafe { std::slice::from_raw_parts(out.body, out.body_len) };
+    println!(
+        "invoke:  /api/v1/users -> ACTION_RESPOND {} {:?} ({} header(s))",
+        out.status,
+        String::from_utf8_lossy(body),
+        out.header_overrides_len
+    );
+
+    // SAFETY: the module was initialised above.
+    unsafe { shutdown() };
+    println!("shutdown: ok");
+    println!("\nOK — the module satisfies the v1 ABI.");
+}
+
+/// The host zero-initialises the verdict struct before every `invoke`.
+fn zeroed_response() -> EphpmResponse {
+    EphpmResponse {
+        action: ACTION_CONTINUE,
+        status: 0,
+        body: std::ptr::null(),
+        body_len: 0,
+        rewrite_path: std::ptr::null(),
+        header_overrides: std::ptr::null(),
+        header_overrides_len: 0,
+        response_headers: std::ptr::null(),
+        response_headers_len: 0,
+    }
+}

--- a/examples/rust-middleware/src/lib.rs
+++ b/examples/rust-middleware/src/lib.rs
@@ -1,0 +1,457 @@
+//! `api-gate` — a complete, loadable ePHPm middleware written in Rust.
+//!
+//! This is the worked example for the **dynamic (dlopen) lane** of the native
+//! middleware ABI. It is a real module, not a toy: it is built as a `cdylib`,
+//! mounted by path in `[[middleware]]`, `dlopen`ed by a stock ePHPm binary at
+//! startup, and it decides every PHP-bound request before the request body is
+//! read.
+//!
+//! It exists because the ABI is easier to use than the C-shim-based
+//! [elephc example][elephc] makes it look. A Rust module needs **no shim at
+//! all**: [`ephpm_middleware::declare!`] emits the four exported C symbols,
+//! the ABI-version handshake, the config parse, panic containment and the
+//! response marshaling. Everything below the `declare!` line at the bottom of
+//! this file is ordinary safe Rust — there is not one `unsafe` block in the
+//! module itself.
+//!
+//! [elephc]: https://github.com/ephpm/elephc-middleware-example
+//!
+//! # What it does
+//!
+//! An API gateway in front of a PHP front controller. Requests under
+//! `prefix` must carry a known `X-Api-Key`; everything else is untouched.
+//!
+//! | Situation | Verdict | Result |
+//! |---|---|---|
+//! | Path outside `prefix` | `CONTINUE` | PHP runs unchanged; `X-Api-Gate: bypass` appended to the response |
+//! | Missing / unknown `X-Api-Key` | `RESPOND` | `401` JSON, PHP never runs |
+//! | Key revoked at runtime (KV) | `RESPOND` | `403` JSON, PHP never runs |
+//! | Over the request budget | `RESPOND` | `429` JSON + `Retry-After`, PHP never runs |
+//! | Accepted | `REWRITE` | version prefix stripped from `REQUEST_URI`, `X-Api-Tenant` injected, PHP runs |
+//!
+//! All three verdicts are on the hot path, including `RESPOND` — the one that
+//! has to marshal a status, a body and headers back out of module memory.
+//!
+//! # Host callbacks used
+//!
+//! The host callback table is what makes a native module worth writing, so
+//! this example leans on it rather than mentioning it:
+//!
+//! * [`kv_incr_ttl`] — one atomic call that both increments the window counter
+//!   and stamps its TTL *only when the call creates the key*. That is the
+//!   whole fixed-window rate limiter, and it becomes **cluster-wide** with no
+//!   change to this code when KV replication is on: every node counts into
+//!   the same key.
+//! * [`kv_get`] — the revocation check. The key lives in the same store PHP
+//!   sees through `ephpm_kv_set()`, so an application page can revoke a tenant
+//!   and the *next* request through the gate is rejected in native code,
+//!   without a restart or a config reload.
+//! * `log` — module diagnostics go through the host's `tracing` subscriber and
+//!   land in ePHPm's own log stream, correctly levelled.
+//!
+//! [`kv_incr_ttl`]: ephpm_middleware::Host::kv_incr_ttl
+//! [`kv_get`]: ephpm_middleware::Host::kv_get
+//!
+//! # Two rules the ABI asks of every module
+//!
+//! Both are handled for you by `declare!`, but a module author should know
+//! they exist, because a hand-written C module has to honour them itself:
+//!
+//! 1. **ABI-major gating.** `ephpm_middleware_init` must refuse a host whose
+//!    ABI major is newer than the module was built against — a struct layout
+//!    disagreement that loads anyway is memory corruption, not a warning.
+//!    `declare!` compares `abi_version >> 24` against
+//!    [`ABI_V1`](ephpm_middleware::abi::ABI_V1) and returns `-1` on mismatch.
+//! 2. **Pointer lifetime.** Every pointer written into `EphpmResponse` must
+//!    stay valid until `invoke` *returns*; the host copies before unwinding.
+//!    So a verdict may not hand out pointers into a temporary. `declare!`
+//!    parks the marshaled body, path and header strings in a thread-local that
+//!    lives until the next `invoke` on that thread. Returning an owned
+//!    [`Response`] — as every function below does — is always safe.
+//!
+//! # Configuration
+//!
+//! Passed as the `[[middleware]] config` table, serialised to JSON:
+//!
+//! | key | default | meaning |
+//! |---|---|---|
+//! | `keys` (object) | **required**, non-empty | `"api key" -> "tenant"` map |
+//! | `prefix` (string) | `"/api/"` | only paths with this prefix are gated |
+//! | `strip_prefix` (string) | unset | removed from the front of the path on `REWRITE` |
+//! | `requests_per_window` (integer) | `100` | budget per tenant per 10-second window |
+//!
+//! # Failure posture
+//!
+//! Authentication is **fail-closed**: an unknown key is rejected, and a panic
+//! anywhere in `invoke` is converted by `declare!` into a `500` rather than a
+//! silent pass. Rate limiting is **fail-open**: if the KV store is
+//! unavailable, the request is allowed with a warning. Dropping all traffic
+//! because the counter tier hiccuped turns a soft protection into a hard
+//! outage — the same trade-off the builtin `ratelimit` module makes.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ephpm_middleware::abi::{LOG_INFO, LOG_WARN};
+use ephpm_middleware::{Middleware, Request, Response};
+
+/// Fixed-window length, in seconds. Coarser windows mean less KV churn.
+const WINDOW_SECS: u64 = 10;
+
+/// Counter-key TTL: one window plus slack for clock skew between nodes, so a
+/// counter can outlive its window slightly but never leak.
+const KEY_TTL_SECS: i64 = 30;
+
+/// Default path prefix the gate applies to.
+const DEFAULT_PREFIX: &str = "/api/";
+
+/// Default per-tenant request budget per window.
+const DEFAULT_BUDGET: i64 = 100;
+
+/// The gate's policy, built once at `init` and shared by every request
+/// thread. `Middleware` requires `Send + Sync`, which this is because it is
+/// immutable after construction — all mutable state lives in the KV store.
+pub struct ApiGate {
+    /// Only paths starting with this are gated.
+    prefix: String,
+    /// Stripped from the front of the path on the accepted (`REWRITE`) path.
+    strip_prefix: Option<String>,
+    /// API key -> tenant identity.
+    keys: HashMap<String, String>,
+    /// Requests allowed per tenant per [`WINDOW_SECS`] window.
+    budget: i64,
+}
+
+impl ApiGate {
+    /// KV key holding the revocation marker for `tenant`. Any value present
+    /// means revoked; PHP can set it with
+    /// `ephpm_kv_set("apigate:revoked:alpha", "1", 3600)`.
+    fn revocation_key(tenant: &str) -> String {
+        format!("apigate:revoked:{tenant}")
+    }
+
+    /// KV key holding this tenant's counter for the current window. The vhost
+    /// is part of the key so two sites in one process cannot share a budget.
+    fn window_key(vhost: &str, tenant: &str, window: u64) -> String {
+        format!("apigate:rl:{vhost}:{tenant}:{window}")
+    }
+
+    /// The path PHP should see, with `strip_prefix` removed. Returns `None`
+    /// when there is nothing to strip, so the module can skip emitting a
+    /// rewrite it does not need.
+    fn stripped_path(&self, path: &str) -> Option<String> {
+        let strip = self.strip_prefix.as_deref()?;
+        let rest = path.strip_prefix(strip)?;
+        // Stripping must not produce an empty or relative path.
+        Some(if rest.starts_with('/') { rest.to_owned() } else { format!("/{rest}") })
+    }
+
+    /// A JSON error body plus the headers every rejection carries.
+    fn reject(status: u16, message: &str) -> Response {
+        Response::respond(status, format!(r#"{{"error":"{message}"}}"#))
+            .header("Content-Type", "application/json")
+            .header("X-Api-Gate", "reject")
+    }
+}
+
+impl Middleware for ApiGate {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let keys_value = config
+            .get("keys")
+            .ok_or("`keys` is required: an object mapping API key -> tenant name")?;
+        let keys_object =
+            keys_value.as_object().ok_or("`keys` must be an object of \"key\": \"tenant\"")?;
+        if keys_object.is_empty() {
+            return Err("`keys` must contain at least one API key".into());
+        }
+        let keys = keys_object
+            .iter()
+            .map(|(key, tenant)| {
+                tenant
+                    .as_str()
+                    .map(|t| (key.clone(), t.to_owned()))
+                    .ok_or_else(|| format!("tenant for key `{key}` must be a string, got {tenant}"))
+            })
+            .collect::<Result<HashMap<_, _>, _>>()?;
+
+        let prefix = match config.get("prefix") {
+            None | Some(serde_json::Value::Null) => DEFAULT_PREFIX.to_owned(),
+            Some(v) => v.as_str().ok_or("`prefix` must be a string")?.to_owned(),
+        };
+        let strip_prefix = match config.get("strip_prefix") {
+            None | Some(serde_json::Value::Null) => None,
+            Some(v) => Some(v.as_str().ok_or("`strip_prefix` must be a string")?.to_owned()),
+        };
+        let budget = match config.get("requests_per_window") {
+            None | Some(serde_json::Value::Null) => DEFAULT_BUDGET,
+            Some(v) => v.as_i64().ok_or("`requests_per_window` must be an integer")?,
+        };
+        if budget <= 0 {
+            return Err("`requests_per_window` must be > 0".into());
+        }
+
+        Ok(Self { prefix, strip_prefix, keys, budget })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        // ── CONTINUE ──────────────────────────────────────────────────────
+        // Not our surface. Hand the request on untouched; the response header
+        // is appended to whatever PHP ultimately produces.
+        if !req.path().starts_with(&self.prefix) {
+            return Response::cont().response_header("X-Api-Gate", "bypass");
+        }
+
+        let host = req.host();
+
+        // ── RESPOND: authentication (fail-closed) ─────────────────────────
+        let Some(tenant) = req.header("X-Api-Key").and_then(|key| self.keys.get(key)) else {
+            return Self::reject(401, "missing or unknown X-Api-Key")
+                .header("WWW-Authenticate", "ApiKey realm=\"api-gate\"");
+        };
+
+        // ── RESPOND: runtime revocation, read from the shared KV store ────
+        // Any value means revoked. This is the same store PHP writes through
+        // `ephpm_kv_set()`, so revocation takes effect on the next request.
+        if host.kv_get(&Self::revocation_key(tenant)).is_some() {
+            host.log(LOG_INFO, &format!("api-gate: rejecting revoked tenant `{tenant}`"));
+            return Self::reject(403, "api key revoked");
+        }
+
+        // ── RESPOND: fixed-window rate limit (fail-open) ──────────────────
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
+        let window = now / WINDOW_SECS;
+        let key = Self::window_key(req.vhost_id(), tenant, window);
+
+        // One atomic call: increment, and stamp the TTL only if this call
+        // created the key. A counter can therefore never exist without an
+        // expiry, and every node in the cluster counts into the same key.
+        let remaining = match host.kv_incr_ttl(&key, 1, KEY_TTL_SECS) {
+            Some(count) if count > self.budget => {
+                let retry_after = WINDOW_SECS - (now % WINDOW_SECS);
+                return Self::reject(429, "rate limit exceeded")
+                    .header("Retry-After", retry_after.to_string())
+                    .header("X-RateLimit-Limit", self.budget.to_string())
+                    .header("X-RateLimit-Remaining", "0");
+            }
+            Some(count) => (self.budget - count).max(0),
+            None => {
+                host.log(
+                    LOG_WARN,
+                    &format!("api-gate: KV unavailable — failing open for tenant `{tenant}`"),
+                );
+                self.budget
+            }
+        };
+
+        // ── REWRITE: accepted ─────────────────────────────────────────────
+        // `header` sets a REQUEST header the PHP side sees as
+        // `$_SERVER['HTTP_X_API_TENANT']`; `response_header` adds a header to
+        // the client's response. `path` rewrites `REQUEST_URI`.
+        //
+        // v1 semantics worth knowing: in fpm mode the script has already been
+        // resolved by the time the chain runs, so a path rewrite changes
+        // `REQUEST_URI` (what a front controller routes on) and not which file
+        // executes. In worker mode every request goes through PHP and the
+        // booted framework routes on the rewritten `REQUEST_URI`.
+        let mut verdict = Response::rewrite()
+            .header("X-Api-Tenant", tenant)
+            .response_header("X-Api-Gate", "allow")
+            .response_header("X-RateLimit-Limit", self.budget.to_string())
+            .response_header("X-RateLimit-Remaining", remaining.to_string());
+        if let Some(stripped) = self.stripped_path(req.path()) {
+            verdict = verdict.path(stripped);
+        }
+        verdict
+    }
+
+    fn shutdown(&self) {
+        // Nothing to release — the policy is plain owned data and the KV store
+        // belongs to the host. Shown because the ABI calls it at shutdown and
+        // a module holding a thread or a file handle must clean up here.
+    }
+
+    fn describe() -> &'static str {
+        concat!("api-gate ", env!("CARGO_PKG_VERSION"), " (rust middleware example)")
+    }
+}
+
+// The whole C ABI: four exported symbols, the version handshake, config
+// parsing, panic containment and response marshaling. This one line is the
+// entire difference between a Rust module and the ~180-line hand-written C
+// shim the elephc example needs.
+ephpm_middleware::declare!(ApiGate);
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // The tests build the FFI request view by hand.
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND, ACTION_REWRITE};
+    use ephpm_middleware::host::{RequestCtx, host_table, set_kv_store};
+
+    use super::*;
+
+    /// Wire a real in-memory KV store into the host table. The table is
+    /// process-wide and first-call-wins, so every test uses a unique vhost to
+    /// keep its counters to itself.
+    fn setup_kv() {
+        set_kv_store(&ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default()));
+    }
+
+    /// A gate that knows exactly one key, `k-<tenant>`, for `tenant`.
+    ///
+    /// Every test uses its own tenant name: the host KV store is
+    /// process-wide and first-call-wins, so tests running in parallel share
+    /// one store, and a shared tenant would let one test's revocation marker
+    /// or window counter decide another test's verdict.
+    fn gate_for(tenant: &str) -> ApiGate {
+        let mut keys = serde_json::Map::new();
+        keys.insert(format!("k-{tenant}"), serde_json::Value::String(tenant.to_owned()));
+        ApiGate::init(&serde_json::json!({
+            "keys": keys,
+            "prefix": "/api/",
+            "strip_prefix": "/api/v1",
+            "requests_per_window": 3,
+        }))
+        .expect("init")
+    }
+
+    fn invoke(mw: &ApiGate, vhost: &str, path: &str, headers: &[(String, String)]) -> Response {
+        let ctx = RequestCtx::new("GET", path, "", "198.51.100.7", vhost, headers);
+        // SAFETY: `ctx` outlives the borrowed view, and `host_table()` is
+        // 'static — exactly the contract `from_raw` documents.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn key_header(tenant: &str) -> Vec<(String, String)> {
+        vec![("X-Api-Key".to_owned(), format!("k-{tenant}"))]
+    }
+
+    fn find<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        headers.iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn init_rejects_unusable_config() {
+        assert!(ApiGate::init(&serde_json::Value::Null).is_err(), "no `keys`");
+        assert!(ApiGate::init(&serde_json::json!({ "keys": {} })).is_err(), "empty `keys`");
+        assert!(ApiGate::init(&serde_json::json!({ "keys": [] })).is_err(), "`keys` not an object");
+        assert!(
+            ApiGate::init(&serde_json::json!({ "keys": { "k": 1 } })).is_err(),
+            "tenant not a string"
+        );
+        assert!(
+            ApiGate::init(&serde_json::json!({ "keys": { "k": "t" }, "requests_per_window": 0 }))
+                .is_err(),
+            "zero budget"
+        );
+        let mw = ApiGate::init(&serde_json::json!({ "keys": { "k": "t" } })).expect("defaults");
+        assert_eq!(mw.prefix, DEFAULT_PREFIX);
+        assert_eq!(mw.budget, DEFAULT_BUDGET);
+        assert!(mw.strip_prefix.is_none());
+    }
+
+    #[test]
+    fn off_prefix_paths_continue_untouched() {
+        setup_kv();
+        let resp = invoke(&gate_for("bypass"), "vh-bypass", "/health.php", &[]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+        assert_eq!(find(resp.__response_headers(), "X-Api-Gate"), Some("bypass"));
+        // No key was required, and nothing was rewritten.
+        assert!(resp.__rewrite_path().is_none());
+    }
+
+    #[test]
+    fn missing_or_unknown_key_is_rejected_with_401() {
+        setup_kv();
+        let mw = gate_for("auth");
+        for headers in [vec![], vec![("X-Api-Key".to_owned(), "nope".to_owned())]] {
+            let resp = invoke(&mw, "vh-401", "/api/v1/users", &headers);
+            assert_eq!(resp.__action(), ACTION_RESPOND);
+            assert_eq!(resp.__status(), 401);
+            assert_eq!(find(resp.__headers(), "Content-Type"), Some("application/json"));
+            assert!(find(resp.__headers(), "WWW-Authenticate").is_some());
+        }
+    }
+
+    #[test]
+    fn accepted_request_rewrites_the_path_and_injects_the_tenant() {
+        setup_kv();
+        let resp = invoke(&gate_for("rw"), "vh-ok", "/api/v1/users", &key_header("rw"));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(resp.__rewrite_path(), Some("/users"));
+        // Request-header override -> $_SERVER['HTTP_X_API_TENANT'].
+        assert_eq!(find(resp.__headers(), "X-Api-Tenant"), Some("rw"));
+        // Client-visible headers.
+        assert_eq!(find(resp.__response_headers(), "X-Api-Gate"), Some("allow"));
+        assert_eq!(find(resp.__response_headers(), "X-RateLimit-Limit"), Some("3"));
+    }
+
+    #[test]
+    fn a_path_with_nothing_to_strip_is_still_accepted() {
+        setup_kv();
+        let resp =
+            invoke(&gate_for("nostrip"), "vh-nostrip", "/api/v2/users", &key_header("nostrip"));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert!(resp.__rewrite_path().is_none(), "no rewrite is emitted when nothing is stripped");
+        assert_eq!(find(resp.__headers(), "X-Api-Tenant"), Some("nostrip"));
+    }
+
+    #[test]
+    fn revoking_a_tenant_in_the_kv_store_rejects_the_next_request() {
+        setup_kv();
+        let mw = gate_for("revoke");
+        let allowed = invoke(&mw, "vh-revoke", "/api/v1/x", &key_header("revoke"));
+        assert_eq!(allowed.__action(), ACTION_REWRITE);
+
+        // Exactly what PHP's `ephpm_kv_set()` writes — same store, same key.
+        let ctx = RequestCtx::new("GET", "/api/v1/x", "", "198.51.100.7", "vh-revoke", &[]);
+        // SAFETY: as in `invoke` above.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert!(req.host().kv_set(&ApiGate::revocation_key("revoke"), b"1", 60));
+
+        let resp = invoke(&mw, "vh-revoke", "/api/v1/x", &key_header("revoke"));
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 403);
+    }
+
+    #[test]
+    fn exceeding_the_window_budget_is_rejected_with_429() {
+        setup_kv();
+        let mw = gate_for("burst");
+        // Budget is 3 per 10s window. A window boundary can reset the counter
+        // once mid-loop, so drive well past the budget before asserting.
+        let mut limited = None;
+        for _ in 0..12 {
+            let resp = invoke(&mw, "vh-429", "/api/v1/x", &key_header("burst"));
+            if resp.__status() == 429 {
+                limited = Some(resp);
+                break;
+            }
+        }
+        let resp = limited.expect("budget of 3 must be exhausted within 12 requests");
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(find(resp.__headers(), "X-RateLimit-Remaining"), Some("0"));
+        let retry: u64 =
+            find(resp.__headers(), "Retry-After").expect("Retry-After").parse().expect("integer");
+        assert!(retry > 0 && retry <= WINDOW_SECS, "Retry-After must fall inside the window");
+    }
+
+    #[test]
+    fn a_separate_tenant_has_a_separate_budget() {
+        setup_kv();
+        let mw = ApiGate::init(&serde_json::json!({
+            "keys": { "k-a": "ten-a", "k-b": "ten-b" },
+            "requests_per_window": 2,
+        }))
+        .expect("init");
+        let a = vec![("X-Api-Key".to_owned(), "k-a".to_owned())];
+        let b = vec![("X-Api-Key".to_owned(), "k-b".to_owned())];
+        // Burn tenant a's budget.
+        for _ in 0..6 {
+            let _ = invoke(&mw, "vh-split", "/api/x", &a);
+        }
+        // Tenant b is unaffected on its first request.
+        assert_ne!(invoke(&mw, "vh-split", "/api/x", &b).__status(), 429);
+    }
+}

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -499,6 +499,11 @@ implemented.
 
 ## Writing your own module in Rust
 
+A complete worked example — all three verdicts, the KV host callbacks, a demo
+site and a build-and-verify walkthrough — lives in the repository at
+[`examples/rust-middleware/`](https://github.com/ephpm/ephpm/tree/main/examples/rust-middleware).
+The sketch below is the minimum.
+
 Add the authoring crate and implement one trait:
 
 ```toml


### PR DESCRIPTION
## Why

We published `ephpm/elephc-middleware-example`, which needs a ~180-line hand-written C shim purely because of elephc's limitations. That makes our middleware ABI look harder than it is. There was no Rust example — the case where the ABI is used *as designed* and needs no shim at all.

This adds it, in-tree.

## What it is

`examples/rust-middleware` — **api-gate**, an API-key gate with a fixed-window rate limiter. One coherent example rather than a grab-bag, chosen so it exercises everything that matters:

| Request | Verdict | Result |
|---|---|---|
| `/health.php` (outside `prefix`) | `ACTION_CONTINUE` | PHP runs; `X-Api-Gate: bypass` appended |
| `/api/v1/users`, no key | `ACTION_RESPOND` | 401 JSON, PHP never runs |
| `/api/v1/users`, revoked key | `ACTION_RESPOND` | 403 JSON |
| `/api/v1/users`, over budget | `ACTION_RESPOND` | 429 + `Retry-After` |
| `/api/v1/users`, valid key | `ACTION_REWRITE` | `REQUEST_URI` → `/users`, `X-Api-Tenant` injected |

Host callbacks: **`kv_incr_ttl`** (the cluster-wide rate-limit primitive), **`kv_get`** (runtime revocation), **`log`**.

`ACTION_RESPOND` was the untested headline path in the elephc example. It is exercised for real here, three different ways.

The module is ~200 lines of ordinary safe Rust with **zero `unsafe`** — `declare!` supplies the four C exports, the version handshake, config parsing, panic containment and response marshaling. That contrast is the point of the example.

## Verified, not just compiled

A freshly built PHP-linked `ephpm.exe` (PHP 8.5.7, `x86_64-pc-windows-msvc`) `dlopen`s the built `api_gate.dll` and serves real HTTP through it. Full transcript is in the README. Highlights:

```
INFO ephpm_server::middleware: middleware initialised
     module=…\api_gate.dll describe=api-gate 0.1.0 (rust middleware example)
```

CONTINUE — PHP ran, gate only appended a header:
```
HTTP/1.1 200 OK
x-powered-by: PHP/8.5.7
x-api-gate: bypass
```

RESPOND — no `x-powered-by`, so PHP genuinely never ran:
```
HTTP/1.1 401 Unauthorized
www-authenticate: ApiKey realm="api-gate"
{"error":"missing or unknown X-Api-Key"}
```

REWRITE — `REQUEST_URI` rewritten and the tenant header echoed back by the front controller:
```
$ curl -H 'X-Api-Key: k-alpha' '…/api/v1/users?limit=5'
x-api-gate: allow
x-ratelimit-remaining: 4
{ "script": "index.php", "request_uri": "/users?limit=5", "tenant": "alpha" }
```

429 after the 5/10s budget: `200 200 200 200 200 429 429 429`, with `retry-after: 7`.

403 via the shared KV store — `revoke.php` calls `ephpm_kv_set()`, and the next request is rejected in native code, then restored:
```
before=200 → revoke → 403 → restore → after_restore=200
INFO ephpm_middleware: api-gate: rejecting revoked tenant `beta`
```
That last line is the module's own `log` host callback landing in ePHPm's `tracing` stream.

ABI handshake, via the included `abi_probe` against the same DLL:
```
handshake: host major 2 refused (rc = -1)
handshake: null host table refused (rc = -1)
handshake: config without `keys` refused (rc = -3)
handshake: ABI_V1 + valid config accepted (rc = 0)
```
Refusals are asserted before the accepted call on purpose — `declare!` uses `OnceLock`s, so a successful init first would make the refusal unfalsifiable.

### Explicitly not verified

* **Linux/macOS artifacts.** Platform-agnostic Rust, no `cfg`, same `libloading` path — but this transcript is Windows only. Labelled unverified in the README. (`cargo xtask e2e` can't complete on Windows, #367, so the server was driven directly rather than through the in-tree E2E harness.)
* **Clustered KV.** Cluster-wide by construction, single node in practice here.

## Why in-tree rather than a standalone repo

`ephpm-middleware` is not published to crates.io, so a standalone repo would need a git dependency on this whole workspace — heavy and version-skew-prone, and nothing would keep it compiling. In-tree, it is a workspace member, so `cargo clippy --workspace` and `cargo +nightly fmt --all` hold it to the current ABI. It is kept **out of `default-members`** so a plain `cargo build` does not pay for it.

Happy to mirror it to `ephpm/rust-middleware-example` later if you want the symmetry with the elephc repo — that is a separate call and needs your go-ahead.

## Also included

* `examples/abi_probe.rs` — loads a module the way the loader does and reports whether the host will accept it, without standing up a server. A debugging aid for module authors.
* `demo/` — runnable site: front controller, un-gated health endpoint, PHP-side revocation page (loudly marked demo-only, it has no auth).
* 8 unit tests: config validation, all three verdicts, per-tenant budget isolation, revocation.
* A pointer from `site/content/guides/native-middleware.md` to the example.

## Documented caveats

The README keeps the honest notes: a fully static musl binary cannot `dlopen` (hence the builtin lane); the chain only sees PHP-dispatched requests in fpm mode; `request_body` is length 0 in v1 by design; loading a module runs its initialisers with the server's privileges; and `REWRITE` changes `REQUEST_URI` only in fpm mode, since script resolution has already happened — which is why the example is built around a front controller.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test -p ephpm-middleware-example` — 8/8

macOS runners are down, so `Test (macos-arm64)` will sit queued.