### PR TITLE
feat(middleware): PHP middleware lane — `library = "php:<path>"` (experimental)

### DIFF
--- a/.claude/agent-memory/ephpm-systems-architect/MEMORY.md
+++ b/.claude/agent-memory/ephpm-systems-architect/MEMORY.md
@@ -1,0 +1,7 @@
+# Memory Index
+
+- [exit() is invisible after php_execute_script](php-exit-not-observable-after-execute-script.md) — run PHP's own compile/execute/inspect loop when a request executes more than one script, or short-circuits silently fall through
+- [PHP middleware lane shape](php-middleware-lane-shape.md) — `php:` mounts run inside the app's request (not their own); two-phase chain, measured costs, why the phase boundary can't be fixed
+- [Windows per-request chdir costs ~55us](windows-chdir-per-request-cost.md) — never add a cwd save/restore to the request path unmeasured; measure with a no-op version to split fixed from variable cost
+- [Shared target dir replays stale rlibs](shared-target-stale-fingerprint.md) — "method not found" on a symbol you just added is a cache lie; touch the file, never `cargo clean`
+- [Windows PHP-linked local builds](windows-php-linked-local-build.md) — vcvars64 + LIBCLANG_PATH + 8.5.7 SDK; test binaries need `/FORCE:MULTIPLE`; CI only `cargo check`s this lane

--- a/.claude/agent-memory/ephpm-systems-architect/php-exit-not-observable-after-execute-script.md
+++ b/.claude/agent-memory/ephpm-systems-architect/php-exit-not-observable-after-execute-script.md
@@ -1,0 +1,46 @@
+---
+name: php-exit-not-observable-after-execute-script
+description: php_execute_script/zend_execute_scripts destroy the exit() signal — check EG(exception) yourself between zend_compile_file and zend_execute, or a short-circuit silently becomes a fall-through
+metadata:
+  type: project
+---
+
+`php_execute_script()` and `zend_execute_scripts()` **cannot tell you that a
+script called `exit()`**. Both funnel every pending exception through
+`zend_exception_error()`, which sets `EG(exception) = NULL` and returns
+`SUCCESS` for PHP 8's unwind-exit. On return, "the script called `exit()`" and
+"the script ran to completion" are byte-identical states.
+
+Corollaries, both verified against php-src (`main/main.c`, `Zend/zend.c`) and
+by running it:
+
+* Any ePHPm code that runs **more than one script per request** and needs to
+  short-circuit on `exit()` must run PHP's own loop body itself —
+  `zend_compile_file` → `zend_execute` → inspect `EG(exception)` with
+  `zend_is_unwind_exit` → then `zend_destroy_static_vars` / `destroy_op_array`
+  / `efree_size`. That is what `ephpm_run_one_middleware` does.
+* The existing `EG(exception) && zend_is_unwind_exit(...)` check *after*
+  `php_execute_script(app_script)` in `ephpm_execute_request` is therefore
+  effectively dead — `exit()` in an application script returns
+  `EPHPM_EXEC_OK`, not `EPHPM_EXEC_SCRIPT_EXIT`. Harmless today (both deliver
+  the captured response) but do not build on it.
+* A second fail-open trap sits next to it: an uncaught `Throwable` is reported
+  with `E_DONT_BAIL`, so execution returns **normally** and only
+  `PG(last_error_type)` records it. A loop that does not check that mask will
+  print a fatal and then keep going.
+* A *parse* error is a thrown `ParseError`, not a bailout —
+  `zend_compile_file` returns NULL with the exception still pending and
+  `PG(last_error_type)` unset. It must be reported explicitly or the request
+  answers 200 with an empty body and the exception leaks into shutdown
+  functions.
+
+**Why:** discovered building the `php:` middleware lane (PR #382). The first
+implementation used `php_execute_script` per mount; its `exit()`
+short-circuit tests failed with the application script's output appended to
+the middleware's — i.e. a middleware that rejected a request still ran the app.
+
+**How to apply:** whenever adding a code path that executes a PHP file outside
+the single primary-script call, do not trust the return value or
+`EG(exception)` after a php-src wrapper. Inspect the exception between execute
+and teardown yourself, and treat `E_DONT_BAIL` fatals as a separate signal from
+bailouts. See [[php-middleware-lane-shape]].

--- a/.claude/agent-memory/ephpm-systems-architect/php-middleware-lane-shape.md
+++ b/.claude/agent-memory/ephpm-systems-architect/php-middleware-lane-shape.md
@@ -1,0 +1,45 @@
+---
+name: php-middleware-lane-shape
+description: Why `php:` middleware runs inside the app's PHP request rather than its own, what that costs, and the two-phase chain that follows from it
+metadata:
+  type: project
+---
+
+The `php:` middleware lane (PR #382, experimental) runs a mount **inside the
+same PHP request as the application script**, immediately before it — not as
+its own `ephpm_execute_request`.
+
+**Why:** `ephpm_execute_request` is a full php-fpm-shaped cycle (lazy
+`php_request_shutdown`, `php_request_startup`, superglobal construction,
+per-request INI apply, exec-timer arm, capture). A mount with its own cycle
+would pay all of that per mount per request, could not see `$_POST` (the
+native chain runs before the body read), and would have its state torn down
+before the app script started. Running in-request makes the mount inherit the
+request's superglobals, `open_basedir`, temp/session paths, OPcache vhost,
+per-site DB session, KV keyspace, execution timer and crash guard **by
+construction** — there is no second PHP context to configure, so none to get
+wrong. That is also the entire multi-tenancy story: paths resolve against the
+request's own document root, so a mount has no more reach than that tenant's
+`index.php`.
+
+**The unavoidable consequence:** a `php:` mount runs *after* the body is read
+and after every native module. It cannot reject before the body transfer,
+which is the main reason the native lane exists. The two lanes are two
+**phases**; `order` sorts within a phase and physically cannot interleave
+them. Do not "fix" this — no ordering can put PHP before the body read.
+
+**Measured cost** (Windows, PHP 8.5, release, OPcache on, HTTP, best of 11 x
+1000 keep-alive requests): baseline 365.7 us; +3.5 us for a Rust builtin
+mount; **+11.9 us for one `php:` mount**; +21.8 us for three (~7 us/mount).
+The Rust builtin's marginal cost measured in isolation is **476 ns**. So a PHP
+mount is ~20x a builtin and ~3% of a trivial request. An *empty* middleware
+file costs the same as a working one — the cost is engaging the lane, not the
+PHP in it.
+
+**How to apply:** reuse this shape for any future "run extra PHP around the
+request" feature (response cache warmers, per-vhost preload hooks): prepend
+inside the live request, never a second request. When someone asks why `php:`
+mounts cannot rate-limit before an upload, the answer is the phase boundary,
+not a missing feature. See
+[[php-exit-not-observable-after-execute-script]] for the engine trap this
+design walks into, and [[windows-chdir-per-request-cost]] for the perf trap.

--- a/.claude/agent-memory/ephpm-systems-architect/shared-target-stale-fingerprint.md
+++ b/.claude/agent-memory/ephpm-systems-architect/shared-target-stale-fingerprint.md
@@ -1,0 +1,38 @@
+---
+name: shared-target-stale-fingerprint
+description: The shared target dir replays stale rlibs across worktrees — a "method not found" on a symbol you just added is a cache lie; touch the source file, don't debug the code
+metadata:
+  type: project
+---
+
+In this repo every worktree shares one `target/` (`[build] target-dir` in the
+root `.cargo/config.toml`). That cache periodically serves a **stale rlib** for
+a path dependency, producing compile errors that contradict the source on disk.
+
+Concretely, 2026-08-22: `cargo test -p ephpm-server --lib` failed with
+`no method named php_script found for &ephpm_config::MiddlewareMount` while
+`cargo test -p ephpm-config` compiled and passed tests that *call*
+`php_script`, and `cargo clippy --workspace --all-targets` was green. Retrying
+reproduced it identically. Fix was one line:
+
+```powershell
+(Get-Item crates\ephpm-config\src\lib.rs).LastWriteTime = Get-Date
+```
+
+after which the same command passed 384 tests.
+
+**Why:** concurrent builds from sibling worktrees contend for the same
+fingerprint database; a unit can be recorded fresh while its dependents keep a
+stale view. The failure is indistinguishable from a real compile error, and
+"green clippy, red test" is the tell.
+
+**How to apply:**
+* If a build error says a symbol you can *see* in the source does not exist —
+  and especially if a different cargo command disagrees — bump the mtime of
+  the defining file and re-run **before** editing anything.
+* Never respond to this by deleting the cache (`cargo clean`, `rm -rf
+  target/`): it is a 78 GB shared dir and a full rebuild costs tens of minutes
+  for every agent using it.
+* The inverse also happens: a stale cache can report **false green**. When a
+  verdict matters (a gate before pushing), make sure the run actually
+  recompiled the crate you changed.

--- a/.claude/agent-memory/ephpm-systems-architect/windows-chdir-per-request-cost.md
+++ b/.claude/agent-memory/ephpm-systems-architect/windows-chdir-per-request-cost.md
@@ -1,0 +1,31 @@
+---
+name: windows-chdir-per-request-cost
+description: VCWD_GETCWD + VCWD_CHDIR_FILE + VCWD_CHDIR costs ~55us per request on Windows — never add a cwd save/restore to the request path without measuring
+metadata:
+  type: project
+---
+
+One `VCWD_GETCWD` + `VCWD_CHDIR_FILE` + `VCWD_CHDIR` triple on the PHP request
+path measured **~55 us per request on Windows** — roughly 5x the cost of
+executing a whole extra OPcache-cached PHP script (~7-12 us), and ~15% of a
+trivial request end-to-end.
+
+**Why:** added to the `php:` middleware chain (PR #382) to mirror
+`php_execute_script`'s chdir and match `auto_prepend_file` semantics exactly.
+Benchmarking showed an *empty* middleware file cost the same as a working one,
+which is what exposed it: the cost was fixed per request, not per mount. An
+A/B behind a temporary env switch confirmed the chdir was ~55 of the ~60 us.
+It was removed; a relative `include`/`require` still resolves against the
+including file's own directory (PHP checks that before the cwd), so only bare
+relative paths to `fopen()` etc. are affected — documented as "use `__DIR__`".
+
+**How to apply:**
+* Treat any per-request cwd manipulation on Windows as expensive until proven
+  otherwise. `VCWD_CHDIR_FILE` does realpath expansion plus a
+  `SetCurrentDirectory` syscall.
+* More generally: when a per-request feature's cost does not scale with the
+  work it nominally does, the cost is fixed overhead somewhere else. Measure
+  with an empty/no-op version of the feature to separate fixed from variable
+  before optimising the wrong thing.
+* `php_execute_script` still does its own chdir for the application script, so
+  application behaviour is unaffected by not doing one ourselves.

--- a/.claude/agent-memory/ephpm-systems-architect/windows-php-linked-local-build.md
+++ b/.claude/agent-memory/ephpm-systems-architect/windows-php-linked-local-build.md
@@ -1,0 +1,40 @@
+---
+name: windows-php-linked-local-build
+description: How to actually build and RUN php_linked code locally on this Windows box — vcvars64, LIBCLANG_PATH, the 8.5.7 SDK, and the /FORCE:MULTIPLE needed for test binaries
+metadata:
+  type: reference
+---
+
+CI's Windows PHP job only runs `cargo check -p ephpm-php` — it never links.
+So linking and running `php_linked` code locally is untested territory and
+needs three things this box does not provide by default:
+
+1. **MSVC env**: `call "C:\Program Files (x86)\Microsoft Visual
+   Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"` — without
+   `INCLUDE`/`LIB` the build fails in bindgen and then in the linker.
+2. **`LIBCLANG_PATH`** = `...\BuildTools\VC\Tools\Llvm\x64\bin` (there is no
+   standalone LLVM install here; bindgen finds nothing otherwise).
+3. **`PHP_SDK_PATH`** = `C:\Users\luther\ephpm\php-sdk\8.5.7-windows-x86_64`.
+   **Not the 8.3.31 SDK** — it ships `libintl_a.lib`, which collides with
+   `libiconv_a.lib` on `locale_charset`; both are linked `+whole-archive`, so
+   `LNK2005`/`LNK1169` and nothing links.
+
+Even on 8.5.7 the same collision surfaces for **test** binaries. Add the
+override to the one target rather than to `RUSTFLAGS` (which would invalidate
+the whole shared cache):
+
+```
+cargo rustc -p ephpm-php --test <name> -- -C link-arg=/FORCE:MULTIPLE
+```
+
+then run `target/{debug,release}/deps/<name>-*.exe --test-threads=1` directly
+(`serial_test` + one `php_embed_init` per process).
+
+**Also known:** enabling OPcache in the bare embed test harness
+(`init_with_ini_file` with `opcache.enable=1`) **crashes** with an access
+violation on Windows — the private-SHM setup the server does at startup is not
+reproduced by the harness. Benchmarks that need OPcache must run against a real
+`ephpm serve`, not the test harness. The `crates/ephpm-php/tests/sessions.rs`
+suite also already fails/crashes on the 8.5.7 SDK **on `main`** (PHP 8.4+
+deprecated `session.use_only_cookies=0`); verified by stashing changes, so do
+not attribute it to your branch.

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Config {
     pub opcache: OpcacheConfig,
 }
 
-/// One native middleware mount (`[[middleware]]`).
+/// One middleware mount (`[[middleware]]`).
 ///
 /// ```toml
 /// [[middleware]]
@@ -61,16 +61,29 @@ pub struct Config {
 /// match = "/api/*"
 /// order = 20
 /// config = { per_ip_rps = 50, burst = 100 }
+///
+/// # EXPERIMENTAL: plain-PHP middleware, no compiler and no shared library.
+/// [[middleware]]
+/// library = "php:middleware.php"
+/// match = "/api/*"
+/// order = 30
 /// ```
 #[derive(Debug, Deserialize)]
 pub struct MiddlewareMount {
-    /// Module to run. Checked against the builtin registry first (`jwt`,
-    /// `cors`, `ratelimit`/`rate-limit`, `security-headers` and their
-    /// `ephpm-middleware-*` long forms are compiled into every binary — no
-    /// dlopen). Anything else is a shared library: either a bare name
-    /// (resolved through the middleware search path with a platform suffix,
-    /// e.g. `auth-jwt` → `auth-jwt.linux-x86_64.so`) or an explicit path — a
-    /// value containing a path separator or a file extension is used as-is.
+    /// Module to run. Resolved in three steps:
+    ///
+    /// 1. A `php:` prefix selects the **PHP middleware lane** (EXPERIMENTAL) —
+    ///    the rest of the value is a path to a `.php` file, relative to the
+    ///    request's document root. See [`MiddlewareMount::php_script`].
+    /// 2. Otherwise the value is checked against the builtin registry (`jwt`,
+    ///    `cors`, `ratelimit`/`rate-limit`, `security-headers` and their
+    ///    `ephpm-middleware-*` long forms are compiled into every binary — no
+    ///    dlopen).
+    /// 3. Anything else is a shared library: either a bare name (resolved
+    ///    through the middleware search path with a platform suffix, e.g.
+    ///    `auth-jwt` → `auth-jwt.linux-x86_64.so`) or an explicit path — a
+    ///    value containing a path separator or a file extension is used as-is.
+    ///
     /// Must not be empty (enforced by [`Config::validate`]).
     pub library: String,
 
@@ -86,11 +99,37 @@ pub struct MiddlewareMount {
     pub order: u32,
 
     /// Arbitrary configuration table for the module, serialised to JSON and
-    /// passed to its `init`.
+    /// passed to its `init`. On a `php:` mount the same JSON is what
+    /// `ephpm_middleware_config()` returns to the script.
     ///
-    /// Default: unset (the module's `init` receives NULL).
+    /// Default: unset (the module's `init` receives NULL; a `php:` mount's
+    /// `ephpm_middleware_config()` returns `null`).
     #[serde(default)]
     pub config: Option<serde_json::Value>,
+}
+
+/// Prefix that selects the PHP middleware lane in `library`.
+pub const PHP_MIDDLEWARE_PREFIX: &str = "php:";
+
+/// Maximum PHP middleware mounts that may run for one request.
+///
+/// Matches `MAX_REQUEST_MIDDLEWARE` in `crates/ephpm-php/ephpm_wrapper.c`;
+/// [`Config::validate`] refuses a config that declares more so the C-side cap
+/// can never silently drop a mount.
+pub const MAX_PHP_MIDDLEWARE: usize = 16;
+
+impl MiddlewareMount {
+    /// The document-root-relative script path when this is a `php:` mount.
+    ///
+    /// `None` for builtin and shared-library mounts. The returned path is the
+    /// raw configured value; [`Config::validate`] has already rejected the
+    /// unsafe shapes (empty, absolute, `..`, backslash, Windows drive prefix),
+    /// so a value that survives validation can be joined onto a document root
+    /// without escaping it.
+    #[must_use]
+    pub fn php_script(&self) -> Option<&str> {
+        self.library.strip_prefix(PHP_MIDDLEWARE_PREFIX)
+    }
 }
 
 /// HTTP server configuration.
@@ -3013,6 +3052,7 @@ impl Config {
 
         // Native middleware: an empty `library` can never resolve, and
         // silently skipping the mount would be a silent no-op config knob.
+        let mut php_mounts = 0usize;
         for (i, mount) in self.middleware.iter().enumerate() {
             if mount.library.is_empty() {
                 return Err(ConfigError::Validation(format!(
@@ -3020,6 +3060,66 @@ impl Config {
                     mount.order,
                 )));
             }
+
+            let Some(script) = mount.php_script() else { continue };
+            php_mounts += 1;
+            let bad = |why: &str| {
+                Err(ConfigError::Validation(format!(
+                    "[[middleware]] entry {i} (library = \"{}\"): {why}",
+                    mount.library,
+                )))
+            };
+
+            if script.is_empty() {
+                return bad("\"php:\" must be followed by a script path");
+            }
+            // A `php:` path is joined onto the REQUEST's document root, which
+            // in multi-tenant mode is the tenant's own directory. Every shape
+            // that could make that join land somewhere else is refused here,
+            // at startup, rather than being re-checked per request:
+            //
+            //   - absolute paths and Windows drive prefixes escape the join
+            //     entirely, and would additionally sit outside every vhost's
+            //     `open_basedir`, so PHP could not load them anyway;
+            //   - `..` walks out of the document root;
+            //   - a backslash is a separator on Windows but an ordinary
+            //     filename character on Unix, so allowing it would make the
+            //     same config mean two different things.
+            if script.starts_with('/') || script.starts_with('\\') {
+                return bad(
+                    "the script path must be relative to the document root, not absolute — \
+                     an operator-owned file shared by every tenant would need a hole in each \
+                     vhost's open_basedir, which this lane deliberately does not create",
+                );
+            }
+            if script.contains('\\') {
+                return bad("the script path must use `/` as its separator, not `\\`");
+            }
+            if script.len() >= 2 && script.as_bytes()[1] == b':' {
+                return bad(
+                    "the script path must be relative to the document root, not a drive path",
+                );
+            }
+            if script.split('/').any(|seg| seg == "..") {
+                return bad("the script path must not contain `..`");
+            }
+            // Worker mode boots the framework once and owns the request loop;
+            // there is no per-request `php_request_startup` to prepend into, so
+            // the mount would never run. Refuse rather than mount a policy
+            // layer that silently does nothing.
+            if self.php.mode == "worker" {
+                return bad(
+                    "PHP middleware is not supported in worker mode (`[php] mode = \"worker\"`) — \
+                     the worker script owns the request loop; use the framework's own middleware \
+                     (PSR-15 / Octane) there",
+                );
+            }
+        }
+        if php_mounts > MAX_PHP_MIDDLEWARE {
+            return Err(ConfigError::Validation(format!(
+                "{php_mounts} `php:` [[middleware]] mounts declared, but at most \
+                 {MAX_PHP_MIDDLEWARE} can run per request",
+            )));
         }
 
         // Fail closed: a multi-tenant RESP listener with no `[kv] secret` would
@@ -5254,6 +5354,117 @@ mod tests {
     // must install it with `EnvVars` — see `crate::test_env`; nothing else in
     // this module may touch `std::env` directly.
     use crate::test_env::EnvVars;
+
+    // ── [[middleware]] library = "php:<path>" ────────────────────────
+
+    /// Load a config from TOML and run `validate`, returning the message.
+    fn validation_error(toml: &str) -> String {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, toml).unwrap();
+        match Config::load(&file).unwrap().validate() {
+            Ok(()) => panic!("expected a validation error for:\n{toml}"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    /// A single `php:` mount. Uses a TOML *literal* string so a backslash in
+    /// `library` reaches validation verbatim instead of being an escape.
+    fn php_mount_toml(library: &str) -> String {
+        format!("[[middleware]]\nlibrary = '{library}'\norder = 10\n")
+    }
+
+    #[test]
+    fn php_mount_is_recognised_and_yields_its_script_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, php_mount_toml("php:auth/middleware.php")).unwrap();
+
+        let config = Config::load(&file).unwrap();
+        config.validate().expect("a plain relative path is valid");
+        assert_eq!(config.middleware[0].php_script(), Some("auth/middleware.php"));
+        // Non-`php:` mounts are untouched by the new lane.
+        assert_eq!(
+            MiddlewareMount { library: "jwt".into(), match_pattern: None, order: 0, config: None }
+                .php_script(),
+            None
+        );
+    }
+
+    /// The whole tenant-isolation story rests on the path being joined onto the
+    /// REQUEST's document root. Every shape that could escape that join is
+    /// refused at startup rather than re-checked per request.
+    #[test]
+    fn php_mount_rejects_paths_that_escape_the_document_root() {
+        for (library, expect) in [
+            ("php:", "must be followed by a script path"),
+            ("php:/etc/ephpm/mw.php", "not absolute"),
+            ("php:\\etc\\mw.php", "not absolute"),
+            ("php:C:/mw.php", "not a drive path"),
+            ("php:../../etc/mw.php", "must not contain `..`"),
+            ("php:app/../../mw.php", "must not contain `..`"),
+            ("php:app\\mw.php", "must use `/` as its separator"),
+        ] {
+            let err = validation_error(&php_mount_toml(library));
+            assert!(
+                err.contains(expect),
+                "\"{library}\" should be rejected with {expect:?}: {err}"
+            );
+            assert!(err.contains(library), "the error must name the mount: {err}");
+        }
+    }
+
+    /// A dot-segment that merely *starts* with `..` is a legal filename and
+    /// must not be caught by the traversal check.
+    #[test]
+    fn php_mount_allows_filenames_that_start_with_dots() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, php_mount_toml("php:..hidden/..mw.php")).unwrap();
+        Config::load(&file).unwrap().validate().expect("`..hidden` is a filename, not a traversal");
+    }
+
+    /// Worker mode owns the request loop, so there is no per-request
+    /// `php_request_startup` to prepend into. Refuse rather than mount a policy
+    /// layer that silently never runs.
+    #[test]
+    fn php_mount_is_rejected_in_worker_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let docroot = dir.path().join("public");
+        std::fs::create_dir_all(&docroot).unwrap();
+        std::fs::write(docroot.join("worker.php"), "<?php\n").unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            format!(
+                "[server]\ndocument_root = {docroot:?}\n\
+                 [php]\nmode = \"worker\"\nworker_script = \"worker.php\"\n\
+                 {}",
+                php_mount_toml("php:middleware.php"),
+            ),
+        )
+        .unwrap();
+
+        let err = match Config::load(&file).unwrap().validate() {
+            Ok(()) => panic!("a php: mount under worker mode must be rejected"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("worker mode"), "{err}");
+        assert!(err.contains("PSR-15"), "the error should point at the alternative: {err}");
+    }
+
+    /// The Rust-side cap must match the C wrapper's `MAX_REQUEST_MIDDLEWARE`,
+    /// so a mount can never be silently dropped at request time.
+    #[test]
+    fn php_mounts_beyond_the_per_request_cap_are_rejected() {
+        let mut toml = String::new();
+        for i in 0..=MAX_PHP_MIDDLEWARE {
+            use std::fmt::Write as _;
+            let _ = writeln!(toml, "[[middleware]]\nlibrary = 'php:mw{i}.php'\norder = {i}");
+        }
+        let err = validation_error(&toml);
+        assert!(err.contains(&MAX_PHP_MIDDLEWARE.to_string()), "{err}");
+    }
 
     // ── [server.http3] ───────────────────────────────────────────────
 

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -331,6 +331,47 @@ static EPHPM_TLS size_t request_ini_count = 0;
 /* Track whether a PHP request is currently active on this thread */
 static EPHPM_TLS int request_active = 0;
 
+/* PHP middleware lane (`[[middleware]] library = "php:<path>"`, EXPERIMENTAL).
+ *
+ * These scripts run inside the SAME PHP request as the application script,
+ * immediately before it — the position PHP's own `auto_prepend_file` occupies,
+ * except there can be several, each scoped by its mount's `match` glob and
+ * carrying its own `config`.
+ *
+ * Running them in-request rather than as their own ephpm_execute_request() is
+ * the whole design: superglobals, open_basedir, sys_temp_dir/session.save_path,
+ * the OPcache vhost, the per-site DB session, the execution timer and the crash
+ * guard are all already correct for this request, so a middleware file inherits
+ * every isolation and safety property the app script has instead of needing a
+ * parallel set. The marginal cost is one extra (OPcache-cached)
+ * php_execute_script() per matching mount.
+ *
+ * Pointers are borrowed from Rust and must stay valid until
+ * ephpm_execute_request() returns — same contract as server_vars above. */
+#define MAX_REQUEST_MIDDLEWARE 16
+
+static EPHPM_TLS const char *req_middleware_paths[MAX_REQUEST_MIDDLEWARE];
+static EPHPM_TLS const char *req_middleware_configs[MAX_REQUEST_MIDDLEWARE];
+static EPHPM_TLS size_t req_middleware_count = 0;
+
+/* Index of the middleware file currently executing, -1 when none. Drives
+ * ephpm_middleware_config(), which therefore returns NULL when called from
+ * anywhere other than a middleware file. */
+static EPHPM_TLS int req_middleware_active = -1;
+
+/* How the chain ended for the request just executed, read back by Rust for the
+ * `ephpm_middleware_invocations_total{action=...}` label. */
+#define EPHPM_MW_CONTINUE 0
+#define EPHPM_MW_EXIT     1
+#define EPHPM_MW_FATAL    2
+static EPHPM_TLS int req_middleware_outcome = EPHPM_MW_CONTINUE;
+
+/* How many mounts actually executed. Equals req_middleware_count when the whole
+ * chain continued; otherwise the 1-based position of the mount that ended it,
+ * so the metric can attribute `respond`/`error` to the right mount instead of
+ * smearing it across every mount that matched. */
+static EPHPM_TLS int req_middleware_ran = 0;
+
 /* Duplicate a C string with plain malloc (must outlive the Zend per-request
  * allocator, so estrdup is unsuitable). Returns NULL on OOM or NULL input. */
 static char *ephpm_strdup_malloc(const char *s)
@@ -870,6 +911,10 @@ void ephpm_request_clear(void)
     req_post_data_offset = 0;
     req_path_translated = NULL;
     server_var_count = 0;
+    req_middleware_count = 0;
+    req_middleware_active = -1;
+    req_middleware_outcome = EPHPM_MW_CONTINUE;
+    req_middleware_ran = 0;
 }
 
 /*
@@ -908,6 +953,48 @@ void ephpm_request_add_server_var(const char *key, const char *value)
         server_vars[server_var_count].value = value;
         server_var_count++;
     }
+}
+
+/*
+ * Queue one PHP middleware script for this request, in chain order.
+ *
+ * `path` is an absolute filesystem path already resolved (and confined to the
+ * request's document root) by the router; `config_json` is the mount's `config`
+ * table serialised to JSON, or NULL when the mount declares none. Both pointers
+ * are borrowed and must outlive ephpm_execute_request().
+ *
+ * Mounts beyond MAX_REQUEST_MIDDLEWARE are dropped rather than growing an
+ * unbounded per-request array; the Rust side enforces the same cap at startup
+ * so this can only fire if the two ever disagree.
+ *
+ * Call before ephpm_execute_request().
+ */
+void ephpm_request_add_middleware(const char *path, const char *config_json)
+{
+    if (!path || req_middleware_count >= MAX_REQUEST_MIDDLEWARE) {
+        return;
+    }
+    req_middleware_paths[req_middleware_count] = path;
+    req_middleware_configs[req_middleware_count] = config_json;
+    req_middleware_count++;
+}
+
+/*
+ * How the middleware chain ended for the request just executed:
+ * EPHPM_MW_CONTINUE / EPHPM_MW_EXIT / EPHPM_MW_FATAL.
+ */
+int ephpm_middleware_outcome(void)
+{
+    return req_middleware_outcome;
+}
+
+/*
+ * How many queued middleware mounts actually executed for the request just
+ * executed. The last one is the mount the outcome above belongs to.
+ */
+int ephpm_middleware_ran(void)
+{
+    return req_middleware_ran;
 }
 
 /*
@@ -986,6 +1073,153 @@ void ephpm_request_set_ini(const char *key, const char *value)
  */
 #define ephpm_bailout_reset()    (CG(unclean_shutdown) = 0)
 #define ephpm_bailout_observed() (CG(unclean_shutdown) != 0)
+
+/*
+ * Run one middleware script and classify how it ended.
+ *
+ * This is php-src's own `zend_execute_scripts()` loop body (Zend/zend.c),
+ * inlined for ONE file, with exactly one change: an unwind-exit exception is
+ * recognised and reported instead of being handed to zend_exception_error().
+ *
+ * That change is the whole reason this is not simply `php_execute_script()`.
+ * PHP 8 implements exit()/die() by throwing an unwind-exit exception, and both
+ * `zend_execute_scripts()` and `php_execute_script()` funnel EVERY pending
+ * exception through `zend_exception_error()`, which clears `EG(exception)` and
+ * — for an unwind exit — returns SUCCESS. By the time either of them returns,
+ * "the script called exit()" and "the script ran to completion" are
+ * indistinguishable. Measured, not assumed: the first cut of this lane used
+ * php_execute_script() and its exit()-short-circuit tests failed with the
+ * application script's output appended to the middleware's.
+ *
+ * Everything else is deliberately identical to upstream, including adding the
+ * resolved path to EG(included_files) (so a middleware file that the app also
+ * `require_once`s is not compiled twice) and the op_array teardown order.
+ * zend_compile_file() is OPcache's hook, so the file is cached in SHM like any
+ * other script — the marginal cost of a mount is a cache lookup plus its own
+ * opcodes, not a compile.
+ *
+ * Returns EPHPM_MW_CONTINUE / EPHPM_MW_EXIT / EPHPM_MW_FATAL. A compile failure
+ * (missing file, parse error) raises E_COMPILE_ERROR, which bails out through
+ * the caller's SETJMP rather than returning here — also fail-closed.
+ */
+static int ephpm_run_one_middleware(const char *path)
+{
+    zend_file_handle fh;
+    zend_op_array *op_array;
+    int outcome = EPHPM_MW_CONTINUE;
+
+    zend_stream_init_filename(&fh, path);
+    op_array = zend_compile_file(&fh, ZEND_REQUIRE);
+    if (fh.opened_path) {
+        zend_hash_add_empty_element(&EG(included_files), fh.opened_path);
+    }
+    zend_destroy_file_handle(&fh);
+
+    if (!op_array) {
+        /* A syntax error is a thrown ParseError in PHP 7+, NOT a bailout:
+         * zend_compile_file returns NULL with EG(exception) still pending and
+         * nothing recorded in PG(last_error_type). Reporting it here is what
+         * turns it into the 500 the caller's last_error_type check produces —
+         * and, just as importantly, clears the exception so it cannot surface
+         * inside a shutdown function later in this request. (A file that is
+         * simply missing takes the other route: ZEND_REQUIRE raises
+         * E_COMPILE_ERROR, which bails out before reaching here.) */
+        if (EG(exception)) {
+            zend_exception_error(EG(exception), E_ERROR);
+        }
+        return EPHPM_MW_FATAL;
+    }
+
+    zend_execute(op_array, NULL);
+    zend_exception_restore();
+
+    if (UNEXPECTED(EG(exception))) {
+        if (zend_is_unwind_exit(EG(exception))) {
+            /* exit()/die() — the lane's ACTION_RESPOND. */
+            zend_clear_exception();
+            outcome = EPHPM_MW_EXIT;
+        } else {
+            if (Z_TYPE(EG(user_exception_handler)) != IS_UNDEF) {
+                zend_user_exception_handler();
+            }
+            if (EG(exception)) {
+                /* Reports the uncaught Throwable as a fatal exactly as
+                 * zend_execute_scripts would, and clears it. */
+                zend_exception_error(EG(exception), E_ERROR);
+            }
+            outcome = EPHPM_MW_FATAL;
+        }
+    }
+
+    zend_destroy_static_vars(op_array);
+    destroy_op_array(op_array);
+    efree_size(op_array, sizeof(zend_op_array));
+    return outcome;
+}
+
+/*
+ * Run the queued PHP middleware scripts, in order, inside the live request.
+ *
+ * The working directory is deliberately NOT changed first, which is the one
+ * place this lane diverges from PHP's `auto_prepend_file` (php_execute_script
+ * chdirs to the primary script's directory, then runs prepend + primary inside
+ * that). Doing the same here — one getcwd + one chdir + one restore — measured
+ * **~55 us per request on Windows**, against ~6 us for actually executing a
+ * mount. That is an order of magnitude of pure overhead for a guarantee PHP
+ * mostly provides anyway: a relative `include` resolves against the *including
+ * script's own directory* before it ever consults the cwd, so
+ * `include 'helper.php'` from a middleware file still finds the file beside it.
+ * What does change is a bare relative path handed to a filesystem call
+ * (`fopen('data.txt')`), which resolves against the server's working directory
+ * — so the guide tells middleware authors to use `__DIR__`. The application
+ * script is unaffected: php_execute_script still does its own chdir for it.
+ *
+ * Three ways a mount ends the chain, all fail-closed:
+ *
+ *   1. exit()/die() — ACTION_RESPOND. Remaining mounts and the app script are
+ *      skipped; whatever the middleware emitted becomes the response.
+ *
+ *   2. An uncaught Throwable or a fatal that does not bail out. Without the
+ *      explicit check the app script would run anyway — a middleware that
+ *      throws would fail OPEN, which for an auth mount is precisely the bug
+ *      that must not exist.
+ *
+ *   3. A zend_bailout (missing file, parse error, OOM, resource limit).
+ *      Nothing here catches it: it longjmps to the SETJMP in
+ *      ephpm_execute_request, which skips the app script and 500s.
+ */
+static int ephpm_run_middleware_chain(void)
+{
+    const int fatal_error_mask = E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR
+                                 | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE;
+    int outcome = EPHPM_MW_CONTINUE;
+
+    /* The overwhelmingly common case: no mounts. A server with no `php:`
+     * middleware pays one predictable branch for this lane existing. */
+    if (req_middleware_count == 0) {
+        return EPHPM_MW_CONTINUE;
+    }
+
+    for (size_t i = 0; i < req_middleware_count; i++) {
+        req_middleware_active = (int)i;
+        outcome = ephpm_run_one_middleware(req_middleware_paths[i]);
+        req_middleware_active = -1;
+        req_middleware_ran = (int)i + 1;
+
+        /* A bailout absorbed elsewhere, or a fatal reported with E_DONT_BAIL,
+         * both mean "do not continue" even when the call above returned
+         * CONTINUE. */
+        if (outcome == EPHPM_MW_CONTINUE
+            && (ephpm_bailout_observed() || (PG(last_error_type) & fatal_error_mask))) {
+            outcome = EPHPM_MW_FATAL;
+        }
+        if (outcome != EPHPM_MW_CONTINUE) {
+            break;
+        }
+    }
+
+    return outcome;
+}
 
 /*
  * Execute a PHP request.
@@ -1141,22 +1375,51 @@ int ephpm_execute_request(const char *filename)
 
     EG(bailout) = &__bailout;
     if (SETJMP(__bailout) == 0) {
-        zend_file_handle file_handle;
-        zend_stream_init_filename(&file_handle, filename);
-        php_execute_script(&file_handle);
+        /* PHP middleware lane: mounts matching this request run first, in the
+         * same request, immediately before the application script. A mount that
+         * exits short-circuits (the lane's RESPOND); a mount that fatals aborts
+         * the request rather than falling through to the app — fail closed. */
+        req_middleware_outcome = ephpm_run_middleware_chain();
 
-        /* PHP 8.x: exit()/die() throws an unwind exit exception instead
-         * of calling zend_bailout(). Treat it like the old bailout path,
-         * but DO NOT mark it as a fatal bailout — exit() is intentional
-         * and should preserve whatever status the script set. */
-        if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
-            zend_clear_exception();
+        if (req_middleware_outcome == EPHPM_MW_EXIT) {
             result = EPHPM_EXEC_SCRIPT_EXIT;
+        } else if (req_middleware_outcome == EPHPM_MW_CONTINUE) {
+            zend_file_handle file_handle;
+            zend_stream_init_filename(&file_handle, filename);
+            php_execute_script(&file_handle);
+
+            /* PHP 8.x: exit()/die() throws an unwind exit exception instead
+             * of calling zend_bailout(). Treat it like the old bailout path,
+             * but DO NOT mark it as a fatal bailout — exit() is intentional
+             * and should preserve whatever status the script set. */
+            if (EG(exception) && zend_is_unwind_exit(EG(exception))) {
+                zend_clear_exception();
+                result = EPHPM_EXEC_SCRIPT_EXIT;
+            }
         }
+        /* EPHPM_MW_FATAL falls through with result still EPHPM_EXEC_OK: the
+         * bailout / last_error_type checks below turn it into the 500 the app
+         * script's own fatal would have produced. */
     } else {
         /* A zend_bailout() raised OUTSIDE php_execute_script's own zend_try
          * (rare — that guard absorbs everything raised by the script itself).
-         * The CG(unclean_shutdown) check below covers both cases. */
+         * The CG(unclean_shutdown) check below covers both cases.
+         *
+         * The middleware chain, unlike the app script, is NOT wrapped in
+         * php_execute_script's zend_try, so a bailout inside a mount (a missing
+         * file, a parse error, OOM) lands HERE — with the app script skipped,
+         * which is the fail-closed answer.
+         *
+         * `req_middleware_active >= 0` says the jump came from inside a mount
+         * rather than from anywhere else in the request, so the outcome is only
+         * rewritten when it really belongs to the chain. Clearing the cursor
+         * also stops a later ephpm_middleware_config() on this thread from
+         * reading a stale index. */
+        if (req_middleware_active >= 0) {
+            req_middleware_ran = req_middleware_active + 1;
+            req_middleware_outcome = EPHPM_MW_FATAL;
+            req_middleware_active = -1;
+        }
         result = EPHPM_EXEC_BAILOUT;
     }
     EG(bailout) = __orig_bailout;
@@ -4176,6 +4439,37 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_cli_get_process_title, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+/* ── PHP middleware lane ─────────────────────────────────────────
+ *
+ * ephpm_middleware_config(): ?string
+ *
+ * Returns the running mount's `config` table from `[[middleware]]`, serialised
+ * to JSON, or NULL when the mount declares no `config` — and NULL from anywhere
+ * that is not a middleware file, which is what makes
+ * `json_decode(ephpm_middleware_config() ?? '{}', true)` safe to call
+ * unconditionally.
+ *
+ * JSON rather than a PHP array on purpose: decoding here would mean linking
+ * ext/json's C API out of a static embed build (PHP_JSON_API is dllimport on
+ * Windows), and `json_decode()` is one idiomatic PHP call away. This is the
+ * ONLY native function the lane adds — verdicts are expressed in stock PHP
+ * (`exit`, `header()`, `$_SERVER`), not through a bespoke API.
+ */
+PHP_FUNCTION(ephpm_middleware_config)
+{
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    if (req_middleware_active < 0
+        || (size_t)req_middleware_active >= req_middleware_count
+        || !req_middleware_configs[req_middleware_active]) {
+        RETURN_NULL();
+    }
+    RETURN_STRING(req_middleware_configs[req_middleware_active]);
+}
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_middleware_config, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 /* ── Function entry table (null-terminated) ──────────────────── */
 
 /* The entries every mode gets. Kept as a macro so the serve-mode table and
@@ -4218,7 +4512,9 @@ ZEND_END_ARG_INFO()
     PHP_FE(ephpm_ws_connection_unsubscribe,  arginfo_ephpm_ws_connection_unsubscribe) \
     PHP_FE(ephpm_ws_broadcast,               arginfo_ephpm_ws_broadcast) \
     PHP_FE(ephpm_ws_close,                   arginfo_ephpm_ws_close) \
-    PHP_FE(ephpm_ws_connection_close,        arginfo_ephpm_ws_connection_close)
+    PHP_FE(ephpm_ws_connection_close,        arginfo_ephpm_ws_connection_close) \
+    /* PHP middleware lane: the running mount's `config` table as JSON. */ \
+    PHP_FE(ephpm_middleware_config,          arginfo_ephpm_middleware_config)
 
 static const zend_function_entry ephpm_kv_functions[] = {
     EPHPM_COMMON_FUNCTION_ENTRIES

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -343,8 +343,10 @@ static EPHPM_TLS int request_active = 0;
  * the OPcache vhost, the per-site DB session, the execution timer and the crash
  * guard are all already correct for this request, so a middleware file inherits
  * every isolation and safety property the app script has instead of needing a
- * parallel set. The marginal cost is one extra (OPcache-cached)
- * php_execute_script() per matching mount.
+ * parallel set. The marginal cost is one extra OPcache-cached script execution
+ * per matching mount — measured at ~7-12 us over HTTP, against ~366 us for a
+ * trivial request. See ephpm_run_one_middleware() for why that execution does
+ * NOT go through php_execute_script().
  *
  * Pointers are borrowed from Rust and must stay valid until
  * ephpm_execute_request() returns — same contract as server_vars above. */

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -98,6 +98,23 @@ mod ffi {
             value: *const ::std::os::raw::c_char,
         );
 
+        /// Queue one PHP middleware script for this request, in chain order.
+        /// `config_json` may be null. Pointers must stay valid until
+        /// `ephpm_execute_request` returns.
+        pub fn ephpm_request_add_middleware(
+            path: *const ::std::os::raw::c_char,
+            config_json: *const ::std::os::raw::c_char,
+        );
+
+        /// How the PHP middleware chain ended for the request just executed:
+        /// 0 = every mount continued, 1 = a mount short-circuited via `exit()`,
+        /// 2 = a mount raised a fatal.
+        pub fn ephpm_middleware_outcome() -> ::std::os::raw::c_int;
+
+        /// How many queued PHP middleware mounts actually executed. The last
+        /// one is the mount `ephpm_middleware_outcome` describes.
+        pub fn ephpm_middleware_ran() -> ::std::os::raw::c_int;
+
         /// Execute a PHP request with full lifecycle management.
         ///
         /// Returns one of the `EPHPM_EXEC_*` codes defined in
@@ -1170,6 +1187,43 @@ impl PhpRuntime {
             }
         }
 
+        // PHP middleware lane: queue the mounts the router matched for this
+        // request. They execute inside this same PHP request, immediately
+        // before the application script — see ephpm_run_middleware_chain().
+        //
+        // A path or config that cannot be a C string is dropped rather than
+        // silently mounting a *different* script: the router only ever produces
+        // paths under the request's document root, so an interior NUL here
+        // means something upstream is wrong and skipping is the safe read.
+        // The strings are bound to locals that outlive ephpm_execute_request.
+        let c_middleware: Vec<(CString, Option<CString>)> = request
+            .middleware
+            .iter()
+            .filter_map(|mw| {
+                let path = CString::new(mw.script.to_str()?).ok()?;
+                let config = match mw.config_json.as_deref() {
+                    Some(json) => Some(CString::new(json).ok()?),
+                    None => None,
+                };
+                Some((path, config))
+            })
+            .collect();
+        if c_middleware.len() != request.middleware.len() {
+            tracing::error!(
+                mounted = request.middleware.len(),
+                usable = c_middleware.len(),
+                "a PHP middleware mount had an unrepresentable path or config and was skipped"
+            );
+        }
+        for (path, config) in &c_middleware {
+            let config_ptr = config.as_ref().map_or(std::ptr::null(), |c| c.as_ptr());
+            // Safety: both CStrings live until this function returns, which is
+            // after ephpm_execute_request has consumed them.
+            unsafe {
+                ffi::ephpm_request_add_middleware(path.as_ptr(), config_ptr);
+            }
+        }
+
         // Execute the PHP request on this thread's TSRM context.
         //
         // Two shapes, selected by the `[php] crash_containment` master switch:
@@ -1606,6 +1660,35 @@ impl PhpRuntime {
         }
     }
 
+    /// How the PHP middleware chain ended for the request this thread just
+    /// executed, and how many mounts actually ran.
+    ///
+    /// Thread-local: must be read on the same blocking thread that called
+    /// [`PhpRuntime::execute`], before that thread runs another request.
+    /// The count is the 1-based position of the mount the outcome belongs to;
+    /// mounts before it all continued and mounts after it never ran.
+    #[cfg(php_linked)]
+    #[must_use]
+    pub fn middleware_outcome() -> (crate::request::MiddlewareOutcome, usize) {
+        // SAFETY: each call reads one `__thread` int in the C wrapper. No PHP
+        // state is touched, so no TSRM registration or bailout guard is needed.
+        #[allow(unsafe_code)]
+        let (raw, ran) = unsafe { (ffi::ephpm_middleware_outcome(), ffi::ephpm_middleware_ran()) };
+        let outcome = match raw {
+            1 => crate::request::MiddlewareOutcome::Respond,
+            2 => crate::request::MiddlewareOutcome::Error,
+            _ => crate::request::MiddlewareOutcome::Continue,
+        };
+        (outcome, usize::try_from(ran).unwrap_or(0))
+    }
+
+    /// Stub when PHP is not linked — no middleware ran, so nothing happened.
+    #[cfg(not(php_linked))]
+    #[must_use]
+    pub fn middleware_outcome() -> (crate::request::MiddlewareOutcome, usize) {
+        (crate::request::MiddlewareOutcome::Continue, 0)
+    }
+
     /// Set a PHP INI directive for the current request.
     ///
     /// Must be called on a TSRM-registered thread (inside `spawn_blocking`)
@@ -1941,6 +2024,7 @@ mod tests {
             is_https: false,
             protocol: "HTTP/1.1".into(),
             env_vars: Vec::new(),
+            middleware: Vec::new(),
         }
     }
 

--- a/crates/ephpm-php/src/request.rs
+++ b/crates/ephpm-php/src/request.rs
@@ -6,6 +6,48 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+/// One PHP middleware mount resolved for a single request.
+///
+/// Produced by the router from a `[[middleware]] library = "php:<path>"` mount
+/// whose `match` glob accepted this request. `script` is already resolved
+/// against the request's own document root, so in multi-tenant mode it names
+/// the tenant's own file and nothing else.
+#[derive(Debug, Clone)]
+pub struct PhpMiddleware {
+    /// Absolute path to the middleware script.
+    pub script: PathBuf,
+
+    /// The mount's `config` table serialised to JSON, surfaced to the script as
+    /// `ephpm_middleware_config()`. `None` when the mount declares no `config`.
+    pub config_json: Option<String>,
+}
+
+/// How the PHP middleware chain ended for one request.
+///
+/// Mirrors the C `EPHPM_MW_*` codes; used for the
+/// `ephpm_middleware_invocations_total{action=...}` label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MiddlewareOutcome {
+    /// Every mount ran and fell through to the application script.
+    Continue,
+    /// A mount short-circuited with `exit()` — the lane's `RESPOND`.
+    Respond,
+    /// A mount raised a fatal; the application script never ran (fail closed).
+    Error,
+}
+
+impl MiddlewareOutcome {
+    /// Metric label for this outcome.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Continue => "continue",
+            Self::Respond => "respond",
+            Self::Error => "error",
+        }
+    }
+}
+
 /// A PHP request, constructed from an incoming HTTP request.
 ///
 /// Contains all the information needed to set up a PHP execution context
@@ -60,6 +102,13 @@ pub struct PhpRequest {
     /// so they can override built-in values if needed. Used for injecting
     /// `EPHPM_REDIS_*` credentials in multi-tenant mode.
     pub env_vars: Vec<(String, String)>,
+
+    /// PHP middleware scripts to run — in chain order — inside this request,
+    /// immediately before `script_filename`.
+    ///
+    /// Empty for every request that has no `php:` mount, which is the default
+    /// and costs nothing. See [`PhpMiddleware`].
+    pub middleware: Vec<PhpMiddleware>,
 }
 
 impl PhpRequest {
@@ -256,6 +305,7 @@ mod tests {
             is_https: false,
             protocol: "HTTP/1.1".into(),
             env_vars: Vec::new(),
+            middleware: Vec::new(),
         }
     }
 

--- a/crates/ephpm-php/tests/php_middleware.rs
+++ b/crates/ephpm-php/tests/php_middleware.rs
@@ -7,9 +7,9 @@
 //! i.e. the application script does not run.
 //!
 //! The fail-open hazard being closed here is specific and easy to reintroduce:
-//! PHP 8 reports an uncaught `Throwable` with `E_DONT_BAIL`, so
-//! `php_execute_script()` returns normally and the naive loop would happily
-//! continue to the app script. For an auth middleware that is an auth bypass.
+//! PHP 8 reports an uncaught `Throwable` with `E_DONT_BAIL`, so execution
+//! returns normally and the naive loop would happily continue to the app
+//! script. For an auth middleware that is an auth bypass.
 //!
 //! Requires a real libphp link (`php_linked`); in stub mode the file compiles
 //! to nothing.
@@ -212,7 +212,7 @@ fn exit_skips_later_mounts() {
 // ── Failure semantics — all fail CLOSED ───────────────────────────────
 
 /// An uncaught exception is the fail-open trap: `zend_exception_error` reports
-/// it with `E_DONT_BAIL`, so `php_execute_script` returns normally and only
+/// it with `E_DONT_BAIL`, so execution returns normally and only
 /// `PG(last_error_type)` records it. The app script must still not run.
 #[test]
 #[serial]

--- a/crates/ephpm-php/tests/php_middleware.rs
+++ b/crates/ephpm-php/tests/php_middleware.rs
@@ -1,0 +1,437 @@
+//! Integration tests for the PHP middleware lane (`library = "php:<path>"`).
+//!
+//! These pin the behaviour that cannot be checked without a real engine: that a
+//! middleware file runs inside the *same* PHP request as the application script
+//! (sharing superglobals and output), that `exit()` short-circuits, and — the
+//! one that matters most — that **every** middleware failure mode fails CLOSED,
+//! i.e. the application script does not run.
+//!
+//! The fail-open hazard being closed here is specific and easy to reintroduce:
+//! PHP 8 reports an uncaught `Throwable` with `E_DONT_BAIL`, so
+//! `php_execute_script()` returns normally and the naive loop would happily
+//! continue to the app script. For an auth middleware that is an auth bypass.
+//!
+//! Requires a real libphp link (`php_linked`); in stub mode the file compiles
+//! to nothing.
+//!
+//! Run with: `cargo test -p ephpm-php --test php_middleware`.
+
+#![cfg(all(test, php_linked))]
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use ephpm_php::PhpRuntime;
+use ephpm_php::request::{MiddlewareOutcome, PhpMiddleware, PhpRequest};
+use ephpm_php::response::PhpResponse;
+use serial_test::serial;
+use tempfile::TempDir;
+
+static SCRIPT_DIR: OnceLock<TempDir> = OnceLock::new();
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Boot PHP once per test process.
+///
+/// Deliberately WITHOUT OPcache: the bare embed harness has no `php.ini`, and
+/// wiring one up here to enable OPcache crashes on Windows (the private-SHM
+/// setup the server does at startup is not reproduced by this harness). The
+/// consequence matters for [`bench_php_mount_marginal_cost`] and is stated
+/// there: with no opcode cache, every request recompiles every mounted file, so
+/// the in-process benchmark measures an **upper bound**, not the cost a real
+/// server pays.
+fn init_once() {
+    INIT.get_or_init(|| {
+        PhpRuntime::init().expect("php_embed_init");
+        PhpRuntime::finalize_for_http().expect("finalize_for_http");
+    });
+}
+
+fn script_dir() -> &'static std::path::Path {
+    SCRIPT_DIR.get_or_init(|| TempDir::new().expect("tempdir for middleware scripts")).path()
+}
+
+fn write_script(name: &str, body: &str) -> PathBuf {
+    let path = script_dir().join(name);
+    std::fs::write(&path, body).expect("write test script");
+    path
+}
+
+/// Run `app` with `middleware` mounted ahead of it, in the one PHP request.
+fn run(app: PathBuf, middleware: Vec<PhpMiddleware>) -> Result<PhpResponse, ephpm_php::PhpError> {
+    init_once();
+    let name = app.file_name().unwrap().to_string_lossy().into_owned();
+    PhpRuntime::execute(PhpRequest {
+        method: "GET".into(),
+        uri: format!("/{name}"),
+        path: format!("/{name}"),
+        query_string: String::new(),
+        document_root: app.parent().unwrap().to_path_buf(),
+        script_filename: app,
+        headers: vec![("X-Probe".into(), "probe-value".into())],
+        body: Vec::new(),
+        content_type: None,
+        remote_addr: "127.0.0.1:12345".parse().unwrap(),
+        server_name: "localhost".into(),
+        server_port: 8080,
+        is_https: false,
+        protocol: "HTTP/1.1".into(),
+        env_vars: Vec::new(),
+        middleware,
+    })
+}
+
+fn mount(script: PathBuf, config_json: Option<&str>) -> PhpMiddleware {
+    PhpMiddleware { script, config_json: config_json.map(str::to_owned) }
+}
+
+fn body_of(resp: &PhpResponse) -> String {
+    String::from_utf8_lossy(&resp.body).trim().to_string()
+}
+
+fn app_marker(name: &str) -> PathBuf {
+    write_script(name, "<?php echo 'APP-RAN';")
+}
+
+/// Assert that a middleware failure kept the application script from running.
+///
+/// PHP has two shapes for "the middleware blew up", and both must fail closed:
+///
+/// * a `zend_bailout` (missing file, parse error, `E_ERROR`, OOM) unwinds out
+///   of the request and surfaces as `PhpError::Bailout`, which the router turns
+///   into a 500 with the partial body discarded;
+/// * an uncaught `Throwable` is reported with `E_DONT_BAIL`, so execution
+///   returns normally and the response is a 500 carrying PHP's fatal message.
+///
+/// The invariant under test is the same either way: `APP-RAN` must not appear.
+fn assert_fails_closed(result: Result<PhpResponse, ephpm_php::PhpError>, what: &str) {
+    match result {
+        Err(ephpm_php::PhpError::Bailout(_)) => {}
+        Err(other) => panic!("{what}: expected a bailout or a 500, got {other:?}"),
+        Ok(resp) => {
+            assert_eq!(resp.status, 500, "{what}: must 500");
+            assert!(
+                !String::from_utf8_lossy(&resp.body).contains("APP-RAN"),
+                "FAIL-OPEN: the application script ran after {what}"
+            );
+        }
+    }
+}
+
+// ── CONTINUE ──────────────────────────────────────────────────────────
+
+/// A middleware that falls off the end is the lane's `ACTION_CONTINUE`: the
+/// app script runs, and both wrote to the same output buffer — proof they
+/// shared one PHP request rather than two.
+#[test]
+#[serial]
+fn continue_runs_the_app_script_in_the_same_request() {
+    let mw = write_script("mw_continue.php", "<?php echo 'MW;';");
+    let app = app_marker("app_continue.php");
+
+    let resp = run(app, vec![mount(mw, None)]).expect("request executed");
+    assert_eq!(body_of(&resp), "MW;APP-RAN");
+    assert_eq!(resp.status, 200);
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Continue, 1));
+}
+
+/// The middleware sees the request's already-built superglobals — the app's
+/// `$_SERVER`, not a synthetic one — and a mutation is visible to the app.
+/// This is the lane's `ACTION_REWRITE`: plain PHP assignment, no bespoke API.
+#[test]
+#[serial]
+fn middleware_shares_superglobals_with_the_app_script() {
+    let mw = write_script(
+        "mw_rewrite.php",
+        "<?php echo $_SERVER['HTTP_X_PROBE'] . ';'; $_SERVER['HTTP_X_ADDED'] = 'from-mw';",
+    );
+    let app = write_script("app_rewrite.php", "<?php echo $_SERVER['HTTP_X_ADDED'];");
+
+    let resp = run(app, vec![mount(mw, None)]).expect("request executed");
+    assert_eq!(body_of(&resp), "probe-value;from-mw");
+}
+
+/// Mounts run in the order the router queued them, and every one of them runs.
+#[test]
+#[serial]
+fn mounts_run_in_chain_order() {
+    let one = write_script("mw_order_1.php", "<?php echo '1';");
+    let two = write_script("mw_order_2.php", "<?php echo '2';");
+    let app = write_script("app_order.php", "<?php echo '3';");
+
+    let resp = run(app, vec![mount(one, None), mount(two, None)]).expect("request executed");
+    assert_eq!(body_of(&resp), "123");
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Continue, 2));
+}
+
+// ── RESPOND ───────────────────────────────────────────────────────────
+
+/// `exit()` is the lane's `ACTION_RESPOND`: the app script never runs, and the
+/// status, headers and body the middleware set are what the client gets.
+#[test]
+#[serial]
+fn exit_short_circuits_with_status_headers_and_body() {
+    let mw = write_script(
+        "mw_respond.php",
+        "<?php http_response_code(401); header('WWW-Authenticate: Bearer'); \
+         echo 'denied'; exit;",
+    );
+    let app = app_marker("app_respond.php");
+
+    let resp = run(app, vec![mount(mw, None)]).expect("request executed");
+    assert_eq!(resp.status, 401);
+    assert_eq!(body_of(&resp), "denied");
+    assert!(
+        !body_of(&resp).contains("APP-RAN"),
+        "the application script must not run after a RESPOND verdict"
+    );
+    assert!(
+        resp.headers
+            .iter()
+            .any(|(n, v)| n.eq_ignore_ascii_case("WWW-Authenticate") && v == "Bearer"),
+        "middleware response headers reach the client: {:?}",
+        resp.headers
+    );
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Respond, 1));
+}
+
+/// A short-circuit stops the REST of the chain too, not just the app script.
+#[test]
+#[serial]
+fn exit_skips_later_mounts() {
+    let first = write_script("mw_first_exit.php", "<?php echo 'FIRST'; exit;");
+    let second = write_script("mw_second.php", "<?php echo 'SECOND';");
+    let app = app_marker("app_skip.php");
+
+    let resp = run(app, vec![mount(first, None), mount(second, None)]).expect("request executed");
+    assert_eq!(body_of(&resp), "FIRST");
+    // Only the mount that short-circuited ran, so the metric attributes
+    // `respond` to it and never counts the one that was skipped.
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Respond, 1));
+}
+
+// ── Failure semantics — all fail CLOSED ───────────────────────────────
+
+/// An uncaught exception is the fail-open trap: `zend_exception_error` reports
+/// it with `E_DONT_BAIL`, so `php_execute_script` returns normally and only
+/// `PG(last_error_type)` records it. The app script must still not run.
+#[test]
+#[serial]
+fn uncaught_exception_fails_closed() {
+    let mw = write_script("mw_throw.php", "<?php throw new RuntimeException('nope');");
+    let app = app_marker("app_throw.php");
+
+    assert_fails_closed(run(app, vec![mount(mw, None)]), "middleware threw");
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Error, 1));
+}
+
+/// A hard fatal (`E_ERROR` via a call to an undefined function) likewise stops
+/// the chain.
+#[test]
+#[serial]
+fn fatal_error_fails_closed() {
+    let mw = write_script("mw_fatal.php", "<?php no_such_function_at_all();");
+    let app = app_marker("app_fatal.php");
+    assert_fails_closed(run(app, vec![mount(mw, None)]), "a middleware fatal");
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Error, 1));
+}
+
+/// A parse error in the middleware file is a compile-time fatal — same rule.
+#[test]
+#[serial]
+fn parse_error_fails_closed() {
+    let mw = write_script("mw_parse.php", "<?php this is not php at all ((( ;");
+    let app = app_marker("app_parse.php");
+    assert_fails_closed(run(app, vec![mount(mw, None)]), "a middleware parse error");
+}
+
+/// A mount whose file does not exist is the case an operator hits by typo, and
+/// the one where failing open would be most tempting. `ZEND_REQUIRE` turns the
+/// failed open into `E_COMPILE_ERROR`, which bails out — the router maps that
+/// to a 500 and the app script never runs, so a mounted policy that vanished is
+/// never silently skipped.
+#[test]
+#[serial]
+fn missing_middleware_file_fails_closed() {
+    let missing = script_dir().join("definitely_not_here.php");
+    let app = app_marker("app_missing.php");
+    assert_fails_closed(run(app, vec![mount(missing, None)]), "a missing middleware file");
+    assert_eq!(
+        PhpRuntime::middleware_outcome(),
+        (MiddlewareOutcome::Error, 1),
+        "the mount that could not be loaded is the one the metric blames"
+    );
+}
+
+/// A later mount never runs once an earlier one fataled.
+#[test]
+#[serial]
+fn fatal_skips_later_mounts_and_the_app() {
+    let boom = write_script("mw_boom.php", "<?php throw new LogicException('boom');");
+    let after = write_script("mw_after_boom.php", "<?php echo 'AFTER';");
+    let app = app_marker("app_after_boom.php");
+
+    let result = run(app, vec![mount(boom, None), mount(after, None)]);
+    if let Ok(resp) = &result {
+        assert!(
+            !String::from_utf8_lossy(&resp.body).contains("AFTER"),
+            "a mount after a fatal must not run"
+        );
+    }
+    assert_fails_closed(result, "a middleware fatal with a later mount queued");
+    assert_eq!(
+        PhpRuntime::middleware_outcome(),
+        (MiddlewareOutcome::Error, 1),
+        "only the mount that fataled ran"
+    );
+}
+
+// ── ephpm_middleware_config() ─────────────────────────────────────────
+
+/// The mount's `config` table reaches the script as JSON, and only inside the
+/// middleware file — the app script sees `null`, so a mount cannot leak its
+/// configuration into application code.
+#[test]
+#[serial]
+fn config_is_visible_to_the_mount_and_null_to_the_app() {
+    let mw = write_script(
+        "mw_config.php",
+        "<?php $c = json_decode(ephpm_middleware_config() ?? '{}', true); \
+         echo $c['realm'] . ';';",
+    );
+    let app = write_script(
+        "app_config.php",
+        "<?php echo ephpm_middleware_config() === null ? 'null' : 'LEAKED';",
+    );
+
+    let resp = run(app, vec![mount(mw, Some(r#"{"realm":"admin"}"#))]).expect("request executed");
+    assert_eq!(body_of(&resp), "admin;null");
+}
+
+/// A mount with no `config` gets `null`, which is what makes the documented
+/// `json_decode(ephpm_middleware_config() ?? '{}', true)` idiom safe.
+#[test]
+#[serial]
+fn config_is_null_when_the_mount_declares_none() {
+    let mw = write_script(
+        "mw_no_config.php",
+        "<?php echo ephpm_middleware_config() === null ? 'none' : 'unexpected';",
+    );
+    let app = write_script("app_no_config.php", "<?php echo ';ok';");
+
+    let resp = run(app, vec![mount(mw, None)]).expect("request executed");
+    assert_eq!(body_of(&resp), "none;ok");
+}
+
+/// Each mount sees its OWN config, not the previous mount's.
+#[test]
+#[serial]
+fn each_mount_sees_its_own_config() {
+    let one = write_script(
+        "mw_cfg_1.php",
+        "<?php echo json_decode(ephpm_middleware_config(), true)['id'];",
+    );
+    let two = write_script(
+        "mw_cfg_2.php",
+        "<?php echo json_decode(ephpm_middleware_config(), true)['id'];",
+    );
+    let app = write_script("app_cfg.php", "<?php echo '!';");
+
+    let resp = run(app, vec![mount(one, Some(r#"{"id":"A"}"#)), mount(two, Some(r#"{"id":"B"}"#))])
+        .expect("request executed");
+    assert_eq!(body_of(&resp), "AB!");
+}
+
+// ── No middleware ─────────────────────────────────────────────────────
+
+/// The overwhelmingly common case: no mounts, nothing changes, and the outcome
+/// counters stay clean for the next request on this thread.
+#[test]
+#[serial]
+fn no_mounts_is_unchanged_behaviour() {
+    let app = app_marker("app_bare.php");
+    let resp = run(app, Vec::new()).expect("request executed");
+    assert_eq!(body_of(&resp), "APP-RAN");
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Continue, 0));
+}
+
+// ── Cost ──────────────────────────────────────────────────────────────
+
+/// Measure what a `php:` mount actually costs per request.
+///
+/// Native middleware exists precisely to avoid entering PHP on the hot path,
+/// so "how much does a PHP mount cost" is the question that decides whether
+/// this lane is defensible. This measures the MARGINAL cost — the same
+/// application script executed with 0, 1 and 3 mounts, all doing equivalent
+/// work to the `security-headers` builtin (three `header()` calls).
+///
+/// **This is an upper bound, not the production cost.** This harness runs
+/// without OPcache (see [`init_once`]), so every iteration recompiles every
+/// mounted file. A real server has OPcache on and `zend_compile_file` — which
+/// is OPcache's hook — becomes a cache lookup instead of a parse. Treat the
+/// number here as "the worst this could ever cost"; the guide quotes the
+/// OPcache-on figure measured against a running server.
+///
+/// The Rust-builtin half of the comparison lives in
+/// `ephpm-server`'s `middleware::tests::bench_builtin_chain_marginal_cost`
+/// (crate boundaries: `ephpm-php` does not depend on the middleware crates).
+/// Both are `#[ignore]`d — they are measurements, not assertions, and their
+/// absolute numbers are machine-specific.
+///
+/// Run with:
+/// `cargo test -p ephpm-php --test php_middleware -- --ignored --nocapture`
+#[test]
+#[ignore = "benchmark: prints timings, asserts nothing"]
+#[serial]
+fn bench_php_mount_marginal_cost() {
+    const ITERATIONS: u32 = 2000;
+
+    let app = write_script("bench_app.php", "<?php echo 'ok';");
+    let header_work = "<?php header('X-Frame-Options: DENY'); \
+                       header('X-Content-Type-Options: nosniff'); \
+                       header('Referrer-Policy: no-referrer');";
+    let mounts: Vec<PathBuf> =
+        (0..3).map(|i| write_script(&format!("bench_mw_{i}.php"), header_work)).collect();
+
+    let measure = |label: &str, mounts: Vec<PhpMiddleware>| {
+        // Warm up: first execution compiles the scripts into OPcache, which is
+        // a one-off the steady state must not be charged for.
+        for _ in 0..50 {
+            run(app.clone(), mounts.clone()).expect("warmup");
+        }
+        let start = std::time::Instant::now();
+        for _ in 0..ITERATIONS {
+            run(app.clone(), mounts.clone()).expect("bench request");
+        }
+        let per_request = start.elapsed() / ITERATIONS;
+        println!("{label:<28} {per_request:?} / request");
+        per_request
+    };
+
+    let baseline = measure("no middleware", Vec::new());
+    let one = measure("1 php: mount", vec![mount(mounts[0].clone(), None)]);
+    let three = measure("3 php: mounts", mounts.iter().map(|p| mount(p.clone(), None)).collect());
+
+    println!("\nmarginal cost of the 1st mount: {:?}", one.saturating_sub(baseline));
+    println!("marginal cost per mount (3):    {:?}", (three.saturating_sub(baseline)) / 3);
+}
+
+/// Per-request state must not leak across requests on the same thread: a
+/// request with mounts followed by one without must report a clean chain.
+#[test]
+#[serial]
+fn outcome_does_not_leak_to_the_next_request_on_this_thread() {
+    let mw = write_script("mw_leak.php", "<?php echo 'X'; exit;");
+    let app = app_marker("app_leak_1.php");
+    let resp = run(app, vec![mount(mw, None)]).expect("request executed");
+    assert_eq!(PhpRuntime::middleware_outcome(), (MiddlewareOutcome::Respond, 1));
+
+    let app2 = app_marker("app_leak_2.php");
+    let resp2 = run(app2, Vec::new()).expect("request executed");
+    assert_eq!(body_of(&resp2), "APP-RAN");
+    assert_eq!(
+        PhpRuntime::middleware_outcome(),
+        (MiddlewareOutcome::Continue, 0),
+        "a previous request's chain outcome leaked onto this thread"
+    );
+    drop(resp);
+}

--- a/crates/ephpm-php/tests/sessions.rs
+++ b/crates/ephpm-php/tests/sessions.rs
@@ -92,6 +92,7 @@ fn make_request(script: PathBuf, sid: Option<&str>) -> PhpRequest {
             // session.use_strict_mode mirrors what the task spec asked for.
             ("PHP_INI_SCAN_DIR".into(), String::new()),
         ],
+        middleware: Vec::new(),
     }
 }
 

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -113,6 +113,19 @@ pub async fn serve(config: Config, dev_mode: bool) -> anyhow::Result<()> {
             modules = ?chain.module_names(),
             "middleware chain loaded"
         );
+        // The two lanes are two PHASES, and saying so at startup is the only
+        // way `order` is not a quiet lie: native modules run before the request
+        // body is read and outside PHP; `php:` mounts run inside the PHP
+        // request, after the body, immediately before the application script.
+        // `order` sorts within each phase and cannot interleave them.
+        if chain.has_php_mounts() {
+            tracing::info!(
+                php_mounts = ?chain.php_mount_names(),
+                "PHP middleware mounted (EXPERIMENTAL) — these run INSIDE the PHP request, \
+                 after the request body has been read and after every native module, so they \
+                 cannot reject before the body transfer the way a native module can"
+            );
+        }
         // In cluster mode, the built-in ratelimit middleware uses local KV
         // INCR to track the request count per window. SET/DEL and EXPIRE
         // now replicate across the cluster (KV replication v1.1), but

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -125,6 +125,10 @@ pub async fn serve(config: Config, dev_mode: bool) -> anyhow::Result<()> {
                  after the request body has been read and after every native module, so they \
                  cannot reject before the body transfer the way a native module can"
             );
+            chain.check_php_mount_scripts(
+                &config.server.document_root,
+                config.server.sites_dir.is_some(),
+            )?;
         }
         // In cluster mode, the built-in ratelimit middleware uses local KV
         // INCR to track the request count per window. SET/DEL and EXPIRE

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -70,6 +70,29 @@ use ephpm_middleware::host::{RequestCtx, ResponseCtx};
 /// any library is unloaded.
 pub struct MiddlewareChain {
     modules: Vec<Loaded>,
+    php: Vec<PhpMount>,
+}
+
+/// One `library = "php:<path>"` mount (EXPERIMENTAL).
+///
+/// PHP mounts are deliberately NOT part of [`MiddlewareChain::evaluate`]: that
+/// runs on the tokio task before the request body is read and outside any PHP
+/// context, where there is no engine to execute a script in. They are collected
+/// here at startup and handed to the router, which passes the matching ones
+/// into the PHP request itself — see [`MiddlewareChain::php_mounts`].
+#[derive(Debug)]
+pub struct PhpMount {
+    /// Mount name (the full `library` string, `php:` prefix included) — used in
+    /// logs and metrics.
+    pub name: String,
+    /// Script path relative to the request's document root. Validated at config
+    /// load: relative, no `..`, no drive prefix, `/`-separated.
+    pub script: String,
+    /// Glob the request path must match (`None` = every PHP-bound request).
+    match_pattern: Option<String>,
+    /// The mount's `config` table as JSON, surfaced to the script through
+    /// `ephpm_middleware_config()`.
+    pub config_json: Option<String>,
 }
 
 /// One mounted module: its identity plus the execution backend.
@@ -219,7 +242,15 @@ impl MiddlewareChain {
     /// non-zero.
     pub fn load(mounts: &[MiddlewareMount]) -> anyhow::Result<Self> {
         let mut modules = Vec::with_capacity(mounts.len());
+        let mut php = Vec::new();
         for mount in sorted_by_order(mounts) {
+            // `php:` mounts resolve first: they are neither a builtin name nor
+            // a library path, and letting them fall through to the dlopen
+            // search would produce a baffling "library not found" error.
+            if let Some(script) = mount.php_script() {
+                php.push(load_php_mount(mount, script)?);
+                continue;
+            }
             let loaded = match builtin(&mount.library) {
                 Some(build) => load_builtin(mount, build)?,
                 None => {
@@ -235,7 +266,31 @@ impl MiddlewareChain {
             };
             modules.push(loaded);
         }
-        Ok(Self { modules })
+        Ok(Self { modules, php })
+    }
+
+    /// The `php:` mounts whose `match` glob accepts `path`, in chain order.
+    ///
+    /// Empty for every request when no `php:` mount is configured, which is the
+    /// default — the router skips the whole lane on an empty slice.
+    #[must_use]
+    pub fn php_mounts(&self, path: &str) -> Vec<&PhpMount> {
+        self.php
+            .iter()
+            .filter(|mount| mount.match_pattern.as_ref().is_none_or(|p| path_matches(p, path)))
+            .collect()
+    }
+
+    /// Whether any `php:` mount is configured at all.
+    #[must_use]
+    pub fn has_php_mounts(&self) -> bool {
+        !self.php.is_empty()
+    }
+
+    /// `php:` mount names in chain order (for the startup log line).
+    #[must_use]
+    pub fn php_mount_names(&self) -> Vec<&str> {
+        self.php.iter().map(|m| m.name.as_str()).collect()
     }
 
     /// Number of loaded modules.
@@ -620,6 +675,36 @@ fn resolve_library(library: &str) -> anyhow::Result<PathBuf> {
         }
     }
     anyhow::bail!("middleware library \"{library}\" not found; tried: {}", tried.join(", "))
+}
+
+/// Prepare a `php:` mount. There is nothing to load — the script is compiled by
+/// PHP (and cached by OPcache) on first use inside a real request — so this only
+/// serialises the mount's `config` and records the glob.
+///
+/// The script's *existence* is deliberately not checked here: the path is
+/// resolved per request against that request's document root, so in
+/// multi-tenant mode there is one file per site and no single path to stat. A
+/// missing file fails closed at request time (`ZEND_REQUIRE` → 500), which is
+/// the same answer a missing dlopen library gives, just later.
+fn load_php_mount(mount: &MiddlewareMount, script: &str) -> anyhow::Result<PhpMount> {
+    let config_json = mount
+        .config
+        .as_ref()
+        .map(|v| serde_json::to_string(v).context("middleware config is not serialisable to JSON"))
+        .transpose()?;
+    tracing::info!(
+        module = %mount.library,
+        script,
+        r#match = mount.match_pattern.as_deref().unwrap_or("*"),
+        "middleware initialised (php, experimental) — runs inside the PHP request, \
+         after the body has been read"
+    );
+    Ok(PhpMount {
+        name: mount.library.clone(),
+        script: script.to_owned(),
+        match_pattern: mount.match_pattern.clone(),
+        config_json,
+    })
 }
 
 /// Initialise a builtin-registry mount in-process (no dlopen anywhere).
@@ -1108,6 +1193,151 @@ mod tests {
         };
         assert!(err.contains("\"jwt\""), "{err}");
         assert!(err.contains("secret"), "{err}");
+    }
+
+    // ── PHP lane (`library = "php:<path>"`) ──────────────────────────────
+
+    fn php_mount(library: &str, pattern: Option<&str>, order: u32) -> MiddlewareMount {
+        MiddlewareMount {
+            library: library.to_string(),
+            match_pattern: pattern.map(str::to_owned),
+            order,
+            config: None,
+        }
+    }
+
+    /// A `php:` mount must never reach the builtin registry or the dlopen
+    /// search path — there is no library to find, and falling through would
+    /// produce a "library not found" error naming file names that were never
+    /// meant to exist.
+    #[test]
+    fn php_mounts_never_hit_the_builtin_or_dlopen_lanes() {
+        assert!(builtin("php:middleware.php").is_none());
+        let chain = MiddlewareChain::load(&[php_mount("php:middleware.php", None, 10)])
+            .expect("a php: mount loads without touching the filesystem");
+        assert_eq!(chain.len(), 0, "php mounts are not in the native chain");
+        assert!(chain.has_php_mounts());
+        assert_eq!(chain.php_mount_names(), ["php:middleware.php"]);
+    }
+
+    /// PHP mounts are their own phase: `evaluate` (which runs before the body
+    /// is read, with no PHP context in reach) must not try to run them.
+    #[test]
+    fn php_mounts_are_invisible_to_the_native_chain_evaluation() {
+        let chain = MiddlewareChain::load(&[php_mount("php:mw.php", None, 10)]).expect("load");
+        let ctx = RequestCtx::new("GET", "/x.php", "", "127.0.0.1", "t.example", &[]);
+        match chain.evaluate(&ctx, "/x.php") {
+            ChainVerdict::Continue { rewrite_path, header_overrides, response_headers } => {
+                assert!(rewrite_path.is_none());
+                assert!(header_overrides.is_empty());
+                assert!(response_headers.is_empty());
+            }
+            ChainVerdict::Respond { status, .. } => {
+                panic!("a php: mount must not produce a native verdict (got {status})")
+            }
+        }
+    }
+
+    #[test]
+    fn php_mounts_are_filtered_by_their_match_glob_and_kept_in_order() {
+        let chain = MiddlewareChain::load(&[
+            php_mount("php:second.php", None, 20),
+            php_mount("php:first.php", Some("/api/*"), 10),
+        ])
+        .expect("load");
+
+        // Ordered by `order`, not declaration.
+        let api: Vec<&str> =
+            chain.php_mounts("/api/x.php").iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(api, ["php:first.php", "php:second.php"]);
+
+        // The globbed mount drops out off its path; the unglobbed one stays.
+        let other: Vec<&str> =
+            chain.php_mounts("/index.php").iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(other, ["php:second.php"]);
+    }
+
+    #[test]
+    fn php_mount_config_is_serialised_to_json_for_the_script() {
+        let chain = MiddlewareChain::load(&[MiddlewareMount {
+            library: "php:mw.php".to_string(),
+            match_pattern: None,
+            order: 10,
+            config: Some(serde_json::json!({ "realm": "admin" })),
+        }])
+        .expect("load");
+        let mounts = chain.php_mounts("/x.php");
+        assert_eq!(mounts[0].config_json.as_deref(), Some(r#"{"realm":"admin"}"#));
+        assert_eq!(mounts[0].script, "mw.php");
+    }
+
+    /// The two lanes coexist: native modules keep producing native verdicts
+    /// while PHP mounts are collected separately.
+    #[test]
+    fn native_and_php_mounts_coexist_in_one_chain() {
+        let chain = MiddlewareChain::load(&[
+            builtin_mount("security-headers", None, 10, serde_json::json!({})),
+            php_mount("php:audit.php", None, 20),
+        ])
+        .expect("load");
+        assert_eq!(chain.module_names(), ["security-headers"]);
+        assert_eq!(chain.php_mount_names(), ["php:audit.php"]);
+
+        let ctx = RequestCtx::new("GET", "/x.php", "", "127.0.0.1", "t.example", &[]);
+        match chain.evaluate(&ctx, "/x.php") {
+            ChainVerdict::Continue { response_headers, .. } => {
+                assert_eq!(find_header(&response_headers, "X-Frame-Options"), Some("DENY"));
+            }
+            ChainVerdict::Respond { .. } => panic!("expected CONTINUE"),
+        }
+    }
+
+    /// The Rust half of the PHP-lane cost comparison.
+    ///
+    /// Measures `MiddlewareChain::evaluate` for the `security-headers` builtin
+    /// — the in-process lane, no FFI round-trip, no dlopen — doing the same
+    /// work the PHP benchmark's mount does (three response headers). Pair it
+    /// with `ephpm-php`'s `bench_php_mount_marginal_cost`, which cannot live
+    /// here because `ephpm-php` does not depend on the middleware crates.
+    ///
+    /// `#[ignore]`d: a measurement, not an assertion. Absolute numbers are
+    /// machine-specific; the ratio is the point.
+    ///
+    /// Run with:
+    /// `cargo test -p ephpm-server --lib bench_builtin -- --ignored --nocapture`
+    #[test]
+    #[ignore = "benchmark: prints timings, asserts nothing"]
+    fn bench_builtin_chain_marginal_cost() {
+        const ITERATIONS: u32 = 200_000;
+
+        let chain = MiddlewareChain::load(&[builtin_mount(
+            "security-headers",
+            None,
+            10,
+            serde_json::json!({}),
+        )])
+        .expect("load security-headers");
+        let empty = MiddlewareChain::load(&[]).expect("empty chain");
+
+        let measure = |label: &str, chain: &MiddlewareChain| {
+            // A fresh ctx per iteration, as the router builds one per request.
+            for _ in 0..1000 {
+                let ctx = RequestCtx::new("GET", "/x.php", "", "127.0.0.1", "bench", &[]);
+                std::hint::black_box(chain.evaluate(&ctx, "/x.php"));
+            }
+            let start = std::time::Instant::now();
+            for _ in 0..ITERATIONS {
+                let ctx = RequestCtx::new("GET", "/x.php", "", "127.0.0.1", "bench", &[]);
+                std::hint::black_box(chain.evaluate(&ctx, "/x.php"));
+            }
+            let per_request = start.elapsed() / ITERATIONS;
+            println!("{label:<28} {per_request:?} / request");
+            per_request
+        };
+
+        let baseline = measure("empty chain (ctx only)", &empty);
+        let builtin = measure("1 builtin mount", &chain);
+        println!("\nmarginal cost of the builtin: {:?}", builtin.saturating_sub(baseline));
     }
 
     /// Locate a built middleware cdylib in the workspace target directory.

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -1658,6 +1658,7 @@ mod tests {
                 loaded_response::<SeqTag>("a", None, serde_json::json!({ "id": "a" })),
                 loaded_response::<SeqTag>("b", None, serde_json::json!({ "id": "b" })),
             ],
+            php: Vec::new(),
         };
         let out = chain.run_response_phase(&resp_ctx(), "/x", 200, Vec::new(), Vec::new());
         assert_eq!(
@@ -1671,6 +1672,7 @@ mod tests {
     fn response_phase_transforms_status_body_and_headers() {
         let chain = MiddlewareChain {
             modules: vec![loaded_response::<Transformer>("t", None, serde_json::Value::Null)],
+            php: Vec::new(),
         };
         let headers = vec![
             ("Content-Type".to_owned(), "text/plain".to_owned()),
@@ -1690,6 +1692,7 @@ mod tests {
     fn response_phase_fails_safe_on_module_panic() {
         let chain = MiddlewareChain {
             modules: vec![loaded_response::<Panicker>("p", None, serde_json::Value::Null)],
+            php: Vec::new(),
         };
         let headers = vec![("X-Keep".to_owned(), "yes".to_owned())];
         let out = chain.run_response_phase(&resp_ctx(), "/x", 200, headers, b"body".to_vec());
@@ -1703,7 +1706,8 @@ mod tests {
     #[test]
     fn modules_without_a_response_phase_are_skipped() {
         // A request-only module reports no response phase.
-        let request_only = MiddlewareChain { modules: vec![loaded_request::<RequestOnly>("r")] };
+        let request_only =
+            MiddlewareChain { modules: vec![loaded_request::<RequestOnly>("r")], php: Vec::new() };
         assert!(!request_only.has_response_phase());
 
         // Mixed: the request-only module is skipped, the transformer still runs.
@@ -1712,6 +1716,7 @@ mod tests {
                 loaded_request::<RequestOnly>("r"),
                 loaded_response::<Transformer>("t", None, serde_json::Value::Null),
             ],
+            php: Vec::new(),
         };
         assert!(mixed.has_response_phase());
         let out = mixed.run_response_phase(&resp_ctx(), "/x", 200, Vec::new(), b"go".to_vec());
@@ -1727,6 +1732,7 @@ mod tests {
                 Some("/api/*"),
                 serde_json::Value::Null,
             )],
+            php: Vec::new(),
         };
         // Off-glob: untouched.
         let out =

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -293,6 +293,53 @@ impl MiddlewareChain {
         self.php.iter().map(|m| m.name.as_str()).collect()
     }
 
+    /// Check that every `php:` mount's script exists, as far as that can be
+    /// known at startup.
+    ///
+    /// A missing script fails the request closed (500) rather than being
+    /// skipped — the right call for a policy layer, but a brutal way to learn
+    /// about a typo. So the determinable case is caught here instead:
+    ///
+    /// * **Single-site** — one `document_root`, so the path is fully
+    ///   determined. A missing file is a **startup error**, matching how an
+    ///   unresolvable shared library aborts startup.
+    /// * **Multi-site** — the path resolves per request against each tenant's
+    ///   own document root, and sites can appear after startup, so there is no
+    ///   single path to check. Startup warns instead, naming the consequence.
+    ///
+    /// # Errors
+    ///
+    /// Single-site only: returns an error naming the mount and the absolute
+    /// path that did not exist.
+    pub fn check_php_mount_scripts(
+        &self,
+        document_root: &Path,
+        multi_site: bool,
+    ) -> anyhow::Result<()> {
+        if multi_site {
+            tracing::warn!(
+                php_mounts = ?self.php_mount_names(),
+                "PHP middleware in multi-site mode resolves per site against each site's own \
+                 document root — a site that does not ship the script answers 500 for every \
+                 matching request (fail-closed). Startup cannot verify this for sites that do \
+                 not exist yet."
+            );
+            return Ok(());
+        }
+        for mount in &self.php {
+            let path = document_root.join(&mount.script);
+            anyhow::ensure!(
+                path.is_file(),
+                "middleware \"{}\": script not found at {} (paths are relative to the document \
+                 root, {})",
+                mount.name,
+                path.display(),
+                document_root.display(),
+            );
+        }
+        Ok(())
+    }
+
     /// Number of loaded modules.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -1255,6 +1302,38 @@ mod tests {
         let other: Vec<&str> =
             chain.php_mounts("/index.php").iter().map(|m| m.name.as_str()).collect();
         assert_eq!(other, ["php:second.php"]);
+    }
+
+    /// Single-site: the path is fully determined at startup, so a typo is an
+    /// immediate startup error rather than a 500 per request in production.
+    #[test]
+    fn php_mount_missing_script_aborts_startup_in_single_site_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let chain = MiddlewareChain::load(&[php_mount("php:auth/mw.php", None, 10)]).expect("load");
+
+        let err = chain
+            .check_php_mount_scripts(dir.path(), false)
+            .expect_err("a missing script must abort startup");
+        let msg = err.to_string();
+        assert!(msg.contains("php:auth/mw.php"), "{msg}");
+        assert!(msg.contains("script not found"), "{msg}");
+        assert!(msg.contains("document root"), "the error must explain what it is relative to");
+
+        // Create it, and startup is happy.
+        std::fs::create_dir_all(dir.path().join("auth")).unwrap();
+        std::fs::write(dir.path().join("auth/mw.php"), "<?php\n").unwrap();
+        chain.check_php_mount_scripts(dir.path(), false).expect("present script passes");
+    }
+
+    /// Multi-site: there is no single path to check (each tenant has its own,
+    /// and sites can appear after startup), so this must NOT fail startup.
+    #[test]
+    fn php_mount_missing_script_does_not_abort_startup_in_multi_site_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let chain = MiddlewareChain::load(&[php_mount("php:mw.php", None, 10)]).expect("load");
+        chain
+            .check_php_mount_scripts(dir.path(), true)
+            .expect("multi-site cannot verify per-tenant scripts and must not fail startup");
     }
 
     #[test]

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -3145,6 +3145,42 @@ impl Router {
         };
         let opcache_watcher = invalidate_version.map(|_| self.opcache_watcher.clone());
 
+        // PHP middleware lane (`library = "php:<path>"`, EXPERIMENTAL).
+        //
+        // Resolved against THIS request's `document_root` — the one
+        // `resolve_site` returned — so in multi-tenant mode the mount names the
+        // tenant's own file, executes in the tenant's own PHP context, and has
+        // exactly the reach the tenant's `index.php` already has. There is no
+        // path here by which a mount could read or run another tenant's code.
+        //
+        // The glob is matched against the post-native-chain `path`: PHP mounts
+        // are the later phase, so they see the request as the native modules
+        // left it.
+        // Walked ONCE: `php_mounts` allocates, and the metric labels ride along
+        // in the same pass so the closure can name a mount without reaching
+        // back into the router. The `has_php_mounts` guard keeps all of it off
+        // the hot path for every server that mounts no PHP middleware — the
+        // default, and for now the overwhelming majority.
+        let (php_middleware, php_middleware_names): (
+            Vec<ephpm_php::request::PhpMiddleware>,
+            Vec<String>,
+        ) = match self.middleware_chain.as_ref() {
+            Some(chain) if chain.has_php_mounts() => chain
+                .php_mounts(&path)
+                .into_iter()
+                .map(|mount| {
+                    (
+                        ephpm_php::request::PhpMiddleware {
+                            script: document_root.join(&mount.script),
+                            config_json: mount.config_json.clone(),
+                        },
+                        mount.name.clone(),
+                    )
+                })
+                .unzip(),
+            _ => (Vec::new(), Vec::new()),
+        };
+
         // The per-request execution body — IDENTICAL for both fpm engines.
         // Both the default `spawn_blocking` path and the dedicated pool run this
         // exact closure, so per-request parity (per-site DB session, KV
@@ -3244,7 +3280,8 @@ impl Router {
             // interval process-wide. No-op in stub mode.
             ephpm_php::jit_metrics::maybe_sample();
 
-            PhpRuntime::execute(PhpRequest {
+            let had_php_middleware = !php_middleware.is_empty();
+            let result = PhpRuntime::execute(PhpRequest {
                 method,
                 uri,
                 path,
@@ -3260,7 +3297,38 @@ impl Router {
                 is_https,
                 protocol,
                 env_vars,
-            })
+                middleware: php_middleware,
+            });
+
+            // The chain outcome lives in a `__thread` int in the C wrapper, so
+            // it has to be read here — on the blocking thread that just ran the
+            // request — not back in the async handler.
+            //
+            // Mounts that ran and fell through are counted `continue`; the one
+            // that ended the chain gets `respond` (it called `exit()`) or
+            // `error` (it fataled); mounts that never ran are not counted at
+            // all. There is deliberately no `rewrite` action for this lane —
+            // PHP expresses a rewrite by assigning to `$_SERVER`, and detecting
+            // that would mean diffing the superglobal on the hot path, so a
+            // `rewrite` label here would be invented rather than observed.
+            if had_php_middleware {
+                let (outcome, ran) = PhpRuntime::middleware_outcome();
+                for (i, name) in php_middleware_names.iter().take(ran).enumerate() {
+                    let terminal = i + 1 == ran;
+                    let action = if terminal {
+                        outcome.label()
+                    } else {
+                        ephpm_php::request::MiddlewareOutcome::Continue.label()
+                    };
+                    counter!(
+                        "ephpm_middleware_invocations_total",
+                        "module" => name.clone(),
+                        "action" => action
+                    )
+                    .increment(1);
+                }
+            }
+            result
         };
 
         // `php.execute` span: brackets exactly the region `php_start` /

--- a/examples/php-middleware/README.md
+++ b/examples/php-middleware/README.md
@@ -1,0 +1,78 @@
+# PHP middleware example — a bearer-token gate (EXPERIMENTAL)
+
+A worked example of the **PHP middleware lane**: `[[middleware]]` with
+`library = "php:<path>"`. Middleware written in plain PHP — **no compiler, no
+`.so`, no C**. This is the shim-free counterpart to the compiled
+[Rust middleware example](../rust-middleware): where that one builds a cdylib
+and loads it via `dlopen`, this one is just a `.php` file you drop next to your
+app.
+
+## What it demonstrates
+
+`demo/public/middleware.php` is a bearer-token gate that exercises every
+verdict the lane understands, each spelled in stock PHP:
+
+| Verdict | How it looks in PHP | In this example |
+|---|---|---|
+| **RESPOND** | set a status, `echo`, `exit;` | 401 when the `Authorization: Bearer …` header is missing or malformed — the app never runs |
+| **REWRITE** | assign to `$_SERVER` | injects the verified token as `$_SERVER['HTTP_X_TOKEN']` |
+| **response header** | `header()` | adds `X-Auth-Checked: 1` to the client response |
+| **CONTINUE** | fall off the end / `return;` | a valid token hands control to the app |
+
+The mount's `config = { realm = "admin" }` is handed to the script verbatim as
+JSON through `ephpm_middleware_config()`.
+
+## Where it runs — and why that matters
+
+A `php:` mount runs **inside the same PHP request as the application script**,
+immediately before it (`auto_prepend_file`'s position). It therefore inherits
+the request's superglobals, `open_basedir`, session/temp roots, OPcache vhost,
+per-site database session and KV keyspace **by construction** — there is no
+second PHP context to configure. That is the whole trade: this lane cannot
+reject *before the request body is read* (the [compiled lane](../rust-middleware)
+is for that), but it needs no build step.
+
+**Fail-closed.** A missing file, parse error, uncaught `Throwable` or fatal in
+the middleware answers **500** and the application script does not run.
+
+## Run it
+
+No build step — just point ephpm at the config:
+
+```bash
+cd demo
+ephpm serve --config ephpm.toml
+```
+
+Then, from another shell:
+
+```bash
+# RESPOND — no token → 401, the app never runs
+curl -i http://127.0.0.1:8099/api/v1/whoami
+
+# CONTINUE + REWRITE + response header — valid token reaches the app,
+# which echoes the token the middleware injected; note X-Auth-Checked: 1
+curl -i -H 'Authorization: Bearer s3cr3t' http://127.0.0.1:8099/api/v1/whoami
+
+# A path outside `match = "/api/*"` skips the lane entirely
+curl -i http://127.0.0.1:8099/
+```
+
+Expected: the first request is `401` with a `WWW-Authenticate` header and never
+touches `index.php`; the second is `200` with `X-Auth-Checked: 1` and a body
+echoing `"token": "s3cr3t"`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `demo/ephpm.toml` | Server + the `library = "php:middleware.php"` mount |
+| `demo/public/middleware.php` | The gate — all four verdicts |
+| `demo/public/index.php` | Front controller the request falls through to |
+
+## See also
+
+- The middleware guide's **"The PHP lane (experimental)"** section:
+  `site/content/guides/native-middleware.md`
+- The compiled C-ABI lane, for rejecting before the body is read:
+  [`examples/rust-middleware`](../rust-middleware)

--- a/examples/php-middleware/demo/ephpm.toml
+++ b/examples/php-middleware/demo/ephpm.toml
@@ -1,0 +1,40 @@
+# Demo config for the PHP middleware lane (`library = "php:<path>"`).
+#
+# EXPERIMENTAL. Middleware written in plain PHP — no compiler, no `.so`, no C.
+# The script runs INSIDE the PHP request, immediately before the application
+# script (auto_prepend_file's position), so it inherits the request's
+# superglobals, open_basedir, session/temp roots, OPcache vhost, per-site DB
+# session and KV keyspace by construction.
+#
+# Run from this directory:
+#   ephpm serve --config ephpm.toml
+#
+# `document_root` is relative to your shell's working directory, so either run
+# from here or make it absolute.
+
+[server]
+listen = "127.0.0.1:8099"
+document_root = "public"
+
+# Left at the default on purpose:
+#   fallback = ["$uri", "$uri/", "/index.php?$query_string"]
+# That is what routes /api/v1/whoami (no such file) to the front controller
+# public/index.php — the request the middleware guards and REWRITEs.
+
+[php]
+mode = "fpm"
+
+# ── the middleware mount ───────────────────────────────────────────────────
+#
+# `library = "php:<path>"` selects the PHP lane. The path is relative to the
+# REQUEST's document root — here public/middleware.php. No build step: PHP
+# compiles it (and OPcache caches it) on first use.
+#
+# `match` scopes the mount to /api/*; other paths skip the lane entirely.
+# `config` is handed to the script verbatim as JSON via
+# `ephpm_middleware_config()`.
+[[middleware]]
+library = "php:middleware.php"
+match = "/api/*"
+order = 30
+config = { realm = "admin" }

--- a/examples/php-middleware/demo/public/index.php
+++ b/examples/php-middleware/demo/public/index.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Front controller for the php-middleware demo.
+ *
+ * Requests to /api/... do not exist as files, so ePHPm's default `fallback`
+ * chain (["$uri", "$uri/", "/index.php?$query_string"]) resolves them here.
+ *
+ * By the time this runs, middleware.php has already executed in this very same
+ * request. If it hit its RESPOND path (401), this file never ran at all. If it
+ * fell through (CONTINUE), the token it verified is waiting in $_SERVER — set
+ * by the mount's REWRITE — because both share one request.
+ */
+
+declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+echo json_encode([
+    'script'  => basename($_SERVER['SCRIPT_NAME'] ?? __FILE__),
+    // Injected by the middleware's REWRITE (assignment to $_SERVER).
+    'token'   => $_SERVER['HTTP_X_TOKEN'] ?? null,
+    // The middleware also set an `X-Auth-Checked: 1` response header — inspect
+    // it with `curl -i`.
+    'checked' => true,
+], JSON_PRETTY_PRINT), "\n";

--- a/examples/php-middleware/demo/public/middleware.php
+++ b/examples/php-middleware/demo/public/middleware.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * PHP middleware — a bearer-token gate (EXPERIMENTAL `php:` lane).
+ *
+ * Mounted with `library = "php:middleware.php"`. This file runs INSIDE the
+ * PHP request, immediately before the application script (public/index.php),
+ * for every request matching the mount's `match = "/api/*"` glob.
+ *
+ * It demonstrates all four verdicts the lane understands. The mapping is stock
+ * PHP — there is no C ABI transliterated into PHP:
+ *
+ *   ACTION_RESPOND  → set a status, echo a body, exit;   (the app never runs)
+ *   ACTION_REWRITE  → assign to $_SERVER
+ *   response header → header()
+ *   ACTION_CONTINUE → fall off the end / return;
+ *
+ * Fail-closed: a parse error, an uncaught Throwable or a fatal here answers
+ * 500 and the application script does not run.
+ */
+
+declare(strict_types=1);
+
+// The mount's `config` table, as JSON. `null` when no `config` was set.
+$cfg   = json_decode(ephpm_middleware_config() ?? '{}', true);
+$realm = $cfg['realm'] ?? 'api';
+
+$auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+
+// ── RESPOND ────────────────────────────────────────────────────────────────
+// No usable bearer token: answer 401 ourselves and stop. `exit` ends the
+// chain — later mounts and the application script are skipped.
+if (!str_starts_with($auth, 'Bearer ')) {
+    http_response_code(401);
+    header('WWW-Authenticate: Bearer realm="' . $realm . '"');
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'missing or malformed bearer token'], JSON_PRETTY_PRINT), "\n";
+    exit; // RESPOND — the application script never runs.
+}
+
+$token = substr($auth, 7);
+
+// ── REWRITE ──────────────────────────────────────────────────────────────
+// Hand the verified token to the application through $_SERVER. Because the
+// mount shares the request's superglobals, the app just reads it back — no
+// side channel, no re-parsing the header.
+$_SERVER['HTTP_X_TOKEN'] = $token;
+
+// ── response header ──────────────────────────────────────────────────────
+// header() here lands on the eventual client response, same as anywhere else.
+header('X-Auth-Checked: 1');
+
+// ── CONTINUE ─────────────────────────────────────────────────────────────
+// Falling off the end (or `return;`) hands control to the next mount, then to
+// the application script. Nothing else to do.

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -804,9 +804,15 @@ with `..`, `\`, and drive prefixes, rejected everywhere.
 
 ### Failure semantics — fail closed, always
 
+Startup catches the case it can: in **single-site** mode the path is fully
+determined, so a mount whose script is missing is a **startup error** naming
+the mount and the absolute path — the same fail-fast an unresolvable shared
+library gets. In **multi-site** mode the path resolves per tenant and sites can
+appear later, so startup warns instead and the per-request rule below applies.
+
 | Failure | Result |
 |---|---|
-| Missing file | 500; the application script does **not** run |
+| Missing file | 500; the application script does **not** run (startup error instead, in single-site mode) |
 | Parse error | 500; application script does not run |
 | Uncaught exception | 500; application script does not run |
 | Fatal (`E_ERROR`) | 500; application script does not run |

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -717,7 +717,17 @@ that transfer is the main reason the native lane exists, so if your
 middleware's job is to shed load or reject uploads cheaply, write it against
 the native lane. `order` sorts mounts *within* a lane; it cannot interleave
 the two, because no ordering can put PHP before the body read. Startup logs
-the resolved two-phase plan so this is never silent.
+the two lanes as separate lines — `middleware chain loaded` for the native
+modules, then a `PHP middleware mounted (EXPERIMENTAL)` line naming the `php:`
+mounts and restating where they run — so the split is never silent:
+
+```
+INFO ephpm_server: middleware chain loaded count=1 modules=["security-headers"]
+INFO ephpm_server: PHP middleware mounted (EXPERIMENTAL) — these run INSIDE the PHP
+     request, after the request body has been read and after every native module, so
+     they cannot reject before the body transfer the way a native module can
+     php_mounts=["php:middleware.php"]
+```
 
 ### What it costs
 

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -664,7 +664,9 @@ The authoritative definition is
 ## The PHP lane (experimental)
 
 **Status: experimental.** Middleware written in plain PHP — no compiler, no
-`.so`, no C:
+`.so`, no C. A complete, runnable version of the gate below — config, the
+middleware script, an app front controller and `curl` commands for each verdict
+— ships in [`examples/php-middleware`](https://github.com/ephpm/ephpm/tree/main/examples/php-middleware).
 
 ```toml
 [[middleware]]

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -14,7 +14,10 @@ KV store and the `tracing` logger are one function call away. That's what
 makes a cluster-wide rate limiter a ~100-line module — the replicated
 counter is a single `kv_incr`.
 
-There are **two ways a module runs**:
+There are **two ways a compiled module runs** — plus an experimental
+[PHP lane](#the-php-lane-experimental) for middleware written in plain PHP,
+which trades the "before PHP, before the body" position for not needing a
+compiler at all:
 
 - **Built-in (static registry).** Ten official modules — `jwt`, `cors`,
   `ratelimit`, `security-headers`, `api-key`, `ip-allowlist`,
@@ -658,6 +661,180 @@ int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
 The authoritative definition is
 [`crates/ephpm-middleware/src/abi.rs`](https://github.com/ephpm/ephpm/blob/main/crates/ephpm-middleware/src/abi.rs).
 
+## The PHP lane (experimental)
+
+**Status: experimental.** Middleware written in plain PHP — no compiler, no
+`.so`, no C:
+
+```toml
+[[middleware]]
+library = "php:middleware.php"   # relative to the request's document root
+match   = "/api/*"
+order   = 30
+config  = { realm = "admin" }
+```
+
+```php
+<?php
+// middleware.php
+$cfg  = json_decode(ephpm_middleware_config() ?? '{}', true);
+$auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+
+if (!str_starts_with($auth, 'Bearer ')) {
+    http_response_code(401);
+    header('WWW-Authenticate: Bearer realm="' . $cfg['realm'] . '"');
+    echo 'missing bearer token';
+    exit;                                    // RESPOND — the app never runs
+}
+
+$_SERVER['HTTP_X_TOKEN'] = substr($auth, 7); // REWRITE
+header('X-Auth-Checked: 1');                 // response header
+// falling off the end = CONTINUE
+```
+
+### Where it runs, and what that costs you
+
+A `php:` mount executes **inside the same PHP request as the application
+script**, immediately before it. That is the position PHP's own
+`auto_prepend_file` occupies; this lane is essentially a first-class,
+multi-file, glob-scoped, config-carrying `auto_prepend_file`.
+
+Running in-request is the entire design. The mount inherits — by
+construction, not by re-implementation — the request's superglobals, its
+`open_basedir`, its `sys_temp_dir` / `session.save_path`, its OPcache vhost,
+its per-site database session, its KV keyspace, its execution timer and its
+crash guard. There is no second PHP context to configure, and therefore no
+second PHP context to get wrong.
+
+The price is the chain position:
+
+```
+native chain (pre-body, outside PHP) → body read → php: mounts → app script
+```
+
+**A `php:` mount cannot reject before the request body transfer.** Avoiding
+that transfer is the main reason the native lane exists, so if your
+middleware's job is to shed load or reject uploads cheaply, write it against
+the native lane. `order` sorts mounts *within* a lane; it cannot interleave
+the two, because no ordering can put PHP before the body read. Startup logs
+the resolved two-phase plan so this is never silent.
+
+### What it costs
+
+Measured end-to-end over HTTP against a release build (Windows, PHP 8.5,
+OPcache on), 1000 sequential keep-alive requests to a trivial
+`<?php echo 'ok';`, best of 11 rounds. Each middleware does the same work as
+the `security-headers` builtin: three response headers.
+
+| Configuration | Per request | Δ vs baseline |
+|---|---|---|
+| No middleware | 365.7 µs | — |
+| 1 Rust builtin mount | 369.2 µs | **+3.5 µs** |
+| 1 `php:` mount | 377.6 µs | **+11.9 µs** |
+| 3 `php:` mounts | 387.5 µs | **+21.8 µs** (≈ 7 µs/mount) |
+
+Measured in isolation rather than over HTTP, the Rust builtin's marginal cost
+is **476 ns** — the +3.5 µs above is mostly measurement noise on a 366 µs
+baseline. So the two framings, both true:
+
+- **Relative to each other:** a `php:` mount is roughly **20x** a Rust
+  builtin mount. If you are counting microseconds, that gap is real and
+  inherent — one is a direct function call, the other loads and executes a
+  cached op_array.
+- **Relative to the request:** a `php:` mount is about **3% of a trivial PHP
+  request**, and scales linearly per mount. It is nowhere near the "a PHP
+  mount means a second PHP request" cost the lane was designed to avoid —
+  because it isn't a second request; it is one more OPcache-cached script
+  inside the request already running.
+
+Two caveats worth stating plainly:
+
+- **These numbers include HTTP and client overhead**, so the *absolute*
+  baseline is not the cost of PHP alone. The deltas are the meaningful part.
+- **The cost is dominated by fixed per-mount work, not by your PHP.** An
+  empty middleware file measured the same as one setting three headers. What
+  you pay for is engaging the lane and executing a cached op_array; what your
+  middleware actually does is on top.
+
+Two benchmarks ship with the tree. Both are `#[ignore]`d, print timings, and
+assert nothing:
+
+```bash
+cargo test -p ephpm-php    --test php_middleware bench_php_mount -- --ignored --nocapture
+cargo test -p ephpm-server --lib bench_builtin                   -- --ignored --nocapture
+```
+
+The `ephpm-php` one runs **without OPcache** (the bare embed harness has no
+`php.ini`), so it recompiles every mounted file on every request. Treat it as
+an upper bound for a cold cache, not as the steady-state cost — the table
+above is the steady state.
+
+**Historical note, because it is the useful part.** The first implementation
+matched PHP's `auto_prepend_file` exactly by `chdir`-ing to the application
+script's directory around the chain. That single getcwd + chdir + restore
+measured **~55 µs per request on Windows** — nearly 5x the cost of everything
+else the lane does — so it was removed. The consequence is the `__DIR__` rule
+below. None of this was visible from reading the code; it took the benchmark.
+
+### Writing a mount
+
+- **Use `__DIR__` for file paths.** The chain does not change the working
+  directory (see above). A relative `include`/`require` still resolves against
+  the *including file's* own directory, which is PHP's normal rule — but a
+  bare relative path handed to `fopen()`, `file_get_contents()`, etc. resolves
+  against the server's working directory, not the document root.
+- Keep it short. Every mount runs on every matching request, before the
+  application. If the logic needs the framework booted, it belongs in the
+  framework, not here.
+
+### Multi-tenancy
+
+`php:` paths resolve against the **request's** document root — the one
+`resolve_site` returned — never against the `Host` header and never against a
+server-wide directory. In `sites_dir` mode that means each site supplies its
+own `middleware.php`, and it runs in that site's own PHP context. A mount
+therefore has exactly the reach that tenant's `index.php` already has, and no
+more.
+
+Sharing one operator-owned file across every tenant is **not supported**:
+that file would have to be inside each vhost's `open_basedir`, and punching
+that hole is a tenant-isolation regression this lane declines to make.
+Absolute paths are rejected at startup when `sites_dir` is set — and, along
+with `..`, `\`, and drive prefixes, rejected everywhere.
+
+### Failure semantics — fail closed, always
+
+| Failure | Result |
+|---|---|
+| Missing file | 500; the application script does **not** run |
+| Parse error | 500; application script does not run |
+| Uncaught exception | 500; application script does not run |
+| Fatal (`E_ERROR`) | 500; application script does not run |
+| `exit()` | The mount's own status/headers/body are returned; remaining mounts and the application script are skipped |
+| Infinite loop | `max_execution_time` (where natively enforced) then `[server.timeouts] request` — unchanged, because it is the same PHP request |
+
+The uncaught-exception row is the one that took work. PHP 8 reports an
+uncaught `Throwable` with `E_DONT_BAIL`: execution returns *normally* and
+only `PG(last_error_type)` records it. A naive implementation would print the
+fatal and then run the application script anyway — for an auth mount, an auth
+bypass. ePHPm checks for it explicitly after every mount.
+
+Likewise, a mounted file that has gone missing 500s rather than being skipped.
+A policy layer that silently vanishes is how bypasses ship.
+
+### Limits
+
+- **Worker mode is rejected at startup.** The worker script owns the request
+  loop, so there is no per-request prepend point. Use the framework's own
+  middleware (PSR-15 / Octane) there.
+- At most **16** `php:` mounts may run for one request; more is a startup
+  error, never a silent drop.
+- Scripts run at **global scope**, so their variables are visible to the
+  application script — same as `auto_prepend_file`. Wrap logic in a function
+  or `return` early.
+- The lane runs only where the native chain runs: PHP-dispatched requests.
+  Static files and router error responses do not pass through it.
+
 ## Observability
 
 Each request-phase invocation increments
@@ -667,6 +844,13 @@ verdict (`continue` / `respond` / `rewrite`; module errors count as
 increments `ephpm_middleware_response_invocations_total{module}`. Module `log`
 calls surface through the host's `tracing` subscriber under the
 `ephpm_middleware` target.
+
+`php:` mounts use the same counter, with `action` ∈ `continue` / `respond` /
+`error`. Mounts that never ran (because an earlier one short-circuited) are
+not counted. There is deliberately **no** `rewrite` action for the PHP lane:
+PHP expresses a rewrite by assigning to `$_SERVER`, and reporting that would
+mean diffing the superglobal on the hot path — so the label would be invented
+rather than observed.
 
 ## Trust model
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -618,10 +618,54 @@ at startup) — see the guide's
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, `header-transform`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
+| `library` | string | **required** | A `php:`-prefixed script path (**experimental PHP lane** — see below), a builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, `header-transform`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
 | `match` | string | (none) | Glob the request path must match for the mount to run. `*` matches any character sequence, including `/`. Unset = every PHP-bound request. |
-| `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. |
-| `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init`. |
+| `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. Orders sort **within a lane**, not across the two lanes — see the PHP lane below. |
+| `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init` (native lanes) or returned by `ephpm_middleware_config()` (PHP lane). |
+
+### PHP middleware — `library = "php:<path>"` (EXPERIMENTAL)
+
+Middleware written in plain PHP: no compiler, no shared library, no C. The
+script runs **inside the same PHP request** as the application script,
+immediately before it — the position PHP's own `auto_prepend_file` occupies,
+except there can be several, each with its own `match` glob and `config`.
+
+```toml
+[[middleware]]
+library = "php:middleware.php"   # relative to the request's document root
+match   = "/api/*"
+order   = 30
+config  = { realm = "admin" }
+```
+
+**This is a different chain position from the native lanes, not a third
+implementation of the same one.** Native modules run before the request body
+is read and outside PHP; a `php:` mount runs after the body has been read and
+after every native module. So a `php:` mount **cannot reject before the body
+transfer**, which is the main reason the native lane exists. Startup logs the
+resolved two-phase plan.
+
+| Aspect | Behaviour |
+|---|---|
+| Verdict: continue | Fall off the end of the script, or `return;` |
+| Verdict: respond | `http_response_code(403); echo '...'; exit;` — remaining mounts and the application script are skipped |
+| Verdict: rewrite | Assign to `$_SERVER` (e.g. `$_SERVER['HTTP_X_USER']`). As in the native lane, a `REQUEST_URI` change does not re-resolve the script in fpm mode. |
+| Response headers | `header()`, as in any PHP script |
+| Mount config | `json_decode(ephpm_middleware_config() ?? '{}', true)` — returns `null` outside a middleware file |
+| Path resolution | Relative to the **request's** document root. Absolute paths, `..`, `\`, and drive prefixes are rejected at startup. |
+| Multi-tenancy | In `sites_dir` mode each site supplies its own file, which runs in that site's PHP context (its `open_basedir`, OPcache vhost, database session, KV keyspace). A mount has no more reach than that tenant's own `index.php`. Sharing one operator-owned file across tenants is **not** supported — it would need a hole in every vhost's `open_basedir`. |
+| Failure | Fail-closed, always. A missing file, parse error, uncaught exception, or fatal returns 500 and the application script does **not** run. |
+| Worker mode | **Rejected at startup.** The worker script owns the request loop; use the framework's own middleware (PSR-15 / Octane). |
+| Limit | At most 16 `php:` mounts may run for one request (rejected at startup, not silently dropped). |
+| Metrics | `ephpm_middleware_invocations_total{module,action}` with `action` = `continue`, `respond`, or `error`. There is no `rewrite` action for this lane — PHP expresses a rewrite by assigning to `$_SERVER`, which is not observable without diffing the superglobal. |
+| Working directory | Unchanged (unlike `auto_prepend_file`). Use `__DIR__` for relative filesystem paths; relative `include`/`require` still resolves against the including file's own directory. |
+| Cost | ~12 µs for one mount, ~7 µs per additional mount, vs ~3.5 µs for a Rust builtin — measured over HTTP on a ~366 µs baseline request. See the guide. |
+
+Scripts execute at global scope, so their variables are visible to the
+application script — same as `auto_prepend_file`. Wrap logic in a function or
+`return` early. See the
+[Native Middleware guide](/guides/native-middleware/#the-php-lane-experimental)
+for the cost measurements.
 
 ## `[opcache]`
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -654,7 +654,7 @@ resolved two-phase plan.
 | Mount config | `json_decode(ephpm_middleware_config() ?? '{}', true)` — returns `null` outside a middleware file |
 | Path resolution | Relative to the **request's** document root. Absolute paths, `..`, `\`, and drive prefixes are rejected at startup. |
 | Multi-tenancy | In `sites_dir` mode each site supplies its own file, which runs in that site's PHP context (its `open_basedir`, OPcache vhost, database session, KV keyspace). A mount has no more reach than that tenant's own `index.php`. Sharing one operator-owned file across tenants is **not** supported — it would need a hole in every vhost's `open_basedir`. |
-| Failure | Fail-closed, always. A missing file, parse error, uncaught exception, or fatal returns 500 and the application script does **not** run. |
+| Failure | Fail-closed, always. A missing file, parse error, uncaught exception, or fatal returns 500 and the application script does **not** run. In single-site mode a missing script is caught earlier still — it aborts **startup**, naming the mount and the path. |
 | Worker mode | **Rejected at startup.** The worker script owns the request loop; use the framework's own middleware (PSR-15 / Octane). |
 | Limit | At most 16 `php:` mounts may run for one request (rejected at startup, not silently dropped). |
 | Metrics | `ephpm_middleware_invocations_total{module,action}` with `action` = `continue`, `respond`, or `error`. There is no `rewrite` action for this lane — PHP expresses a rewrite by assigning to `$_SERVER`, which is not observable without diffing the superglobal. |

--- a/site/content/reference/metrics.md
+++ b/site/content/reference/metrics.md
@@ -102,6 +102,13 @@ These appear when at least one `[[middleware]]` mount is configured.
 |--------|------|--------|-------------|
 | `ephpm_middleware_invocations_total` | counter | `module`, `action` | Middleware invocations, one per module per matching request. `action` is the verdict: `continue`, `respond`, or `rewrite`. A module `invoke` error (non-zero return, including a caught panic) counts as `respond` — the host fails closed with a 500. |
 
+**PHP mounts** (`library = "php:<path>"`, experimental) share this counter,
+with `module` set to the full `library` string. Their `action` is `continue`,
+`respond` (the mount called `exit()`), or `error` (the mount fataled) — never
+`rewrite`, because PHP expresses a rewrite by assigning to `$_SERVER` and
+detecting that would mean diffing the superglobal on the hot path. Mounts that
+never ran because an earlier one short-circuited are not counted.
+
 ## Worker mode
 
 These appear when `[php] mode = "worker"`.


### PR DESCRIPTION
Middleware written in plain PHP — no compiler, no `.so`, no C. Closes the gap
that pushed us into the elephc + C-shim experiment.

```toml
[[middleware]]
library = "php:middleware.php"   # relative to the request's document root
match   = "/api/*"
order   = 30
config  = { realm = "admin" }
```

```php
<?php
$cfg  = json_decode(ephpm_middleware_config() ?? '{}', true);
$auth = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
if (!str_starts_with($auth, 'Bearer ')) {
    http_response_code(401);
    header('WWW-Authenticate: Bearer realm="' . $cfg['realm'] . '"');
    echo 'missing bearer token';
    exit;                                     // RESPOND — the app never runs
}
$_SERVER['HTTP_X_TOKEN'] = substr($auth, 7);  // REWRITE
header('X-Auth-Checked: 1');                  // response header
// falling off the end = CONTINUE
```

## Where it runs — and why that is the whole design

A `php:` mount executes **inside the same PHP request as the application
script**, immediately before it. That is `auto_prepend_file`'s position; this
lane is a first-class, multi-file, glob-scoped, config-carrying version of it.

The mount therefore inherits — by construction, not by re-implementation — the
request's superglobals, `open_basedir`, `sys_temp_dir`/`session.save_path`,
OPcache vhost, per-site database session, KV keyspace, execution timer and
crash guard. **There is no second PHP context to configure, and so none to get
wrong.** The alternative (its own `ephpm_execute_request` per mount) costs a
full `php_request_shutdown`/`startup` cycle, cannot see `$_POST`, and throws
away everything it computes before the app script starts.

The verdicts are spelled in stock PHP, not a C ABI transliterated into PHP:

| ABI verdict | PHP |
|---|---|
| `ACTION_CONTINUE` | fall off the end / `return;` |
| `ACTION_RESPOND` | `http_response_code(403); echo '...'; exit;` |
| `ACTION_REWRITE` | assign to `$_SERVER` |
| response headers | `header()` |

One native function is added: `ephpm_middleware_config(): ?string` — the
mount's `config` table as JSON (`json_decode(... ?? '{}', true)`). JSON rather
than an array to avoid linking ext/json's C API out of a static embed build.

## Three things that only came out of running it

1. **`php_execute_script()` cannot be used.** PHP 8 implements `exit()` by
   throwing an unwind-exit exception, and both it and `zend_execute_scripts()`
   funnel every pending exception through `zend_exception_error()` — which
   clears `EG(exception)` and returns SUCCESS for an unwind exit. On return,
   "called `exit()`" and "ran to completion" are indistinguishable. The first
   cut used `php_execute_script()` and its short-circuit tests failed with the
   app script's output appended. The chain now runs PHP's own loop body inline
   with that one case split out.
2. **An uncaught `Throwable` is a fail-open trap.** `zend_exception_error`
   reports it with `E_DONT_BAIL`, so execution returns normally and only
   `PG(last_error_type)` records it. Without an explicit check the app script
   runs anyway — for an auth mount, an auth bypass. Checked after every mount.
3. **The `chdir` had to go.** Matching `auto_prepend_file` exactly meant one
   getcwd + chdir + restore around the chain. That measured **~55 µs/request
   on Windows** — ~5x everything else the lane does. Removed; relative
   `include`/`require` still resolves against the including file's own
   directory, and the guide tells authors to use `__DIR__` for other paths.

## Cost

Over HTTP, release build, OPcache on, 1000 sequential keep-alive requests to
`<?php echo 'ok';`, best of 11. Each middleware sets three response headers.

| Configuration | Per request | Δ |
|---|---|---|
| No middleware | 365.7 µs | — |
| 1 Rust builtin mount | 369.2 µs | +3.5 µs |
| 1 `php:` mount | 377.6 µs | **+11.9 µs** |
| 3 `php:` mounts | 387.5 µs | **+21.8 µs** (≈7 µs/mount) |

Measured in isolation the Rust builtin's marginal cost is **476 ns**. So both
framings, both true: a `php:` mount is **~20x a Rust builtin**, and **~3% of a
trivial PHP request**. Linear per mount. An *empty* middleware file costs the
same as a working one — the cost is engaging the lane, not your PHP.

Both benchmarks ship `#[ignore]`d:

```
cargo test -p ephpm-php    --test php_middleware bench_php_mount -- --ignored --nocapture
cargo test -p ephpm-server --lib bench_builtin                   -- --ignored --nocapture
```

## Deliberate constraints

- **Two phases, not one chain.** Native modules run before the body is read
  and outside PHP; `php:` mounts run after. A `php:` mount **cannot reject
  before the body transfer** — the main reason the native lane exists. `order`
  sorts within a lane; no ordering can put PHP before the body read. Startup
  logs the resolved plan so this is never silent.
- **Multi-tenancy.** Paths resolve against the **request's** document root, so
  in `sites_dir` mode each tenant supplies its own file and runs it in its own
  context — a mount has no more reach than that tenant's `index.php`. Sharing
  one operator file across tenants would need a hole in every vhost's
  `open_basedir`, so absolute paths are rejected when `sites_dir` is set;
  `..`, `\` and drive prefixes are rejected everywhere.
- **Worker mode is a startup error**, not a warning — there is no per-request
  prepend point, so the mount would silently never run.
- **≤16 mounts per request**, enforced in config so the C-side cap can never
  silently drop one.
- No `rewrite` metric action for this lane: PHP rewrites by assigning to
  `$_SERVER`, and detecting that means diffing the superglobal on the hot
  path. A label we cannot observe is not emitted.

## Failure semantics — fail closed, always

Missing file, parse error, uncaught exception, fatal → **500, application
script does not run**. `exit()` → the mount's own response, remaining mounts
and the app skipped. Infinite loop → unchanged timers, because it is the same
PHP request.

## Tests

- `crates/ephpm-php/tests/php_middleware.rs` — 15 PHP-linked tests: same-request
  semantics, superglobal sharing, chain order, `exit()` short-circuit (incl.
  skipping later mounts), all five failure modes asserting the app script did
  **not** run, per-mount config isolation, and no cross-request state leak.
- `crates/ephpm-config` — path-shape rejection (absolute, `..`, `\`, drive
  prefix, empty), worker-mode rejection, per-request cap.
- `crates/ephpm-server` — `php:` never reaches the builtin/dlopen lanes, is
  invisible to `evaluate`, glob + order filtering, config JSON, coexistence
  with native mounts.

Docs updated in the same PR: `reference/config.md`, `reference/metrics.md`,
and a new "The PHP lane (experimental)" section in the middleware guide
carrying the measurements above verbatim.

## Note for reviewers

`Test (macos-arm64)` will sit queued — the macOS runner fleet is down.