### PR TITLE
feat(otlp): OTLP/gRPC transport — PhpStorm's trace viewer with no Collector bridge (#378)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml",
+ "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2171,6 +2172,19 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3254,6 +3268,7 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -3283,6 +3298,9 @@ dependencies = [
  "prost",
  "reqwest",
  "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
 ]
 
 [[package]]
@@ -5157,13 +5175,21 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5185,9 +5211,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,39 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # ephpm-server (forwarded by the ephpm binary's `otlp` feature). The
 # opentelemetry / tracing-opentelemetry pair must be bumped in lockstep:
 # tracing-opentelemetry 0.32.x targets the opentelemetry 0.31.x line.
-# http-proto + reqwest-blocking-client keeps the exporter off the tokio
-# runtime (the subscriber is initialized before the runtime exists, because
-# PHP must init single-threaded).
+#
+# BOTH OTLP transports are compiled in, and the one used is chosen at runtime
+# by `OTEL_EXPORTER_OTLP_PROTOCOL` (`grpc` | `http/protobuf`), per the OTel
+# spec. See `ephpm-server/src/otlp.rs` for why runtime selection rather than a
+# cargo feature: ePHPm ships one release binary, so a compile-time choice would
+# have to pick a transport for every user.
+#
+# - `http-proto` + `reqwest-blocking-client`: the http/protobuf transport, on a
+#   blocking client so it needs no tokio runtime.
+# - `grpc-tonic`: the OTLP/gRPC transport. tonic is async, so `otlp.rs` owns a
+#   small dedicated tokio runtime for it — the tracing subscriber is built in
+#   `main` before the server's runtime exists (PHP must init single-threaded).
+# - `internal-logs`: routes the SDK's own export failures into `tracing`.
+#   It is in this crate's DEFAULT feature set, and turning defaults off without
+#   restoring it is what made every export failure silent (#378).
+#
+# `tls-provider-agnostic` is the ONLY correct TLS feature here, for exactly the
+# reason spelled out for reqwest below: `tls`, `tls-ring`, `tls-roots` and
+# `tls-webpki-roots` all expand to `tonic/tls-ring` and link `ring`. The
+# provider-agnostic variant enables no provider at all, and tonic then resolves
+# one via `CryptoProvider::get_default()` — which `otlp.rs` installs from
+# `tls::crypto_provider()`, so gRPC follows the same provider as everything
+# else by construction.
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "http-proto", "reqwest-blocking-client", "grpc-tonic", "tls-provider-agnostic", "internal-logs"] }
 tracing-opentelemetry = { version = "0.32", default-features = false }
+# Depended on directly only for the gRPC exporter's root store: the two
+# `tls-*-roots` features are what make `ClientTlsConfig::with_enabled_roots()`
+# exist. Neither pulls a crypto provider (`tls-native-roots` and
+# `tls-webpki-roots` expand to `_tls-any` + `channel` + the roots crate), which
+# is what makes them safe here where `tonic/tls` is not.
+tonic = { version = "0.14", default-features = false, features = ["tls-native-roots", "tls-webpki-roots"] }
 # The OTLP exporter's HTTP client, so an `https://` collector endpoint works
 # (without these features reqwest is built with no TLS backend at all and
 # every https:// export fails at connect time).

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -964,6 +964,31 @@ pub struct DiagnosticsConfig {
     /// Default: unset (no trace export).
     #[serde(default)]
     pub otlp_endpoint: Option<String>,
+
+    /// OTLP wire protocol for [`Self::otlp_endpoint`]: `"grpc"` or
+    /// `"http/protobuf"`.
+    ///
+    /// The two differ in more than encoding, so this must match what the
+    /// collector expects: `http/protobuf` takes a *signal* URL and gets
+    /// `/v1/traces` appended when missing (conventional port 4318), while
+    /// `grpc` takes a *base* URL used verbatim (conventional port 4317).
+    /// Pointing one at the other's port is the usual cause of "no traces
+    /// arrive"; ePHPm logs a startup warning when it detects that.
+    ///
+    /// `"http/json"` is a real OTLP protocol that ePHPm does **not**
+    /// implement, and is rejected at startup rather than silently falling
+    /// back to another one.
+    ///
+    /// The standard `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` /
+    /// `OTEL_EXPORTER_OTLP_PROTOCOL` environment variables take precedence
+    /// over this knob, mirroring how the endpoint variables behave.
+    ///
+    /// Env override: `EPHPM_SERVER__DIAGNOSTICS__OTLP_PROTOCOL`.
+    ///
+    /// Default: unset, meaning `http/protobuf` — the OTel default, and what
+    /// ePHPm used before gRPC was supported.
+    #[serde(default)]
+    pub otlp_protocol: Option<String>,
 }
 
 impl DiagnosticsConfig {
@@ -5468,6 +5493,7 @@ idle_timeout_secs = 15
         let config = Config::load(&file).unwrap();
         assert_eq!(config.server.diagnostics.request_log, None);
         assert_eq!(config.server.diagnostics.otlp_endpoint, None);
+        assert_eq!(config.server.diagnostics.otlp_protocol, None);
         assert!(
             config.server.diagnostics.effective_request_log(true),
             "unset request_log must resolve ON in dev mode"
@@ -5481,6 +5507,7 @@ idle_timeout_secs = 15
         let direct = ServerConfig::default();
         assert_eq!(direct.diagnostics.request_log, None);
         assert_eq!(direct.diagnostics.otlp_endpoint, None);
+        assert_eq!(direct.diagnostics.otlp_protocol, None);
     }
 
     /// An explicit value wins over the mode default in both directions.
@@ -5505,7 +5532,8 @@ idle_timeout_secs = 15
         let file = dir.path().join("ephpm.toml");
         std::fs::write(
             &file,
-            "[server.diagnostics]\nrequest_log = true\notlp_endpoint = \"http://127.0.0.1:4318\"\n",
+            "[server.diagnostics]\nrequest_log = true\notlp_endpoint = \"http://127.0.0.1:4318\"\n\
+             otlp_protocol = \"grpc\"\n",
         )
         .unwrap();
 
@@ -5515,6 +5543,18 @@ idle_timeout_secs = 15
             config.server.diagnostics.otlp_endpoint.as_deref(),
             Some("http://127.0.0.1:4318")
         );
+        assert_eq!(config.server.diagnostics.otlp_protocol.as_deref(), Some("grpc"));
+    }
+
+    #[test]
+    fn test_env_var_overrides_diagnostics_otlp_protocol() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server.diagnostics]\notlp_protocol = \"http/protobuf\"\n").unwrap();
+
+        let _env = EnvVars::set("EPHPM_SERVER__DIAGNOSTICS__OTLP_PROTOCOL", "grpc");
+        let config = Config::load(&file).unwrap();
+        assert_eq!(config.server.diagnostics.otlp_protocol.as_deref(), Some("grpc"));
     }
 
     #[test]

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -76,6 +76,11 @@ tracing-subscriber = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 rustls-native-certs = { workspace = true, optional = true }
 webpki-roots = { workspace = true, optional = true }
+# The gRPC transport's TLS config type (`ClientTlsConfig`) and its root-store
+# switches. tonic is already in the graph via opentelemetry-proto; naming it
+# here is what enables the two `tls-*-roots` features — neither of which pulls
+# a crypto provider. See the workspace manifest.
+tonic = { workspace = true, optional = true }
 
 # Privilege drop ([server] run_as_user/run_as_group): setgroups/setgid/setuid
 # and getpwnam/getgrnam name resolution live behind libc on Unix. No-op on
@@ -85,9 +90,11 @@ libc = "0.2"
 
 [features]
 # OTLP trace export: `tracing` spans (http.request / worker.queue_wait /
-# php.execute) shipped to an OpenTelemetry collector over OTLP http/protobuf.
-# Runtime activation is still opt-in via OTEL_EXPORTER_OTLP_ENDPOINT /
-# [server.diagnostics] otlp_endpoint — see src/otlp.rs.
+# php.execute) shipped to an OpenTelemetry collector over OTLP. Both
+# transports — http/protobuf and gRPC — are compiled in; the choice is made at
+# runtime by OTEL_EXPORTER_OTLP_PROTOCOL. Runtime activation is still opt-in
+# via OTEL_EXPORTER_OTLP_ENDPOINT / [server.diagnostics] otlp_endpoint — see
+# src/otlp.rs.
 otlp = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -97,6 +104,10 @@ otlp = [
     "dep:reqwest",
     "dep:rustls-native-certs",
     "dep:webpki-roots",
+    "dep:tonic",
+    # The gRPC exporter is async; `otlp.rs` drives it on a dedicated
+    # single-worker runtime built in `main`, before the server's own.
+    "tokio/rt-multi-thread",
 ]
 
 [dev-dependencies]

--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -2,16 +2,16 @@
 //!
 //! Exports the router's request spans (`http.request` with children
 //! `worker.queue_wait` and `php.execute`, all emitted under
-//! [`crate::OTEL_TRACE_TARGET`]) to an OpenTelemetry collector over
-//! OTLP/HTTP with protobuf payloads.
+//! [`crate::OTEL_TRACE_TARGET`]) to an OpenTelemetry collector, over either
+//! OTLP transport — see [Transports](#transports).
 //!
 //! Activation is strictly opt-in at runtime, in precedence order:
 //!
 //! 1. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT`
 //!    environment variables (standard OTel semantics — the exporter builder
-//!    reads them itself, so `.../v1/traces` handling follows the spec).
-//! 2. `[server.diagnostics] otlp_endpoint` from config (a base URL;
-//!    `/v1/traces` is appended when missing).
+//!    reads them itself, so signal-path handling follows the spec).
+//! 2. `[server.diagnostics] otlp_endpoint` from config (a base URL; see
+//!    [`normalize_endpoint`] for the per-transport path rules).
 //!
 //! When none of these are set, [`init_layer`] returns `Ok(None)`: no
 //! exporter is built, no background thread is spawned, and no global
@@ -153,29 +153,42 @@ impl Transport {
     }
 }
 
-/// Resolve the transport from the standard environment variables.
+/// Resolve the transport, environment first.
 ///
-/// `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` wins over
-/// `OTEL_EXPORTER_OTLP_PROTOCOL`, matching the endpoint variables' precedence.
-/// Unset means `http/protobuf`, which is both the OTel default and what ePHPm
-/// did before gRPC existed — so this stays additive.
+/// Precedence, highest to lowest — the same shape as the endpoint's:
+///
+/// 1. `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
+/// 2. `OTEL_EXPORTER_OTLP_PROTOCOL`
+/// 3. `config_protocol` — `[server.diagnostics] otlp_protocol`, which itself
+///    already reflects `EPHPM_SERVER__DIAGNOSTICS__OTLP_PROTOCOL`
+///
+/// All unset means `http/protobuf`, which is both the OTel default and what
+/// ePHPm did before gRPC existed — so this stays additive.
 ///
 /// # Errors
 ///
 /// Returns an error for a value this build cannot honour, rather than falling
 /// back to a transport the operator did not ask for. Silently exporting over
 /// the wrong protocol is exactly the class of failure #378 is about.
-fn resolve_transport() -> anyhow::Result<Transport> {
-    let Some((var, value)) = ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "OTEL_EXPORTER_OTLP_PROTOCOL"]
+fn resolve_transport(config_protocol: Option<&str>) -> anyhow::Result<Transport> {
+    let from_env = ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "OTEL_EXPORTER_OTLP_PROTOCOL"]
         .iter()
         .find_map(|var| {
-            std::env::var(var).ok().map(|v| (*var, v)).filter(|(_, v)| !v.trim().is_empty())
-        })
-    else {
+            std::env::var(var)
+                .ok()
+                .map(|v| ((*var).to_string(), v))
+                .filter(|(_, v)| !v.trim().is_empty())
+        });
+
+    let Some((var, value)) = from_env.or_else(|| {
+        config_protocol
+            .filter(|v| !v.trim().is_empty())
+            .map(|v| ("[server.diagnostics] otlp_protocol".to_string(), v.to_string()))
+    }) else {
         return Ok(Transport::HttpBinary);
     };
 
-    parse_transport(var, &value)
+    parse_transport(&var, &value)
 }
 
 /// The pure half of [`resolve_transport`], so the mapping can be tested
@@ -556,6 +569,7 @@ fn build_grpc_exporter(
 /// [`build_http_client`] and [`build_grpc_exporter`]).
 pub fn init_layer<S>(
     config_endpoint: Option<&str>,
+    config_protocol: Option<&str>,
 ) -> anyhow::Result<Option<(impl Layer<S>, OtlpGuard, OtlpStartupInfo)>>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
@@ -572,7 +586,7 @@ where
 
     // Resolved before any client is built so an unsupported protocol fails
     // fast, with a message, instead of exporting over the wrong one.
-    let transport = resolve_transport()?;
+    let transport = resolve_transport(config_protocol)?;
 
     // The endpoint the *exporter* will use, for the port sanity check. When it
     // comes from the environment we leave the actual value to the builder's own
@@ -600,7 +614,8 @@ where
     // standard semantics (`OTEL_EXPORTER_OTLP_ENDPOINT` is a base URL that
     // gets `/v1/traces` appended on http/protobuf and is used as-is on gRPC;
     // the TRACES variant is verbatim on both).
-    let builder_endpoint = if env_endpoint.is_some() { None } else { effective_endpoint.as_deref() };
+    let builder_endpoint =
+        if env_endpoint.is_some() { None } else { effective_endpoint.as_deref() };
 
     let service_name = std::env::var("OTEL_SERVICE_NAME")
         .ok()
@@ -632,8 +647,7 @@ where
             if let Some(endpoint) = builder_endpoint {
                 builder = builder.with_endpoint(endpoint);
             }
-            let exporter =
-                builder.build().context("failed to build the OTLP span exporter")?;
+            let exporter = builder.build().context("failed to build the OTLP span exporter")?;
             let provider = SdkTracerProvider::builder()
                 .with_batch_exporter(exporter)
                 .with_resource(resource)
@@ -657,8 +671,7 @@ where
 
     let description =
         format!("{endpoint_source} (service.name = {service_name}; {transport_description})");
-    let info =
-        OtlpStartupInfo { protocol: transport.as_str(), description, warnings };
+    let info = OtlpStartupInfo { protocol: transport.as_str(), description, warnings };
     Ok(Some((layer, OtlpGuard { provider, _grpc_runtime: grpc_runtime }, info)))
 }
 
@@ -726,6 +739,35 @@ mod tests {
 
         let err = parse_transport(var, "gprc").unwrap_err().to_string();
         assert!(err.contains("not a valid OTLP protocol"), "unexpected error: {err}");
+    }
+
+    /// The config knob is honoured, and an invalid one still errors.
+    ///
+    /// Only the config path is exercised here: asserting that
+    /// `OTEL_EXPORTER_OTLP_PROTOCOL` beats it would require setting a
+    /// process-global variable that any concurrently running test could
+    /// observe. The precedence itself is a one-line `or_else` in
+    /// `resolve_transport`, and the env-vs-config order is verified end to end
+    /// in the lab rather than here.
+    #[test]
+    fn config_protocol_is_used_when_no_env_var_is_set() {
+        // The env vars are not set in a normal test run; if a future test
+        // leaks one, this assertion is what will catch it.
+        for var in ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "OTEL_EXPORTER_OTLP_PROTOCOL"] {
+            assert!(
+                std::env::var(var).is_err(),
+                "{var} leaked into the test process; this test cannot be trusted"
+            );
+        }
+
+        assert_eq!(resolve_transport(Some("grpc")).unwrap(), Transport::Grpc);
+        assert_eq!(resolve_transport(Some("http/protobuf")).unwrap(), Transport::HttpBinary);
+        // Unset and empty both mean "the default", never an error.
+        assert_eq!(resolve_transport(None).unwrap(), Transport::HttpBinary);
+        assert_eq!(resolve_transport(Some("   ")).unwrap(), Transport::HttpBinary);
+
+        let err = resolve_transport(Some("http/json")).unwrap_err().to_string();
+        assert!(err.contains("otlp_protocol"), "error must name the config key: {err}");
     }
 
     /// gRPC takes a base URL; http/protobuf takes a signal URL.

--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -435,24 +435,27 @@ impl<E: opentelemetry_sdk::trace::SpanExporter> opentelemetry_sdk::trace::SpanEx
 /// Returns a warning when some *other* provider was already installed, which
 /// would mean gRPC TLS silently uses it.
 fn install_default_crypto_provider() -> Option<String> {
-    let ours = crate::tls::crypto_provider();
+    // `install_default` is a one-shot for the whole process, so the attempt is
+    // memoized: a second call (two tests in one binary, or any future second
+    // exporter) must report the same answer as the first rather than seeing
+    // its own earlier installation and mistaking it for a foreign one.
+    static INSTALLED_OURS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
-    if rustls::crypto::CryptoProvider::install_default((*ours).clone()).is_ok() {
+    let ours_won = *INSTALLED_OURS.get_or_init(|| {
+        let ours = crate::tls::crypto_provider();
+        rustls::crypto::CryptoProvider::install_default((*ours).clone()).is_ok()
+    });
+
+    if ours_won {
         return None;
     }
 
-    // Err means one was already installed. Ours is installed exactly here, so
-    // an existing one is either ours (idempotent, fine) or a foreign one.
-    let installed = rustls::crypto::CryptoProvider::get_default();
-    match installed {
-        Some(p) if std::ptr::eq(std::ptr::from_ref(&**p), std::ptr::from_ref(&*ours)) => None,
-        _ => Some(
-            "a rustls crypto provider was already installed as the process \
-             default before the OTLP gRPC exporter was built; gRPC TLS will \
-             use that provider, which may differ from the HTTPS listener's"
-                .to_string(),
-        ),
-    }
+    Some(
+        "a rustls crypto provider was already installed as the process default \
+         before the OTLP gRPC exporter was built; gRPC TLS will use that \
+         provider, which may differ from the HTTPS listener's"
+            .to_string(),
+    )
 }
 
 /// Build the OTLP/gRPC exporter together with the runtime that drives it.
@@ -843,6 +846,24 @@ mod tests {
 
         // The runtime is real and usable — this is what drives every export.
         assert_eq!(runtime.block_on(async { 1 + 1 }), 2);
+    }
+
+    /// Building a second gRPC exporter must not report a foreign provider.
+    ///
+    /// `CryptoProvider::install_default` is a process-wide one-shot, so the
+    /// second call necessarily fails. Reading that as "somebody else installed
+    /// one" would emit a bogus warning — and, since the test binary shares one
+    /// process, would make whichever gRPC test ran second fail depending on
+    /// ordering.
+    #[test]
+    fn building_a_second_grpc_exporter_is_idempotent() {
+        let (_e1, _r1, first) =
+            build_grpc_exporter(Some("http://127.0.0.1:4317")).expect("first exporter");
+        let (_e2, _r2, second) =
+            build_grpc_exporter(Some("http://127.0.0.1:4317")).expect("second exporter");
+
+        assert!(!first.contains("already installed"), "first: {first}");
+        assert!(!second.contains("already installed"), "second: {second}");
     }
 
     /// The client must speak plaintext exactly as before TLS was added.

--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -18,11 +18,41 @@
 //! propagator is installed — the only remaining cost is the disabled-span
 //! callsite check in the router.
 //!
-//! The exporter uses a blocking `reqwest` client driven by the OTel SDK's
-//! own batch-export thread, deliberately avoiding any dependency on the
-//! tokio runtime: the tracing subscriber (and therefore this layer) is
+//! # Transports
+//!
+//! Both OTLP transports are compiled in and the choice is made at **runtime**
+//! by the standard `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` /
+//! `OTEL_EXPORTER_OTLP_PROTOCOL` variables:
+//!
+//! | value | transport | default port |
+//! |---|---|---|
+//! | `http/protobuf` (default) | OTLP/HTTP, protobuf payloads | 4318 |
+//! | `grpc` | OTLP/gRPC | 4317 |
+//!
+//! Runtime selection rather than a second cargo feature is deliberate. ePHPm
+//! ships **one** release binary (`xtask`'s `RELEASE_FEATURES`), so a
+//! compile-time switch would have to pick a transport on behalf of every user
+//! — and since the feature would then always be on in releases, it would cost
+//! exactly what compiling both costs anyway. Runtime selection is also the
+//! behaviour the OTel ecosystem expects, so a user's existing
+//! `OTEL_EXPORTER_OTLP_PROTOCOL` just works.
+//!
+//! `http/json` is *not* supported; it is rejected with a clear error rather
+//! than silently falling back to a transport the operator did not ask for.
+//!
+//! # Runtimes
+//!
+//! The http/protobuf transport uses a blocking `reqwest` client driven by the
+//! OTel SDK's own batch-export thread, deliberately avoiding any dependency on
+//! the tokio runtime: the tracing subscriber (and therefore this layer) is
 //! initialized in `main` *before* the runtime exists, because PHP must be
 //! initialized single-threaded.
+//!
+//! The gRPC transport cannot avoid tokio — tonic is async to the core. It gets
+//! its own small runtime, owned by [`OtlpGuard`], rather than borrowing the
+//! server's: the server's does not exist yet at this point in `main`. See
+//! [`RuntimeBoundExporter`] for how the SDK's synchronous batch thread drives
+//! it.
 //!
 //! # TLS
 //!
@@ -61,6 +91,11 @@ use tracing_subscriber::registry::LookupSpan;
 /// sitting in the batch queue — hold it for the whole server lifetime.
 pub struct OtlpGuard {
     provider: SdkTracerProvider,
+    /// The gRPC transport's dedicated tokio runtime, `None` on the
+    /// http/protobuf path. Declared after `provider` so it outlives the
+    /// explicit `provider.shutdown()` in [`Drop`] — that shutdown performs the
+    /// final flush, which for gRPC still needs this runtime alive.
+    _grpc_runtime: Option<tokio::runtime::Runtime>,
 }
 
 impl Drop for OtlpGuard {
@@ -71,6 +106,148 @@ impl Drop for OtlpGuard {
             tracing::debug!(error = %e, "OTLP tracer provider shutdown reported an error");
         }
     }
+}
+
+/// What [`init_layer`] resolved, for the caller to log.
+///
+/// `init_layer` runs *before* the tracing subscriber is installed, so it
+/// cannot log anything itself — everything it wants to say comes back here.
+pub struct OtlpStartupInfo {
+    /// The wire protocol in OTel's own spelling: `"http/protobuf"` or `"grpc"`.
+    pub protocol: &'static str,
+    /// The resolved endpoint, its source, and the transport's TLS/timeout
+    /// details.
+    pub description: String,
+    /// Misconfigurations worth an operator's attention that are nonetheless
+    /// legal, so they must not fail startup. Log each at WARN.
+    pub warnings: Vec<String>,
+}
+
+/// The OTLP transport, chosen at runtime. See the module docs.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Transport {
+    /// OTLP/HTTP with protobuf payloads — the default, and what every
+    /// pre-existing ePHPm deployment uses.
+    HttpBinary,
+    /// OTLP/gRPC.
+    Grpc,
+}
+
+impl Transport {
+    /// OTel's spelling of this transport, as used by
+    /// `OTEL_EXPORTER_OTLP_PROTOCOL` and in log lines.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::HttpBinary => "http/protobuf",
+            Self::Grpc => "grpc",
+        }
+    }
+
+    /// The IANA-registered default collector port for this transport. Used
+    /// only to spot an endpoint that names the *other* transport's port.
+    const fn default_port(self) -> u16 {
+        match self {
+            Self::HttpBinary => 4318,
+            Self::Grpc => 4317,
+        }
+    }
+}
+
+/// Resolve the transport from the standard environment variables.
+///
+/// `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` wins over
+/// `OTEL_EXPORTER_OTLP_PROTOCOL`, matching the endpoint variables' precedence.
+/// Unset means `http/protobuf`, which is both the OTel default and what ePHPm
+/// did before gRPC existed — so this stays additive.
+///
+/// # Errors
+///
+/// Returns an error for a value this build cannot honour, rather than falling
+/// back to a transport the operator did not ask for. Silently exporting over
+/// the wrong protocol is exactly the class of failure #378 is about.
+fn resolve_transport() -> anyhow::Result<Transport> {
+    let Some((var, value)) = ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "OTEL_EXPORTER_OTLP_PROTOCOL"]
+        .iter()
+        .find_map(|var| {
+            std::env::var(var).ok().map(|v| (*var, v)).filter(|(_, v)| !v.trim().is_empty())
+        })
+    else {
+        return Ok(Transport::HttpBinary);
+    };
+
+    parse_transport(var, &value)
+}
+
+/// The pure half of [`resolve_transport`], so the mapping can be tested
+/// without mutating process-global environment state.
+fn parse_transport(var: &str, value: &str) -> anyhow::Result<Transport> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "http/protobuf" | "http/proto" => Ok(Transport::HttpBinary),
+        "grpc" => Ok(Transport::Grpc),
+        "http/json" => Err(anyhow::anyhow!(
+            "{var}=http/json is not supported by ePHPm's OTLP exporter; use \
+             `grpc` or `http/protobuf`"
+        )),
+        other => Err(anyhow::anyhow!(
+            "{var}={other} is not a valid OTLP protocol; expected `grpc` or \
+             `http/protobuf`"
+        )),
+    }
+}
+
+/// Normalize `[server.diagnostics] otlp_endpoint` for the chosen transport.
+///
+/// The two transports disagree about paths, and getting this wrong is silent:
+///
+/// - **http/protobuf** takes a *signal* URL, so `/v1/traces` is appended when
+///   the configured value does not already end with it.
+/// - **gRPC** takes a *base* URL and no signal path — the signal is the gRPC
+///   method name. Appending `/v1/traces` here produces a 404-equivalent from
+///   the collector and no spans.
+fn normalize_endpoint(transport: Transport, endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    match transport {
+        Transport::Grpc => trimmed.to_string(),
+        Transport::HttpBinary => {
+            if endpoint.ends_with("/v1/traces") {
+                endpoint.to_string()
+            } else {
+                format!("{trimmed}/v1/traces")
+            }
+        }
+    }
+}
+
+/// Warn when an endpoint names the *other* transport's default port.
+///
+/// This is the single most likely OTLP misconfiguration: 4317 and 4318 are one
+/// character apart and a collector accepts both, on different protocols. The
+/// symptom is silence, which is precisely what #378 is about.
+///
+/// Deliberately a **warning, not an error**. Nothing stops an operator running
+/// a gRPC receiver on 4318, so failing startup here would reject a legal
+/// configuration. The goal is that the log says why, not that the server
+/// refuses to run.
+fn port_mismatch_warning(transport: Transport, endpoint: &str) -> Option<String> {
+    let other = match transport {
+        Transport::HttpBinary => Transport::Grpc,
+        Transport::Grpc => Transport::HttpBinary,
+    };
+    let port = endpoint.parse::<http::Uri>().ok()?.port_u16()?;
+    if port != other.default_port() {
+        return None;
+    }
+
+    Some(format!(
+        "OTLP endpoint {endpoint} uses port {port}, the conventional port for \
+         {other_proto}, but the exporter is configured for {this_proto} (the \
+         conventional port for which is {this_port}). If no spans arrive, \
+         either set OTEL_EXPORTER_OTLP_PROTOCOL={other_proto} or point the \
+         endpoint at port {this_port}.",
+        other_proto = other.as_str(),
+        this_proto = transport.as_str(),
+        this_port = transport.default_port(),
+    ))
 }
 
 /// The OTLP spec's default export timeout when no env var overrides it
@@ -167,6 +344,193 @@ fn build_http_client() -> anyhow::Result<(reqwest::blocking::Client, String)> {
     Ok((client, description))
 }
 
+/// Adapts an async [`SpanExporter`] to the SDK's synchronous batch thread.
+///
+/// [`opentelemetry_sdk::trace::BatchSpanProcessor`] runs on a plain
+/// `std::thread` and drives exports with `futures_executor::block_on`
+/// (`opentelemetry_sdk-0.31.0/src/trace/span_processor.rs`, the thread at
+/// `:316` and the `block_on` at `:507`). That executor provides no tokio
+/// reactor, so tonic's hyper connection would fail with "no reactor running".
+///
+/// So the export future is handed to our own runtime with
+/// [`tokio::runtime::Handle::block_on`], which polls it on the calling thread
+/// while the runtime's worker drives the IO. Blocking that thread is correct
+/// and not a regression: it is the batch exporter's own dedicated thread, and
+/// the http/protobuf transport already blocks it the same way via
+/// `reqwest::blocking`.
+///
+/// `Handle::block_on` panics only when called from *inside* a runtime, which
+/// the paragraph above rules out — the batch processor never runs on a tokio
+/// worker. Keeping `inner` by value (rather than behind an `Arc`, as a
+/// `Handle::spawn` implementation would require) is what lets the `&mut`
+/// methods below forward directly; `set_resource` in particular carries
+/// `service.name`, and silently dropping it would be a real defect.
+#[derive(Debug)]
+struct RuntimeBoundExporter<E> {
+    inner: E,
+    handle: tokio::runtime::Handle,
+}
+
+impl<E: opentelemetry_sdk::trace::SpanExporter> opentelemetry_sdk::trace::SpanExporter
+    for RuntimeBoundExporter<E>
+{
+    fn export(
+        &self,
+        batch: Vec<opentelemetry_sdk::trace::SpanData>,
+    ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        let handle = self.handle.clone();
+        let export = self.inner.export(batch);
+        async move { handle.block_on(export) }
+    }
+
+    fn shutdown_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        let _entered = self.handle.enter();
+        self.inner.shutdown_with_timeout(timeout)
+    }
+
+    fn force_flush(&mut self) -> opentelemetry_sdk::error::OTelSdkResult {
+        let _entered = self.handle.enter();
+        self.inner.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(resource);
+    }
+}
+
+/// Make [`crate::tls::crypto_provider`] the process-default rustls provider.
+///
+/// Unlike reqwest, tonic offers no `use_preconfigured_tls` escape hatch — it
+/// builds the [`rustls::ClientConfig`] itself. What it *does* do is consult
+/// `CryptoProvider::get_default()` **first**, ahead of any crate-feature
+/// fallback (`tonic-0.14.5/src/transport/channel/service/tls.rs`, the `match`
+/// at the top of `TlsConnector::new`). Installing our provider as the process
+/// default is therefore the supported way to keep gRPC on the same provider as
+/// the HTTPS listener.
+///
+/// Without this, the `tls-provider-agnostic` build reaches tonic's final arm,
+/// a bare `ClientConfig::builder()`, which resolves via
+/// `from_crate_features()` — `None` in a binary that has had two providers
+/// linked — and panics. That is the same trap #371 hit with reqwest.
+///
+/// Installing a default is inert for the rest of the server: every other call
+/// site names its provider explicitly with `builder_with_provider`.
+///
+/// Returns a warning when some *other* provider was already installed, which
+/// would mean gRPC TLS silently uses it.
+fn install_default_crypto_provider() -> Option<String> {
+    let ours = crate::tls::crypto_provider();
+
+    if rustls::crypto::CryptoProvider::install_default((*ours).clone()).is_ok() {
+        return None;
+    }
+
+    // Err means one was already installed. Ours is installed exactly here, so
+    // an existing one is either ours (idempotent, fine) or a foreign one.
+    let installed = rustls::crypto::CryptoProvider::get_default();
+    match installed {
+        Some(p) if std::ptr::eq(std::ptr::from_ref(&**p), std::ptr::from_ref(&*ours)) => None,
+        _ => Some(
+            "a rustls crypto provider was already installed as the process \
+             default before the OTLP gRPC exporter was built; gRPC TLS will \
+             use that provider, which may differ from the HTTPS listener's"
+                .to_string(),
+        ),
+    }
+}
+
+/// Build the OTLP/gRPC exporter together with the runtime that drives it.
+///
+/// `endpoint` is the already-normalized endpoint, or `None` to let
+/// `opentelemetry-otlp` apply its own `OTEL_EXPORTER_OTLP_*` handling.
+///
+/// # TLS
+///
+/// The trust anchors match the http/protobuf transport's policy — the union of
+/// the OS trust store and the bundled Mozilla set — so switching protocol does
+/// not silently change which collectors are reachable. The two are configured
+/// differently only because tonic owns its `ClientConfig`: it reads the OS
+/// store itself (honouring `SSL_CERT_FILE` / `SSL_CERT_DIR` via the same
+/// `rustls-native-certs`) rather than being handed one.
+///
+/// Native roots are requested only when the OS store actually has certificates
+/// in it: tonic's `with_native_roots` fails the whole handshake with
+/// `NativeCertsNotFound` on an empty store, which would make a
+/// `scratch`/distroless image unable to reach even a publicly trusted
+/// collector that the bundled roots cover.
+///
+/// # Errors
+///
+/// Returns an error when the runtime or the exporter cannot be built.
+fn build_grpc_exporter(
+    endpoint: Option<&str>,
+) -> anyhow::Result<(
+    // `use<>`: the exporter captures nothing from `endpoint` (the builder
+    // copies it), and the SDK requires `'static` to hand it to the batch
+    // processor. Without this, Rust 2024's capture rules infer a borrow.
+    impl opentelemetry_sdk::trace::SpanExporter + use<>,
+    tokio::runtime::Runtime,
+    String,
+)> {
+    use opentelemetry_otlp::{WithExportConfig as _, WithTonicConfig as _};
+
+    let provider_warning = install_default_crypto_provider();
+
+    let native_count = rustls_native_certs::load_native_certs().certs.len();
+    let bundled = webpki_roots::TLS_SERVER_ROOTS.len();
+
+    let mut tls = tonic::transport::ClientTlsConfig::new().with_webpki_roots();
+    if native_count > 0 {
+        tls = tls.with_native_roots();
+    }
+
+    let timeout = export_timeout();
+
+    // One worker is plenty: this runtime carries a single gRPC stream of
+    // batched spans, and every export is serialized by the SDK anyway ("this
+    // function will never be called concurrently for the same exporter
+    // instance"). It costs one thread — the same order as the
+    // `reqwest-internal-sync-runtime` thread the http transport spawns.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .thread_name("ephpm-otlp-grpc")
+        .build()
+        .context("failed to build the OTLP gRPC exporter's tokio runtime")?;
+
+    // tonic's `connect_lazy` builds the channel without connecting, but it
+    // still expects to be inside a runtime context. Building here rather than
+    // relying on that being optional keeps it correct by construction.
+    let exporter = {
+        let _entered = runtime.enter();
+
+        let mut builder =
+            opentelemetry_otlp::SpanExporter::builder().with_tonic().with_tls_config(tls);
+        if let Some(endpoint) = endpoint {
+            builder = builder.with_endpoint(endpoint);
+        }
+        builder
+            .with_timeout(timeout)
+            .build()
+            .context("failed to build the OTLP gRPC span exporter")?
+    };
+
+    let handle = runtime.handle().clone();
+    let mut description = format!(
+        "TLS trust anchors: {native_count} from the OS store + {bundled} bundled; timeout {}ms",
+        timeout.as_millis()
+    );
+    if let Some(warning) = provider_warning {
+        description.push_str("; ");
+        description.push_str(&warning);
+    }
+
+    Ok((RuntimeBoundExporter { inner: exporter, handle }, runtime, description))
+}
+
 /// Resolve the endpoint and build the OTLP tracing layer.
 ///
 /// `config_endpoint` is `[server.diagnostics] otlp_endpoint`. The standard
@@ -179,17 +543,20 @@ fn build_http_client() -> anyhow::Result<(reqwest::blocking::Client, String)> {
 ///
 /// The service name is `OTEL_SERVICE_NAME` when set, else `"ephpm"`.
 ///
-/// The returned `String` describes the resolved endpoint and its source for
-/// the caller to log — this function runs *before* the tracing subscriber is
-/// installed, so it cannot log anything itself.
+/// The returned [`OtlpStartupInfo`] describes the resolved transport,
+/// endpoint and its source for the caller to log — this function runs *before*
+/// the tracing subscriber is installed, so it cannot log anything itself. Its
+/// `warnings` must be logged at WARN.
 ///
 /// # Errors
 ///
-/// Returns an error when the exporter cannot be built (malformed endpoint),
-/// or when its HTTP client cannot be built (see [`build_http_client`]).
+/// Returns an error when `OTEL_EXPORTER_OTLP_PROTOCOL` names a protocol this
+/// build cannot honour, when the exporter cannot be built (malformed
+/// endpoint), or when its transport client cannot be built (see
+/// [`build_http_client`] and [`build_grpc_exporter`]).
 pub fn init_layer<S>(
     config_endpoint: Option<&str>,
-) -> anyhow::Result<Option<(impl Layer<S>, OtlpGuard, String)>>
+) -> anyhow::Result<Option<(impl Layer<S>, OtlpGuard, OtlpStartupInfo)>>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
@@ -197,41 +564,43 @@ where
         .iter()
         .find_map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()));
 
-    // Resolve the endpoint before building the client: when nothing is
+    // Resolve the endpoint before building anything: when nothing is
     // configured we return early and never touch the OS trust store.
     if env_endpoint.is_none() && config_endpoint.is_none() {
         return Ok(None);
     }
 
-    use opentelemetry_otlp::WithHttpConfig as _;
-    let (http_client, tls_description) = build_http_client()?;
+    // Resolved before any client is built so an unsupported protocol fails
+    // fast, with a message, instead of exporting over the wrong one.
+    let transport = resolve_transport()?;
 
-    let builder = opentelemetry_otlp::SpanExporter::builder()
-        .with_http()
-        .with_http_client(http_client)
-        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary);
+    // The endpoint the *exporter* will use, for the port sanity check. When it
+    // comes from the environment we leave the actual value to the builder's own
+    // env handling (standard OTel semantics) and only inspect it here.
+    let effective_endpoint = env_endpoint
+        .clone()
+        .or_else(|| config_endpoint.map(|ep| normalize_endpoint(transport, ep)));
+    let mut warnings = Vec::new();
+    if let Some(ref endpoint) = effective_endpoint
+        && let Some(warning) = port_mismatch_warning(transport, endpoint)
+    {
+        warnings.push(warning);
+    }
 
-    let (builder, endpoint_source) = if let Some(ref env_ep) = env_endpoint {
-        // Leave the endpoint to the builder's own env handling so the
-        // standard semantics apply (OTEL_EXPORTER_OTLP_ENDPOINT is a base
-        // URL that gets `/v1/traces` appended; the TRACES variant is used
-        // verbatim).
-        (builder, format!("env: {env_ep}"))
-    } else if let Some(cfg_ep) = config_endpoint {
-        let url = if cfg_ep.ends_with("/v1/traces") {
-            cfg_ep.to_string()
-        } else {
-            format!("{}/v1/traces", cfg_ep.trim_end_matches('/'))
-        };
-        (builder.with_endpoint(&url), format!("config: {url}"))
-    } else {
+    let endpoint_source = match (&env_endpoint, &effective_endpoint) {
+        (Some(env_ep), _) => format!("env: {env_ep}"),
+        (None, Some(endpoint)) => format!("config: {endpoint}"),
         // Unreachable: the guard above already returned for "no endpoint
         // configured anywhere". Kept so the arm structure stays total.
-        return Ok(None);
+        (None, None) => return Ok(None),
     };
 
-    use opentelemetry_otlp::WithExportConfig as _;
-    let exporter = builder.build().context("failed to build the OTLP span exporter")?;
+    // `with_endpoint` is applied only for the config source: for the env
+    // source the builder reads the variables itself, which is what keeps the
+    // standard semantics (`OTEL_EXPORTER_OTLP_ENDPOINT` is a base URL that
+    // gets `/v1/traces` appended on http/protobuf and is used as-is on gRPC;
+    // the TRACES variant is verbatim on both).
+    let builder_endpoint = if env_endpoint.is_some() { None } else { effective_endpoint.as_deref() };
 
     let service_name = std::env::var("OTEL_SERVICE_NAME")
         .ok()
@@ -241,8 +610,37 @@ where
     let resource =
         opentelemetry_sdk::Resource::builder().with_service_name(service_name.clone()).build();
 
-    let provider =
-        SdkTracerProvider::builder().with_batch_exporter(exporter).with_resource(resource).build();
+    // The two transports produce different exporter types, so each branch
+    // builds its own provider and they converge on `SdkTracerProvider`.
+    let (provider, grpc_runtime, transport_description) = match transport {
+        Transport::Grpc => {
+            let (exporter, runtime, description) = build_grpc_exporter(builder_endpoint)?;
+            let provider = SdkTracerProvider::builder()
+                .with_batch_exporter(exporter)
+                .with_resource(resource)
+                .build();
+            (provider, Some(runtime), description)
+        }
+        Transport::HttpBinary => {
+            use opentelemetry_otlp::{WithExportConfig as _, WithHttpConfig as _};
+
+            let (http_client, description) = build_http_client()?;
+            let mut builder = opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_http_client(http_client)
+                .with_protocol(opentelemetry_otlp::Protocol::HttpBinary);
+            if let Some(endpoint) = builder_endpoint {
+                builder = builder.with_endpoint(endpoint);
+            }
+            let exporter =
+                builder.build().context("failed to build the OTLP span exporter")?;
+            let provider = SdkTracerProvider::builder()
+                .with_batch_exporter(exporter)
+                .with_resource(resource)
+                .build();
+            (provider, None, description)
+        }
+    };
 
     // W3C trace-context propagation: the router extracts an incoming
     // `traceparent` through the global propagator, which defaults to a
@@ -258,8 +656,10 @@ where
     );
 
     let description =
-        format!("{endpoint_source} (service.name = {service_name}; {tls_description})");
-    Ok(Some((layer, OtlpGuard { provider }, description)))
+        format!("{endpoint_source} (service.name = {service_name}; {transport_description})");
+    let info =
+        OtlpStartupInfo { protocol: transport.as_str(), description, warnings };
+    Ok(Some((layer, OtlpGuard { provider, _grpc_runtime: grpc_runtime }, info)))
 }
 
 /// Parent `span` to the trace context carried in an incoming W3C
@@ -304,6 +704,104 @@ mod tests {
     use std::io::{Read as _, Write as _};
 
     use super::*;
+
+    /// Every protocol spelling the OTel spec allows, plus the rejections.
+    ///
+    /// Pure over `parse_transport` rather than the env-reading wrapper: the
+    /// test suite shares one process, so mutating `OTEL_EXPORTER_OTLP_*` here
+    /// would leak into any sibling test that builds an exporter.
+    #[test]
+    fn protocol_values_map_to_transports() {
+        let var = "OTEL_EXPORTER_OTLP_PROTOCOL";
+        assert_eq!(parse_transport(var, "grpc").unwrap(), Transport::Grpc);
+        assert_eq!(parse_transport(var, "http/protobuf").unwrap(), Transport::HttpBinary);
+        // Case and surrounding whitespace are not the operator's problem.
+        assert_eq!(parse_transport(var, "  GRPC \n").unwrap(), Transport::Grpc);
+
+        // http/json is a real OTLP protocol we deliberately do not implement,
+        // so it must say so rather than silently exporting over another one.
+        let err = parse_transport(var, "http/json").unwrap_err().to_string();
+        assert!(err.contains("not supported"), "unexpected error: {err}");
+        assert!(err.contains("http/protobuf"), "error must name the alternatives: {err}");
+
+        let err = parse_transport(var, "gprc").unwrap_err().to_string();
+        assert!(err.contains("not a valid OTLP protocol"), "unexpected error: {err}");
+    }
+
+    /// gRPC takes a base URL; http/protobuf takes a signal URL.
+    ///
+    /// Appending `/v1/traces` on the gRPC path is silent — the collector
+    /// simply never sees a recognised method — so the asymmetry is pinned.
+    #[test]
+    fn endpoint_normalization_differs_by_transport() {
+        let base = "http://127.0.0.1:4317";
+        assert_eq!(normalize_endpoint(Transport::Grpc, base), base);
+        assert_eq!(normalize_endpoint(Transport::Grpc, "http://127.0.0.1:4317/"), base);
+
+        assert_eq!(
+            normalize_endpoint(Transport::HttpBinary, "http://127.0.0.1:4318"),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+        assert_eq!(
+            normalize_endpoint(Transport::HttpBinary, "http://127.0.0.1:4318/"),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+        // Already-suffixed values must not be doubled.
+        assert_eq!(
+            normalize_endpoint(Transport::HttpBinary, "http://127.0.0.1:4318/v1/traces"),
+            "http://127.0.0.1:4318/v1/traces"
+        );
+    }
+
+    /// The 4317/4318 mix-up must produce a message, and nothing else must.
+    #[test]
+    fn port_mismatch_is_reported_only_when_it_is_a_mismatch() {
+        let warning = port_mismatch_warning(Transport::Grpc, "http://127.0.0.1:4318")
+            .expect("gRPC pointed at 4318 must warn");
+        assert!(warning.contains("4318"), "warning must name the port: {warning}");
+        assert!(warning.contains("grpc"), "warning must name the configured protocol: {warning}");
+
+        let warning =
+            port_mismatch_warning(Transport::HttpBinary, "http://127.0.0.1:4317/v1/traces")
+                .expect("http/protobuf pointed at 4317 must warn");
+        assert!(warning.contains("http/protobuf"), "unexpected warning: {warning}");
+
+        // Matching ports, and any unrelated port, are silent — an operator is
+        // free to run either transport anywhere.
+        assert!(port_mismatch_warning(Transport::Grpc, "http://127.0.0.1:4317").is_none());
+        assert!(
+            port_mismatch_warning(Transport::HttpBinary, "http://127.0.0.1:4318/v1/traces")
+                .is_none()
+        );
+        assert!(port_mismatch_warning(Transport::Grpc, "http://collector:9999").is_none());
+        // A port-less endpoint has nothing to compare.
+        assert!(port_mismatch_warning(Transport::Grpc, "https://collector.example").is_none());
+    }
+
+    /// The gRPC exporter must build offline, with its own runtime.
+    ///
+    /// This is the guard on the crypto-provider wiring: with
+    /// `tls-provider-agnostic` and nothing installed as the process default,
+    /// tonic falls through to a bare `ClientConfig::builder()` and **panics**
+    /// in a binary that has had two providers linked (#241). Building the
+    /// exporter is enough to exercise that path because tonic's
+    /// `connect_lazy` constructs the TLS connector eagerly.
+    #[test]
+    fn grpc_exporter_builds_with_its_own_runtime() {
+        let (_exporter, runtime, description) =
+            build_grpc_exporter(Some("http://127.0.0.1:4317")).expect("build gRPC exporter");
+
+        assert!(description.contains("trust anchors"), "unexpected description: {description}");
+        // A foreign provider would mean gRPC TLS silently diverges from the
+        // HTTPS listener; the description carries that warning when it happens.
+        assert!(
+            !description.contains("already installed"),
+            "another crypto provider won the process default: {description}"
+        );
+
+        // The runtime is real and usable — this is what drives every export.
+        assert_eq!(runtime.block_on(async { 1 + 1 }), 2);
+    }
 
     /// The client must speak plaintext exactly as before TLS was added.
     ///

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -1002,8 +1002,11 @@ fn run_with_config(
     // export layer joins the same registry; when nothing requests it, no
     // exporter is built and no background thread is spawned.
     #[cfg(feature = "otlp")]
-    let otlp = ephpm_server::otlp::init_layer(config.server.diagnostics.otlp_endpoint.as_deref())
-        .context("failed to initialize OTLP trace export")?;
+    let otlp = ephpm_server::otlp::init_layer(
+        config.server.diagnostics.otlp_endpoint.as_deref(),
+        config.server.diagnostics.otlp_protocol.as_deref(),
+    )
+    .context("failed to initialize OTLP trace export")?;
 
     // Layer stack. The env filter must be scoped to the fmt layer with
     // `with_filter`, never pushed into the Vec as a sibling layer: `Vec`'s
@@ -1059,6 +1062,18 @@ fn run_with_config(
         for warning in &info.warnings {
             tracing::warn!("{warning}");
         }
+    }
+
+    // add-config-knob: `otlp_protocol` only means anything alongside an
+    // endpoint. Setting it alone exports nothing, which must not look like it
+    // took effect.
+    #[cfg(feature = "otlp")]
+    if _otlp_guard.is_none() && config.server.diagnostics.otlp_protocol.is_some() {
+        tracing::warn!(
+            "[server.diagnostics] otlp_protocol is set but no OTLP endpoint is configured \
+             (otlp_endpoint / OTEL_EXPORTER_OTLP_*), so no spans are exported and the \
+             protocol has no effect."
+        );
     }
 
     // add-config-knob: never let an OTLP request die silently in a binary

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -1040,16 +1040,25 @@ fn run_with_config(
     // The guard flushes the exporter's batch queue on drop — hold it until
     // the server has exited.
     #[cfg(feature = "otlp")]
-    let _otlp_guard = otlp.map(|(otlp_layer, guard, description)| {
+    let _otlp_guard = otlp.map(|(otlp_layer, guard, info)| {
         layers.push(otlp_layer.boxed());
-        (guard, description)
+        (guard, info)
     });
 
     tracing_subscriber::registry().with(layers).init();
 
     #[cfg(feature = "otlp")]
-    if let Some((_, ref description)) = _otlp_guard {
-        tracing::info!(endpoint = %description, "OTLP trace export enabled (http/protobuf)");
+    if let Some((_, ref info)) = _otlp_guard {
+        tracing::info!(
+            endpoint = %info.description,
+            protocol = info.protocol,
+            "OTLP trace export enabled"
+        );
+        // Legal-but-probably-wrong configuration (e.g. the other transport's
+        // conventional port). Never fatal — see `otlp::port_mismatch_warning`.
+        for warning in &info.warnings {
+            tracing::warn!("{warning}");
+        }
     }
 
     // add-config-knob: never let an OTLP request die silently in a binary

--- a/site/content/architecture/_index.md
+++ b/site/content/architecture/_index.md
@@ -22,7 +22,7 @@ This document describes the full vision for ePHPm. The matrix below tracks what 
 | Signal handling | Partial | Ctrl+C only; no SIGHUP reload |
 | Observability — logging | **Implemented** | `tracing` crate, structured logs, request lifecycle events |
 | Observability — query stats | **Implemented** | `ephpm-query-stats`: SQL normalization, digest tracking, slow query log, Prometheus metrics |
-| Observability — OTLP export | Planned | Auto-instrumentation pipeline — not started |
+| Observability — OTLP export | **Implemented** | Request spans (`http.request` / `worker.queue_wait` / `php.execute`) over OTLP gRPC or http/protobuf, W3C `traceparent` continuation. Auto-instrumentation of PHP code, and an OTLP *receiver*, are still planned |
 | DB proxy (MySQL) | **Implemented** | Wire protocol, connection pooling, transparent forwarding to upstream MySQL |
 | DB proxy (PostgreSQL) | **Implemented** | Wire protocol, connection pooling, trust/md5/SCRAM auth, R/W splitting |
 | Read/write splitting | **Implemented** | `ephpm-db` routes reads to replicas, writes to primary |
@@ -295,8 +295,8 @@ password = "changeme"                 # admin UI auth (separate from node API au
 | PostgreSQL protocol | Implemented in `ephpm-db` — wire protocol frontend, connection pooling, trust/md5/SCRAM auth, R/W splitting |
 | Query observability | Custom in `ephpm-query-stats` (digest tracker, normalizer state machine, slow-query log, Prometheus export) |
 | Prometheus metrics | `prometheus` crate |
-| OTLP receiver/exporter | `opentelemetry-otlp`, `opentelemetry-sdk` (planned) |
-| Protobuf (OTLP wire format) | `prost`, `tonic` (gRPC) (planned) |
+| OTLP exporter | `opentelemetry-otlp`, `opentelemetry_sdk` (**implemented**, `otlp` cargo feature). OTLP *receiver*: planned |
+| Protobuf (OTLP wire format) | `prost`; `tonic` for the gRPC transport (**implemented**) |
 | Static PHP builds | `crazywhalecc/static-php-cli` (in `cargo xtask release`) |
 | Embedded static assets | `rust-embed` |
 | CLI | `clap` |

--- a/site/content/guides/otlp-tracing.md
+++ b/site/content/guides/otlp-tracing.md
@@ -4,8 +4,8 @@ weight = 20
 +++
 
 ePHPm can export a span per HTTP request to any OpenTelemetry collector over
-OTLP **http/protobuf**. This guide sets up a local trace UI, points ePHPm at
-it, and covers what your IDE can and cannot do for you.
+OTLP — either **gRPC** or **http/protobuf**. This guide sets up a local trace
+UI, points ePHPm at it, and covers what your IDE can and cannot do for you.
 
 Set expectations first, because "tracing" means different things:
 
@@ -43,6 +43,50 @@ is deliberate. The consequence in multi-tenant mode (`[server] sites_dir`) is
 that traces from different vhosts are currently indistinguishable — see
 [Known rough edges](#known-rough-edges).
 
+## Choosing a transport
+
+OTLP has two wire protocols and ePHPm speaks both. The choice is made at
+runtime by the standard environment variable — there is no rebuild and no
+cargo feature involved:
+
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport | Conventional port | Endpoint form |
+|---|---|---|---|
+| unset (default) | http/protobuf | 4318 | base URL; `/v1/traces` appended |
+| `http/protobuf` | http/protobuf | 4318 | base URL; `/v1/traces` appended |
+| `grpc` | OTLP/gRPC | 4317 | base URL, **no path appended** |
+
+`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` overrides it for traces specifically, the
+same way the `_TRACES_ENDPOINT` variable overrides the endpoint.
+
+If you would rather keep everything in one file, there is a config knob with
+the same meaning — the environment variables above win over it:
+
+```toml
+[server.diagnostics]
+otlp_endpoint = "http://127.0.0.1:4317"
+otlp_protocol = "grpc"
+```
+
+**Which should you use?** For a collector, either — they carry identical data.
+Pick gRPC when the consumer only accepts gRPC, which is the case for
+[PhpStorm's OpenTelemetry plugin](#phpstorm). Pick http/protobuf when
+something between you and the collector is an HTTP proxy that does not speak
+HTTP/2. `http/json` is not supported, and asking for it is a startup error
+rather than a silent fallback.
+
+**Mind the port.** 4317 and 4318 differ by one character and a collector
+usually listens on both, so pointing gRPC at 4318 is the single most common
+way to end up with no traces. ePHPm warns when the endpoint uses the other
+transport's conventional port:
+
+```text
+WARN ephpm: OTLP endpoint http://127.0.0.1:4318 uses port 4318, the
+     conventional port for http/protobuf, but the exporter is configured for
+     grpc (the conventional port for which is 4317). ...
+```
+
+It is a warning, not an error — running either transport on any port is legal.
+
 ## Step 1: run a collector
 
 Two options. Both were verified against ePHPm while writing this guide.
@@ -70,6 +114,8 @@ way to answer "what exactly is ePHPm sending?". Save as `otelcol.yaml`:
 receivers:
   otlp:
     protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
 
@@ -87,33 +133,46 @@ service:
 ```
 
 ```bash
-docker run --rm -p 4318:4318 \
+docker run --rm -p 4317:4317 -p 4318:4318 \
   -v "$PWD/otelcol.yaml:/etc/otelcol/config.yaml" -v "$PWD/out:/out" \
   otel/opentelemetry-collector-contrib:0.135.0 --config /etc/otelcol/config.yaml
 ```
+
+With both receivers enabled you can switch `OTEL_EXPORTER_OTLP_PROTOCOL`
+between `grpc` and `http/protobuf` (and the endpoint between 4317 and 4318)
+without touching the collector.
 
 You can also run both: add an `otlphttp` exporter pointing at Jaeger and get
 the UI and the JSON from one pipeline.
 
 ## Step 2: point ePHPm at it
 
+For **http/protobuf** (the default), a base URL is enough — `/v1/traces` is
+appended when missing:
+
 ```toml
 [server.diagnostics]
 otlp_endpoint = "http://127.0.0.1:4318"
 ```
 
-`/v1/traces` is appended when missing, so the base URL is enough. Then:
+For **gRPC**, use the gRPC port and set the protocol. No path is appended,
+because on gRPC the signal is the method name, not the URL:
+
+```toml
+[server.diagnostics]
+otlp_endpoint = "http://127.0.0.1:4317"
+```
 
 ```bash
-ephpm serve --config ephpm.toml
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc ephpm serve --config ephpm.toml
 ```
 
 Startup confirms it, and this line is your first checkpoint — if it is absent,
-nothing downstream matters:
+nothing downstream matters. Note it names the transport in use:
 
 ```text
-INFO ephpm: OTLP trace export enabled (http/protobuf)
-     endpoint=config: http://127.0.0.1:4318/v1/traces (service.name = ephpm; ...)
+INFO ephpm: OTLP trace export enabled
+     endpoint=config: http://127.0.0.1:4317 (service.name = ephpm; ...) protocol="grpc"
 ```
 
 Drive a request or two, wait a few seconds for the batch to flush, and open
@@ -126,7 +185,9 @@ The standard OTel variables work and **take precedence over the config knob**:
 | Variable | Effect |
 |----------|--------|
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Used verbatim. Highest precedence. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base URL; `/v1/traces` appended. Beats the config knob. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base URL; `/v1/traces` appended on http/protobuf, used as-is on gRPC. Beats the config knob. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` or `http/protobuf`. Default `http/protobuf`. |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Same, traces only. Highest precedence. |
 | `OTEL_SERVICE_NAME` | Service name in the trace UI. Default `ephpm`. |
 | `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` | Sampler. Default `parentbased_always_on`. |
 | `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` / `OTEL_EXPORTER_OTLP_TIMEOUT` | Export timeout in ms. Default `10000`. |
@@ -175,9 +236,11 @@ a broken exporter.
 
 ## HTTPS collectors
 
-An `https://` endpoint works with no extra configuration. TLS is rustls (the
-same crypto provider the HTTPS listener uses), and the trust anchors are the
-union of the OS trust store and a bundled Mozilla root set.
+An `https://` endpoint works with no extra configuration, on **both**
+transports. TLS is rustls (the same crypto provider the HTTPS listener uses —
+never OpenSSL and never a second TLS stack), and the trust anchors are the
+union of the OS trust store and a bundled Mozilla root set, identically for
+gRPC and http/protobuf.
 
 For a collector behind a private CA, point the standard `SSL_CERT_FILE` (a PEM
 bundle) or `SSL_CERT_DIR` at it. Note that doing so **replaces** the OS trust
@@ -188,7 +251,7 @@ description.
 
 ## PhpStorm
 
-### The in-IDE trace viewer, and why it needs a bridge
+### The in-IDE trace viewer — no bridge needed
 
 JetBrains ships a **free, first-party** plugin called
 [OpenTelemetry](https://plugins.jetbrains.com/plugin/27488-opentelemetry)
@@ -196,39 +259,52 @@ JetBrains ships a **free, first-party** plugin called
 is a genuine trace viewer: a Traces tab, and *"Double-click a trace, or select
 it and click Examine Trace, to open its span hierarchy."*
 
-There is a catch that matters here. Per
-[JetBrains' documentation](https://www.jetbrains.com/help/rider/OpenTelemetry.html):
-*"The built-in receiver accepts OTLP over gRPC."* **ePHPm only speaks OTLP
-http/protobuf**, so it cannot feed the plugin directly. To use it you need a
-local OpenTelemetry Collector receiving http/protobuf on 4318 and re-exporting
-over gRPC to the plugin's port (enable *Use fixed OTLP server port* in
-Settings → Tools → OpenTelemetry; the documented default is 17011):
+Per [JetBrains' documentation](https://www.jetbrains.com/help/rider/OpenTelemetry.html),
+*"the built-in receiver accepts OTLP over gRPC."* ePHPm speaks gRPC, so you
+can point it straight at the IDE — **no OpenTelemetry Collector in between**.
 
-```yaml
-receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 0.0.0.0:4318
-exporters:
-  otlp/ide:
-    endpoint: localhost:17011
-    tls:
-      insecure: true
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlp/ide]
-```
+1. **Install the plugin.** Settings → Plugins → Marketplace → search
+   *OpenTelemetry* (vendor JetBrains) → Install → restart.
+2. **Pin the receiver port.** Settings → Tools → OpenTelemetry → enable
+   *Use fixed OTLP server port*. The documented default is **17011**. Without
+   this the IDE picks a fresh port per run and there is nothing stable to
+   configure ePHPm against.
+3. **Point ePHPm at the IDE:**
 
-Also note the plugin has no PHP module — its automatic
-`OTEL_EXPORTER_OTLP_*` injection covers other languages' run configurations,
-not PHP. For ePHPm you set the endpoint in `ephpm.toml` anyway, so this costs
-you nothing.
+   ```toml
+   [server.diagnostics]
+   otlp_endpoint = "http://127.0.0.1:17011"
+   ```
 
-If you would rather not run the bridge, use Jaeger in a browser tab. That is
-the simpler setup and loses nothing but the tab.
+   ```bash
+   OTEL_EXPORTER_OTLP_PROTOCOL=grpc OTEL_SERVICE_NAME=my-app \
+     ephpm serve --config ephpm.toml
+   ```
+
+   `http://`, not `https://` — the IDE receiver is plaintext on loopback.
+
+4. **Check the startup line** says `protocol="grpc"` and names port 17011.
+5. **Drive a request**, wait a few seconds for the batch to flush, and open
+   the **OpenTelemetry** tool window → *Traces*. Double-click a trace (or
+   *Examine Trace*) to get the span hierarchy: `http.request` with
+   `php.execute` — and `worker.queue_wait` too, in worker mode — nested under
+   it.
+
+Set `OTEL_SERVICE_NAME` per project; it is what the plugin labels traces with.
+
+Note the plugin has no PHP module — its automatic `OTEL_EXPORTER_OTLP_*`
+injection covers other languages' run configurations, not PHP. For ePHPm you
+set the endpoint in `ephpm.toml` anyway, so this costs you nothing.
+
+If the Traces tab stays empty, work down this list: is the startup line
+present and does it say `grpc`; does it name 17011; is *Use fixed OTLP server
+port* actually enabled; and is there an `ERROR ... BatchSpanProcessor.
+ExportError` in the ePHPm log (a refused connection means the IDE is not
+listening on that port). Export failures are logged — see
+[Known rough edges](#known-rough-edges).
+
+Jaeger in a browser tab remains a perfectly good alternative, and is what to
+fall back to if the plugin misbehaves.
 
 ### What PhpStorm contributes either way
 
@@ -322,11 +398,21 @@ flushes the batch queue before exiting — verified. `SIGKILL` does not, and the
 last few seconds of spans are gone. If your last request never shows up, check
 how you stopped the server before you check anything else.
 
-**Export failures are silent.** If the endpoint is wrong, unreachable, or
-presents a certificate ePHPm does not trust, nothing is logged — the startup
-line still says export is enabled and then the server goes quiet. Check the
-collector's own log. Tracked in
-[#378](https://github.com/ephpm/ephpm/issues/378).
+**Export failures are logged, and repeat.** A wrong endpoint, an unreachable
+collector or an untrusted certificate produces an error line naming the cause,
+on the `opentelemetry_sdk` target:
+
+```text
+ERROR opentelemetry_sdk: name="BatchSpanProcessor.ExportError"
+      error="Operation failed: ... tcp connect error ... Connection refused"
+```
+
+This was silent before ([#378](https://github.com/ephpm/ephpm/issues/378)).
+Two things to know: the message is emitted **once per failed batch**, so a
+collector that stays down produces a steady trickle of error lines rather than
+one; and a `[server.logging] level` / `RUST_LOG` filter strict enough to
+exclude the `opentelemetry_sdk` target will hide it again. Serving is never
+affected — requests keep returning normally while export fails.
 
 **Spans are `SPAN_KIND_INTERNAL`, including `http.request`.** Backends that
 build service graphs or RED metrics from span kind will not recognise ePHPm as

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -125,9 +125,28 @@ ini_overrides = [
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `request_log` | bool | (mode default) | Per-request timeline: the last 256 completed requests (method, path, status, total/queue-wait/PHP durations in ms, response bytes, timestamp) served as JSON at `GET /_ephpm/requests`, newest first. Unset resolves per mode: **on** under `ephpm dev` / bare `ephpm`, **off** under `ephpm serve`. `queue_wait_ms` is `null` outside worker mode (there is no dispatch queue on the fpm path); in worker mode `php_ms` includes the queue wait, matching `ephpm_php_execution_duration_seconds`. Requests to `/_ephpm/*` and the metrics path are not recorded. When off, `/_ephpm/requests` is not registered and the path falls through to normal routing. Env override: `EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG`. |
-| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"` (OTLP **http/protobuf**; `/v1/traces` is appended when missing). Exports one `http.request` span per request (attrs: method, path, status) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. Requires a binary built with the `otlp` cargo feature. **Official release binaries and the Docker image have it** (`cargo xtask release` builds with it); a plain `cargo build` does not, and there a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs (verified — thread count is identical to a binary without the feature). Both `http://` and `https://` endpoints are supported — see the note below. |
+| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"`. The transport is chosen by `OTEL_EXPORTER_OTLP_PROTOCOL` — **http/protobuf** by default (`/v1/traces` appended when missing, conventional port 4318) or **grpc** (used as-is, no path appended, conventional port 4317). Exports one `http.request` span per request (attrs: method, path, status) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. Requires a binary built with the `otlp` cargo feature. **Official release binaries and the Docker image have it** (`cargo xtask release` builds with it); a plain `cargo build` does not, and there a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs (verified — thread count is identical to a binary without the feature). Both `http://` and `https://` endpoints are supported on both transports — see the notes below. |
+| `otlp_protocol` | string | (none → `http/protobuf`) | OTLP wire protocol for `otlp_endpoint`: `"grpc"` or `"http/protobuf"`. `"http/json"` is rejected at startup. The standard `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `OTEL_EXPORTER_OTLP_PROTOCOL` env vars take precedence over this knob. Setting it without an endpoint logs a startup warning and does nothing. Env override: `EPHPM_SERVER__DIAGNOSTICS__OTLP_PROTOCOL`. |
 
-**OTLP over HTTPS.** An `https://` endpoint works with no extra configuration.
+**OTLP transport selection.** `OTEL_EXPORTER_OTLP_PROTOCOL` (or
+`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, which wins for traces) selects the wire
+protocol: `http/protobuf` (the default, and what every release before this one
+used) or `grpc`. `http/json` is rejected at startup rather than silently
+falling back. Both transports are compiled into the same binary — there is no
+rebuild and no separate cargo feature. The endpoint's path handling differs:
+http/protobuf gets `/v1/traces` appended when missing, gRPC uses the value
+as-is. When the configured endpoint uses the *other* transport's conventional
+port (4317 vs 4318) ePHPm logs a WARN naming both, since that mix-up otherwise
+presents as silence; it is a warning rather than an error because running
+either transport on any port is legal.
+
+**OTLP export failures are logged**, once per failed batch, on the
+`opentelemetry_sdk` target (`name="BatchSpanProcessor.ExportError"`). Serving
+is never affected by a failing exporter. A `[server.logging] level` or
+`RUST_LOG` filter that excludes that target will hide them.
+
+**OTLP over HTTPS.** An `https://` endpoint works with no extra configuration,
+on either transport.
 TLS is rustls (the same crypto provider the HTTPS listener uses — never
 OpenSSL or a second TLS stack), and the exporter trusts the **union of the
 operating system's trust store and the bundled Mozilla root set**. The OS

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -43,6 +43,10 @@ const TAILCALL_MINORS: &[&str] = &["8.5"];
 /// spawned (measured: identical thread count with the endpoint unset), so the
 /// cost of shipping it is binary size and nothing else.
 ///
+/// It covers **both** OTLP transports, gRPC and http/protobuf; the choice is
+/// made at runtime by `OTEL_EXPORTER_OTLP_PROTOCOL`, not by a cargo feature,
+/// so there is nothing further to add here for gRPC.
+///
 /// Anything added here must also be added to the CI lanes that lint and test
 /// it (`.github/workflows/ci.yml`) and to the Docker builder's dependency
 /// warm-up stage (`docker/Dockerfile`), or it ships uncompiled by CI.


### PR DESCRIPTION
JetBrains' free first-party **OpenTelemetry** plugin (ID 27488, PhpStorm
2026.2+) has a real span-hierarchy viewer, and per JetBrains' docs its built-in
receiver **accepts OTLP over gRPC**. ePHPm spoke http/protobuf only, so
#381's guide had to tell people to run an OpenTelemetry Collector purely as a
protocol bridge. This removes the bridge.

**Stacking: #371 → #381 → this.** `origin/fix-otlp-https` is merged into this
branch (it is what `build_http_client` and the provider-agnostic TLS story come
from), so the diff here contains #371's commits until it lands. Base is #381.

## The hazard, resolved: no second crypto provider

This was the thing most likely to block the task, so it was checked first and
against the source rather than assumed.

**`opentelemetry-otlp`'s obvious TLS feature is the trap**, exactly mirroring
what #371 found for reqwest. From its manifest:

```toml
tls                    = ["tonic/tls-ring"]
tls-ring               = ["tonic/tls-ring"]
tls-roots              = ["tls", "tonic/tls-native-roots"]      # -> tls -> ring
tls-webpki-roots       = ["tls", "tonic/tls-webpki-roots"]      # -> tls -> ring
tls-aws-lc             = ["tonic/tls-aws-lc"]
tls-provider-agnostic  = ["tonic/_tls-any"]                     # <- no provider
```

So four of the six link `ring`. This PR uses **`tls-provider-agnostic`**, and
`tonic/tls-native-roots` + `tonic/tls-webpki-roots` directly — neither of which
pulls a provider (`tls-native-roots = ["_tls-any", "channel",
"dep:rustls-native-certs"]`). tonic itself declares `tokio-rustls` with
`default-features = false, features = ["logging", "tls12"]`, so it contributes
no provider of its own.

`tls-aws-lc` was rejected deliberately: it would hardcode a provider and drift
the moment `tls.rs` changes, which is the failure mode #241 exists to prevent.

**How tonic then finds a provider.** Unlike reqwest it has no
`use_preconfigured_tls`, but `TlsConnector::new` checks
`CryptoProvider::get_default()` **first**, ahead of any crate-feature fallback
(`tonic-0.14.5/src/transport/channel/service/tls.rs`). `otlp.rs` installs
`crate::tls::crypto_provider()` as the process default, so gRPC follows
whatever `tls.rs` names — automatically, including #368's ring→aws-lc-rs flip.
Without that install, the `_tls-any` build reaches tonic's final arm, a bare
`ClientConfig::builder()`, which is a **runtime panic** in a two-provider
binary. That is trap 2 from #371 in a new place.

**Verified, not reasoned:**

- `cargo test -p ephpm-server --features otlp --test tls_single_crypto_provider`
  on this branch merged with **#368** → **passes**. That is #368's own guard.
- `cargo tree -e features,no-dev -p ephpm --features otlp -i ring` on that
  merged tree: the only inbound edge is the pre-existing `opensrv-mysql →
  tokio-rustls 0.25 → rustls 0.22` stack that
  `tls_single_crypto_provider.rs` already documents. **tonic and reqwest do not
  appear.** rustls 0.23 — the one tonic, reqwest and the server share — is
  absent from the `ring` tree entirely.
- `otlp::tests::grpc_exporter_builds_with_its_own_runtime` builds a real gRPC
  exporter offline. tonic constructs its TLS connector eagerly inside
  `connect_lazy`, so this test *is* the panic guard.

**Cost: one new package.** `hyper-timeout`, via tonic's `channel` feature.
tonic, tonic-prost, tokio-rustls, rustls-native-certs and webpki-roots were all
already in the graph. `cargo deny check` → `advisories ok, bans ok, licenses
ok, sources ok`.

## Design decisions

### 1. Runtime selection, not a cargo feature

`OTEL_EXPORTER_OTLP_PROTOCOL` (`grpc` | `http/protobuf`), with
`OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` taking precedence — the OTel convention.

The deciding argument is that **ePHPm ships one release binary**.
`RELEASE_FEATURES` is a single const, so an `otlp-grpc` cargo feature would be
either on in releases (identical cost to compiling both, but now a
feature-combination matrix to keep green — and #381 just demonstrated how
quickly an un-linted feature rots) or off in releases (PhpStorm unsupported in
every downloadable binary, which defeats the point). The "cheaper" option is
only cheaper for people building from source who also don't want gRPC.

`http/json` is rejected with a message naming the alternatives rather than
silently falling back.

### 2. Endpoint normalisation differs per transport

http/protobuf takes a signal URL and gets `/v1/traces` appended when missing;
gRPC takes a base URL used verbatim, because on gRPC the signal is the method
name. Appending the path on gRPC is silent — the collector just never sees a
recognised method. Pinned by `endpoint_normalization_differs_by_transport`.

**Port mix-ups get a warning, not an error.** 4317 vs 4318 is one character and
collectors usually listen on both, so this is the most likely misconfiguration
and its symptom is silence:

```text
WARN ephpm: OTLP endpoint http://127.0.0.1:4318 uses port 4318, the conventional
     port for http/protobuf, but the exporter is configured for grpc (the
     conventional port for which is 4317). If no spans arrive, either set
     OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf or point the endpoint at 4317.
```

It is deliberately **not** fatal: running either transport on any port is
legal, and failing startup would reject a valid configuration.

### 3. Config knob `[server.diagnostics] otlp_protocol`

Added, following `.claude/skills/add-config-knob/`. Without it the endpoint is
configurable in TOML but the protocol would be env-var-only — a half-feature.
Env vars win over it, mirroring the endpoint's precedence. Setting it with no
endpoint logs a warning rather than looking effective. Default unset =
`http/protobuf` = existing behaviour, so this is additive.

### 4. The gRPC exporter needs a tokio runtime; it owns a small one

`otlp.rs` builds the subscriber in `main` *before* the server's runtime exists,
because PHP must init single-threaded. tonic is async, and the SDK's
`BatchSpanProcessor` drives exports from a plain `std::thread` with
`futures_executor::block_on` (`opentelemetry_sdk-0.31.0/src/trace/span_processor.rs`,
thread at `:316`, `block_on` at `:507`) — no tokio reactor.

So `RuntimeBoundExporter` forwards each export to a dedicated single-worker
runtime via `Handle::block_on`. Blocking that thread is correct: it is the
batch exporter's own thread, and the http transport already blocks it the same
way through `reqwest::blocking`. `block_on` panics only when called from inside
a runtime, which the source references above rule out. Keeping the inner
exporter by value (rather than behind an `Arc`, as a `Handle::spawn` version
would need) is what lets `set_resource` forward correctly — dropping it would
silently lose `service.name`.

**Measured: this costs the same thread count as the http path.** Same fpm
config, same binary, three endpoint states:

| endpoint | threads | OTLP threads |
|---|---|---|
| unset | 34 | *(none)* |
| http/protobuf | 36 | `OpenTelemetry.T`, `reqwest-interna` |
| grpc | 36 | `OpenTelemetry.T`, `ephpm-otlp-grpc` |

Our runtime thread replaces reqwest's internal one, one for one.

## #378 fixed: export failures are audible

Root cause was as diagnosed in the issue — `default-features = false` dropped
`opentelemetry-otlp`'s default `internal-logs`. Restored. gRPC at a closed
port, previously *completely* silent:

```text
ERROR opentelemetry_sdk: name="BatchSpanProcessor.ExportError"
      error="Operation failed: code: 'The service is currently unavailable',
      message: \"tcp connect error\", source: ... 127.0.0.1:4399,
      Os { code: 111, kind: ConnectionRefused, ... }"
```

Requests kept returning 200 throughout — export failure must never affect
serving. Two caveats now documented rather than discovered later: it is **one
line per failed batch**, so a collector that stays down trickles; and a
`RUST_LOG` filter excluding the `opentelemetry_sdk` target hides it again.

## Verification

Linux x86_64, PHP 8.5.7 SDK, PHP-linked. The last three legs ran against the
**release** binary (fat LTO) built exactly as `xtask release` builds it.

**Spans arrive over gRPC, with correct parenting.** Against `otelcol-contrib`
0.135.0 (file exporter — raw JSON with `parentSpanId`, better evidence than a
UI). fpm gives `http.request` → `php.execute`; worker mode gives the full tree,
zero orphans:

```
service=grpcworker  spans=12  roots=4
http.request  26.87ms  span=9d33092e parent=ROOT  method=GET status=200 path=/index.php
    worker.queue_wait  0.08ms  span=44cfc780 parent=9d33092e
    php.execute        5.63ms  span=8f622e2c parent=9d33092e
...
orphan spans (parent not in batch): 0
```

**http/protobuf still works — regression-tested every round**, including on the
final release binary. Three spans per leg on both transports, and the endpoint
correctly gets `/v1/traces` on http and not on gRPC.

**TLS on gRPC completes a real handshake.** `https://127.0.0.1:4320` against a
collector fronted by a private CA, `SSL_CERT_FILE` pointing at it: spans
arrive, and the startup line reports `trust anchors: 1 from the OS store`
(vs 121 without) — confirming `SSL_CERT_FILE` *replaces* the OS store, the same
standard #371 used.

**W3C `traceparent` continuation works over gRPC.** A request carrying
`00-4bf92f35…-00f067aa0ba902b7-01` produced an `http.request` whose parent is
`00f067aa`, under the caller's trace id. (The parser reports that span as an
"orphan" because the parent belongs to the caller and is not in our batch —
which is the correct outcome.)

**Jaeger v2, zero config, OTLP/gRPC on 4317**, queried through its API rather
than screenshotted:

```
services: {"data":["ephpm-grpc-jaeger"],...}
traceID: ea602037cc5173f4af0b98c0cba2fa7f
  php.execute    dur=3455us  parent=http.request
  http.request   dur=3792us  parent=ROOT
```

**Inertness holds**, A/B'd directly between the two release binaries with the
endpoint unset and everything else identical:

```
bin-baseline  req=200  threads=34  otlp-threads=0
bin-final     req=200  threads=34  otlp-threads=0
```

Identical thread count, and **no** OTLP-related thread of any kind in either —
the gRPC machinery is entirely inert until an endpoint is configured, exactly
as the http path was. (34 rather than #381's 33 is this box's core count; the
comparison that matters is the two rows against each other.)

## Binary size

Same build command, profile (fat LTO, `codegen-units = 1`), triple and target
directory; baseline is this branch minus the gRPC commit (i.e. #381 + #371).

| | baseline | this PR | delta |
|---|---|---|---|
| as shipped | 129,587,656 B | 131,890,608 B | **+2,302,952 B (+1.78%)** |
| `strip`ped | 119,078,024 B | 121,198,856 B | **+2,120,832 B (+1.78%)** |

**This is much larger than #381's +33 KB stripped, and the reason is worth
stating plainly.** #381 measured tonic being *linked but never instantiated* —
`opentelemetry-proto` pulls it in for message types, and fat LTO discarded
essentially all of it. Instantiating the gRPC transport means LTO can no longer
discard tonic, hyper's HTTP/2 client stack, or the tower layers underneath. So
+2.1 MB is the real, unavoidable cost of the second transport, not overhead
that better feature gating would remove. On a 119 MB binary it is 1.78%.

The baseline's *stripped* size is byte-identical to #381's reported figure
(119,078,024), which is a useful cross-check that the two measurements are
comparable.

**The Windows release lane is unmeasured.** It runs `LTO: "off"`, so its delta
will differ — very likely larger, since the discard-what-is-unused effect that
made #381's number so small does not apply there at all. Flagging rather than
guessing; it needs a Windows runner to measure, and the Windows fleet is not
something this PR should block on.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets --features ephpm/otlp -- -D warnings` — clean
  (the lane #381 added; `--workspace` alone still never compiles `otlp.rs`)
- `cargo +nightly fmt --all -- --check` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo test -p ephpm-server --features otlp --lib otlp::` — 7 pass, 1 ignored
  (network)
- `cargo test -p ephpm-config diagnostics` — 6 pass

No CI or `xtask` changes are needed: gRPC is not a new cargo feature, so
#381's `RELEASE_FEATURES = "otlp"` and both of its CI lanes already cover it.

New tests, all pure or offline: transport parsing incl. both rejections,
per-transport endpoint normalisation, the port-mismatch warning in both
directions and its non-firing cases, config-knob resolution, the gRPC exporter
building with its own runtime, and that building a second one is idempotent
(`install_default` is a process-wide one-shot; reading its second failure as "a
foreign provider won" would have made whichever gRPC test ran second fail on
ordering).

## Docs

`site/content/guides/otlp-tracing.md` — a "Choosing a transport" section
(ports, path rules, which to pick), gRPC in the setup steps, the collector
example now with both receivers, and the **PhpStorm section rewritten to drop
the Collector bridge**: install the plugin, pin the receiver port, point
`otlp_endpoint` at it, done. The honest note that **VS Code has no credible
in-editor OTLP trace viewer** is kept as-is.

The "export failures are silent" rough edge is replaced with what actually
happens now. `reference/config.md` documents `otlp_protocol`, transport
selection, the port warning and failure logging. Two stale rows in
`architecture/_index.md` are corrected — they still called OTLP export
"Planned" and `tonic` "(planned)", both false as of #381 and this PR.

## What I could not verify

**The PhpStorm UI itself.** I cannot drive a desktop IDE, and I did not claim
to. What I *did* verify is the whole path up to the IDE's front door: a
plaintext OTLP/**gRPC** receiver on **17011** — the port JetBrains documents
for *Use fixed OTLP server port* — receiving a correctly parented three-span
tree from the release binary, with no Collector in between:

```
service=idedirect  spans=6  roots=2
http.request  5.66ms  parent=ROOT  method=GET status=200 path=/index.php
    worker.queue_wait  0.04ms  parent=c6a0492a
    php.execute        5.50ms  parent=c6a0492a
orphan spans: 0
```

The stand-in was `otelcol-contrib` configured as a gRPC receiver on 17011. What
remains unproven is only that the plugin renders what it receives — the wire
side is done. **Five-minute check for you** (step-by-step also in the guide):

1. Settings → Plugins → Marketplace → *OpenTelemetry* (vendor JetBrains) →
   Install → restart.
2. Settings → Tools → OpenTelemetry → tick **Use fixed OTLP server port**
   (default 17011).
3. In `ephpm.toml`:
   ```toml
   [server.diagnostics]
   otlp_endpoint = "http://127.0.0.1:17011"
   otlp_protocol = "grpc"
   ```
4. `ephpm serve --config ephpm.toml`; confirm the startup line says
   `protocol="grpc"` and names 17011.
5. Hit a page, wait ~5s for the batch, open the **OpenTelemetry** tool window →
   *Traces* → double-click a trace.

If it is empty, the ePHPm log now tells you why (see #378 above) — a refused
connection means the IDE is not listening on that port.

Also unverified on this platform: the Windows size delta (above), and clustered
/ multi-tenant interaction, which gRPC does not touch — spans carry no tenant
identity either way (#380, unchanged).
