### PR TITLE
test: kill rate-limit refill clock race (#392) and derived cluster-channel port collisions (#383)

### DIFF
--- a/crates/ephpm-cluster/src/cluster_channel.rs
+++ b/crates/ephpm-cluster/src/cluster_channel.rs
@@ -1183,13 +1183,9 @@ mod tests {
 
     /// The lazy-bind proof. When no feature is enabled, `maybe_start`
     /// must return `Ok(None)` and MUST NOT touch the network — no
-    /// listener appears on the port derived from the gossip address.
+    /// listener appears on the configured channel port.
     #[tokio::test]
     async fn channel_stays_off_when_no_features_enabled() {
-        // Bring up a real gossip listener so we have a real
-        // ClusterHandle to derive from. The bound gossip port dictates
-        // what "port + 2" would be — we then confirm nothing is
-        // listening on that port after `maybe_start`.
         let gossip_bind = pick_free_port_addr();
 
         let cfg = ephpm_config::ClusterConfig {
@@ -1200,10 +1196,17 @@ mod tests {
         };
         let cluster = Arc::new(crate::start_gossip(&cfg).await.expect("gossip start"));
 
-        let derived_port = cluster.gossip_socket_addr().port() + 2;
-        let derived_addr = format!("127.0.0.1:{derived_port}");
-
-        let channel_cfg = ephpm_config::ClusterChannelConfig::default();
+        // Pin the channel to an explicit, freshly-reserved ephemeral port
+        // rather than the derived `gossip_port + 2`. A derived port is not
+        // reserved from the OS, so a sibling test (or the e2e suite) can be
+        // holding it and this "prove nothing is bound" probe then fails
+        // spuriously — issue #383. An OS-assigned port carries no such
+        // correlation.
+        let channel_addr = reserve_free_tcp_addr();
+        let channel_cfg = ephpm_config::ClusterChannelConfig {
+            listen: Some(channel_addr.clone()),
+            ..ephpm_config::ClusterChannelConfig::default()
+        };
         let features = FeatureFlags::default(); // NOTHING enabled
 
         let result =
@@ -1211,22 +1214,24 @@ mod tests {
 
         assert!(result.is_none(), "channel handle must be None when no feature is enabled");
 
-        // Prove nothing is bound: we should be able to bind the
-        // derived port ourselves. If maybe_start had bound it in
-        // violation of the contract, this would fail with EADDRINUSE.
-        let probe = TcpListener::bind(&derived_addr).await;
+        // Prove nothing is bound: we should be able to bind the configured
+        // port ourselves. If maybe_start had bound it in violation of the
+        // contract, this would fail with EADDRINUSE.
+        let probe = TcpListener::bind(&channel_addr).await;
         assert!(
             probe.is_ok(),
-            "the channel port {derived_addr} must be unbound when no feature is enabled \
+            "the channel port {channel_addr} must be unbound when no feature is enabled \
              (got: {probe:?})"
         );
     }
 
-    /// When a feature IS enabled, the channel must bind. Also confirms
-    /// the derived-address rule (`gossip_port + 2`) is honored when
-    /// `[cluster.channel] listen` is unset.
+    /// The derived-address rule (`gossip_port + 2`) is honored when
+    /// `[cluster.channel] listen` is unset. Checked against the pure
+    /// [`resolve_listen_addr`] helper so nothing binds the derived port —
+    /// a derived port isn't reserved from the OS and racing to bind it
+    /// flakes under parallelism (issue #383).
     #[tokio::test]
-    async fn channel_binds_when_a_feature_is_enabled_and_derives_port_from_gossip() {
+    async fn channel_listen_addr_derives_from_gossip_port() {
         let gossip_bind = pick_free_port_addr();
 
         let cfg = ephpm_config::ClusterConfig {
@@ -1239,12 +1244,37 @@ mod tests {
         let expected_port = cluster.gossip_socket_addr().port() + 2;
 
         let channel_cfg = ephpm_config::ClusterChannelConfig::default();
+        let derived = resolve_listen_addr(&channel_cfg, &cluster).expect("derive listen addr");
+
+        assert_eq!(derived.port(), expected_port);
+    }
+
+    /// When a feature IS enabled, the channel actually binds a listener.
+    /// Binds an OS-assigned port (`listen = 127.0.0.1:0`) and reads the
+    /// bound address back, mirroring the QUIC listener's bind-0-then-read
+    /// pattern — no derived port to race (issue #383).
+    #[tokio::test]
+    async fn channel_binds_when_a_feature_is_enabled() {
+        let gossip_bind = pick_free_port_addr();
+
+        let cfg = ephpm_config::ClusterConfig {
+            enabled: true,
+            bind: gossip_bind.clone(),
+            secret: "a-secret-value-for-tests".to_string(),
+            ..ephpm_config::ClusterConfig::default()
+        };
+        let cluster = Arc::new(crate::start_gossip(&cfg).await.expect("gossip start"));
+
+        let channel_cfg = ephpm_config::ClusterChannelConfig {
+            listen: Some("127.0.0.1:0".to_string()),
+            ..ephpm_config::ClusterChannelConfig::default()
+        };
         let handle = maybe_start(&channel_cfg, &cfg.secret, &cluster, FeatureFlags { cdc: true })
             .await
             .expect("maybe_start")
             .expect("channel handle");
 
-        assert_eq!(handle.listen_addr().port(), expected_port);
+        assert_ne!(handle.listen_addr().port(), 0, "channel must bind a real, non-zero port");
     }
 
     /// When a feature is enabled but no secret is configured anywhere,
@@ -1443,6 +1473,16 @@ mod tests {
         s.local_addr().unwrap().to_string()
     }
 
+    /// Reserve a free loopback **TCP** port by binding then dropping, and
+    /// return its `127.0.0.1:PORT` string. Inherently TOCTOU, but an
+    /// OS-assigned port is uncorrelated with any other listener — unlike a
+    /// port derived from a base (`gossip_port + 2`), which is what flaked in
+    /// issue #383.
+    fn reserve_free_tcp_addr() -> String {
+        let s = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        s.local_addr().unwrap().to_string()
+    }
+
     // -----------------------------------------------------------------
     // advertise_addr — the "don't publish 0.0.0.0 to peers" contract.
     //
@@ -1513,15 +1553,17 @@ mod tests {
             ..ephpm_config::ClusterConfig::default()
         };
         let cluster = Arc::new(crate::start_gossip(&cfg).await.expect("gossip start"));
-        let handle = maybe_start(
-            &ephpm_config::ClusterChannelConfig::default(),
-            &cfg.secret,
-            &cluster,
-            FeatureFlags { cdc: true },
-        )
-        .await
-        .expect("maybe_start")
-        .expect("channel handle");
+        // Bind an OS-assigned loopback port (bind-0-then-read) rather than the
+        // derived `gossip_port + 2`, which is unreserved and races under
+        // parallelism (issue #383).
+        let channel_cfg = ephpm_config::ClusterChannelConfig {
+            listen: Some("127.0.0.1:0".to_string()),
+            ..ephpm_config::ClusterChannelConfig::default()
+        };
+        let handle = maybe_start(&channel_cfg, &cfg.secret, &cluster, FeatureFlags { cdc: true })
+            .await
+            .expect("maybe_start")
+            .expect("channel handle");
         assert_eq!(handle.advertise_addr(), Some(handle.listen_addr()));
     }
 
@@ -1548,13 +1590,13 @@ mod tests {
         };
         let cluster = Arc::new(crate::start_gossip(&cfg).await.expect("gossip start"));
 
-        // Pick a free TCP port for the channel by binding and dropping.
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let chan_port = probe.local_addr().unwrap().port();
-        drop(probe);
-
+        // Bind a wildcard address on an OS-assigned port (`0.0.0.0:0`) and read
+        // the bound port back, rather than reserving a concrete port up front —
+        // the assertions below only care that the bind is wildcard and that
+        // advertise swaps in a routable IP, not which port it landed on. This
+        // avoids racing to bind a specific port (issue #383).
         let channel_cfg = ephpm_config::ClusterChannelConfig {
-            listen: Some(format!("0.0.0.0:{chan_port}")),
+            listen: Some("0.0.0.0:0".to_string()),
             secret: None,
         };
         let handle = maybe_start(&channel_cfg, &cfg.secret, &cluster, FeatureFlags { cdc: true })

--- a/crates/ephpm-e2e/tests/turso_cdc.rs
+++ b/crates/ephpm-e2e/tests/turso_cdc.rs
@@ -101,6 +101,9 @@ node_id = "{NODE_ID}"
 cluster_id = "ephpm-e2e-turso-cdc"
 secret = "{SECRET}"
 
+[cluster.channel]
+listen = "127.0.0.1:{CHANNEL_PORT}"
+
 [cluster.kv]
 data_port = {KV_DATA_PORT}
 "#;
@@ -110,6 +113,11 @@ struct NodePorts {
     mysql: u16,
     hrana: u16,
     gossip: u16,
+    /// Cluster-channel (CDC transport) listen port. Reserved as its own
+    /// OS-assigned ephemeral port and pinned via `[cluster.channel] listen`
+    /// rather than derived as `gossip + 2` — a derived port is not reserved
+    /// from the kernel and collided under parallelism (issue #383).
+    channel: u16,
     kv_data: u16,
 }
 
@@ -124,7 +132,7 @@ enum RoleSpec {
     Auto,
     Primary,
     /// Replica of the node at this index. The address a replica dials is the
-    /// primary's **cluster channel** — gossip port + 2, not the gossip port.
+    /// primary's **cluster channel** (`channel_addr`), not its gossip port.
     ReplicaOf(usize),
 }
 
@@ -155,7 +163,8 @@ impl CdcCluster {
                 http: reserve_port().await?,
                 mysql: reserve_port().await?,
                 hrana: reserve_port().await?,
-                gossip: reserve_gossip_port().await?,
+                gossip: reserve_port().await?,
+                channel: reserve_port().await?,
                 kv_data: reserve_port().await?,
             });
         }
@@ -165,9 +174,10 @@ impl CdcCluster {
         Ok(Self { binary: binary.to_path_buf(), docroot, ports, children, tempdir })
     }
 
-    /// The cluster-channel address peers dial to reach node `i`.
+    /// The cluster-channel address peers dial to reach node `i` — the
+    /// explicit `[cluster.channel] listen` port, not a `gossip + 2` derivation.
     fn channel_addr(&self, i: usize) -> String {
-        format!("127.0.0.1:{}", self.ports[i].gossip + 2)
+        format!("127.0.0.1:{}", self.ports[i].channel)
     }
 
     /// Spawn node `i` with the given replication role and wait for it to
@@ -203,6 +213,7 @@ impl CdcCluster {
             .replace("{MYSQL_PORT}", &p.mysql.to_string())
             .replace("{HRANA_PORT}", &p.hrana.to_string())
             .replace("{GOSSIP_PORT}", &p.gossip.to_string())
+            .replace("{CHANNEL_PORT}", &p.channel.to_string())
             .replace("{KV_DATA_PORT}", &p.kv_data.to_string())
             .replace("{NODE_ID}", &format!("cdc-node-{i}"))
             .replace("{CLUSTER_JOIN}", &join)
@@ -420,22 +431,6 @@ impl Drop for CdcCluster {
 async fn reserve_port() -> Result<u16> {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.context("bind :0")?;
     Ok(listener.local_addr().context("local_addr")?.port())
-}
-
-/// Reserve a gossip port whose derived cluster-channel port (`gossip + 2` —
-/// see `ephpm_cluster::cluster_channel`) is also currently free, so the CDC
-/// transport can bind.
-async fn reserve_gossip_port() -> Result<u16> {
-    for _ in 0..16 {
-        let p = reserve_port().await?;
-        if p >= u16::MAX - 2 {
-            continue;
-        }
-        if tokio::net::TcpListener::bind(("127.0.0.1", p + 2)).await.is_ok() {
-            return Ok(p);
-        }
-    }
-    bail!("could not reserve a gossip port with a free channel port (+2)")
 }
 
 fn escape_toml(path: &Path) -> String {

--- a/crates/ephpm-server/src/rate_limit.rs
+++ b/crates/ephpm-server/src/rate_limit.rs
@@ -652,14 +652,20 @@ mod tests {
     /// The bucket refills at `per_site_rate`, so a denied site recovers.
     #[test]
     fn site_bucket_refills_over_time() {
-        // 1000 tokens/s → one token per millisecond; a short sleep is enough.
-        let limiter = Limiter::new(site_config(1000.0, 2));
+        // 10 tokens/s → one token every 100 ms. The refill interval is chosen
+        // so this test never races the wall clock (issue #392): the three
+        // back-to-back `check_site_rate` calls below complete in microseconds,
+        // far inside a single 100 ms interval, so no scheduler hiccup can sneak
+        // an extra token across a refill boundary and spuriously satisfy the
+        // "burst exhausted" assertion. The deliberate sleep then clears more
+        // than one full interval, guaranteeing at least one token has refilled.
+        let limiter = Limiter::new(site_config(10.0, 2));
 
         assert!(limiter.check_site_rate("s.example.com"));
         assert!(limiter.check_site_rate("s.example.com"));
         assert!(!limiter.check_site_rate("s.example.com"), "burst exhausted");
 
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::thread::sleep(std::time::Duration::from_millis(250));
         assert!(limiter.check_site_rate("s.example.com"), "refilled after waiting");
     }
 


### PR DESCRIPTION
## What

Two test-only CI flakes, both already root-caused. Zero production-code change — clean hygiene wins for v0.7.4.

### #392 — `rate_limit::tests::site_bucket_refills_over_time`

The test configured `rate = 1000.0` (tokens scaled ×1000 → **one token per millisecond**). Its three back-to-back `check_site_rate` calls only exhaust the burst if they all land in the same millisecond; a scheduler hiccup across a ms boundary legitimately refilled a token and let the third call through, failing the "burst exhausted" assertion (~5%, 1-in-20 isolated runs).

Fix: lower the *test's* rate to `10.0` (100 ms per token) so no realistic jitter crosses a refill boundary during the three microsecond-apart calls, and lengthen the recovery sleep to 250 ms so the "refilled after waiting" assertion still holds. No clock-injection seam added to production (`now_ms` still reads the wall clock) — lowering the rate is sufficient and keeps this test-only.

### #383 — derived cluster-channel port collisions

Several tests bound a **derived** channel port (`gossip_port + 2`) that nothing reserves from the OS, so it collided under parallelism (`EADDRINUSE` / os error 10048). Fix follows the in-tree QUIC precedent — bind port `0`, read the OS-assigned port back:

- **`crates/ephpm-cluster/src/cluster_channel.rs`** unit tests:
  - `channel_binds_when_a_feature_is_enabled` and `advertise_addr_matches_listen_when_bound_to_loopback` now pass `[cluster.channel] listen = "127.0.0.1:0"` and read `handle.listen_addr()`.
  - `advertise_addr_substitutes_wildcard_bound_channel` now binds `0.0.0.0:0` (no reserved-port TOCTOU).
  - `channel_stays_off_when_no_features_enabled` pins an independently-reserved ephemeral port instead of `gossip+2` for its lazy-bind probe.
  - The `gossip+2` derivation rule is still covered, but now via the **pure** `resolve_listen_addr` helper (`channel_listen_addr_derives_from_gossip_port`) — no bind, so nothing to race.
- **`crates/ephpm-e2e/tests/turso_cdc.rs`** harness: reserves an independent ephemeral channel port per node and pins it via `[cluster.channel] listen`, dropping the `gossip+2` derivation (`reserve_gossip_port` removed). `channel_addr()` returns the explicit port, which the auto-election path advertises and explicit replicas dial.

No production port selection changed — `resolve_listen_addr` already honored an explicit `[cluster.channel] listen`, and the auto path advertises the resolved listen addr.

## Verification

Built against the shared target from a worktree.

- **#392:** ran the compiled test 50× in a loop — **50/50 pass** (previously ~5% fail).
- **#383:** ran the whole `cluster_channel::tests` binary 120× under default parallelism — **120/120 pass**. Before the fix, the same loop reproduced the collision (`EADDRINUSE`) within ~30 runs.
- `cargo clippy -p ephpm-server -p ephpm-cluster --all-targets -- -D warnings` — clean; the `turso_cdc` e2e target is clippy-clean.
- `cargo +nightly fmt` — workspace clean; `turso_cdc.rs` clean.

Note: the e2e crate shows pre-existing clippy/fmt drift in untouched files (`sqlite_advanced.rs`, `worker_mode.rs`, `websockets.rs`) from a newer local toolchain than CI pins — not introduced here.
