### PR TITLE
feat(middleware): session-cookie builtin — signed session cookies with redirect-to-login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephpm-middleware-session-cookie"
+version = "0.1.0"
+dependencies = [
+ "ephpm-middleware",
+ "ephpm-middleware-builtins",
+]
+
+[[package]]
 name = "ephpm-php"
 version = "0.1.0"
 dependencies = [

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -65,7 +65,8 @@ pub struct Config {
 #[derive(Debug, Deserialize)]
 pub struct MiddlewareMount {
     /// Module to run. Checked against the builtin registry first (`jwt`,
-    /// `cors`, `ratelimit`/`rate-limit`, `security-headers` and their
+    /// `cors`, `ratelimit`/`rate-limit`, `security-headers`,
+    /// `session-cookie` and their
     /// `ephpm-middleware-*` long forms are compiled into every binary — no
     /// dlopen). Anything else is a shared library: either a bare name
     /// (resolved through the middleware search path with a platform suffix,

--- a/crates/ephpm-middleware-builtins/src/hs256.rs
+++ b/crates/ephpm-middleware-builtins/src/hs256.rs
@@ -1,0 +1,271 @@
+//! Shared HS256 token verification, used by both token-validating builtins.
+//!
+//! [`jwt`](crate::jwt) (API bearer tokens, `401` on failure) and
+//! [`session_cookie`](crate::session_cookie) (browser session cookies, `302`
+//! to a login service on failure) are deliberately separate modules — two
+//! threat models, two failure behaviours, two config surfaces. What they must
+//! **not** have separately is the verification itself: one implementation,
+//! one set of tests, no chance of one growing a weakness the other fixed.
+//!
+//! The policy is strict by construction:
+//!
+//! * the signature is checked **first**, so no unauthenticated JSON is ever
+//!   parsed;
+//! * comparison is constant-time (`hmac::Mac::verify_slice`);
+//! * `alg` is pinned to `HS256` after verification, so `alg: none` is
+//!   rejected even when the HMAC happens to match;
+//! * `exp` is **required** — a token that cannot expire is a config bug;
+//! * `nbf` is honoured when present, `iss`/`aud` when configured.
+
+use base64ct::{Base64UrlUnpadded, Encoding};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+/// An HS256 validation policy: the shared secret plus the optional
+/// registered-claim constraints. Built once at `init`.
+pub struct Hs256Policy {
+    secret: Vec<u8>,
+    issuer: Option<String>,
+    audience: Option<String>,
+}
+
+impl Hs256Policy {
+    /// Build a policy from an already-validated secret and claim constraints.
+    #[must_use]
+    pub fn new(secret: Vec<u8>, issuer: Option<String>, audience: Option<String>) -> Self {
+        Self { secret, issuer, audience }
+    }
+
+    /// Read `secret`/`issuer`/`audience` out of a mount's `config` table.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message when `secret` is missing, empty or
+    /// not a string, or when `issuer`/`audience` are present but not strings.
+    pub fn from_config(config: &serde_json::Value) -> Result<Self, String> {
+        let secret = config
+            .get("secret")
+            .ok_or("`secret` is required (HS256 shared secret)")?
+            .as_str()
+            .ok_or("`secret` must be a string")?;
+        if secret.is_empty() {
+            return Err("`secret` must not be empty".into());
+        }
+        Ok(Self::new(
+            secret.as_bytes().to_vec(),
+            opt_str(config, "issuer")?,
+            opt_str(config, "audience")?,
+        ))
+    }
+
+    /// Verify `token` against this policy at time `now` (unix seconds).
+    /// Returns the raw claims JSON on success, `None` on any failure.
+    ///
+    /// Every rejection collapses to `None` on purpose: the caller turns that
+    /// into one indistinguishable outcome, so a client cannot learn *why* a
+    /// token was refused (bad signature vs expired vs wrong audience).
+    #[must_use]
+    pub fn verify(&self, token: &str, now: u64) -> Option<String> {
+        let mut parts = token.split('.');
+        let (header_b64, payload_b64, sig_b64) = (parts.next()?, parts.next()?, parts.next()?);
+        if parts.next().is_some() {
+            return None;
+        }
+
+        // Signature first — never parse unauthenticated JSON.
+        let sig = Base64UrlUnpadded::decode_vec(sig_b64).ok()?;
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.secret).ok()?;
+        mac.update(header_b64.as_bytes());
+        mac.update(b".");
+        mac.update(payload_b64.as_bytes());
+        // Constant-time comparison via the hmac crate.
+        mac.verify_slice(&sig).ok()?;
+
+        // The signature is ours, but still pin the algorithm: HS256 only.
+        let header: serde_json::Value =
+            serde_json::from_slice(&Base64UrlUnpadded::decode_vec(header_b64).ok()?).ok()?;
+        if header.get("alg").and_then(serde_json::Value::as_str) != Some("HS256") {
+            return None;
+        }
+
+        let payload = Base64UrlUnpadded::decode_vec(payload_b64).ok()?;
+        let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+
+        // `exp` is required — a token that cannot expire is a config bug.
+        // RFC 7519 NumericDate allows non-integer values, so accept a JSON
+        // float (floored) as well as an integer rather than rejecting a valid
+        // token.
+        let exp = claims.get("exp").and_then(numeric_date)?;
+        if exp <= now {
+            return None;
+        }
+        if let Some(nbf) = claims.get("nbf")
+            && numeric_date(nbf)? > now
+        {
+            return None;
+        }
+        if let Some(expected) = &self.issuer
+            && claims.get("iss").and_then(serde_json::Value::as_str) != Some(expected.as_str())
+        {
+            return None;
+        }
+        if let Some(expected) = &self.audience {
+            let ok = match claims.get("aud") {
+                Some(serde_json::Value::String(aud)) => aud == expected,
+                Some(serde_json::Value::Array(auds)) => {
+                    auds.iter().any(|a| a.as_str() == Some(expected.as_str()))
+                }
+                _ => false,
+            };
+            if !ok {
+                return None;
+            }
+        }
+
+        String::from_utf8(payload).ok()
+    }
+}
+
+/// Read an optional non-empty string key from a mount's `config` table.
+///
+/// An absent key, JSON `null`, and the empty string all mean "unset" — the
+/// same shape every builtin's optional string knobs use.
+///
+/// # Errors
+///
+/// Returns a message when the key is present but not a string.
+pub fn opt_str(config: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
+    match config.get(key) {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
+        None | Some(serde_json::Value::Null | serde_json::Value::String(_)) => Ok(None),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+/// Read an optional boolean key, falling back to `default` when absent.
+///
+/// # Errors
+///
+/// Returns a message when the key is present but not a boolean. A security
+/// knob is never allowed to be silently mistyped into its permissive state.
+pub fn opt_bool(config: &serde_json::Value, key: &str, default: bool) -> Result<bool, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("`{key}` must be a boolean, got {other}")),
+    }
+}
+
+/// Current unix time in whole seconds (0 if the clock predates the epoch).
+#[must_use]
+pub fn now_unix() -> u64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_secs())
+}
+
+/// Parse an RFC 7519 NumericDate claim (`exp`/`nbf`) as seconds since the
+/// epoch. Accepts a JSON integer or a JSON float (floored to whole seconds,
+/// negatives rejected); returns `None` for any other JSON type. This keeps
+/// enforcement identical while tolerating the non-integer NumericDates the
+/// spec permits.
+fn numeric_date(v: &serde_json::Value) -> Option<u64> {
+    if let Some(u) = v.as_u64() {
+        return Some(u);
+    }
+    let f = v.as_f64()?;
+    // floor() keeps the "not valid until this whole second" semantics; only
+    // finite, non-negative values within u64 range map to a NumericDate.
+    if f.is_finite() && (0.0..18_446_744_073_709_551_616.0).contains(&f) {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "bounds checked: finite, in [0, u64::MAX), floored"
+        )]
+        Some(f.floor() as u64)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "test-secret-please-rotate";
+
+    /// Forge a token through the same HMAC code path the module verifies
+    /// with (independent of `Hs256Policy::verify`'s parsing).
+    pub(crate) fn sign(secret: &str, header_json: &str, claims_json: &str) -> String {
+        let h = Base64UrlUnpadded::encode_string(header_json.as_bytes());
+        let p = Base64UrlUnpadded::encode_string(claims_json.as_bytes());
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("hmac key");
+        mac.update(format!("{h}.{p}").as_bytes());
+        let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+        format!("{h}.{p}.{sig}")
+    }
+
+    fn policy() -> Hs256Policy {
+        Hs256Policy::from_config(&serde_json::json!({ "secret": SECRET })).expect("init")
+    }
+
+    fn token(claims: &str) -> String {
+        sign(SECRET, r#"{"alg":"HS256","typ":"JWT"}"#, claims)
+    }
+
+    #[test]
+    fn from_config_rejects_a_missing_or_unusable_secret() {
+        assert!(Hs256Policy::from_config(&serde_json::Value::Null).is_err());
+        assert!(Hs256Policy::from_config(&serde_json::json!({ "secret": "" })).is_err());
+        assert!(Hs256Policy::from_config(&serde_json::json!({ "secret": 42 })).is_err());
+    }
+
+    #[test]
+    fn valid_token_returns_its_claims_json() {
+        let claims = r#"{"sub":"u1","exp":2000}"#;
+        assert_eq!(policy().verify(&token(claims), 1000).as_deref(), Some(claims));
+    }
+
+    #[test]
+    fn tampering_with_any_segment_is_rejected() {
+        let good = token(r#"{"sub":"u1","exp":2000}"#);
+        let mut parts = good.split('.');
+        let (h, p, s) =
+            (parts.next().expect("h"), parts.next().expect("p"), parts.next().expect("s"));
+        // Swapped payload with a signature that no longer covers it.
+        let forged_payload = Base64UrlUnpadded::encode_string(br#"{"sub":"root","exp":2000}"#);
+        assert!(policy().verify(&format!("{h}.{forged_payload}.{s}"), 1000).is_none());
+        // Flipped last signature character.
+        let flipped = if s.ends_with('A') { "B" } else { "A" };
+        let tampered_sig = format!("{}{flipped}", &s[..s.len() - 1]);
+        assert!(policy().verify(&format!("{h}.{p}.{tampered_sig}"), 1000).is_none());
+        // Truncated signature.
+        assert!(policy().verify(&format!("{h}.{p}."), 1000).is_none());
+    }
+
+    #[test]
+    fn exp_is_mandatory_and_enforced() {
+        assert!(policy().verify(&token(r#"{"sub":"u1"}"#), 1000).is_none());
+        assert!(policy().verify(&token(r#"{"exp":1000}"#), 1000).is_none(), "exp == now expires");
+        assert!(policy().verify(&token(r#"{"exp":1001}"#), 1000).is_some());
+    }
+
+    #[test]
+    fn alg_none_is_rejected_even_with_a_valid_hmac() {
+        let t = sign(SECRET, r#"{"alg":"none"}"#, r#"{"exp":2000}"#);
+        assert!(policy().verify(&t, 1000).is_none());
+    }
+
+    #[test]
+    fn wrong_secret_is_rejected() {
+        let t = sign("other-secret", r#"{"alg":"HS256"}"#, r#"{"exp":2000}"#);
+        assert!(policy().verify(&t, 1000).is_none());
+    }
+
+    #[test]
+    fn opt_bool_rejects_a_mistyped_security_knob() {
+        assert_eq!(opt_bool(&serde_json::json!({}), "k", true), Ok(true));
+        assert_eq!(opt_bool(&serde_json::json!({ "k": false }), "k", true), Ok(false));
+        // "false" as a STRING must not be read as `true` (nor silently as
+        // false): a mistyped security knob has to fail startup.
+        assert!(opt_bool(&serde_json::json!({ "k": "false" }), "k", true).is_err());
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/jwt.rs
+++ b/crates/ephpm-middleware-builtins/src/jwt.rs
@@ -7,10 +7,16 @@
 //! claims JSON in a request header (`claims_header`) so PHP can read them
 //! without re-verifying.
 //!
-//! Verification: constant-time HMAC check (`hmac::Mac::verify_slice`), the
-//! token's `alg` must be `HS256`, `exp` is **required** and must be in the
-//! future, `nbf` is honoured when present, and `iss`/`aud` are enforced when
-//! configured.
+//! Verification lives in [`crate::hs256`] and is shared with the
+//! `session-cookie` builtin: constant-time HMAC check
+//! (`hmac::Mac::verify_slice`), the token's `alg` must be `HS256`, `exp` is
+//! **required** and must be in the future, `nbf` is honoured when present,
+//! and `iss`/`aud` are enforced when configured.
+//!
+//! This module is for **API clients**: the token arrives in a header and a
+//! failure is a `401` the caller is expected to handle. Gating a *browser*
+//! on a signed session cookie is [`crate::session_cookie`] — same crypto,
+//! different threat model and a redirect instead of a `401`.
 //!
 //! Configuration (`[[middleware]] config = { ... }`):
 //!
@@ -22,18 +28,14 @@
 //! | `header` (string) | `"Authorization"` | request header carrying the token; a `Bearer ` prefix is stripped |
 //! | `claims_header` (string) | unset | when set, REWRITE with this request header = the raw claims JSON |
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use base64ct::{Base64UrlUnpadded, Encoding};
 use ephpm_middleware::{Middleware, Request, Response};
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
+
+use crate::hs256::{Hs256Policy, now_unix, opt_str};
 
 /// JWT validation policy, built once at `init`.
 pub struct Jwt {
-    secret: Vec<u8>,
-    issuer: Option<String>,
-    audience: Option<String>,
+    /// Signature + registered-claim policy, shared with `session-cookie`.
+    policy: Hs256Policy,
     header: String,
     claims_header: Option<String>,
 }
@@ -51,117 +53,12 @@ fn strip_bearer(value: &str) -> &str {
     trimmed
 }
 
-impl Jwt {
-    /// Verify `token` against this policy at time `now` (unix seconds).
-    /// Returns the raw claims JSON on success, `None` on any failure.
-    fn verify(&self, token: &str, now: u64) -> Option<String> {
-        let mut parts = token.split('.');
-        let (header_b64, payload_b64, sig_b64) = (parts.next()?, parts.next()?, parts.next()?);
-        if parts.next().is_some() {
-            return None;
-        }
-
-        // Signature first — never parse unauthenticated JSON.
-        let sig = Base64UrlUnpadded::decode_vec(sig_b64).ok()?;
-        let mut mac = Hmac::<Sha256>::new_from_slice(&self.secret).ok()?;
-        mac.update(header_b64.as_bytes());
-        mac.update(b".");
-        mac.update(payload_b64.as_bytes());
-        // Constant-time comparison via the hmac crate.
-        mac.verify_slice(&sig).ok()?;
-
-        // The signature is ours, but still pin the algorithm: HS256 only.
-        let header: serde_json::Value =
-            serde_json::from_slice(&Base64UrlUnpadded::decode_vec(header_b64).ok()?).ok()?;
-        if header.get("alg").and_then(serde_json::Value::as_str) != Some("HS256") {
-            return None;
-        }
-
-        let payload = Base64UrlUnpadded::decode_vec(payload_b64).ok()?;
-        let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
-
-        // `exp` is required — a token that cannot expire is a config bug.
-        // RFC 7519 NumericDate allows non-integer values, so accept a JSON
-        // float (floored) as well as an integer rather than 401-ing a valid
-        // token.
-        let exp = claims.get("exp").and_then(numeric_date)?;
-        if exp <= now {
-            return None;
-        }
-        if let Some(nbf) = claims.get("nbf")
-            && numeric_date(nbf)? > now
-        {
-            return None;
-        }
-        if let Some(expected) = &self.issuer
-            && claims.get("iss").and_then(serde_json::Value::as_str) != Some(expected.as_str())
-        {
-            return None;
-        }
-        if let Some(expected) = &self.audience {
-            let ok = match claims.get("aud") {
-                Some(serde_json::Value::String(aud)) => aud == expected,
-                Some(serde_json::Value::Array(auds)) => {
-                    auds.iter().any(|a| a.as_str() == Some(expected.as_str()))
-                }
-                _ => false,
-            };
-            if !ok {
-                return None;
-            }
-        }
-
-        String::from_utf8(payload).ok()
-    }
-}
-
-/// Parse an RFC 7519 NumericDate claim (`exp`/`nbf`) as seconds since the
-/// epoch. Accepts a JSON integer or a JSON float (floored to whole seconds,
-/// negatives rejected); returns `None` for any other JSON type. This keeps
-/// enforcement identical while tolerating the non-integer NumericDates the
-/// spec permits.
-fn numeric_date(v: &serde_json::Value) -> Option<u64> {
-    if let Some(u) = v.as_u64() {
-        return Some(u);
-    }
-    let f = v.as_f64()?;
-    // floor() keeps the "not valid until this whole second" semantics; only
-    // finite, non-negative values within u64 range map to a NumericDate.
-    if f.is_finite() && (0.0..18_446_744_073_709_551_616.0).contains(&f) {
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "bounds checked: finite, in [0, u64::MAX), floored"
-        )]
-        Some(f.floor() as u64)
-    } else {
-        None
-    }
-}
-
 impl Middleware for Jwt {
     fn init(config: &serde_json::Value) -> Result<Self, String> {
-        let secret = config
-            .get("secret")
-            .ok_or("`secret` is required (HS256 shared secret)")?
-            .as_str()
-            .ok_or("`secret` must be a string")?;
-        if secret.is_empty() {
-            return Err("`secret` must not be empty".into());
-        }
-        let opt_str = |key: &str| -> Result<Option<String>, String> {
-            match config.get(key) {
-                Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
-                None | Some(serde_json::Value::Null | serde_json::Value::String(_)) => Ok(None),
-                Some(other) => Err(format!("`{key}` must be a string, got {other}")),
-            }
-        };
         Ok(Self {
-            secret: secret.as_bytes().to_vec(),
-            issuer: opt_str("issuer")?,
-            audience: opt_str("audience")?,
-            header: opt_str("header")?.unwrap_or_else(|| "Authorization".to_owned()),
-            claims_header: opt_str("claims_header")?,
+            policy: Hs256Policy::from_config(config)?,
+            header: opt_str(config, "header")?.unwrap_or_else(|| "Authorization".to_owned()),
+            claims_header: opt_str(config, "claims_header")?,
         })
     }
 
@@ -173,8 +70,7 @@ impl Middleware for Jwt {
         if token.is_empty() {
             return Response::respond(401, "missing bearer token");
         }
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
-        match self.verify(token, now) {
+        match self.policy.verify(token, now_unix()) {
             Some(claims_json) => match &self.claims_header {
                 Some(name) => Response::rewrite().header(name.as_str(), claims_json),
                 None => Response::cont(),
@@ -188,8 +84,13 @@ impl Middleware for Jwt {
 mod tests {
     #![allow(unsafe_code)] // tests build the FFI Request view by hand.
 
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use base64ct::{Base64UrlUnpadded, Encoding};
     use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND, ACTION_REWRITE};
     use ephpm_middleware::host::{RequestCtx, host_table};
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
 
     use super::*;
 

--- a/crates/ephpm-middleware-builtins/src/lib.rs
+++ b/crates/ephpm-middleware-builtins/src/lib.rs
@@ -1,4 +1,4 @@
-//! The four in-tree ePHPm middleware modules as plain Rust library code.
+//! The in-tree ePHPm middleware modules as plain Rust library code.
 //!
 //! Each module here is an ordinary [`ephpm_middleware::Middleware`]
 //! implementation with **no C ABI exports** — that is what lets
@@ -6,15 +6,23 @@
 //! through the static builtin registry (`library = "jwt"` works even in a
 //! custom fully static build, where `dlopen` does not exist).
 //!
-//! The sibling `ephpm-middleware-{jwt,cors,ratelimit,security-headers}`
+//! The sibling
+//! `ephpm-middleware-{jwt,cors,ratelimit,security-headers,session-cookie}`
 //! crates are thin cdylib shells: they re-export these types and add the
 //! `declare!` C ABI glue, producing the loadable `.so`/`.dylib`/`.dll`
 //! artifacts for the dynamic (dlopen) lane. The shells cannot be merged into
-//! one binary — four copies of the same `ephpm_middleware_*` export symbols
-//! collide at link time — which is exactly why the implementations live
-//! here instead.
+//! one binary — several copies of the same `ephpm_middleware_*` export
+//! symbols collide at link time — which is exactly why the implementations
+//! live here instead.
+//!
+//! [`hs256`] is not a middleware: it is the token-verification core that
+//! [`jwt`] (API bearer tokens) and [`session_cookie`] (browser sessions)
+//! both call, so the two gates can differ in policy and failure behaviour
+//! without ever differing in crypto.
 
 pub mod cors;
+pub mod hs256;
 pub mod jwt;
 pub mod ratelimit;
 pub mod security_headers;
+pub mod session_cookie;

--- a/crates/ephpm-middleware-builtins/src/session_cookie.rs
+++ b/crates/ephpm-middleware-builtins/src/session_cookie.rs
@@ -1,0 +1,790 @@
+//! `session-cookie` — ePHPm native middleware gating a whole site on a
+//! signed session cookie minted by an external identity service, redirecting
+//! unauthenticated browsers to that service's login URL.
+//!
+//! The split this exists for: an external service ("the login service") runs
+//! whatever identity dance it likes — OAuth, SSO, SAML, a magic link — and,
+//! once it is satisfied, mints an HS256 token and sets it as a cookie on the
+//! application's domain. ePHPm then does the *only* part that has to happen
+//! on every request: verify the signature and the expiry, locally, and send
+//! the browser to the login URL when that fails.
+//!
+//! **ePHPm never talks to the identity provider.** Verification is a single
+//! HMAC over bytes already in the request: no network call, no rate limits,
+//! no OAuth client secret on the serving nodes. The nodes hold one shared
+//! HMAC secret, and a compromise of a node yields the ability to mint
+//! sessions for that one deployment — not access to the identity provider.
+//!
+//! Relationship to [`crate::jwt`]: identical verification (both call
+//! [`crate::hs256`]) and deliberately *nothing* else. `jwt` is an API gate —
+//! token in a header, `401` on failure, a machine reads the status code.
+//! This is a browser gate — token in a cookie, redirect on failure, a human
+//! reads the login page. Keeping them apart means neither module's config
+//! can accidentally change the other's failure behaviour, and an operator
+//! mounting `jwt` in front of an API is never one key away from turning
+//! their `401`s into redirects.
+//!
+//! Configuration (`[[middleware]] config = { ... }`):
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `secret` (string) | **required** | HS256 shared secret, same key the login service signs with |
+//! | `login_url` (string) | **required** | absolute `https://`/`http://` URL, or a same-origin absolute path, to redirect unauthenticated browsers to |
+//! | `cookie` (string) | `"ephpm_session"` | name of the cookie carrying the token |
+//! | `return_to_param` (string) | unset (no return-to is sent) | query parameter on `login_url` carrying the validated, same-origin return path |
+//! | `site_param` (string) | unset | query parameter carrying this request's vhost id, so one login service can serve many sites |
+//! | `issuer` (string) | unset | required `iss` claim value |
+//! | `audience` (string) | unset | required `aud` claim value (string or array member) |
+//! | `claims_header` (string) | unset | when set, REWRITE with this request header = the verified claims JSON |
+//! | `require_https` (bool) | `true` | refuse to accept a session cookie on a cleartext request (loopback clients exempt) |
+
+use std::net::IpAddr;
+
+use ephpm_middleware::{Middleware, Request, Response};
+
+use crate::hs256::{Hs256Policy, now_unix, opt_bool, opt_str};
+
+/// Default cookie name when the mount does not set one.
+const DEFAULT_COOKIE: &str = "ephpm_session";
+
+/// Longest return-to target (path + query) we are willing to hand to the
+/// login service. Anything longer is dropped — the user still reaches the
+/// login page, just without a return-to. Well under the ~8 KB request-line
+/// limit typical proxies enforce, so the redirect can never build a URL the
+/// next hop refuses.
+const MAX_RETURN_TO: usize = 2048;
+
+/// Session-cookie gate policy, built once at `init`.
+pub struct SessionCookie {
+    /// Signature + registered-claim policy, shared with `jwt`.
+    policy: Hs256Policy,
+    cookie: String,
+    login_url: String,
+    return_to_param: Option<String>,
+    site_param: Option<String>,
+    claims_header: Option<String>,
+    require_https: bool,
+}
+
+impl SessionCookie {
+    /// Build the `Location` for an unauthenticated request.
+    ///
+    /// `return_to` is already sanitized by [`same_origin_return_to`]; both it
+    /// and the vhost id are percent-encoded into the query, so nothing the
+    /// client controls can add a parameter, a fragment, or a second URL.
+    fn login_location(&self, return_to: Option<&str>, vhost: &str) -> String {
+        let mut url = self.login_url.clone();
+        // A login_url may already carry query parameters of its own.
+        let mut sep = if url.contains('?') { '&' } else { '?' };
+        if let (Some(param), Some(target)) = (self.return_to_param.as_deref(), return_to) {
+            url.push(sep);
+            url.push_str(&percent_encode(param));
+            url.push('=');
+            url.push_str(&percent_encode(target));
+            sep = '&';
+        }
+        if let Some(param) = self.site_param.as_deref()
+            && !vhost.is_empty()
+        {
+            url.push(sep);
+            url.push_str(&percent_encode(param));
+            url.push('=');
+            url.push_str(&percent_encode(vhost));
+        }
+        url
+    }
+
+    /// The redirect verdict for an unauthenticated request.
+    ///
+    /// `302` for GET/HEAD, `303` for everything else: after an unauthenticated
+    /// POST, `303` is what tells the browser to *GET* the login page rather
+    /// than re-submit the form body to the identity service.
+    ///
+    /// `Cache-Control: no-store` keeps a shared cache from serving one user's
+    /// redirect to another, and `Vary: Cookie` keeps any cache from treating
+    /// the authenticated and unauthenticated responses for a URL as the same
+    /// entry.
+    fn redirect(&self, req: &Request<'_>) -> Response {
+        let status = if matches!(req.method(), "GET" | "HEAD") { 302 } else { 303 };
+        let return_to = same_origin_return_to(req.path(), req.query());
+        Response::respond(status, "redirecting to login")
+            .header("Location", self.login_location(return_to.as_deref(), req.vhost_id()))
+            .header("Cache-Control", "no-store")
+            .header("Vary", "Cookie")
+    }
+}
+
+impl Middleware for SessionCookie {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let login_url = opt_str(config, "login_url")?
+            .ok_or("`login_url` is required (where to send unauthenticated browsers)")?;
+        // Constrain the redirect target we will emit. A `javascript:` or
+        // `data:` login_url would turn this module into an XSS primitive on
+        // every unauthenticated request, so only real HTTP origins and
+        // same-origin absolute paths are accepted. `//host` is rejected for
+        // the same reason it is rejected in a return-to: it is a
+        // protocol-relative URL, not a path.
+        let absolute = login_url.starts_with("https://") || login_url.starts_with("http://");
+        let same_origin_path = login_url.starts_with('/') && !login_url.starts_with("//");
+        if !absolute && !same_origin_path {
+            return Err(format!(
+                "`login_url` must be an https:// or http:// URL, or a same-origin absolute path \
+                 starting with `/` — got {login_url:?}"
+            ));
+        }
+        let require_https = opt_bool(config, "require_https", true)?;
+        Ok(Self {
+            policy: Hs256Policy::from_config(config)?,
+            cookie: opt_str(config, "cookie")?.unwrap_or_else(|| DEFAULT_COOKIE.to_owned()),
+            login_url,
+            return_to_param: opt_str(config, "return_to_param")?,
+            site_param: opt_str(config, "site_param")?,
+            claims_header: opt_str(config, "claims_header")?,
+            require_https,
+        })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        // Transport check first: a session cookie presented over cleartext is
+        // one an on-path observer has already read, so it is not evidence of
+        // anything. Loopback is exempt because the web platform itself treats
+        // `http://127.0.0.1` as a secure context — that is what makes local
+        // development possible without an opt-out that then ships to prod.
+        //
+        // This is a hard stop, not a redirect: bouncing to an HTTPS login
+        // service that sets a cookie the browser then returns over HTTP would
+        // loop forever, and a loop is a worse diagnostic than a message.
+        if self.require_https && !req.is_https() && !is_loopback(req.remote_ip()) {
+            return Response::respond(
+                403,
+                "session cookie authentication requires HTTPS (see `require_https`)",
+            )
+            .header("Cache-Control", "no-store");
+        }
+
+        let Some(raw) = req.header("Cookie") else {
+            return self.redirect(req);
+        };
+
+        // Try EVERY cookie of this name, not just the first. A cookie set on
+        // a parent domain shadows one set on this host, so accepting only the
+        // first match would let anyone who can write a cookie on the parent
+        // domain lock every user out of the site. Each candidate still has to
+        // pass the same HMAC and expiry check, so trying them all costs an
+        // HMAC and grants nothing.
+        let now = now_unix();
+        let verified =
+            cookie_values(raw, &self.cookie).find_map(|token| self.policy.verify(token, now));
+
+        match verified {
+            Some(claims_json) => match &self.claims_header {
+                Some(name) => Response::rewrite().header(name.as_str(), claims_json),
+                None => Response::cont(),
+            },
+            None => self.redirect(req),
+        }
+    }
+
+    fn describe() -> &'static str {
+        "session-cookie/1.0"
+    }
+}
+
+/// Iterate the values of every cookie named `name` in a `Cookie` header.
+///
+/// RFC 6265 §4.2.1: the header is `name=value` pairs separated by `;`, with
+/// optional surrounding whitespace. Two details a naive `split('=')` or a
+/// `contains("name=")` check get wrong, and both are exploitable:
+///
+/// * a value may itself contain `=` (base64 padding, for one), so the split
+///   is on the **first** `=` only;
+/// * substring matching would let `evil_ephpm_session=...` satisfy a lookup
+///   for `ephpm_session`, so names are compared **whole and exactly** —
+///   cookie names are case-sensitive.
+///
+/// A matched pair of surrounding double quotes is stripped (RFC 6265's
+/// `cookie-value` production permits them).
+fn cookie_values<'a>(header: &'a str, name: &'a str) -> impl Iterator<Item = &'a str> {
+    header.split(';').filter_map(move |pair| {
+        let (raw_name, raw_value) = pair.split_once('=')?;
+        if raw_name.trim_matches([' ', '\t']) != name {
+            return None;
+        }
+        let value = raw_value.trim_matches([' ', '\t']);
+        Some(match value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) {
+            Some(unquoted) => unquoted,
+            None => value,
+        })
+    })
+}
+
+/// Validate this request's own path+query for use as a return-to target,
+/// returning `None` when it cannot be proven same-origin.
+///
+/// The target is never taken from a client-supplied parameter — it is the
+/// path the browser actually asked for. That removes most of the open-redirect
+/// surface by construction, but not all of it: the request line is still
+/// client-controlled, and a login service that does `Location: <return_to>`
+/// would happily follow a *protocol-relative* URL. `GET //evil.example/ HTTP/1.1`
+/// is a legal request whose path is `//evil.example/`.
+///
+/// So the target must be an absolute path and nothing else:
+///
+/// * it starts with a single `/` — never `//` (protocol-relative) and never
+///   `/\` or `\`, which browsers normalise to `/` and therefore treat exactly
+///   like `//`;
+/// * it contains no ASCII control character, space, or `DEL`, which could
+///   split a header or truncate a URL, and no non-ASCII byte (paths reach us
+///   percent-encoded);
+/// * it fits in [`MAX_RETURN_TO`].
+///
+/// Anything else yields `None` and the user is simply sent to the login page
+/// without a return-to — failing safe, never failing open. Percent-encoded
+/// slashes (`/%2F%2Fevil.example`) survive validation and are harmless: they
+/// stay a single-segment path when resolved, and a browser does not decode
+/// `%2F` before deciding a URL's origin.
+fn same_origin_return_to(path: &str, query: &str) -> Option<String> {
+    if !path.starts_with('/') || path.starts_with("//") || path.starts_with("/\\") {
+        return None;
+    }
+    if path.len() + query.len() + 1 > MAX_RETURN_TO {
+        return None;
+    }
+    let unsafe_byte =
+        |s: &str| s.bytes().any(|b| !(0x21..=0x7E).contains(&b) || b == b'\\' || b == b'#');
+    if unsafe_byte(path) || unsafe_byte(query) {
+        return None;
+    }
+    if query.is_empty() { Some(path.to_owned()) } else { Some(format!("{path}?{query}")) }
+}
+
+/// Percent-encode a string for use as a URL query component.
+///
+/// Everything outside the RFC 3986 unreserved set is encoded, `/` and `&` and
+/// `=` and `#` included. Over-encoding is the point: whatever the login
+/// service's URL parser does, a value produced here cannot introduce a
+/// parameter, a fragment, or a second URL.
+fn percent_encode(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(char::from(byte));
+        } else {
+            out.push('%');
+            out.push(char::from(HEX[usize::from(byte >> 4)]));
+            out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    out
+}
+
+/// Whether a client-IP string is a loopback address.
+///
+/// The host passes the client IP **after** trusted-proxy resolution, so this
+/// is loopback only for a client genuinely on this machine (or one a trusted
+/// proxy reported as such). An unparseable value is treated as not loopback —
+/// the fail-closed direction.
+fn is_loopback(remote_ip: &str) -> bool {
+    remote_ip.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use base64ct::{Base64UrlUnpadded, Encoding};
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND, ACTION_REWRITE};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    use super::*;
+
+    const SECRET: &str = "test-secret-please-rotate";
+    const LOGIN: &str = "https://login.example/start";
+
+    /// Forge a token through the same HMAC code path the module verifies with.
+    fn sign(secret: &str, header_json: &str, claims_json: &str) -> String {
+        let h = Base64UrlUnpadded::encode_string(header_json.as_bytes());
+        let p = Base64UrlUnpadded::encode_string(claims_json.as_bytes());
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("hmac key");
+        mac.update(format!("{h}.{p}").as_bytes());
+        let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+        format!("{h}.{p}.{sig}")
+    }
+
+    fn token(secret: &str, claims_json: &str) -> String {
+        sign(secret, r#"{"alg":"HS256","typ":"JWT"}"#, claims_json)
+    }
+
+    fn future_exp() -> u64 {
+        now_unix() + 3600
+    }
+
+    fn valid_token() -> String {
+        token(SECRET, &format!(r#"{{"sub":"octocat","exp":{}}}"#, future_exp()))
+    }
+
+    fn gate(mut config: serde_json::Value) -> SessionCookie {
+        // Every test mount shares the secret and login URL unless it set them.
+        let map = config.as_object_mut().expect("object config");
+        map.entry("secret").or_insert_with(|| SECRET.into());
+        map.entry("login_url").or_insert_with(|| LOGIN.into());
+        SessionCookie::init(&config).expect("init")
+    }
+
+    /// Invoke over HTTPS from a non-loopback client — the production shape.
+    fn invoke(mw: &SessionCookie, headers: &[(String, String)]) -> Response {
+        invoke_full(mw, "GET", "/index.php", "", headers, true, "203.0.113.9")
+    }
+
+    fn invoke_full(
+        mw: &SessionCookie,
+        method: &str,
+        path: &str,
+        query: &str,
+        headers: &[(String, String)],
+        https: bool,
+        ip: &str,
+    ) -> Response {
+        let ctx = RequestCtx::new(method, path, query, ip, "pr-42.preview.example", headers)
+            .with_https(https);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn cookie(value: &str) -> Vec<(String, String)> {
+        vec![("Cookie".to_owned(), value.to_owned())]
+    }
+
+    fn header_of<'a>(resp: &'a Response, name: &str) -> Option<&'a str> {
+        resp.__headers().iter().find(|(n, _)| n == name).map(|(_, v)| v.as_str())
+    }
+
+    /// Assert the verdict is a redirect to the login service, and return the
+    /// `Location` so the caller can inspect the query it carries.
+    fn assert_redirect(resp: &Response) -> String {
+        assert_eq!(resp.__action(), ACTION_RESPOND, "unauthenticated must short-circuit");
+        assert_eq!(resp.__status(), 302);
+        assert_eq!(header_of(resp, "Cache-Control"), Some("no-store"));
+        assert_eq!(header_of(resp, "Vary"), Some("Cookie"));
+        header_of(resp, "Location").expect("Location header").to_owned()
+    }
+
+    // ── config ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn init_requires_secret_and_login_url() {
+        assert!(SessionCookie::init(&serde_json::json!({ "secret": SECRET })).is_err());
+        assert!(SessionCookie::init(&serde_json::json!({ "login_url": LOGIN })).is_err());
+        assert!(
+            SessionCookie::init(&serde_json::json!({ "secret": "", "login_url": LOGIN })).is_err()
+        );
+    }
+
+    #[test]
+    fn init_rejects_a_dangerous_login_url() {
+        // A `javascript:` login_url would be an XSS primitive fired on every
+        // unauthenticated request; `//host` is protocol-relative, not a path.
+        for bad in
+            ["javascript:alert(1)", "data:text/html,x", "//evil.example/login", "evil.example"]
+        {
+            let cfg = serde_json::json!({ "secret": SECRET, "login_url": bad });
+            assert!(SessionCookie::init(&cfg).is_err(), "{bad} must be rejected");
+        }
+        for good in ["https://login.example/start", "http://login.local/start", "/login.php"] {
+            let cfg = serde_json::json!({ "secret": SECRET, "login_url": good });
+            assert!(SessionCookie::init(&cfg).is_ok(), "{good} must be accepted");
+        }
+    }
+
+    #[test]
+    fn config_absent_keys_take_their_documented_defaults() {
+        // "section absent": only the two required keys are set. The cookie
+        // name defaults, require_https defaults ON, and no return-to or site
+        // parameter is emitted unless asked for.
+        let mw = gate(serde_json::json!({}));
+        assert_eq!(mw.cookie, DEFAULT_COOKIE);
+        assert!(mw.require_https, "require_https must default to ON");
+        assert_eq!(mw.login_location(Some("/a"), "site"), LOGIN, "no params unless configured");
+        let resp = invoke(&mw, &cookie(&format!("{DEFAULT_COOKIE}={}", valid_token())));
+        assert_eq!(resp.__action(), ACTION_CONTINUE, "the default cookie name is honoured");
+    }
+
+    #[test]
+    fn config_present_keys_are_all_honoured() {
+        let mw = gate(serde_json::json!({
+            "cookie": "sb_session",
+            "return_to_param": "next",
+            "site_param": "site",
+            "claims_header": "X-Session-Claims",
+            "require_https": false,
+        }));
+        assert_eq!(mw.cookie, "sb_session");
+        assert!(!mw.require_https);
+        let resp = invoke_full(&mw, "GET", "/a.php", "b=1", &[], true, "203.0.113.9");
+        let location = assert_redirect(&resp);
+        assert_eq!(location, format!("{LOGIN}?next=%2Fa.php%3Fb%3D1&site=pr-42.preview.example"));
+    }
+
+    #[test]
+    fn a_mistyped_require_https_fails_startup() {
+        // `require_https = "false"` (a string) must not be quietly read as
+        // "set, therefore truthy" nor as false — it fails the mount.
+        let cfg =
+            serde_json::json!({ "secret": SECRET, "login_url": LOGIN, "require_https": "false" });
+        assert!(SessionCookie::init(&cfg).is_err());
+    }
+
+    // ── the happy path ───────────────────────────────────────────────────
+
+    #[test]
+    fn valid_cookie_continues_to_php() {
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke(&mw, &cookie(&format!("ephpm_session={}", valid_token())));
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn valid_cookie_forwards_claims_when_configured() {
+        let mw = gate(serde_json::json!({ "claims_header": "X-Session-Claims" }));
+        let claims = format!(r#"{{"sub":"octocat","exp":{}}}"#, future_exp());
+        let resp = invoke(&mw, &cookie(&format!("ephpm_session={}", token(SECRET, &claims))));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(header_of(&resp, "X-Session-Claims"), Some(claims.as_str()));
+    }
+
+    // ── the rejection paths ──────────────────────────────────────────────
+
+    #[test]
+    fn missing_cookie_header_redirects() {
+        assert_redirect(&invoke(&gate(serde_json::json!({})), &[]));
+    }
+
+    #[test]
+    fn a_differently_named_cookie_redirects() {
+        let mw = gate(serde_json::json!({}));
+        let t = valid_token();
+        assert_redirect(&invoke(&mw, &cookie(&format!("other={t}"))));
+        // Substring matching would accept this; whole-name matching must not.
+        assert_redirect(&invoke(&mw, &cookie(&format!("evil_ephpm_session={t}"))));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session_x={t}"))));
+    }
+
+    #[test]
+    fn expired_cookie_redirects() {
+        let mw = gate(serde_json::json!({}));
+        let expired = token(SECRET, r#"{"sub":"octocat","exp":1000}"#);
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={expired}"))));
+    }
+
+    #[test]
+    fn a_cookie_without_exp_redirects() {
+        // A session token that cannot expire is a config bug, not a session.
+        let mw = gate(serde_json::json!({}));
+        let no_exp = token(SECRET, r#"{"sub":"octocat"}"#);
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={no_exp}"))));
+    }
+
+    #[test]
+    fn tampered_signature_redirects_and_the_tamper_is_actually_detected() {
+        let mw = gate(serde_json::json!({}));
+        let good = valid_token();
+
+        // Control: the untampered token IS accepted, so a redirect below
+        // proves detection rather than the token never having been valid.
+        assert_eq!(
+            invoke(&mw, &cookie(&format!("ephpm_session={good}"))).__action(),
+            ACTION_CONTINUE
+        );
+
+        let mut parts = good.split('.');
+        let (h, p, s) =
+            (parts.next().expect("h"), parts.next().expect("p"), parts.next().expect("s"));
+
+        // 1. Payload swapped for a privilege-escalating one, signature kept.
+        let forged = Base64UrlUnpadded::encode_string(
+            format!(r#"{{"sub":"root","exp":{}}}"#, future_exp()).as_bytes(),
+        );
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={h}.{forged}.{s}"))));
+
+        // 2. One flipped character in the signature.
+        let flipped = if s.ends_with('A') { 'B' } else { 'A' };
+        let tampered = format!("{}{flipped}", &s[..s.len() - 1]);
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={h}.{p}.{tampered}"))));
+
+        // 3. Signed with a different key.
+        let other = token("attacker-key", &format!(r#"{{"sub":"root","exp":{}}}"#, future_exp()));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={other}"))));
+
+        // 4. `alg: none` with a signature that verifies under our key.
+        let alg_none = sign(SECRET, r#"{"alg":"none"}"#, &format!(r#"{{"exp":{}}}"#, future_exp()));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={alg_none}"))));
+
+        // 5. Structurally broken tokens.
+        for junk in ["", "not-a-jwt", "a.b.c.d", "..", "e30.e30."] {
+            assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={junk}"))));
+        }
+    }
+
+    #[test]
+    fn a_non_get_request_redirects_with_303() {
+        // 303 makes the browser GET the login page instead of re-POSTing the
+        // form body to the identity service.
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke_full(&mw, "POST", "/submit.php", "", &[], true, "203.0.113.9");
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 303);
+        assert!(header_of(&resp, "Location").is_some());
+    }
+
+    // ── cookie parsing ───────────────────────────────────────────────────
+
+    #[test]
+    fn cookie_parsing_handles_real_browser_headers() {
+        let mw = gate(serde_json::json!({}));
+        let t = valid_token();
+        for header in [
+            // Surrounded by other cookies, with the usual "; " separator.
+            format!("_ga=GA1.1.9; ephpm_session={t}; wordpress_test_cookie=WP"),
+            // No space after the separator.
+            format!("a=1;ephpm_session={t};b=2"),
+            // Leading/trailing whitespace and tabs around the pair.
+            format!("a=1; \t ephpm_session={t} \t ; b=2"),
+            // RFC 6265 permits a quoted cookie-value.
+            format!("ephpm_session=\"{t}\""),
+            // Last cookie in the header, no trailing separator.
+            format!("a=1; ephpm_session={t}"),
+        ] {
+            assert_eq!(
+                invoke(&mw, &cookie(&header)).__action(),
+                ACTION_CONTINUE,
+                "must find the cookie in {header:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cookie_value_containing_equals_survives_parsing() {
+        // Splitting on every `=` instead of the first would truncate this.
+        let padded = format!("{}==", valid_token());
+        assert_eq!(
+            cookie_values(&format!("ephpm_session={padded}"), "ephpm_session").next(),
+            Some(padded.as_str())
+        );
+        // And a value that is only `=` signs still parses as a value.
+        assert_eq!(cookie_values("a==b=c", "a").next(), Some("=b=c"));
+    }
+
+    #[test]
+    fn a_shadowing_cookie_cannot_lock_a_user_out() {
+        // An attacker who can set `ephpm_session` on a PARENT domain gets it
+        // sent first, shadowing the real one. Taking only the first match
+        // would be a trivial denial of service; every candidate is tried.
+        let mw = gate(serde_json::json!({}));
+        let t = valid_token();
+        let shadowed = format!("ephpm_session=garbage-from-parent-domain; ephpm_session={t}");
+        assert_eq!(invoke(&mw, &cookie(&shadowed)).__action(), ACTION_CONTINUE);
+        // ...and a valid token first, junk second, also works.
+        let reversed = format!("ephpm_session={t}; ephpm_session=junk");
+        assert_eq!(invoke(&mw, &cookie(&reversed)).__action(), ACTION_CONTINUE);
+        // Two invalid ones still redirect — trying all candidates must not
+        // become "accept anything".
+        assert_redirect(&invoke(&mw, &cookie("ephpm_session=junk; ephpm_session=more-junk")));
+    }
+
+    #[test]
+    fn malformed_cookie_headers_do_not_panic_or_admit() {
+        let mw = gate(serde_json::json!({}));
+        for header in ["", ";", ";;;", "=", "=value", "ephpm_session", "ephpm_session;", "   "] {
+            assert_redirect(&invoke(&mw, &cookie(header)));
+        }
+    }
+
+    // ── return-to (open redirect) ────────────────────────────────────────
+
+    #[test]
+    fn return_to_carries_the_requested_path_and_query() {
+        let mw = gate(serde_json::json!({ "return_to_param": "next" }));
+        let resp =
+            invoke_full(&mw, "GET", "/wp-admin/edit.php", "post=7&x=a b", &[], true, "203.0.113.9");
+        // Space is not a legal request-target byte; such a query is dropped
+        // rather than encoded, so this one yields no `next` at all.
+        assert_eq!(assert_redirect(&resp), LOGIN);
+
+        let resp =
+            invoke_full(&mw, "GET", "/wp-admin/edit.php", "post=7", &[], true, "203.0.113.9");
+        assert_eq!(
+            assert_redirect(&resp),
+            format!("{LOGIN}?next=%2Fwp-admin%2Fedit.php%3Fpost%3D7")
+        );
+    }
+
+    #[test]
+    fn hostile_return_to_targets_are_rejected() {
+        // Every one of these is a legal request target that a login service
+        // doing `Location: <next>` would follow off-origin, or that could
+        // break out of the query parameter. None may ever appear in `next`.
+        let hostile = [
+            "//evil.example/",              // protocol-relative
+            "///evil.example/",             // three slashes, still off-origin
+            "//evil.example/path?a=b",      //
+            "/\\evil.example/",             // browsers normalise \ to /
+            "/\\/evil.example",             //
+            "\\\\evil.example",             // does not start with / at all
+            "https://evil.example/",        // absolute URL
+            "http:/evil.example",           //
+            "javascript:alert(1)",          // XSS payload
+            "/x\nLocation:%20https://evil", // header injection attempt
+            "/x\r\nSet-Cookie:%20a=b",      //
+            "/x y",                         // raw space truncates a URL
+            "/x#@evil.example",             // fragment/userinfo confusion
+            "/\u{7f}",                      // DEL
+            "/\u{e9}vil",                   // raw non-ASCII
+            "",                             // empty
+            "relative/path",                // not absolute
+        ];
+        let mw = gate(serde_json::json!({ "return_to_param": "next" }));
+        for target in hostile {
+            assert_eq!(
+                same_origin_return_to(target, ""),
+                None,
+                "{target:?} must not be usable as a return-to"
+            );
+            // ...and end to end: the emitted Location carries no `next`.
+            let resp = invoke_full(&mw, "GET", target, "", &[], true, "203.0.113.9");
+            let location = assert_redirect(&resp);
+            assert_eq!(location, LOGIN, "{target:?} leaked into {location}");
+        }
+        // A hostile QUERY is caught too, even with an innocuous path.
+        assert_eq!(same_origin_return_to("/ok.php", "a=b\r\nX: y"), None);
+        assert_eq!(same_origin_return_to("/ok.php", "a=#b"), None);
+
+        // A NUL is rejected here...
+        assert_eq!(same_origin_return_to("/x\u{0}y", ""), None);
+        // ...but never reaches a module as one: the host strips interior NULs
+        // when it builds the request context, so end to end this arrives as
+        // the perfectly ordinary path `/xy` and is returned to as such. Both
+        // layers are checked because either alone would be load-bearing.
+        let resp = invoke_full(&mw, "GET", "/x\u{0}y", "", &[], true, "203.0.113.9");
+        assert_eq!(assert_redirect(&resp), format!("{LOGIN}?next=%2Fxy"));
+    }
+
+    #[test]
+    fn a_percent_encoded_slash_is_safe_to_return_to() {
+        // `/%2F%2Fevil.example` is a single-segment path, not a
+        // protocol-relative URL: a browser does not decode %2F before
+        // deciding origin, so this one is allowed through — and it comes back
+        // double-encoded, so it cannot decode into `//` at the login service.
+        let mw = gate(serde_json::json!({ "return_to_param": "next" }));
+        let resp = invoke_full(&mw, "GET", "/%2F%2Fevil.example", "", &[], true, "203.0.113.9");
+        assert_eq!(assert_redirect(&resp), format!("{LOGIN}?next=%2F%252F%252Fevil.example"));
+    }
+
+    #[test]
+    fn an_overlong_return_to_is_dropped_not_truncated() {
+        let long = format!("/{}", "a".repeat(MAX_RETURN_TO));
+        assert_eq!(same_origin_return_to(&long, ""), None);
+    }
+
+    #[test]
+    fn return_to_appends_to_a_login_url_that_already_has_a_query() {
+        let mw = gate(serde_json::json!({
+            "login_url": "https://login.example/start?tenant=acme",
+            "return_to_param": "next",
+            "site_param": "site",
+        }));
+        let resp = invoke_full(&mw, "GET", "/a.php", "", &[], true, "203.0.113.9");
+        assert_eq!(
+            assert_redirect(&resp),
+            "https://login.example/start?tenant=acme&next=%2Fa.php&site=pr-42.preview.example"
+        );
+    }
+
+    #[test]
+    fn the_site_identity_lets_one_login_service_serve_many_sites() {
+        let mw = gate(serde_json::json!({ "site_param": "site" }));
+        let resp = invoke(&mw, &[]);
+        assert_eq!(assert_redirect(&resp), format!("{LOGIN}?site=pr-42.preview.example"));
+    }
+
+    // ── transport ────────────────────────────────────────────────────────
+
+    #[test]
+    fn cleartext_from_a_remote_client_is_refused_by_default() {
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke_full(
+            &mw,
+            "GET",
+            "/index.php",
+            "",
+            &cookie(&format!("ephpm_session={}", valid_token())),
+            false,
+            "203.0.113.9",
+        );
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 403, "a valid cookie over cleartext is still refused");
+    }
+
+    #[test]
+    fn cleartext_from_loopback_is_allowed_so_local_development_works() {
+        let mw = gate(serde_json::json!({}));
+        for ip in ["127.0.0.1", "::1"] {
+            let resp = invoke_full(
+                &mw,
+                "GET",
+                "/index.php",
+                "",
+                &cookie(&format!("ephpm_session={}", valid_token())),
+                false,
+                ip,
+            );
+            assert_eq!(resp.__action(), ACTION_CONTINUE, "loopback {ip} is a secure context");
+        }
+        // And a loopback client with no cookie still gets the redirect, not
+        // the 403 — the transport check must not swallow the normal path.
+        let resp = invoke_full(&mw, "GET", "/index.php", "", &[], false, "127.0.0.1");
+        assert_redirect(&resp);
+    }
+
+    #[test]
+    fn require_https_false_allows_cleartext_from_anywhere() {
+        let mw = gate(serde_json::json!({ "require_https": false }));
+        let resp = invoke_full(
+            &mw,
+            "GET",
+            "/index.php",
+            "",
+            &cookie(&format!("ephpm_session={}", valid_token())),
+            false,
+            "203.0.113.9",
+        );
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn an_unparseable_client_ip_is_not_treated_as_loopback() {
+        assert!(!is_loopback(""));
+        assert!(!is_loopback("localhost"));
+        assert!(!is_loopback("127.0.0.1, 203.0.113.9"));
+        assert!(is_loopback("127.0.0.1"));
+        assert!(is_loopback("127.99.1.2"));
+        assert!(is_loopback("::1"));
+        assert!(!is_loopback("203.0.113.9"));
+    }
+
+    #[test]
+    fn a_forged_x_forwarded_proto_does_not_satisfy_require_https() {
+        // The header reaches modules exactly as the client sent it; only the
+        // host's own verdict counts.
+        let mw = gate(serde_json::json!({}));
+        let headers = vec![
+            ("X-Forwarded-Proto".to_owned(), "https".to_owned()),
+            ("Cookie".to_owned(), format!("ephpm_session={}", valid_token())),
+        ];
+        let resp = invoke_full(&mw, "GET", "/i.php", "", &headers, false, "203.0.113.9");
+        assert_eq!(resp.__status(), 403, "a client-set X-Forwarded-Proto must not unlock this");
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/session_cookie.rs
+++ b/crates/ephpm-middleware-builtins/src/session_cookie.rs
@@ -83,13 +83,14 @@ impl SessionCookie {
             url.push_str(&percent_encode(target));
             sep = '&';
         }
-        if let Some(param) = self.site_param.as_deref()
-            && !vhost.is_empty()
-        {
-            url.push(sep);
-            url.push_str(&percent_encode(param));
-            url.push('=');
-            url.push_str(&percent_encode(vhost));
+        if let Some(param) = self.site_param.as_deref() {
+            let site = normalize_vhost(vhost);
+            if !site.is_empty() {
+                url.push(sep);
+                url.push_str(&percent_encode(param));
+                url.push('=');
+                url.push_str(&percent_encode(&site));
+            }
         }
         url
     }
@@ -277,6 +278,27 @@ fn percent_encode(value: &str) -> String {
         }
     }
     out
+}
+
+/// Normalise the ABI's vhost id into a stable site identity.
+///
+/// `request_vhost_id` is the router's `SERVER_NAME`: the `Host` header with
+/// the port removed and **nothing else** — not lowercased, trailing
+/// FQDN-root dot not stripped. `Host` is case-insensitive per RFC 9110 and
+/// entirely client-controlled, so `Site.Example`, `site.example.` and
+/// `site.example` are one site sending three different strings. Emitting
+/// them raw would hand the login service three identities for one site, and
+/// any exact-match lookup it does would miss for two of them.
+///
+/// This duplicates `ephpm-server`'s `normalize_host_key`, which is
+/// `pub(crate)` and so unreachable from here; the duplication is deliberate
+/// and must stay in step with it.
+///
+/// Normalising does **not** make the value trustworthy: an unrecognised
+/// `Host` still reaches the middleware chain, so the login service must
+/// validate the identity against its own registry rather than trusting it.
+fn normalize_vhost(vhost: &str) -> String {
+    vhost.split(':').next().unwrap_or("").trim_end_matches('.').to_ascii_lowercase()
 }
 
 /// Whether a client-IP string is a loopback address.
@@ -708,6 +730,28 @@ mod tests {
         let mw = gate(serde_json::json!({ "site_param": "site" }));
         let resp = invoke(&mw, &[]);
         assert_eq!(assert_redirect(&resp), format!("{LOGIN}?site=pr-42.preview.example"));
+    }
+
+    #[test]
+    fn the_site_identity_is_normalized_before_it_is_emitted() {
+        // `request_vhost_id` is the raw `Host` minus the port: not
+        // lowercased, trailing FQDN-root dot not stripped. `Host` is
+        // case-insensitive and client-controlled, so without normalising,
+        // one site would present the login service with several identities
+        // and any exact-match lookup there would miss.
+        for raw in [
+            "PR-42.Preview.Example",
+            "pr-42.preview.example.",
+            "PR-42.PREVIEW.EXAMPLE.",
+            "pr-42.preview.example",
+        ] {
+            assert_eq!(normalize_vhost(raw), "pr-42.preview.example", "{raw}");
+        }
+        // A vhost that normalises away emits no parameter at all rather than
+        // an empty one.
+        let mw = gate(serde_json::json!({ "site_param": "site" }));
+        assert_eq!(mw.login_location(None, ""), LOGIN);
+        assert_eq!(mw.login_location(None, "."), LOGIN);
     }
 
     // ── transport ────────────────────────────────────────────────────────

--- a/crates/ephpm-middleware-session-cookie/Cargo.toml
+++ b/crates/ephpm-middleware-session-cookie/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ephpm-middleware-session-cookie"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ePHPm native middleware: signed session-cookie validation with redirect-to-login (loadable cdylib shell; implementation in ephpm-middleware-builtins)"
+
+[lib]
+# cdylib = the loadable module for the dlopen lane. The implementation (and
+# the rlib ephpm-server links) is ephpm-middleware-builtins — this shell only
+# adds the C ABI exports, which must never be linked into the host binary
+# (several modules exporting the same `ephpm_middleware_*` symbols collide).
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ephpm-middleware.workspace = true
+ephpm-middleware-builtins.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ephpm-middleware-session-cookie/src/lib.rs
+++ b/crates/ephpm-middleware-session-cookie/src/lib.rs
@@ -1,0 +1,13 @@
+//! `session-cookie` — loadable cdylib shell around the shared implementation
+//! in [`ephpm_middleware_builtins::session_cookie`].
+//!
+//! The middleware itself (signed session-cookie validation with
+//! redirect-to-login, docs and tests included) lives in
+//! `ephpm-middleware-builtins`, where it is also compiled into every ePHPm
+//! binary as the builtin `session-cookie` registry entry — no cdylib needed
+//! there. This crate only adds the C ABI exports (`declare!`) so the same
+//! module can be dlopened by dynamically linked builds.
+
+pub use ephpm_middleware_builtins::session_cookie::SessionCookie;
+
+ephpm_middleware::declare!(SessionCookie);

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -112,8 +112,10 @@ pub struct EphpmHostV1 {
     pub request_query: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
     /// Client IP after trusted-proxy resolution.
     pub request_remote_ip: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
-    /// Header lookup by case-insensitive name; NULL when absent. Multi-value
-    /// headers return the values pre-joined per HTTP list semantics.
+    /// Header lookup by case-insensitive name; NULL when absent. Repeated
+    /// header lines are pre-joined per HTTP list semantics — `", "` for
+    /// ordinary headers (RFC 9110 §5.3) and `"; "` for `Cookie`, which HTTP/2
+    /// is explicitly allowed to split across field lines (RFC 9113 §8.2.3).
     pub request_header:
         unsafe extern "C" fn(*const EphpmRequest, name: *const c_char) -> *const c_char,
     /// Request body view. v1: bodies are not read before the middleware chain
@@ -177,6 +179,21 @@ pub struct EphpmHostV1 {
         ttl_secs: i64,
         out: *mut i64,
     ) -> c_int,
+
+    /// Whether this request reached the server over a secure transport:
+    /// `1` for HTTPS, `0` for cleartext.
+    ///
+    /// This is the host's own, trusted-proxy-aware verdict — the same value
+    /// PHP sees as `$_SERVER['HTTPS']`. It is the TLS state of the accepted
+    /// connection, overridden by `X-Forwarded-Proto` **only** when the peer
+    /// matches `[server.proxy] trusted_proxies`. A module must use this
+    /// rather than reading `X-Forwarded-Proto` itself: that header reaches
+    /// modules exactly as the client sent it, so any client can set it.
+    ///
+    /// Appended after [`EphpmHostV1::kv_incr_ttl`] — same major version, so
+    /// modules built against the shorter table never read past the offsets
+    /// they know.
+    pub request_is_https: unsafe extern "C" fn(*const EphpmRequest) -> c_int,
 }
 
 /// Symbol names the loader looks up.

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -19,11 +19,24 @@ pub struct RequestCtx {
     vhost: CString,
     /// Lower-cased name → value (values pre-joined per HTTP list semantics).
     headers: Vec<(CString, CString)>,
+    /// Secure-transport verdict for this request; see
+    /// [`abi::EphpmHostV1::request_is_https`].
+    https: bool,
 }
 
 impl RequestCtx {
     /// Build the context. Interior NULs are stripped (invalid in HTTP
     /// metadata anyway) rather than failing the request.
+    ///
+    /// Repeated header lines are joined into one value, as the ABI promises
+    /// modules: `"; "` for `Cookie` (HTTP/2 may split it across field lines —
+    /// RFC 9113 §8.2.3 — and the reassembled value must use the cookie-string
+    /// separator), `", "` for everything else (RFC 9110 §5.3). Without this a
+    /// module doing `req.header("cookie")` would silently see only the first
+    /// line and could miss the very cookie it authenticates on.
+    ///
+    /// Defaults to `https = false`; the host sets the real verdict with
+    /// [`RequestCtx::with_https`].
     #[must_use]
     pub fn new(
         method: &str,
@@ -36,14 +49,34 @@ impl RequestCtx {
         fn c(s: &str) -> CString {
             CString::new(s.replace('\0', "")).unwrap_or_default()
         }
+        let mut joined: Vec<(String, String)> = Vec::with_capacity(headers.len());
+        for (name, value) in headers {
+            let lower = name.to_ascii_lowercase();
+            if let Some((_, existing)) = joined.iter_mut().find(|(n, _)| *n == lower) {
+                existing.push_str(if lower == "cookie" { "; " } else { ", " });
+                existing.push_str(value);
+            } else {
+                joined.push((lower, value.clone()));
+            }
+        }
         Self {
             method: c(method),
             path: c(path),
             query: c(query),
             remote_ip: c(remote_ip),
             vhost: c(vhost),
-            headers: headers.iter().map(|(n, v)| (c(&n.to_ascii_lowercase()), c(v))).collect(),
+            headers: joined.iter().map(|(n, v)| (c(n), c(v))).collect(),
+            https: false,
         }
+    }
+
+    /// Record whether this request arrived over a secure transport. The host
+    /// passes its own trusted-proxy-aware verdict (the value PHP sees as
+    /// `$_SERVER['HTTPS']`), never a raw client header.
+    #[must_use]
+    pub fn with_https(mut self, https: bool) -> Self {
+        self.https = https;
+        self
     }
 
     /// The opaque pointer to pass through the ABI. Valid while `self` lives.
@@ -79,6 +112,10 @@ unsafe extern "C" fn request_remote_ip(req: *const EphpmRequest) -> *const c_cha
 unsafe extern "C" fn request_vhost_id(req: *const EphpmRequest) -> *const c_char {
     // SAFETY: ABI contract.
     unsafe { ctx(req) }.map_or(std::ptr::null(), |c| c.vhost.as_ptr())
+}
+unsafe extern "C" fn request_is_https(req: *const EphpmRequest) -> c_int {
+    // SAFETY: ABI contract.
+    c_int::from(unsafe { ctx(req) }.is_some_and(|c| c.https))
 }
 unsafe extern "C" fn request_header(
     req: *const EphpmRequest,
@@ -286,6 +323,7 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     kv_free,
     log: host_log,
     kv_incr_ttl,
+    request_is_https,
 };
 
 /// Wire the embedded KV store into the host table. Call once at startup,
@@ -298,4 +336,53 @@ pub fn set_kv_store(store: &Arc<ephpm_kv::store::Store>) {
 #[must_use]
 pub fn host_table() -> &'static EphpmHostV1 {
     &HOST_TABLE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Request;
+
+    fn view(ctx: &RequestCtx) -> Request<'_> {
+        // SAFETY: `ctx` outlives the returned view; host_table() is 'static.
+        unsafe { Request::from_raw(ctx.as_abi(), host_table()) }
+    }
+
+    fn ctx(headers: &[(String, String)]) -> RequestCtx {
+        RequestCtx::new("GET", "/x.php", "", "203.0.113.5", "t.example", headers)
+    }
+
+    fn h(name: &str, value: &str) -> (String, String) {
+        (name.to_owned(), value.to_owned())
+    }
+
+    #[test]
+    fn repeated_cookie_lines_are_joined_with_the_cookie_separator() {
+        // HTTP/2 may split `Cookie` across field lines (RFC 9113 §8.2.3) and
+        // hyper surfaces them separately. A module reading `cookie` must see
+        // ALL of them, or it can miss the very cookie it authenticates on.
+        let ctx = ctx(&[h("cookie", "a=1"), h("Cookie", "b=2"), h("COOKIE", "c=3")]);
+        assert_eq!(view(&ctx).header("cookie"), Some("a=1; b=2; c=3"));
+    }
+
+    #[test]
+    fn repeated_ordinary_headers_are_joined_as_a_comma_list() {
+        let ctx = ctx(&[h("accept", "text/html"), h("Accept", "application/json")]);
+        assert_eq!(view(&ctx).header("Accept"), Some("text/html, application/json"));
+    }
+
+    #[test]
+    fn a_single_header_is_unchanged_and_lookup_is_case_insensitive() {
+        let ctx = ctx(&[h("X-Api-Key", "k1")]);
+        assert_eq!(view(&ctx).header("x-api-key"), Some("k1"));
+        assert_eq!(view(&ctx).header("X-API-KEY"), Some("k1"));
+        assert_eq!(view(&ctx).header("absent"), None);
+    }
+
+    #[test]
+    fn https_defaults_off_and_is_set_only_by_the_host() {
+        assert!(!view(&ctx(&[])).is_https(), "default must be the cleartext (safe) verdict");
+        let secure = ctx(&[]).with_https(true);
+        assert!(view(&secure).is_https());
+    }
 }

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -146,6 +146,19 @@ impl Request<'_> {
         self.str_of(unsafe { (self.host.request_vhost_id)(self.raw) })
     }
 
+    /// Whether this request reached the server over a secure transport.
+    ///
+    /// This is the host's own verdict: the accepted connection's TLS state,
+    /// overridden by `X-Forwarded-Proto` **only** for peers matching
+    /// `[server.proxy] trusted_proxies`. Prefer it over reading
+    /// `X-Forwarded-Proto` yourself — that header arrives exactly as the
+    /// client sent it, so any client can claim `https`.
+    #[must_use]
+    pub fn is_https(&self) -> bool {
+        // SAFETY: contract of `from_raw`.
+        unsafe { (self.host.request_is_https)(self.raw) != 0 }
+    }
+
     /// Host services (KV store, logging) scoped to the table this request
     /// was invoked with. Equivalent to `Host::new(__ephpm_mw_host())` but
     /// also works in unit tests that build a [`Request`] by hand.

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -7,7 +7,7 @@
 //!
 //! Each mount resolves through two lanes, in order:
 //!
-//! 1. **Builtin registry** ([`builtin`]) — the four in-tree modules compiled
+//! 1. **Builtin registry** ([`builtin`]) — the in-tree modules compiled
 //!    into this binary and invoked in-process (no FFI, no dlopen). Works in
 //!    every binary, including custom fully static builds where `dlopen` does
 //!    not exist.
@@ -92,6 +92,11 @@ pub type BuiltinBuilder = fn(&serde_json::Value) -> Result<BuiltinModule, String
 /// per module: the short name and the crate name, with `-` and `_`
 /// interchangeable — e.g. `"jwt"`, `"ephpm-middleware-jwt"`,
 /// `"ephpm_middleware_jwt"`. (`"ratelimit"` also answers to `"rate-limit"`.)
+///
+/// Adding an entry here also means checking [`crate::router`]'s ingest-strip
+/// list: any module that forwards data to PHP in a request header must have
+/// that header name stripped at ingest, or a client can forge it on a path
+/// the module's `match` glob skips.
 #[must_use]
 pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
     let canonical = name.replace('_', "-");
@@ -107,6 +112,9 @@ pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
         }
         "security-headers" | "ephpm-middleware-security-headers" => {
             BuiltinModule::init::<ephpm_middleware_builtins::security_headers::SecurityHeaders>
+        }
+        "session-cookie" | "ephpm-middleware-session-cookie" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::session_cookie::SessionCookie>
         }
         _ => return None,
     })
@@ -714,6 +722,10 @@ mod tests {
             "ephpm_middleware_ratelimit",
             "ephpm-middleware-security-headers",
             "ephpm_middleware_security_headers",
+            "session-cookie",
+            "session_cookie",
+            "ephpm-middleware-session-cookie",
+            "ephpm_middleware_session_cookie",
         ] {
             assert!(builtin(name).is_some(), "\"{name}\" should resolve as builtin");
         }
@@ -721,6 +733,60 @@ mod tests {
         for name in ["", "jwtx", "my-auth", "jwt.so", "./jwt", "middleware/jwt", "JWT"] {
             assert!(builtin(name).is_none(), "\"{name}\" should NOT resolve as builtin");
         }
+    }
+
+    /// `session-cookie` mounted from the static registry: an unauthenticated
+    /// browser request short-circuits the chain with a redirect to the login
+    /// service, and PHP never runs. The mount is `match`-scoped so the test
+    /// also covers a skipped path continuing normally.
+    #[test]
+    fn builtin_session_cookie_redirects_an_unauthenticated_request() {
+        let mounts = vec![builtin_mount(
+            "session-cookie",
+            Some("/app/*"),
+            10,
+            serde_json::json!({
+                "secret": "shared-with-the-login-service",
+                "login_url": "https://login.example/start",
+                "return_to_param": "next",
+                "site_param": "site",
+            }),
+        )];
+        let chain = MiddlewareChain::load(&mounts).expect("load builtin session-cookie");
+
+        // No cookie on a matching path → 302 to the login service, carrying a
+        // same-origin return-to and the site identity.
+        let ctx = RequestCtx::new(
+            "GET",
+            "/app/dashboard.php",
+            "tab=1",
+            "203.0.113.7",
+            "pr-42.preview.example",
+            &[],
+        )
+        .with_https(true);
+        match chain.evaluate(&ctx, "/app/dashboard.php") {
+            ChainVerdict::Respond { status, headers, .. } => {
+                assert_eq!(status, 302);
+                assert_eq!(
+                    find_header(&headers, "Location"),
+                    Some(
+                        "https://login.example/start?next=%2Fapp%2Fdashboard.php%3Ftab%3D1\
+                         &site=pr-42.preview.example"
+                    )
+                );
+                assert_eq!(find_header(&headers, "Cache-Control"), Some("no-store"));
+            }
+            ChainVerdict::Continue { .. } => {
+                panic!("an unauthenticated request must not reach PHP")
+            }
+        }
+
+        // A path outside the `match` glob is not gated at all.
+        let open =
+            RequestCtx::new("GET", "/health.php", "", "203.0.113.7", "pr-42.preview.example", &[])
+                .with_https(true);
+        assert!(matches!(chain.evaluate(&open, "/health.php"), ChainVerdict::Continue { .. }));
     }
 
     /// The full four-module chain, loaded purely from the static registry —

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -552,21 +552,24 @@ const ALWAYS_STRIPPED_INGEST_HEADERS: &[&str] = &["proxy"];
 /// Build the lowercased list of inbound headers to strip at ingest.
 ///
 /// Combines [`ALWAYS_STRIPPED_INGEST_HEADERS`] with the `claims_header` of
-/// every configured `jwt` middleware mount. Because the claims header is only
-/// sanitized by the jwt module when that module actually runs (and in fpm
-/// mode it only runs on `match`-glob paths), stripping it up-front guarantees
-/// a client can never forge it on a path the module skips. Names are
-/// deduplicated and lowercased for the case-insensitive compare in
-/// [`extract_headers`].
+/// every configured `jwt` and `session-cookie` middleware mount. Because the
+/// claims header is only sanitized by those modules when they actually run
+/// (and in fpm mode they only run on `match`-glob paths), stripping it
+/// up-front guarantees a client can never forge it on a path the module
+/// skips. Names are deduplicated and lowercased for the case-insensitive
+/// compare in [`extract_headers`].
 fn build_ingest_strip_headers(mounts: &[MiddlewareMount]) -> Vec<String> {
     let mut names: Vec<String> =
         ALWAYS_STRIPPED_INGEST_HEADERS.iter().map(|s| (*s).to_owned()).collect();
     for mount in mounts {
-        // Only the builtin `jwt` module (and its long-form spellings) forwards
-        // a claims header; match the same canonicalization the middleware
-        // registry uses.
+        // Only the builtin `jwt` and `session-cookie` modules (and their
+        // long-form spellings) forward a claims header; match the same
+        // canonicalization the middleware registry uses.
         let canonical = mount.library.replace('_', "-");
-        if !matches!(canonical.as_str(), "jwt" | "ephpm-middleware-jwt") {
+        if !matches!(
+            canonical.as_str(),
+            "jwt" | "ephpm-middleware-jwt" | "session-cookie" | "ephpm-middleware-session-cookie"
+        ) {
             continue;
         }
         if let Some(name) = mount
@@ -2400,7 +2403,12 @@ impl Router {
                 &remote_addr.ip().to_string(),
                 &server_name,
                 &headers,
-            );
+            )
+            // The host's own trusted-proxy-aware verdict — the same value PHP
+            // sees as `$_SERVER['HTTPS']`. Modules must not re-derive this
+            // from `X-Forwarded-Proto`, which reaches them exactly as the
+            // client sent it.
+            .with_https(is_https);
             match chain.evaluate(&ctx, &path) {
                 crate::middleware::ChainVerdict::Respond { status, body, headers } => {
                     return middleware_response(status, body, &headers);
@@ -4755,9 +4763,28 @@ mod tests {
     }
 
     #[test]
+    fn ingest_strip_list_includes_configured_session_cookie_claims_header() {
+        // `session-cookie` forwards verified claims exactly like `jwt` does,
+        // so its claims header needs the same ingest strip — otherwise a
+        // client can forge it on a path the mount's `match` glob skips.
+        let mount = MiddlewareMount {
+            library: "session_cookie".to_string(),
+            match_pattern: Some("/app/*".to_owned()),
+            order: 10,
+            config: Some(serde_json::json!({
+                "secret": "s",
+                "login_url": "https://login.example/start",
+                "claims_header": "X-Session-Claims",
+            })),
+        };
+        let strip = build_ingest_strip_headers(&[mount]);
+        assert!(strip.iter().any(|h| h == "x-session-claims"), "{strip:?}");
+    }
+
+    #[test]
     fn ingest_strip_list_ignores_non_jwt_mounts() {
         // A cors mount carrying an incidental `claims_header` key must not
-        // contribute — only the jwt module forwards claims.
+        // contribute — only the claims-forwarding modules do.
         let cors = MiddlewareMount {
             library: "cors".to_string(),
             match_pattern: None,

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -16,10 +16,10 @@ counter is a single `kv_incr`.
 
 There are **two ways a module runs**:
 
-- **Built-in (static registry).** Four modules — `jwt`, `cors`,
-  `ratelimit`, `security-headers` — are compiled into **every** ePHPm
-  binary. `library = "jwt"` just works: no shared library on disk, no
-  `dlopen`, no special build.
+- **Built-in (static registry).** Five modules — `jwt`, `cors`,
+  `ratelimit`, `security-headers`, `session-cookie` — are compiled into
+  **every** ePHPm binary. `library = "jwt"` just works: no shared library
+  on disk, no `dlopen`, no special build.
 - **Dynamic (shared library).** Custom out-of-tree modules are `.so` /
   `.dylib` / `.dll` files speaking a small, versioned C ABI, loaded once at
   startup via `dlopen` (`LoadLibrary` on Windows). This works out of the
@@ -121,8 +121,9 @@ the mount.
 The `library` value is checked against the **builtin registry first**.
 Each built-in answers to its short name and its crate name, with `-` and
 `_` interchangeable: `jwt`, `cors`, `ratelimit` (also `rate-limit`),
-`security-headers`, and the `ephpm-middleware-*` / `ephpm_middleware_*`
-long forms. Builtin mounts never touch the filesystem.
+`security-headers`, `session-cookie`, and the `ephpm-middleware-*` /
+`ephpm_middleware_*` long forms. Builtin mounts never touch the
+filesystem.
 
 Anything else is resolved as a shared library. A value containing a path
 separator or a file extension is used as-is. A bare name tries, in each
@@ -185,7 +186,7 @@ chain sees everything — static, dynamic, and error paths alike.
 
 ## The built-in modules
 
-All four are compiled into every ePHPm binary and run in-process — the
+All five are compiled into every ePHPm binary and run in-process — the
 sections below apply identically whether you mount them by short name
 (built-in) or dlopen their cdylib builds on a dynamic binary.
 
@@ -246,6 +247,175 @@ therefore trust `HTTP_X_JWT_CLAIMS` regardless of request path.
 > defense), so it never surfaces as `$_SERVER['HTTP_PROXY']`.
 
 v1 is HS256 only — RS256/JWKS is not implemented.
+
+### `session-cookie`
+
+Gates a whole site in a **browser** on a signed session cookie minted by an
+external identity service, and redirects unauthenticated visitors to that
+service. Same crypto as `jwt` (they share one verification core), different
+threat model: a token in a cookie instead of a header, and a redirect
+instead of a `401`, because a browser can do nothing useful with a `401`.
+
+They are separate modules on purpose. Mounting `jwt` in front of an API and
+`session-cookie` in front of a UI keeps each one's failure behaviour where
+it belongs — no key in the `jwt` config can turn its `401`s into redirects,
+and no key here can silently stop redirecting.
+
+**ePHPm never calls the identity provider.** Verification is one HMAC over
+bytes already in the request: no network call on the request path, no
+provider rate limits, and no OAuth client secret on the serving nodes. The
+nodes hold one shared HMAC secret; compromising a node lets an attacker mint
+sessions for that deployment, and gets them nothing at the provider.
+
+| key | default | meaning |
+|-----|---------|---------|
+| `secret` (string) | **required** | HS256 shared secret — the same key the login service signs with |
+| `login_url` (string) | **required** | where to send unauthenticated browsers. Must be an `https://`/`http://` URL or a same-origin absolute path; anything else (`javascript:`, `//host`) fails startup |
+| `cookie` (string) | `"ephpm_session"` | name of the cookie carrying the token |
+| `return_to_param` (string) | unset — **no return-to is sent** | query parameter on `login_url` carrying the validated return path |
+| `site_param` (string) | unset | query parameter carrying this request's vhost id, so one login service can serve many sites |
+| `issuer` (string) | unset | required `iss` claim value |
+| `audience` (string) | unset | required `aud` claim value (string or array member) |
+| `claims_header` (string) | unset | forward the verified claims JSON to PHP in this request header |
+| `require_https` (bool) | `true` | refuse to accept a session cookie on a cleartext request (loopback exempt) |
+
+```toml
+[[middleware]]
+library = "session-cookie"
+order   = 10
+config  = {
+  secret          = "shared-with-the-login-service",
+  login_url       = "https://previews.example/auth/start",
+  cookie          = "preview_session",
+  return_to_param = "next",
+  site_param      = "site",
+  claims_header   = "X-Session-Claims",
+}
+```
+
+What the module does per request:
+
+- **No cookie, wrong cookie name, expired, tampered, wrong signing key, or
+  `alg: none`** → a redirect to `login_url`, and **PHP never runs**. Every
+  rejection produces the same response, so a client cannot learn *why* it
+  was refused.
+- **Valid cookie** → the request continues to PHP. With `claims_header` set,
+  the module REWRITEs that request header to the verified claims JSON and
+  PHP reads it from `$_SERVER['HTTP_X_SESSION_CLAIMS']`.
+
+The redirect is `302` for `GET`/`HEAD` and `303` for every other method —
+after an unauthenticated `POST`, `303` is what tells the browser to *GET*
+the login page rather than re-submit the form body to the identity service.
+It carries `Cache-Control: no-store` and `Vary: Cookie` so no shared cache
+serves one visitor's redirect to another.
+
+Verification is exactly `jwt`'s: signature checked **first** (constant-time
+HMAC, so no unauthenticated JSON is ever parsed), `alg` pinned to HS256,
+`exp` **required** and in the future, `nbf` honoured, `iss`/`aud` enforced
+when configured. **A session token with no `exp` is rejected** — a session
+that cannot expire is a configuration bug, not a session.
+
+#### Return-to, and why it is not `?next=`
+
+With `return_to_param`, the redirect tells the login service where to send
+the visitor afterwards. That value is taken from **the path the browser
+actually requested**, never from a client-supplied parameter — an
+unvalidated `?next=` is an open redirect and a ready-made phishing
+primitive, so this module does not read one.
+
+The request line is still client-controlled, so the target is validated
+anyway before it is emitted. It must be an absolute path and nothing else:
+
+- starts with a single `/` — `//evil.example` and `///evil.example` are
+  protocol-relative URLs, not paths, and are rejected;
+- no `\` anywhere — browsers normalise `\` to `/`, so `/\evil.example`
+  behaves exactly like `//evil.example`;
+- no ASCII control character, space, `DEL`, `#`, or non-ASCII byte
+  (anything that could split a header or truncate a URL);
+- at most 2048 bytes.
+
+Anything that fails is **dropped**, not sanitised: the visitor still reaches
+the login page, just without a return-to. The value that does survive is
+percent-encoded aggressively (everything outside `A-Za-z0-9-._~`), so it
+cannot introduce a parameter, a fragment, or a second URL into the login
+URL's query.
+
+This is one half of the defence. **The login service must validate the
+return-to it receives as well** — it is the component that actually issues
+the final `Location`, and it must not follow one off its own origin.
+
+#### HTTPS
+
+A session cookie is a bearer credential: anyone who reads it is the user. On
+a cleartext connection it is readable in transit, so with the default
+`require_https = true` the module refuses such a request outright with a
+`403` rather than accepting the cookie.
+
+- The verdict is **the host's**, not a header the module read. ePHPm uses
+  the accepted connection's TLS state, overridden by `X-Forwarded-Proto`
+  only for peers matching `[server.proxy] trusted_proxies` — the same value
+  PHP sees as `$_SERVER['HTTPS']`. A client-set `X-Forwarded-Proto: https`
+  from an untrusted peer does **not** satisfy this. If ePHPm sits behind a
+  TLS-terminating proxy, that proxy's address must be in `trusted_proxies`
+  or every request will look like cleartext.
+- **Loopback clients are exempt**, so `http://127.0.0.1:8080` works for
+  local development. This mirrors the web platform's own treatment of
+  `localhost` as a secure context, and it means you never have to ship a
+  `require_https = false` you meant only for your laptop.
+- It is a hard `403`, not a redirect: bouncing to an HTTPS login service
+  that sets a cookie the browser then returns over HTTP would loop forever,
+  and a loop is a worse diagnostic than a message.
+- What the module **cannot** do is make the cookie itself secure. Only the
+  issuer can, with the cookie's own attributes — see below.
+
+#### The other half: what the login service must do
+
+ePHPm validates; something else must issue. A login service ("switchboard"
+in the preview-hosting case) has to:
+
+1. **Authenticate the visitor** however it likes — OAuth, SSO, a magic link
+   — and decide whether they may see this site. It knows which site to
+   decide about from the `site_param` value on the redirect. This is where
+   all provider-specific work lives, and it happens **once per session**,
+   not once per request.
+2. **Mint an HS256 JWT** signed with the same `secret`, with an `exp` in the
+   future (required) and whatever `sub`/`iss`/`aud`/custom claims the app
+   needs. Keep it short-lived: this module has no revocation list, so
+   `exp` is the only thing that ends a session early.
+3. **Set it as a cookie** on the site's domain, under the name in `cookie`,
+   with `Secure` (so the browser never sends it over cleartext),
+   `HttpOnly` (so page JavaScript cannot read it), a `SameSite` value the
+   flow tolerates, and a `Path`/`Domain` no broader than necessary. These
+   attributes are the issuer's job — ePHPm never sets the cookie and cannot
+   add them after the fact.
+4. **Validate the return-to** it was handed and redirect the visitor back
+   to it, refusing anything that is not a path on the site it is returning
+   the user to.
+
+Both halves must be configured with the same secret and the same cookie
+name, and the login service must be able to set cookies on the site's
+domain (typically a parent domain of the preview hostnames).
+
+#### Claims forwarding
+
+With `claims_header = "X-Session-Claims"`, PHP reads the verified claims
+from `$_SERVER['HTTP_X_SESSION_CLAIMS']` without re-verifying. As with
+`jwt`'s `claims_header`, any client-sent header of that name is **stripped
+at ingest** — before the chain runs and before any header crosses to PHP —
+so a request on a path this mount's `match` glob skips can never smuggle a
+forged claims value through.
+
+#### Limits worth knowing
+
+- **HS256 only**, like `jwt` — no RS256/JWKS, so the signing key is a shared
+  secret and every serving node can mint tokens as well as verify them.
+- **No revocation.** A token is valid until its `exp`. Rotating `secret`
+  invalidates every outstanding session at once, which is the only
+  bulk revocation available.
+- **Coverage follows the chain's** (see below): in fpm mode the gate runs on
+  PHP-dispatched requests only, so static assets under the document root are
+  **not** gated. Gate a site whose static files are also confidential with
+  worker mode, or in front of ePHPm.
 
 ### `ratelimit`
 
@@ -350,7 +520,10 @@ declare!(MyAuth);
 config JSON parsing, response marshaling, and panic containment (a panicking
 `invoke` becomes a fail-closed 500).
 
-Inside `invoke`, `req.host()` exposes host services:
+Inside `invoke`, `req` exposes the request (`method()`, `path()`,
+`query()`, `remote_ip()`, `vhost_id()`, `header()`, and `is_https()` — the
+host's trusted-proxy-aware secure-transport verdict), and `req.host()`
+exposes host services:
 
 ```rust
 let host = req.host();
@@ -378,7 +551,8 @@ The artifact lands at `target/release/lib<crate_name>.so`; a bare
 `library = "<crate_name>"` mount finds the `lib<name>.so` form through
 the search path. The four in-tree modules build exactly the same way
 (`-p ephpm-middleware-jwt -p ephpm-middleware-cors
--p ephpm-middleware-ratelimit -p ephpm-middleware-security-headers`).
+-p ephpm-middleware-ratelimit -p ephpm-middleware-security-headers
+-p ephpm-middleware-session-cookie`).
 
 Build on a distro whose glibc is not newer than the deployment target's
 (the usual glibc forward-compatibility rule — a module built on Debian 12
@@ -407,8 +581,15 @@ const char* ephpm_middleware_describe(void);   /* optional, nullable */
   for the process lifetime — modules do not `dlsym` host symbols (that
   would need `-rdynamic` on Linux and has no clean Windows analogue). It
   contains request accessors (method, path, query, remote IP, header
-  lookup, vhost id), the KV operations (`kv_get`/`kv_set`/`kv_set_nx`/
-  `kv_incr`/`kv_free`) and `log`.
+  lookup, vhost id, secure-transport flag), the KV operations
+  (`kv_get`/`kv_set`/`kv_set_nx`/`kv_incr`/`kv_incr_ttl`/`kv_free`) and
+  `log`.
+- Repeated request-header lines are pre-joined before a module sees them:
+  `", "` for ordinary headers, `"; "` for `Cookie` (HTTP/2 is allowed to
+  split it across field lines).
+- `request_is_https` is the **host's** trusted-proxy-aware verdict, the
+  same value PHP sees as `$_SERVER['HTTPS']`. Use it instead of reading
+  `X-Forwarded-Proto`, which reaches modules exactly as the client sent it.
 - The request pointer is only valid during `invoke`; never store it.
   Everything a module writes into `response_out` must stay valid until its
   `invoke` returns — the host copies before unwinding.

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -273,7 +273,7 @@ sessions for that deployment, and gets them nothing at the provider.
 | `login_url` (string) | **required** | where to send unauthenticated browsers. Must be an `https://`/`http://` URL or a same-origin absolute path; anything else (`javascript:`, `//host`) fails startup |
 | `cookie` (string) | `"ephpm_session"` | name of the cookie carrying the token |
 | `return_to_param` (string) | unset — **no return-to is sent** | query parameter on `login_url` carrying the validated return path |
-| `site_param` (string) | unset | query parameter carrying this request's vhost id, so one login service can serve many sites |
+| `site_param` (string) | unset | query parameter carrying this request's site identity, so one login service can serve many sites |
 | `issuer` (string) | unset | required `iss` claim value |
 | `audience` (string) | unset | required `aud` claim value (string or array member) |
 | `claims_header` (string) | unset | forward the verified claims JSON to PHP in this request header |
@@ -378,6 +378,14 @@ in the preview-hosting case) has to:
    decide about from the `site_param` value on the redirect. This is where
    all provider-specific work lives, and it happens **once per session**,
    not once per request.
+
+   The site identity is derived from the request's `Host` header, so it is
+   normalised (port and any trailing dot removed, lowercased) but **not
+   trusted**: ePHPm does not reject unrecognised hosts by default, so a
+   client can present one the operator never configured. The login service
+   must look the identity up in its own registry and refuse anything it does
+   not recognise — never mint a session for a site simply because a request
+   named one.
 2. **Mint an HS256 JWT** signed with the same `secret`, with an `exp` in the
    future (required) and whatever `sub`/`iss`/`aud`/custom claims the app
    needs. Keep it short-lived: this module has no revocation list, so

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -572,8 +572,9 @@ and the membership check is per-host and trusts the TCP source address.
 ## `[[middleware]]`
 
 Native middleware mounts — repeatable array-of-tables. Each mount resolves
-against the **builtin registry first**: the four in-tree modules (`jwt`,
-`cors`, `ratelimit`, `security-headers`) are compiled into every binary and
+against the **builtin registry first**: the five in-tree modules (`jwt`,
+`cors`, `ratelimit`, `security-headers`, `session-cookie`) are compiled
+into every binary and
 run in-process — no shared library on disk, no `dlopen`. Any other name
 loads a shared library (`.so`/`.dylib`/`.dll`) at startup. Loading is
 fail-fast: a builtin rejecting its config, an unresolvable library, a
@@ -593,7 +594,7 @@ at startup) — see the guide's
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
+| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `session-cookie`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
 | `match` | string | (none) | Glob the request path must match for the mount to run. `*` matches any character sequence, including `/`. Unset = every PHP-bound request. |
 | `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. |
 | `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init`. |


### PR DESCRIPTION
## What

Adds a fifth builtin native middleware, **`session-cookie`**: it gates a site in a **browser** on a signed session cookie minted by an external identity service, and redirects unauthenticated visitors to that service's login URL.

The motivating use case is preview hosting for **private** repos — access gated on "is this user someone with read access?" rather than a shared password. The architecture is deliberately split, and **this PR is only the ePHPm half**:

- The **external login service** runs the OAuth/SSO dance, decides access, mints an HS256 token, and sets it as a cookie on the preview domain.
- **ePHPm** verifies that token on every request and redirects when it is missing, invalid, or expired.

**ePHPm never calls the identity provider.** Verification is one HMAC over bytes already in the request: no per-request network call, no provider rate limits, and no OAuth client secret on the serving nodes.

## Why a sibling module instead of extending `jwt`

`jwt` is an **API** gate: token in a header, `401` on failure, a machine reads the status code. This is a **browser** gate: token in a cookie, redirect on failure, a human reads a login page. Same crypto, two different threat models and two different failure behaviours.

Extending `jwt` would have been less code but would have put both on one config surface, where a single key flips an API's `401`s into redirects. Separate modules keep each honest, and `jwt`'s existing behaviour is **completely untouched** — the new module is purely additive and opt-in.

The usual cost of a sibling — duplicated verification — is avoided: `Hs256Policy` moves into a new shared `hs256` module that **both** modules call. Signature checked first (so no unauthenticated JSON is ever parsed), constant-time `Mac::verify_slice`, `alg` pinned to HS256, `exp` required. The two gates can differ in policy and failure behaviour but can never diverge in crypto.

## Security properties

Each of these has a test, and the hostile cases are listed with the exact inputs tried.

**Open redirect.** The return-to is taken from the path the browser actually requested, **never from a client-supplied `?next=`** — that removes most of the surface by construction. The request line is still client-controlled, so the target is validated anyway before it is emitted: absolute path only; no `//` or `\` (browsers normalise `\` to `/`, so `/\evil.example` behaves exactly like `//evil.example`); no ASCII control character, space, `DEL`, `#`, or non-ASCII; 2048-byte cap. A failing target is **dropped, not sanitised** — the user still reaches the login page, just without a return-to. What survives is percent-encoded down to `A-Za-z0-9-._~`, so it cannot introduce a parameter, fragment, or second URL.

`login_url` itself is constrained at **startup**: `javascript:`, `data:`, `//host`, and bare hostnames fail the mount rather than becoming an XSS or open-redirect primitive fired on every unauthenticated request.

**Cookie parsing.** RFC 6265: split on the **first** `=` only (values containing `=` survive), whole-name comparison (so `evil_ephpm_session` cannot satisfy a lookup for `ephpm_session`), surrounding whitespace and a quoted `cookie-value` handled. **Every** cookie of the name is tried, not just the first: otherwise anyone who can set a cookie on a parent domain could shadow the real one and lock every user out. Each candidate still has to pass the same HMAC and expiry check, so trying them all costs an HMAC and grants nothing.

**Constant-time comparison and mandatory `exp`** are inherited from `jwt`'s existing approach via the shared core, not re-implemented.

**HTTPS.** `require_https` defaults to **on**: a session cookie presented over cleartext is refused with `403`. Three decisions worth reviewing:

- The verdict is **the host's**, not a header the module read. I added a `request_is_https` accessor to the host table rather than letting the module read `X-Forwarded-Proto` — that header reaches modules exactly as the client sent it, so a module trusting it would be trusting the attacker. The new accessor exposes the router's existing trusted-proxy-aware value, the same one PHP sees as `$_SERVER['HTTPS']`.
- **Loopback is exempt**, mirroring the web platform's own treatment of `localhost` as a secure context. This is what avoids a `require_https = false` that an operator sets for their laptop and then ships.
- It is a hard `403`, not a redirect: bouncing to an HTTPS login service that sets a cookie the browser then returns over HTTP would loop forever.

**Site identity.** `site_param` puts `request_vhost_id` on the redirect, so one login service can serve many preview sites.

**Claims forwarding.** The claims header is added to the router's ingest-strip list, exactly as `jwt`'s is, so a client cannot forge it on a path the mount's `match` glob skips.

## Two supporting host changes

1. **`request_is_https`**, appended to the end of the v1 host table (same major version — the documented ABI-append rule, following `kv_incr_ttl`'s precedent).
2. **`RequestCtx` now joins repeated header lines**, as the ABI already documented but the code did not do: `", "` normally, `"; "` for `Cookie`, which HTTP/2 is explicitly allowed to split across field lines (RFC 9113 §8.2.3). Previously only the *first* line was visible to a module — meaning a module could silently miss the very cookie it authenticates on. Duplicate `Authorization`/`Origin` now join rather than silently using the first, which fails closed in both cases.

## Verification

Beyond unit tests, I built a **PHP-linked release binary** (Windows MSVC, PHP 8.5.7 ZTS, confirmed newer than the shared target dir's pre-existing artifact) and drove real HTTP with `curl`.

Rejection paths — every one returns 302 (303 for non-GET) with **no `x-powered-by`**, i.e. PHP never ran:

| case | result |
|---|---|
| no cookie | 302, `location: …?next=%2Findex.php&site=…`, `cache-control: no-store`, `vary: Cookie` |
| wrong cookie name | 302 |
| expired token | 302 |
| tampered signature (last sig char flipped) | 302 |
| payload swapped, signature kept | 302 |
| signed with a different key | 302 |
| `alg: none` | 302 |
| token with no `exp` | 302 |
| structurally broken (`""`, `not-a-jwt`, `a.b.c.d`, `..`) | 302 |
| unauthenticated `POST` | **303** (so the browser GETs the login page instead of re-POSTing) |

Valid token → `200`, `x-powered-by: PHP/8.5.7`, and PHP read the verified claims from `$_SERVER['HTTP_X_SESSION_CLAIMS']`.

Tamper detection is proved rather than assumed: the same test first asserts the untampered token **is** accepted, so a redirect afterwards means the tamper was detected, not that the token was never valid.

Hostile return-to values, sent as **raw request lines** over a socket so nothing normalised them first:

| request target | `next` emitted |
|---|---|
| `//evil.example/` | none |
| `///evil.example/` | none |
| `//evil.example/x?a=b` | none |
| `/\evil.example/` | none |
| `/\/evil.example` | none |
| `/x#@evil.example` | `%2Fx` (hyper strips the fragment first) |
| `/x y` | 400 from hyper — never reaches the module |
| `/%2F%2Fevil.example` | 400 from the server — never reaches the module |
| `/ok.php?a=b` (control) | `%2Fok.php%3Fa%3Db` |

HTTPS matrix, driven from a non-loopback local address so the client IP was not exempt:

| scenario | result |
|---|---|
| valid token, cleartext, remote client | **403** |
| no token, cleartext, remote client | 403 |
| valid token, cleartext, **loopback** client | 200 (secure-context exemption) |
| valid token + `X-Forwarded-Proto: https` from an **untrusted** peer | **403** — the forged header does not unlock it |
| trusted proxy + `X-Forwarded-Proto: https` | 200 |
| trusted proxy + `X-Forwarded-Proto: http` | 403 |
| trusted proxy, no `X-Forwarded-Proto` | 403 |

Claims-forgery, with real PHP observing `$_SERVER`:

- Forged `X-Session-Claims` + valid cookie → PHP saw the **verified** claims (`sub: octocat`), not the forged `sub: root`.
- Forged `X-Session-Claims` on a path **outside** the mount's `match` glob, where the module never ran at all → PHP saw `claims=NONE`. The ingest strip holds.

Startup fail-fast, each confirmed against a running binary: missing `secret`, missing `login_url`, `login_url = "javascript:alert(1)"`, `login_url = "//evil.example/login"`, and `require_https = "false"` (a string, not a bool) all abort startup naming the mount.

Gates: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check`, `cargo deny check`, and `cargo test --workspace` all pass (exit 0).

**Not verified on this platform:** the dlopen lane for the new cdylib shell (`ephpm-middleware-session-cookie`) was compiled but not loaded from disk; the builtin lane, which is what the docs recommend, was exercised end to end.

## Docs

`site/content/guides/native-middleware.md` gains a full `session-cookie` section covering the config table, the redirect semantics, the return-to rules, the HTTPS reasoning — and a **"what the login service must do"** subsection so a reader can implement both halves: authenticate and authorise once per session, mint an HS256 JWT with a required `exp`, set it with `Secure` / `HttpOnly` / a suitable `SameSite` (those attributes are the issuer's job — ePHPm never sets the cookie), and validate the return-to before redirecting back.

No GitHub API specifics are documented, since I did not verify any.

## Coordination

Another agent is concurrently adding an **HTTP Basic auth** builtin. We both touch the builtin registry in `crates/ephpm-server/src/middleware.rs` and the middleware docs, so **whoever merges second will need to rebase** — the conflicts should be limited to the registry `match` arm, the "five in-tree modules" counts, and the docs module list. I have not touched the Basic-auth work.

Also note **#375** (open) adds `examples/rust-middleware/`; I read its `api-gate` example for the module shape but changed nothing there.

CI notes: `Windows PHP Check` only passes on a runner that already has VS Build Tools (#377), and `Test (linux-x64)` has a known `ephpm-cluster::cluster_channel` flake (#383).
