### PR TITLE
feat(middleware): basic-auth builtin — HTTP Basic in front of PHP, per-site credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "ephpm-config",
  "ephpm-db",
  "ephpm-kv",
+ "ephpm-middleware-builtins",
  "ephpm-php",
  "ephpm-server",
  "libc",
@@ -1358,12 +1359,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephpm-middleware-basicauth"
+version = "0.1.0"
+dependencies = [
+ "ephpm-middleware",
+ "ephpm-middleware-builtins",
+]
+
+[[package]]
 name = "ephpm-middleware-builtins"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "base64ct",
+ "dashmap",
  "ephpm-kv",
  "ephpm-middleware",
+ "getrandom 0.3.4",
  "hmac 0.12.1",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/ephpm-middleware-basicauth/Cargo.toml
+++ b/crates/ephpm-middleware-basicauth/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ephpm-middleware-cors"
+name = "ephpm-middleware-basicauth"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "ePHPm native middleware: CORS preflight handling and response headers (loadable cdylib shell; implementation in ephpm-middleware-builtins)"
+description = "ePHPm native middleware: HTTP Basic authentication with per-site credentials (loadable cdylib shell; implementation in ephpm-middleware-builtins)"
 
 [lib]
 # cdylib = the loadable module for the dlopen lane. The implementation (and

--- a/crates/ephpm-middleware-basicauth/src/lib.rs
+++ b/crates/ephpm-middleware-basicauth/src/lib.rs
@@ -1,0 +1,19 @@
+//! `basic-auth` — loadable cdylib shell around the shared implementation in
+//! [`ephpm_middleware_builtins::basicauth`].
+//!
+//! The middleware itself (HTTP Basic authentication with static or
+//! KV-resolved per-site credentials, docs and tests included) lives in
+//! `ephpm-middleware-builtins`, where it is also compiled into every ePHPm
+//! binary as the builtin `basic-auth` registry entry — no cdylib needed
+//! there. This crate only adds the C ABI exports (`declare!`) so the same
+//! module can be dlopened by dynamically linked builds.
+//!
+//! This artifact is **larger** than the other middleware cdylibs because it
+//! statically links `aws-lc-rs` for PBKDF2. In the ePHPm binary that library
+//! is already present and shared; here it is a second copy. Prefer
+//! `library = "basic-auth"` (the builtin lane) unless you specifically need a
+//! loadable module.
+
+pub use ephpm_middleware_builtins::basicauth::BasicAuth;
+
+ephpm_middleware::declare!(BasicAuth);

--- a/crates/ephpm-middleware-builtins/Cargo.toml
+++ b/crates/ephpm-middleware-builtins/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "The in-tree ePHPm middleware implementations (jwt, cors, ratelimit, security-headers) as plain Rust types — compiled into every ePHPm binary via the static registry"
+description = "The in-tree ePHPm middleware implementations (jwt, cors, ratelimit, security-headers, basic-auth) as plain Rust types — compiled into every ePHPm binary via the static registry"
 
 # Deliberately rlib-only and free of C ABI exports: `ephpm-server` links this
 # crate into the (possibly fully static) binary. The loadable cdylib shells
@@ -17,9 +17,19 @@ description = "The in-tree ePHPm middleware implementations (jwt, cors, ratelimi
 ephpm-middleware.workspace = true
 serde_json.workspace = true
 # jwt: HS256 via hmac/sha2 — no heavyweight JWT dependency.
+# basic-auth: the same hmac/sha2 pair keys its verification cache.
 hmac.workspace = true
 sha2.workspace = true
 base64ct.workspace = true
+# basic-auth: PBKDF2-HMAC-SHA256 password hashing. aws-lc-rs is ALREADY in the
+# dependency graph (rustls-acme's crypto provider, and ephpm-db's RSA-OAEP), so
+# this adds nothing to Cargo.lock and nothing for cargo-deny to weigh — which
+# is why it won over adding argon2/bcrypt. See crate::password_hash.
+aws-lc-rs.workspace = true
+# basic-auth: random salts, the verification-cache key, and the decoy credential.
+getrandom.workspace = true
+# basic-auth: the bounded verification cache.
+dashmap.workspace = true
 
 [dev-dependencies]
 ephpm-middleware = { workspace = true, features = ["host"] }

--- a/crates/ephpm-middleware-builtins/src/basicauth.rs
+++ b/crates/ephpm-middleware-builtins/src/basicauth.rs
@@ -1,0 +1,1272 @@
+//! `basic-auth` — ePHPm native middleware gating a whole site behind
+//! HTTP Basic authentication (RFC 7617) before PHP runs.
+//!
+//! The motivating deployment is per-PR preview hosting: a preview of a
+//! *private* repository must not be publicly readable, the credential has to
+//! appear and disappear with the preview, and an unauthorised request must
+//! never reach the interpreter. Because the whole site is gated rather than a
+//! route, this belongs in the middleware chain — a `RESPOND` verdict here
+//! short-circuits before the request body is read and before PHP dispatch.
+//!
+//! # Where credentials come from
+//!
+//! [`MiddlewareMount`](ephpm_config::MiddlewareMount) matches on **path glob
+//! only** — there is no host or site matcher — so a per-site credential
+//! cannot be expressed as one mount per site. Instead a single global mount
+//! resolves credentials at request time, from either source:
+//!
+//! - **`users`** — a static `{ username = "<hash>" }` table in the mount's
+//!   `config`. Applies to every vhost. Right for a single-site deployment.
+//! - **`kv_prefix`** — a KV lookup at `<kv_prefix><vhost>` whose value is the
+//!   same `{ username: "<hash>" }` JSON object. This is what makes previews
+//!   workable: the control plane writes one key when it creates a preview and
+//!   deletes it when the preview dies, with no `ephpm.toml` edit and no
+//!   restart.
+//!
+//! When both are configured the KV entry wins for that vhost and `users` is
+//! the fallback for vhosts with no entry. A KV entry whose value is exactly
+//! `public` marks a managed site as deliberately un-gated, so a fleet mixing
+//! public and private previews can keep the fail-closed
+//! `missing_credentials = "deny"` default instead of opening every unknown
+//! `Host`.
+//!
+//! The lookup key is the request's vhost identity **normalised** (lowercased,
+//! trailing FQDN dot stripped) by [`normalize_vhost`] — `Host` is
+//! client-controlled and case-insensitive, and using it raw would let
+//! `Host: Site.Example` miss `site.example`'s credential.
+//!
+//! The KV callbacks on the middleware host table are **process-global**, not
+//! scoped to the request's site (issue #376). For an operator-level credential
+//! store that is the semantics this middleware wants and relies on
+//! deliberately: the control plane writing `basicauth:preview-42.example` must
+//! reach the same store the middleware reads, and a tenant's PHP must *not* be
+//! able to reach it at all. In multi-tenant (`sites_dir`) mode PHP's
+//! `ephpm_kv_*` hits that vhost's own store, so a tenant cannot read or
+//! rewrite its own credential — which is the property you want here.
+//!
+//! The flip side, and a real limitation today: with `sites_dir` set the RESP
+//! listener scopes every authenticated connection to one site's store, so
+//! there is no `ephpm kv set` path to the process-global store this module
+//! reads (issue #384). KV-sourced credentials are therefore usable in
+//! single-site mode; multi-tenant deployments need the static `users` table
+//! until #384 lands.
+//!
+//! # Passwords are stored hashed
+//!
+//! Both sources hold PBKDF2-HMAC-SHA256 hashes in the PHC-style encoding
+//! documented in [`crate::password_hash`], never plaintext. A value that does
+//! not parse as one is a **startup error** for `users` and a rejected
+//! credential set for KV — there is no plaintext fallback to accidentally
+//! depend on. Generate them with `ephpm hash-password`.
+//!
+//! Verification is [`PasswordHash::verify`], i.e. `aws-lc-rs`'s constant-time
+//! `pbkdf2::verify`. An **unknown username still performs a full derivation**
+//! against a decoy hash, so response latency does not tell an attacker which
+//! usernames exist. That property is asserted by
+//! `unknown_user_costs_the_same_kdf_work_as_a_known_one` below, which fails if
+//! anyone reintroduces an early return on the "no such user" path.
+//!
+//! Because a KDF that is worth using is slow, successful verifications are
+//! cached for `cache_ttl_secs` keyed by
+//! `HMAC(per-process key, vhost ‖ user ‖ password ‖ stored hash)`. The stored
+//! hash is part of the key, so **rotating or removing a credential takes
+//! effect on the next request** — the TTL bounds memory, not revocation.
+//! Failures are never cached, so a brute-force attempt pays the full KDF every
+//! time. Pair the mount with `ratelimit` (see below) to bound that.
+//!
+//! # Transport security
+//!
+//! Basic sends base64, which is not encryption. What to do about a plain-HTTP
+//! request is the `require_https` knob, and its default is deliberate — see
+//! the table below and the guide.
+//!
+//! # Composing with `ratelimit`
+//!
+//! Brute-force protection is a chain decision, not a reimplementation. Mount
+//! `ratelimit` at a lower `order` so it runs first:
+//!
+//! ```toml
+//! [[middleware]]
+//! library = "ratelimit"
+//! order = 10
+//! config = { per_ip_rps = 2, burst = 10 }
+//!
+//! [[middleware]]
+//! library = "basic-auth"
+//! order = 20
+//! config = { kv_prefix = "basicauth:", realm = "Preview" }
+//! ```
+//!
+//! Ordered this way an over-budget client is turned away with `429` before
+//! this module spends a KDF on it.
+//!
+//! # Configuration (`[[middleware]] config = { ... }`)
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `users` (object) | `{}` | static username → PBKDF2 hash table, applied to every vhost |
+//! | `kv_prefix` (string) | unset | look up `<kv_prefix><vhost>` in the KV store for a per-site credential table |
+//! | `realm` (string) | `"Restricted"` | `WWW-Authenticate` realm. No `"`, `\` or control characters |
+//! | `require_https` (string) | `"warn"` | `"enforce"` / `"warn"` / `"off"` — what a non-HTTPS request gets |
+//! | `missing_credentials` (string) | `"deny"` | `"deny"` / `"allow"` — what a vhost with no credential table gets |
+//! | `forward_user_header` (string) | unset | on success, REWRITE with this request header set to the authenticated username (our SAPI does not populate `PHP_AUTH_USER` — issue #386) |
+//! | `cache_ttl_secs` (integer) | `300` | how long a successful verification is remembered; `0` disables the cache |
+//! | `cache_max_entries` (integer) | `4096` | hard ceiling on cached verifications |
+//!
+//! At least one of `users` or `kv_prefix` must be set: a mount that can never
+//! authenticate anyone is a configuration error, not a locked door, so it
+//! fails startup.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use base64ct::{Base64, Base64Unpadded, Encoding};
+use dashmap::DashMap;
+use ephpm_middleware::abi::{LOG_ERROR, LOG_WARN};
+use ephpm_middleware::{Host, Middleware, Request, Response};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::password_hash::{DEFAULT_ITERATIONS, PasswordHash};
+
+/// Largest KV credential document this module will parse, in bytes. A
+/// credential table is a handful of entries; anything larger is a mistake or
+/// an attempt to make every request pay for a big JSON parse.
+const MAX_KV_DOCUMENT_BYTES: usize = 64 * 1024;
+
+/// Minimum seconds between `require_https = "warn"` log lines, so a busy
+/// plain-HTTP deployment warns rather than floods.
+const WARN_INTERVAL_SECS: u64 = 60;
+
+/// What a request that did not arrive over HTTPS gets.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpsPolicy {
+    /// Refuse to issue the challenge: `403`, no `WWW-Authenticate`.
+    Enforce,
+    /// Issue the challenge anyway, logging a throttled warning.
+    Warn,
+    /// Issue the challenge, say nothing.
+    Off,
+}
+
+/// What a vhost with no resolvable credential table gets.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MissingPolicy {
+    /// `403`. The safe default: an unconfigured site is not an open site.
+    Deny,
+    /// Continue to PHP unauthenticated. For a fleet that mixes public and
+    /// private sites behind one mount.
+    Allow,
+}
+
+/// Username → password hash for one vhost.
+type Credentials = HashMap<String, PasswordHash>;
+
+/// What a vhost's credential source resolved to.
+enum Source<'a> {
+    /// Authenticate against this table.
+    Table(std::borrow::Cow<'a, Credentials>),
+    /// The control plane deliberately marked this site public.
+    Public,
+    /// No credential source for this vhost — `missing_credentials` decides.
+    None,
+}
+
+/// HTTP Basic authentication policy, built once at `init`.
+pub struct BasicAuth {
+    realm: String,
+    users: Credentials,
+    kv_prefix: Option<String>,
+    require_https: HttpsPolicy,
+    missing_credentials: MissingPolicy,
+    forward_user_header: Option<String>,
+    cache: VerifyCache,
+    /// Burned when the presented username is unknown, so the "no such user"
+    /// path costs the same derivation a real one does.
+    decoy: PasswordHash,
+    /// Unix second of the last throttled warning (0 = never).
+    last_warn: AtomicU64,
+}
+
+/// Redacting `Debug`: never let a credential table, a cache key or a decoy
+/// hash reach a log line or a test failure message. Only the policy knobs and
+/// the *shape* of the credential sources are shown.
+impl std::fmt::Debug for BasicAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BasicAuth")
+            .field("realm", &self.realm)
+            .field("static_users", &self.users.len())
+            .field("kv_prefix", &self.kv_prefix)
+            .field("require_https", &self.require_https)
+            .field("missing_credentials", &self.missing_credentials)
+            .field("forward_user_header", &self.forward_user_header)
+            .field("cache_enabled", &self.cache.enabled())
+            .finish_non_exhaustive()
+    }
+}
+
+// ── Verification cache ────────────────────────────────────────────────────
+
+/// Remembers successful verifications so the steady-state request path costs
+/// one HMAC instead of a full KDF.
+///
+/// The cache key commits to the **stored hash** as well as the presented
+/// credential, so changing or removing a credential invalidates its entry
+/// immediately; the TTL only bounds how long an unused entry occupies memory.
+/// Only successes are stored — a wrong password pays the full KDF every time,
+/// which is the cost that makes brute force expensive.
+struct VerifyCache {
+    /// Per-process HMAC key. Cache keys are unpredictable to anyone who has
+    /// not compromised the process, so the map's (non-constant-time) lookup
+    /// is not an oracle on the credential.
+    key: [u8; 32],
+    entries: DashMap<[u8; 32], Instant>,
+    ttl: Duration,
+    max_entries: usize,
+}
+
+impl VerifyCache {
+    fn new(ttl_secs: u64, max_entries: usize) -> Result<Self, String> {
+        let mut key = [0u8; 32];
+        getrandom::fill(&mut key).map_err(|e| {
+            format!(
+                "failed to draw the verification-cache key from OS entropy: {e}. \
+                 Refusing to start rather than use a predictable key."
+            )
+        })?;
+        Ok(Self { key, entries: DashMap::new(), ttl: Duration::from_secs(ttl_secs), max_entries })
+    }
+
+    fn enabled(&self) -> bool {
+        !self.ttl.is_zero() && self.max_entries > 0
+    }
+
+    /// Tag identifying one (vhost, user, password, stored hash) tuple.
+    ///
+    /// Fields are length-prefixed so no two different tuples can serialise to
+    /// the same byte string (`("ab", "c")` vs `("a", "bc")`).
+    fn tag(&self, vhost: &str, user: &str, password: &str, stored: &PasswordHash) -> [u8; 32] {
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(&self.key).expect("HMAC accepts any key length");
+        for field in [vhost.as_bytes(), user.as_bytes(), password.as_bytes()] {
+            mac.update(&(field.len() as u64).to_le_bytes());
+            mac.update(field);
+        }
+        let phc = stored.to_phc_string();
+        mac.update(&(phc.len() as u64).to_le_bytes());
+        mac.update(phc.as_bytes());
+        mac.finalize().into_bytes().into()
+    }
+
+    /// Whether this tuple verified recently. Expired entries are evicted on
+    /// the way past.
+    fn contains(&self, tag: &[u8; 32]) -> bool {
+        match self.entries.get(tag).map(|e| *e.value()) {
+            Some(expiry) if expiry > Instant::now() => true,
+            Some(_) => {
+                self.entries.remove(tag);
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// Record a success, keeping the map under `max_entries`.
+    fn insert(&self, tag: [u8; 32]) {
+        if self.entries.len() >= self.max_entries {
+            let now = Instant::now();
+            self.entries.retain(|_, expiry| *expiry > now);
+            if self.entries.len() >= self.max_entries {
+                // Full of live entries: skip rather than grow without bound.
+                // The only cost is paying the KDF again.
+                return;
+            }
+        }
+        self.entries.insert(tag, Instant::now() + self.ttl);
+    }
+}
+
+// ── Config parsing ────────────────────────────────────────────────────────
+
+/// Read an optional non-empty string field.
+fn opt_str(config: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
+    match config.get(key) {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
+        None | Some(serde_json::Value::Null | serde_json::Value::String(_)) => Ok(None),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+/// Read an optional unsigned integer field.
+fn opt_u64(config: &serde_json::Value, key: &str, default: u64) -> Result<u64, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(v) => v.as_u64().ok_or_else(|| format!("`{key}` must be a non-negative integer")),
+    }
+}
+
+/// Reject header values and realms that could break out of their header.
+fn is_safe_header_text(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| !c.is_control() && c != '"' && c != '\\')
+}
+
+/// Parse a `{ username: "<hash>" }` table. `origin` names the source in error
+/// messages so a bad `ephpm.toml` and a bad KV document are distinguishable.
+fn parse_credentials(value: &serde_json::Value, origin: &str) -> Result<Credentials, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| format!("{origin} must be a table of username = \"<hash>\" entries"))?;
+    let mut out = Credentials::with_capacity(obj.len());
+    for (user, hash) in obj {
+        if user.is_empty() {
+            return Err(format!("{origin}: username must not be empty"));
+        }
+        // RFC 7617 splits user-id from password at the FIRST colon, so a
+        // username containing one can never be presented.
+        if user.contains(':') {
+            return Err(format!(
+                "{origin}: username `{user}` contains `:`, which HTTP Basic cannot represent"
+            ));
+        }
+        if !is_safe_header_text(user) {
+            return Err(format!("{origin}: username `{user}` contains control characters"));
+        }
+        let hash = hash
+            .as_str()
+            .ok_or_else(|| format!("{origin}: `{user}` must be a password hash string"))?;
+        let parsed = PasswordHash::parse(hash).map_err(|e| format!("{origin}: `{user}`: {e}"))?;
+        out.insert(user.clone(), parsed);
+    }
+    Ok(out)
+}
+
+// ── Request handling ──────────────────────────────────────────────────────
+
+/// KV value that marks a site as deliberately public: managed by the control
+/// plane, no credential required.
+///
+/// Spelled as an exact literal rather than "an empty credential table" on
+/// purpose. A control plane that writes an empty or truncated document
+/// through a *bug* must fail closed; only a deliberate, unmistakable marker
+/// opens a site.
+const PUBLIC_MARKER: &[u8] = b"public";
+
+/// Canonical vhost key for a credential lookup.
+///
+/// The middleware ABI's `request_vhost_id` is the router's `SERVER_NAME` —
+/// the `Host` header with its port stripped, **but neither lowercased nor
+/// stripped of a trailing FQDN-root dot**. Host is case-insensitive and
+/// client-controlled, so using it raw would mean `Host: Site.Example` and
+/// `Host: site.example` hash to different KV keys: a private site's
+/// credential would simply not be found, and under
+/// `missing_credentials = "allow"` that is an authentication bypass by
+/// changing one letter's case.
+///
+/// This applies the same normalisation the server's own `normalize_host_key`
+/// does to everything else host-keyed (the port is already gone by here).
+fn normalize_vhost(vhost: &str) -> String {
+    vhost.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase()
+}
+
+/// Decode an `Authorization: Basic <base64>` value into `(user, password)`.
+///
+/// Returns `None` for any other scheme or malformed input. Per RFC 7617 the
+/// decoded form is `user-id ":" password` split at the **first** colon, and we
+/// advertise `charset="UTF-8"`, so non-UTF-8 credentials are rejected rather
+/// than silently reinterpreted.
+fn parse_basic(raw: &str) -> Option<(String, String)> {
+    let (scheme, encoded) = raw.trim().split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("basic") {
+        return None;
+    }
+    let encoded = encoded.trim();
+    // Padded is what the RFC specifies and what clients send; accept unpadded
+    // too rather than 401 a credential that is otherwise perfectly valid.
+    let decoded =
+        Base64::decode_vec(encoded).or_else(|_| Base64Unpadded::decode_vec(encoded)).ok()?;
+    let text = String::from_utf8(decoded).ok()?;
+    let (user, password) = text.split_once(':')?;
+    Some((user.to_owned(), password.to_owned()))
+}
+
+impl BasicAuth {
+    /// `401` plus the `WWW-Authenticate` challenge (RFC 7617 §2: `realm` and
+    /// `charset="UTF-8"`).
+    fn challenge(&self) -> Response {
+        Response::respond(401, "401 Unauthorized")
+            .header(
+                "WWW-Authenticate",
+                format!("Basic realm=\"{}\", charset=\"UTF-8\"", self.realm),
+            )
+            // A 401 is per-credential; never let a shared cache keep it.
+            .header("Cache-Control", "no-store")
+            .header("Content-Type", "text/plain; charset=utf-8")
+    }
+
+    /// Refusal that deliberately carries **no** challenge — used where
+    /// inviting the client to send credentials would be wrong.
+    fn refuse(body: &'static str) -> Response {
+        Response::respond(403, body)
+            .header("Cache-Control", "no-store")
+            .header("Content-Type", "text/plain; charset=utf-8")
+    }
+
+    /// Emit `message` at most once per [`WARN_INTERVAL_SECS`].
+    fn warn_throttled(&self, host: &Host<'_>, message: &str) {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
+        let last = self.last_warn.load(Ordering::Relaxed);
+        if now.saturating_sub(last) < WARN_INTERVAL_SECS && last != 0 {
+            return;
+        }
+        if self.last_warn.compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed).is_ok()
+        {
+            host.log(LOG_WARN, message);
+        }
+    }
+
+    /// What this vhost's credential source says: a table to authenticate
+    /// against, an explicit "this site is public", or nothing at all.
+    ///
+    /// The KV entry (when `kv_prefix` is configured) wins; a vhost with no
+    /// entry falls back to the static `users` table. A KV document that fails
+    /// to parse yields [`Source::None`] and logs — it must never fall through
+    /// to the static table, or a corrupt per-site credential would silently
+    /// inherit whatever global credential happens to be configured.
+    fn credentials_for<'a>(&'a self, vhost: &str, host: &Host<'_>) -> Source<'a> {
+        if let Some(prefix) = &self.kv_prefix {
+            let key = format!("{prefix}{vhost}");
+            if let Some(raw) = host.kv_get(&key) {
+                if raw.len() > MAX_KV_DOCUMENT_BYTES {
+                    host.log(
+                        LOG_ERROR,
+                        &format!(
+                            "basic-auth: credential document at `{key}` is {} bytes \
+                             (limit {MAX_KV_DOCUMENT_BYTES}) — ignoring",
+                            raw.len()
+                        ),
+                    );
+                    return Source::None;
+                }
+                // The one deliberate way to declare a managed site public.
+                if raw == PUBLIC_MARKER {
+                    return Source::Public;
+                }
+                let parsed = serde_json::from_slice::<serde_json::Value>(&raw)
+                    .map_err(|e| e.to_string())
+                    .and_then(|v| parse_credentials(&v, "KV credential document"));
+                return match parsed {
+                    Ok(creds) if !creds.is_empty() => Source::Table(std::borrow::Cow::Owned(creds)),
+                    // An empty table is NOT "public" — see PUBLIC_MARKER.
+                    Ok(_) => Source::None,
+                    Err(e) => {
+                        host.log(
+                            LOG_ERROR,
+                            &format!("basic-auth: unusable credential document at `{key}`: {e}"),
+                        );
+                        Source::None
+                    }
+                };
+            }
+        }
+        if self.users.is_empty() {
+            Source::None
+        } else {
+            Source::Table(std::borrow::Cow::Borrowed(&self.users))
+        }
+    }
+
+    /// Verify a presented credential against `creds`, doing the same amount of
+    /// KDF work whether or not the username exists.
+    fn verify(&self, vhost: &str, user: &str, password: &str, creds: &Credentials) -> bool {
+        // Deliberately NOT `let Some(stored) = creds.get(user) else { return
+        // false }`: returning early here makes response latency an oracle for
+        // which usernames exist. The decoy costs one derivation, exactly as a
+        // real miss would.
+        let Some(stored) = creds.get(user) else {
+            let _ = self.decoy.verify(password);
+            return false;
+        };
+
+        if self.cache.enabled() {
+            let tag = self.cache.tag(vhost, user, password, stored);
+            if self.cache.contains(&tag) {
+                return true;
+            }
+            if stored.verify(password) {
+                self.cache.insert(tag);
+                return true;
+            }
+            return false;
+        }
+        stored.verify(password)
+    }
+}
+
+impl Middleware for BasicAuth {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let users = match config.get("users") {
+            None | Some(serde_json::Value::Null) => Credentials::new(),
+            Some(v) => parse_credentials(v, "`users`")?,
+        };
+        let kv_prefix = opt_str(config, "kv_prefix")?;
+        if users.is_empty() && kv_prefix.is_none() {
+            return Err("at least one of `users` or `kv_prefix` is required — a mount with no \
+                 credential source can never authenticate anyone"
+                .into());
+        }
+
+        let realm = opt_str(config, "realm")?.unwrap_or_else(|| "Restricted".to_owned());
+        if !is_safe_header_text(&realm) {
+            return Err(
+                "`realm` must not be empty or contain `\"`, `\\` or control characters".into()
+            );
+        }
+
+        let require_https = match opt_str(config, "require_https")?.as_deref() {
+            None | Some("warn") => HttpsPolicy::Warn,
+            Some("enforce") => HttpsPolicy::Enforce,
+            Some("off") => HttpsPolicy::Off,
+            Some(other) => {
+                return Err(format!(
+                    "`require_https` must be \"enforce\", \"warn\" or \"off\", got \"{other}\""
+                ));
+            }
+        };
+        let missing_credentials = match opt_str(config, "missing_credentials")?.as_deref() {
+            None | Some("deny") => MissingPolicy::Deny,
+            Some("allow") => MissingPolicy::Allow,
+            Some(other) => {
+                return Err(format!(
+                    "`missing_credentials` must be \"deny\" or \"allow\", got \"{other}\""
+                ));
+            }
+        };
+
+        let forward_user_header = opt_str(config, "forward_user_header")?;
+        if let Some(name) = &forward_user_header
+            && !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        {
+            return Err(format!(
+                "`forward_user_header` must be a header name (letters, digits, `-`), got `{name}`"
+            ));
+        }
+
+        let cache_ttl_secs = opt_u64(config, "cache_ttl_secs", 300)?;
+        let cache_max_entries = usize::try_from(opt_u64(config, "cache_max_entries", 4096)?)
+            .map_err(|_| "`cache_max_entries` is too large".to_owned())?;
+        let cache = VerifyCache::new(cache_ttl_secs, cache_max_entries)?;
+
+        // A decoy at the generation cost, drawn from fresh entropy: its
+        // password is unknowable, so it can only ever fail to verify.
+        let mut filler = [0u8; 32];
+        getrandom::fill(&mut filler)
+            .map_err(|e| format!("failed to draw the decoy credential from OS entropy: {e}"))?;
+        let decoy = PasswordHash::generate(&Base64::encode_string(&filler), DEFAULT_ITERATIONS)?;
+
+        Ok(Self {
+            realm,
+            users,
+            kv_prefix,
+            require_https,
+            missing_credentials,
+            forward_user_header,
+            cache,
+            decoy,
+            last_warn: AtomicU64::new(0),
+        })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        let host = req.host();
+        // Host is client-controlled and case-insensitive; normalise before it
+        // is used as a credential-lookup key. See `normalize_vhost`.
+        let vhost = normalize_vhost(req.vhost_id());
+
+        let creds = match self.credentials_for(&vhost, &host) {
+            Source::Table(creds) => creds,
+            Source::Public => return Response::cont(),
+            Source::None => {
+                return match self.missing_credentials {
+                    MissingPolicy::Allow => Response::cont(),
+                    MissingPolicy::Deny => {
+                        self.warn_throttled(
+                            &host,
+                            &format!(
+                                "basic-auth: no credentials configured for vhost `{vhost}` — \
+                                 denying. Write a credential for it, mark it public, or set \
+                                 `missing_credentials = \"allow\"`."
+                            ),
+                        );
+                        Self::refuse("403 Forbidden: this site has no credentials configured")
+                    }
+                };
+            }
+        };
+
+        // Basic sends base64, which is not encryption. `is_https()` is the
+        // determination PHP sees, i.e. already through trusted-proxy
+        // `X-Forwarded-Proto` resolution — see the knob's docs for why the
+        // default is to warn rather than refuse.
+        if !req.is_https() {
+            match self.require_https {
+                HttpsPolicy::Enforce => {
+                    return Self::refuse(
+                        "403 Forbidden: authentication requires HTTPS. If TLS terminates \
+                         at a proxy, add that proxy to [server.security] trusted_proxies \
+                         so its X-Forwarded-Proto is honoured.",
+                    );
+                }
+                HttpsPolicy::Warn => self.warn_throttled(
+                    &host,
+                    &format!(
+                        "basic-auth: challenging over plain HTTP on vhost `{vhost}` — \
+                         credentials are base64, not encrypted. If TLS terminates at a \
+                         proxy, add it to [server.security] trusted_proxies; otherwise \
+                         enable TLS and set require_https = \"enforce\"."
+                    ),
+                ),
+                HttpsPolicy::Off => {}
+            }
+        }
+
+        let Some(raw) = req.header("Authorization") else {
+            return self.challenge();
+        };
+        let Some((user, password)) = parse_basic(raw) else {
+            return self.challenge();
+        };
+        if !self.verify(&vhost, &user, &password, &creds) {
+            return self.challenge();
+        }
+
+        match &self.forward_user_header {
+            // REWRITE header overrides *replace* any same-named header the
+            // client sent, so a forged `X-Auth-User` cannot survive this.
+            Some(name) => Response::rewrite().header(name.as_str(), user),
+            None => Response::cont(),
+        }
+    }
+
+    fn describe() -> &'static str {
+        concat!("basic-auth ", env!("CARGO_PKG_VERSION"), " (HTTP Basic authentication)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND, ACTION_REWRITE};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+
+    use super::*;
+    use crate::password_hash::{MIN_ITERATIONS, kdf_invocations};
+
+    /// Cheap-but-legal cost for tests; the real default is 100 000.
+    fn hash(password: &str) -> String {
+        PasswordHash::generate(password, MIN_ITERATIONS).expect("hash").to_phc_string()
+    }
+
+    fn basic_header(user: &str, password: &str) -> Vec<(String, String)> {
+        let encoded = Base64::encode_string(format!("{user}:{password}").as_bytes());
+        vec![("Authorization".to_owned(), format!("Basic {encoded}"))]
+    }
+
+    fn mw(config: &serde_json::Value) -> BasicAuth {
+        BasicAuth::init(config).expect("init")
+    }
+
+    /// Drive one request. `https` is the router's resolved determination.
+    fn invoke_on(
+        mw: &BasicAuth,
+        vhost: &str,
+        https: bool,
+        headers: &[(String, String)],
+    ) -> Response {
+        let ctx = RequestCtx::new("GET", "/index.php", "", "203.0.113.9", vhost, headers)
+            .with_https(https);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn invoke(mw: &BasicAuth, headers: &[(String, String)]) -> Response {
+        invoke_on(mw, "site.example", true, headers)
+    }
+
+    fn header_of<'a>(resp: &'a Response, name: &str) -> Option<&'a str> {
+        resp.__headers().iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.as_str())
+    }
+
+    /// Wire the crate-shared store and hand it back, so a test can delete a
+    /// key directly — the v1 middleware ABI has no delete callback.
+    fn wire_kv() -> &'static std::sync::Arc<ephpm_kv::store::Store> {
+        crate::test_kv::wire()
+    }
+
+    // ── Configuration ────────────────────────────────────────────────────
+
+    #[test]
+    fn init_requires_a_credential_source() {
+        let err = BasicAuth::init(&serde_json::Value::Null).expect_err("must fail");
+        assert!(err.contains("`users` or `kv_prefix`"), "{err}");
+        let err = BasicAuth::init(&serde_json::json!({ "users": {} })).expect_err("must fail");
+        assert!(err.contains("`users` or `kv_prefix`"), "{err}");
+        // Either source alone is enough.
+        assert!(BasicAuth::init(&serde_json::json!({ "kv_prefix": "ba:" })).is_ok());
+    }
+
+    #[test]
+    fn init_rejects_plaintext_passwords() {
+        // The whole point: there is no plaintext fallback to lean on.
+        let err = BasicAuth::init(&serde_json::json!({ "users": { "bob": "hunter2" } }))
+            .expect_err("plaintext must be refused");
+        assert!(err.contains("not a password hash"), "{err}");
+        assert!(err.contains("hash-password"), "error should say how to make one: {err}");
+    }
+
+    #[test]
+    fn init_rejects_unrepresentable_and_unsafe_usernames() {
+        let h = hash("pw");
+        let err = BasicAuth::init(&serde_json::json!({ "users": { "a:b": h.clone() } }))
+            .expect_err("must reject");
+        assert!(err.contains("cannot represent"), "{err}");
+        let err = BasicAuth::init(&serde_json::json!({ "users": { "a\nb": h.clone() } }))
+            .expect_err("must reject");
+        assert!(err.contains("control characters"), "{err}");
+        let err =
+            BasicAuth::init(&serde_json::json!({ "users": { "": h } })).expect_err("must reject");
+        assert!(err.contains("must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn init_rejects_a_realm_that_would_break_the_header() {
+        let cfg = serde_json::json!({
+            "kv_prefix": "ba:",
+            "realm": "evil\", charset=\"UTF-8\", x=\"",
+        });
+        assert!(BasicAuth::init(&cfg).is_err(), "a quote in the realm must be refused");
+    }
+
+    #[test]
+    fn init_rejects_unknown_policy_values() {
+        for (key, value) in
+            [("require_https", "yes"), ("missing_credentials", "maybe"), ("require_https", "")]
+        {
+            let cfg = serde_json::json!({ "kv_prefix": "ba:", key: value });
+            // An empty string reads as "unset" and is accepted; anything else
+            // must be refused rather than silently defaulted.
+            if value.is_empty() {
+                assert!(BasicAuth::init(&cfg).is_ok(), "empty {key} should mean unset");
+            } else {
+                assert!(BasicAuth::init(&cfg).is_err(), "{key} = {value} must be refused");
+            }
+        }
+    }
+
+    #[test]
+    fn defaults_are_the_documented_ones() {
+        let mw = mw(&serde_json::json!({ "kv_prefix": "ba:" }));
+        assert_eq!(mw.realm, "Restricted");
+        assert_eq!(mw.require_https, HttpsPolicy::Warn);
+        assert_eq!(mw.missing_credentials, MissingPolicy::Deny);
+        assert!(mw.forward_user_header.is_none());
+        assert!(mw.cache.enabled());
+    }
+
+    // ── The 401 challenge ────────────────────────────────────────────────
+
+    #[test]
+    fn no_credentials_gets_401_with_a_conformant_challenge() {
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        let resp = invoke(&mw, &[]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 401);
+        // RFC 7617: scheme, realm, and the charset parameter.
+        let challenge = header_of(&resp, "WWW-Authenticate").expect("challenge header");
+        assert_eq!(challenge, "Basic realm=\"Restricted\", charset=\"UTF-8\"");
+        assert_eq!(header_of(&resp, "Cache-Control"), Some("no-store"));
+    }
+
+    #[test]
+    fn realm_is_configurable() {
+        let mw = mw(&serde_json::json!({
+            "users": { "bob": hash("pw") },
+            "realm": "PR Preview",
+        }));
+        assert_eq!(
+            header_of(&invoke(&mw, &[]), "WWW-Authenticate"),
+            Some("Basic realm=\"PR Preview\", charset=\"UTF-8\"")
+        );
+    }
+
+    #[test]
+    fn wrong_password_and_unknown_user_are_401() {
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        assert_eq!(invoke(&mw, &basic_header("bob", "nope")).__status(), 401);
+        assert_eq!(invoke(&mw, &basic_header("eve", "pw")).__status(), 401);
+        // Both still carry the challenge, so a client can retry.
+        assert!(header_of(&invoke(&mw, &basic_header("eve", "pw")), "WWW-Authenticate").is_some());
+    }
+
+    #[test]
+    fn correct_password_continues_to_php() {
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("s3cret") } }));
+        assert_eq!(invoke(&mw, &basic_header("bob", "s3cret")).__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn malformed_authorization_headers_are_401_not_500() {
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        for value in [
+            "Basic",
+            "Basic ",
+            "Basic !!!not-base64!!!",
+            "Bearer abc.def.ghi",
+            "Basic Ym9i",     // "bob" — no colon
+            "Basic //79/A==", // valid base64, invalid UTF-8
+            "basic",
+        ] {
+            let headers = vec![("Authorization".to_owned(), value.to_owned())];
+            let resp = invoke(&mw, &headers);
+            assert_eq!(resp.__status(), 401, "value {value:?} should 401");
+        }
+    }
+
+    #[test]
+    fn a_password_may_contain_colons() {
+        // RFC 7617 splits at the FIRST colon; the rest is all password.
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("a:b:c") } }));
+        assert_eq!(invoke(&mw, &basic_header("bob", "a:b:c")).__action(), ACTION_CONTINUE);
+    }
+
+    // ── Timing / enumeration ─────────────────────────────────────────────
+
+    /// The property that matters for a login endpoint: an unknown username
+    /// must cost the same KDF work a known one does, or response latency
+    /// becomes a user-enumeration oracle.
+    ///
+    /// This fails the moment someone "optimises" the miss path with an early
+    /// return, which is the realistic way the protection gets lost.
+    #[test]
+    fn unknown_user_costs_the_same_kdf_work_as_a_known_one() {
+        // Cache off, so both arms are measured on the cold path.
+        let mw = mw(&serde_json::json!({
+            "users": { "bob": hash("pw") },
+            "cache_ttl_secs": 0,
+        }));
+
+        let before = kdf_invocations();
+        assert_eq!(invoke(&mw, &basic_header("bob", "wrong")).__status(), 401);
+        let known_user_cost = kdf_invocations() - before;
+
+        let before = kdf_invocations();
+        assert_eq!(invoke(&mw, &basic_header("nosuchuser", "wrong")).__status(), 401);
+        let unknown_user_cost = kdf_invocations() - before;
+
+        assert_eq!(
+            known_user_cost, unknown_user_cost,
+            "an unknown username must perform the same number of derivations as a \
+             known one ({known_user_cost} vs {unknown_user_cost}) — otherwise response \
+             latency reveals which usernames exist"
+        );
+        assert_eq!(known_user_cost, 1, "expected exactly one derivation per attempt");
+    }
+
+    #[test]
+    fn a_missing_authorization_header_costs_no_kdf() {
+        // No credential presented means no secret to compare, so there is
+        // nothing to make uniform — and spending a KDF would hand an
+        // unauthenticated client a CPU amplifier.
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        let before = kdf_invocations();
+        assert_eq!(invoke(&mw, &[]).__status(), 401);
+        assert_eq!(kdf_invocations(), before);
+    }
+
+    // ── Verification cache ───────────────────────────────────────────────
+
+    #[test]
+    fn cache_skips_the_kdf_on_repeat_but_never_on_failure() {
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        let creds = basic_header("bob", "pw");
+
+        let before = kdf_invocations();
+        assert_eq!(invoke(&mw, &creds).__action(), ACTION_CONTINUE);
+        assert_eq!(kdf_invocations(), before + 1, "first hit derives");
+
+        let before = kdf_invocations();
+        assert_eq!(invoke(&mw, &creds).__action(), ACTION_CONTINUE);
+        assert_eq!(kdf_invocations(), before, "second hit is cached");
+
+        // A wrong password must never be cached away: brute force pays full
+        // price on every attempt.
+        let wrong = basic_header("bob", "nope");
+        for _ in 0..3 {
+            let before = kdf_invocations();
+            assert_eq!(invoke(&mw, &wrong).__status(), 401);
+            assert_eq!(kdf_invocations(), before + 1);
+        }
+    }
+
+    #[test]
+    fn cache_is_scoped_per_vhost() {
+        // The same user/password on a different vhost is a different tuple,
+        // so one site's success can never satisfy another's check.
+        let mw = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        let creds = basic_header("bob", "pw");
+        assert_eq!(invoke_on(&mw, "a.example", true, &creds).__action(), ACTION_CONTINUE);
+        let before = kdf_invocations();
+        assert_eq!(invoke_on(&mw, "b.example", true, &creds).__action(), ACTION_CONTINUE);
+        assert_eq!(
+            kdf_invocations(),
+            before + 1,
+            "a second vhost must derive rather than reuse the first vhost's entry"
+        );
+    }
+
+    #[test]
+    fn cache_ttl_zero_disables_it() {
+        let mw = mw(&serde_json::json!({
+            "users": { "bob": hash("pw") },
+            "cache_ttl_secs": 0,
+        }));
+        assert!(!mw.cache.enabled());
+        let creds = basic_header("bob", "pw");
+        for _ in 0..2 {
+            let before = kdf_invocations();
+            assert_eq!(invoke(&mw, &creds).__action(), ACTION_CONTINUE);
+            assert_eq!(kdf_invocations(), before + 1);
+        }
+    }
+
+    #[test]
+    fn cache_stays_under_its_ceiling() {
+        let mw = mw(&serde_json::json!({
+            "users": { "bob": hash("pw") },
+            "cache_max_entries": 2,
+        }));
+        for vhost in ["v1", "v2", "v3", "v4", "v5"] {
+            assert_eq!(
+                invoke_on(&mw, vhost, true, &basic_header("bob", "pw")).__action(),
+                ACTION_CONTINUE
+            );
+        }
+        assert!(mw.cache.entries.len() <= 2, "cache grew past its ceiling");
+    }
+
+    #[test]
+    fn rotating_the_stored_hash_invalidates_the_cached_success() {
+        // The cache key commits to the stored hash, so revocation is
+        // immediate — the TTL only bounds memory.
+        let old = mw(&serde_json::json!({ "users": { "bob": hash("pw") } }));
+        let creds = basic_header("bob", "pw");
+        assert_eq!(invoke(&old, &creds).__action(), ACTION_CONTINUE);
+
+        let stored = old.users.get("bob").expect("entry");
+        let tag_old = old.cache.tag("site.example", "bob", "pw", stored);
+        let rotated = PasswordHash::generate("pw", MIN_ITERATIONS).expect("rehash");
+        let tag_new = old.cache.tag("site.example", "bob", "pw", &rotated);
+        assert_ne!(tag_old, tag_new, "a rehash must produce a different cache key");
+        assert!(old.cache.contains(&tag_old));
+        assert!(!old.cache.contains(&tag_new));
+    }
+
+    // ── HTTPS policy ─────────────────────────────────────────────────────
+
+    #[test]
+    fn enforce_refuses_to_challenge_over_plain_http() {
+        let mw = mw(&serde_json::json!({
+            "users": { "bob": hash("pw") },
+            "require_https": "enforce",
+        }));
+        let resp = invoke_on(&mw, "site.example", false, &basic_header("bob", "pw"));
+        assert_eq!(resp.__status(), 403);
+        assert!(
+            header_of(&resp, "WWW-Authenticate").is_none(),
+            "enforce must NOT invite the client to send credentials in the clear"
+        );
+        // The message has to say how to fix it behind a TLS-terminating proxy.
+        let body = String::from_utf8_lossy(resp.__body()).into_owned();
+        assert!(body.contains("trusted_proxies"), "{body}");
+        // Over HTTPS the same request succeeds.
+        assert_eq!(
+            invoke_on(&mw, "site.example", true, &basic_header("bob", "pw")).__action(),
+            ACTION_CONTINUE
+        );
+    }
+
+    #[test]
+    fn warn_and_off_still_authenticate_over_plain_http() {
+        for policy in ["warn", "off"] {
+            let mw = mw(&serde_json::json!({
+                "users": { "bob": hash("pw") },
+                "require_https": policy,
+            }));
+            let resp = invoke_on(&mw, "site.example", false, &[]);
+            assert_eq!(resp.__status(), 401, "{policy} should still challenge");
+            assert!(header_of(&resp, "WWW-Authenticate").is_some(), "{policy}");
+            assert_eq!(
+                invoke_on(&mw, "site.example", false, &basic_header("bob", "pw")).__action(),
+                ACTION_CONTINUE,
+                "{policy} should still authenticate"
+            );
+        }
+    }
+
+    // ── Per-vhost credentials from the KV store ──────────────────────────
+
+    #[test]
+    fn kv_credentials_resolve_per_vhost() {
+        wire_kv();
+        let mw = mw(&serde_json::json!({ "kv_prefix": "t1:basicauth:" }));
+        let host = Host::new(host_table());
+        let doc_a = serde_json::json!({ "alice": hash("alice-pw") }).to_string();
+        let doc_b = serde_json::json!({ "bob": hash("bob-pw") }).to_string();
+        assert!(host.kv_set("t1:basicauth:a.example", doc_a.as_bytes(), 0));
+        assert!(host.kv_set("t1:basicauth:b.example", doc_b.as_bytes(), 0));
+
+        // Each site accepts only its own credential.
+        assert_eq!(
+            invoke_on(&mw, "a.example", true, &basic_header("alice", "alice-pw")).__action(),
+            ACTION_CONTINUE
+        );
+        assert_eq!(
+            invoke_on(&mw, "b.example", true, &basic_header("bob", "bob-pw")).__action(),
+            ACTION_CONTINUE
+        );
+        // Cross-site credentials do not work.
+        assert_eq!(
+            invoke_on(&mw, "b.example", true, &basic_header("alice", "alice-pw")).__status(),
+            401
+        );
+        assert_eq!(
+            invoke_on(&mw, "a.example", true, &basic_header("bob", "bob-pw")).__status(),
+            401
+        );
+    }
+
+    #[test]
+    fn deleting_the_kv_entry_revokes_access_immediately() {
+        let store = wire_kv();
+        let mw = mw(&serde_json::json!({ "kv_prefix": "t2:basicauth:" }));
+        let host = Host::new(host_table());
+        let doc = serde_json::json!({ "alice": hash("pw") }).to_string();
+        assert!(host.kv_set("t2:basicauth:gone.example", doc.as_bytes(), 0));
+        let creds = basic_header("alice", "pw");
+        assert_eq!(invoke_on(&mw, "gone.example", true, &creds).__action(), ACTION_CONTINUE);
+
+        // Tear the preview down: the very next request is refused despite the
+        // cached success, because there is no longer a credential table at all.
+        assert!(store.remove("t2:basicauth:gone.example"));
+        assert_eq!(invoke_on(&mw, "gone.example", true, &creds).__status(), 403);
+    }
+
+    #[test]
+    fn rotating_the_kv_credential_invalidates_the_cache_immediately() {
+        // The rotation half of the same story: the credential table still
+        // exists, but its hash changed, so the cached tag no longer matches
+        // and the old password stops working on the next request.
+        wire_kv();
+        let mw = mw(&serde_json::json!({ "kv_prefix": "t7:basicauth:" }));
+        let host = Host::new(host_table());
+        let key = "t7:basicauth:rotate.example";
+        let old_doc = serde_json::json!({ "alice": hash("old-pw") }).to_string();
+        assert!(host.kv_set(key, old_doc.as_bytes(), 0));
+        assert_eq!(
+            invoke_on(&mw, "rotate.example", true, &basic_header("alice", "old-pw")).__action(),
+            ACTION_CONTINUE
+        );
+
+        let new_doc = serde_json::json!({ "alice": hash("new-pw") }).to_string();
+        assert!(host.kv_set(key, new_doc.as_bytes(), 0));
+        assert_eq!(
+            invoke_on(&mw, "rotate.example", true, &basic_header("alice", "old-pw")).__status(),
+            401,
+            "the old password must stop working immediately, not after the cache TTL"
+        );
+        assert_eq!(
+            invoke_on(&mw, "rotate.example", true, &basic_header("alice", "new-pw")).__action(),
+            ACTION_CONTINUE
+        );
+    }
+
+    #[test]
+    fn kv_entry_takes_precedence_over_the_static_table() {
+        wire_kv();
+        let mw = mw(&serde_json::json!({
+            "kv_prefix": "t3:basicauth:",
+            "users": { "global": hash("global-pw") },
+        }));
+        let host = Host::new(host_table());
+        let doc = serde_json::json!({ "local": hash("local-pw") }).to_string();
+        assert!(host.kv_set("t3:basicauth:override.example", doc.as_bytes(), 0));
+
+        // The per-site table replaces the global one; it does not merge.
+        assert_eq!(
+            invoke_on(&mw, "override.example", true, &basic_header("local", "local-pw")).__action(),
+            ACTION_CONTINUE
+        );
+        assert_eq!(
+            invoke_on(&mw, "override.example", true, &basic_header("global", "global-pw"))
+                .__status(),
+            401
+        );
+        // A vhost with no KV entry still falls back to the static table.
+        assert_eq!(
+            invoke_on(&mw, "fallback.example", true, &basic_header("global", "global-pw"))
+                .__action(),
+            ACTION_CONTINUE
+        );
+    }
+
+    #[test]
+    fn an_unusable_kv_document_denies_and_never_falls_back() {
+        wire_kv();
+        let mw = mw(&serde_json::json!({
+            "kv_prefix": "t4:basicauth:",
+            "users": { "global": hash("global-pw") },
+        }));
+        let host = Host::new(host_table());
+        // Plaintext where a hash belongs, and outright junk.
+        for (vhost, doc) in [
+            ("plain.example", r#"{"bob":"hunter2"}"#),
+            ("junk.example", "not json at all"),
+            ("empty.example", "{}"),
+        ] {
+            assert!(host.kv_set(&format!("t4:basicauth:{vhost}"), doc.as_bytes(), 0));
+            // Falling back to the global credential here would silently open
+            // the site to whoever holds it.
+            assert_eq!(
+                invoke_on(&mw, vhost, true, &basic_header("global", "global-pw")).__status(),
+                403,
+                "vhost {vhost} must deny, not inherit the global credential"
+            );
+        }
+    }
+
+    // ── Unconfigured sites ───────────────────────────────────────────────
+
+    #[test]
+    fn missing_credentials_deny_is_the_default_and_carries_no_challenge() {
+        wire_kv();
+        let mw = mw(&serde_json::json!({ "kv_prefix": "t5:basicauth:" }));
+        let resp = invoke_on(&mw, "unknown.example", true, &[]);
+        assert_eq!(resp.__status(), 403);
+        assert!(
+            header_of(&resp, "WWW-Authenticate").is_none(),
+            "no credential can ever satisfy this, so do not prompt for one"
+        );
+    }
+
+    /// `Host` is client-controlled and case-insensitive. Without
+    /// normalisation `Host: Locked.Example` would miss the credential this
+    /// site's key holds — under `missing_credentials = "allow"` that is an
+    /// authentication bypass by changing one letter's case.
+    #[test]
+    fn vhost_lookup_is_case_and_trailing_dot_insensitive() {
+        wire_kv();
+        let mw = mw(&serde_json::json!({
+            "kv_prefix": "t8:basicauth:",
+            "missing_credentials": "allow",
+        }));
+        let host = Host::new(host_table());
+        let doc = serde_json::json!({ "alice": hash("pw") }).to_string();
+        assert!(host.kv_set("t8:basicauth:locked.example", doc.as_bytes(), 0));
+
+        // Every spelling of the same host must land on the same credential.
+        for spelling in ["locked.example", "Locked.Example", "LOCKED.EXAMPLE", "locked.example."] {
+            assert_eq!(
+                invoke_on(&mw, spelling, true, &[]).__status(),
+                401,
+                "Host {spelling:?} must still be gated"
+            );
+            assert_eq!(
+                invoke_on(&mw, spelling, true, &basic_header("alice", "pw")).__action(),
+                ACTION_CONTINUE,
+                "Host {spelling:?} must accept the site's credential"
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_public_marker_opens_a_managed_site() {
+        wire_kv();
+        // Default (deny) policy: a fleet can still mix public and private
+        // sites without opening every unknown Host.
+        let mw = mw(&serde_json::json!({ "kv_prefix": "t9:basicauth:" }));
+        let host = Host::new(host_table());
+        assert!(host.kv_set("t9:basicauth:open.example", b"public", 0));
+        assert_eq!(invoke_on(&mw, "open.example", true, &[]).__action(), ACTION_CONTINUE);
+        // An unmanaged host is still refused.
+        assert_eq!(invoke_on(&mw, "unmanaged.example", true, &[]).__status(), 403);
+    }
+
+    #[test]
+    fn an_empty_or_truncated_document_is_not_public() {
+        // A control plane bug that writes an empty/partial document must fail
+        // CLOSED. Only the exact `public` marker opens a site.
+        wire_kv();
+        let mw = mw(&serde_json::json!({ "kv_prefix": "t10:basicauth:" }));
+        let host = Host::new(host_table());
+        for (vhost, doc) in [
+            ("empty.example", "{}"),
+            ("blank.example", ""),
+            ("partial.example", "{\"alice\":"),
+            ("nearly.example", "publicX"),
+            ("cased.example", "PUBLIC"),
+        ] {
+            assert!(host.kv_set(&format!("t10:basicauth:{vhost}"), doc.as_bytes(), 0));
+            assert_eq!(
+                invoke_on(&mw, vhost, true, &[]).__status(),
+                403,
+                "{vhost} ({doc:?}) must fail closed, not read as public"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_credentials_allow_lets_public_sites_through() {
+        // The mixed-fleet case: some previews are public, some are not.
+        wire_kv();
+        let mw = mw(&serde_json::json!({
+            "kv_prefix": "t6:basicauth:",
+            "missing_credentials": "allow",
+        }));
+        assert_eq!(invoke_on(&mw, "public.example", true, &[]).__action(), ACTION_CONTINUE);
+
+        let host = Host::new(host_table());
+        let doc = serde_json::json!({ "alice": hash("pw") }).to_string();
+        assert!(host.kv_set("t6:basicauth:private.example", doc.as_bytes(), 0));
+        assert_eq!(invoke_on(&mw, "private.example", true, &[]).__status(), 401);
+    }
+
+    // ── Forwarding the authenticated user ────────────────────────────────
+
+    #[test]
+    fn forward_user_header_overrides_a_forged_one() {
+        let mw = mw(&serde_json::json!({
+            "users": { "bob": hash("pw") },
+            "forward_user_header": "X-Auth-User",
+        }));
+        let mut headers = basic_header("bob", "pw");
+        // A client claiming to be someone else.
+        headers.push(("X-Auth-User".to_owned(), "admin".to_owned()));
+        let resp = invoke(&mw, &headers);
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(header_of(&resp, "X-Auth-User"), Some("bob"));
+        // REWRITE overrides are applied with `override_header`, which replaces
+        // rather than appends — asserted end to end in the server's tests.
+        assert_eq!(resp.__headers().len(), 1);
+    }
+
+    #[test]
+    fn forward_user_header_name_is_validated() {
+        let cfg = serde_json::json!({
+            "kv_prefix": "ba:",
+            "forward_user_header": "X-Auth: injected\r\nX-Evil",
+        });
+        assert!(BasicAuth::init(&cfg).is_err());
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/lib.rs
+++ b/crates/ephpm-middleware-builtins/src/lib.rs
@@ -1,4 +1,4 @@
-//! The four in-tree ePHPm middleware modules as plain Rust library code.
+//! The five in-tree ePHPm middleware modules as plain Rust library code.
 //!
 //! Each module here is an ordinary [`ephpm_middleware::Middleware`]
 //! implementation with **no C ABI exports** — that is what lets
@@ -6,15 +6,42 @@
 //! through the static builtin registry (`library = "jwt"` works even in a
 //! custom fully static build, where `dlopen` does not exist).
 //!
-//! The sibling `ephpm-middleware-{jwt,cors,ratelimit,security-headers}`
+//! The sibling `ephpm-middleware-{jwt,cors,ratelimit,security-headers,basicauth}`
 //! crates are thin cdylib shells: they re-export these types and add the
 //! `declare!` C ABI glue, producing the loadable `.so`/`.dylib`/`.dll`
 //! artifacts for the dynamic (dlopen) lane. The shells cannot be merged into
-//! one binary — four copies of the same `ephpm_middleware_*` export symbols
+//! one binary — five copies of the same `ephpm_middleware_*` export symbols
 //! collide at link time — which is exactly why the implementations live
 //! here instead.
 
+pub mod basicauth;
 pub mod cors;
 pub mod jwt;
+pub mod password_hash;
 pub mod ratelimit;
 pub mod security_headers;
+
+/// Shared KV wiring for this crate's unit tests.
+///
+/// [`ephpm_middleware::host::set_kv_store`] is a `OnceLock`: the first caller
+/// in a test binary wins and every later call is a silent no-op. Since
+/// `basicauth` and `ratelimit` both need a live store, they must agree on one
+/// instance — otherwise whichever module's test ran first would own the store
+/// and the other would silently exercise the "KV unavailable" path. Tests keep
+/// their keys apart by vhost/prefix rather than by owning separate stores.
+#[cfg(test)]
+mod test_kv {
+    use std::sync::{Arc, OnceLock};
+
+    use ephpm_kv::store::{Store, StoreConfig};
+
+    /// Wire the shared in-memory store into the host table and hand it back,
+    /// so a test can also reach it directly (e.g. to delete a key — the v1
+    /// middleware ABI exposes get/set/incr but no delete).
+    pub fn wire() -> &'static Arc<Store> {
+        static SHARED: OnceLock<Arc<Store>> = OnceLock::new();
+        let store = SHARED.get_or_init(|| Store::new(StoreConfig::default()));
+        ephpm_middleware::host::set_kv_store(store);
+        store
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/password_hash.rs
+++ b/crates/ephpm-middleware-builtins/src/password_hash.rs
@@ -1,0 +1,351 @@
+//! PBKDF2-HMAC-SHA256 password hashing for the `basic-auth` middleware.
+//!
+//! # Why PBKDF2, and why from `aws-lc-rs`
+//!
+//! ePHPm already links `aws-lc-rs` — it is the crypto provider behind
+//! `rustls-acme` and the RSA-OAEP implementation the MySQL
+//! `caching_sha2_password` handshake uses — so PBKDF2 costs **no new
+//! dependency**: no new crate in `Cargo.toml`, no new entry in `Cargo.lock`,
+//! nothing new for `cargo deny` to judge. That was the deciding factor over
+//! adding `argon2`/`bcrypt`.
+//!
+//! A plain keyed hash (the [`ephpm_kv::auth::derive_site_password`] shape,
+//! HMAC-SHA256) would have been cheaper still, and is adequate for the
+//! *generated* high-entropy passwords a preview-hosting control plane issues.
+//! It is not adequate for the human-chosen password an operator types into
+//! `ephpm.toml`, which is the other half of this middleware's audience. A
+//! deliberately slow KDF is the difference between "the leaked hash is
+//! useless" and "the leaked hash is `hunter2` in a second", so the slow KDF
+//! wins and the per-request cost is dealt with by caching successful
+//! verifications (see [`crate::basicauth`]).
+//!
+//! # Encoding
+//!
+//! Hashes are stored as a PHC-style string:
+//!
+//! ```text
+//! $pbkdf2-sha256$i=100000$cmFuZG9tc2FsdDEyMzQ1$aGFzaGhhc2hoYXNoaGFzaGhhc2hoYXNoaGFzaGhhc2g
+//! ```
+//!
+//! `i=` is the iteration count, then the salt and the derived key, both in
+//! unpadded standard base64. The iteration count travels **with the hash**
+//! rather than in configuration so a credential can be re-hashed at a higher
+//! cost without an `ephpm.toml` edit, and so two credentials generated years
+//! apart both keep verifying.
+//!
+//! Iteration counts outside [`MIN_ITERATIONS`]`..=`[`MAX_ITERATIONS`] are
+//! rejected at parse time. The ceiling matters: a stored hash is attacker-
+//! controlled data the moment an operator's credential store is writable, and
+//! `i=4000000000` would otherwise be a one-line denial of service.
+
+use std::fmt::Write as _;
+use std::num::NonZeroU32;
+
+use aws_lc_rs::pbkdf2;
+use base64ct::{Base64Unpadded, Encoding};
+
+/// Algorithm identifier at the head of every hash string.
+const ALG: &str = "pbkdf2-sha256";
+
+/// Derived-key length in bytes (SHA-256 output).
+const KEY_LEN: usize = 32;
+
+/// Salt length in bytes. 16 bytes is the NIST SP 800-132 recommendation and
+/// what `aws-lc-rs`'s own PBKDF2 documentation asks for.
+pub const SALT_LEN: usize = 16;
+
+/// Lowest iteration count a stored hash may declare.
+///
+/// Below this the KDF stops being a KDF. Rejected at parse time so a
+/// downgraded credential fails loudly instead of verifying quickly.
+pub const MIN_ITERATIONS: u32 = 1_000;
+
+/// Highest iteration count a stored hash may declare.
+///
+/// A stored hash is data, and data can be hostile: without a ceiling, one
+/// credential reading `i=4000000000` turns every login attempt into a CPU
+/// exhaustion attack against the server.
+pub const MAX_ITERATIONS: u32 = 5_000_000;
+
+/// Iteration count used when generating a new hash (`ephpm hash-password`).
+///
+/// Roughly 50–100 ms on 2020s server hardware. The cost is paid once per
+/// distinct credential presented, not once per request — see the verification
+/// cache in [`crate::basicauth`].
+pub const DEFAULT_ITERATIONS: u32 = 100_000;
+
+thread_local! {
+    /// PBKDF2 derivations performed on **this thread**.
+    ///
+    /// Exists so tests can assert the *uniform work* property that actually
+    /// matters for a login endpoint: an unknown username must cost the same
+    /// derivation a known one does, or response latency becomes a
+    /// user-enumeration oracle. A test reads this counter around a call and
+    /// fails the moment someone adds an early return on the "no such user"
+    /// path.
+    ///
+    /// Thread-local rather than a global atomic on purpose: libtest runs each
+    /// test on its own thread, and a process-wide counter would be raced by
+    /// every sibling test in the same binary — the exact shape of flake this
+    /// repo has been bitten by before. A `Cell<u64>` with `const` init
+    /// registers no TLS destructor, so it cannot participate in
+    /// thread-teardown ordering hazards.
+    static KDF_INVOCATIONS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Record one PBKDF2 derivation on this thread.
+fn note_kdf_invocation() {
+    // `try_with` rather than `with`: accessing a TLS key during another key's
+    // destruction panics, and a diagnostic counter must never be the thing
+    // that takes a request down.
+    let _ = KDF_INVOCATIONS.try_with(|c| c.set(c.get().saturating_add(1)));
+}
+
+/// PBKDF2 derivations performed on this thread so far. Test-support only.
+#[doc(hidden)]
+#[must_use]
+pub fn kdf_invocations() -> u64 {
+    KDF_INVOCATIONS.try_with(std::cell::Cell::get).unwrap_or(0)
+}
+
+/// A parsed PBKDF2-HMAC-SHA256 password hash.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PasswordHash {
+    iterations: NonZeroU32,
+    salt: Vec<u8>,
+    key: Vec<u8>,
+}
+
+impl PasswordHash {
+    /// Parse a `$pbkdf2-sha256$i=<n>$<salt>$<key>` string.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message when the string is not a hash of this
+    /// form, when the base64 is invalid, when the derived key is not
+    /// [`KEY_LEN`] bytes, or when the iteration count is outside
+    /// [`MIN_ITERATIONS`]`..=`[`MAX_ITERATIONS`].
+    pub fn parse(s: &str) -> Result<Self, String> {
+        // Leading `$` then exactly four fields: alg, params, salt, key.
+        let rest = s.strip_prefix('$').ok_or(
+            "not a password hash (expected a leading `$`); \
+                    generate one with `ephpm hash-password`",
+        )?;
+        let mut parts = rest.split('$');
+        let (Some(alg), Some(params), Some(salt_b64), Some(key_b64), None) =
+            (parts.next(), parts.next(), parts.next(), parts.next(), parts.next())
+        else {
+            return Err(format!(
+                "malformed password hash: expected `${ALG}$i=<iterations>$<salt>$<hash>`"
+            ));
+        };
+        if alg != ALG {
+            return Err(format!("unsupported password hash algorithm `{alg}` (only `{ALG}`)"));
+        }
+
+        let iterations: u32 = params
+            .strip_prefix("i=")
+            .ok_or("malformed password hash: expected an `i=<iterations>` parameter field")?
+            .parse()
+            .map_err(|_| "malformed password hash: `i=` is not an integer".to_owned())?;
+        if !(MIN_ITERATIONS..=MAX_ITERATIONS).contains(&iterations) {
+            return Err(format!(
+                "password hash iteration count {iterations} is outside the accepted range \
+                 {MIN_ITERATIONS}..={MAX_ITERATIONS}"
+            ));
+        }
+        let iterations = NonZeroU32::new(iterations)
+            .ok_or_else(|| "password hash iteration count must be > 0".to_owned())?;
+
+        let salt = Base64Unpadded::decode_vec(salt_b64)
+            .map_err(|_| "malformed password hash: salt is not unpadded base64".to_owned())?;
+        if salt.len() < SALT_LEN {
+            return Err(format!(
+                "password hash salt is {} bytes; at least {SALT_LEN} are required",
+                salt.len()
+            ));
+        }
+        let key = Base64Unpadded::decode_vec(key_b64)
+            .map_err(|_| "malformed password hash: hash is not unpadded base64".to_owned())?;
+        if key.len() != KEY_LEN {
+            return Err(format!(
+                "password hash is {} bytes; PBKDF2-HMAC-SHA256 produces {KEY_LEN}",
+                key.len()
+            ));
+        }
+
+        Ok(Self { iterations, salt, key })
+    }
+
+    /// Derive a fresh hash for `password` with a random salt.
+    ///
+    /// `iterations` is clamped into [`MIN_ITERATIONS`]`..=`[`MAX_ITERATIONS`]
+    /// so a caller cannot mint a credential this crate would then refuse to
+    /// parse.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the OS entropy source is unavailable. Deriving a
+    /// salt from anything predictable would defeat the point, so this fails
+    /// rather than falling back.
+    pub fn generate(password: &str, iterations: u32) -> Result<Self, String> {
+        let mut salt = vec![0u8; SALT_LEN];
+        getrandom::fill(&mut salt)
+            .map_err(|e| format!("failed to draw a password salt from OS entropy: {e}"))?;
+        let iterations = iterations.clamp(MIN_ITERATIONS, MAX_ITERATIONS);
+        let iterations = NonZeroU32::new(iterations).unwrap_or(NonZeroU32::MIN);
+
+        let mut key = vec![0u8; KEY_LEN];
+        note_kdf_invocation();
+        pbkdf2::derive(
+            pbkdf2::PBKDF2_HMAC_SHA256,
+            iterations,
+            &salt,
+            password.as_bytes(),
+            &mut key,
+        );
+        Ok(Self { iterations, salt, key })
+    }
+
+    /// Check `password` against this hash in constant time.
+    ///
+    /// The comparison is [`aws_lc_rs::pbkdf2::verify`], which derives into a
+    /// scratch buffer, compares with `constant_time::verify_slices_are_equal`
+    /// and zeroizes. This function never has the stored key and a freshly
+    /// derived key in scope as two comparable values, so there is no `==` for
+    /// a later edit to reach for.
+    #[must_use]
+    pub fn verify(&self, password: &str) -> bool {
+        note_kdf_invocation();
+        pbkdf2::verify(
+            pbkdf2::PBKDF2_HMAC_SHA256,
+            self.iterations,
+            &self.salt,
+            password.as_bytes(),
+            &self.key,
+        )
+        .is_ok()
+    }
+
+    /// The iteration count this hash declares.
+    #[must_use]
+    pub fn iterations(&self) -> u32 {
+        self.iterations.get()
+    }
+
+    /// Render back to the `$pbkdf2-sha256$i=…$…$…` storage form.
+    #[must_use]
+    pub fn to_phc_string(&self) -> String {
+        let mut out = String::with_capacity(96);
+        // Writing to a String is infallible; the Result is discarded on
+        // purpose rather than unwrapped.
+        let _ = write!(out, "${ALG}$i={}$", self.iterations);
+        out.push_str(&Base64Unpadded::encode_string(&self.salt));
+        out.push('$');
+        out.push_str(&Base64Unpadded::encode_string(&self.key));
+        out
+    }
+}
+
+impl std::fmt::Display for PasswordHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_phc_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fast enough for tests, still a legal iteration count.
+    const TEST_ITERS: u32 = MIN_ITERATIONS;
+
+    #[test]
+    fn generate_then_verify_round_trips() {
+        let h = PasswordHash::generate("correct horse battery staple", TEST_ITERS).expect("gen");
+        assert!(h.verify("correct horse battery staple"));
+        assert!(!h.verify("Correct horse battery staple"));
+        assert!(!h.verify(""));
+    }
+
+    #[test]
+    fn phc_string_round_trips_through_parse() {
+        let h = PasswordHash::generate("s3cret", TEST_ITERS).expect("gen");
+        let encoded = h.to_phc_string();
+        let parsed = PasswordHash::parse(&encoded).expect("parse");
+        assert_eq!(parsed, h);
+        assert_eq!(parsed.to_phc_string(), encoded);
+        assert!(parsed.verify("s3cret"));
+    }
+
+    #[test]
+    fn salt_is_random_per_generation() {
+        let a = PasswordHash::generate("same", TEST_ITERS).expect("gen");
+        let b = PasswordHash::generate("same", TEST_ITERS).expect("gen");
+        assert_ne!(a, b, "two hashes of the same password must not collide");
+        assert!(a.verify("same") && b.verify("same"));
+    }
+
+    #[test]
+    fn parse_rejects_junk_and_wrong_algorithms() {
+        for bad in [
+            "",
+            "hunter2",
+            "$argon2id$v=19$m=65536,t=3,p=4$c2FsdA$aGFzaA",
+            "$pbkdf2-sha256$i=100000$onlythreefields",
+            "$pbkdf2-sha256$i=100000$c2FsdHNhbHRzYWx0c2FsdA$aGFzaA$extra",
+            "$pbkdf2-sha256$100000$c2FsdHNhbHRzYWx0c2FsdA$aGFzaA",
+            "$pbkdf2-sha256$i=notanumber$c2FsdHNhbHRzYWx0c2FsdA$aGFzaA",
+        ] {
+            assert!(PasswordHash::parse(bad).is_err(), "should reject: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn parse_enforces_the_iteration_bounds() {
+        let h = PasswordHash::generate("x", TEST_ITERS).expect("gen");
+        let good = h.to_phc_string();
+        assert!(PasswordHash::parse(&good).is_ok());
+
+        // A ceiling is what stops a hostile stored credential from turning
+        // one login attempt into a CPU exhaustion attack.
+        let too_slow = good.replace("i=1000$", &format!("i={}$", u64::from(MAX_ITERATIONS) + 1));
+        let err = PasswordHash::parse(&too_slow).expect_err("must reject");
+        assert!(err.contains("outside the accepted range"), "{err}");
+
+        let too_fast = good.replace("i=1000$", "i=999$");
+        assert!(PasswordHash::parse(&too_fast).is_err(), "must reject a downgraded cost");
+    }
+
+    #[test]
+    fn parse_rejects_a_truncated_key_or_salt() {
+        let h = PasswordHash::generate("x", TEST_ITERS).expect("gen");
+        let phc = h.to_phc_string();
+        let mut fields: Vec<&str> = phc.split('$').collect();
+        // fields = ["", alg, params, salt, key]
+        let short_key = format!("{}${}${}$aGFzaA", fields[1], fields[2], fields[3]);
+        assert!(PasswordHash::parse(&format!("${short_key}")).is_err());
+        fields[3] = "c2hvcnQ"; // "short" — 5 bytes, under SALT_LEN
+        assert!(PasswordHash::parse(&format!("${}", fields[1..].join("$"))).is_err());
+    }
+
+    #[test]
+    fn generate_clamps_out_of_range_iteration_counts() {
+        let low = PasswordHash::generate("x", 1).expect("gen");
+        assert_eq!(low.iterations(), MIN_ITERATIONS);
+        // Round-trips, which is the property the clamp exists to protect.
+        assert!(PasswordHash::parse(&low.to_phc_string()).is_ok());
+    }
+
+    #[test]
+    fn every_verify_attempt_runs_the_kdf() {
+        // The uniform-work property this counter exists for: a *failed*
+        // verify must cost the same derivation a successful one does.
+        let h = PasswordHash::generate("right", TEST_ITERS).expect("gen");
+        let before = kdf_invocations();
+        assert!(!h.verify("wrong"));
+        assert_eq!(kdf_invocations(), before + 1);
+        assert!(h.verify("right"));
+        assert_eq!(kdf_invocations(), before + 2);
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/ratelimit.rs
+++ b/crates/ephpm-middleware-builtins/src/ratelimit.rs
@@ -120,14 +120,15 @@ mod tests {
     #![allow(unsafe_code)] // tests build the FFI Request view by hand.
 
     use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
-    use ephpm_middleware::host::{RequestCtx, host_table, set_kv_store};
+    use ephpm_middleware::host::{RequestCtx, host_table};
 
     use super::*;
 
-    /// Wire a real in-memory Store into the host table (first call wins;
-    /// all tests in this binary share it, so each uses a unique vhost).
+    /// Wire the crate-shared in-memory Store into the host table. All tests in
+    /// this binary share one store (see [`crate::test_kv`]), so each uses a
+    /// unique vhost to keep its counters apart.
     fn setup_kv() {
-        set_kv_store(&ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default()));
+        let _ = crate::test_kv::wire();
     }
 
     fn invoke(mw: &RateLimit, vhost: &str, ip: &str, headers: &[(String, String)]) -> Response {

--- a/crates/ephpm-middleware-jwt/Cargo.toml
+++ b/crates/ephpm-middleware-jwt/Cargo.toml
@@ -11,7 +11,7 @@ description = "ePHPm native middleware: HS256 JWT bearer-token validation (loada
 # cdylib = the loadable module for the dlopen lane. The implementation (and
 # the rlib ephpm-server links) is ephpm-middleware-builtins — this shell only
 # adds the C ABI exports, which must never be linked into the host binary
-# (four modules exporting the same `ephpm_middleware_*` symbols collide).
+# (several modules exporting the same `ephpm_middleware_*` symbols collide).
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/crates/ephpm-middleware-ratelimit/Cargo.toml
+++ b/crates/ephpm-middleware-ratelimit/Cargo.toml
@@ -11,7 +11,7 @@ description = "ePHPm native middleware: fixed-window per-client rate limiting vi
 # cdylib = the loadable module for the dlopen lane. The implementation (and
 # the rlib ephpm-server links) is ephpm-middleware-builtins — this shell only
 # adds the C ABI exports, which must never be linked into the host binary
-# (four modules exporting the same `ephpm_middleware_*` symbols collide).
+# (several modules exporting the same `ephpm_middleware_*` symbols collide).
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/crates/ephpm-middleware-security-headers/Cargo.toml
+++ b/crates/ephpm-middleware-security-headers/Cargo.toml
@@ -11,7 +11,7 @@ description = "ePHPm native middleware: standard security response headers (load
 # cdylib = the loadable module for the dlopen lane. The implementation (and
 # the rlib ephpm-server links) is ephpm-middleware-builtins — this shell only
 # adds the C ABI exports, which must never be linked into the host binary
-# (four modules exporting the same `ephpm_middleware_*` symbols collide).
+# (several modules exporting the same `ephpm_middleware_*` symbols collide).
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -177,6 +177,24 @@ pub struct EphpmHostV1 {
         ttl_secs: i64,
         out: *mut i64,
     ) -> c_int,
+
+    /// Whether this request reached ePHPm over an encrypted channel: `1` for
+    /// yes, `0` for no. This is the SAME determination PHP sees as
+    /// `$_SERVER['HTTPS']`, not a raw "was this socket TLS" flag — when the
+    /// peer is inside `[server.security] trusted_proxies`, an
+    /// `X-Forwarded-Proto` header overrides the local socket state, and when
+    /// it is not, the header is ignored entirely.
+    ///
+    /// The practical consequence for a module: **`0` does not prove the
+    /// client's connection was cleartext.** ePHPm behind a TLS-terminating
+    /// proxy with no `trusted_proxies` configured reports `0` for traffic that
+    /// reached the proxy over HTTPS. A module that refuses to operate on `0`
+    /// must document that its strict mode requires `trusted_proxies`.
+    ///
+    /// Appended after [`EphpmHostV1::kv_incr_ttl`]: older middleware built
+    /// against a table without this field never reads past the offsets it
+    /// knows, so growing the table at the end is ABI-compatible.
+    pub request_is_https: unsafe extern "C" fn(*const EphpmRequest) -> c_int,
 }
 
 /// Symbol names the loader looks up.

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -19,6 +19,10 @@ pub struct RequestCtx {
     vhost: CString,
     /// Lower-cased name → value (values pre-joined per HTTP list semantics).
     headers: Vec<(CString, CString)>,
+    /// The router's resolved HTTPS determination — the same value PHP gets as
+    /// `$_SERVER['HTTPS']`, i.e. already through trusted-proxy resolution.
+    /// Defaults to `false`; set with [`RequestCtx::with_https`].
+    https: bool,
 }
 
 impl RequestCtx {
@@ -43,7 +47,22 @@ impl RequestCtx {
             remote_ip: c(remote_ip),
             vhost: c(vhost),
             headers: headers.iter().map(|(n, v)| (c(&n.to_ascii_lowercase()), c(v))).collect(),
+            https: false,
         }
+    }
+
+    /// Record the router's resolved HTTPS determination for this request —
+    /// the value PHP would see as `$_SERVER['HTTPS']`, i.e. after
+    /// trusted-proxy `X-Forwarded-Proto` resolution.
+    ///
+    /// A builder method rather than a `new` parameter so existing callers
+    /// (and out-of-tree code constructing a context in tests) keep compiling;
+    /// the default is `false`, which is the conservative answer for a context
+    /// built without transport information.
+    #[must_use]
+    pub fn with_https(mut self, https: bool) -> Self {
+        self.https = https;
+        self
     }
 
     /// The opaque pointer to pass through the ABI. Valid while `self` lives.
@@ -79,6 +98,11 @@ unsafe extern "C" fn request_remote_ip(req: *const EphpmRequest) -> *const c_cha
 unsafe extern "C" fn request_vhost_id(req: *const EphpmRequest) -> *const c_char {
     // SAFETY: ABI contract.
     unsafe { ctx(req) }.map_or(std::ptr::null(), |c| c.vhost.as_ptr())
+}
+unsafe extern "C" fn request_is_https(req: *const EphpmRequest) -> c_int {
+    // SAFETY: ABI contract. A null/unrecognised context reports "not HTTPS",
+    // matching the conservative default a bare RequestCtx carries.
+    c_int::from(unsafe { ctx(req) }.is_some_and(|c| c.https))
 }
 unsafe extern "C" fn request_header(
     req: *const EphpmRequest,
@@ -286,6 +310,7 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     kv_free,
     log: host_log,
     kv_incr_ttl,
+    request_is_https,
 };
 
 /// Wire the embedded KV store into the host table. Call once at startup,

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -146,6 +146,24 @@ impl Request<'_> {
         self.str_of(unsafe { (self.host.request_vhost_id)(self.raw) })
     }
 
+    /// Whether this request reached ePHPm over an encrypted channel — the
+    /// same determination PHP sees as `$_SERVER['HTTPS']`.
+    ///
+    /// This is **not** a raw "was this socket TLS" flag. When the peer is
+    /// inside `[server.security] trusted_proxies`, an `X-Forwarded-Proto`
+    /// header decides; when it is not, that header is ignored. So `false`
+    /// does not prove the client's connection was cleartext: ePHPm behind a
+    /// TLS-terminating proxy with no `trusted_proxies` configured reports
+    /// `false` for traffic that reached the proxy over HTTPS. Modules that
+    /// refuse to operate without transport security must say so in their own
+    /// docs and offer a way to relax it.
+    #[must_use]
+    pub fn is_https(&self) -> bool {
+        // SAFETY: contract of `from_raw`.
+        let raw = unsafe { (self.host.request_is_https)(self.raw) };
+        raw != 0
+    }
+
     /// Host services (KV store, logging) scoped to the table this request
     /// was invoked with. Equivalent to `Host::new(__ephpm_mw_host())` but
     /// also works in unit tests that build a [`Request`] by hand.

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -14,7 +14,7 @@ ephpm-config.workspace = true
 ephpm-db.workspace = true
 ephpm-kv.workspace = true
 ephpm-middleware = { workspace = true, features = ["host"] }
-# Builtin middleware registry: the four in-tree module implementations
+# Builtin middleware registry: the five in-tree module implementations
 # linked in as a plain rlib (no C ABI exports), so `library = "jwt"` works
 # in every binary — including custom fully static builds, where dlopen
 # does not exist.

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -7,7 +7,7 @@
 //!
 //! Each mount resolves through two lanes, in order:
 //!
-//! 1. **Builtin registry** ([`builtin`]) — the four in-tree modules compiled
+//! 1. **Builtin registry** ([`builtin`]) — the five in-tree modules compiled
 //!    into this binary and invoked in-process (no FFI, no dlopen). Works in
 //!    every binary, including custom fully static builds where `dlopen` does
 //!    not exist.
@@ -91,7 +91,8 @@ pub type BuiltinBuilder = fn(&serde_json::Value) -> Result<BuiltinModule, String
 /// names fall through to the shared-library search path. Accepted spellings
 /// per module: the short name and the crate name, with `-` and `_`
 /// interchangeable — e.g. `"jwt"`, `"ephpm-middleware-jwt"`,
-/// `"ephpm_middleware_jwt"`. (`"ratelimit"` also answers to `"rate-limit"`.)
+/// `"ephpm_middleware_jwt"`. (`"ratelimit"` also answers to `"rate-limit"`,
+/// and `"basic-auth"` to `"basicauth"`.)
 #[must_use]
 pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
     let canonical = name.replace('_', "-");
@@ -107,6 +108,9 @@ pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
         }
         "security-headers" | "ephpm-middleware-security-headers" => {
             BuiltinModule::init::<ephpm_middleware_builtins::security_headers::SecurityHeaders>
+        }
+        "basic-auth" | "basicauth" | "ephpm-middleware-basicauth" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::basicauth::BasicAuth>
         }
         _ => return None,
     })
@@ -714,6 +718,11 @@ mod tests {
             "ephpm_middleware_ratelimit",
             "ephpm-middleware-security-headers",
             "ephpm_middleware_security_headers",
+            "basic-auth",
+            "basic_auth",
+            "basicauth",
+            "ephpm-middleware-basicauth",
+            "ephpm_middleware_basicauth",
         ] {
             assert!(builtin(name).is_some(), "\"{name}\" should resolve as builtin");
         }
@@ -855,6 +864,90 @@ mod tests {
             .parse()
             .expect("numeric Retry-After");
         assert!((1..=10).contains(&retry), "retry_after = {retry}");
+    }
+
+    /// `basic-auth` through the real chain: 401 with the RFC 7617 challenge
+    /// when nothing is presented, 200-path CONTINUE when the credential is
+    /// right, and — the composition the guide documents — `ratelimit` at a
+    /// lower `order` turning a client away with 429 *before* `basic-auth`
+    /// spends a KDF on it.
+    #[test]
+    fn builtin_basic_auth_chains_with_ratelimit_by_order() {
+        wire_kv();
+        // `MIN_ITERATIONS` keeps the test fast; the shipped default is 100k.
+        let hash = ephpm_middleware_builtins::password_hash::PasswordHash::generate(
+            "preview-pw",
+            ephpm_middleware_builtins::password_hash::MIN_ITERATIONS,
+        )
+        .expect("hash")
+        .to_phc_string();
+
+        let mounts = vec![
+            builtin_mount(
+                "ratelimit",
+                None,
+                10,
+                serde_json::json!({ "per_ip_rps": 1, "burst": 0 }),
+            ),
+            builtin_mount(
+                "basic-auth",
+                None,
+                20,
+                serde_json::json!({ "users": { "dev": hash }, "realm": "Preview" }),
+            ),
+        ];
+        let chain = MiddlewareChain::load(&mounts).expect("basic-auth loads from the registry");
+        assert_eq!(chain.module_names(), ["ratelimit", "basic-auth"]);
+
+        let vhost = "vhost-basicauth-chain";
+        let ctx = |headers: &[(String, String)]| {
+            RequestCtx::new("GET", "/index.php", "", "198.51.100.9", vhost, headers)
+                .with_https(true)
+        };
+
+        // No credentials: 401 carrying the challenge. PHP never runs.
+        match chain.evaluate(&ctx(&[]), "/index.php") {
+            ChainVerdict::Respond { status, headers, .. } => {
+                assert_eq!(status, 401);
+                assert_eq!(
+                    find_header(&headers, "WWW-Authenticate"),
+                    Some("Basic realm=\"Preview\", charset=\"UTF-8\"")
+                );
+            }
+            ChainVerdict::Continue { .. } => {
+                panic!("an unauthenticated request must not reach PHP")
+            }
+        }
+
+        // Correct credentials: the chain continues to PHP dispatch.
+        let encoded = {
+            use base64ct::Encoding as _;
+            base64ct::Base64::encode_string(b"dev:preview-pw")
+        };
+        let auth = [("Authorization".to_owned(), format!("Basic {encoded}"))];
+        assert!(
+            matches!(chain.evaluate(&ctx(&auth), "/index.php"), ChainVerdict::Continue { .. }),
+            "a correct credential must continue to PHP"
+        );
+
+        // Keep going and `ratelimit` (order 10) trips first: 429, not 401, so
+        // brute-force protection is genuinely a chain decision.
+        let mut limited = None;
+        for _ in 0..40 {
+            if let ChainVerdict::Respond { status, headers, .. } =
+                chain.evaluate(&ctx(&[]), "/index.php")
+                && status == 429
+            {
+                limited = Some(headers);
+                break;
+            }
+        }
+        let headers = limited.expect("ratelimit never tripped ahead of basic-auth");
+        assert!(find_header(&headers, "Retry-After").is_some());
+        assert!(
+            find_header(&headers, "WWW-Authenticate").is_none(),
+            "the 429 is ratelimit's response — basic-auth must not have run"
+        );
     }
 
     #[test]

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -2400,7 +2400,11 @@ impl Router {
                 &remote_addr.ip().to_string(),
                 &server_name,
                 &headers,
-            );
+            )
+            // The router's resolved HTTPS determination, not the raw socket
+            // state: `is_https` already went through `resolve_proxy_info`, so
+            // a module sees exactly what PHP sees in `$_SERVER['HTTPS']`.
+            .with_https(is_https);
             match chain.evaluate(&ctx, &path) {
                 crate::middleware::ChainVerdict::Respond { status, body, headers } => {
                     return middleware_response(status, body, &headers);

--- a/crates/ephpm-server/tests/middleware_dlopen.rs
+++ b/crates/ephpm-server/tests/middleware_dlopen.rs
@@ -3,7 +3,7 @@
 //! resolutions, the ABI major-version handshake, and `init`/`invoke`/
 //! `shutdown` across the C boundary.
 //!
-//! Why this file exists: the four in-tree modules are well covered, but they
+//! Why this file exists: the five in-tree modules are well covered, but they
 //! all take the *static registry* path (`Backend::Builtin`), which never
 //! touches dlopen. The dynamic lane — the one the docs promise "works out of
 //! the box with the stock release binaries on every platform" — had no

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -25,6 +25,10 @@ clap.workspace = true
 ephpm-config.workspace = true
 ephpm-db.workspace = true
 ephpm-kv.workspace = true
+# `ephpm hash-password` mints credentials for the basic-auth middleware
+# through the same PBKDF2 code the middleware verifies with — a second
+# implementation here would be a way for the two to silently disagree.
+ephpm-middleware-builtins.workspace = true
 ephpm-php.workspace = true
 ephpm-server.workspace = true
 # mimalloc as the global allocator for the ephpm binary. Non-Windows only.
@@ -50,6 +54,7 @@ ephpm-server.workspace = true
 # `run_with_config`), because a predictable path under a shared /tmp is
 # attacker-plantable.
 tempfile = "3"
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -127,6 +127,30 @@ enum Commands {
         subcommand: KvSubcommand,
     },
 
+    /// Hash a password for the `basic-auth` middleware
+    ///
+    /// Prints a PBKDF2-HMAC-SHA256 hash in the form the middleware's `users`
+    /// table and its KV credential documents expect. The password is read
+    /// from stdin so it never reaches your shell history or the process list.
+    ///
+    ///   echo -n 'my-password' | ephpm hash-password
+    HashPassword {
+        /// PBKDF2 iteration count. Higher is slower to verify and slower to
+        /// crack; clamped into the range the middleware will accept.
+        #[arg(long, default_value_t = ephpm_middleware_builtins::password_hash::DEFAULT_ITERATIONS)]
+        iterations: u32,
+
+        /// Print `<user>:<hash>` instead of the bare hash.
+        #[arg(long)]
+        user: Option<String>,
+
+        /// Print a ready-to-store JSON credential document
+        /// (`{"<user>":"<hash>"}`) for the middleware's `kv_prefix` lookup.
+        /// Requires --user.
+        #[arg(long, requires = "user")]
+        json: bool,
+    },
+
     /// Install ephpm as a system service and start it
     Install,
 
@@ -304,11 +328,52 @@ fn main() -> ExitCode {
     }
 }
 
+/// `ephpm hash-password` — mint a credential for the `basic-auth` middleware.
+///
+/// The password comes from **stdin**, not an argument: an argument would land
+/// in shell history and, on Unix, in every other process's view of the
+/// command line for as long as this runs. A single trailing newline is
+/// stripped so `echo 'pw' | ephpm hash-password` and
+/// `echo -n 'pw' | ephpm hash-password` agree; any other whitespace is part
+/// of the password.
+fn run_hash_password(iterations: u32, user: Option<&str>, json: bool) -> anyhow::Result<ExitCode> {
+    use std::io::Read as _;
+
+    let mut password = String::new();
+    std::io::stdin()
+        .read_to_string(&mut password)
+        .context("failed to read the password from stdin")?;
+    // Exactly one trailing newline (and its CR on Windows), nothing more.
+    let password = password.strip_suffix('\n').unwrap_or(&password);
+    let password = password.strip_suffix('\r').unwrap_or(password);
+    anyhow::ensure!(
+        !password.is_empty(),
+        "no password on stdin — pipe one in, e.g. `echo -n 'my-password' | ephpm hash-password`"
+    );
+
+    let hash =
+        ephpm_middleware_builtins::password_hash::PasswordHash::generate(password, iterations)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    match (user, json) {
+        (Some(user), true) => {
+            let doc = serde_json::json!({ user: hash.to_phc_string() });
+            println!("{doc}");
+        }
+        (Some(user), false) => println!("{user}:{hash}"),
+        (None, _) => println!("{hash}"),
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
 fn run() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
 
     match cli.command {
         Some(Commands::Php { args }) => run_php(&php_cli_args(&args)),
+        Some(Commands::HashPassword { iterations, user, json }) => {
+            run_hash_password(iterations, user.as_deref(), json)
+        }
         Some(Commands::Kv { host, port, password, user, subcommand }) => {
             let auth = KvAuth::resolve(user, password)?;
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
@@ -2042,6 +2107,45 @@ mod disable_functions_tests {
 #[cfg(test)]
 mod cli_tests {
     use super::*;
+
+    #[test]
+    fn parses_hash_password_defaults() {
+        let cli = Cli::try_parse_from(["ephpm", "hash-password"]).unwrap();
+        match cli.command {
+            Some(Commands::HashPassword { iterations, user, json }) => {
+                assert_eq!(
+                    iterations,
+                    ephpm_middleware_builtins::password_hash::DEFAULT_ITERATIONS
+                );
+                assert_eq!(user, None);
+                assert!(!json);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_hash_password_flags() {
+        let args = ["ephpm", "hash-password", "--iterations", "50000", "--user", "dev", "--json"];
+        let cli = Cli::try_parse_from(args).unwrap();
+        match cli.command {
+            Some(Commands::HashPassword { iterations, user, json }) => {
+                assert_eq!(iterations, 50_000);
+                assert_eq!(user.as_deref(), Some("dev"));
+                assert!(json);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hash_password_json_requires_a_user() {
+        // `--json` alone would print `{"":"<hash>"}`, which is not a usable
+        // credential document — clap rejects it instead.
+        let err = Cli::try_parse_from(["ephpm", "hash-password", "--json"]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--user"), "expected a requires error, got: {msg}");
+    }
 
     #[test]
     fn parses_install_subcommand() {

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -16,10 +16,10 @@ counter is a single `kv_incr`.
 
 There are **two ways a module runs**:
 
-- **Built-in (static registry).** Four modules — `jwt`, `cors`,
-  `ratelimit`, `security-headers` — are compiled into **every** ePHPm
-  binary. `library = "jwt"` just works: no shared library on disk, no
-  `dlopen`, no special build.
+- **Built-in (static registry).** Five modules — `jwt`, `cors`,
+  `ratelimit`, `security-headers`, `basic-auth` — are compiled into
+  **every** ePHPm binary. `library = "jwt"` just works: no shared library on
+  disk, no `dlopen`, no special build.
 - **Dynamic (shared library).** Custom out-of-tree modules are `.so` /
   `.dylib` / `.dll` files speaking a small, versioned C ABI, loaded once at
   startup via `dlopen` (`LoadLibrary` on Windows). This works out of the
@@ -185,7 +185,7 @@ chain sees everything — static, dynamic, and error paths alike.
 
 ## The built-in modules
 
-All four are compiled into every ePHPm binary and run in-process — the
+All five are compiled into every ePHPm binary and run in-process — the
 sections below apply identically whether you mount them by short name
 (built-in) or dlopen their cdylib builds on a dynamic binary.
 
@@ -276,6 +276,201 @@ Note this is a *fixed-window* limiter (a full window's allowance can be
 consumed instantly at a window boundary), and it is distinct from the
 built-in connection-level limiter in `[server.limits]` — the two are
 independent.
+
+### `basic-auth`
+
+HTTP Basic authentication (RFC 7617) in front of PHP. Gates a **whole site**
+rather than a route: an unauthenticated request is answered with `401` from
+native code and never reaches the interpreter.
+
+| key | default | meaning |
+|-----|---------|---------|
+| `users` (table) | `{}` | static `username = "<hash>"` table, applied to every vhost |
+| `kv_prefix` (string) | unset | look up `<kv_prefix><vhost>` in the KV store for a per-site credential table |
+| `realm` (string) | `"Restricted"` | `WWW-Authenticate` realm. Must not be empty or contain `"`, `\` or control characters |
+| `require_https` (string) | `"warn"` | `"enforce"` / `"warn"` / `"off"` — what a non-HTTPS request gets |
+| `missing_credentials` (string) | `"deny"` | `"deny"` / `"allow"` — what a vhost with no credential table gets |
+| `forward_user_header` (string) | unset | on success, set this request header to the authenticated username |
+| `cache_ttl_secs` (integer) | `300` | how long a successful verification is remembered; `0` disables the cache |
+| `cache_max_entries` (integer) | `4096` | hard ceiling on cached verifications |
+
+At least one of `users` or `kv_prefix` is **required** — a mount with no
+credential source can never authenticate anyone, so it fails startup rather
+than locking the site out silently.
+
+#### Passwords are stored hashed
+
+Both sources hold **PBKDF2-HMAC-SHA256** hashes, never plaintext. Mint one
+with `ephpm hash-password`, which reads the password from stdin so it never
+lands in shell history:
+
+```bash
+$ echo -n 'preview-pw' | ephpm hash-password
+$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…
+```
+
+```toml
+[[middleware]]
+library = "basic-auth"
+order   = 20
+config  = { realm = "Staging", users = { dev = "$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…" } }
+```
+
+A value that is not a valid hash is a **startup error**. There is no
+plaintext fallback, so a mistyped credential fails loudly instead of
+silently weakening the gate.
+
+Verification uses `aws-lc-rs`'s constant-time `pbkdf2::verify`. An unknown
+username still performs a full derivation against a decoy, so response
+latency does not reveal which usernames exist.
+
+#### Per-site credentials for preview hosting
+
+`[[middleware]]` mounts match on **path glob only** — there is no host
+matcher — so per-site credentials come from a single global mount that
+resolves them at request time. Set `kv_prefix` and write one KV key per
+site:
+
+```toml
+[[middleware]]
+library = "basic-auth"
+order   = 20
+config  = { kv_prefix = "basicauth:", realm = "Preview" }
+```
+
+```bash
+# Lock preview-42.example.com; the value is a JSON credential table.
+$ echo -n 'preview-pw' | ephpm hash-password --user dev --json
+{"dev":"$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…"}
+
+$ ephpm kv set 'basicauth:preview-42.example.com' '{"dev":"$pbkdf2-sha256$…"}'
+```
+
+The key is `<kv_prefix>` plus the request's vhost identity (its server name),
+**normalised**: lowercased, with the port and any trailing FQDN-root dot
+stripped. `Host` is case-insensitive and client-controlled, so
+`Host: Preview-42.Example.com` resolves to the same credential as
+`preview-42.example.com`.
+
+Creating and deleting a preview is two KV writes — no `ephpm.toml` edit, no
+restart. **Deleting the key revokes access on the very next request**: the
+verification cache commits to the stored hash, so rotating or removing a
+credential invalidates its cache entry immediately. `cache_ttl_secs` bounds
+memory, not revocation.
+
+When both sources are configured, a vhost's KV entry **replaces** the static
+`users` table — it does not merge with it. A KV document that fails to parse
+is logged and treated as no credentials at all; it never falls back to the
+static table, which would silently open the site to whoever holds the global
+credential.
+
+The middleware's KV callbacks read the **process-global** store (issue
+#376), not the per-vhost store PHP's `ephpm_kv_*` sees. For an operator
+credential store that is the property you want: in `sites_dir` mode a tenant
+cannot read or rewrite its own credential from PHP.
+
+> **Seeding the credential store in `sites_dir` mode.** With
+> `[server] sites_dir` set and `[kv.redis_compat] enabled = true`, ePHPm
+> requires `[kv] secret` and the RESP listener then scopes **every**
+> authenticated connection to a single site's store (`AUTH <host>
+> <derived>`). There is currently no RESP path to the process-global store
+> that this middleware reads, so `ephpm kv set` cannot seed it in
+> multi-tenant mode — see issue #384. Until that is addressed, KV-sourced
+> credentials are usable in single-site mode; multi-tenant deployments must
+> use the static `users` table.
+
+#### Marking a managed site public
+
+Write the exact value `public` (not JSON) instead of a credential table:
+
+```bash
+$ ephpm kv set 'basicauth:open-preview.example.com' public
+OK
+```
+
+That lets one mount front a fleet mixing public and private previews while
+keeping the fail-closed `missing_credentials = "deny"` default. The marker is
+deliberately an exact literal rather than "an empty credential table": a
+control plane that writes an empty or truncated document through a *bug* must
+fail closed, and it does — `{}`, `""`, `PUBLIC` and `publicX` are all
+rejected, not read as public.
+
+#### Unconfigured sites: `missing_credentials`
+
+`"deny"` (the default) answers `403` for a vhost with no credential table —
+an unconfigured site is not an open site. It deliberately carries **no**
+`WWW-Authenticate` header, because no credential could ever satisfy it.
+
+`"allow"` passes such a vhost through to PHP unauthenticated.
+
+> **`"allow"` trusts the `Host` header.** The vhost identity comes from the
+> request's `Host`, which the client controls. Under `"allow"`, a request
+> carrying a `Host` that has no credential entry is served **unauthenticated** —
+> so on a deployment where an unrecognised `Host` still reaches content (any
+> single-site deployment, and `sites_dir` deployments where an unmatched host
+> falls back to `[server] document_root`), `curl -H 'Host: anything.invalid'`
+> bypasses the gate entirely.
+>
+> Prefer the `public` marker above, which keeps the default `"deny"`. If you
+> do need `"allow"`, constrain the accepted hosts with
+> [`[server.request] trusted_hosts`](/reference/config/) so an unrecognised
+> `Host` is rejected with `421` before the chain runs.
+
+#### `require_https`, and why it defaults to `warn`
+
+Basic sends base64, which is not encryption, so the honest thing would be to
+refuse on plain HTTP. The problem is that **ePHPm cannot always tell**.
+`require_https` is evaluated against the same determination PHP sees in
+`$_SERVER['HTTPS']`, which honours `X-Forwarded-Proto` **only** from a peer
+inside [`[server.security] trusted_proxies`](/reference/config/). ePHPm
+behind a TLS-terminating proxy with no `trusted_proxies` configured
+therefore reports "not HTTPS" for traffic that reached the proxy over
+HTTPS — a very common and perfectly secure deployment.
+
+Defaulting to `"enforce"` would `403` those deployments, and the natural
+operator response would be to switch the check off entirely. So:
+
+| value | behaviour on a request that is not HTTPS |
+|-------|------------------------------------------|
+| `"warn"` (default) | issue the challenge, log a throttled warning naming the vhost (at most one line per minute) |
+| `"enforce"` | `403` with **no** `WWW-Authenticate` header — refuse to invite credentials onto a channel we believe is cleartext |
+| `"off"` | issue the challenge, log nothing |
+
+Once TLS terminates at ePHPm, or the terminating proxy is listed in
+`trusted_proxies`, set `require_https = "enforce"`.
+
+#### Brute force: compose with `ratelimit`
+
+A failed password always pays the full KDF — successes are cached, failures
+never are — so guessing is expensive by construction. Bound it properly by
+mounting `ratelimit` at a **lower `order`** so it runs first:
+
+```toml
+[[middleware]]
+library = "ratelimit"
+order   = 10
+config  = { per_ip_rps = 2, burst = 10 }
+
+[[middleware]]
+library = "basic-auth"
+order   = 20
+config  = { kv_prefix = "basicauth:", realm = "Preview" }
+```
+
+An over-budget client gets `429` before `basic-auth` spends any CPU on it.
+Note `ratelimit`'s own per-node caveat above.
+
+#### Forwarding the authenticated user
+
+`forward_user_header = "X-Auth-User"` makes a successful request REWRITE
+with that request header set to the verified username, readable from PHP as
+`$_SERVER['HTTP_X_AUTH_USER']`. Header overrides **replace** any same-named
+header the client sent, so a forged value cannot survive.
+
+> ePHPm's SAPI does not currently populate `PHP_AUTH_USER` / `PHP_AUTH_PW` /
+> `AUTH_TYPE` (issue #386). `forward_user_header` is the supported way to get
+> the authenticated identity into PHP today. The raw header is still visible
+> as `$_SERVER['HTTP_AUTHORIZATION']`.
 
 ## The dynamic lane
 
@@ -376,9 +571,13 @@ cargo build --release -p my-auth
 
 The artifact lands at `target/release/lib<crate_name>.so`; a bare
 `library = "<crate_name>"` mount finds the `lib<name>.so` form through
-the search path. The four in-tree modules build exactly the same way
+the search path. The five in-tree modules build exactly the same way
 (`-p ephpm-middleware-jwt -p ephpm-middleware-cors
--p ephpm-middleware-ratelimit -p ephpm-middleware-security-headers`).
+-p ephpm-middleware-ratelimit -p ephpm-middleware-security-headers
+-p ephpm-middleware-basicauth`). The `basicauth` cdylib is noticeably
+larger than the others — it statically links `aws-lc-rs` for PBKDF2, which
+the ePHPm binary already carries and shares. Prefer the built-in lane
+unless you specifically need a loadable module.
 
 Build on a distro whose glibc is not newer than the deployment target's
 (the usual glibc forward-compatibility rule — a module built on Debian 12

--- a/site/content/reference/cli/_index.md
+++ b/site/content/reference/cli/_index.md
@@ -174,6 +174,39 @@ $ ephpm kv del counter temp
 
 ---
 
+## `ephpm hash-password`
+
+Mint a credential for the [`basic-auth` middleware](/guides/native-middleware/#basic-auth). Prints a PBKDF2-HMAC-SHA256 hash in the form the middleware's `users` table and its KV credential documents expect.
+
+The password is read from **stdin**, never from an argument — an argument would land in shell history and, on Unix, in every other process's view of the command line. Exactly one trailing newline is stripped; any other whitespace is part of the password.
+
+```bash
+ephpm hash-password [--iterations <N>] [--user <NAME>] [--json]
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--iterations <N>` | `100000` | PBKDF2 iteration count. Clamped into the range the middleware accepts (1 000–5 000 000) |
+| `--user <NAME>` | — | Print `<user>:<hash>` instead of the bare hash |
+| `--json` | off | Print a ready-to-store JSON credential document `{"<user>":"<hash>"}`. Requires `--user` |
+
+```bash
+# Bare hash — paste into a `users` table in ephpm.toml
+$ echo -n 'preview-pw' | ephpm hash-password
+$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…
+
+# JSON document — write straight into the KV store for a per-site credential
+$ echo -n 'preview-pw' | ephpm hash-password --user dev --json
+{"dev":"$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…"}
+
+$ ephpm kv set 'basicauth:preview-42.example.com' '{"dev":"$pbkdf2-sha256$…"}'
+OK
+```
+
+The iteration count is stored **inside** the hash, so raising `--iterations` for new credentials does not invalidate existing ones and needs no config change.
+
+---
+
 ## Service Lifecycle
 
 Install and manage ePHPm as a system service — systemd on Linux, launchd on macOS, SCM on Windows.
@@ -236,6 +269,7 @@ ephpm serve          Start the production server (--config/--listen/--document-r
 ephpm dev            Development server (--port/--document-root/--sites)
 ephpm php            Run the embedded PHP CLI (pure passthrough)
 ephpm kv             KV store client (keys/get/set/del/incr/ttl/ping)
+ephpm hash-password  Hash a password for the basic-auth middleware (reads stdin)
 
 ephpm install        Install + start the system service
 ephpm uninstall      Remove the system service (--keep-data)

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -572,8 +572,9 @@ and the membership check is per-host and trusts the TCP source address.
 ## `[[middleware]]`
 
 Native middleware mounts — repeatable array-of-tables. Each mount resolves
-against the **builtin registry first**: the four in-tree modules (`jwt`,
-`cors`, `ratelimit`, `security-headers`) are compiled into every binary and
+against the **builtin registry first**: the five in-tree modules (`jwt`,
+`cors`, `ratelimit`, `security-headers`, `basic-auth`) are compiled into
+every binary and
 run in-process — no shared library on disk, no `dlopen`. Any other name
 loads a shared library (`.so`/`.dylib`/`.dll`) at startup. Loading is
 fail-fast: a builtin rejecting its config, an unresolvable library, a
@@ -593,7 +594,7 @@ at startup) — see the guide's
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
+| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `basic-auth`/`basicauth`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
 | `match` | string | (none) | Glob the request path must match for the mount to run. `*` matches any character sequence, including `/`. Unset = every PHP-bound request. |
 | `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. |
 | `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init`. |


### PR DESCRIPTION
## Why

There is no Basic auth anywhere in ePHPm today — the only auth middleware is `jwt` (Bearer/HS256). The driving case is preview hosting: a per-PR preview of a **private** repository must not be publicly readable, the credential has to appear and disappear with the preview, and an unauthorised request must never reach the interpreter. Because it gates a whole site rather than a route, it belongs in the middleware chain, where a `RESPOND` verdict short-circuits before the body is read and before PHP dispatch.

Adds `basic-auth` as a compiled-in builtin (fifth in the static registry), plus a `hash-password` CLI subcommand, plus one small ABI addition.

## Where credentials come from

`MiddlewareMount` matches on **path glob only** — there is no host or site matcher — so a single global mount resolves credentials at request time:

| source | shape | for |
|---|---|---|
| `users` | `{ dev = "$pbkdf2-sha256$…" }` in the mount config | single-site |
| `kv_prefix` | KV key `<kv_prefix><vhost>` holding the same JSON object | per-PR previews: one key per site, no `ephpm.toml` edit, no restart |

A KV entry replaces the static table for that vhost rather than merging. A document that fails to parse is logged and treated as *no* credentials — it never falls back to the static table, which would silently open the site to whoever holds the global credential.

The middleware's KV callbacks read the **process-global** store (#376), not the per-vhost store PHP's `ephpm_kv_*` sees. For an operator credential store that is exactly the property you want: in `sites_dir` mode a tenant cannot read or rewrite its own credential from PHP. This relies on #376's current semantics deliberately and does not change them.

## Hashes, not plaintext

Both sources hold **PBKDF2-HMAC-SHA256** in a PHC-style string. A value that is not a valid hash is a **startup error** — there is no plaintext fallback to accidentally depend on.

`aws-lc-rs` supplies the KDF. It is already in the dependency graph (rustls-acme's crypto provider; ephpm-db's RSA-OAEP for `caching_sha2_password`), so this adds **zero** new crates — `Cargo.lock` gains only the new workspace member and edges to crates already present, and `cargo deny` has nothing new to weigh. That was the deciding factor over adding `argon2`/`bcrypt`.

A plain keyed hash (`derive_site_password`'s HMAC-SHA256 shape) would have been cheaper and is fine for the generated high-entropy passwords a control plane issues — but not for the human-chosen password an operator types into `ephpm.toml`, which is the other half of the audience. Hence the slow KDF, with the per-request cost handled by caching.

The iteration count travels **inside** the hash, so raising it for new credentials neither invalidates old ones nor needs a config change. Parsing enforces `1_000..=5_000_000`: a stored hash is attacker-controlled data the moment a credential store is writable, and `i=4000000000` would otherwise be a one-line DoS.

## Constant-time comparison, and what that actually buys

Verification is `aws_lc_rs::pbkdf2::verify`, which derives into a scratch buffer, compares with `constant_time::verify_slices_are_equal`, and zeroizes. The code never holds the stored key and a freshly derived key as two comparable values, so there is no `==` for a later edit to reach for.

**On "a test that would fail if someone swapped in `==`":** I did not ship one, because for this shape it cannot be honest. Comparing two 32-byte digests with `memcmp` versus in constant time differs by nanoseconds and is not remotely resolvable over HTTP; worse, an attacker cannot iteratively refine a PBKDF2 digest they do not control. A test asserting that difference would be flaky theatre.

The oracle that *is* real here is **user enumeration** — an early return on "no such user" makes an unknown username measurably faster than a known one with a wrong password. That is deterministic and testable, so it is what the test asserts:

```rust
assert_eq!(
    known_user_cost, unknown_user_cost,
    "an unknown username must perform the same number of derivations as a known one …"
);
```

An unknown username burns a full derivation against a decoy built at init from OS entropy. `unknown_user_costs_the_same_kdf_work_as_a_known_one` fails the moment anyone "optimises" the miss path — which is the realistic way this protection gets lost. A missing `Authorization` header deliberately costs *no* KDF: there is no secret to compare, and spending one would hand an unauthenticated client a CPU amplifier.

## Caching, and why revocation is still immediate

A KDF worth using is too slow to run per request, so successful verifications are cached keyed by `HMAC(per-process key, vhost ‖ user ‖ password ‖ stored hash)`.

Because the key commits to the **stored hash**, rotating or removing a credential invalidates its entry immediately — `cache_ttl_secs` bounds memory, not revocation. Failures are never cached, so brute force pays the full KDF every time. The map is bounded (`cache_max_entries`, purge-then-skip rather than grow).

## Two hazards found while building this

**1. The vhost identity is the raw `Host` header.** `request_vhost_id` is the router's `SERVER_NAME` — port stripped, but **neither lowercased nor stripped of a trailing dot**. Used raw as a lookup key, `Host: Site.Example` and `Host: site.example` hash to different KV keys, so a private site's credential is simply not found. Under `missing_credentials = "allow"` that is an authentication bypass by changing one letter's case. The key is now normalised the same way `normalize_host_key` normalises every other host-keyed lookup, and `vhost_lookup_is_case_and_trailing_dot_insensitive` pins it — confirmed live against a real server.

**2. `missing_credentials = "allow"` trusts a client-controlled header.** Rather than leave that as the only way to run a mixed public/private fleet, an explicit `public` marker value keeps the fail-closed `"deny"` default usable:

```bash
ephpm kv set 'basicauth:open-preview.example.com' public
```

It is an exact literal, not "an empty credential table", so a control plane writing an empty or truncated document through a bug fails **closed** — `{}`, `""`, `PUBLIC` and `publicX` are all rejected. `"allow"` remains available and its `Host`-forgery hazard is now documented in full, pointing at `trusted_hosts`.

## `require_https` defaults to `warn`, deliberately

Basic sends base64, which is not encryption, so the instinct is to refuse on plain HTTP. The problem is that **ePHPm cannot always tell.** The check runs against the same determination PHP sees in `$_SERVER['HTTPS']`, which honours `X-Forwarded-Proto` only from a peer inside `[server.security] trusted_proxies`. Behind a TLS-terminating proxy that is not configured there, ePHPm reports "not HTTPS" for traffic that reached the proxy over HTTPS — a common, perfectly secure deployment.

Defaulting to `enforce` would 403 those deployments, and the natural operator response is to switch the check off entirely, which is strictly worse than warning.

| value | behaviour on a non-HTTPS request |
|---|---|
| `warn` (default) | issue the challenge; log a throttled warning naming the vhost (≤1/min) |
| `enforce` | **403 with no `WWW-Authenticate`** — refuse to invite credentials onto a channel we believe is cleartext |
| `off` | issue the challenge, say nothing |

The `enforce` body names `trusted_proxies` so the operator gets the fix, not just the refusal.

## Composability

Brute-force protection is a config decision, not a reimplementation — mount `ratelimit` at a lower `order`:

```toml
[[middleware]]
library = "ratelimit"
order = 10
config = { per_ip_rps = 2, burst = 10 }

[[middleware]]
library = "basic-auth"
order = 20
config = { kv_prefix = "basicauth:", realm = "Preview" }
```

`builtin_basic_auth_chains_with_ratelimit_by_order` asserts the over-budget client gets `429` **without** a `WWW-Authenticate` header — i.e. `basic-auth` never ran and spent no KDF.

## ABI change

`request_is_https` appended to the end of `EphpmHostV1` — compatible under the same major, per the table's documented growth rule (older modules never read past offsets they know). `RequestCtx` gains `with_https()` as a **builder** rather than a `new()` parameter, so every existing caller — including #375's example — keeps compiling untouched.

## Config

| key | default | meaning |
|---|---|---|
| `users` | `{}` | static username → hash table |
| `kv_prefix` | unset | KV lookup at `<kv_prefix><vhost>` |
| `realm` | `"Restricted"` | `WWW-Authenticate` realm; no `"`, `\` or control chars |
| `require_https` | `"warn"` | `enforce` / `warn` / `off` |
| `missing_credentials` | `"deny"` | `deny` / `allow` |
| `forward_user_header` | unset | REWRITE this request header to the authenticated username |
| `cache_ttl_secs` | `300` | `0` disables the cache |
| `cache_max_entries` | `4096` | hard ceiling |

Per `add-config-knob`: every knob is read and enforced in this PR (no silent no-ops), tests cover both "key present" and "key absent", and the docs land here. Startup **fails** when neither `users` nor `kv_prefix` is set — a mount that can never authenticate anyone is a config error, not a locked door.

## `ephpm hash-password`

Mints credentials through the same code the middleware verifies with — a second implementation would be a way for the two to silently disagree. Password comes from **stdin**, never an argument (shell history; `/proc/*/cmdline`).

```bash
$ echo -n 'preview-pw' | ephpm hash-password
$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…

$ echo -n 'preview-pw' | ephpm hash-password --user dev --json
{"dev":"$pbkdf2-sha256$i=100000$Xy9k…$Qm5s…"}
```

## Verified, not just compiled

A freshly built PHP-linked `ephpm.exe` (PHP 8.5.7, `x86_64-pc-windows-msvc`, timestamp checked against the build to rule out a stale artifact from the shared target dir) served real HTTP through the chain. **44 checks across three server configurations, 0 failures.**

Scenario A — single-site + KV credentials, `ratelimit` + `basic-auth` mounted (29 checks):

```
INFO ephpm_server::middleware: middleware initialised (builtin)
     module=basic-auth describe=basic-auth 0.1.0 (HTTP Basic authentication)
INFO ephpm_server: middleware chain loaded count=2 modules=["ratelimit", "basic-auth"]
```

| what | result |
|---|---|
| no credentials | `401` + `www-authenticate: Basic realm="Preview", charset="UTF-8"` |
| …and **no `x-powered-by`**, no `PHP_RAN` in the body | PHP genuinely never ran |
| wrong password / unknown user / malformed base64 / `Bearer` | `401`, still no `x-powered-by` |
| correct password | `200`, `PHP_RAN=yes`, `X_AUTH_USER=alice` |
| `b.example` with alice's credential | `401` (per-vhost isolation) |
| `Host: A.EXAMPLE` | gated, and accepts alice — the normalisation fix |
| `open.example` marked `public` | `200` |
| unmanaged host | `403`, no challenge, no `x-powered-by` |
| forged `X-Auth-User: admin` + valid creds | PHP sees `X_AUTH_USER=alice` |
| `kv del` the credential | next request `403` — no cache window |
| rotate the hash | old password `401`, new password `200`, immediately |
| ~29 plain-HTTP requests | exactly **1** warning line (throttle works) |

Scenario B — `sites_dir` multi-tenant + static `users` (10 checks): each vhost gated independently, each served its own document root (`SITE=a.example` / `SITE=b.example`) once authenticated, unmatched host still gated.

Scenario C — `require_https = "enforce"` over plain HTTP (5 checks): `403`, **no** `WWW-Authenticate`, no `x-powered-by`, body names `trusted_proxies`, and correct credentials are still `403`.

Unit tests: 71 in `ephpm-middleware-builtins` (31 new), plus the chain and registry tests in `ephpm-server`.

### Explicitly not verified

- **Linux/macOS.** Platform-agnostic Rust, no `cfg`, but this transcript is Windows only.
- **Clustered KV.** Credentials replicate by construction when KV replication is on; single node in practice here.
- **The `basicauth` cdylib on the dlopen lane.** The builtin lane is what every deployment uses; the shell is built for symmetry and is documented as larger than its siblings (it statically links `aws-lc-rs`, which the ePHPm binary already carries and shares).

## Two gaps found, filed rather than smuggled in

**#384 — no RESP path to the process-global KV store in multi-tenant mode.** With `sites_dir` + `[kv.redis_compat]`, `[kv] secret` is required and `handle_auth` then takes the HMAC branch *exclusively*: a one-arg `AUTH <password>` is rejected, so every connection is scoped to one site's store. The middleware reads the global store, so `ephpm kv set` cannot seed it there. KV-sourced credentials therefore work in single-site mode today; multi-tenant needs the static `users` table. **This is documented in the guide as a limitation rather than papered over** — the alternative was shipping a documented workflow that silently does nothing.

**#386 — the SAPI does not populate `PHP_AUTH_USER` / `PHP_AUTH_PW` / `AUTH_TYPE`.** Kept out of this PR as asked. It turned out to be more than a small fix: doing it properly also means setting `SG(request_info).auth_user` in `ephpm_wrapper.c` at both dispatch sites (otherwise extensions still see NULL), and fpm/worker currently diverge on interior NULs in a decoded credential in a way the existing equality test cannot catch. Full analysis is in the issue. `forward_user_header` covers the authenticated-identity case meanwhile.

## Relationship to #375

No overlap and no conflict. #375 adds an out-of-tree Rust example on the **dlopen** lane; this adds an in-tree module on the **builtin** lane. The one shared file is `RequestCtx`, and `with_https` is additive precisely so #375's `RequestCtx::new` calls keep compiling either merge order.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo test -p ephpm-middleware-builtins -p ephpm-middleware -p ephpm-server -p ephpm` — all pass

macOS runners are down and the Windows PHP check needs a runner that already has VS Build Tools (#377), so those legs may sit queued or flake independently of this change.
