### PR TITLE
ci(release): source-driven PHP build matrix so GITHUB_TOKEN can push the bump (#374)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,13 @@ name: Release
 # trade-off k3s and rke2 make. The real SemVer string is preserved on each
 # image via the org.opencontainers.image.version label.
 #
-# PHP version pins must match xtask::PHP_SDK_VERSIONS -- keep the matrix
-# entries below in sync if you bump a pin.
+# PHP version pins are NOT hardcoded in this file. The `setup` job below
+# derives every build matrix at runtime from xtask::PHP_SDK_VERSIONS (via
+# `cargo xtask php-versions`), and each build job consumes it with
+# `strategy.matrix: ${{ fromJSON(needs.setup.outputs.<matrix>) }}`. So a PHP
+# bump touches only xtask/src/main.rs + docs -- never this workflow -- which is
+# what lets the automated bump PR be pushed with the default GITHUB_TOKEN
+# (forbidden by the API from modifying .github/workflows/). See issue #374.
 
 on:
   push:
@@ -83,6 +88,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # -- Derive the PHP build matrix from the single source of truth -------------
+  # The pinned PHP versions live ONLY in xtask/src/main.rs (PHP_SDK_VERSIONS).
+  # This job reads that table and emits the build matrices as JSON on its
+  # outputs; every downstream build job consumes one via
+  # `strategy.matrix: ${{ fromJSON(needs.setup.outputs.<matrix>) }}`. Keeping
+  # the pins out of this workflow file is what makes a bump pushable by
+  # GITHUB_TOKEN (issue #374) -- see the header comment above.
+  #
+  # Runs for BOTH a tag push and the workflow_dispatch republish path, because
+  # docker-image (which runs on dispatch too) needs docker_matrix either way.
+  setup:
+    name: Derive PHP matrix
+    runs-on: [self-hosted, linux, x64]
+    container: "ephpm/ephpm-ci:latest"
+    outputs:
+      # JSON arrays of {minor, full} (php/tailcall) and {minor, full, default}
+      # (docker). See `cargo xtask php-versions --github-matrix`.
+      php_matrix: ${{ steps.matrix.outputs.php_matrix }}
+      tailcall_matrix: ${{ steps.matrix.outputs.tailcall_matrix }}
+      docker_matrix: ${{ steps.matrix.outputs.docker_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Emit PHP build matrix from xtask PHP_SDK_VERSIONS
+        id: matrix
+        # xtask prints three `key=value` lines (each value a single-line JSON
+        # array) straight into $GITHUB_OUTPUT. cargo's own progress goes to
+        # stderr, so stdout carries only those lines.
+        run: cargo run --quiet -p xtask -- php-versions --github-matrix >> "$GITHUB_OUTPUT"
+
   # -- Linux x86_64 binaries ---------------------------------------------------
   # arm64 lives in its own job (build-linux-arm64) so it can be throttled
   # independently: the v0.5.1 release run proved that firing every leg at
@@ -94,15 +129,14 @@ jobs:
     # Binary legs run only for a real tag push; the workflow_dispatch
     # republish path reuses the archives from the original run.
     if: github.event_name == 'push'
+    needs: setup
     runs-on: [self-hosted, linux, x64]
     container: "ephpm/ephpm-ci:${{ matrix.arch.image }}"
     strategy:
       fail-fast: false
       matrix:
-        php:
-          - { minor: "8.3", full: "8.3.33" }
-          - { minor: "8.4", full: "8.4.23" }
-          - { minor: "8.5", full: "8.5.7" }
+        # {minor, full} per supported PHP minor, from xtask::PHP_SDK_VERSIONS.
+        php: ${{ fromJSON(needs.setup.outputs.php_matrix) }}
         arch:
           - runner: x64
             image: latest
@@ -168,7 +202,7 @@ jobs:
     # keeps the VM to one heavy link at a time. Without both, the v0.5.1
     # release run put 6 concurrent release builds on that one host and every
     # runner on it died mid-build.
-    needs: build-macos
+    needs: [build-macos, setup]
     if: github.event_name == 'push'
     runs-on: [self-hosted, linux, arm64]
     container: "ephpm/ephpm-ci:latest-arm64"
@@ -176,10 +210,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        php:
-          - { minor: "8.3", full: "8.3.33" }
-          - { minor: "8.4", full: "8.4.23" }
-          - { minor: "8.5", full: "8.5.7" }
+        # {minor, full} per supported PHP minor, from xtask::PHP_SDK_VERSIONS.
+        php: ${{ fromJSON(needs.setup.outputs.php_matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -232,8 +264,9 @@ jobs:
 
   # -- macOS binaries ---------------------------------------------------------
   build-macos:
-    name: Build (PHP ${{ matrix.php_full }}, macos-aarch64)
+    name: Build (PHP ${{ matrix.php.full }}, macos-aarch64)
     if: github.event_name == 'push'
+    needs: setup
     runs-on: [self-hosted, macos, arm64]
     strategy:
       fail-fast: false
@@ -242,13 +275,8 @@ jobs:
       # to 2 only after a release proves real headroom.
       max-parallel: 1
       matrix:
-        include:
-          - php_minor: "8.3"
-            php_full: "8.3.33"
-          - php_minor: "8.4"
-            php_full: "8.4.23"
-          - php_minor: "8.5"
-            php_full: "8.5.7"
+        # {minor, full} per supported PHP minor, from xtask::PHP_SDK_VERSIONS.
+        php: ${{ fromJSON(needs.setup.outputs.php_matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -285,13 +313,13 @@ jobs:
           # dropped support for anything older) resolves it and matches the
           # SDK's build environment. 8.3/8.4 SDKs also link cleanly at 12.0.
           MACOSX_DEPLOYMENT_TARGET: "12.0"
-        run: cargo xtask release ${{ matrix.php_minor }}
+        run: cargo xtask release ${{ matrix.php.minor }}
 
       - name: Package archive
         id: pkg
         env:
           VERSION: ${{ github.ref_name }}
-          PHP_FULL: ${{ matrix.php_full }}
+          PHP_FULL: ${{ matrix.php.full }}
         run: |
           set -eu
           name="ephpm-${VERSION}+php${PHP_FULL}-macos-aarch64"
@@ -307,13 +335,14 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-macos-aarch64
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php.full }}-macos-aarch64
           path: ${{ steps.pkg.outputs.archive }}
 
   # -- Windows binaries (native on self-hosted Windows runner) --------------
   build-windows:
-    name: Build (PHP ${{ matrix.php_full }}, windows-x86_64)
+    name: Build (PHP ${{ matrix.php.full }}, windows-x86_64)
     if: github.event_name == 'push'
+    needs: setup
     runs-on: [self-hosted, windows, x64]
     strategy:
       fail-fast: false
@@ -322,13 +351,8 @@ jobs:
       # vanished under the runner). Loosen only with proven headroom.
       max-parallel: 1
       matrix:
-        include:
-          - php_minor: "8.3"
-            php_full: "8.3.33"
-          - php_minor: "8.4"
-            php_full: "8.4.23"
-          - php_minor: "8.5"
-            php_full: "8.5.7"
+        # {minor, full} per supported PHP minor, from xtask::PHP_SDK_VERSIONS.
+        php: ${{ fromJSON(needs.setup.outputs.php_matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -434,14 +458,14 @@ jobs:
           # made heavier by codegen-units=1 + opt-level=3. 32 MiB clears it.
           # linux-aarch64 compiles sqlparser fine, so this is windows-only.
           RUST_MIN_STACK: "33554432"
-        run: cargo xtask release ${{ matrix.php_minor }} --target windows
+        run: cargo xtask release ${{ matrix.php.minor }} --target windows
 
       - name: Package archive
         id: pkg
         shell: powershell
         env:
           VERSION: ${{ github.ref_name }}
-          PHP_FULL: ${{ matrix.php_full }}
+          PHP_FULL: ${{ matrix.php.full }}
         run: |
           $name = "ephpm-$env:VERSION+php$env:PHP_FULL-windows-x86_64"
           $stage = "dist\$name"
@@ -458,7 +482,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-windows-x86_64
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php.full }}-windows-x86_64
           path: ${{ steps.pkg.outputs.archive }}
 
   # -- Windows TAILCALL binary (EXPERIMENTAL, NON-GATING) ---------------------
@@ -482,13 +506,14 @@ jobs:
   # If the -clang SDK asset is missing from the php-sdk release, or anything
   # else fails, the leg goes red and nothing downstream notices.
   build-windows-tailcall:
-    name: Build (PHP ${{ matrix.php_full }}, windows-x86_64, TAILCALL)
+    name: Build (PHP ${{ matrix.php.full }}, windows-x86_64, TAILCALL)
     if: github.event_name == 'push'
     # Serialized behind the MSVC Windows legs: one release build per Windows
     # worker at a time (the v0.5.1 run's concurrent legs took the pool down).
     # Side effect: if build-windows fails this leg is skipped -- fine, the
-    # release is not publishing in that case anyway.
-    needs: build-windows
+    # release is not publishing in that case anyway. `setup` supplies the
+    # tailcall_matrix (the TAILCALL-capable minors -- 8.5-only today).
+    needs: [build-windows, setup]
     runs-on: [self-hosted, windows, x64]
     continue-on-error: true
     # VS Build Tools install (~20 min on a cold ephemerd VM) + a full
@@ -500,10 +525,10 @@ jobs:
       # For the best-effort late attach of the tarball to the GitHub release.
       contents: write
     strategy:
+      # {minor, full} for the TAILCALL-capable minors, from
+      # xtask::PHP_SDK_VERSIONS filtered by xtask::TAILCALL_MINORS (8.5 today).
       matrix:
-        include:
-          - php_minor: "8.5"
-            php_full: "8.5.7"
+        php: ${{ fromJSON(needs.setup.outputs.tailcall_matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -601,12 +626,12 @@ jobs:
         # zend_vm_kind() out of php8embed.lib and requires mov eax,5
         # (ZEND_VM_KIND_TAILCALL) before linking. A mislabeled CALL-VM SDK
         # fails the build here rather than shipping under a -tailcall name.
-        run: cargo xtask release ${{ matrix.php_minor }} --target windows --variant clang
+        run: cargo xtask release ${{ matrix.php.minor }} --target windows --variant clang
 
       - name: Assert the produced binary is the TAILCALL build
         shell: powershell
         env:
-          PHP_FULL: ${{ matrix.php_full }}
+          PHP_FULL: ${{ matrix.php.full }}
         # Belt over the xtask gate's suspenders, this time on the built exe:
         # the embedded PHP must report the exact pinned version + ZTS, and the
         # clang SDK cache dir must be the one the build populated. (The VM
@@ -632,7 +657,7 @@ jobs:
         shell: powershell
         env:
           VERSION: ${{ github.ref_name }}
-          PHP_FULL: ${{ matrix.php_full }}
+          PHP_FULL: ${{ matrix.php.full }}
         # The artifact name says what the binary IS (-tailcall: the TAILCALL
         # VM), not how it is built (clang) -- consumers care about the former.
         run: |
@@ -650,7 +675,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-${{ github.ref_name }}-php${{ matrix.php_full }}-windows-x86_64-tailcall
+          name: ephpm-${{ github.ref_name }}-php${{ matrix.php.full }}-windows-x86_64-tailcall
           path: ${{ steps.pkg.outputs.archive }}
 
       - name: Attach to the GitHub release if it already exists (best effort)
@@ -710,22 +735,18 @@ jobs:
 
   # -- Docker images on Docker Hub --------------------------------------------
   docker-image:
-    name: Docker (PHP ${{ matrix.php_full }})
+    name: Docker (PHP ${{ matrix.php.full }})
+    needs: setup
     runs-on: [self-hosted, linux, x64]
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php_minor: "8.3"
-            php_full: "8.3.33"
-          - php_minor: "8.4"
-            php_full: "8.4.23"
-            default: false
-          - php_minor: "8.5"
-            php_full: "8.5.7"
-            default: true
+        # {minor, full, default} per supported PHP minor, from
+        # xtask::PHP_SDK_VERSIONS. `default` is true for exactly the default
+        # minor (xtask::DEFAULT_PHP_MINOR) and drives the rolling :latest tags.
+        php: ${{ fromJSON(needs.setup.outputs.docker_matrix) }}
     steps:
       # On a tag push this is the tag; on a workflow_dispatch republish it is
       # the tag named in the input (the run itself is dispatched from main, so
@@ -768,9 +789,9 @@ jobs:
         id: tags
         env:
           VERSION: ${{ github.event.inputs.tag || github.ref_name }}
-          PHP_MINOR: ${{ matrix.php_minor }}
-          PHP_FULL: ${{ matrix.php_full }}
-          IS_DEFAULT: ${{ matrix.default }}
+          PHP_MINOR: ${{ matrix.php.minor }}
+          PHP_FULL: ${{ matrix.php.full }}
+          IS_DEFAULT: ${{ matrix.php.default }}
         run: |
           set -eu
           # Strip leading "v" so EPHPM_RELEASE_VERSION matches clap formatting
@@ -814,7 +835,7 @@ jobs:
       - name: Build and push image
         env:
           TAGS: ${{ steps.tags.outputs.tags }}
-          PHP_FULL: ${{ matrix.php_full }}
+          PHP_FULL: ${{ matrix.php.full }}
           RELEASE_VERSION: ${{ steps.tags.outputs.release_version }}
           SEMVER: ${{ steps.tags.outputs.semver }}
           SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/windows-php-check.yml
+++ b/.github/workflows/windows-php-check.yml
@@ -156,17 +156,32 @@ jobs:
       # read as a compile failure.
       - name: Download PHP SDK (8.3)
         shell: powershell
-        run: cargo xtask php-sdk 8.3
+        # Download the 8.3 SDK, then resolve its cache dir by MINOR glob and
+        # export PHP_SDK_PATH. Globbing on the minor (never the patch version)
+        # means a PHP patch bump -- which edits only xtask::PHP_SDK_VERSIONS --
+        # never has to touch this workflow file, so the automated bump PR stays
+        # pushable by GITHUB_TOKEN (issue #374). xtask's Windows cache layout is
+        # php-sdk/<full>-windows-x86_64 (php_sdk_dir_for in xtask/src/main.rs);
+        # the clang/TAILCALL variant carries a trailing -clang suffix and is
+        # never downloaded here, so it can't match the glob.
+        run: |
+          cargo xtask php-sdk 8.3
+          $sdk = Get-ChildItem "$env:GITHUB_WORKSPACE\php-sdk" -Directory |
+            Where-Object { $_.Name -like '8.3.*-windows-x86_64' } |
+            Select-Object -First 1
+          if (-not $sdk) {
+            Write-Host "::error::no 8.3.*-windows-x86_64 SDK cache dir found under php-sdk\"
+            exit 1
+          }
+          Write-Host "Resolved PHP SDK: $($sdk.FullName)"
+          "PHP_SDK_PATH=$($sdk.FullName)" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 
       # ---- The actual gate ---------------------------------------------------
       - name: cargo check -p ephpm-php (PHP-linked)
         shell: powershell
         env:
-          # xtask's cache layout is php-sdk/<full-version>-<os>-<arch>/ with no
-          # libc suffix on Windows (php_sdk_dir_for in xtask/src/main.rs). The
-          # full version must match xtask::PHP_SDK_VERSIONS["8.3"] — same
-          # keep-in-sync rule as the release.yml matrix pins.
-          PHP_SDK_PATH: ${{ github.workspace }}\php-sdk\8.3.33-windows-x86_64
+          # PHP_SDK_PATH is exported by the download step above (resolved by
+          # minor glob, so no full patch version is pinned in this file).
           # sqlparser (a turso dependency, in this crate's graph via litewire)
           # has deeply recursive AST types that overflow the Windows
           # toolchain's default rustc thread stack in release.yml's build

--- a/xtask/src/bump.rs
+++ b/xtask/src/bump.rs
@@ -1,21 +1,22 @@
 //! `cargo xtask bump-php-pin` — update or verify every PHP SDK pin site.
 //!
-//! The pinned full PHP version for a given minor lives in several places
-//! that must stay in lockstep:
+//! The pinned full PHP version for a given minor lives in a few places that
+//! must stay in lockstep:
 //!
 //! 1. `xtask/src/main.rs` — the `PHP_SDK_VERSIONS` table (source of truth)
-//! 2. `.github/workflows/release.yml` — matrix sites, one entry per minor
-//!    in each: two inline-map matrices (`build-linux`, `build-linux-arm64`)
-//!    and three `php_minor`/`php_full` include blocks (`build-macos`,
-//!    `build-windows`, `docker-image`); minors in `TAILCALL_MINORS`
-//!    additionally appear in the `build-windows-tailcall` include block
-//! 3. `docker/Dockerfile` — `ARG PHP_SDK_VERSION` default (+ its inline
+//! 2. `docker/Dockerfile` — `ARG PHP_SDK_VERSION` default (+ its inline
 //!    example), only for the default minor
-//! 4. `site/content/developer/architecture-overview.md` — the support table
+//! 3. `site/content/developer/architecture-overview.md` — the support table
 //!    listing the CI-pinned full versions
-//! 5. `.github/workflows/windows-php-check.yml` — the `PHP_SDK_PATH` cache
-//!    path for the Windows PHP-linked compile gate, only for
-//!    `WINDOWS_CHECK_MINOR`
+//!
+//! No `.github/workflows/` file is a pin site any more (issue #374).
+//! `release.yml` derives its build matrix at runtime from `PHP_SDK_VERSIONS`
+//! via `cargo xtask php-versions` (so a bump no longer rewrites five matrix
+//! sites), and `windows-php-check.yml` resolves its SDK cache path from a
+//! minor glob instead of the hardcoded full version. That is what makes a bump
+//! pushable by the default `GITHUB_TOKEN`, which the GitHub API forbids from
+//! modifying files under `.github/workflows/` — the exact coupling that used
+//! to make the automated bump PR fail at `git push` every night.
 //!
 //! A missed pin site has broken a release before, so every substitution
 //! asserts its exact expected match count and the command refuses to write
@@ -26,20 +27,6 @@ use std::fs;
 use std::process::ExitCode;
 
 use crate::{DEFAULT_PHP_MINOR, PHP_SDK_VERSIONS, workspace_root};
-
-/// Minors that also appear in release.yml's experimental
-/// `build-windows-tailcall` job (one extra `php_full:` include-block pin
-/// site each). 8.5-only today: the TAILCALL VM does not exist in 8.3/8.4.
-const TAILCALL_MINORS: &[&str] = &["8.5"];
-
-/// The PHP minor pinned by `.github/workflows/windows-php-check.yml`.
-///
-/// That workflow spells one SDK cache path out in full
-/// (`php-sdk\<full>-windows-x86_64`) instead of deriving it from
-/// `PHP_SDK_VERSIONS`, so it is a pin site for exactly this minor and drifts
-/// silently when the minor moves. Keep in sync with the `cargo xtask php-sdk
-/// <minor>` argument in that workflow.
-const WINDOWS_CHECK_MINOR: &str = "8.3";
 
 /// One exact-substring substitution in one file, with a required match count.
 struct Substitution {
@@ -58,37 +45,12 @@ struct Substitution {
 /// `--check` (counting only, replacement is a no-op).
 fn substitutions(minor: &str, old_full: &str, new_full: &str) -> Vec<Substitution> {
     let mut subs = vec![
-        // The PHP_SDK_VERSIONS table entry itself.
+        // The PHP_SDK_VERSIONS table entry itself — the source of truth.
         Substitution {
             path: "xtask/src/main.rs",
             needle: format!("(\"{minor}\", \"{old_full}\")"),
             replacement: format!("(\"{minor}\", \"{new_full}\")"),
             expected: 1,
-        },
-        // The 5 release matrix sites, matched by their structured pin keys
-        // rather than the bare quoted version so that prose (a comment or a
-        // step name that happens to mention a version) can never be counted
-        // as — or rewritten like — a pin. The count asserts still catch any
-        // structural change to the matrices (a job added or removed).
-        //
-        // Shape 1: the inline-map matrices in build-linux and build-linux-arm64:
-        //   - { minor: "8.3", full: "8.3.31" }
-        Substitution {
-            path: ".github/workflows/release.yml",
-            needle: format!("{{ minor: \"{minor}\", full: \"{old_full}\" }}"),
-            replacement: format!("{{ minor: \"{minor}\", full: \"{new_full}\" }}"),
-            expected: 2,
-        },
-        // Shape 2: the `include:` blocks in build-macos, build-windows and
-        // docker-image:
-        //   - php_minor: "8.3"
-        //     php_full: "8.3.31"
-        // TAILCALL minors also pin the build-windows-tailcall include block.
-        Substitution {
-            path: ".github/workflows/release.yml",
-            needle: format!("php_full: \"{old_full}\""),
-            replacement: format!("php_full: \"{new_full}\""),
-            expected: if TAILCALL_MINORS.contains(&minor) { 4 } else { 3 },
         },
         // The PHP support table ("Supported — in CI (pinned X.Y.Z)").
         Substitution {
@@ -98,17 +60,13 @@ fn substitutions(minor: &str, old_full: &str, new_full: &str) -> Vec<Substitutio
             expected: 1,
         },
     ];
-    // The Windows PHP-linked compile gate hardcodes one SDK cache path for
-    // WINDOWS_CHECK_MINOR. Missing this site left that job checking against a
-    // stale SDK after a bump — see the module docs on why that matters.
-    if minor == WINDOWS_CHECK_MINOR {
-        subs.push(Substitution {
-            path: ".github/workflows/windows-php-check.yml",
-            needle: format!("php-sdk\\{old_full}-windows-x86_64"),
-            replacement: format!("php-sdk\\{new_full}-windows-x86_64"),
-            expected: 1,
-        });
-    }
+    // NOTE (issue #374): `.github/workflows/release.yml` is deliberately NOT a
+    // pin site any more. Its build matrix is derived at runtime from
+    // `PHP_SDK_VERSIONS` (via `cargo xtask php-versions`), so a bump never
+    // rewrites the workflow. `windows-php-check.yml` likewise resolves its SDK
+    // path from a minor glob, not the full version. Both changes keep every
+    // remaining pin site (Rust + docs) pushable by `GITHUB_TOKEN`.
+    //
     // The Dockerfile only pins the default minor: once as the ARG default
     // and once in the comment example right above it ("e.g., v8.5.7").
     if minor == DEFAULT_PHP_MINOR {
@@ -316,70 +274,36 @@ mod tests {
     ///
     /// The bug this pins: each substitution was applied to a fresh read of the
     /// file and staged as its own write, so the last write won and the first
-    /// substitution vanished. Live effect — `bump-php-pin 8.3 8.3.33` moved
-    /// release.yml's three `php_full:` sites but silently left both
-    /// `{ minor: "8.3", full: "8.3.31" }` inline-map sites behind, so the two
-    /// Linux release legs kept building the old SDK. `--check` then failed on
-    /// the tool's own output.
+    /// substitution vanished. No real pin file carries two distinct shapes any
+    /// more (release.yml stopped being a pin site in #374), but `apply_all`'s
+    /// compose-per-file logic is still load-bearing, so this exercises it with
+    /// two synthetic substitutions targeting one file.
     #[test]
     fn apply_all_composes_substitutions_targeting_one_file() {
-        let subs = substitutions("8.3", "8.3.31", "8.3.33");
-        let release: Vec<&Substitution> =
-            subs.iter().filter(|s| s.path == ".github/workflows/release.yml").collect();
-        assert_eq!(release.len(), 2, "release.yml should carry both pin shapes");
+        let subs = vec![
+            Substitution {
+                path: "same.txt",
+                needle: "alpha-1.0".into(),
+                replacement: "alpha-2.0".into(),
+                expected: 1,
+            },
+            Substitution {
+                path: "same.txt",
+                needle: "beta-1.0".into(),
+                replacement: "beta-2.0".into(),
+                expected: 1,
+            },
+        ];
+        let file = "alpha-1.0\nbeta-1.0\n";
+        let staged = apply_all(&subs, |_| Ok(file.to_string())).expect("both sites should match");
 
-        let file = concat!(
-            "          - { minor: \"8.3\", full: \"8.3.31\" }\n",
-            "          - { minor: \"8.3\", full: \"8.3.31\" }\n",
-            "            php_full: \"8.3.31\"\n",
-            "            php_full: \"8.3.31\"\n",
-            "            php_full: \"8.3.31\"\n",
-        );
-        let staged = apply_all(&subs, |path| {
-            if path == ".github/workflows/release.yml" {
-                Ok(file.to_string())
-            } else {
-                // Every other pin site: a minimal body carrying its own needle.
-                Ok(subs
-                    .iter()
-                    .filter(|s| s.path == path)
-                    .map(|s| s.needle.repeat(s.expected))
-                    .collect::<String>())
-            }
-        })
-        .expect("all sites should match");
-
-        let (_, out) = staged
-            .iter()
-            .find(|(path, _)| *path == ".github/workflows/release.yml")
-            .expect("release.yml must be staged");
-        assert!(!out.contains("8.3.31"), "no 8.3.31 may survive, got:\n{out}");
-        assert_eq!(out.matches("{ minor: \"8.3\", full: \"8.3.33\" }").count(), 2);
-        assert_eq!(out.matches("php_full: \"8.3.33\"").count(), 3);
-        assert_eq!(
-            staged.iter().filter(|(path, _)| *path == ".github/workflows/release.yml").count(),
-            1,
-            "one file must stage exactly one write"
-        );
-    }
-
-    /// The Windows PHP-linked compile gate is a pin site for its own minor.
-    #[test]
-    fn windows_php_check_path_is_a_pin_site() {
-        let subs = substitutions(WINDOWS_CHECK_MINOR, "8.3.31", "8.3.33");
-        let sub = subs
-            .iter()
-            .find(|s| s.path == ".github/workflows/windows-php-check.yml")
-            .expect("windows-php-check.yml must be a pin site for WINDOWS_CHECK_MINOR");
-        assert_eq!(sub.needle, r"php-sdk\8.3.31-windows-x86_64");
-        assert_eq!(sub.replacement, r"php-sdk\8.3.33-windows-x86_64");
-
-        // ...and only for that minor.
-        assert!(
-            substitutions("8.5", "8.5.7", "8.5.9")
-                .iter()
-                .all(|s| s.path != ".github/workflows/windows-php-check.yml"),
-        );
+        assert_eq!(staged.len(), 1, "one file must stage exactly one write");
+        let (_, out) = &staged[0];
+        // Both substitutions survived — neither was clobbered by the other's
+        // fresh read of the original file.
+        assert!(out.contains("alpha-2.0"), "first substitution lost: {out}");
+        assert!(out.contains("beta-2.0"), "second substitution lost: {out}");
+        assert!(!out.contains("1.0"), "no old version may survive: {out}");
     }
 
     #[test]
@@ -421,73 +345,23 @@ mod tests {
         assert_eq!(apply(input, &sub).unwrap(), input);
     }
 
-    /// Mirrors the current release.yml shape: two inline-map matrices
-    /// (build-linux, build-linux-arm64) plus three `php_minor`/`php_full`
-    /// include blocks (build-macos, build-windows, docker-image), and a prose
-    /// comment that mentions a full version — which must NOT count as a pin.
+    /// Invariant for #374: no `.github/workflows/` file is a pin site for ANY
+    /// minor. That is what keeps a bump pushable by `GITHUB_TOKEN` (which may
+    /// not modify files under `.github/workflows/`). If a future change
+    /// re-introduces a workflow pin, this fails loudly.
     #[test]
-    fn release_yml_fixture_hits_all_five_matrix_sites() {
-        let fixture = r#"
-          - { minor: "8.4", full: "8.4.23" }
-          - { minor: "8.4", full: "8.4.23" }
-          - php_minor: "8.4"
-            php_full: "8.4.23"
-          # PHP SDK 8.4.23 macOS objects are built with a newer Xcode that
-          - php_minor: "8.4"
-            php_full: "8.4.23"
-          - php_minor: "8.4"
-            php_full: "8.4.23"
-            default: true
-"#;
-        let subs = substitutions("8.4", "8.4.23", "8.4.30");
-        let yml_subs: Vec<_> = subs.iter().filter(|s| s.path.ends_with("release.yml")).collect();
-        assert_eq!(yml_subs.len(), 2, "inline-map + php_full shapes");
-        let mut out = fixture.to_string();
-        for sub in yml_subs {
-            out = apply(&out, sub).unwrap();
+    fn no_workflow_file_is_a_pin_site() {
+        for (minor, full) in PHP_SDK_VERSIONS {
+            // Use a same-minor patch target so the substitution set is valid.
+            let bumped = format!("{full}9");
+            for sub in substitutions(minor, full, &bumped) {
+                assert!(
+                    !sub.path.contains(".github/workflows/"),
+                    "{minor}: {} is a workflow pin site — #374 requires none",
+                    sub.path
+                );
+            }
         }
-        assert_eq!(out.matches("\"8.4.30\"").count(), 5);
-        // The comment is prose, not a pin site — it must survive untouched
-        // and must not have been counted toward either expected total.
-        assert!(out.contains("# PHP SDK 8.4.23 macOS objects"));
-        assert!(!out.contains("\"8.4.23\""));
-    }
-
-    /// A structural change to the matrices (a job added or removed) must be
-    /// refused, not silently half-applied — the fail-safe that caught the
-    /// build-linux-arm64 job split in the first place.
-    #[test]
-    fn release_yml_shape_change_is_refused() {
-        // One extra inline-map job (3 instead of the expected 2).
-        let fixture = r#"
-          - { minor: "8.4", full: "8.4.23" }
-          - { minor: "8.4", full: "8.4.23" }
-          - { minor: "8.4", full: "8.4.23" }
-"#;
-        let subs = substitutions("8.4", "8.4.23", "8.4.30");
-        let inline = subs
-            .iter()
-            .find(|s| s.path.ends_with("release.yml") && s.needle.contains("{ minor:"))
-            .unwrap();
-        let err = apply(fixture, inline).unwrap_err();
-        assert!(err.contains("expected exactly 2"), "unexpected message: {err}");
-        assert!(err.contains("found 3"), "unexpected message: {err}");
-    }
-
-    /// TAILCALL minors carry one extra `php_full:` include-block pin site
-    /// (the build-windows-tailcall job); every other minor keeps three.
-    #[test]
-    fn tailcall_minor_expects_extra_windows_include_site() {
-        let php_full_expected = |minor: &str, full: &str| {
-            substitutions(minor, full, full)
-                .iter()
-                .find(|s| s.path.ends_with("release.yml") && s.needle.starts_with("php_full"))
-                .unwrap()
-                .expected
-        };
-        assert_eq!(php_full_expected("8.5", "8.5.7"), 4, "8.5 pins build-windows-tailcall too");
-        assert_eq!(php_full_expected("8.4", "8.4.23"), 3);
-        assert_eq!(php_full_expected("8.3", "8.3.31"), 3);
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@ mod bump;
 mod cli_conformance;
 mod doctor;
 mod e2e_bare;
+mod php_versions;
 
 /// Pinned full PHP versions per supported minor.
 ///
@@ -18,6 +19,13 @@ const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.33"), ("8.4", "8.4.23")
 
 /// Default PHP minor when no version is specified on the command line.
 const DEFAULT_PHP_MINOR: &str = "8.5";
+
+/// PHP minors that additionally get the experimental clang-cl / TAILCALL VM
+/// Windows build (`release.yml`'s `build-windows-tailcall` job, and the
+/// `tailcall_matrix` that `php-versions` derives for it). 8.5-only today: the
+/// TAILCALL VM does not exist in PHP 8.3/8.4. Single source of truth — both the
+/// matrix generator (`php_versions`) and any future pin tooling read this.
+const TAILCALL_MINORS: &[&str] = &["8.5"];
 
 /// Pinned version of Hugo (extended) for the documentation site.
 /// Newer versions dropped darwin tarballs in favor of .pkg installers.
@@ -40,6 +48,7 @@ fn main() -> ExitCode {
         Some("docs") => docs(&args[1..]),
         Some("doctor") => doctor::doctor(&args[1..]),
         Some("bump-php-pin") => bump::bump_php_pin(&args[1..]),
+        Some("php-versions") => php_versions::run(&args[1..]),
         Some("help" | "--help" | "-h") | None => {
             print_usage();
             ExitCode::SUCCESS
@@ -70,6 +79,7 @@ Commands:
   docs <subcommand>                 Build/serve the Hugo + Hextra documentation site
   doctor [--target windows]         Check build prerequisites (toolchains, PHP SDK cache, optional tools)
   bump-php-pin <minor> <full>       Update every PHP SDK pin site for <minor> (--check: verify pin drift)
+  php-versions [--github-matrix]    Emit the pinned PHP build matrix as JSON (release.yml's source of truth)
 
 The PHP SDK is downloaded from github.com/ephpm/php-sdk releases. Pass a minor
 shorthand (e.g. \"8.5\") to use the pinned patch release, or a full version

--- a/xtask/src/php_versions.rs
+++ b/xtask/src/php_versions.rs
@@ -1,0 +1,173 @@
+//! `cargo xtask php-versions` — emit the pinned PHP SDK build matrix as JSON.
+//!
+//! This is the single-source-of-truth bridge for `.github/workflows/release.yml`.
+//! The release build matrices are *derived at runtime* from the
+//! `PHP_SDK_VERSIONS` table in `xtask/src/main.rs` rather than being hardcoded
+//! as `php_minor`/`php_full` pairs inside the workflow file.
+//!
+//! Why that matters (issue #374): when the pins lived inside a workflow file,
+//! every PHP bump had to edit `.github/workflows/release.yml`, and the nightly
+//! automated bump runs as `GITHUB_TOKEN` — which the GitHub API forbids from
+//! pushing changes under `.github/workflows/`. So the bump PR failed at push
+//! every night and no bump could ever land (this once shipped Windows PHP 8.3
+//! with OPcache silently off for three weeks). With the matrix derived here, a
+//! bump touches only Rust (`PHP_SDK_VERSIONS`) plus docs, both of which
+//! `GITHUB_TOKEN` may push.
+//!
+//! The `setup` job in `release.yml` runs `php-versions --github-matrix` and
+//! pipes the `key=value` lines into `$GITHUB_OUTPUT`; the build jobs then
+//! consume each matrix with `strategy.matrix: ${{ fromJSON(...) }}`.
+//!
+//! No `serde` dependency: the emitted objects are flat and their values
+//! (version strings, booleans) never need JSON escaping, so the small builders
+//! below assemble the JSON by hand and are unit-tested for shape.
+
+use std::process::ExitCode;
+
+use crate::{DEFAULT_PHP_MINOR, PHP_SDK_VERSIONS, TAILCALL_MINORS};
+
+/// JSON array of every pinned `{minor, full}` pair.
+///
+/// The matrix for `build-linux`, `build-linux-arm64`, `build-macos` and
+/// `build-windows` — every platform builds every supported minor.
+fn php_matrix_json() -> String {
+    let items: Vec<String> = PHP_SDK_VERSIONS
+        .iter()
+        .map(|(minor, full)| format!(r#"{{"minor":"{minor}","full":"{full}"}}"#))
+        .collect();
+    format!("[{}]", items.join(","))
+}
+
+/// JSON array of the TAILCALL minors' `{minor, full}` pairs.
+///
+/// The matrix for the experimental, non-gating `build-windows-tailcall` job.
+/// `TAILCALL_MINORS` is 8.5-only today — the TAILCALL VM does not exist in
+/// PHP 8.3/8.4.
+fn tailcall_matrix_json() -> String {
+    let items: Vec<String> = PHP_SDK_VERSIONS
+        .iter()
+        .filter(|(minor, _)| TAILCALL_MINORS.contains(minor))
+        .map(|(minor, full)| format!(r#"{{"minor":"{minor}","full":"{full}"}}"#))
+        .collect();
+    format!("[{}]", items.join(","))
+}
+
+/// JSON array of every pinned `{minor, full, default}` triple.
+///
+/// The matrix for `docker-image`. `default` marks the minor whose images get
+/// the rolling `:latest` / `:vX.Y.Z` tags (see the tag logic in that job); it
+/// is `true` for exactly `DEFAULT_PHP_MINOR` and `false` otherwise. Emitting an
+/// explicit `false` (rather than omitting the key, as the old hand-written
+/// matrix did for 8.3) is behaviour-identical: the job's `[ "$IS_DEFAULT" =
+/// "true" ]` test reads an unset `matrix.default` as the empty string, which is
+/// also not `"true"`.
+fn docker_matrix_json() -> String {
+    let items: Vec<String> = PHP_SDK_VERSIONS
+        .iter()
+        .map(|(minor, full)| {
+            let is_default = *minor == DEFAULT_PHP_MINOR;
+            format!(r#"{{"minor":"{minor}","full":"{full}","default":{is_default}}}"#)
+        })
+        .collect();
+    format!("[{}]", items.join(","))
+}
+
+/// Entry point for `cargo xtask php-versions [--github-matrix | --json]`.
+///
+/// * `--github-matrix` prints the three `key=value` lines the `release.yml`
+///   `setup` job appends to `$GITHUB_OUTPUT`.
+/// * otherwise (or with `--json`) prints one combined JSON object — a
+///   human/debug view and a stable contract for any other consumer.
+pub fn run(args: &[String]) -> ExitCode {
+    let github = args.iter().any(|a| a == "--github-matrix");
+
+    if github {
+        // Consumed by `>> "$GITHUB_OUTPUT"`; each value is a single-line JSON
+        // array (no newlines inside), so the plain `key=value` form is safe.
+        println!("php_matrix={}", php_matrix_json());
+        println!("tailcall_matrix={}", tailcall_matrix_json());
+        println!("docker_matrix={}", docker_matrix_json());
+    } else {
+        println!(
+            r#"{{"php_matrix":{},"tailcall_matrix":{},"docker_matrix":{}}}"#,
+            php_matrix_json(),
+            tailcall_matrix_json(),
+            docker_matrix_json()
+        );
+    }
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `php_matrix` has exactly one `{minor, full}` object per pinned minor,
+    /// each carrying the table's own values. Asserted by derivation from
+    /// `PHP_SDK_VERSIONS` (not hardcoded versions) so a bump never has to touch
+    /// this test — that is the whole point of moving the pins out of files.
+    #[test]
+    fn php_matrix_has_one_object_per_pinned_minor() {
+        let json = php_matrix_json();
+        for (minor, full) in PHP_SDK_VERSIONS {
+            assert!(
+                json.contains(&format!(r#"{{"minor":"{minor}","full":"{full}"}}"#)),
+                "php_matrix missing {minor} → {full}: {json}"
+            );
+        }
+        assert_eq!(
+            json.matches(r#""minor""#).count(),
+            PHP_SDK_VERSIONS.len(),
+            "php_matrix object count must equal the table length: {json}"
+        );
+    }
+
+    /// `tailcall_matrix` is exactly the TAILCALL subset of the table — same
+    /// full versions the table pins, no more, no fewer.
+    #[test]
+    fn tailcall_matrix_is_the_tailcall_subset() {
+        let json = tailcall_matrix_json();
+        for (minor, full) in PHP_SDK_VERSIONS {
+            let present = json.contains(&format!(r#"{{"minor":"{minor}","full":"{full}"}}"#));
+            assert_eq!(
+                present,
+                TAILCALL_MINORS.contains(minor),
+                "tailcall_matrix membership wrong for {minor}: {json}"
+            );
+        }
+        assert_eq!(json.matches(r#""minor""#).count(), TAILCALL_MINORS.len(), "{json}");
+    }
+
+    /// `docker_matrix` marks exactly the default minor `true` and every other
+    /// minor `false`, and covers every pinned minor.
+    #[test]
+    fn docker_matrix_flags_only_the_default_minor() {
+        let json = docker_matrix_json();
+        for (minor, full) in PHP_SDK_VERSIONS {
+            let is_default = *minor == DEFAULT_PHP_MINOR;
+            assert!(
+                json.contains(&format!(
+                    r#"{{"minor":"{minor}","full":"{full}","default":{is_default}}}"#
+                )),
+                "docker_matrix wrong entry for {minor} (expected default={is_default}): {json}"
+            );
+        }
+        assert_eq!(json.matches(r#""default":true"#).count(), 1, "exactly one default: {json}");
+        assert_eq!(json.matches(r#""minor""#).count(), PHP_SDK_VERSIONS.len(), "{json}");
+    }
+
+    /// Every emitted matrix is valid, non-empty JSON array syntax (balanced
+    /// brackets, comma-separated objects) — a cheap guard that `fromJSON` in
+    /// the workflow will not choke.
+    #[test]
+    fn matrices_are_well_formed_arrays() {
+        for json in [php_matrix_json(), tailcall_matrix_json(), docker_matrix_json()] {
+            assert!(json.starts_with('[') && json.ends_with(']'), "not an array: {json}");
+            let inner = &json[1..json.len() - 1];
+            let objects = inner.split("},{").count();
+            // No trailing/leading commas, one more `{` than `},{` separators.
+            assert_eq!(inner.matches('{').count(), objects, "object/comma mismatch: {json}");
+            assert!(!inner.contains(",,") && !inner.starts_with(',') && !inner.ends_with(','));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #374.

## Problem
`release.yml`'s build matrices hardcoded five `php_minor`/`php_full` pin sites (two inline-map matrices + three `include` blocks). Because the version pins lived *inside a workflow file*, every PHP bump had to edit `.github/workflows/`. The nightly automated bump runs as `GITHUB_TOKEN`, which the GitHub API forbids from modifying files under `.github/workflows/`, so the bump PR failed at `git push` every night and no bump could ever land — this once shipped Windows PHP 8.3 with OPcache silently off for three weeks, and drove the pin-drift bug class fixed in #373.

## Fix — make the matrix source-driven
- **New `cargo xtask php-versions [--github-matrix]`** derives `php_matrix`, `tailcall_matrix` and `docker_matrix` as JSON from the single source of truth, `PHP_SDK_VERSIONS` in `xtask/src/main.rs`. `TAILCALL_MINORS` moves to `main.rs` so it has one home too. No new dependencies (xtask has none) — the flat JSON is assembled by hand and unit-tested for shape.
- **A `setup` job** in `release.yml` runs `php-versions --github-matrix` into `$GITHUB_OUTPUT`; every build job now consumes its matrix via `strategy.matrix: ${{ fromJSON(needs.setup.outputs.<matrix>) }}`. `build-linux` keeps its static `arch` dimension inline and only its `php` key is injected.
- **`windows-php-check.yml`** resolves its SDK cache path by *minor* glob (`8.3.*-windows-x86_64`) instead of the hardcoded full patch version, so it stops being a workflow-file pin site as well.
- **`bump.rs`** drops both `release.yml` substitutions and the `windows-php-check.yml` one, and its module docs are rewritten. The remaining pin sites are all `GITHUB_TOKEN`-pushable: `PHP_SDK_VERSIONS` (Rust), the Dockerfile `ARG` default, and the docs support table.

After this, a PHP bump touches only `xtask/src/main.rs` + docs, so the bump PR is pushable by `GITHUB_TOKEN`.

## Verification
- **Effective matrix is identical.** `cargo run -p xtask -- php-versions --github-matrix` emits:
  - `php_matrix` = `(8.3,8.3.33),(8.4,8.4.23),(8.5,8.5.7)` — same set the four all-platform build jobs hardcoded.
  - `tailcall_matrix` = `(8.5,8.5.7)` — same single entry `build-windows-tailcall` hardcoded.
  - `docker_matrix` = same three, with `default:true` on 8.5 only. The one nominal difference — 8.3 now carries `default:false` where the old matrix omitted the key — is behaviorally identical: the tag step's `[ "$IS_DEFAULT" = "true" ]` treats an empty and a `false` value the same.
- `cargo test -p xtask` — 37 passed (new `php_versions` tests derive from the table so a bump never breaks them; new `bump::tests::no_workflow_file_is_a_pin_site` guards the #374 invariant).
- `cargo run -p xtask -- bump-php-pin --check` — all remaining pin sites agree.
- `cargo clippy -p xtask --all-targets -- -D warnings` and `cargo +nightly fmt -p xtask -- --check` — clean.
- `actionlint` on `release.yml` and `windows-php-check.yml` — exit 0 (validates the `fromJSON`/`needs` wiring and shellchecks the run steps).
- No real release was triggered; the workflow was reasoned about statically.

## Residual (out of scope)
This removes the *workflow-file* coupling and makes `GITHUB_TOKEN` sufficient for the bump PR itself. If the org wants the **cross-repo dispatch** (php-sdk → ephpm) to fully *auto-land* bumps, that still needs a token with `workflow` scope or a GitHub App — a remaining decision, not addressed here.
