### PR TITLE
build(docker): pin base images to multi-arch digests; reconcile glibc-floor docs (v0.8.0)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -42,7 +42,7 @@ Known leg-specific failures: see `triage-ci` (macOS llvm@17/libclang, Windows ep
 gh release view vX.Y.Z --json isDraft,isPrerelease,assets   # expect 13 assets (12 tarballs + SHA256SUMS); 14 if the non-gating windows-tailcall leg landed its archive
 gh release download vX.Y.Z --pattern "*php<DEFAULT_PHP>-linux-x86_64.tar.gz" --pattern "*windows-x86_64.tar.gz"
 ```
-Smoke each downloaded binary: `ephpm --version` reports the tag; serve a one-line `<?php echo "PHPOK ".PHP_VERSION;` docroot and curl it (Linux binary is glibc-dynamic with a glibc >= 2.39 floor - run it in `debian:13-slim` via podman, NOT alpine and NOT debian:12; Windows runs natively). Expect HTTP 200 + `PHPOK <php-version>`.
+Smoke each downloaded binary: `ephpm --version` reports the tag; serve a one-line `<?php echo "PHPOK ".PHP_VERSION;` docroot and curl it (Linux binary is glibc-dynamic with a glibc >= 2.28 floor, built on `almalinux:8` - run it in `debian:12-slim` via podman, the shipped runtime base, or any glibc >= 2.28 host, NOT alpine; Windows runs natively). Expect HTTP 200 + `PHPOK <php-version>`.
 
 ## 6. After
 

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -22,12 +22,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Pinned to the multi-arch OCI-index digest — resolves per-arch even
+          # on these native single-arch builds (docker picks the arch-matching
+          # child of the index), and cannot drift when almalinux:8 is
+          # republished. Keep in sync with docker/Dockerfile.gha's pinned
+          # default (its "Base image digest pins" refresh note). To bump:
+          # `docker buildx imagetools inspect docker.io/library/almalinux:8`.
           - arch: x64
             suffix: ""
-            base_image: docker.io/library/almalinux:8
+            base_image: docker.io/library/almalinux:8@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb
           - arch: arm64
             suffix: "-arm64"
-            base_image: docker.io/library/almalinux:8
+            base_image: docker.io/library/almalinux:8@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb
     steps:
       - uses: actions/checkout@v4
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,39 @@
 # xtask::PHP_SDK_VERSIONS — keep them in sync if you bump.
 ARG PHP_SDK_VERSION=8.5.7
 
+# ── Base image digest pins ───────────────────────────────────────────────────
+#
+# Every base below is pinned to an immutable content digest (image:tag@sha256:…)
+# so a rebuild is reproducible and cannot drift when an upstream tag is
+# republished. The human-readable tag is kept alongside the digest for clarity;
+# the digest is authoritative.
+#
+# CRITICAL — these images are built on BOTH x86_64 and aarch64 (release.yml has
+# a linux-x86_64 leg and a linux-aarch64 leg; the RUN steps below `uname -m` at
+# build time). The pinned digest MUST be the multi-arch MANIFEST-LIST / OCI-INDEX
+# digest (the one that resolves per-arch), NOT a single-arch manifest digest.
+# A single-arch pin breaks the other arch's build ("no match for platform").
+#
+# To refresh a pin (upstream security update, new base, etc.):
+#
+#   docker buildx imagetools inspect docker.io/library/almalinux:8
+#
+# The FIRST "Digest:" it prints (Manifest MediaType:
+# application/vnd.oci.image.index.v1+json or …manifest.list.v2+json) is the
+# index digest to pin. Confirm its children list BOTH linux/amd64 and
+# linux/arm64 before copying it in. Without a local docker, the same digest
+# comes from the registry HEAD:
+#
+#   TOK=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/almalinux:pull" | jq -r .token)
+#   curl -sI -H "Authorization: Bearer $TOK" \
+#     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+#     https://registry-1.docker.io/v2/library/almalinux/manifests/8 | grep -i docker-content-digest
+#
+# These pins go stale as upstreams ship security fixes; bumping them is a manual
+# step today. Dependabot (docker ecosystem) and Renovate BOTH understand the
+# `image:tag@sha256:…` form and can open automated digest-bump PRs — not wired
+# up here, but either would automate the refresh if enabled.
+
 # ── Stage 1: base — system deps + Rust toolchain ─────────────────────────────
 #
 # GLIBC FLOOR: the builder stage links the release binary, so its base sets the
@@ -44,8 +77,10 @@ ARG PHP_SDK_VERSION=8.5.7
 # Docker-format so it's pullable on the runner fleet (the manylinux OCI-index
 # format is not). gcc-toolset-13 (not 14): GCC 14 makes implicit-function-
 # declaration a hard error; 13 matches php-sdk's toolchain. Mirrors Dockerfile.gha.
-
-ARG BASE_IMAGE=docker.io/library/almalinux:8
+#
+# Pinned to the multi-arch OCI-index digest (resolves per-arch on the x64 and
+# arm64 legs). See the "Base image digest pins" block above to refresh.
+ARG BASE_IMAGE=docker.io/library/almalinux:8@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb
 FROM ${BASE_IMAGE} AS base
 
 # System tools needed by the ephpm Rust build (dnf / AlmaLinux 8). Stock
@@ -266,7 +301,10 @@ RUN cp $(find target -name ephpm -type f -path '*/release/*' | head -1) /ephpm &
 # requirement was an artifact of the 2.39 floor from building on ubuntu:24.04;
 # see docs/architecture/dynamic-baseline-design.md §2.1.) debian:11-slim
 # (bullseye, glibc 2.31) would also work if an even older runtime is wanted.
-FROM debian:12-slim
+#
+# Pinned to the multi-arch OCI-index digest (resolves per-arch). See the
+# "Base image digest pins" block near the top of this file to refresh.
+FROM debian:12-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini ca-certificates \

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -9,7 +9,13 @@
 # Build:
 #   podman build -f docker/Dockerfile.e2e -t ephpm-e2e:dev .
 
-FROM rust:1.88-bookworm
+# Pinned to the multi-arch OCI-index digest (resolves per-arch — this image is
+# built on both x64 and arm64 runners), so the E2E toolchain cannot drift when
+# the rust:1.88-bookworm tag is republished. To refresh: `docker buildx
+# imagetools inspect rust:1.88-bookworm` and pin the top-level index "Digest:"
+# (confirm children list both linux/amd64 and linux/arm64). Dependabot (docker)
+# and Renovate both understand this `tag@sha256:…` form and can automate it.
+FROM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.gha
+++ b/docker/Dockerfile.gha
@@ -42,7 +42,15 @@
 # almalinux:8 base (glibc 2.28). A single image serves both arches — the
 # runner pulls the arch-matching manifest natively (x86_64 on the x64 runner,
 # aarch64 on the arm64 runner), so ci-image.yml passes the same value for both.
-ARG BASE_IMAGE=docker.io/library/almalinux:8
+#
+# Pinned to the multi-arch OCI-index digest (NOT a single-arch manifest digest),
+# so it resolves per-arch on both runners and cannot drift when almalinux:8 is
+# republished. To refresh: `docker buildx imagetools inspect
+# docker.io/library/almalinux:8` and pin the top-level index "Digest:" (confirm
+# its children list both linux/amd64 and linux/arm64). Dependabot (docker) and
+# Renovate both understand this `tag@sha256:…` form and can automate the bump.
+# Mirrors the pin in docker/Dockerfile's "Base image digest pins" block.
+ARG BASE_IMAGE=docker.io/library/almalinux:8@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb
 FROM ${BASE_IMAGE}
 
 # ── System build tools (dnf, AlmaLinux 8) ────────────────────────────────────

--- a/docs/architecture/dynamic-baseline-design.md
+++ b/docs/architecture/dynamic-baseline-design.md
@@ -222,8 +222,12 @@ consecutive requests return `boot #1, request #N` with N climbing
 - SDK assets gained the `-gnu` libc suffix
   (`php-sdk-<ver>-linux-<arch>-gnu.tar.gz`); the cache dir carries the
   suffix too, so stale musl-era caches are never reused.
-- Container runtime base: `debian:13-slim` (was `debian:12-slim` in the
-  pivot draft — changed for the glibc floor, §2.1).
+- Container runtime base: `debian:12-slim` (bookworm, glibc 2.36). An
+  interim pivot draft moved this to `debian:13-slim` to clear a **2.39**
+  floor that came from building on `ubuntu:24.04`; once both build
+  environments moved to `almalinux:8` and the floor dropped to **2.28**
+  (§2.1), the runtime returned to `debian:12-slim` (its 2.36 comfortably
+  clears 2.28). Any glibc ≥ 2.28 runtime works.
 - Windows and macOS release lanes are untouched by the pivot.
 
 ## 8. Phasing / remaining work

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -860,12 +860,12 @@ Dev suites include Zend extensions (xdebug, pcov, spx) that are statically compi
 ### Container Images
 
 ```dockerfile
-FROM debian:13-slim
+FROM debian:12-slim
 COPY ephpm /usr/local/bin/ephpm
 ENTRYPOINT ["ephpm"]
 ```
 
-Linux binaries are glibc-dynamic (so they can `dlopen` shared PHP extensions and middleware), so images use a slim glibc base (`debian:13-slim` — the binary's glibc floor is 2.39, set by the php-sdk build toolchain, so Debian 12's glibc 2.36 is too old) rather than Alpine or `FROM scratch`. Multi-arch images support both `linux/amd64` and `linux/arm64`.
+Linux binaries are glibc-dynamic (so they can `dlopen` shared PHP extensions and middleware), so images use a slim glibc base (`debian:12-slim` — the binary's glibc floor is **2.28**, set by the `almalinux:8` build toolchain both the release tarball and the Docker image link on, so Debian 12's glibc 2.36 comfortably clears it) rather than Alpine or `FROM scratch`. Any glibc ≥ 2.28 runtime works. Multi-arch images support both `linux/amd64` and `linux/arm64`.
 
 Tags follow the suite model:
 

--- a/site/content/roadmap/kubernetes.md
+++ b/site/content/roadmap/kubernetes.md
@@ -7,10 +7,12 @@ gossip clustering, and environment-based configuration.
 
 ## Container Image
 
-ePHPm ships as a single self-contained binary (glibc-dynamic on Linux). A minimal Dockerfile:
+ePHPm ships as a single self-contained binary (glibc-dynamic on Linux, glibc
+floor 2.28 — any glibc ≥ 2.28 base works; this matches the official image's
+`debian:12-slim` runtime). A minimal Dockerfile:
 
 ```dockerfile
-FROM debian:trixie-slim
+FROM debian:12-slim
 COPY ephpm /usr/local/bin/ephpm
 COPY ephpm.toml /etc/ephpm/ephpm.toml
 COPY /var/www/html /var/www/html


### PR DESCRIPTION
Targets **v0.8.0**. Please sequence after v0.7.4 tags — do not merge yet.

## Part A — pin base images to immutable multi-arch digests

Every Dockerfile base was tag-pinned and could drift when an upstream tag is republished. Each is now pinned to an immutable **multi-arch OCI-index digest** (`image:tag@sha256:…`), with the human-readable tag kept alongside.

| Image | Where | Index digest (pinned) |
|-------|-------|-----------------------|
| `almalinux:8` | `docker/Dockerfile` build base (ARG default), `docker/Dockerfile.gha`, `ci-image.yml` matrix | `sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb` |
| `debian:12-slim` | `docker/Dockerfile` runtime stage | `sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241` |
| `rust:1.88-bookworm` | `docker/Dockerfile.e2e` | `sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0` |

### Proof they are multi-arch (index, not per-arch)

Resolved via the Docker Hub registry v2 API (no local daemon available). All three return `Content-Type: application/vnd.oci.image.index.v1+json` on the HEAD, and the index body lists both required platforms:

- `almalinux:8` children: **linux/amd64**, **linux/arm64/v8**, ppc64le, s390x (+ attestation manifests)
- `debian:12-slim` children: **linux/amd64**, **linux/arm64/v8**, arm/v7, 386, ppc64le
- `rust:1.88-bookworm` children: **linux/amd64**, **linux/arm64/v8**, arm/v7, 386, ppc64le, s390x

The digest pinned is the top-level index digest (from `Docker-Content-Digest` on the manifest-list HEAD), so it resolves per-arch on both the linux-x86_64 and linux-aarch64 release legs. A single-arch pin would have broken the aarch64 leg — that pitfall is called out in the in-file comments.

### Override mechanism preserved

`${BASE_IMAGE}` is still an `ARG`; only the **default** is pinned. `ci-image.yml` passes `BASE_IMAGE` explicitly, which would otherwise shadow the `Dockerfile.gha` default with a floating tag, so its matrix values are pinned to the same index digest too (the index digest still resolves per-arch on the native single-arch CI-image builds). `release.yml`'s `docker-image` job does **not** pass `BASE_IMAGE`, so `docker/Dockerfile`'s pinned default takes effect there.

### Refreshing a pin

Each pinned base carries a comment with the refresh command:

```
docker buildx imagetools inspect docker.io/library/almalinux:8
```

Pin the top-level index `Digest:` and confirm its children list both `linux/amd64` and `linux/arm64`. `docker/Dockerfile` has a fuller "Base image digest pins" block including a daemon-free registry-HEAD recipe. **Dependabot** (docker ecosystem) and **Renovate** both understand the `tag@sha256:…` form and can open automated digest-bump PRs — noted in-comment, not wired up here.

## Part B — reconcile the glibc-floor docs (they contradicted each other)

### Ground truth (the crux: where does the tarball build?)

The release **tarball** does **not** build on `ubuntu-latest`. In `release.yml`, `build-linux` and `build-linux-arm64` run with `container: ephpm/ephpm-ci:…`, which is built from `docker/Dockerfile.gha` on **`almalinux:8` (glibc 2.28)**. So the tarball and the Docker image share the **same** build environment and the **same glibc 2.28 floor** — they do **not** differ.

- **Tarball floor:** glibc **2.28** (built in the `almalinux:8` CI container).
- **Docker image floor:** glibc **2.28** (`docker/Dockerfile` builder stage is also `almalinux:8`); runtime base `debian:12-slim` (glibc 2.36) comfortably clears it.
- **Minimum runtime, both artifacts:** any glibc **≥ 2.28** host (RHEL8/AlmaLinux8, Ubuntu 20.04+, Debian 10+/`debian:12-slim`, Amazon Linux 2023, Fedora 40+).

### How the floor was determined

- **Static:** both build paths (`release.yml` container and `docker/Dockerfile` builder) are `almalinux:8` + gcc-toolset-13 — verified by reading the workflow and Dockerfiles.
- **Empirical (pre-existing, in-repo):** `docs/architecture/dynamic-baseline-design.md` §2.1 records `objdump -T ephpm | grep GLIBC_ | sort -V | tail -1 → GLIBC_2.28` (only 2.28 symbols: `fcntl64`, `statx`; Rust std targets 2.17), verified 2026-07-05 against the real `php-sdk-8.5.7-linux-x86_64-gnu` asset.
- **Not re-run here:** I could not re-run `objdump` on a freshly built Linux binary from this Windows host (needs the build fleet / a Linux binary). I relied on the recorded empirical result plus the static proof that both build paths use the identical `almalinux:8` toolchain. The **docker-build-canary** (`docker build --target deps`) also could not run — no docker/podman daemon on this host. Digests were instead verified to resolve via the registry API.

### Stale hits fixed (were claiming 2.39 / debian:13-slim)

- `docs/architecture/dynamic-baseline-design.md` §7 — said the runtime base is `debian:13-slim` "changed for the glibc floor," directly contradicting its own §2.1 and the actual `docker/Dockerfile` (`debian:12-slim`). Rewritten to explain the interim 2.39/debian:13 draft was reverted once the floor dropped to 2.28.
- `site/content/developer/architecture-overview.md` — removed the false "the binary's glibc floor is 2.39 … Debian 12's glibc 2.36 is too old"; example `FROM debian:12-slim`.
- `site/content/roadmap/kubernetes.md` — example `FROM debian:trixie-slim` → `debian:12-slim` (matches the shipped image and the real floor).
- `.claude/skills/release/SKILL.md` — smoke-test guidance said "glibc ≥ 2.39 … run in debian:13-slim, NOT debian:12"; corrected to floor 2.28 / `debian:12-slim`.

### Deliberately left as-is

- `dynamic-baseline-design.md` §2.1 and the historical "moved off ubuntu:24.04 (2.39)" narrative — correct history of *why* the floor dropped.
- `docs/turso-gate5-results.md` (`debian:13-slim`) — a historical benchmark-run record (what was used at the time), not a floor claim.
- `docs/architecture/build-compose-design.md` (Ubuntu 24.04) — explicitly "DESIGN ONLY, nothing shipped"; refers to the unshipped `forge` musl static-builder, a different toolchain.
- Sury `bookworm/trixie` apt-index mentions in `php-extensions.md` — about extension repos, not our base.

### Recommendation (not implemented)

Tarball and image already share the `almalinux:8` floor, so no unification is needed. If a future change moves the tarball build back onto a bare `ubuntu-latest` runner (`cargo xtask release` directly, no container), the floor would jump to ~2.39 and this reconciliation would regress — keep the tarball build inside the `ephpm/ephpm-ci` (`almalinux:8`) container to hold the 2.28 floor.

## Notes

- No image build or `--target deps` canary was run (no docker/podman daemon on the dev host; release Docker builds need the ephemerd fleet). Digests were verified to resolve and be multi-arch via the registry v2 API. The pinned-digest `FROM`/`ARG` syntax is standard for both the legacy builder (`DOCKER_BUILDKIT=0`, as the fleet uses) and BuildKit.
- Did not touch `router.rs` / `static_files.rs` / `site_overrides.rs`.
