### PR TITLE
feat(middleware): GitHub OAuth login gate — dlopen'd module issuing stateless signed sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephpm-middleware-github-auth"
+version = "0.1.0"
+dependencies = [
+ "base64ct",
+ "ephpm-middleware",
+ "getrandom 0.3.4",
+ "hmac 0.12.1",
+ "reqwest",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "serde_json",
+ "sha2 0.10.9",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "ephpm-middleware-jwt"
 version = "0.1.0"
 dependencies = [

--- a/crates/ephpm-middleware-github-auth/Cargo.toml
+++ b/crates/ephpm-middleware-github-auth/Cargo.toml
@@ -1,0 +1,82 @@
+[package]
+name = "ephpm-middleware-github-auth"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "ePHPm native middleware: GitHub OAuth login gate (cold path) that issues a stateless signed session for private preview sites"
+
+[lib]
+# Artifact name: libgithub_auth.so / libgithub_auth.dylib / github_auth.dll.
+# That file is what `[[middleware]] library = "..."` points at.
+name = "github_auth"
+# cdylib is the loadable module. The rlib exists only so the unit and
+# integration tests can link the same code; a shipped module needs cdylib
+# alone.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ephpm-middleware.workspace = true
+serde_json.workspace = true
+# Session/state token signing. Same primitives (and the same constant-time
+# `Mac::verify_slice`) as the builtin `jwt` module, so a token minted here and
+# a token verified there agree by construction.
+base64ct.workspace = true
+hmac.workspace = true
+sha2.workspace = true
+# OS entropy for the OAuth `state` nonce. A syscall shim, not a generator.
+getrandom.workspace = true
+
+# NOTE: `tracing` is deliberately NOT a dependency. A dlopen'd module links
+# its own copy of the `tracing` crate with its own global dispatcher, which is
+# never the host's — a `tracing::info!` here would be silently swallowed. The
+# ABI's `log` callback (`ephpm_middleware::Host::log`) is the only thing that
+# reaches ePHPm's log stream, and it is what this module uses.
+
+# ── Outbound HTTPS to GitHub ──────────────────────────────────────────────
+#
+# This is the reason the module ships as a dlopen'd cdylib rather than a
+# builtin: an HTTP client and a TLS stack are real weight, and none of it
+# belongs in the ephpm binary. Nothing below is a dependency of `ephpm`.
+#
+# `rustls-tls-manual-roots-no-provider` is the ONLY correct reqwest TLS
+# feature here. Every other `rustls-tls-*` feature also enables reqwest's
+# `__rustls-ring` and links `ring`, which is the multi-provider bug tracked in
+# ephpm#241. "manual roots" + "no provider" means reqwest supplies neither a
+# crypto provider nor a root store; `github.rs` hands it a fully-built
+# `rustls::ClientConfig` instead. Inherited from the workspace, which pins
+# exactly that feature set for the OTLP exporter.
+reqwest.workspace = true
+# rustls is declared here rather than inherited with `workspace = true`, for
+# one reason: the workspace pin still carries `features = ["ring"]`, and
+# inheriting it would put a SECOND crypto provider in the shipped `.so`.
+#
+# `aws-lc-rs` is the right single provider: it is what ephpm#241/PR#368
+# converges the server on, it is already enabled on rustls 0.23 elsewhere in
+# this workspace (rustls-acme, rcgen, pgwire, hyper-rustls), and it is what
+# `github.rs` names explicitly in `builder_with_provider`. Naming `ring`
+# instead would break the moment #368 drops it from the pin.
+#
+# Verified with `cargo tree -e features,no-dev -p ephpm-middleware-github-auth
+# -i ring` (no match) and `... -p ephpm -i ring` (byte-identical to main).
+# The version tracks the workspace pin below it; Cargo resolves both to the
+# same 0.23.x lock entry, so there is no second rustls. When #368 lands and
+# the workspace pin loses `ring`, this can become `workspace = true`.
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "tls12",
+    "logging",
+    "aws-lc-rs",
+] }
+rustls-native-certs.workspace = true
+webpki-roots.workspace = true
+
+[dev-dependencies]
+# `host` supplies the request context and callback table so tests can build a
+# real `Request` without a running server. A shipped module never enables it.
+ephpm-middleware = { workspace = true, features = ["host"] }
+
+[lints]
+workspace = true

--- a/crates/ephpm-middleware-github-auth/README.md
+++ b/crates/ephpm-middleware-github-auth/README.md
@@ -1,0 +1,62 @@
+# `ephpm-middleware-github-auth`
+
+A GitHub OAuth **login gate** for ePHPm, shipped as a `dlopen`'d native
+middleware module. It answers *"does the person at this browser have access,
+on GitHub, to the repo this preview is for?"* — **once**, at login — and then
+issues a stateless signed session.
+
+Full operator documentation: **[GitHub OAuth Gate
+(native middleware)](../../site/content/guides/github-auth-middleware.md)**.
+
+```bash
+cargo build --release -p ephpm-middleware-github-auth
+# target/release/libgithub_auth.so | .dylib | github_auth.dll
+```
+
+```toml
+[[middleware]]
+library = "/opt/ephpm/modules/libgithub_auth.so"
+order   = 10
+config  = { client_id = "Iv1.…", client_secret = "env:GH_CLIENT_SECRET",
+            session_secret = "env:EPHPM_SESSION_SECRET", repo = "acme/web" }
+```
+
+## Three things to know before reading the code
+
+1. **This is the cold path only.** It issues sessions; it never verifies one.
+   A request carrying the session cookie gets `CONTINUE` and a separate
+   session-verifier module decides. **Mounted alone it is not an
+   authenticator** — it logs that at startup.
+2. **No GitHub call ever happens on a request that has a session.** That is
+   structural: `GithubAuth::route` is a pure function, only its `Callback`
+   variant reaches `github.rs`, and only the exact configured `callback_path`
+   produces it. `tests/oauth_round_trip.rs` asserts the stub GitHub's request
+   counter does not move across 50 authenticated requests.
+3. **It is a `cdylib`, not a builtin, on purpose.** It needs an HTTP client
+   and TLS; none of that is in the `ephpm` binary
+   (`cargo tree -e features,no-dev -p ephpm -i ring` is byte-identical with
+   and without this crate). The module itself links exactly one crypto
+   provider, `aws-lc-rs` — see the comment on the `rustls` dependency in
+   `Cargo.toml`, which is load-bearing.
+
+## Layout
+
+| file | what it holds |
+|---|---|
+| `src/lib.rs` | routing (`Route`), the login/callback/bypass flows, `declare!` |
+| `src/config.rs` | strict, fail-closed config parsing; `env:` secret indirection |
+| `src/github.rs` | the outbound half: TLS, token exchange, the three access checks |
+| `src/token.rs` | HS256 minting, key derivation, constant-time comparison |
+| `src/redirect.rs` | return-to validation (the open-redirect defence) |
+| `src/cookie.rs` | cookie reading and `Set-Cookie` construction |
+| `tests/oauth_round_trip.rs` | the whole flow against a stub GitHub over real sockets |
+
+## Tests
+
+```bash
+cargo test -p ephpm-middleware-github-auth
+```
+
+What is **not** covered, and needs a human: a round trip against the real
+`github.com` with a registered GitHub App. Everything this side of that is
+exercised over real TCP against a stub.

--- a/crates/ephpm-middleware-github-auth/src/config.rs
+++ b/crates/ephpm-middleware-github-auth/src/config.rs
@@ -372,7 +372,7 @@ impl Config {
             None | Some(serde_json::Value::Null) => {}
             Some(serde_json::Value::Object(map)) => {
                 for (host, entry) in map {
-                    let host_key = host.trim().to_ascii_lowercase();
+                    let host_key = normalize_vhost(host);
                     validate_vhost(&host_key)?;
                     let check = parse_check(entry, &format!("sites.{host}"))?
                         .ok_or_else(|| format!("sites.{host}: no repo/org/team configured"))?;
@@ -522,6 +522,10 @@ impl Config {
 
     /// The access check that applies to `vhost`.
     ///
+    /// `vhost` must already have been through [`normalize_vhost`]; the keys
+    /// of `sites` were normalised at parse time, so anything else silently
+    /// misses.
+    ///
     /// When a `sites` table is configured it is authoritative: a vhost with
     /// no entry gets **no** check and therefore no access, even if a
     /// top-level `repo` is also set. Falling back would mean a hostname
@@ -531,7 +535,7 @@ impl Config {
         if self.sites.is_empty() {
             return self.default_check.as_ref();
         }
-        self.sites.get(&vhost.trim().to_ascii_lowercase())
+        self.sites.get(vhost)
     }
 
     /// Paths the gate owns, for the return-to loop check.
@@ -539,6 +543,30 @@ impl Config {
     pub fn reserved_paths(&self) -> [&str; 2] {
         [self.login_path.as_str(), self.callback_path.as_str()]
     }
+}
+
+/// Canonicalise the middleware ABI's `request_vhost_id` before it is used as
+/// a key or written into a token.
+///
+/// **This is not cosmetic.** `request_vhost_id` is the router's `SERVER_NAME`
+/// — the raw `Host` header with the port split off and *nothing else*. It is
+/// **not** lowercased, the FQDN-root dot is not stripped, and it is not the
+/// canonical site key that `Router::resolve_site` produces. `Host` is
+/// case-insensitive per RFC 9110 and entirely client-controlled, so without
+/// this a `sites` lookup misses on `Host: PR-1.Preview.Test`, and — worse —
+/// two spellings of the same host would mint sessions with two different
+/// `site` claims and two different derived `redirect_uri`s.
+///
+/// The port is deliberately **not** split off here: the server already
+/// removed it, and splitting on `:` would corrupt an IPv6 literal
+/// (`[::1]` → `[`). If a future ABI change reintroduced the port, the key
+/// would simply stop matching, which fails closed.
+///
+/// `ephpm-server`'s own `normalize_host_key` is `pub(crate)`, so a module
+/// cannot call it; the duplication is forced.
+#[must_use]
+pub fn normalize_vhost(raw: &str) -> String {
+    raw.trim().trim_end_matches('.').to_ascii_lowercase()
 }
 
 /// Reject a vhost id that could not appear in a URL authority.
@@ -703,14 +731,39 @@ mod tests {
             c.check_for("pr-1.preview.example.com"),
             Some(&Check::Repo { owner: "acme".into(), name: "web".into() })
         );
-        // Host matching is case-insensitive in both directions.
+        // A `sites` KEY written in mixed case is normalised at parse time.
         assert_eq!(
-            c.check_for("pr-2.PREVIEW.example.com"),
+            c.check_for("pr-2.preview.example.com"),
             Some(&Check::Org { org: "acme".into() })
         );
         // An unmapped vhost gets nothing — it does NOT inherit the top-level
         // `repo`, which is also set in this config.
         assert_eq!(c.check_for("pr-99.preview.example.com"), None);
+    }
+
+    #[test]
+    fn vhost_normalisation_closes_the_case_bypass() {
+        // `request_vhost_id` is the RAW `Host` header. Without normalisation
+        // a client picks its own key by changing a letter's case, and mints
+        // sessions whose `site` claim disagrees with everyone else's.
+        for raw in [
+            "PR-1.Preview.Example.COM",
+            "pr-1.preview.example.com.",
+            "  pr-1.preview.example.com  ",
+            "PR-1.PREVIEW.EXAMPLE.COM.",
+        ] {
+            assert_eq!(normalize_vhost(raw), "pr-1.preview.example.com", "{raw:?}");
+        }
+        // An IPv6 literal survives: the port is already gone, and splitting
+        // on ':' here would truncate it to "[".
+        assert_eq!(normalize_vhost("[::1]"), "[::1]");
+        assert!(validate_vhost(&normalize_vhost("[::1]")).is_ok());
+
+        let mut v = base();
+        v["sites"] = serde_json::json!({ "PR-1.Preview.Example.COM": { "repo": "acme/web" } });
+        let c = parse(v).expect("parse");
+        assert!(c.check_for(&normalize_vhost("pr-1.PREVIEW.example.com")).is_some());
+        assert!(c.check_for(&normalize_vhost("PR-1.preview.example.com.")).is_some());
     }
 
     #[test]

--- a/crates/ephpm-middleware-github-auth/src/config.rs
+++ b/crates/ephpm-middleware-github-auth/src/config.rs
@@ -1,0 +1,776 @@
+//! Configuration parsing for the gate.
+//!
+//! Everything arrives as the `[[middleware]] config` table, serialised to
+//! JSON by ePHPm. Parsing is strict and fail-closed: an unusable value is an
+//! `Err` out of `init`, which aborts server startup with the message rather
+//! than booting a gate that silently lets everyone through.
+//!
+//! # Where the secrets come from
+//!
+//! Three values are secrets: `client_secret`, `session_secret` and the
+//! optional `bypass_token`. Each accepts either a literal or an
+//! **`env:NAME`** indirection that reads the named environment variable at
+//! startup. `env:` is the recommended form — `ephpm.toml` is frequently
+//! templated, checked in, or rendered into a ConfigMap, and a literal in it
+//! is a secret in git.
+//!
+//! Read [`Secret`] and then the crate-level "Operational cost" section: the
+//! OAuth client secret genuinely lives on the node, and that is the price of
+//! doing this in-process instead of in an external identity service.
+
+use std::collections::BTreeMap;
+
+use crate::cookie::{CookieAttrs, SameSite, validate_cookie_name};
+
+/// Default reserved path that receives GitHub's OAuth redirect.
+pub const DEFAULT_CALLBACK_PATH: &str = "/_ephpm/auth/github/callback";
+/// Default reserved path that starts a login.
+pub const DEFAULT_LOGIN_PATH: &str = "/_ephpm/auth/github/login";
+/// Default session cookie name.
+pub const DEFAULT_COOKIE_NAME: &str = "ephpm_session";
+/// Default session lifetime: one working day.
+pub const DEFAULT_SESSION_TTL: u64 = 8 * 60 * 60;
+/// Lifetime of the OAuth `state` cookie — long enough to type a password and
+/// answer an MFA prompt, short enough that a stolen one is worthless.
+pub const STATE_TTL_SECS: u64 = 600;
+/// Default automation-bypass session lifetime.
+pub const DEFAULT_BYPASS_TTL: u64 = 60 * 60;
+/// Default header carrying the automation bypass token.
+pub const DEFAULT_BYPASS_HEADER: &str = "x-ephpm-bypass";
+/// Default `iss` claim.
+pub const DEFAULT_ISSUER: &str = "ephpm-github-auth";
+
+/// A configured secret.
+///
+/// The `Debug` impl redacts, so a secret cannot reach a log through a
+/// derived `Debug` on some struct that happens to contain one. That is not
+/// hypothetical tidiness: `tracing`'s `?value` sigil is one keystroke away
+/// from `%value`.
+#[derive(Clone)]
+pub struct Secret(Vec<u8>);
+
+impl Secret {
+    /// The raw bytes, for signing and comparison only.
+    #[must_use]
+    pub fn expose(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Secret(<redacted>)")
+    }
+}
+
+/// Which GitHub relationship grants access to a preview.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Check {
+    /// The user can read `owner/name`. The default, and the tightest answer
+    /// to "does this person have access to the repo this preview is for?".
+    Repo {
+        /// `owner` segment.
+        owner: String,
+        /// Repository name.
+        name: String,
+    },
+    /// The user is an *active* member of the organisation.
+    Org {
+        /// Organisation login.
+        org: String,
+    },
+    /// The user is an *active* member of a specific team.
+    Team {
+        /// Organisation login.
+        org: String,
+        /// Team slug.
+        team: String,
+    },
+}
+
+impl Check {
+    /// A short, non-secret description for logs and error bodies.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Repo { owner, name } => format!("repo {owner}/{name}"),
+            Self::Org { org } => format!("org {org}"),
+            Self::Team { org, team } => format!("team {org}/{team}"),
+        }
+    }
+}
+
+/// The gate's fully-resolved configuration.
+#[derive(Debug)]
+pub struct Config {
+    /// OAuth client id (not a secret).
+    pub client_id: String,
+    /// OAuth client secret.
+    pub client_secret: Secret,
+    /// HMAC key for the session token. Shared with the hot-path verifier.
+    pub session_secret: Secret,
+    /// Key for the OAuth `state` cookie, derived from `session_secret`.
+    pub state_secret: Secret,
+
+    /// Access check applied when the request's vhost has no `sites` entry.
+    pub default_check: Option<Check>,
+    /// Per-vhost access checks (`request_vhost_id` → check).
+    pub sites: BTreeMap<String, Check>,
+
+    /// Reserved path that starts a login.
+    pub login_path: String,
+    /// Reserved path that receives GitHub's redirect.
+    pub callback_path: String,
+
+    /// Session cookie name. Must match the hot-path verifier's.
+    pub cookie_name: String,
+    /// OAuth `state` cookie name.
+    pub state_cookie_name: String,
+    /// Attributes applied to both cookies.
+    pub cookie_attrs: CookieAttrs,
+    /// Session lifetime, seconds.
+    pub session_ttl_secs: u64,
+
+    /// `iss` claim written into issued tokens.
+    pub issuer: String,
+    /// `aud` claim written into issued tokens, when configured.
+    pub audience: Option<String>,
+
+    /// Pre-shared automation bypass token.
+    pub bypass_token: Option<Secret>,
+    /// Header carrying the bypass token.
+    pub bypass_header: String,
+    /// Query parameter carrying the bypass token; off unless configured.
+    pub bypass_query: Option<String>,
+    /// Lifetime of a bypass-issued session, seconds.
+    pub bypass_ttl_secs: u64,
+
+    /// OAuth authorize/token host (`https://github.com`, or a GHES host).
+    pub github_base: String,
+    /// REST API base (`https://api.github.com`, or `https://ghes/api/v3`).
+    pub github_api_base: String,
+    /// Explicit `redirect_uri`. When unset it is derived per request as
+    /// `https://<vhost><callback_path>`.
+    pub redirect_uri: Option<String>,
+    /// OAuth scopes requested. Empty is correct for a GitHub App.
+    pub scopes: Vec<String>,
+    /// Timeout for each outbound GitHub call, seconds.
+    pub http_timeout_secs: u64,
+}
+
+/// Read a string field.
+fn opt_str(config: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s)) if s.is_empty() => Ok(None),
+        Some(serde_json::Value::String(s)) => Ok(Some(s.clone())),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+fn req_str(config: &serde_json::Value, key: &str) -> Result<String, String> {
+    opt_str(config, key)?.ok_or_else(|| format!("`{key}` is required and must be non-empty"))
+}
+
+fn opt_bool(config: &serde_json::Value, key: &str, default: bool) -> Result<bool, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("`{key}` must be a boolean, got {other}")),
+    }
+}
+
+fn opt_u64(config: &serde_json::Value, key: &str, default: u64) -> Result<u64, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(v) => v.as_u64().ok_or_else(|| format!("`{key}` must be a positive integer, got {v}")),
+    }
+}
+
+/// How a secret's `env:NAME` indirection is resolved.
+///
+/// Injected rather than calling [`std::env::var`] inline so the tests can
+/// exercise the indirection without `set_var`, which is `unsafe` in the 2024
+/// edition and a genuine data race in a multi-threaded test binary.
+pub type EnvLookup<'a> = &'a dyn Fn(&str) -> Option<String>;
+
+/// Resolve a secret, following an `env:NAME` indirection.
+fn secret(
+    config: &serde_json::Value,
+    key: &str,
+    env: EnvLookup<'_>,
+) -> Result<Option<Secret>, String> {
+    let Some(raw) = opt_str(config, key)? else {
+        return Ok(None);
+    };
+    let value = if let Some(var) = raw.strip_prefix("env:") {
+        if var.is_empty() {
+            return Err(format!("`{key}` is `env:` with no variable name"));
+        }
+        // The variable NAME is safe to name in an error; the value never is.
+        env(var).ok_or_else(|| {
+            format!("`{key}` points at environment variable `{var}`, which is not set")
+        })?
+    } else {
+        raw
+    };
+    if value.is_empty() {
+        return Err(format!("`{key}` resolved to an empty value"));
+    }
+    Ok(Some(Secret(value.into_bytes())))
+}
+
+/// Shortest accepted `session_secret`.
+///
+/// 32 bytes is the HMAC-SHA256 block-security level. Shorter keys are what
+/// make an offline forgery attempt on a self-contained token worth
+/// attempting, and the whole security of the session rests on this one value.
+const MIN_SESSION_SECRET: usize = 32;
+
+/// Parse a `check` selection out of a JSON object (the top-level config or
+/// one `sites` entry). Returns `None` when the object names no target.
+fn parse_check(v: &serde_json::Value, ctx: &str) -> Result<Option<Check>, String> {
+    let kind = opt_str(v, "check")?;
+    let repo = opt_str(v, "repo")?;
+    let org = opt_str(v, "org")?;
+    let team = opt_str(v, "team")?;
+
+    // Infer the kind when it is unambiguous, so the common single-key form
+    // (`{ repo = "acme/web" }`) needs no ceremony.
+    let kind = match kind.as_deref() {
+        Some(k) => k.to_ascii_lowercase(),
+        None if team.is_some() => "team".into(),
+        None if repo.is_some() => "repo".into(),
+        None if org.is_some() => "org".into(),
+        None => return Ok(None),
+    };
+
+    match kind.as_str() {
+        "repo" => {
+            let spec = repo.ok_or_else(|| format!("{ctx}: `check = \"repo\"` needs `repo` set"))?;
+            let (owner, name) = spec
+                .split_once('/')
+                .ok_or_else(|| format!("{ctx}: `repo` must be `owner/name`, got {spec:?}"))?;
+            if owner.is_empty() || name.is_empty() || name.contains('/') {
+                return Err(format!("{ctx}: `repo` must be exactly `owner/name`, got {spec:?}"));
+            }
+            validate_path_segment(owner, &format!("{ctx}: repo owner"))?;
+            validate_path_segment(name, &format!("{ctx}: repo name"))?;
+            Ok(Some(Check::Repo { owner: owner.to_owned(), name: name.to_owned() }))
+        }
+        "org" => {
+            let org = org.ok_or_else(|| format!("{ctx}: `check = \"org\"` needs `org` set"))?;
+            validate_path_segment(&org, &format!("{ctx}: org"))?;
+            Ok(Some(Check::Org { org }))
+        }
+        "team" => {
+            let org = org.ok_or_else(|| format!("{ctx}: `check = \"team\"` needs `org` set"))?;
+            let team = team.ok_or_else(|| format!("{ctx}: `check = \"team\"` needs `team` set"))?;
+            validate_path_segment(&org, &format!("{ctx}: org"))?;
+            validate_path_segment(&team, &format!("{ctx}: team"))?;
+            Ok(Some(Check::Team { org, team }))
+        }
+        other => Err(format!("{ctx}: `check` must be repo, org or team, got {other:?}")),
+    }
+}
+
+/// Reject anything that would not survive being interpolated into a GitHub
+/// API path. This is the one place configured strings become part of an
+/// outbound URL, so it is the one place path traversal or a smuggled query
+/// could be introduced.
+fn validate_path_segment(s: &str, what: &str) -> Result<(), String> {
+    let ok = !s.is_empty()
+        && s.len() <= 100
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        && s != "."
+        && s != "..";
+    if ok { Ok(()) } else { Err(format!("{what}: {s:?} is not a valid GitHub name")) }
+}
+
+/// Validate a reserved path: absolute, no query, no traversal.
+fn validate_reserved_path(p: &str, key: &str) -> Result<(), String> {
+    if !p.starts_with('/') || p.contains(['?', '#', '\\', ' ']) || !p.is_ascii() {
+        return Err(format!("`{key}` must be an absolute ASCII path with no query, got {p:?}"));
+    }
+    Ok(())
+}
+
+/// Validate an `https://…` (or loopback `http://…`) base URL.
+///
+/// Plaintext is permitted **only** to a loopback literal. That single
+/// exception is what lets the integration tests point the module at a stub
+/// OAuth server on `127.0.0.1`; it cannot be turned into "plaintext to
+/// github.com", which would put the client secret and the access token on
+/// the wire in clear.
+fn validate_base_url(url: &str, key: &str) -> Result<(), String> {
+    let rest = if let Some(r) = url.strip_prefix("https://") {
+        r
+    } else if let Some(r) = url.strip_prefix("http://") {
+        let host = r.split(['/', ':']).next().unwrap_or("");
+        if !matches!(host, "127.0.0.1" | "localhost" | "[::1]" | "::1") {
+            return Err(format!(
+                "`{key}` may only use http:// for a loopback host (got {url:?}); \
+                 plaintext to a real GitHub host would expose the client secret \
+                 and the user's access token"
+            ));
+        }
+        r
+    } else {
+        return Err(format!("`{key}` must start with https:// (got {url:?})"));
+    };
+    if rest.is_empty() || url.ends_with('/') {
+        return Err(format!("`{key}` must have a host and no trailing slash (got {url:?})"));
+    }
+    if !url.is_ascii() || url.chars().any(|c| c.is_ascii_control()) {
+        return Err(format!("`{key}` must be printable ASCII (got {url:?})"));
+    }
+    Ok(())
+}
+
+impl Config {
+    /// Parse and validate the mount's config table.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message for any missing, malformed or unsafe
+    /// value. Every one of these aborts server startup.
+    pub fn parse(config: &serde_json::Value) -> Result<Self, String> {
+        Self::parse_with_env(config, &|var| std::env::var(var).ok())
+    }
+
+    /// [`Config::parse`] with the `env:` resolver injected.
+    ///
+    /// # Errors
+    ///
+    /// As [`Config::parse`].
+    #[allow(clippy::too_many_lines, reason = "one flat, auditable validation pass")]
+    pub fn parse_with_env(config: &serde_json::Value, env: EnvLookup<'_>) -> Result<Self, String> {
+        if !config.is_object() {
+            return Err("config must be a table (`config = { client_id = ... }`)".into());
+        }
+
+        let client_id = req_str(config, "client_id")?;
+        let client_secret =
+            secret(config, "client_secret", env)?.ok_or("`client_secret` is required")?;
+        let session_secret =
+            secret(config, "session_secret", env)?.ok_or("`session_secret` is required")?;
+        if session_secret.expose().len() < MIN_SESSION_SECRET {
+            return Err(format!(
+                "`session_secret` must be at least {MIN_SESSION_SECRET} bytes; the whole \
+                 security of an unrevocable, self-contained session token rests on it"
+            ));
+        }
+        let state_secret = Secret(crate::token::derive_key(
+            session_secret.expose(),
+            crate::token::STATE_KEY_LABEL,
+        ));
+
+        // Access targets. `sites` maps a vhost id to its own check, which is
+        // what lets one mount serve a fleet of per-PR preview hostnames.
+        let mut sites = BTreeMap::new();
+        match config.get("sites") {
+            None | Some(serde_json::Value::Null) => {}
+            Some(serde_json::Value::Object(map)) => {
+                for (host, entry) in map {
+                    let host_key = host.trim().to_ascii_lowercase();
+                    validate_vhost(&host_key)?;
+                    let check = parse_check(entry, &format!("sites.{host}"))?
+                        .ok_or_else(|| format!("sites.{host}: no repo/org/team configured"))?;
+                    sites.insert(host_key, check);
+                }
+            }
+            Some(other) => return Err(format!("`sites` must be a table, got {other}")),
+        }
+        let default_check = parse_check(config, "config")?;
+        if default_check.is_none() && sites.is_empty() {
+            return Err(
+                "no access target configured: set `repo` (or `org`/`team`), or a `sites` table \
+                 mapping each vhost to one. A gate with nothing to check would authenticate \
+                 every GitHub user in the world."
+                    .into(),
+            );
+        }
+
+        let login_path =
+            opt_str(config, "login_path")?.unwrap_or_else(|| DEFAULT_LOGIN_PATH.to_owned());
+        let callback_path =
+            opt_str(config, "callback_path")?.unwrap_or_else(|| DEFAULT_CALLBACK_PATH.to_owned());
+        validate_reserved_path(&login_path, "login_path")?;
+        validate_reserved_path(&callback_path, "callback_path")?;
+        if login_path == callback_path {
+            return Err("`login_path` and `callback_path` must differ".into());
+        }
+
+        let cookie_name =
+            opt_str(config, "cookie_name")?.unwrap_or_else(|| DEFAULT_COOKIE_NAME.to_owned());
+        validate_cookie_name(&cookie_name)?;
+        let state_cookie_name =
+            opt_str(config, "state_cookie_name")?.unwrap_or_else(|| format!("{cookie_name}_oauth"));
+        validate_cookie_name(&state_cookie_name)?;
+        if state_cookie_name == cookie_name {
+            return Err("`state_cookie_name` must differ from `cookie_name`".into());
+        }
+
+        let cookie_path = opt_str(config, "cookie_path")?.unwrap_or_else(|| "/".to_owned());
+        validate_reserved_path(&cookie_path, "cookie_path")?;
+        let same_site =
+            SameSite::parse(opt_str(config, "cookie_samesite")?.as_deref().unwrap_or("Lax"))?;
+        let secure = opt_bool(config, "cookie_secure", true)?;
+        if same_site == SameSite::None && !secure {
+            return Err("`cookie_samesite = \"None\"` requires `cookie_secure = true`".into());
+        }
+
+        let session_ttl_secs = opt_u64(config, "session_ttl_secs", DEFAULT_SESSION_TTL)?;
+        if !(60..=7 * 24 * 60 * 60).contains(&session_ttl_secs) {
+            return Err(
+                "`session_ttl_secs` must be between 60 and 604800: the token cannot be revoked \
+                 before it expires, so its lifetime is the blast radius of a stolen cookie"
+                    .into(),
+            );
+        }
+
+        let bypass_token = secret(config, "bypass_token", env)?;
+        if let Some(t) = &bypass_token
+            && t.expose().len() < MIN_SESSION_SECRET
+        {
+            return Err(format!(
+                "`bypass_token` must be at least {MIN_SESSION_SECRET} bytes — it is a password \
+                 that skips GitHub entirely"
+            ));
+        }
+        let bypass_ttl_secs = opt_u64(config, "bypass_ttl_secs", DEFAULT_BYPASS_TTL)?;
+        if !(60..=7 * 24 * 60 * 60).contains(&bypass_ttl_secs) {
+            return Err("`bypass_ttl_secs` must be between 60 and 604800".into());
+        }
+        let bypass_header = opt_str(config, "bypass_header")?
+            .unwrap_or_else(|| DEFAULT_BYPASS_HEADER.to_owned())
+            .to_ascii_lowercase();
+        let bypass_query = opt_str(config, "bypass_query")?;
+
+        let github_base =
+            opt_str(config, "github_base")?.unwrap_or_else(|| "https://github.com".to_owned());
+        let github_api_base = opt_str(config, "github_api_base")?
+            .unwrap_or_else(|| "https://api.github.com".to_owned());
+        validate_base_url(&github_base, "github_base")?;
+        validate_base_url(&github_api_base, "github_api_base")?;
+
+        let redirect_uri = opt_str(config, "redirect_uri")?;
+        if let Some(uri) = &redirect_uri {
+            let base = uri.split(['?', '#']).next().unwrap_or(uri);
+            validate_base_url(base, "redirect_uri")?;
+            if !base.ends_with(&callback_path) {
+                return Err(format!(
+                    "`redirect_uri` must end with `callback_path` ({callback_path}); GitHub \
+                     redirects there and only that path is handled"
+                ));
+            }
+        }
+
+        let scopes = match config.get("scopes") {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(serde_json::Value::Array(items)) => items
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(str::to_owned)
+                        .ok_or_else(|| format!("`scopes` entries must be strings, got {v}"))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            Some(other) => return Err(format!("`scopes` must be an array, got {other}")),
+        };
+        for s in &scopes {
+            if !s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '-')) {
+                return Err(format!("`scopes` entry {s:?} contains unexpected characters"));
+            }
+        }
+
+        let http_timeout_secs = opt_u64(config, "http_timeout_secs", 10)?;
+        if !(1..=60).contains(&http_timeout_secs) {
+            return Err(
+                "`http_timeout_secs` must be between 1 and 60 — `invoke` is synchronous, so this \
+                 is how long one request thread can be parked on GitHub"
+                    .into(),
+            );
+        }
+
+        Ok(Self {
+            client_id,
+            client_secret,
+            session_secret,
+            state_secret,
+            default_check,
+            sites,
+            login_path,
+            callback_path,
+            cookie_name,
+            state_cookie_name,
+            cookie_attrs: CookieAttrs { path: cookie_path, secure, same_site },
+            session_ttl_secs,
+            issuer: opt_str(config, "issuer")?.unwrap_or_else(|| DEFAULT_ISSUER.to_owned()),
+            audience: opt_str(config, "audience")?,
+            bypass_token,
+            bypass_header,
+            bypass_query,
+            bypass_ttl_secs,
+            github_base,
+            github_api_base,
+            redirect_uri,
+            scopes,
+            http_timeout_secs,
+        })
+    }
+
+    /// The access check that applies to `vhost`.
+    ///
+    /// When a `sites` table is configured it is authoritative: a vhost with
+    /// no entry gets **no** check and therefore no access, even if a
+    /// top-level `repo` is also set. Falling back would mean a hostname
+    /// nobody mapped quietly inherits some other tenant's rule.
+    #[must_use]
+    pub fn check_for(&self, vhost: &str) -> Option<&Check> {
+        if self.sites.is_empty() {
+            return self.default_check.as_ref();
+        }
+        self.sites.get(&vhost.trim().to_ascii_lowercase())
+    }
+
+    /// Paths the gate owns, for the return-to loop check.
+    #[must_use]
+    pub fn reserved_paths(&self) -> [&str; 2] {
+        [self.login_path.as_str(), self.callback_path.as_str()]
+    }
+}
+
+/// Reject a vhost id that could not appear in a URL authority.
+///
+/// The vhost is interpolated into the derived `redirect_uri`, so it is
+/// attacker-influenced input (it comes from the `Host` header) heading for an
+/// outbound URL.
+///
+/// # Errors
+///
+/// Returns a message when the name is empty, over-long, non-ASCII, or
+/// contains anything outside the host/port character set.
+pub fn validate_vhost(host: &str) -> Result<(), String> {
+    let ok = !host.is_empty()
+        && host.len() <= 253
+        && host.is_ascii()
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | ':' | '[' | ']'));
+    if ok { Ok(()) } else { Err(format!("{host:?} is not a usable virtual-host name")) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> serde_json::Value {
+        serde_json::json!({
+            "client_id": "Iv1.abc",
+            "client_secret": "shhh",
+            "session_secret": "0123456789abcdef0123456789abcdef",
+            "repo": "acme/web",
+        })
+    }
+
+    fn parse(v: serde_json::Value) -> Result<Config, String> {
+        Config::parse(&v)
+    }
+
+    #[test]
+    fn defaults_are_the_documented_ones() {
+        let c = parse(base()).expect("parse");
+        assert_eq!(c.login_path, DEFAULT_LOGIN_PATH);
+        assert_eq!(c.callback_path, DEFAULT_CALLBACK_PATH);
+        assert_eq!(c.cookie_name, DEFAULT_COOKIE_NAME);
+        assert_eq!(c.state_cookie_name, "ephpm_session_oauth");
+        assert_eq!(c.session_ttl_secs, DEFAULT_SESSION_TTL);
+        assert!(c.cookie_attrs.secure);
+        assert_eq!(c.cookie_attrs.same_site, SameSite::Lax);
+        assert_eq!(c.cookie_attrs.path, "/");
+        assert_eq!(c.github_base, "https://github.com");
+        assert_eq!(c.github_api_base, "https://api.github.com");
+        assert_eq!(c.issuer, DEFAULT_ISSUER);
+        assert!(c.scopes.is_empty(), "empty scopes is correct for a GitHub App");
+        assert_eq!(c.http_timeout_secs, 10);
+        assert_eq!(c.default_check, Some(Check::Repo { owner: "acme".into(), name: "web".into() }));
+    }
+
+    #[test]
+    fn required_fields_are_required() {
+        for missing in ["client_id", "client_secret", "session_secret"] {
+            let mut v = base();
+            v.as_object_mut().expect("object").remove(missing);
+            assert!(parse(v).is_err(), "{missing} must be required");
+        }
+        // No target at all.
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        let err = parse(v).expect_err("a gate with no target must not start");
+        assert!(err.contains("every GitHub user in the world"));
+    }
+
+    #[test]
+    fn weak_session_secret_is_refused() {
+        let mut v = base();
+        v["session_secret"] = serde_json::json!("too-short");
+        assert!(parse(v).expect_err("weak secret").contains("at least 32 bytes"));
+    }
+
+    #[test]
+    fn env_indirection_reads_the_variable() {
+        let env = |var: &str| {
+            (var == "GH_SESSION_SECRET").then(|| "0123456789abcdef0123456789abcdef".to_owned())
+        };
+        let mut v = base();
+        v["session_secret"] = serde_json::json!("env:GH_SESSION_SECRET");
+        let c = Config::parse_with_env(&v, &env).expect("parse");
+        assert_eq!(c.session_secret.expose(), b"0123456789abcdef0123456789abcdef");
+
+        let mut v = base();
+        v["session_secret"] = serde_json::json!("env:NOT_SET_ANYWHERE");
+        let err = Config::parse_with_env(&v, &env).expect_err("unset var");
+        assert!(err.contains("is not set"));
+        assert!(err.contains("NOT_SET_ANYWHERE"), "the variable NAME is safe to report");
+
+        // `env:` with no name is a config error, not a lookup of "".
+        let mut v = base();
+        v["client_secret"] = serde_json::json!("env:");
+        assert!(Config::parse_with_env(&v, &env).is_err());
+    }
+
+    #[test]
+    fn secret_debug_is_redacted() {
+        let c = parse(base()).expect("parse");
+        let rendered = format!("{:?}", c.client_secret);
+        assert_eq!(rendered, "Secret(<redacted>)");
+        // And through the whole struct, which derives Debug.
+        let whole = format!("{c:?}");
+        assert!(!whole.contains("shhh"), "a secret must not reach a Debug rendering");
+        assert!(!whole.contains("0123456789abcdef"));
+    }
+
+    #[test]
+    fn plaintext_github_base_is_refused_except_on_loopback() {
+        for bad in ["http://github.com", "http://evil.test", "ftp://x", "github.com", "https://x/"]
+        {
+            let mut v = base();
+            v["github_base"] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{bad:?} must be refused");
+        }
+        for ok in ["http://127.0.0.1:9000", "http://localhost:1", "https://ghe.corp.example"] {
+            let mut v = base();
+            v["github_base"] = serde_json::json!(ok);
+            assert!(parse(v).is_ok(), "{ok:?} must be accepted");
+        }
+    }
+
+    #[test]
+    fn repo_spec_must_be_owner_slash_name() {
+        for bad in ["acme", "acme/web/extra", "/web", "acme/", "../../etc", "acme/we b"] {
+            let mut v = base();
+            v["repo"] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{bad:?} must be refused");
+        }
+    }
+
+    #[test]
+    fn org_and_team_checks_parse() {
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        v["org"] = serde_json::json!("acme");
+        assert_eq!(
+            parse(v.clone()).expect("org").default_check,
+            Some(Check::Org { org: "acme".into() })
+        );
+        v["team"] = serde_json::json!("platform");
+        assert_eq!(
+            parse(v).expect("team").default_check,
+            Some(Check::Team { org: "acme".into(), team: "platform".into() })
+        );
+    }
+
+    #[test]
+    fn sites_table_is_authoritative_when_present() {
+        let mut v = base();
+        v["sites"] = serde_json::json!({
+            "pr-1.preview.example.com": { "repo": "acme/web" },
+            "PR-2.preview.example.com": { "org": "acme" },
+        });
+        let c = parse(v).expect("parse");
+        assert_eq!(
+            c.check_for("pr-1.preview.example.com"),
+            Some(&Check::Repo { owner: "acme".into(), name: "web".into() })
+        );
+        // Host matching is case-insensitive in both directions.
+        assert_eq!(
+            c.check_for("pr-2.PREVIEW.example.com"),
+            Some(&Check::Org { org: "acme".into() })
+        );
+        // An unmapped vhost gets nothing — it does NOT inherit the top-level
+        // `repo`, which is also set in this config.
+        assert_eq!(c.check_for("pr-99.preview.example.com"), None);
+    }
+
+    #[test]
+    fn session_ttl_is_bounded() {
+        for bad in [0u64, 59, 7 * 24 * 60 * 60 + 1] {
+            let mut v = base();
+            v["session_ttl_secs"] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{bad} must be refused");
+        }
+    }
+
+    #[test]
+    fn reserved_paths_must_be_absolute_and_distinct() {
+        for (k, bad) in [
+            ("login_path", "no-slash"),
+            ("callback_path", "/cb?x=1"),
+            ("login_path", "/a b"),
+            ("callback_path", "/a\\b"),
+        ] {
+            let mut v = base();
+            v[k] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{k}={bad:?} must be refused");
+        }
+        let mut v = base();
+        v["login_path"] = serde_json::json!("/same");
+        v["callback_path"] = serde_json::json!("/same");
+        assert!(parse(v).is_err());
+    }
+
+    #[test]
+    fn redirect_uri_must_end_at_the_callback_path() {
+        let mut v = base();
+        v["redirect_uri"] = serde_json::json!("https://preview.example.com/somewhere-else");
+        assert!(parse(v.clone()).is_err());
+        v["redirect_uri"] =
+            serde_json::json!(format!("https://preview.example.com{DEFAULT_CALLBACK_PATH}"));
+        assert!(parse(v).is_ok());
+    }
+
+    #[test]
+    fn samesite_none_requires_secure() {
+        let mut v = base();
+        v["cookie_samesite"] = serde_json::json!("None");
+        v["cookie_secure"] = serde_json::json!(false);
+        assert!(parse(v).is_err());
+    }
+
+    #[test]
+    fn weak_bypass_token_is_refused() {
+        let mut v = base();
+        v["bypass_token"] = serde_json::json!("hunter2");
+        assert!(parse(v).expect_err("weak bypass").contains("at least 32 bytes"));
+    }
+
+    #[test]
+    fn vhost_validation() {
+        assert!(validate_vhost("pr-1.preview.example.com").is_ok());
+        assert!(validate_vhost("localhost:8080").is_ok());
+        for bad in ["", "has space", "evil.test/path", "a@b", "caf\u{e9}.test", "x\r\ny"] {
+            assert!(validate_vhost(bad).is_err(), "{bad:?}");
+        }
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/cookie.rs
+++ b/crates/ephpm-middleware-github-auth/src/cookie.rs
@@ -1,0 +1,201 @@
+//! Cookie reading and `Set-Cookie` construction.
+//!
+//! # Why these attributes
+//!
+//! Every cookie this module sets — the session and the short-lived OAuth
+//! `state` — carries the same set, and each one is load-bearing:
+//!
+//! * **`HttpOnly`** — the token *is* the session. A preview site is
+//!   pre-production code, which is precisely where XSS lives; script must not
+//!   be able to read the value that gets a stranger past the gate.
+//! * **`Secure`** (default on) — the token is a bearer credential, so it must
+//!   never ride a plaintext hop. Configurable only because a local
+//!   `http://…localhost` preview cannot set it at all, and silently dropping
+//!   the flag there would be worse than making the operator ask for it.
+//! * **`SameSite=Lax`** — `Strict` breaks the product: a preview link is
+//!   almost always clicked from somewhere else (a PR comment, Slack), and
+//!   `Strict` withholds the cookie on that first cross-site navigation, so an
+//!   already-logged-in user gets bounced back through GitHub every time.
+//!   `Lax` sends it on top-level GET navigations, which is exactly that case
+//!   and also exactly what the OAuth callback needs. `None` would be strictly
+//!   worse — it permits the cookie on cross-site subrequests, which nothing
+//!   here needs.
+//! * **`Path`** (default `/`) — the gate protects the whole site, so the
+//!   cookie has to be sent for the whole site.
+//! * **`Max-Age`** — a real expiry, matching the `exp` inside the signed
+//!   token. The signature is what actually enforces it; `Max-Age` just stops
+//!   the browser from keeping a corpse around.
+//! * **no `Domain`** — deliberately absent, which makes the cookie
+//!   **host-only**. Adding `Domain=.preview.example.com` would send one
+//!   tenant's session to every other tenant on the wildcard, and in this
+//!   product the tenants are different customers' code. Host-only is the
+//!   isolation boundary, and it is not configurable for that reason.
+
+use std::fmt::Write as _;
+
+/// `SameSite` values this module will emit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SameSite {
+    /// Sent on same-site requests and top-level cross-site GET navigations.
+    Lax,
+    /// Never sent on any cross-site request.
+    Strict,
+    /// Sent on all cross-site requests; requires `Secure`.
+    None,
+}
+
+impl SameSite {
+    /// Parse the config spelling (case-insensitive).
+    ///
+    /// # Errors
+    ///
+    /// Returns a message naming the accepted values for anything else.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "lax" => Ok(Self::Lax),
+            "strict" => Ok(Self::Strict),
+            "none" => Ok(Self::None),
+            other => Err(format!("`cookie_samesite` must be Lax, Strict or None, got {other:?}")),
+        }
+    }
+
+    /// The attribute value as it appears in a `Set-Cookie` header.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Lax => "Lax",
+            Self::Strict => "Strict",
+            Self::None => "None",
+        }
+    }
+}
+
+/// Attributes shared by every cookie this module sets.
+#[derive(Clone, Debug)]
+pub struct CookieAttrs {
+    /// `Path` attribute.
+    pub path: String,
+    /// Emit `Secure`.
+    pub secure: bool,
+    /// `SameSite` attribute.
+    pub same_site: SameSite,
+}
+
+/// Build a `Set-Cookie` value.
+///
+/// `max_age` of `0` emits `Max-Age=0` plus an expired `Expires`, i.e. a
+/// deletion — used when a login attempt consumes its `state` cookie.
+#[must_use]
+pub fn set_cookie(name: &str, value: &str, max_age: i64, attrs: &CookieAttrs) -> String {
+    let mut out = String::with_capacity(name.len() + value.len() + 96);
+    // `name` and `value` are validated at init / produced by this crate, so
+    // neither can contain a `;` or a control character.
+    let _ = write!(out, "{name}={value}; Path={}; Max-Age={max_age}", attrs.path);
+    if max_age == 0 {
+        out.push_str("; Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+    }
+    out.push_str("; HttpOnly");
+    if attrs.secure {
+        out.push_str("; Secure");
+    }
+    let _ = write!(out, "; SameSite={}", attrs.same_site.as_str());
+    out
+}
+
+/// Read one cookie out of a raw `Cookie:` request header.
+///
+/// Returns the **first** occurrence, which is what RFC 6265 §5.4 orders most
+/// specific first, and — more to the point — is what stops an attacker who
+/// can set a cookie on a broader path or a parent domain from shadowing the
+/// real session by appending a second one.
+#[must_use]
+pub fn read_cookie<'a>(header: &'a str, name: &str) -> Option<&'a str> {
+    header.split(';').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k.trim() == name).then(|| v.trim())
+    })
+}
+
+/// Reject cookie names that would need quoting or could not round-trip.
+///
+/// RFC 6265 says a cookie name is an RFC 7230 `token`. Validating at `init`
+/// means [`set_cookie`] can concatenate without escaping.
+///
+/// # Errors
+///
+/// Returns a message when the name is empty or contains a separator,
+/// a control character, or a non-ASCII byte.
+pub fn validate_cookie_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("cookie name must not be empty".into());
+    }
+    const SEPARATORS: &[char] = &[
+        '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ',
+    ];
+    if name.chars().any(|c| !c.is_ascii() || c.is_ascii_control() || SEPARATORS.contains(&c)) {
+        return Err(format!("cookie name {name:?} is not a valid RFC 6265 token"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attrs() -> CookieAttrs {
+        CookieAttrs { path: "/".into(), secure: true, same_site: SameSite::Lax }
+    }
+
+    #[test]
+    fn set_cookie_carries_every_required_attribute() {
+        let c = set_cookie("ephpm_session", "abc.def.ghi", 28_800, &attrs());
+        assert_eq!(
+            c,
+            "ephpm_session=abc.def.ghi; Path=/; Max-Age=28800; HttpOnly; Secure; SameSite=Lax"
+        );
+        // The isolation-critical negative: never a Domain attribute.
+        assert!(!c.contains("Domain"), "cookies must stay host-only");
+    }
+
+    #[test]
+    fn secure_can_be_dropped_for_plaintext_local_previews() {
+        let a = CookieAttrs { secure: false, ..attrs() };
+        let c = set_cookie("s", "v", 60, &a);
+        assert!(!c.contains("Secure"));
+        assert!(c.contains("HttpOnly"), "HttpOnly is never optional");
+    }
+
+    #[test]
+    fn zero_max_age_deletes() {
+        let c = set_cookie("s", "", 0, &attrs());
+        assert!(c.contains("Max-Age=0"));
+        assert!(c.contains("Expires=Thu, 01 Jan 1970"));
+    }
+
+    #[test]
+    fn read_cookie_finds_values_and_ignores_neighbours() {
+        let h = "a=1; ephpm_session=tok.en; b=2";
+        assert_eq!(read_cookie(h, "ephpm_session"), Some("tok.en"));
+        assert_eq!(read_cookie(h, "a"), Some("1"));
+        assert_eq!(read_cookie(h, "missing"), None);
+        // A name that is a prefix/suffix of another must not match.
+        assert_eq!(read_cookie("ephpm_session_x=no", "ephpm_session"), None);
+        assert_eq!(read_cookie("x_ephpm_session=no", "ephpm_session"), None);
+    }
+
+    #[test]
+    fn duplicate_cookie_resolves_to_the_first() {
+        // A shadowing cookie set on a parent domain or broader path arrives
+        // after the host-only one; taking the first is what ignores it.
+        assert_eq!(read_cookie("s=real; s=forged", "s"), Some("real"));
+    }
+
+    #[test]
+    fn cookie_name_validation() {
+        assert!(validate_cookie_name("ephpm_session").is_ok());
+        assert!(validate_cookie_name("__Host-sess").is_ok());
+        for bad in ["", "has space", "has;semi", "has=eq", "has,comma", "tab\there", "caf\u{e9}"] {
+            assert!(validate_cookie_name(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/github.rs
+++ b/crates/ephpm-middleware-github-auth/src/github.rs
@@ -1,0 +1,448 @@
+//! The outbound half: exchanging an OAuth `code` for a token and asking
+//! GitHub whether this user may see this preview.
+//!
+//! **Everything in this module runs exactly once per login.** It is the cold
+//! path by construction — nothing here is reachable from a request that
+//! already carries a session cookie, and the crate's request routing is
+//! written so that it cannot become reachable by accident. See the crate
+//! docs, and `lib.rs`'s `route` table.
+//!
+//! # The calls this module makes
+//!
+//! In order, per login, against `github_api_base` unless noted:
+//!
+//! | # | Call | Purpose | Minimum GitHub App permission / OAuth scope |
+//! |---|---|---|---|
+//! | 1 | `POST {github_base}/login/oauth/access_token` | code → user access token | none (this *is* the grant) |
+//! | 2 | `GET /user` | the login name that becomes the token's `sub` | GitHub App: none beyond the grant. OAuth App: `read:user` |
+//! | 3a | `GET /repos/{owner}/{name}` | `check = "repo"` | GitHub App: `metadata: read` on the installation. OAuth App: `repo` (private repos) |
+//! | 3b | `GET /user/memberships/orgs/{org}` | `check = "org"` | `read:org` |
+//! | 3c | `GET /orgs/{org}/teams/{team}/memberships/{login}` | `check = "team"` | `read:org` |
+//!
+//! Three requests, once, at login. A session then lasts `session_ttl_secs`
+//! and costs GitHub nothing.
+//!
+//! # Why a GitHub App is the recommended shape
+//!
+//! With a classic OAuth App, seeing a private repository at all requires the
+//! `repo` scope — which is read **and write** on **every** repository the
+//! user can touch, granted to a preview-hosting service. With a GitHub App,
+//! the user-to-server token is bounded by the app's installation: `GET
+//! /repos/{owner}/{name}` returns 200 only when the user has access *and* the
+//! app is installed there, and no `repo` scope is involved. That is why
+//! `scopes` defaults to empty rather than to something that "just works".
+//!
+//! # Redirects are not followed
+//!
+//! The client is built with [`reqwest::redirect::Policy::none()`]. A 3xx on
+//! the token exchange is an attempt to move a request carrying the client
+//! secret somewhere else; a 3xx on an API call is treated as "no access".
+//! The visible consequence is that a **renamed** repository stops matching
+//! until the config is updated, which is the safe direction.
+
+use std::io::Read as _;
+use std::time::Duration;
+
+use crate::config::{Check, Config};
+
+/// Largest response body read from GitHub. Every response this module parses
+/// is a small JSON object; the cap turns a hostile or broken endpoint into an
+/// error instead of unbounded memory on a request thread.
+const MAX_RESPONSE_BYTES: u64 = 256 * 1024;
+
+/// User agent sent on every call. GitHub requires one.
+const USER_AGENT: &str = concat!("ephpm-middleware-github-auth/", env!("CARGO_PKG_VERSION"));
+
+/// Failures from the GitHub round trip.
+///
+/// `Display` is written to be safe to log and safe to show a user: no
+/// variant carries a code, a token or a secret. That is enforced by
+/// construction — the values simply are not in the type.
+#[derive(Debug)]
+pub enum GhError {
+    /// The client could not be built (TLS or configuration).
+    Client(String),
+    /// The request never completed (DNS, connect, TLS, timeout).
+    Transport {
+        /// Which call failed, e.g. `"token exchange"`.
+        what: &'static str,
+    },
+    /// GitHub answered, but not with something usable.
+    Status {
+        /// Which call.
+        what: &'static str,
+        /// HTTP status returned.
+        status: u16,
+    },
+    /// The body was not the JSON this module expects.
+    Body {
+        /// Which call.
+        what: &'static str,
+    },
+    /// GitHub reported an OAuth-level error (its `error` field). The value is
+    /// one of GitHub's fixed identifiers, never user data.
+    OAuth {
+        /// GitHub's `error` identifier, e.g. `bad_verification_code`.
+        code: String,
+    },
+}
+
+impl std::fmt::Display for GhError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Client(m) => write!(f, "GitHub client could not be built: {m}"),
+            Self::Transport { what } => write!(f, "{what} could not reach GitHub"),
+            Self::Status { what, status } => write!(f, "{what} returned HTTP {status}"),
+            Self::Body { what } => write!(f, "{what} returned an unexpected body"),
+            Self::OAuth { code } => write!(f, "GitHub rejected the authorization: {code}"),
+        }
+    }
+}
+
+impl std::error::Error for GhError {}
+
+/// The identity behind an access token.
+#[derive(Debug, Clone)]
+pub struct User {
+    /// GitHub login (the `sub` claim).
+    pub login: String,
+    /// Numeric account id — stable across renames, which `login` is not.
+    pub id: u64,
+}
+
+/// Blocking GitHub client, built once at `init`.
+pub struct GitHub {
+    http: reqwest::blocking::Client,
+    github_base: String,
+    api_base: String,
+    client_id: String,
+    client_secret: Vec<u8>,
+    trust_anchors: String,
+}
+
+/// Build the TLS configuration for the outbound client.
+///
+/// Two things here are deliberate and neither is stylistic:
+///
+/// 1. **The crypto provider is named.** This workspace compiles both `ring`
+///    and `aws-lc-rs` into the graph, so rustls' `from_crate_features()`
+///    returns `None` and a bare `ClientConfig::builder()` panics at runtime
+///    (ephpm#241, and the long comment on `ephpm-server`'s
+///    `tls::crypto_provider`). `aws_lc_rs` is named rather than `ring`
+///    because it is the provider ePHPm is converging on — this module keeps
+///    working when `ring` leaves the workspace pin.
+/// 2. **Roots are the union of the OS store and the bundled Mozilla set** —
+///    the same choice the OTLP exporter makes. The OS store is what lets a
+///    GitHub Enterprise Server behind a private CA work at all (and it
+///    honours `SSL_CERT_FILE`/`SSL_CERT_DIR`, so no ePHPm-specific trust
+///    knob is needed); the bundled set is what keeps `api.github.com`
+///    reachable from a distroless image that ships no CA bundle.
+///
+/// Returns the config and a non-secret description of the trust store, which
+/// the caller logs through the host once. A GHES certificate problem is
+/// otherwise invisible until the first login fails.
+fn tls_config() -> Result<(rustls::ClientConfig, String), GhError> {
+    let mut roots = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    let (native_added, _ignored) = roots.add_parsable_certificates(native.certs);
+    let bundled = webpki_roots::TLS_SERVER_ROOTS.len();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let description = format!("{native_added} OS trust anchors + {bundled} bundled");
+
+    rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| GhError::Client(format!("crypto provider rejected the default TLS versions: {e}")))
+    .map(|b| (b.with_root_certificates(roots).with_no_client_auth(), description))
+}
+
+impl GitHub {
+    /// Build the client.
+    ///
+    /// # Errors
+    ///
+    /// [`GhError::Client`] when TLS or the HTTP client cannot be constructed.
+    pub fn new(config: &Config) -> Result<Self, GhError> {
+        let (tls, trust_anchors) = tls_config()?;
+        let timeout = Duration::from_secs(config.http_timeout_secs);
+
+        // `reqwest::blocking::Client::builder().build()` starts a background
+        // runtime, and reqwest documents that as a panic when it happens
+        // inside one. `init` runs before ePHPm's runtime exists, so this is
+        // already safe; building on a plain thread makes it a local
+        // guarantee rather than an obligation on whoever calls `init` next.
+        // (Per-request *use* is fine from any thread — the blocking client
+        // hands work to that background runtime over a channel.)
+        let http = std::thread::spawn(move || {
+            reqwest::blocking::Client::builder()
+                .timeout(timeout)
+                .connect_timeout(timeout)
+                // See the module docs: a 3xx is never followed.
+                .redirect(reqwest::redirect::Policy::none())
+                .user_agent(USER_AGENT)
+                .use_preconfigured_tls(tls)
+                .build()
+        })
+        .join()
+        .map_err(|_| GhError::Client("client builder thread panicked".into()))?
+        .map_err(|e| GhError::Client(e.to_string()))?;
+
+        Ok(Self {
+            http,
+            github_base: config.github_base.clone(),
+            api_base: config.github_api_base.clone(),
+            client_id: config.client_id.clone(),
+            client_secret: config.client_secret.expose().to_vec(),
+            trust_anchors,
+        })
+    }
+
+    /// Non-secret description of the TLS trust store, for the startup log.
+    #[must_use]
+    pub fn trust_anchors(&self) -> &str {
+        &self.trust_anchors
+    }
+
+    /// Exchange an authorization `code` for a user access token.
+    ///
+    /// The returned token is a live credential: it is used for the access
+    /// check and then dropped. It is never written to a cookie, a log, or
+    /// the issued session — the session carries the *verdict*, not the token.
+    ///
+    /// # Errors
+    ///
+    /// See [`GhError`]. GitHub answers OAuth failures with HTTP 200 and an
+    /// `error` field, which becomes [`GhError::OAuth`].
+    pub fn exchange_code(&self, code: &str, redirect_uri: &str) -> Result<String, GhError> {
+        let what = "token exchange";
+        let secret = String::from_utf8_lossy(&self.client_secret).into_owned();
+        let resp = self
+            .http
+            .post(format!("{}/login/oauth/access_token", self.github_base))
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", secret.as_str()),
+                ("code", code),
+                ("redirect_uri", redirect_uri),
+            ])
+            .send()
+            .map_err(|_| GhError::Transport { what })?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            return Err(GhError::Status { what, status });
+        }
+        let body = read_json(resp, what)?;
+        // GitHub reports `bad_verification_code`, `redirect_uri_mismatch`,
+        // ... with HTTP 200. Checking `error` first is mandatory.
+        if let Some(code) = body.get("error").and_then(serde_json::Value::as_str) {
+            return Err(GhError::OAuth { code: sanitize_identifier(code) });
+        }
+        body.get("access_token")
+            .and_then(serde_json::Value::as_str)
+            .filter(|t| !t.is_empty())
+            .map(str::to_owned)
+            .ok_or(GhError::Body { what })
+    }
+
+    /// `GET /user` — the identity the session will name.
+    ///
+    /// # Errors
+    ///
+    /// See [`GhError`].
+    pub fn current_user(&self, token: &str) -> Result<User, GhError> {
+        let what = "user lookup";
+        let body =
+            self.api_get(token, "/user", what)?.ok_or(GhError::Status { what, status: 404 })?;
+        let login = body
+            .get("login")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .ok_or(GhError::Body { what })?;
+        let id =
+            body.get("id").and_then(serde_json::Value::as_u64).ok_or(GhError::Body { what })?;
+        Ok(User { login: login.to_owned(), id })
+    }
+
+    /// Does `user` satisfy `check`?
+    ///
+    /// Returns `Ok(false)` for a clean "no" (GitHub answered, the answer was
+    /// negative) and `Err` only when the question could not be asked. The
+    /// caller must treat `Err` as a denial too — see `lib.rs` — but the two
+    /// produce different messages, because "you are not on this repo" and
+    /// "GitHub is down" are different problems for the person reading the
+    /// page.
+    ///
+    /// # Errors
+    ///
+    /// See [`GhError`].
+    pub fn check_access(&self, token: &str, check: &Check, user: &User) -> Result<bool, GhError> {
+        match check {
+            Check::Repo { owner, name } => {
+                let what = "repository access check";
+                // A user access token only ever sees repositories the user
+                // can see, so a 200 here *is* the authorization answer. 404
+                // is GitHub's deliberate "exists but not for you" — it does
+                // not distinguish absence from denial, and neither do we.
+                let Some(body) = self.api_get(token, &format!("/repos/{owner}/{name}"), what)?
+                else {
+                    return Ok(false);
+                };
+                // When the field is present, require read. When it is absent
+                // (some token types omit it), the 200 stands on its own.
+                Ok(body
+                    .get("permissions")
+                    .and_then(|p| p.get("pull"))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(true))
+            }
+            Check::Org { org } => {
+                let what = "organisation membership check";
+                let Some(body) =
+                    self.api_get(token, &format!("/user/memberships/orgs/{org}"), what)?
+                else {
+                    return Ok(false);
+                };
+                // `pending` means invited but not joined — not a member.
+                Ok(body.get("state").and_then(serde_json::Value::as_str) == Some("active"))
+            }
+            Check::Team { org, team } => {
+                let what = "team membership check";
+                // The login is URL-safe: it came from GitHub's own `/user`,
+                // and `encode_segment` is applied regardless.
+                let path =
+                    format!("/orgs/{org}/teams/{team}/memberships/{}", encode_segment(&user.login));
+                let Some(body) = self.api_get(token, &path, what)? else {
+                    return Ok(false);
+                };
+                Ok(body.get("state").and_then(serde_json::Value::as_str) == Some("active"))
+            }
+        }
+    }
+
+    /// One authenticated `GET`. `Ok(None)` means 403/404 — a clean "no".
+    fn api_get(
+        &self,
+        token: &str,
+        path: &str,
+        what: &'static str,
+    ) -> Result<Option<serde_json::Value>, GhError> {
+        let resp = self
+            .http
+            .get(format!("{}{path}", self.api_base))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(token)
+            .send()
+            .map_err(|_| GhError::Transport { what })?;
+
+        match resp.status().as_u16() {
+            200 => Ok(Some(read_json(resp, what)?)),
+            // 403 = forbidden, 404 = GitHub's "not visible to you", 302/301 =
+            // a redirect we refuse to follow. All of them are "no".
+            301 | 302 | 403 | 404 => Ok(None),
+            status => Err(GhError::Status { what, status }),
+        }
+    }
+}
+
+/// Read a bounded JSON body.
+fn read_json(
+    resp: reqwest::blocking::Response,
+    what: &'static str,
+) -> Result<serde_json::Value, GhError> {
+    let mut buf = Vec::new();
+    resp.take(MAX_RESPONSE_BYTES).read_to_end(&mut buf).map_err(|_| GhError::Transport { what })?;
+    serde_json::from_slice(&buf).map_err(|_| GhError::Body { what })
+}
+
+/// Keep only characters GitHub uses in its OAuth error identifiers, so a
+/// hostile endpoint cannot inject markup or newlines into a page or a log
+/// line through the `error` field.
+fn sanitize_identifier(s: &str) -> String {
+    s.chars().filter(|c| c.is_ascii_alphanumeric() || *c == '_').take(64).collect()
+}
+
+/// Percent-encode one path segment.
+#[must_use]
+pub fn encode_segment(s: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+            out.push(char::from(b));
+        } else {
+            let _ = write!(out, "%{b:02X}");
+        }
+    }
+    out
+}
+
+/// Percent-encode a query-string value (`application/x-www-form-urlencoded`
+/// component rules, but with space as `%20` since these go in a URL path
+/// query rather than a form body).
+#[must_use]
+pub fn encode_query(s: &str) -> String {
+    encode_segment(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_never_carries_a_credential() {
+        // The point of the check: no variant of GhError has a field that
+        // could hold a code, a token or a secret, so no Display can leak one.
+        let cases = [
+            GhError::Client("boom".into()),
+            GhError::Transport { what: "token exchange" },
+            GhError::Status { what: "token exchange", status: 500 },
+            GhError::Body { what: "user lookup" },
+            GhError::OAuth { code: "bad_verification_code".into() },
+        ];
+        for e in cases {
+            let rendered = format!("{e} {e:?}");
+            assert!(!rendered.contains("secret"));
+            assert!(!rendered.contains("access_token"));
+        }
+    }
+
+    #[test]
+    fn oauth_error_identifiers_are_sanitized() {
+        assert_eq!(sanitize_identifier("bad_verification_code"), "bad_verification_code");
+        assert_eq!(sanitize_identifier("<script>alert(1)</script>"), "scriptalert1script");
+        assert_eq!(sanitize_identifier("a\r\nSet-Cookie: x"), "aSetCookiex");
+        assert_eq!(sanitize_identifier(&"x".repeat(200)).len(), 64);
+    }
+
+    #[test]
+    fn tls_names_its_provider_and_never_installs_a_process_default() {
+        // A dlopen'd module shares a process with the host. `install_default`
+        // is process-global and single-shot, so a module that called it would
+        // either lose a race with ePHPm's own TLS setup or win one and change
+        // the server's provider out from under it. This module must build a
+        // config from a NAMED provider and leave the process default alone.
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "nothing in this crate may install a process-default provider"
+        );
+        let (_config, description) = tls_config().expect("aws-lc-rs supports the default versions");
+        assert!(description.contains("bundled"), "trust store is described for the log");
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "building a ClientConfig must not have installed a process default"
+        );
+    }
+
+    #[test]
+    fn segment_encoding_blocks_traversal_and_query_smuggling() {
+        assert_eq!(encode_segment("octocat"), "octocat");
+        assert_eq!(encode_segment("../../admin"), "..%2F..%2Fadmin");
+        assert_eq!(encode_segment("a?b=c"), "a%3Fb%3Dc");
+        assert_eq!(encode_segment("a b"), "a%20b");
+        assert_eq!(encode_segment("a#b"), "a%23b");
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -1,0 +1,1087 @@
+//! `github-auth` — a GitHub OAuth login gate for ePHPm, shipped as a
+//! `dlopen`'d native middleware module.
+//!
+//! It answers one question for a private preview site: *does the person at
+//! this browser have access, on GitHub, to the thing this preview is for?*
+//! It answers it **once**, at login, and then issues a stateless signed
+//! session that every later request is judged by locally.
+//!
+//! # This module is the cold path. It is half of a pair.
+//!
+//! There are two jobs here and they are deliberately in two modules:
+//!
+//! | | Cold path — **this module** | Hot path — the session verifier |
+//! |---|---|---|
+//! | Runs on | login, callback, and the first request of a session | every request |
+//! | Talks to GitHub | yes, ~3 calls | **never** |
+//! | Owns | issuing tokens | the token format and its verification |
+//! | Verdict when unhappy | `RESPOND` 302 → GitHub | `RESPOND` 302 → `login_path` |
+//!
+//! Mount them in that order and they compose into a complete gate:
+//!
+//! ```toml
+//! [[middleware]]
+//! library = "/opt/ephpm/modules/libgithub_auth.so"
+//! order   = 10                       # cold path: owns the reserved paths
+//! config  = { client_id = "Iv1.…", client_secret = "env:GH_CLIENT_SECRET",
+//!             session_secret = "env:EPHPM_SESSION_SECRET", repo = "acme/web" }
+//!
+//! [[middleware]]
+//! library = "…the session verifier…"  # hot path: verifies, redirects to login
+//! order   = 20
+//! config  = { session_secret = "env:EPHPM_SESSION_SECRET",
+//!             login_path = "/_ephpm/auth/github/login" }
+//! ```
+//!
+//! **This module performs no signature verification of a session cookie, by
+//! design.** On a request that already carries the session cookie it returns
+//! `CONTINUE` immediately and lets the verifier decide. Which leads to the
+//! one thing an operator must not get wrong:
+//!
+//! > **Mounted alone, this module is not an authenticator.** It stops a
+//! > request that has *no* cookie, but it does not — and must not — judge one
+//! > that has a cookie of any kind. It logs that fact at every startup. Mount
+//! > the verifier.
+//!
+//! Splitting it this way is not ceremony. It is what keeps a network call off
+//! the hot path structurally rather than by discipline: the code that can
+//! reach GitHub is only reachable from two fixed paths and from a request
+//! with no session cookie at all, and [`GithubAuth::route`] is a flat,
+//! testable statement of exactly that.
+//!
+//! # The flow
+//!
+//! | Request | Verdict | Cost |
+//! |---|---|---|
+//! | no session cookie | `RESPOND` 302 → GitHub `authorize`, `Set-Cookie` state | no network |
+//! | `GET {callback_path}?code=…&state=…` | `RESPOND` 302 → return-to, `Set-Cookie` session | 3 GitHub calls |
+//! | `GET {login_path}` | `RESPOND` 302 → GitHub `authorize` | no network |
+//! | valid bypass token, no cookie | `RESPOND` 302 → same path, `Set-Cookie` session | no network |
+//! | session cookie present | `CONTINUE` | **no network, no PHP-side work** |
+//!
+//! PHP does not run on any of the `RESPOND` rows — the middleware chain is
+//! evaluated before PHP dispatch and before the request body is read.
+//!
+//! # Sessions are self-contained
+//!
+//! The session is an HS256 JWT (see [`token`]) carrying its subject, the
+//! vhost it was issued for, how it was obtained, and an expiry. There is no
+//! server-side session record: restarts do not log anyone out, a second node
+//! needs no replication, and the module never touches the middleware KV
+//! surface — which is process-global rather than per-site (ephpm#376) and
+//! therefore the wrong place for anything tenant-scoped.
+//!
+//! The cost of that, stated plainly: **an issued session cannot be revoked
+//! before it expires.** Rotating `session_secret` invalidates every session
+//! at once and is the only revocation available. `session_ttl_secs` is
+//! therefore the blast radius of a stolen cookie, and it defaults to eight
+//! hours.
+//!
+//! # Share links, for free
+//!
+//! Issuance and verification are separate on purpose, and issuance is not
+//! privileged: anything holding `session_secret` can mint an acceptable
+//! token. A hosting control plane that wants to give a designer with no
+//! GitHub account a two-hour link needs **no change to this module** — it
+//! mints the same HS256 JWT with `via: "share"` and a short `exp`, and hands
+//! out `https://<preview>/?…` with the cookie set by its own redirect. The
+//! claim set is documented under [`GithubAuth::session_claims`]; a share
+//! token differs from a login token only in `sub` and `via`.
+//!
+//! # Automation bypass
+//!
+//! Set `bypass_token` and CI can reach a protected preview without a browser.
+//! Presenting it (header `bypass_header`, default `x-ephpm-bypass`) yields
+//! *the same kind of session* — a 302 and a `Set-Cookie` — rather than a
+//! special-cased pass-through, so Playwright and Lighthouse follow one extra
+//! redirect on their first request and behave normally afterwards. Designing
+//! it now rather than retrofitting is the whole point: a bypass bolted on
+//! later tends to become a header that skips the gate entirely on every
+//! request, which is a second, weaker authenticator.
+//!
+//! # Operational cost: the client secret lives on the node
+//!
+//! Doing OAuth in-process means the OAuth **client secret** is on every node
+//! that serves previews, readable by the ePHPm process. That is the real
+//! price of not running a separate identity service, and it should be
+//! supplied as `client_secret = "env:GH_CLIENT_SECRET"` from a secret store,
+//! never as a literal in a templated `ephpm.toml`.
+//!
+//! Blast radius if a node is compromised: the attacker can impersonate the
+//! OAuth app — i.e. complete an authorization flow for any user who can be
+//! induced to click an authorize link — and, holding `session_secret`, can
+//! mint sessions for any user and any site this gate protects. They cannot
+//! read a user's GitHub data without that user authorizing, and no long-lived
+//! GitHub token is stored: the access token is used during the login and
+//! dropped. Rotate `client_secret` and `session_secret` together after any
+//! node compromise.
+//!
+//! # Why a `dlopen`'d module and not a builtin
+//!
+//! The gate needs an HTTP client and a TLS stack. Compiling those into every
+//! ePHPm binary is real weight for a feature most deployments do not use, and
+//! it would put a second TLS surface next to the one ephpm#241/#368 is busy
+//! converging onto a single crypto provider. As a separate `cdylib` none of
+//! it is in the `ephpm` binary — `cargo build -p ephpm` does not compile a
+//! line of this crate.
+//!
+//! The trade-off is explicit: **a fully static (musl) ePHPm cannot `dlopen`,
+//! so it cannot use this module.** The stock Linux release is glibc-dynamic
+//! and can; a custom `-musl` build cannot, and would need this compiled in as
+//! a builtin instead.
+//!
+//! # Requirement: the reserved paths must reach PHP routing
+//!
+//! ePHPm evaluates the middleware chain on the **PHP-bound** path, so
+//! `login_path` and `callback_path` must resolve to a PHP script for this
+//! module to see them. With ePHPm's default
+//! `fallback = ["$uri", "$uri/", "/index.php?$query_string"]` and a front
+//! controller at `index.php` — WordPress, Laravel, Symfony, and every preview
+//! shape this was written for — that is automatic, and PHP still never runs
+//! because the chain short-circuits first. A site with **no** `index.php` and
+//! a `=404` fallback would 404 the callback before the module is consulted.
+//! [`GithubAuth::describe`] repeats this at startup.
+
+pub mod config;
+pub mod cookie;
+pub mod github;
+pub mod redirect;
+pub mod token;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ephpm_middleware::abi::{LOG_ERROR, LOG_INFO, LOG_WARN};
+use ephpm_middleware::{Middleware, Request, Response};
+
+use crate::config::{Check, Config, STATE_TTL_SECS};
+use crate::cookie::{read_cookie, set_cookie};
+use crate::github::{GhError, GitHub, encode_query};
+
+/// What the gate decided to do with a request, before any work is done.
+///
+/// Extracted from [`GithubAuth::invoke`] so the routing rule — *which
+/// requests can reach the network* — is a value a test can assert on rather
+/// than a shape inferred from control flow.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Route {
+    /// Start a login. Never touches the network.
+    StartLogin {
+        /// Where to send the user after a successful login.
+        return_to: String,
+    },
+    /// Handle GitHub's redirect. **The only variant that reaches GitHub.**
+    Callback,
+    /// A valid automation bypass token was presented. No network.
+    Bypass,
+    /// A session cookie is present: hand off to the verifier. No network.
+    HasSession,
+}
+
+/// The gate.
+pub struct GithubAuth {
+    config: Config,
+    github: GitHub,
+    /// Startup banner is emitted on the first request, because `init` has no
+    /// usable host logger of its own.
+    banner_done: AtomicBool,
+}
+
+impl GithubAuth {
+    /// Decide what to do with a request from its path, query and cookies
+    /// alone.
+    ///
+    /// Pure, and pure on purpose: this is the function that makes
+    /// "no network call on the hot path" checkable. Only [`Route::Callback`]
+    /// leads to `github.rs`, and it is reachable only from the exact
+    /// configured `callback_path`.
+    #[must_use]
+    pub fn route(&self, path: &str, query: &str, cookies: &str, bypass: Option<&str>) -> Route {
+        let reserved = self.config.reserved_paths();
+
+        if path == self.config.callback_path {
+            return Route::Callback;
+        }
+        if path == self.config.login_path {
+            // `?next=` lets the verifier hand the original destination over
+            // when it redirects an expired session here.
+            let next = query_param(query, "next").unwrap_or_default();
+            return Route::StartLogin { return_to: redirect::sanitize_return_to(&next, &reserved) };
+        }
+        // A request that already carries a session belongs to the verifier —
+        // checked before the bypass so an automation client mints once and
+        // then behaves like any other client.
+        if read_cookie(cookies, &self.config.cookie_name).is_some_and(|v| !v.is_empty()) {
+            return Route::HasSession;
+        }
+        if let (Some(expected), Some(presented)) = (self.config.bypass_token.as_ref(), bypass)
+            && token::constant_time_eq(
+                self.config.state_secret.expose(),
+                presented.as_bytes(),
+                expected.expose(),
+            )
+        {
+            return Route::Bypass;
+        }
+        Route::StartLogin { return_to: redirect::sanitize_return_to(&here(path, query), &reserved) }
+    }
+
+    /// The claim set of an issued session.
+    ///
+    /// | claim | meaning |
+    /// |---|---|
+    /// | `iss` | `issuer` (default `ephpm-github-auth`) |
+    /// | `sub` | GitHub login, or the bypass subject |
+    /// | `aud` | `audience`, when configured |
+    /// | `exp` / `iat` | expiry / issue time, seconds since the epoch |
+    /// | `site` | the vhost this session is for — a session for one preview must not open another |
+    /// | `via` | `"github"` or `"bypass"`; an external minter uses `"share"` |
+    /// | `gh_id` | numeric GitHub account id (stable across renames), for `via = "github"` |
+    /// | `check` | the rule that was satisfied, e.g. `repo acme/web` — for audit |
+    #[must_use]
+    pub fn session_claims(
+        &self,
+        subject: &str,
+        vhost: &str,
+        via: &str,
+        gh_id: Option<u64>,
+        check: Option<&Check>,
+        now: u64,
+        ttl: u64,
+    ) -> serde_json::Value {
+        let mut claims = serde_json::json!({
+            "iss": self.config.issuer,
+            "sub": subject,
+            "iat": now,
+            "exp": now.saturating_add(ttl),
+            "site": vhost,
+            "via": via,
+        });
+        if let Some(aud) = &self.config.audience {
+            claims["aud"] = serde_json::Value::String(aud.clone());
+        }
+        if let Some(id) = gh_id {
+            claims["gh_id"] = serde_json::Value::from(id);
+        }
+        if let Some(c) = check {
+            claims["check"] = serde_json::Value::String(c.describe());
+        }
+        claims
+    }
+
+    /// Build the `redirect_uri` for this request.
+    fn redirect_uri(&self, vhost: &str) -> String {
+        self.config
+            .redirect_uri
+            .clone()
+            .unwrap_or_else(|| format!("https://{vhost}{}", self.config.callback_path))
+    }
+
+    /// 302 to GitHub's authorize endpoint, with a fresh signed `state`.
+    fn start_login(&self, req: &Request<'_>, vhost: &str, return_to: &str, now: u64) -> Response {
+        let Some(check) = self.config.check_for(vhost) else {
+            log(
+                req,
+                LOG_WARN,
+                &format!(
+                    "github-auth: refusing login for vhost {vhost:?} — it has no `sites` entry and \
+                 no default target, so there is nothing to check access against"
+                ),
+            );
+            return deny(403, "This preview is not configured for GitHub access control.");
+        };
+
+        let nonce = token::random_nonce();
+        let state_claims = serde_json::json!({
+            "n": nonce,
+            "rt": return_to,
+            "v": vhost,
+            "exp": now.saturating_add(STATE_TTL_SECS),
+        });
+        let Some(state_cookie) = token::mint(self.config.state_secret.expose(), &state_claims)
+        else {
+            log(req, LOG_ERROR, "github-auth: could not mint the OAuth state token");
+            return deny(500, "Login could not be started.");
+        };
+
+        let mut url = format!(
+            "{}/login/oauth/authorize?client_id={}&redirect_uri={}&state={}&response_type=code",
+            self.config.github_base,
+            encode_query(&self.config.client_id),
+            encode_query(&self.redirect_uri(vhost)),
+            encode_query(&nonce),
+        );
+        if !self.config.scopes.is_empty() {
+            url.push_str("&scope=");
+            url.push_str(&encode_query(&self.config.scopes.join(" ")));
+        }
+
+        log(
+            req,
+            LOG_INFO,
+            &format!(
+                "github-auth: starting login for vhost {vhost:?} against {}",
+                check.describe()
+            ),
+        );
+        redirect_to(&url).header(
+            "Set-Cookie",
+            set_cookie(
+                &self.config.state_cookie_name,
+                &state_cookie,
+                i64::try_from(STATE_TTL_SECS).unwrap_or(600),
+                &self.config.cookie_attrs,
+            ),
+        )
+    }
+
+    /// Handle GitHub's redirect: verify `state`, exchange the code, check
+    /// access, issue the session.
+    #[allow(clippy::too_many_lines, reason = "one linear flow, each step guarded")]
+    fn handle_callback(&self, req: &Request<'_>, vhost: &str, now: u64) -> Response {
+        let query = req.query();
+        let clear_state =
+            set_cookie(&self.config.state_cookie_name, "", 0, &self.config.cookie_attrs);
+
+        // GitHub reports a user-side refusal (`access_denied`) here.
+        if let Some(err) = query_param(query, "error") {
+            let id: String = err.chars().filter(char::is_ascii_alphanumeric).take(64).collect();
+            log(req, LOG_INFO, &format!("github-auth: GitHub declined the authorization ({id})"));
+            return deny(403, "GitHub did not authorize this login.")
+                .header("Set-Cookie", clear_state);
+        }
+
+        // ── CSRF: the state parameter must match the signed state cookie ──
+        //
+        // Both halves are required. The cookie is HttpOnly and was set by a
+        // login this browser started, so an attacker who plants their own
+        // `code`+`state` in a victim's browser cannot also supply the
+        // matching cookie — which is exactly the login-CSRF an unvalidated
+        // callback allows.
+        let Some(cookie_value) =
+            req.header("cookie").and_then(|c| read_cookie(c, &self.config.state_cookie_name))
+        else {
+            log(req, LOG_WARN, "github-auth: callback with no OAuth state cookie — rejected");
+            return deny(400, "This login link is not valid here. Start again.");
+        };
+        let Some(state_claims) =
+            token::verify(self.config.state_secret.expose(), cookie_value, now)
+        else {
+            log(req, LOG_WARN, "github-auth: OAuth state cookie failed verification — rejected");
+            return deny(400, "This login has expired. Start again.")
+                .header("Set-Cookie", clear_state);
+        };
+        let presented_state = query_param(query, "state").unwrap_or_default();
+        let expected_nonce =
+            state_claims.get("n").and_then(serde_json::Value::as_str).unwrap_or_default();
+        if expected_nonce.is_empty()
+            || !token::constant_time_eq(
+                self.config.state_secret.expose(),
+                presented_state.as_bytes(),
+                expected_nonce.as_bytes(),
+            )
+        {
+            log(req, LOG_WARN, "github-auth: OAuth state mismatch — rejected");
+            return deny(400, "This login link is not valid here. Start again.")
+                .header("Set-Cookie", clear_state);
+        }
+        // The state is bound to the vhost it was issued on, so a state minted
+        // for one tenant cannot complete a login on another.
+        if state_claims.get("v").and_then(serde_json::Value::as_str) != Some(vhost) {
+            log(req, LOG_WARN, "github-auth: OAuth state was issued for a different host");
+            return deny(400, "This login link is not valid here. Start again.")
+                .header("Set-Cookie", clear_state);
+        }
+
+        // Re-sanitize even though we signed it: the value was attacker-chosen
+        // before it was signed, and a signature attests origin, not safety.
+        let return_to = redirect::sanitize_return_to(
+            state_claims.get("rt").and_then(serde_json::Value::as_str).unwrap_or("/"),
+            &self.config.reserved_paths(),
+        );
+
+        let Some(check) = self.config.check_for(vhost) else {
+            return deny(403, "This preview is not configured for GitHub access control.")
+                .header("Set-Cookie", clear_state);
+        };
+
+        let Some(code) = query_param(query, "code").filter(|c| is_plausible_code(c)) else {
+            log(req, LOG_WARN, "github-auth: callback with no usable `code`");
+            return deny(400, "This login link is not valid here. Start again.")
+                .header("Set-Cookie", clear_state);
+        };
+
+        // ── The only network calls in the module ─────────────────────────
+        let outcome =
+            self.github.exchange_code(&code, &self.redirect_uri(vhost)).and_then(|access| {
+                let user = self.github.current_user(&access)?;
+                let allowed = self.github.check_access(&access, check, &user)?;
+                Ok((user, allowed))
+            });
+
+        let (user, allowed) = match outcome {
+            Ok(v) => v,
+            Err(e) => {
+                // `GhError`'s Display carries no credential — see github.rs.
+                log(req, LOG_ERROR, &format!("github-auth: login failed: {e}"));
+                let status = if matches!(e, GhError::OAuth { .. }) { 400 } else { 502 };
+                return deny(status, "Could not complete the GitHub login.")
+                    .header("Set-Cookie", clear_state);
+            }
+        };
+
+        if !allowed {
+            log(
+                req,
+                LOG_INFO,
+                &format!(
+                    "github-auth: denied {} on vhost {vhost:?} — no access to {}",
+                    user.login,
+                    check.describe()
+                ),
+            );
+            return deny(403, "Your GitHub account does not have access to this preview.")
+                .header("Set-Cookie", clear_state);
+        }
+
+        self.issue(
+            req,
+            vhost,
+            &user.login,
+            "github",
+            Some(user.id),
+            Some(check),
+            now,
+            self.config.session_ttl_secs,
+            &return_to,
+        )
+        .header("Set-Cookie", clear_state)
+    }
+
+    /// Mint a session and 302 to `return_to` carrying it.
+    #[allow(clippy::too_many_arguments, reason = "one call site each; all values are required")]
+    fn issue(
+        &self,
+        req: &Request<'_>,
+        vhost: &str,
+        subject: &str,
+        via: &str,
+        gh_id: Option<u64>,
+        check: Option<&Check>,
+        now: u64,
+        ttl: u64,
+        return_to: &str,
+    ) -> Response {
+        let claims = self.session_claims(subject, vhost, via, gh_id, check, now, ttl);
+        let Some(session) = token::mint(self.config.session_secret.expose(), &claims) else {
+            log(req, LOG_ERROR, "github-auth: could not mint the session token");
+            return deny(500, "Login could not be completed.");
+        };
+        log(
+            req,
+            LOG_INFO,
+            &format!("github-auth: session issued for {subject} on vhost {vhost:?} (via {via})"),
+        );
+        redirect_to(return_to).header(
+            "Set-Cookie",
+            set_cookie(
+                &self.config.cookie_name,
+                &session,
+                i64::try_from(ttl).unwrap_or(i64::MAX),
+                &self.config.cookie_attrs,
+            ),
+        )
+    }
+
+    /// One-shot startup banner, emitted on the first request because `init`
+    /// has no host logger available to it.
+    fn banner(&self, req: &Request<'_>) {
+        if self.banner_done.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let target = self.config.default_check.as_ref().map_or_else(
+            || format!("{} vhost(s) mapped", self.config.sites.len()),
+            Check::describe,
+        );
+        log(
+            req,
+            LOG_INFO,
+            &format!(
+                "github-auth: active — login {}, callback {}, cookie {} ({}s), target {}, \
+                 bypass {}, TLS {}. This module ISSUES sessions only; a session-verifier \
+                 middleware must be mounted at a higher `order` or a request carrying any \
+                 cookie value will pass through unchecked.",
+                self.config.login_path,
+                self.config.callback_path,
+                self.config.cookie_name,
+                self.config.session_ttl_secs,
+                target,
+                if self.config.bypass_token.is_some() { "enabled" } else { "off" },
+                self.github.trust_anchors(),
+            ),
+        );
+    }
+}
+
+impl Middleware for GithubAuth {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let config = Config::parse(config)?;
+        let github = GitHub::new(&config).map_err(|e| e.to_string())?;
+        Ok(Self { config, github, banner_done: AtomicBool::new(false) })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        self.banner(req);
+
+        let vhost = req.vhost_id();
+        if config::validate_vhost(vhost).is_err() {
+            log(req, LOG_WARN, "github-auth: request with an unusable Host header — rejected");
+            return deny(400, "Bad request.");
+        }
+
+        let cookies = req.header("cookie").unwrap_or_default();
+        let bypass = self.presented_bypass(req);
+        let now = unix_now();
+
+        match self.route(req.path(), req.query(), cookies, bypass.as_deref()) {
+            Route::HasSession => Response::cont(),
+            Route::StartLogin { return_to } => self.start_login(req, vhost, &return_to, now),
+            Route::Callback => self.handle_callback(req, vhost, now),
+            Route::Bypass => {
+                let return_to = redirect::sanitize_return_to(
+                    &here(req.path(), req.query()),
+                    &self.config.reserved_paths(),
+                );
+                self.issue(
+                    req,
+                    vhost,
+                    "automation",
+                    "bypass",
+                    None,
+                    None,
+                    now,
+                    self.config.bypass_ttl_secs,
+                    &return_to,
+                )
+            }
+        }
+    }
+
+    fn describe() -> &'static str {
+        "github-auth (GitHub OAuth login gate — issues sessions; pair with a session verifier)"
+    }
+}
+
+impl GithubAuth {
+    /// The bypass token presented on this request, if any.
+    ///
+    /// The header form is the default. A query-parameter form exists because
+    /// some tools (and every "just paste a link into a browser" case) cannot
+    /// set headers, but it is **off unless `bypass_query` is configured**:
+    /// a query string lands in access logs, browser history and `Referer`,
+    /// which a header does not.
+    fn presented_bypass(&self, req: &Request<'_>) -> Option<String> {
+        self.config.bypass_token.as_ref()?;
+        if let Some(v) = req.header(&self.config.bypass_header).filter(|v| !v.is_empty()) {
+            return Some(v.to_owned());
+        }
+        let name = self.config.bypass_query.as_deref()?;
+        query_param(req.query(), name)
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+/// Log through the host's `tracing` subscriber.
+///
+/// The module's own `tracing` crate instance has a different global
+/// dispatcher than ePHPm's, so this callback is the only thing that reaches
+/// the server's logs. Nothing passed here may contain a code, a token or a
+/// secret; every call site in this crate is written to that rule.
+fn log(req: &Request<'_>, level: i32, msg: &str) {
+    req.host().log(level, msg);
+}
+
+/// Seconds since the Unix epoch.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_secs())
+}
+
+/// The current request as a return-to (`path` plus `?query`).
+fn here(path: &str, query: &str) -> String {
+    if query.is_empty() { path.to_owned() } else { format!("{path}?{query}") }
+}
+
+/// A 302 with caching disabled.
+///
+/// `no-store` matters: without it a shared cache (or the browser's back/
+/// forward cache) can serve one user the redirect — and the `Set-Cookie` —
+/// minted for another.
+fn redirect_to(location: &str) -> Response {
+    Response::respond(302, Vec::new())
+        .header("Location", location)
+        .header("Cache-Control", "no-store, private")
+}
+
+/// A refusal page. Plain text on purpose: no template, no interpolation of
+/// anything GitHub or the client said, and therefore no way to turn the gate
+/// into a reflected-XSS surface on the preview's own origin.
+fn deny(status: u16, message: &str) -> Response {
+    Response::respond(status, message.as_bytes().to_vec())
+        .header("Content-Type", "text/plain; charset=utf-8")
+        .header("Cache-Control", "no-store, private")
+}
+
+/// An OAuth `code` is an opaque token; anything else is not one.
+fn is_plausible_code(code: &str) -> bool {
+    !code.is_empty()
+        && code.len() <= 512
+        && code.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~'))
+}
+
+/// Read one parameter out of a raw query string, percent-decoded.
+#[must_use]
+pub fn query_param(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (percent_decode(k) == name).then(|| percent_decode(v))
+    })
+}
+
+/// `application/x-www-form-urlencoded` decoding. Invalid escapes are left
+/// literal rather than dropped, so a malformed value stays visibly malformed
+/// instead of silently becoming a different valid one.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).ok();
+                if let Some(b) = hex.and_then(|h| u8::from_str_radix(h, 16).ok()) {
+                    out.push(b);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+ephpm_middleware::declare!(GithubAuth);
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code, reason = "tests build the FFI Request view by hand")]
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+
+    use super::*;
+
+    const SESSION_SECRET: &str = "0123456789abcdef0123456789abcdef";
+    const BYPASS: &str = "bypass-token-that-is-long-enough-32";
+
+    fn gate(extra: serde_json::Value) -> GithubAuth {
+        let mut cfg = serde_json::json!({
+            "client_id": "Iv1.test",
+            "client_secret": "client-secret",
+            "session_secret": SESSION_SECRET,
+            "repo": "acme/web",
+            // Loopback so `init` does not need to be pointed at real GitHub.
+            "github_base": "http://127.0.0.1:1",
+            "github_api_base": "http://127.0.0.1:1",
+        });
+        for (k, v) in extra.as_object().cloned().unwrap_or_default() {
+            cfg[k] = v;
+        }
+        GithubAuth::init(&cfg).expect("init")
+    }
+
+    fn invoke(mw: &GithubAuth, path: &str, query: &str, headers: &[(String, String)]) -> Response {
+        let ctx = RequestCtx::new("GET", path, query, "203.0.113.9", "pr-1.preview.test", headers);
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn header(resp: &Response, name: &str) -> Option<String> {
+        resp.__headers().iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.clone())
+    }
+
+    fn all_headers(resp: &Response, name: &str) -> Vec<String> {
+        resp.__headers()
+            .iter()
+            .filter(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+            .collect()
+    }
+
+    // ── routing: what can reach the network ──────────────────────────────
+
+    #[test]
+    fn only_the_callback_path_can_reach_github() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        let cases = [
+            ("/", "", "", None),
+            ("/index.php", "a=b", "", None),
+            ("/_ephpm/auth/github/login", "", "", None),
+            ("/wp-admin/", "", "ephpm_session=tok", None),
+            ("/", "", "", Some(BYPASS)),
+            // Near misses on the callback path must NOT route to Callback.
+            ("/_ephpm/auth/github/callback/", "code=x", "", None),
+            ("/_ephpm/auth/github/CALLBACK", "code=x", "", None),
+            ("/_ephpm/auth/github/callbackx", "code=x", "", None),
+        ];
+        for (path, query, cookies, bypass) in cases {
+            assert_ne!(
+                mw.route(path, query, cookies, bypass),
+                Route::Callback,
+                "{path} must not reach the GitHub round trip"
+            );
+        }
+        assert_eq!(
+            mw.route("/_ephpm/auth/github/callback", "code=x&state=y", "", None),
+            Route::Callback
+        );
+    }
+
+    #[test]
+    fn a_request_with_a_session_cookie_is_handed_straight_to_the_verifier() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        // Present, valid-looking: CONTINUE.
+        assert_eq!(mw.route("/", "", "ephpm_session=anything", None), Route::HasSession);
+        // Present but garbage: still CONTINUE — judging it is the verifier's
+        // job, and re-deciding it here would be a second, divergent verifier.
+        assert_eq!(mw.route("/", "", "ephpm_session=not.a.token", None), Route::HasSession);
+        // Present alongside a bypass token: the cookie wins, so an automation
+        // client mints once instead of on every request.
+        assert_eq!(mw.route("/", "", "ephpm_session=x", Some(BYPASS)), Route::HasSession);
+        // Empty value is not a session.
+        assert_ne!(mw.route("/", "", "ephpm_session=", None), Route::HasSession);
+    }
+
+    #[test]
+    fn no_cookie_starts_a_login_that_remembers_where_you_were() {
+        let mw = gate(serde_json::json!({}));
+        assert_eq!(
+            mw.route("/wp-admin/edit.php", "post=7", "", None),
+            Route::StartLogin { return_to: "/wp-admin/edit.php?post=7".into() }
+        );
+    }
+
+    #[test]
+    fn login_path_honours_next_but_sanitizes_it() {
+        let mw = gate(serde_json::json!({}));
+        assert_eq!(
+            mw.route("/_ephpm/auth/github/login", "next=%2Fdashboard", "", None),
+            Route::StartLogin { return_to: "/dashboard".into() }
+        );
+        // The verifier hands `next` over verbatim from a client-controlled
+        // URL, so it gets the same treatment as any other return-to.
+        for hostile in ["next=https%3A%2F%2Fevil.test", "next=%2F%2Fevil.test", "next=%2F%5Cevil"] {
+            assert_eq!(
+                mw.route("/_ephpm/auth/github/login", hostile, "", None),
+                Route::StartLogin { return_to: "/".into() },
+                "{hostile} must not survive"
+            );
+        }
+    }
+
+    // ── the 302 to GitHub ───────────────────────────────────────────────
+
+    #[test]
+    fn unauthenticated_request_redirects_to_github_with_a_state() {
+        let mw = gate(serde_json::json!({ "github_base": "http://127.0.0.1:1" }));
+        let resp = invoke(&mw, "/secret.php", "x=1", &[]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 302);
+        assert!(resp.__body().is_empty(), "no body — PHP never ran and neither did a template");
+
+        let location = header(&resp, "Location").expect("Location");
+        assert!(location.starts_with("http://127.0.0.1:1/login/oauth/authorize?"));
+        assert!(location.contains("client_id=Iv1.test"));
+        assert!(location.contains("&state="), "state is mandatory (CSRF)");
+        assert!(
+            location.contains(
+                "redirect_uri=https%3A%2F%2Fpr-1.preview.test%2F_ephpm%2Fauth%2Fgithub%2Fcallback"
+            ),
+            "redirect_uri derives from the request's vhost: {location}"
+        );
+
+        let set = header(&resp, "Set-Cookie").expect("state cookie");
+        assert!(set.starts_with("ephpm_session_oauth="));
+        assert!(set.contains("HttpOnly") && set.contains("Secure") && set.contains("SameSite=Lax"));
+        assert!(set.contains("Max-Age=600"));
+        assert_eq!(header(&resp, "Cache-Control").as_deref(), Some("no-store, private"));
+    }
+
+    #[test]
+    fn scopes_are_omitted_unless_configured() {
+        assert!(
+            !header(&invoke(&gate(serde_json::json!({})), "/", "", &[]), "Location")
+                .expect("Location")
+                .contains("scope="),
+            "an empty scope list is the GitHub App shape and must not send `scope=`"
+        );
+        let mw = gate(serde_json::json!({ "scopes": ["read:user", "repo"] }));
+        assert!(
+            header(&invoke(&mw, "/", "", &[]), "Location")
+                .expect("Location")
+                .contains("scope=read%3Auser%20repo")
+        );
+    }
+
+    #[test]
+    fn an_unmapped_vhost_is_denied_rather_than_defaulted() {
+        let mw = gate(serde_json::json!({
+            "sites": { "pr-2.preview.test": { "repo": "acme/other" } },
+        }));
+        let resp = invoke(&mw, "/", "", &[]);
+        assert_eq!(resp.__status(), 403, "an unmapped host must not inherit another tenant's rule");
+    }
+
+    // ── callback: CSRF ──────────────────────────────────────────────────
+
+    /// Drive a login, then replay its state cookie into a callback.
+    fn login_state_cookie(mw: &GithubAuth) -> (String, String) {
+        let resp = invoke(mw, "/dashboard", "", &[]);
+        let location = header(&resp, "Location").expect("Location");
+        let state = query_param(location.split_once('?').expect("query").1, "state")
+            .expect("state parameter");
+        let cookie = header(&resp, "Set-Cookie").expect("Set-Cookie");
+        let value = cookie.split(';').next().expect("cookie pair").to_owned();
+        (state, value)
+    }
+
+    #[test]
+    fn callback_without_a_state_cookie_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=whatever", &[]);
+        assert_eq!(resp.__status(), 400);
+        assert!(
+            all_headers(&resp, "Set-Cookie").iter().all(|c| !c.starts_with("ephpm_session=")),
+            "a rejected callback must not issue a session"
+        );
+    }
+
+    #[test]
+    fn callback_with_a_forged_state_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let (_state, cookie) = login_state_cookie(&mw);
+        let headers = vec![("Cookie".to_owned(), cookie)];
+        for forged in
+            ["", "state=", "state=guessed", "state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
+        {
+            let q = if forged.is_empty() {
+                "code=abc".to_owned()
+            } else {
+                format!("code=abc&{forged}")
+            };
+            let resp = invoke(&mw, "/_ephpm/auth/github/callback", &q, &headers);
+            assert_eq!(resp.__status(), 400, "state {forged:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn callback_with_a_state_cookie_signed_by_someone_else_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        // Mint a state token under a different key — the shape is right, the
+        // signature is not.
+        let other = token::derive_key(b"a-completely-different-secret-key", token::STATE_KEY_LABEL);
+        let forged = token::mint(
+            &other,
+            &serde_json::json!({ "n": "abc", "rt": "/", "v": "pr-1.preview.test", "exp": unix_now() + 300 }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={forged}"))];
+        let resp = invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=abc", &headers);
+        assert_eq!(resp.__status(), 400);
+    }
+
+    #[test]
+    fn callback_state_is_bound_to_the_host_it_was_issued_on() {
+        let mw = gate(serde_json::json!({}));
+        let state_token = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({
+                "n": "nonce-value", "rt": "/", "v": "other.preview.test",
+                "exp": unix_now() + 300,
+            }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state_token}"))];
+        let resp =
+            invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=nonce-value", &headers);
+        assert_eq!(
+            resp.__status(),
+            400,
+            "a state minted for another tenant must not complete here"
+        );
+    }
+
+    #[test]
+    fn expired_state_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let state_token = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({ "n": "n", "rt": "/", "v": "pr-1.preview.test", "exp": 1_000 }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state_token}"))];
+        let resp = invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=n", &headers);
+        assert_eq!(resp.__status(), 400);
+    }
+
+    #[test]
+    fn callback_rejects_an_implausible_code_before_any_network_call() {
+        let mw = gate(serde_json::json!({}));
+        let (state, cookie) = login_state_cookie(&mw);
+        let headers = vec![("Cookie".to_owned(), cookie)];
+        // `github_base` points at 127.0.0.1:1 (closed), so a network attempt
+        // would surface as 502. A 400 proves the code was refused first.
+        for bad in ["", "a b", "a/b", "<script>", &"x".repeat(513)] {
+            let q = format!("code={}&state={state}", github::encode_query(bad));
+            let resp = invoke(&mw, "/_ephpm/auth/github/callback", &q, &headers);
+            assert_eq!(resp.__status(), 400, "code {bad:?} must be refused locally");
+        }
+    }
+
+    // ── bypass ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn bypass_token_issues_a_normal_session() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS, "bypass_ttl_secs": 900 }));
+        let headers = vec![("x-ephpm-bypass".to_owned(), BYPASS.to_owned())];
+        let resp = invoke(&mw, "/report", "a=1", &headers);
+        assert_eq!(resp.__status(), 302);
+        assert_eq!(header(&resp, "Location").as_deref(), Some("/report?a=1"));
+        let set = header(&resp, "Set-Cookie").expect("session cookie");
+        assert!(set.starts_with("ephpm_session="));
+        assert!(set.contains("Max-Age=900"));
+    }
+
+    #[test]
+    fn a_wrong_bypass_token_falls_through_to_github_and_never_pretends_otherwise() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        for wrong in
+            ["", "x", "bypass-token-that-is-long-enough-3", "bypass-token-that-is-long-enough-320"]
+        {
+            let headers = vec![("x-ephpm-bypass".to_owned(), wrong.to_owned())];
+            let resp = invoke(&mw, "/", "", &headers);
+            assert_eq!(resp.__status(), 302);
+            assert!(
+                header(&resp, "Location").expect("Location").contains("/login/oauth/authorize"),
+                "a wrong bypass token must behave exactly like no token at all"
+            );
+        }
+    }
+
+    #[test]
+    fn the_bypass_query_parameter_is_off_unless_asked_for() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        let resp = invoke(&mw, "/", &format!("_bypass={BYPASS}"), &[]);
+        assert!(header(&resp, "Location").expect("Location").contains("/login/oauth/authorize"));
+
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS, "bypass_query": "_bypass" }));
+        let resp = invoke(&mw, "/", &format!("_bypass={BYPASS}"), &[]);
+        assert!(header(&resp, "Set-Cookie").expect("Set-Cookie").starts_with("ephpm_session="));
+    }
+
+    // ── issued token ────────────────────────────────────────────────────
+
+    #[test]
+    fn issued_sessions_carry_the_documented_claims() {
+        let mw = gate(serde_json::json!({ "audience": "preview", "issuer": "switchboard" }));
+        let claims = mw.session_claims(
+            "octocat",
+            "pr-1.preview.test",
+            "github",
+            Some(583_231),
+            Some(&Check::Repo { owner: "acme".into(), name: "web".into() }),
+            1_000,
+            3_600,
+        );
+        assert_eq!(claims["iss"], "switchboard");
+        assert_eq!(claims["sub"], "octocat");
+        assert_eq!(claims["aud"], "preview");
+        assert_eq!(claims["iat"], 1_000);
+        assert_eq!(claims["exp"], 4_600);
+        assert_eq!(claims["site"], "pr-1.preview.test");
+        assert_eq!(claims["via"], "github");
+        assert_eq!(claims["gh_id"], 583_231);
+        assert_eq!(claims["check"], "repo acme/web");
+    }
+
+    #[test]
+    fn an_externally_minted_share_token_is_the_same_object() {
+        // The share-link claim: a control plane holding `session_secret` can
+        // mint an acceptable session with no help from this module.
+        let mw = gate(serde_json::json!({}));
+        let external = token::mint(
+            mw.config.session_secret.expose(),
+            &serde_json::json!({
+                "iss": "ephpm-github-auth", "sub": "share:designer@example.com",
+                "site": "pr-1.preview.test", "via": "share",
+                "iat": unix_now(), "exp": unix_now() + 7_200,
+            }),
+        )
+        .expect("mint");
+        // Same three-part HS256 shape as one this module issues.
+        assert_eq!(external.split('.').count(), 3);
+        // And it is what the gate treats as a session.
+        assert_eq!(
+            mw.route("/", "", &format!("ephpm_session={external}"), None),
+            Route::HasSession
+        );
+    }
+
+    // ── misc ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_session_cookie_costs_nothing_and_adds_no_headers() {
+        let mw = gate(serde_json::json!({}));
+        let headers = vec![("Cookie".to_owned(), "ephpm_session=abc.def.ghi".to_owned())];
+        let resp = invoke(&mw, "/index.php", "", &headers);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+        assert!(resp.__headers().is_empty());
+        assert!(resp.__response_headers().is_empty());
+    }
+
+    #[test]
+    fn a_hostile_host_header_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", "evil.test/../x", &[]);
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert_eq!(mw.invoke(&req).__status(), 400);
+    }
+
+    #[test]
+    fn query_parsing_decodes_and_does_not_confuse_prefixes() {
+        assert_eq!(query_param("a=1&next=%2Fx%20y", "next").as_deref(), Some("/x y"));
+        assert_eq!(query_param("nextish=1&next=2", "next").as_deref(), Some("2"));
+        assert_eq!(query_param("a=1", "b"), None);
+        assert_eq!(query_param("", "a"), None);
+        assert_eq!(query_param("a=b+c", "a").as_deref(), Some("b c"));
+        // A truncated escape stays literal rather than silently changing.
+        assert_eq!(query_param("a=%2", "a").as_deref(), Some("%2"));
+        assert_eq!(query_param("a=%zz", "a").as_deref(), Some("%zz"));
+    }
+
+    #[test]
+    fn describe_names_the_pairing_requirement() {
+        assert!(GithubAuth::describe().contains("session verifier"));
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -346,6 +346,13 @@ impl GithubAuth {
 
     /// Handle GitHub's redirect: verify `state`, exchange the code, check
     /// access, issue the session.
+    ///
+    /// **Every local rejection happens before the first network call** — the
+    /// `state` cookie, its signature, its expiry, the nonce comparison, the
+    /// vhost binding and the shape of `code` are all checked first. An
+    /// attacker without a valid `state` cookie therefore cannot make this
+    /// module talk to GitHub at all, which is what keeps the callback from
+    /// being an amplification endpoint.
     #[allow(clippy::too_many_lines, reason = "one linear flow, each step guarded")]
     fn handle_callback(&self, req: &Request<'_>, vhost: &str, now: u64) -> Response {
         let query = req.query();

--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -17,7 +17,10 @@
 //! | Owns | issuing tokens | the token format and its verification |
 //! | Verdict when unhappy | `RESPOND` 302 → GitHub | `RESPOND` 302 → `login_path` |
 //!
-//! Mount them in that order and they compose into a complete gate:
+//! Mount them in that order and they compose into a complete gate. The
+//! verifier this is designed to pair with is the **`session-cookie` builtin**
+//! (ephpm#388), which performs exactly the HS256 verification this module's
+//! tokens are minted for:
 //!
 //! ```toml
 //! [[middleware]]
@@ -27,11 +30,18 @@
 //!             session_secret = "env:EPHPM_SESSION_SECRET", repo = "acme/web" }
 //!
 //! [[middleware]]
-//! library = "…the session verifier…"  # hot path: verifies, redirects to login
+//! library = "session-cookie"          # hot path: verifies, redirects to login
 //! order   = 20
-//! config  = { session_secret = "env:EPHPM_SESSION_SECRET",
-//!             login_path = "/_ephpm/auth/github/login" }
+//! config  = { secret = "env:EPHPM_SESSION_SECRET", cookie = "ephpm_session",
+//!             login_url = "/_ephpm/auth/github/login",
+//!             return_to_param = "next" }
 //! ```
+//!
+//! Exactly three things have to line up: the HMAC key
+//! (`session_secret` ↔ `secret`), the cookie name (`cookie_name` ↔ `cookie`,
+//! whose defaults already match), and the login path (`login_path` ↔
+//! `login_url`, with `return_to_param = "next"` because this module reads the
+//! return-to from `?next=`).
 //!
 //! **This module performs no signature verification of a session cookie, by
 //! design.** On a request that already carries the session cookie it returns
@@ -532,7 +542,12 @@ impl Middleware for GithubAuth {
     fn invoke(&self, req: &Request<'_>) -> Response {
         self.banner(req);
 
-        let vhost = req.vhost_id();
+        // Canonicalise ONCE, here, and use only this value below — as the
+        // `sites` key, in the `site` claim, in the state binding and in the
+        // derived `redirect_uri`. `request_vhost_id` is the raw `Host`
+        // header; see `config::normalize_vhost` for why that matters.
+        let vhost = config::normalize_vhost(req.vhost_id());
+        let vhost = vhost.as_str();
         if config::validate_vhost(vhost).is_err() {
             log(req, LOG_WARN, "github-auth: request with an unusable Host header — rejected");
             return deny(400, "Bad request.");
@@ -1057,6 +1072,33 @@ mod tests {
         assert_eq!(resp.__action(), ACTION_CONTINUE);
         assert!(resp.__headers().is_empty());
         assert!(resp.__response_headers().is_empty());
+    }
+
+    #[test]
+    fn the_host_header_is_normalised_before_it_becomes_an_identity() {
+        // `request_vhost_id` hands over the RAW `Host` header. Two spellings
+        // of one host must not produce two identities, or a session minted
+        // under one would not match the other's `site` claim — and a `sites`
+        // lookup would be bypassable by changing a letter's case.
+        let mw = gate(serde_json::json!({}));
+        let mut seen = std::collections::BTreeSet::new();
+        for host in ["pr-1.preview.test", "PR-1.Preview.TEST", "pr-1.preview.test."] {
+            let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", host, &[]);
+            // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+            let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+            let resp = mw.invoke(&req);
+            assert_eq!(resp.__status(), 302);
+            let loc = header(&resp, "Location").expect("Location");
+            let redirect_uri = loc
+                .split("redirect_uri=")
+                .nth(1)
+                .and_then(|s| s.split('&').next())
+                .expect("redirect_uri")
+                .to_owned();
+            seen.insert(redirect_uri);
+        }
+        assert_eq!(seen.len(), 1, "every spelling must derive one redirect_uri: {seen:?}");
+        assert!(seen.iter().next().expect("one").contains("pr-1.preview.test"));
     }
 
     #[test]

--- a/crates/ephpm-middleware-github-auth/src/redirect.rs
+++ b/crates/ephpm-middleware-github-auth/src/redirect.rs
@@ -1,0 +1,200 @@
+//! Return-to validation — the open-redirect and header-injection defence.
+//!
+//! A login gate has to remember where the user was going, and that value is
+//! attacker-controlled: anyone can hand a victim
+//! `https://preview.example.com/anything` and the gate will faithfully carry
+//! the path through GitHub and back into a `Location:` header. If the check
+//! is sloppy the gate becomes an open redirector wearing the preview site's
+//! hostname — which is exactly the property phishing wants, because the
+//! *first* hop is genuinely the site the victim expects.
+//!
+//! [`sanitize_return_to`] therefore does not try to parse a URL and compare
+//! origins. It applies an allowlist: a return-to is either an unambiguous
+//! **same-origin absolute path** or it is replaced by `/`. There is no
+//! rejection path a caller can forget to handle.
+//!
+//! # What is rejected, and why
+//!
+//! | Input shape | Example | Why |
+//! |---|---|---|
+//! | absolute URL | `https://evil.test/x` | different origin |
+//! | scheme-relative | `//evil.test/x` | browsers resolve this against the current scheme — a different origin |
+//! | backslash forms | `/\evil.test`, `\\evil.test` | WHATWG URL parsing treats `\` as `/`, so these are scheme-relative too |
+//! | any `\` at all | `/a\b` | belt and braces: no legitimate path needs one, and normalisation differs between browsers |
+//! | non-`/` start | `evil.test`, `?a=1`, `javascript:…` | relative or a scheme; only absolute paths are same-origin by construction |
+//! | control characters | a raw CR/LF (a decoded `%0d%0a`) | `Location:` header injection / response splitting |
+//! | `..` segments | `/..//evil.test` | same-origin per RFC 3986 and WHATWG, rejected anyway — no return-to needs one |
+//! | non-ASCII | `/café` | a `Location` value must be ASCII; clients percent-encode, so a raw non-ASCII byte is a sign of something else |
+//! | over-long | 2 KiB+ | bounded work, bounded header |
+//! | the gate's own paths | `/…/auth/github/login` | a redirect loop, not a destination |
+//!
+//! Percent-encoded separators (`/%2f%2fevil.test`, `/%5c%5cevil.test`) are
+//! **kept**. They are not a bypass: browsers do not decode `%2f`/`%5c` before
+//! resolving a URL, so the request stays on this origin as a path whose first
+//! segment happens to be `%2f%2fevil.test`. Rejecting them would break
+//! legitimate paths that contain encoded slashes.
+
+/// Longest return-to accepted. Anything beyond this is replaced by `/`.
+const MAX_RETURN_TO: usize = 2048;
+
+/// Reduce an attacker-supplied return-to to a safe same-origin path.
+///
+/// Returns the input unchanged when it is an unambiguous absolute path on
+/// this origin, and `"/"` in every other case — including the empty string.
+/// `reserved` lists paths the gate owns (login, callback); a return-to that
+/// targets one of them would loop, so it is replaced too.
+///
+/// This is deliberately total: there is no `Err` for a caller to swallow.
+#[must_use]
+pub fn sanitize_return_to(raw: &str, reserved: &[&str]) -> String {
+    if is_safe_return_to(raw, reserved) { raw.to_owned() } else { "/".to_owned() }
+}
+
+/// The predicate behind [`sanitize_return_to`], split out so tests can state
+/// the intent directly.
+#[must_use]
+pub fn is_safe_return_to(raw: &str, reserved: &[&str]) -> bool {
+    if raw.len() > MAX_RETURN_TO {
+        return false;
+    }
+    // Must be an absolute path. This alone rules out `https://evil.test`,
+    // `javascript:…`, `evil.test` and `?a=1`.
+    let Some(rest) = raw.strip_prefix('/') else {
+        return false;
+    };
+    // `//evil.test` is scheme-relative; `/\evil.test` is the same thing after
+    // WHATWG backslash normalisation. Checking the *whole* string for `\`
+    // covers both and costs nothing.
+    if rest.starts_with('/') || raw.contains('\\') {
+        return false;
+    }
+    // ASCII, no controls, no DEL. Blocks CR/LF response splitting into the
+    // `Location:` header, and raw tabs/NULs that different parsers disagree
+    // about.
+    if !raw.is_ascii() || raw.chars().any(|c| c.is_ascii_control()) {
+        return false;
+    }
+    // A space is legal in a path only percent-encoded; a raw one would be
+    // re-parsed by some clients as the end of the header value.
+    if raw.contains(' ') {
+        return false;
+    }
+    // Reject `..` segments. `/..//evil.test` is *technically* still
+    // same-origin — RFC 3986 dot-segment removal leaves the authority alone,
+    // and so does the WHATWG parser — but the value of that guarantee is
+    // "every client agrees with the spec", which is not a bet worth taking on
+    // a redirect target when no legitimate return-to needs a `..`.
+    let path_part = raw.split(['?', '#']).next().unwrap_or(raw);
+    if path_part.split('/').any(|seg| seg == "..") {
+        return false;
+    }
+    // The gate's own endpoints are not destinations.
+    let path_only = raw.split(['?', '#']).next().unwrap_or(raw);
+    !reserved.contains(&path_only)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Paths the gate owns, as `lib.rs` passes them.
+    const RESERVED: &[&str] = &["/_ephpm/auth/github/login", "/_ephpm/auth/github/callback"];
+
+    #[test]
+    fn plain_paths_survive() {
+        for ok in [
+            "/",
+            "/index.php",
+            "/wp-admin/",
+            "/a/b/c?d=e&f=g",
+            "/search?q=%20quoted%20",
+            "/page#anchor",
+            // Encoded separators stay: browsers do not decode them before
+            // resolving, so these remain same-origin paths.
+            "/%2f%2fevil.test",
+            "/%5c%5cevil.test",
+            // A query value that merely *mentions* another origin is fine —
+            // the browser still navigates to this origin.
+            "/redirect?next=https://evil.test",
+        ] {
+            assert!(is_safe_return_to(ok, RESERVED), "{ok} should be accepted");
+            assert_eq!(sanitize_return_to(ok, RESERVED), ok);
+        }
+    }
+
+    #[test]
+    fn hostile_inputs_collapse_to_root() {
+        // Every one of these was tried against the gate; each must come back
+        // as `/` rather than as a redirect off this origin.
+        for bad in [
+            "",
+            // Absolute URLs, every scheme shape.
+            "https://evil.test",
+            "http://evil.test/x",
+            "//evil.test",
+            "///evil.test",
+            "////evil.test",
+            "https:/\\evil.test",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "vbscript:msgbox(1)",
+            // Dot segments: same-origin per spec, rejected anyway (see the
+            // predicate) because it costs nothing and removes a whole class
+            // of "does this client normalise like the spec says" doubt.
+            "/..//evil.test",
+            "/a/../../evil",
+            "/..",
+            "/foo/..",
+            // Backslash normalisation.
+            "/\\evil.test",
+            "\\\\evil.test",
+            "\\/evil.test",
+            "/path\\..\\..\\evil",
+            // Not absolute.
+            "evil.test",
+            "?next=/",
+            "#fragment",
+            "../../etc/passwd",
+            // Userinfo trick — still not a path.
+            "//user@evil.test/",
+            "https://preview.example.com@evil.test/",
+            // Header injection / response splitting.
+            "/ok\r\nSet-Cookie: pwned=1",
+            "/ok\nLocation: https://evil.test",
+            "/ok\rX: y",
+            "/ok\0",
+            "/ok\ttab",
+            "/ok\x0bvtab",
+            // Raw space ends a header value for some parsers.
+            "/ok evil",
+            // Non-ASCII.
+            "/café",
+            "/\u{202e}gnp.exe",
+            // Loops back into the gate.
+            "/_ephpm/auth/github/login",
+            "/_ephpm/auth/github/callback",
+            "/_ephpm/auth/github/callback?code=x&state=y",
+        ] {
+            assert!(!is_safe_return_to(bad, RESERVED), "{bad:?} must be rejected");
+            assert_eq!(sanitize_return_to(bad, RESERVED), "/", "{bad:?} must collapse to /");
+        }
+    }
+
+    #[test]
+    fn over_long_is_rejected() {
+        let long = format!("/{}", "a".repeat(MAX_RETURN_TO));
+        assert!(!is_safe_return_to(&long, RESERVED));
+        // Exactly at the cap is still fine.
+        let at_cap = format!("/{}", "a".repeat(MAX_RETURN_TO - 1));
+        assert_eq!(at_cap.len(), MAX_RETURN_TO);
+        assert!(is_safe_return_to(&at_cap, RESERVED));
+    }
+
+    #[test]
+    fn reserved_match_is_exact_not_prefix() {
+        // A real application page that merely shares a prefix with the gate's
+        // endpoints is a legitimate destination.
+        assert!(is_safe_return_to("/_ephpm/auth/github/login-help", RESERVED));
+        assert!(is_safe_return_to("/_ephpm/auth/github/callbacks", RESERVED));
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/token.rs
+++ b/crates/ephpm-middleware-github-auth/src/token.rs
@@ -1,0 +1,271 @@
+//! HS256 token minting, plus the two constant-time comparisons this module
+//! needs.
+//!
+//! # Format, and who owns it
+//!
+//! The session this module issues is a **compact HS256 JWT** — the same shape
+//! the in-tree `jwt` builtin (`crates/ephpm-middleware-builtins/src/jwt.rs`)
+//! already verifies, down to `alg` pinning and a mandatory `exp`. That is not
+//! a coincidence and not a new invention: the hot-path verifier is a separate
+//! module, this one only *issues*, and picking the format the workspace
+//! already verifies is what keeps the two from diverging.
+//!
+//! Nothing here verifies a session token. Reading the session cookie is the
+//! verifier's job; see the crate docs for how the two modules compose.
+//!
+//! # Why it is self-contained
+//!
+//! No server-side session record exists, anywhere. The token carries its own
+//! subject, its own expiry and its own audience, and a restart or a second
+//! node changes nothing — there is no store to lose, replicate or evict. It
+//! also keeps the module clear of the process-global (not per-site)
+//! middleware KV surface tracked in ephpm#376.
+//!
+//! The direct consequence, which belongs in the operator's head and not just
+//! in a footnote: **an issued token cannot be revoked before it expires.**
+//! Session lifetime is therefore the blast radius of a stolen cookie, which
+//! is why `session_ttl_secs` defaults to eight hours rather than a week.
+//!
+//! # Key separation
+//!
+//! The OAuth `state` cookie is signed with a key *derived* from the session
+//! secret rather than the secret itself
+//! ([`derive_key`]). A `state` token and a session token can then never be
+//! swapped for one another even though both are HS256 and both are minted
+//! here — forging one from the other would require inverting HMAC.
+
+use base64ct::{Base64UrlUnpadded, Encoding as _};
+use hmac::{Hmac, Mac as _};
+use sha2::Sha256;
+
+/// Fixed JOSE header. `alg` is pinned so a verifier can reject anything else
+/// (the `alg: none` family of attacks).
+const HEADER_JSON: &str = r#"{"alg":"HS256","typ":"JWT"}"#;
+
+/// Domain-separation label for the OAuth `state` signing key.
+pub const STATE_KEY_LABEL: &[u8] = b"ephpm-github-auth/oauth-state/v1";
+
+/// Derive a subkey from the session secret for a specific purpose.
+///
+/// `HMAC-SHA256(secret, label)`. Used so the `state` cookie and the session
+/// cookie are signed under keys that cannot be substituted for each other.
+#[must_use]
+pub fn derive_key(secret: &[u8], label: &[u8]) -> Vec<u8> {
+    let mut mac = new_mac(secret);
+    mac.update(label);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// `Hmac<Sha256>` over an arbitrary-length key.
+///
+/// `new_from_slice` is documented as infallible for HMAC (any key length is
+/// accepted, being hashed down when over-long), so the `expect` is a type
+/// artefact rather than a reachable path.
+fn new_mac(key: &[u8]) -> Hmac<Sha256> {
+    Hmac::<Sha256>::new_from_slice(key).expect("HMAC accepts keys of any length")
+}
+
+/// Mint a compact HS256 JWT carrying `claims`.
+///
+/// `claims` must be a JSON object; the caller is responsible for including
+/// `exp`. Returns `None` only if `claims` cannot be serialised, which for a
+/// `serde_json::Value` built in-process does not happen.
+#[must_use]
+pub fn mint(secret: &[u8], claims: &serde_json::Value) -> Option<String> {
+    let payload = serde_json::to_vec(claims).ok()?;
+    let header_b64 = Base64UrlUnpadded::encode_string(HEADER_JSON.as_bytes());
+    let payload_b64 = Base64UrlUnpadded::encode_string(&payload);
+
+    let mut mac = new_mac(secret);
+    mac.update(header_b64.as_bytes());
+    mac.update(b".");
+    mac.update(payload_b64.as_bytes());
+    let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+
+    Some(format!("{header_b64}.{payload_b64}.{sig}"))
+}
+
+/// Verify a token minted by [`mint`] and return its claims.
+///
+/// **Only used for this module's own OAuth `state` cookie.** The session
+/// cookie is verified by the separate hot-path module, never here.
+///
+/// The signature is checked *before* the payload is parsed, so no
+/// unauthenticated JSON is ever deserialised, and `exp` is mandatory.
+#[must_use]
+pub fn verify(secret: &[u8], token: &str, now: u64) -> Option<serde_json::Value> {
+    let mut parts = token.split('.');
+    let (header_b64, payload_b64, sig_b64) = (parts.next()?, parts.next()?, parts.next()?);
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let sig = Base64UrlUnpadded::decode_vec(sig_b64).ok()?;
+    let mut mac = new_mac(secret);
+    mac.update(header_b64.as_bytes());
+    mac.update(b".");
+    mac.update(payload_b64.as_bytes());
+    // Constant-time: `verify_slice` compares through `subtle::ConstantTimeEq`.
+    mac.verify_slice(&sig).ok()?;
+
+    // The MAC is ours, but still pin the algorithm.
+    let header: serde_json::Value =
+        serde_json::from_slice(&Base64UrlUnpadded::decode_vec(header_b64).ok()?).ok()?;
+    if header.get("alg").and_then(serde_json::Value::as_str) != Some("HS256") {
+        return None;
+    }
+
+    let claims: serde_json::Value =
+        serde_json::from_slice(&Base64UrlUnpadded::decode_vec(payload_b64).ok()?).ok()?;
+    let exp = claims.get("exp").and_then(serde_json::Value::as_u64)?;
+    if exp <= now {
+        return None;
+    }
+    Some(claims)
+}
+
+/// Constant-time equality for two secrets of arbitrary, possibly differing,
+/// length.
+///
+/// Comparing the HMACs rather than the bytes is what makes the timing
+/// independent of both the contents *and* the length of `presented` — a plain
+/// `==` on `&str` leaks the length of the shared secret and the position of
+/// the first differing byte, which is enough to walk a token out of a server
+/// one character at a time.
+///
+/// `key` only needs to be unpredictable to the attacker; the module passes
+/// the derived state key.
+#[must_use]
+pub fn constant_time_eq(key: &[u8], presented: &[u8], expected: &[u8]) -> bool {
+    let mut a = new_mac(key);
+    a.update(presented);
+    let mut b = new_mac(key);
+    b.update(expected);
+    a.verify_slice(&b.finalize().into_bytes()).is_ok()
+}
+
+/// Fill `out` with cryptographically secure random bytes.
+///
+/// # Panics
+///
+/// Panics if the OS entropy source fails. That is not a recoverable
+/// condition for a module whose whole job is issuing credentials, and
+/// `declare!` converts the panic into a fail-closed `500` rather than a
+/// login with a predictable `state`.
+pub fn random_bytes(out: &mut [u8]) {
+    getrandom::fill(out).expect("OS entropy source unavailable");
+}
+
+/// 32 bytes of entropy, base64url-encoded — the OAuth `state` nonce.
+#[must_use]
+pub fn random_nonce() -> String {
+    let mut buf = [0u8; 32];
+    random_bytes(&mut buf);
+    Base64UrlUnpadded::encode_string(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"a-test-secret-at-least-32-bytes-long!!";
+
+    fn claims(exp: u64) -> serde_json::Value {
+        serde_json::json!({ "sub": "octocat", "exp": exp })
+    }
+
+    #[test]
+    fn round_trip() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        let got = verify(SECRET, &t, 1_000).expect("verify");
+        assert_eq!(got["sub"], "octocat");
+    }
+
+    #[test]
+    fn minted_token_has_the_jwt_shape_the_builtin_verifier_expects() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        let parts: Vec<&str> = t.split('.').collect();
+        assert_eq!(parts.len(), 3, "compact JWS serialisation");
+        let header = Base64UrlUnpadded::decode_vec(parts[0]).expect("header b64url");
+        let header: serde_json::Value = serde_json::from_slice(&header).expect("header json");
+        assert_eq!(header["alg"], "HS256");
+        assert_eq!(header["typ"], "JWT");
+        // Unpadded base64url: no '=' anywhere, and no '+' or '/'.
+        assert!(!t.contains('='), "padding would break cookie and URL use");
+        assert!(!t.contains('+') && !t.contains('/'));
+    }
+
+    #[test]
+    fn wrong_secret_fails() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        assert!(verify(b"different-secret", &t, 1_000).is_none());
+    }
+
+    #[test]
+    fn tampered_payload_fails() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        let mut parts: Vec<String> = t.split('.').map(str::to_owned).collect();
+        parts[1] = Base64UrlUnpadded::encode_string(br#"{"sub":"admin","exp":2000}"#);
+        assert!(verify(SECRET, &parts.join("."), 1_000).is_none());
+    }
+
+    #[test]
+    fn expired_and_missing_exp_fail() {
+        let t = mint(SECRET, &claims(1_000)).expect("mint");
+        assert!(verify(SECRET, &t, 1_000).is_none(), "exp == now is expired");
+        assert!(verify(SECRET, &t, 5_000).is_none());
+        let no_exp = mint(SECRET, &serde_json::json!({ "sub": "x" })).expect("mint");
+        assert!(verify(SECRET, &no_exp, 1_000).is_none(), "exp is mandatory");
+    }
+
+    #[test]
+    fn alg_none_is_rejected_even_with_a_valid_mac() {
+        // Forge a token through the same MAC path but with `alg: none`.
+        let header_b64 = Base64UrlUnpadded::encode_string(br#"{"alg":"none"}"#);
+        let payload_b64 = Base64UrlUnpadded::encode_string(br#"{"sub":"x","exp":2000}"#);
+        let mut mac = new_mac(SECRET);
+        mac.update(header_b64.as_bytes());
+        mac.update(b".");
+        mac.update(payload_b64.as_bytes());
+        let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+        let forged = format!("{header_b64}.{payload_b64}.{sig}");
+        assert!(verify(SECRET, &forged, 1_000).is_none());
+    }
+
+    #[test]
+    fn malformed_tokens_fail() {
+        for bad in ["", "a", "a.b", "a.b.c.d", "....", "not-base64!.x.y"] {
+            assert!(verify(SECRET, bad, 1_000).is_none(), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn derived_keys_are_domain_separated() {
+        let state_key = derive_key(SECRET, STATE_KEY_LABEL);
+        assert_ne!(state_key.as_slice(), SECRET, "the state key is not the session key");
+        // A token signed for one domain must not verify under the other.
+        let t = mint(&state_key, &claims(2_000)).expect("mint");
+        assert!(verify(SECRET, &t, 1_000).is_none());
+        let s = mint(SECRET, &claims(2_000)).expect("mint");
+        assert!(verify(&state_key, &s, 1_000).is_none());
+    }
+
+    #[test]
+    fn constant_time_eq_matches_semantics_of_equality() {
+        let k = b"key";
+        assert!(constant_time_eq(k, b"abc", b"abc"));
+        assert!(!constant_time_eq(k, b"abc", b"abd"));
+        assert!(!constant_time_eq(k, b"abc", b"abcd"), "length differences are unequal");
+        assert!(!constant_time_eq(k, b"", b"abc"));
+        assert!(constant_time_eq(k, b"", b""));
+    }
+
+    #[test]
+    fn nonces_are_unique_and_url_safe() {
+        let a = random_nonce();
+        let b = random_nonce();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 43, "32 bytes, unpadded base64url");
+        assert!(a.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+}

--- a/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
+++ b/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
@@ -1,0 +1,484 @@
+//! The OAuth round trip, driven against a stub GitHub over real sockets.
+//!
+//! A real `github.com` round trip cannot be completed unattended — it needs a
+//! human at a browser and a registered GitHub App. Everything *this side* of
+//! that can be exercised for real, and is: a loopback HTTP server stands in
+//! for `github.com` and `api.github.com`, and the module's own
+//! `reqwest`/`rustls` client talks to it over an actual TCP connection with
+//! actual request and response bytes. The token exchange, the `Authorization`
+//! header, the JSON parsing, the access decision, the `Set-Cookie` and the
+//! `Location` are all the shipping code paths.
+//!
+//! What the stub cannot tell you: that GitHub's real responses match these
+//! shapes, and that a real App's redirect URL is registered correctly. Those
+//! need a human with a GitHub App — see the README's verification table.
+//!
+//! The stub also **counts every request it receives**, which is how the most
+//! important assertion in this file is made:
+//! [`a_request_with_a_session_makes_no_network_call`] shows the counter does
+//! not move.
+//!
+//! The crate's `[lib] name` is `github_auth` (that is what the loadable
+//! artefact is called), so it is imported under that name here.
+#![allow(unsafe_code, reason = "the test builds the FFI Request view by hand")]
+
+use std::io::{BufRead as _, BufReader, Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+use ephpm_middleware::host::{RequestCtx, host_table};
+use ephpm_middleware::{Middleware as _, Request, Response};
+use github_auth::{GithubAuth, query_param};
+
+const VHOST: &str = "pr-1.preview.test";
+const SESSION_SECRET: &str = "0123456789abcdef0123456789abcdef";
+const CLIENT_SECRET: &str = "stub-client-secret";
+const GOOD_CODE: &str = "goodcode";
+const ACCESS_TOKEN: &str = "gho_stubtoken";
+
+// ── the stub GitHub ───────────────────────────────────────────────────────
+
+/// What the stub saw, so tests can assert on traffic rather than on outcomes
+/// alone.
+#[derive(Default)]
+struct Seen {
+    /// `"METHOD PATH"` for every request served.
+    requests: Vec<String>,
+    /// Bodies of the token-exchange POSTs.
+    token_bodies: Vec<String>,
+    /// `Authorization` header values seen on API calls.
+    authorizations: Vec<String>,
+}
+
+struct Stub {
+    base: String,
+    seen: Arc<Mutex<Seen>>,
+    count: Arc<AtomicUsize>,
+}
+
+impl Stub {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        let seen = Arc::new(Mutex::new(Seen::default()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let (seen_t, count_t) = (Arc::clone(&seen), Arc::clone(&count));
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                // One request per connection; every response carries
+                // `Connection: close`, so the client opens a fresh one.
+                handle(stream, &seen_t, &count_t);
+            }
+        });
+        Self { base, seen, count }
+    }
+
+    fn requests(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+
+    fn seen(&self) -> std::sync::MutexGuard<'_, Seen> {
+        self.seen.lock().expect("stub state")
+    }
+}
+
+fn handle(mut stream: TcpStream, seen: &Arc<Mutex<Seen>>, count: &Arc<AtomicUsize>) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+    let mut line = String::new();
+    if reader.read_line(&mut line).is_err() || line.is_empty() {
+        return;
+    }
+    let mut parts = line.split_whitespace();
+    let (method, path) =
+        (parts.next().unwrap_or("").to_owned(), parts.next().unwrap_or("").to_owned());
+
+    let mut content_length = 0usize;
+    let mut authorization = String::new();
+    loop {
+        let mut h = String::new();
+        if reader.read_line(&mut h).is_err() || h.trim().is_empty() {
+            break;
+        }
+        let lower = h.to_ascii_lowercase();
+        if let Some(v) = lower.strip_prefix("content-length:") {
+            content_length = v.trim().parse().unwrap_or(0);
+        } else if lower.starts_with("authorization:") {
+            // Split the ORIGINAL line — the token is case-sensitive.
+            authorization.clear();
+            authorization.push_str(h.split_once(':').map_or("", |(_, v)| v.trim()));
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 && reader.read_exact(&mut body).is_err() {
+        return;
+    }
+    let body = String::from_utf8_lossy(&body).into_owned();
+
+    count.fetch_add(1, Ordering::SeqCst);
+    {
+        let mut s = seen.lock().expect("stub state");
+        s.requests.push(format!("{method} {path}"));
+        if path.starts_with("/login/oauth/access_token") {
+            s.token_bodies.push(body.clone());
+        } else if !authorization.is_empty() {
+            s.authorizations.push(authorization.clone());
+        }
+    }
+
+    let (status, json) = respond(&method, &path, &body, &authorization);
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{json}",
+        json.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// The stub's GitHub. Deliberately literal about the two behaviours that
+/// catch real bugs: GitHub reports OAuth failures with **HTTP 200** and an
+/// `error` field, and it answers "exists but not for you" with **404**.
+fn respond(method: &str, path: &str, body: &str, authorization: &str) -> (&'static str, String) {
+    match (method, path) {
+        ("POST", "/login/oauth/access_token") => {
+            if !body.contains(&format!("code={GOOD_CODE}")) {
+                return ("200 OK", r#"{"error":"bad_verification_code"}"#.to_owned());
+            }
+            if !body.contains("client_secret=stub-client-secret") {
+                return ("200 OK", r#"{"error":"incorrect_client_credentials"}"#.to_owned());
+            }
+            ("200 OK", format!(r#"{{"access_token":"{ACCESS_TOKEN}","token_type":"bearer"}}"#))
+        }
+        // Everything below requires the token the exchange handed out.
+        _ if authorization != format!("Bearer {ACCESS_TOKEN}") => {
+            ("401 Unauthorized", r#"{"message":"Bad credentials"}"#.to_owned())
+        }
+        ("GET", "/user") => ("200 OK", r#"{"login":"octocat","id":583231}"#.to_owned()),
+        ("GET", "/repos/acme/web") => (
+            "200 OK",
+            r#"{"full_name":"acme/web","permissions":{"pull":true,"push":false}}"#.to_owned(),
+        ),
+        // Visible, but read is explicitly denied.
+        ("GET", "/repos/acme/noread") => ("200 OK", r#"{"permissions":{"pull":false}}"#.to_owned()),
+        ("GET", "/user/memberships/orgs/acme") => ("200 OK", r#"{"state":"active"}"#.to_owned()),
+        ("GET", "/user/memberships/orgs/other") => ("200 OK", r#"{"state":"pending"}"#.to_owned()),
+        ("GET", "/orgs/acme/teams/platform/memberships/octocat") => {
+            ("200 OK", r#"{"state":"active"}"#.to_owned())
+        }
+        // Everything else — including `/repos/acme/secret` and
+        // `/orgs/acme/teams/secret-team/memberships/octocat` — is GitHub's
+        // deliberate "exists but not for you": a 404, not a 403.
+        _ => ("404 Not Found", r#"{"message":"Not Found"}"#.to_owned()),
+    }
+}
+
+// ── driving the module ────────────────────────────────────────────────────
+
+fn gate(stub: &Stub, extra: serde_json::Value) -> GithubAuth {
+    let mut cfg = serde_json::json!({
+        "client_id": "Iv1.stub",
+        "client_secret": CLIENT_SECRET,
+        "session_secret": SESSION_SECRET,
+        "repo": "acme/web",
+        "github_base": stub.base,
+        "github_api_base": stub.base,
+        // The derived redirect_uri would be https://<vhost>/…; pin it so the
+        // exchange body is deterministic.
+        "redirect_uri": format!("https://{VHOST}/_ephpm/auth/github/callback"),
+    });
+    for (k, v) in extra.as_object().cloned().unwrap_or_default() {
+        cfg[k] = v;
+    }
+    GithubAuth::init(&cfg).expect("init")
+}
+
+fn call(mw: &GithubAuth, path: &str, query: &str, headers: &[(String, String)]) -> Response {
+    let ctx = RequestCtx::new("GET", path, query, "203.0.113.9", VHOST, headers);
+    // SAFETY: `ctx` outlives the borrow and `host_table()` is 'static — the
+    // exact contract `Request::from_raw` documents.
+    let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+    mw.invoke(&req)
+}
+
+fn header(resp: &Response, name: &str) -> Option<String> {
+    resp.__headers().iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.clone())
+}
+
+fn set_cookies(resp: &Response) -> Vec<String> {
+    resp.__headers()
+        .iter()
+        .filter(|(n, _)| n.eq_ignore_ascii_case("set-cookie"))
+        .map(|(_, v)| v.clone())
+        .collect()
+}
+
+/// Run the login half and return `(state parameter, state cookie pair)`.
+fn begin_login(mw: &GithubAuth, from: &str) -> (String, String) {
+    let resp = call(mw, from, "", &[]);
+    assert_eq!(resp.__status(), 302);
+    let location = header(&resp, "Location").expect("Location");
+    let state = query_param(location.split_once('?').expect("query").1, "state").expect("state");
+    let cookie = set_cookies(&resp)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session_oauth="))
+        .expect("state cookie");
+    (state, cookie.split(';').next().expect("pair").to_owned())
+}
+
+/// Complete a callback with the given code.
+fn finish_login(mw: &GithubAuth, state: &str, cookie: &str, code: &str) -> Response {
+    call(
+        mw,
+        "/_ephpm/auth/github/callback",
+        &format!("code={code}&state={state}"),
+        &[("Cookie".to_owned(), cookie.to_owned())],
+    )
+}
+
+/// The session cookie value out of a successful callback.
+fn session_value(resp: &Response) -> String {
+    set_cookies(resp)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session="))
+        .expect("session cookie")
+        .split(';')
+        .next()
+        .expect("pair")
+        .to_owned()
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn happy_path_exchanges_the_code_checks_access_and_issues_a_session() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+
+    let (state, cookie) = begin_login(&mw, "/wp-admin/index.php");
+    assert_eq!(stub.requests(), 0, "starting a login must not touch GitHub");
+
+    let resp = finish_login(&mw, &state, &cookie, GOOD_CODE);
+    assert_eq!(resp.__action(), ACTION_RESPOND);
+    assert_eq!(resp.__status(), 302);
+    assert_eq!(
+        header(&resp, "Location").as_deref(),
+        Some("/wp-admin/index.php"),
+        "the user lands where they were going"
+    );
+
+    // Exactly the three documented calls, in order.
+    let seen = stub.seen();
+    assert_eq!(
+        seen.requests,
+        vec![
+            "POST /login/oauth/access_token".to_owned(),
+            "GET /user".to_owned(),
+            "GET /repos/acme/web".to_owned(),
+        ]
+    );
+    // The exchange carried the client credentials and the redirect_uri.
+    let body = seen.token_bodies.first().expect("token body");
+    assert!(body.contains("client_id=Iv1.stub"));
+    assert!(body.contains("client_secret=stub-client-secret"));
+    assert!(body.contains(&format!("code={GOOD_CODE}")));
+    assert!(body.contains("redirect_uri="));
+    // Both API calls were bearer-authenticated with the exchanged token.
+    assert_eq!(seen.authorizations.len(), 2);
+    assert!(seen.authorizations.iter().all(|a| a == &format!("Bearer {ACCESS_TOKEN}")));
+    drop(seen);
+
+    // The session cookie is a three-part HS256 JWT with the right attributes.
+    let session = session_value(&resp);
+    let value = session.strip_prefix("ephpm_session=").expect("prefix");
+    assert_eq!(value.split('.').count(), 3);
+    let raw = set_cookies(&resp).into_iter().find(|c| c.starts_with("ephpm_session=")).expect("c");
+    assert!(raw.contains("HttpOnly") && raw.contains("Secure") && raw.contains("SameSite=Lax"));
+    assert!(raw.contains("Max-Age=28800"));
+    assert!(!raw.contains("Domain="), "host-only, so one tenant's session cannot reach another");
+
+    // The state cookie is cleared on the way out.
+    assert!(
+        set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session_oauth=;")
+            || c.starts_with("ephpm_session_oauth=; ")
+            || (c.starts_with("ephpm_session_oauth=") && c.contains("Max-Age=0"))),
+        "the one-shot state cookie must be deleted: {:?}",
+        set_cookies(&resp)
+    );
+
+    // And the payload says what it should.
+    let payload = value.split('.').nth(1).expect("payload");
+    let json: serde_json::Value =
+        serde_json::from_slice(&base64_url_decode(payload).expect("payload is base64url"))
+            .expect("payload is JSON");
+    assert_eq!(json["sub"], "octocat");
+    assert_eq!(json["gh_id"], 583_231);
+    assert_eq!(json["site"], VHOST);
+    assert_eq!(json["via"], "github");
+    assert_eq!(json["check"], "repo acme/web");
+}
+
+#[test]
+fn a_request_with_a_session_makes_no_network_call() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+
+    let (state, cookie) = begin_login(&mw, "/");
+    let session = session_value(&finish_login(&mw, &state, &cookie, GOOD_CODE));
+    let after_login = stub.requests();
+    assert_eq!(after_login, 3);
+
+    // Fifty ordinary requests carrying the session. This is the constraint
+    // the whole design exists to satisfy: the counter must not move.
+    let headers = vec![("Cookie".to_owned(), session)];
+    for i in 0..50 {
+        let resp = call(&mw, "/index.php", &format!("i={i}"), &headers);
+        assert_eq!(resp.__action(), ACTION_CONTINUE, "request {i} must reach PHP");
+    }
+    assert_eq!(
+        stub.requests(),
+        after_login,
+        "a request with a session cookie must never reach GitHub"
+    );
+}
+
+#[test]
+fn a_bad_code_is_rejected_and_issues_nothing() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+    let (state, cookie) = begin_login(&mw, "/");
+
+    let resp = finish_login(&mw, &state, &cookie, "wrongcode");
+    // GitHub answers HTTP 200 with an `error` field; treating that as success
+    // is the classic OAuth implementation bug.
+    assert_eq!(resp.__status(), 400);
+    assert!(
+        !set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")),
+        "a failed exchange must not issue a session"
+    );
+    assert_eq!(
+        stub.seen().requests,
+        vec!["POST /login/oauth/access_token".to_owned()],
+        "the flow stops at the exchange — no identity or access call is made"
+    );
+}
+
+#[test]
+fn a_user_without_repo_access_is_denied() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({ "repo": "acme/secret" }));
+    let (state, cookie) = begin_login(&mw, "/");
+
+    let resp = finish_login(&mw, &state, &cookie, GOOD_CODE);
+    assert_eq!(resp.__status(), 403);
+    assert!(!set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")));
+    // The 404 GitHub returns for "exists but not yours" is a denial, not an
+    // error — the flow completed and answered no.
+    assert_eq!(stub.seen().requests.len(), 3);
+}
+
+#[test]
+fn a_repo_with_read_explicitly_denied_is_denied() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({ "repo": "acme/noread" }));
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 403);
+}
+
+#[test]
+fn org_membership_must_be_active_not_pending() {
+    let stub = Stub::start();
+
+    let mw = gate(&stub, serde_json::json!({ "check": "org", "org": "acme", "repo": null }));
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 302);
+
+    // `pending` is an unaccepted invitation — not a member.
+    let mw = gate(&stub, serde_json::json!({ "check": "org", "org": "other", "repo": null }));
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 403);
+}
+
+#[test]
+fn team_membership_is_checked_against_the_logged_in_user() {
+    let stub = Stub::start();
+
+    let mw = gate(
+        &stub,
+        serde_json::json!({ "check": "team", "org": "acme", "team": "platform", "repo": null }),
+    );
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 302);
+    // The path is built from `/user`'s login, not from anything the client said.
+    assert!(
+        stub.seen()
+            .requests
+            .iter()
+            .any(|r| r == "GET /orgs/acme/teams/platform/memberships/octocat")
+    );
+
+    let mw = gate(
+        &stub,
+        serde_json::json!({ "check": "team", "org": "acme", "team": "secret-team", "repo": null }),
+    );
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 403);
+}
+
+#[test]
+fn state_is_a_signed_value_not_a_one_time_server_side_record() {
+    // Replaying a completed login's state with a fresh code still requires the
+    // state to verify — it does, because it is stateless and not yet expired.
+    // What it CANNOT do is complete without the cookie, which is the property
+    // that matters and which `callback_without_a_state_cookie_is_rejected`
+    // pins. This test records the honest limitation rather than implying a
+    // stronger one: a stateless state token is replayable within its 10-minute
+    // window by whoever holds the cookie, i.e. by the user themselves.
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+    let (state, cookie) = begin_login(&mw, "/");
+
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 302);
+    // Second use: the state still verifies (it is a signed value with a TTL),
+    // and GitHub is what refuses a reused authorization code.
+    assert_eq!(finish_login(&mw, &state, &cookie, "wrongcode").__status(), 400);
+}
+
+#[test]
+fn github_being_unreachable_is_a_502_not_a_pass() {
+    // Point the gate at a closed port: the exchange cannot complete.
+    let stub = Stub::start();
+    let mw = gate(
+        &stub,
+        serde_json::json!({
+            "github_base": "http://127.0.0.1:1",
+            "github_api_base": "http://127.0.0.1:1",
+            "http_timeout_secs": 2,
+        }),
+    );
+    let (state, cookie) = begin_login(&mw, "/");
+    let resp = finish_login(&mw, &state, &cookie, GOOD_CODE);
+    assert_eq!(resp.__status(), 502, "an unreachable identity provider must fail closed");
+    assert!(!set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")));
+}
+
+/// Minimal unpadded base64url decoder for asserting on the issued payload.
+fn base64_url_decode(s: &str) -> Option<Vec<u8>> {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut acc: u32 = 0;
+    let mut bits = 0u32;
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    for c in s.bytes() {
+        let v = u32::try_from(TABLE.iter().position(|t| *t == c)?).ok()?;
+        acc = (acc << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(u8::try_from((acc >> bits) & 0xFF).ok()?);
+        }
+    }
+    Some(out)
+}

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -35,6 +35,10 @@ that does — that is the verifier's job, and doing it in two places would give
 you two subtly different verifiers. The module logs this at startup on its
 first request.
 
+The verifier this is designed to pair with is the **`session-cookie` builtin**
+(ephpm#388) — same HS256 verification as the `jwt` builtin, but reading a
+cookie and redirecting instead of answering `401`:
+
 ```toml
 [[middleware]]
 library = "/opt/ephpm/modules/libgithub_auth.so"
@@ -45,11 +49,23 @@ config  = { client_id = "Iv1.0123456789abcdef",
             repo = "acme/web" }
 
 [[middleware]]
-library = "…session verifier…"    # hot path — verifies, redirects to login
+library = "session-cookie"       # hot path — verifies, redirects to login
 order   = 20
-config  = { session_secret = "env:EPHPM_SESSION_SECRET",
-            login_path = "/_ephpm/auth/github/login" }
+config  = { secret = "env:EPHPM_SESSION_SECRET",
+            cookie = "ephpm_session",
+            login_url = "/_ephpm/auth/github/login",
+            return_to_param = "next" }
 ```
+
+Three things must line up, and only three:
+
+| this module | `session-cookie` | note |
+|---|---|---|
+| `session_secret` | `secret` | the same HMAC key — that is what makes the token verify |
+| `cookie_name` (`ephpm_session`) | `cookie` (`ephpm_session`) | defaults already match |
+| `login_path` | `login_url` + `return_to_param = "next"` | this module reads the return-to from `?next=` and sanitizes it |
+
+`issuer` / `audience` are optional on both sides; set them on both or neither.
 
 ## What happens per request
 

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -1,0 +1,317 @@
++++
+title = "GitHub OAuth Gate (native middleware)"
+weight = 11
++++
+
+> **Status.** The module is implemented and tested. The OAuth round trip is
+> exercised end to end against a stub GitHub over real sockets; **a round trip
+> against the real `github.com` with a real GitHub App has not been performed**
+> and needs a human. See [Verification status](#verification-status) — nothing
+> on this page is claimed beyond what is tested.
+
+`github-auth` gates a private preview site on **GitHub identity**: *does the
+person at this browser have access, on GitHub, to the repository (or org, or
+team) this preview belongs to?*
+
+It is a [dynamic (`dlopen`) middleware module](/guides/native-middleware/),
+not a builtin — it needs an HTTP client and a TLS stack, and none of that
+belongs in the `ephpm` binary.
+
+## It is half of a pair
+
+Two jobs, deliberately in two modules:
+
+| | **`github-auth`** (this module) | a session-verifier module |
+|---|---|---|
+| Runs on | login, the OAuth callback, and the first request of a session | every request |
+| Talks to GitHub | yes, 3 calls | **never** |
+| Owns | issuing sessions | the token format and its verification |
+| When unhappy | `RESPOND` 302 → GitHub | `RESPOND` 302 → `login_path` |
+
+**Mounted alone, `github-auth` is not an authenticator.** It stops a request
+that carries *no* session cookie, but it deliberately does **not** verify one
+that does — that is the verifier's job, and doing it in two places would give
+you two subtly different verifiers. The module logs this at startup on its
+first request.
+
+```toml
+[[middleware]]
+library = "/opt/ephpm/modules/libgithub_auth.so"
+order   = 10                     # cold path — owns the reserved paths
+config  = { client_id = "Iv1.0123456789abcdef",
+            client_secret  = "env:GH_CLIENT_SECRET",
+            session_secret = "env:EPHPM_SESSION_SECRET",
+            repo = "acme/web" }
+
+[[middleware]]
+library = "…session verifier…"    # hot path — verifies, redirects to login
+order   = 20
+config  = { session_secret = "env:EPHPM_SESSION_SECRET",
+            login_path = "/_ephpm/auth/github/login" }
+```
+
+## What happens per request
+
+| Request | Verdict | Cost |
+|---|---|---|
+| no session cookie | 302 → GitHub `authorize`, `Set-Cookie` state | no network |
+| `GET {callback_path}?code=…&state=…` | 302 → where you were, `Set-Cookie` session | 3 GitHub calls |
+| `GET {login_path}` | 302 → GitHub `authorize` | no network |
+| valid bypass token, no cookie | 302 → same URL, `Set-Cookie` session | no network |
+| session cookie present | `CONTINUE` — the verifier decides | **no network** |
+
+PHP does not run on any redirect row: the middleware chain is evaluated before
+PHP dispatch and before the request body is read.
+
+**A GitHub API call is never made on a request that already has a session.**
+That is structural, not a discipline: only the exact configured
+`callback_path` can reach the network, and the routing decision is a pure
+function with its own tests.
+
+## Requirements
+
+**Use a GitHub App, not a classic OAuth App.** With an OAuth App, seeing a
+private repository at all requires the `repo` scope — read *and write* on
+every repository the user can touch, handed to a preview host. A GitHub App's
+user-to-server token is bounded by the app's installation instead, and needs
+no scope for the repository check. That is why `scopes` defaults to empty.
+
+**The reserved paths must reach PHP routing.** ePHPm evaluates middleware on
+the PHP-bound path, so `login_path` and `callback_path` must resolve to a PHP
+script for the module to see them. With the default
+`fallback = ["$uri", "$uri/", "/index.php?$query_string"]` and a front
+controller at `index.php` — WordPress, Laravel, Symfony — that is automatic,
+and PHP still never runs because the chain short-circuits first. A site with
+no `index.php` and a `=404` fallback would 404 the callback before the module
+is consulted.
+
+**`dlopen` must work.** The stock Linux release is glibc-dynamic and can load
+this. A custom fully static (musl) ePHPm **cannot `dlopen` at all** and
+therefore cannot use this module; such a build would need it compiled in as a
+builtin instead.
+
+## Build and mount
+
+```bash
+cargo build --release -p ephpm-middleware-github-auth
+# target/release/libgithub_auth.so    (Linux)
+# target/release/libgithub_auth.dylib (macOS)
+# target/release/github_auth.dll      (Windows)
+```
+
+`library` must be a **path** (something containing a separator or an
+extension). A bare name is resolved against the compiled-in builtin registry
+first, so it would not load this module.
+
+## Configuration
+
+Secrets accept an **`env:NAME`** indirection, read once at startup. Prefer it:
+`ephpm.toml` is often templated or rendered into a ConfigMap, and a literal in
+it is a secret in git.
+
+| key | default | meaning |
+|---|---|---|
+| `client_id` | **required** | OAuth client id of the GitHub App / OAuth App |
+| `client_secret` | **required** | its client secret; `env:NAME` supported |
+| `session_secret` | **required**, ≥ 32 bytes | HMAC key for issued sessions. Must match the verifier's |
+| `check` | `"repo"` | `"repo"`, `"org"` or `"team"`. Inferred when unambiguous |
+| `repo` | — | `owner/name`, for `check = "repo"` |
+| `org` | — | organisation login, for `check = "org"` / `"team"` |
+| `team` | — | team slug, for `check = "team"` |
+| `sites` | unset | table mapping each vhost to its own `{ repo \| org \| team }` |
+| `login_path` | `/_ephpm/auth/github/login` | reserved: starts a login |
+| `callback_path` | `/_ephpm/auth/github/callback` | reserved: receives GitHub's redirect |
+| `redirect_uri` | derived | full callback URL sent to GitHub. Defaults to `https://<vhost><callback_path>` |
+| `cookie_name` | `ephpm_session` | session cookie. Must match the verifier's |
+| `state_cookie_name` | `<cookie_name>_oauth` | short-lived OAuth `state` cookie |
+| `cookie_path` | `/` | `Path` attribute on both cookies |
+| `cookie_secure` | `true` | emit `Secure`. Turn off only for a plaintext local preview |
+| `cookie_samesite` | `"Lax"` | `Lax`, `Strict` or `None` (`None` requires `cookie_secure`) |
+| `session_ttl_secs` | `28800` (8 h) | 60 – 604800 |
+| `issuer` | `ephpm-github-auth` | `iss` claim |
+| `audience` | unset | `aud` claim |
+| `scopes` | `[]` | OAuth scopes. Empty is correct for a GitHub App |
+| `bypass_token` | unset | pre-shared automation token, ≥ 32 bytes |
+| `bypass_header` | `x-ephpm-bypass` | header carrying it |
+| `bypass_query` | unset | query parameter carrying it — **off unless set** |
+| `bypass_ttl_secs` | `3600` | lifetime of a bypass-issued session |
+| `github_base` | `https://github.com` | authorize/token host (a GHES host works) |
+| `github_api_base` | `https://api.github.com` | REST base (`https://ghes/api/v3`) |
+| `http_timeout_secs` | `10` | 1 – 60, per outbound call |
+
+`github_base` / `github_api_base` must be `https://`, with one exception:
+`http://` is accepted for a **loopback** host, which is what lets the test
+suite point the module at a stub server. Plaintext to a real GitHub host is
+refused outright — it would put the client secret and the user's access token
+on the wire in clear.
+
+If `sites` is present it is **authoritative**: a vhost with no entry gets no
+access at all, even when a top-level `repo` is also configured. A hostname
+nobody mapped must not quietly inherit another tenant's rule.
+
+## Which GitHub calls are made
+
+Per login, once:
+
+| # | Call | Purpose | Minimum permission |
+|---|---|---|---|
+| 1 | `POST {github_base}/login/oauth/access_token` | code → user access token | none — this *is* the grant |
+| 2 | `GET /user` | the login that becomes `sub` | GitHub App: none. OAuth App: `read:user` |
+| 3a | `GET /repos/{owner}/{name}` | `check = "repo"` | GitHub App: `metadata: read`. OAuth App: `repo` |
+| 3b | `GET /user/memberships/orgs/{org}` | `check = "org"` — must be `active` | `read:org` |
+| 3c | `GET /orgs/{org}/teams/{team}/memberships/{login}` | `check = "team"` — must be `active` | `read:org` |
+
+Redirects are never followed. A visible consequence: a **renamed** repository
+stops matching until the config is updated, which is the safe direction.
+
+The access token is used for those calls and then dropped. It is never stored,
+never written to a cookie, and never logged.
+
+## The session
+
+An HS256 JWT — the same shape the builtin `jwt` module already verifies, down
+to `alg` pinning and a mandatory `exp`.
+
+| claim | meaning |
+|---|---|
+| `iss` | `issuer` |
+| `sub` | GitHub login, or `automation` for a bypass session |
+| `aud` | `audience`, when configured |
+| `iat` / `exp` | issue / expiry, seconds since the epoch |
+| `site` | the vhost this session is for |
+| `via` | `github`, `bypass` — or `share` for an externally minted token |
+| `gh_id` | numeric GitHub account id (stable across renames) |
+| `check` | the rule that was satisfied, e.g. `repo acme/web` |
+
+There is **no server-side session record**. Restarts do not log anyone out, a
+second node needs no replication, and the module never touches the middleware
+KV surface (which is process-global rather than per-site — issue #376).
+
+The cost, plainly: **an issued session cannot be revoked before it expires.**
+Rotating `session_secret` invalidates every session at once and is the only
+revocation available. `session_ttl_secs` is therefore the blast radius of a
+stolen cookie.
+
+### Cookie attributes, and why
+
+`HttpOnly` (the token *is* the session, and a preview site is pre-production
+code — exactly where XSS lives), `Secure` (a bearer credential must not ride a
+plaintext hop), `SameSite=Lax` (`Strict` would bounce a user through GitHub
+every time they clicked a preview link from a PR comment or Slack; `Lax` sends
+the cookie on top-level GET navigations, which is that case *and* the OAuth
+callback), `Path` (the gate covers the whole site), a real `Max-Age` matching
+the token's `exp` — and **no `Domain`**, which makes the cookie host-only.
+`Domain=.preview.example.com` would send one tenant's session to every other
+tenant on the wildcard. That one is not configurable.
+
+## Automation bypass
+
+Playwright, Lighthouse and smoke tests need in. Set `bypass_token` (≥ 32
+bytes) and present it:
+
+```bash
+curl -sL -c jar.txt -H "x-ephpm-bypass: $EPHPM_BYPASS" https://pr-123.preview.example.com/
+lighthouse https://pr-123.preview.example.com/ \
+  --extra-headers "{\"x-ephpm-bypass\":\"$EPHPM_BYPASS\"}"
+```
+
+Presenting it yields *the same kind of session* — a 302 and a `Set-Cookie` —
+not a per-request pass-through. The client follows one extra redirect on its
+first request and behaves normally afterwards. The comparison is constant-time
+and independent of length; a wrong token behaves exactly like no token at all
+(302 to GitHub), so the header is not an oracle.
+
+`bypass_query` exists for tools that cannot set headers, and is **off unless
+configured**: a query string lands in access logs, browser history and
+`Referer` headers, which a header does not.
+
+## Share links
+
+Because issuance and verification are separate, and issuance is not
+privileged, **a hosting control plane can mint its own sessions with no change
+to this module.** Anything holding `session_secret` can produce an acceptable
+token: same HS256 JWT, `via = "share"`, whatever `sub` and `exp` you want.
+
+```php
+$claims = ['iss' => 'ephpm-github-auth', 'sub' => 'share:designer@example.com',
+           'site' => 'pr-123.preview.example.com', 'via' => 'share',
+           'iat' => time(), 'exp' => time() + 7200];
+$b64 = fn($v) => rtrim(strtr(base64_encode($v), '+/', '-_'), '=');
+$signing = $b64('{"alg":"HS256","typ":"JWT"}') . '.' . $b64(json_encode($claims));
+$token = $signing . '.' . $b64(hash_hmac('sha256', $signing, $secret, true));
+// then: Set-Cookie: ephpm_session=$token; Path=/; Max-Age=7200; HttpOnly; Secure; SameSite=Lax
+```
+
+This is a real capability and a real risk: `session_secret` is a minting key.
+Treat it like one.
+
+## Security properties
+
+**CSRF on the callback is enforced.** A login mints a 32-byte random nonce,
+puts it in the `state` parameter *and* in an `HttpOnly` signed cookie bound to
+the vhost and expiring in 10 minutes. The callback requires both, compares
+them in constant time, and refuses when the cookie is missing, unsigned,
+expired, or issued for another host. An attacker who plants their own
+`code`+`state` in a victim's browser cannot supply the matching cookie.
+
+**Return-to is constrained to a same-origin path.** Absolute URLs,
+scheme-relative `//evil.test`, backslash forms, `javascript:`/`data:`, raw
+control characters, non-ASCII, `..` segments and over-long values all collapse
+to `/`. Values are re-validated after being read back out of the signed state
+cookie — a signature attests origin, not safety.
+
+**Constant-time comparison** is used for every secret and signature (HMAC
+verification for tokens; an HMAC-of-both comparison for the bypass token, so
+the timing leaks neither the contents nor the length).
+
+**Nothing secret is logged.** No code, token, secret or minted session appears
+in any log line; the error type physically cannot carry one. GitHub's OAuth
+error identifiers are filtered to `[A-Za-z0-9_]` before being logged. Refusal
+pages are plain text with no interpolation, so the gate cannot become a
+reflected-XSS surface on the preview's own origin.
+
+**Fail-closed everywhere.** GitHub unreachable → 502. A vhost with no
+configured target → 403. A panic anywhere in the module → 500 (the `declare!`
+macro's containment). None of these fall through to PHP.
+
+### The client secret lives on the node
+
+This is the real cost of doing OAuth in-process instead of in a separate
+identity service. The OAuth **client secret** is present on every node serving
+previews, readable by the ePHPm process.
+
+If a node is compromised the attacker can impersonate the OAuth app — complete
+an authorization flow for any user who can be induced to click an authorize
+link — and, holding `session_secret`, mint sessions for any user and any site
+this gate protects. They cannot read a user's GitHub data without that user
+authorizing, and no long-lived GitHub token is stored: the access token is
+used during the login and dropped. **Rotate `client_secret` and
+`session_secret` together after any node compromise.**
+
+## Limitations
+
+- **One callback host per app.** GitHub does not support wildcard callback
+  URLs. A fleet of per-PR hostnames needs a single auth origin and a
+  cross-host hand-off; that is **not implemented here**. Today, `redirect_uri`
+  is derived per request from the vhost, which works when each preview host is
+  registered (or when one host is used).
+- **No revocation before expiry.** See [The session](#the-session).
+- **The `state` cookie is replayable within its 10-minute window** by whoever
+  holds it — i.e. by the user themselves. Reuse of an authorization *code* is
+  refused by GitHub, not here.
+- **No `dlopen`, no module** — see [Requirements](#requirements).
+
+## Verification status
+
+| Behaviour | How it was verified |
+|---|---|
+| No cookie → 302 to GitHub with a `state`, PHP never runs | real HTTP against a running ePHPm with the module `dlopen`ed |
+| Session cookie → `CONTINUE`, PHP dispatched, no headers added | same |
+| Callback with missing / forged / empty / wrong-host / expired `state` → 400 | real HTTP + unit tests |
+| Hostile return-to values (27 shapes) collapse to `/` | real HTTP, decoding the signed state cookie |
+| Bypass token accepted / a wrong one falls through to GitHub | real HTTP |
+| Code exchange, `/user`, and all three access checks | integration test against a stub GitHub over real sockets, using the module's own reqwest/rustls client |
+| A request with a session makes **zero** outbound calls | integration test asserting the stub's request counter does not move across 50 requests |
+| Denials: no repo access, `pull: false`, `pending` org membership, missing team | integration test |
+| GitHub unreachable → 502, no session issued | integration test |
+| **A round trip against real `github.com` with a real GitHub App** | **not done — needs a human.** Register an App, set `client_id`/`client_secret`, log in, confirm the `Set-Cookie` and the landing page |

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -3,11 +3,12 @@ title = "GitHub OAuth Gate (native middleware)"
 weight = 11
 +++
 
-> **Status.** The module is implemented and tested. The OAuth round trip is
-> exercised end to end against a stub GitHub over real sockets; **a round trip
-> against the real `github.com` with a real GitHub App has not been performed**
-> and needs a human. See [Verification status](#verification-status) — nothing
-> on this page is claimed beyond what is tested.
+> **Status.** The module is implemented and tested. The complete login has
+> been driven over real HTTP through a running ePHPm against a **stub** GitHub;
+> **a round trip against the real `github.com` with a registered GitHub App has
+> not been performed** and needs a human. See
+> [Verification status](#verification-status) — nothing on this page is claimed
+> beyond what was actually observed.
 
 `github-auth` gates a private preview site on **GitHub identity**: *does the
 person at this browser have access, on GitHub, to the repository (or org, or
@@ -305,13 +306,15 @@ used during the login and dropped. **Rotate `client_secret` and
 
 | Behaviour | How it was verified |
 |---|---|
-| No cookie → 302 to GitHub with a `state`, PHP never runs | real HTTP against a running ePHPm with the module `dlopen`ed |
-| Session cookie → `CONTINUE`, PHP dispatched, no headers added | same |
+| **The whole login, cold: no cookie → 302 → callback → 3 GitHub calls → session → the app** | **real HTTP through a running ePHPm with the module `dlopen`ed**, against a stub GitHub in its own process, driven with `curl` and a cookie jar |
+| The callback emits **both** `Set-Cookie` headers (session issued, `state` cleared) | same run — two `set-cookie` lines on the wire |
+| No cookie → 302 to GitHub carrying a `state`, PHP never runs | same run: `content-length: 0`, no PHP output; the same URL *with* a cookie reaches PHP |
+| Session cookie → `CONTINUE`, PHP dispatched, gate adds no headers | same run |
+| A request with a session makes **zero** outbound calls | 21 live requests after login left the stub GitHub's log unchanged; the integration test asserts the same across 50 |
 | Callback with missing / forged / empty / wrong-host / expired `state` → 400 | real HTTP + unit tests |
 | Hostile return-to values (27 shapes) collapse to `/` | real HTTP, decoding the signed state cookie |
-| Bypass token accepted / a wrong one falls through to GitHub | real HTTP |
+| Bypass token accepted; a wrong one is indistinguishable from none | real HTTP |
 | Code exchange, `/user`, and all three access checks | integration test against a stub GitHub over real sockets, using the module's own reqwest/rustls client |
-| A request with a session makes **zero** outbound calls | integration test asserting the stub's request counter does not move across 50 requests |
 | Denials: no repo access, `pull: false`, `pending` org membership, missing team | integration test |
 | GitHub unreachable → 502, no session issued | integration test |
-| **A round trip against real `github.com` with a real GitHub App** | **not done — needs a human.** Register an App, set `client_id`/`client_secret`, log in, confirm the `Set-Cookie` and the landing page |
+| **A round trip against real `github.com` with a real GitHub App** | **not done — needs a human.** Register an App, set `client_id`/`client_secret`, log in with a browser, confirm the `Set-Cookie` and the landing page |

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -316,6 +316,14 @@ used during the login and dropped. **Rotate `client_secret` and
 - **The `state` cookie is replayable within its 10-minute window** by whoever
   holds it — i.e. by the user themselves. Reuse of an authorization *code* is
   refused by GitHub, not here.
+- **The callback is not rate-limited by this module.** Every check that can
+  reject a callback locally — the `state` cookie, its signature, its expiry,
+  the nonce comparison, the vhost binding, and the shape of `code` — runs
+  *before* any network call, so an attacker with no valid `state` cookie
+  cannot make this module talk to GitHub at all. A user who has started a
+  real login can replay their own callback within its 10-minute window,
+  though, and each replay costs one exchange attempt. Mount the `ratelimit`
+  builtin on `match = "/_ephpm/auth/*"` if that matters to you.
 - **No `dlopen`, no module** — see [Requirements](#requirements).
 
 ## Verification status

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -296,6 +296,11 @@ The module's libc must match the host binary's: on Linux, build modules
 for the gnu target (the default on every mainstream distro toolchain) —
 see [Building modules on Linux](#building-modules-on-linux).
 
+A worked, shipped example of this lane lives in the workspace:
+[the GitHub OAuth gate](/guides/github-auth-middleware/)
+(`crates/ephpm-middleware-github-auth`), which authenticates a browser user
+against GitHub and issues a stateless signed session.
+
 **Building a fully static binary yourself:** you can still produce a
 fully static musl ePHPm (`x86_64-unknown-linux-musl` with `crt-static`)
 if your deployment demands it, but be aware that a fully static binary


### PR DESCRIPTION
A native middleware module that gates a private preview site on **GitHub
identity** — *does the person at this browser have access, on GitHub, to the
repo this preview is for?* — answered **once**, at login, then carried in a
stateless signed session.

Full operator docs: `site/content/guides/github-auth-middleware.md`.

## Coordination — please read first

**This is the cold path. It is half of a pair, and the other half is being
built concurrently.**

| | `github-auth` (this PR) | the session verifier (separate work) |
|---|---|---|
| Runs on | login, callback, first request of a session | every request |
| Talks to GitHub | yes, 3 calls | never |
| Owns | issuing sessions | **the token format and its verification** |
| When unhappy | 302 → GitHub | 302 → `login_path` |

This module **never verifies a session cookie**. A request carrying one gets
`CONTINUE` and the verifier decides. That split is what keeps the network call
off the hot path structurally rather than by discipline.

Two things the verifier author and I need to agree on, and which I could not
wait for because that work is not on `main` yet:

1. **Token format.** I mint a compact **HS256 JWT** — deliberately the shape
   the already-merged builtin `jwt` module verifies (`alg` pinned, `exp`
   mandatory, constant-time `Mac::verify_slice`). Claims are documented on
   `GithubAuth::session_claims` and in the guide. **If the verifier picks
   something else, say so and I will follow it** — issuance is ~40 lines in
   `src/token.rs` and nothing else changes.
2. **Config names.** `cookie_name` (default `ephpm_session`) and
   `session_secret` must match the verifier's. `login_path` defaults to
   `/_ephpm/auth/github/login`; the verifier should redirect there, optionally
   with `?next=<path>` (I sanitize it).

**Conflict surface with the other two middleware agents:** deliberately
minimal. I touch **no** shared registry — this is `dlopen`-only, so
`crates/ephpm-middleware-builtins/src/lib.rs` is untouched. The only shared
file in this diff is **4 added lines in
`site/content/guides/native-middleware.md`** pointing at the new guide.
Everything else is a new crate and a new doc page.

## The flow

| Request | Verdict | Cost |
|---|---|---|
| no session cookie | 302 → GitHub `authorize`, `Set-Cookie` state | no network |
| `GET {callback_path}?code=…&state=…` | 302 → return-to, `Set-Cookie` session | 3 GitHub calls |
| `GET {login_path}` | 302 → GitHub `authorize` | no network |
| valid bypass token, no cookie | 302 → same URL, `Set-Cookie` session | no network |
| session cookie present | `CONTINUE` | **no network** |

PHP runs on none of the redirect rows.

## Design decisions, and why

**Which GitHub check?** `repo` by default — the tightest answer to the actual
question. `org` and `team` are supported (`active` membership only; `pending`
is an unaccepted invitation, not a member). `scopes` defaults to **empty**,
which is correct for a **GitHub App**: with a classic OAuth App, seeing a
private repo at all needs the `repo` scope — read *and write* on every repo the
user can touch, handed to a preview host. The exact calls and the minimum
permission for each are in the guide and in `github.rs`'s module docs.

**Reserved paths.** `/_ephpm/auth/github/login` and `/…/callback`, both
configurable, both validated (absolute, no query, distinct). They must resolve
to PHP for the chain to see them — with ePHPm's default `fallback` and an
`index.php` front controller that is automatic, and PHP still never runs. A
site with no `index.php` and a `=404` fallback would 404 the callback first;
that is documented, not implied.

**The client secret lives on the node.** Stated plainly in the crate docs and
the guide, with the supply mechanism (`client_secret = "env:GH_CLIENT_SECRET"`)
and the blast radius: a compromised node can impersonate the OAuth app and,
holding `session_secret`, mint sessions for any user and any site this gate
protects. No long-lived GitHub token is stored — the access token is used
during the login and dropped. Rotate both together.

**Automation bypass, designed now.** `bypass_token` (>= 32 bytes) yields *the
same kind of session* — a 302 and a `Set-Cookie` — not a per-request
pass-through, so Playwright/Lighthouse follow one extra redirect once and
behave normally after. A wrong token is indistinguishable from no token (302 to
GitHub), so the header is not an oracle. `bypass_query` exists for tools that
cannot set headers and is **off unless configured**, because query strings land
in logs, history and `Referer`.

**Share links need no code here — confirmed.** Issuance is not privileged:
anything holding `session_secret` mints an acceptable token (`via: "share"`).
The guide has a 6-line PHP snippet. A test asserts an externally minted token
is treated as a session. The flip side is documented: `session_secret` is a
minting key.

**Sessions are stateless**, so restarts do not log anyone out and the module
never touches the process-global middleware KV (#376). The cost is stated
rather than buried: **an issued session cannot be revoked before it expires**;
rotating the secret is the only revocation, so TTL is the blast radius of a
stolen cookie (default 8 h, bounded 60 s – 7 d).

## Security

- **CSRF on the callback.** 32-byte nonce in the `state` parameter *and* in an
  `HttpOnly` signed cookie bound to the vhost, 10-minute expiry, constant-time
  compare. Missing / unsigned / expired / mismatched / wrong-host → 400.
- **Open redirect.** Return-to must be an unambiguous same-origin absolute
  path; everything else collapses to `/`. Re-validated after being read back
  out of the signed cookie — a signature attests origin, not safety.
- **Constant time** for every secret and signature. The bypass compare is
  HMAC-of-both, so timing leaks neither contents nor length.
- **Cookies**: `HttpOnly`, `Secure` (off only for plaintext local previews),
  `SameSite=Lax` (`Strict` would bounce a user through GitHub on every preview
  link clicked from a PR comment), `Path`, a real `Max-Age`, and **no
  `Domain`** — host-only, so one tenant's session cannot reach another. Not
  configurable.
- **No secret is logged.** `GhError` physically cannot carry a code, token or
  secret; GitHub's OAuth error identifiers are filtered to `[A-Za-z0-9_]`;
  refusal pages are plain text with no interpolation. `Secret`'s `Debug`
  redacts. `tracing` is deliberately **not** a dependency — a dlopen'd module's
  `tracing` has its own dispatcher and would log into the void; everything goes
  through the ABI's `log` callback.
- **Fail-closed**: GitHub unreachable → 502, unmapped vhost → 403, panic → 500.
  `sites` is authoritative when present — an unmapped host does *not* inherit a
  top-level `repo`.
- **`request_vhost_id`** is used: one mount serves a fleet via `sites`, and the
  vhost is bound into both the `state` and the session (`site` claim).

## Dependencies / crypto provider

`Cargo.lock` gains **no packages** — only the workspace-member entry.

- `cargo tree -e features,no-dev -p ephpm -i ring` → **byte-identical** to
  `main`. The `ephpm` binary is untouched; `cargo build -p ephpm` compiles no
  line of this crate.
- `cargo tree -e features,no-dev -p ephpm-middleware-github-auth -i ring` →
  **no match**. The module links exactly one provider, `aws-lc-rs`.
- That required declaring `rustls` explicitly instead of `workspace = true`:
  the workspace pin still carries `features = ["ring"]`, and inheriting it
  would put a second provider in the shipped `.so`. The `Cargo.toml` comment
  says so, and says it can become `workspace = true` once #368 lands.
- `reqwest` uses the workspace's `rustls-tls-manual-roots-no-provider` — the
  only `rustls-tls-*` feature that does not link `ring` — and is handed a
  preconfigured `ClientConfig` built with `builder_with_provider`, the same
  recipe as `otlp.rs`. A unit test asserts the module never installs a
  **process-default** provider, which would fight the host.

`cargo deny check` → advisories ok, bans ok, licenses ok, sources ok.

## Verification

70 tests (61 unit + 9 integration). Gates: workspace clippy `-D warnings`,
`+nightly fmt --check`, `cargo deny check` — all clean.

**The complete login was driven over real HTTP through a running ePHPm** with
the module `dlopen`ed (`ephpm serve` + `curl` + a cookie jar), against a stub
GitHub running in its own process:

| Probe | Result |
|---|---|
| cold browser: no cookie → 302 → callback → 3 GitHub calls → session → the app | end to end |
| the callback emits **both** `Set-Cookie` headers (session issued, `state` cleared) | two `set-cookie` lines on the wire |
| no cookie → 302 to GitHub with a `state`; PHP never runs | `content-length: 0`, no PHP output; the same URL *with* a cookie reaches PHP, so the contrast is the proof |
| session cookie → PHP dispatched, gate adds no headers | pass |
| 21 live requests after login | stub GitHub's log **unchanged** |
| callback with no / forged / empty / absent `state` | 400 x4 |
| bypass: valid token → 302 + session; wrong token → 302 to GitHub | pass |
| 27 hostile return-to values, decoded out of the signed state cookie | all collapse to `/`; legitimate paths survive |

Hostile return-to inputs tried: `//evil.test`, `///evil.test`, `/\evil.test`,
`\\evil.test`, `https://evil.test/x`, `http:/\evil.test`, `//user@evil.test/`,
`javascript:alert(1)`, `data:text/html,x`, `vbscript:msgbox(1)`,
`/ok%0d%0aSet-Cookie:+pwned%3D1` (raw CRLF after decoding), `/ok%00`,
`/ok%09tab`, `%2f%2fevil.test`, `%09//evil.test`, `/..//evil.test`,
`/a/../../evil`, `..%2f..%2fetc`, `/caf%c3%a9`, `/ok+evil`, the gate's own two
paths, empty, `?a=1`, `#frag`, `/%2f%2fevil.test`.

**The OAuth exchange** is also covered by an integration test against a stub
GitHub over real sockets, using the module's own reqwest/rustls client
(`tests/oauth_round_trip.rs`): happy path (exactly the 3 documented calls, in
order, with the client credentials in the exchange body and `Bearer` on both
API calls), `error` in a **200** response → 400, no-repo-access → 403,
`pull: false` → 403, `pending` org membership → 403, missing team → 403,
unreachable GitHub → 502 with no session issued, and 50 authenticated requests
that leave the stub's request counter unmoved.

### Not verified — needs a human

**A round trip against real `github.com` with a registered GitHub App.**
Register an App, set `client_id` / `client_secret`, log in with a browser,
confirm the `Set-Cookie` and the landing page. Everything this side of that is
exercised; I have not seen a real GitHub authorize screen, and the guide's
"Verification status" table says so.

## Known limitations (all documented)

- **One callback host per app** — GitHub has no wildcard callback URLs. A fleet
  of per-PR hostnames needs a single auth origin and a cross-host hand-off;
  **not implemented**. Today `redirect_uri` derives from the request vhost (or
  is set explicitly).
- **No revocation before expiry.**
- The `state` cookie is replayable within its 10-minute window by whoever holds
  it (i.e. the user). Authorization-*code* reuse is refused by GitHub.
- No `dlopen`, no module — a fully static musl build cannot use this.

## CI notes

`Windows PHP Check` passes only on runners that already have VS Build Tools
(#377) and `Test (linux-x64)` has a known `ephpm-cluster::cluster_channel`
flake (#383) — neither is this PR.
