### PR TITLE
feat(service): ephpm install --user/--group for non-root service accounts

### DIFF
--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -128,7 +128,27 @@ enum Commands {
     },
 
     /// Install ephpm as a system service and start it
-    Install,
+    Install {
+        /// Run the service as this dedicated user instead of the elevated
+        /// installing account (root/Administrator). Implemented on Linux
+        /// (systemd `User=` plus a conservative hardening profile —
+        /// `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`,
+        /// `CAP_NET_BIND_SERVICE` so a non-root service can still bind
+        /// port 80/443, and `ReadWritePaths` for the data dir, log dir, and
+        /// document root) and macOS (launchd `UserName`). Not yet supported
+        /// on Windows — the SCM needs a stored account password ephpm has no
+        /// secure way to collect, so passing this flag there is a hard error
+        /// rather than a silent no-op. Omit for the historical default
+        /// (root, no sandboxing) — that behavior is unchanged.
+        #[arg(long)]
+        user: Option<String>,
+
+        /// Group to run the service as. Defaults to the same name as
+        /// `--user` when omitted. Ignored (with a parse error) unless
+        /// `--user` is also given.
+        #[arg(long, requires = "user")]
+        group: Option<String>,
+    },
 
     /// Uninstall the system service
     Uninstall {
@@ -324,7 +344,13 @@ fn run() -> anyhow::Result<ExitCode> {
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
             rt.block_on(run_cache(&host, port, &auth, subcommand))
         }
-        Some(Commands::Install) => run_service_cmd(service::install),
+        Some(Commands::Install { user, group }) => {
+            let owner = user.map(|user| {
+                let group = group.unwrap_or_else(|| user.clone());
+                service::ServiceOwner { user, group }
+            });
+            run_service_cmd(move || service::install(owner.as_ref()))
+        }
         Some(Commands::Uninstall { keep_data }) => {
             run_service_cmd(|| service::uninstall(keep_data))
         }
@@ -2046,7 +2072,45 @@ mod cli_tests {
     #[test]
     fn parses_install_subcommand() {
         let cli = Cli::try_parse_from(["ephpm", "install"]).unwrap();
-        assert!(matches!(cli.command, Some(Commands::Install)));
+        match cli.command {
+            Some(Commands::Install { user, group }) => {
+                assert!(user.is_none());
+                assert!(group.is_none());
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_install_with_user_and_group() {
+        let cli =
+            Cli::try_parse_from(["ephpm", "install", "--user", "ephpm-web", "--group", "www"])
+                .unwrap();
+        match cli.command {
+            Some(Commands::Install { user, group }) => {
+                assert_eq!(user.as_deref(), Some("ephpm-web"));
+                assert_eq!(group.as_deref(), Some("www"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_install_with_user_only() {
+        let cli = Cli::try_parse_from(["ephpm", "install", "--user", "ephpm-web"]).unwrap();
+        match cli.command {
+            Some(Commands::Install { user, group }) => {
+                assert_eq!(user.as_deref(), Some("ephpm-web"));
+                assert!(group.is_none());
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_install_group_without_user() {
+        let err = Cli::try_parse_from(["ephpm", "install", "--group", "www"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/crates/ephpm/src/service/launchd.rs
+++ b/crates/ephpm/src/service/launchd.rs
@@ -5,16 +5,34 @@
 
 use std::process::Command;
 
-use super::{Paths, Result, ServiceError, StatusReport};
+use super::{Paths, Result, ServiceError, ServiceOwner, StatusReport};
 
 /// launchd service label used in the plist.
 const LABEL: &str = "dev.ephpm";
 
-/// Render the launchd plist body for the daemon.
-fn plist_body(paths: &Paths) -> String {
+/// Render the `UserName`/`GroupName` plist keys. Empty when `owner` is `None`
+/// so the default plist is unaffected — see the `systemd::owner_directives`
+/// doc comment for the same backward-compatibility contract.
+fn owner_keys(owner: Option<&ServiceOwner>) -> String {
+    let Some(ServiceOwner { user, group }) = owner else {
+        return String::new();
+    };
+    format!(
+        "    <key>UserName</key>\n\
+    <string>{user}</string>\n\
+    <key>GroupName</key>\n\
+    <string>{group}</string>\n"
+    )
+}
+
+/// Render the launchd plist body for the daemon. `owner` is `None` for the
+/// historical root-with-no-`UserName` plist, or `Some` to run the daemon as a
+/// dedicated non-root user/group.
+fn plist_body(paths: &Paths, owner: Option<&ServiceOwner>) -> String {
     let binary = paths.binary.display();
     let config = paths.config.display();
     let log = paths.log_file.display();
+    let owner_keys = owner_keys(owner);
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
 <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
@@ -29,6 +47,7 @@ fn plist_body(paths: &Paths) -> String {
         <string>--config</string>\n\
         <string>{config}</string>\n\
     </array>\n\
+{owner_keys}\
     <key>RunAtLoad</key>\n\
     <true/>\n\
     <key>KeepAlive</key>\n\
@@ -42,11 +61,11 @@ fn plist_body(paths: &Paths) -> String {
     )
 }
 
-pub(super) fn register(paths: &Paths) -> Result<()> {
+pub(super) fn register(paths: &Paths, owner: Option<&ServiceOwner>) -> Result<()> {
     if let Some(parent) = paths.service_unit.parent() {
         std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
     }
-    std::fs::write(&paths.service_unit, plist_body(paths))
+    std::fs::write(&paths.service_unit, plist_body(paths, owner))
         .map_err(|e| ServiceError::io(&paths.service_unit, e))?;
     run_launchctl(&["bootstrap", "system", &paths.service_unit.display().to_string()])
 }
@@ -130,11 +149,28 @@ mod tests {
             document_root: PathBuf::from("/var/www/html"),
             log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
         };
-        let body = plist_body(&paths);
+        let body = plist_body(&paths, None);
         assert!(body.contains("<string>dev.ephpm</string>"));
         assert!(body.contains("<string>/usr/local/bin/ephpm</string>"));
         assert!(body.contains("<string>--config</string>"));
         assert!(body.contains("<string>/var/log/ephpm/ephpm.log</string>"));
         assert!(body.contains("<key>RunAtLoad</key>"));
+        assert!(!body.contains("UserName"));
+    }
+
+    #[test]
+    fn plist_body_with_owner_sets_username_groupname() {
+        let paths = Paths {
+            binary: PathBuf::from("/usr/local/bin/ephpm"),
+            config: PathBuf::from("/etc/ephpm/ephpm.toml"),
+            service_unit: PathBuf::from("/Library/LaunchDaemons/dev.ephpm.plist"),
+            data_dir: PathBuf::from("/var/lib/ephpm"),
+            document_root: PathBuf::from("/var/www/html"),
+            log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
+        };
+        let owner = ServiceOwner { user: "ephpm-web".to_string(), group: "ephpm-web".to_string() };
+        let body = plist_body(&paths, Some(&owner));
+        assert!(body.contains("<key>UserName</key>\n    <string>ephpm-web</string>"));
+        assert!(body.contains("<key>GroupName</key>\n    <string>ephpm-web</string>"));
     }
 }

--- a/crates/ephpm/src/service/launchd.rs
+++ b/crates/ephpm/src/service/launchd.rs
@@ -17,11 +17,12 @@ fn owner_keys(owner: Option<&ServiceOwner>) -> String {
     let Some(ServiceOwner { user, group }) = owner else {
         return String::new();
     };
+    // NOTE: no `\` line-continuations here — a trailing backslash swallows the
+    // next source line's leading whitespace, which previously left the
+    // `<string>`/`<key>` lines unindented (the launchd test caught it). Keep
+    // every indent explicit as `\n    ` inside a single literal.
     format!(
-        "    <key>UserName</key>\n\
-    <string>{user}</string>\n\
-    <key>GroupName</key>\n\
-    <string>{group}</string>\n"
+        "    <key>UserName</key>\n    <string>{user}</string>\n    <key>GroupName</key>\n    <string>{group}</string>\n"
     )
 }
 

--- a/crates/ephpm/src/service/mod.rs
+++ b/crates/ephpm/src/service/mod.rs
@@ -14,6 +14,14 @@
 //! | Windows  | `C:\Program Files\ephpm\ephpm.exe` | `C:\ProgramData\ephpm\ephpm.toml` | Windows service `ephpm` | `C:\ProgramData\ephpm\data\` | `C:\ProgramData\ephpm\logs\ephpm.log` |
 //!
 //! All lifecycle commands require elevated privileges (root / Administrator).
+//!
+//! `install` optionally takes a [`ServiceOwner`] (`ephpm install --user
+//! --group`) so the installed service runs as a dedicated non-root account
+//! instead of the elevated installer. Currently implemented on Linux
+//! (systemd `User=`/`Group=` plus a conservative hardening profile) and
+//! macOS (launchd `UserName`/`GroupName`); the Windows SCM backend rejects
+//! `Some(owner)` rather than silently ignoring it, since it has no secure way
+//! to collect and store the account password SCM requires.
 
 #![cfg_attr(unix, allow(unsafe_code))]
 #![allow(clippy::module_name_repetitions)]
@@ -251,6 +259,30 @@ fn copy_binary(src: &Path, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Recursively `chown` `path` to `owner.user:owner.group` by shelling out to
+/// the `chown` binary — present on every Unix ePHPm supports, and it accepts
+/// names directly so this needs no `getpwnam`/`getgrnam` FFI. Matches the
+/// existing pattern in this module of shelling out to platform CLIs
+/// (`systemctl`, `launchctl`) rather than linking their APIs directly.
+#[cfg(unix)]
+fn chown_path(path: &Path, owner: &ServiceOwner) -> Result<()> {
+    let spec = format!("{}:{}", owner.user, owner.group);
+    let out = std::process::Command::new("chown")
+        .arg("-R")
+        .arg(&spec)
+        .arg(path)
+        .output()
+        .map_err(|e| ServiceError::command("chown", e.to_string()))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(ServiceError::command(
+            format!("chown {spec} {}", path.display()),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ))
+    }
+}
+
 /// Write the default config to `path` unless the file already exists. Returns
 /// `true` if a fresh file was written, `false` if an existing config was left
 /// untouched.
@@ -269,12 +301,18 @@ fn write_default_config(path: &Path, document_root: &Path) -> Result<bool> {
 
 /// Install the binary, write a default config, register the service, and start it.
 ///
+/// `owner` is `None` for the historical default (service runs as the elevated
+/// installing account, unit has no sandboxing) or `Some` to run the service as
+/// a dedicated non-root user/group — see [`ServiceOwner`].
+///
 /// # Errors
 ///
 /// Returns [`ServiceError::NotElevated`] if the caller lacks root /
 /// Administrator rights, or an I/O / backend error if any step (binary copy,
-/// config write, service registration, start) fails.
-pub fn install() -> Result<()> {
+/// config write, service registration, start) fails. On Windows, returns
+/// [`ServiceError::Other`] if `owner` is `Some` — the SCM backend does not
+/// yet support installing under a specific account (see `windows::register`).
+pub fn install(owner: Option<&ServiceOwner>) -> Result<()> {
     require_elevation()?;
     let paths = Paths::for_current_platform();
 
@@ -291,7 +329,22 @@ pub fn install() -> Result<()> {
         std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
     }
 
-    backend::register(&paths)?;
+    // The directories above were just created by `require_elevation()`'s
+    // caller — root/Administrator — so they're root-owned. That's the
+    // "root-only assumption" `owner: Some` needs to skip: once the unit runs
+    // as a non-root `User=`, that account needs write access to the data and
+    // log directories itself (ePHPm's own tracing layer opens the log file
+    // directly, not just via systemd's `StandardOutput=append:`). Chowning
+    // is a no-op for `owner: None`, and idempotent on re-install.
+    #[cfg(unix)]
+    if let Some(owner) = owner {
+        chown_path(&paths.data_dir, owner)?;
+        if let Some(parent) = paths.log_file.parent() {
+            chown_path(parent, owner)?;
+        }
+    }
+
+    backend::register(&paths, owner)?;
     backend::start(&paths)?;
     tracing::info!("ephpm service installed and started");
     Ok(())
@@ -430,6 +483,23 @@ pub fn status() -> Result<()> {
 pub fn logs(follow: bool) -> Result<()> {
     let paths = Paths::for_current_platform();
     backend::logs(&paths, follow)
+}
+
+/// Non-root identity the installed service should run as.
+///
+/// When `install()` is called with `None`, the generated unit is byte-for-byte
+/// identical to the pre-#XXX output: no `User=`/`Group=`, no sandboxing
+/// directives, service runs as whatever account performed the (elevated)
+/// install — historically root. Passing `Some` opts into running the service
+/// as `user`/`group` plus a conservative systemd hardening profile (see
+/// `systemd::unit_body`). This is what lets a multi-tenant deployment run
+/// ePHPm under a dedicated non-root account instead of hand-rolling the unit.
+#[derive(Debug, Clone)]
+pub struct ServiceOwner {
+    /// Unix user (or Windows/macOS equivalent) the service process runs as.
+    pub user: String,
+    /// Primary group the service process runs as.
+    pub group: String,
 }
 
 /// Snapshot of service state returned by platform backends.

--- a/crates/ephpm/src/service/systemd.rs
+++ b/crates/ephpm/src/service/systemd.rs
@@ -8,10 +8,53 @@
 
 use std::process::Command;
 
-use super::{Paths, Result, ServiceError, StatusReport};
+use super::{Paths, Result, ServiceError, ServiceOwner, StatusReport};
 
-/// Render the systemd unit file body.
-fn unit_body(paths: &Paths) -> String {
+/// Render the `[Service]`-section lines that opt the unit into running as a
+/// dedicated non-root user, plus a conservative sandboxing profile.
+///
+/// `AmbientCapabilities`/`CapabilityBoundingSet` grant exactly
+/// `CAP_NET_BIND_SERVICE` so a non-root `ExecStart` can still bind `[server]
+/// listen` on a privileged port (80/443) — without it, opting into `--user`
+/// would silently break the common "web service on port 80" case.
+/// `ProtectSystem=strict` makes the whole filesystem read-only except `/dev`,
+/// `/proc`, `/sys`, and the paths listed in `ReadWritePaths`; those are the
+/// three directories ePHPm's own code needs to write after startup — the
+/// data dir (per-site SQLite files, ACME cache), the log directory, and the
+/// document root (multi-tenant `sites_dir` installs typically nest under or
+/// equal `document_root`; a `sites_dir` configured elsewhere needs adding to
+/// `ReadWritePaths` by hand). Each entry is `-`-prefixed (systemd's
+/// ignore-if-missing marker) because `install()` never creates
+/// `document_root`, and a caller providing their own pre-seeded config with a
+/// `sites_dir` outside it may not create it either — an absent path would
+/// otherwise make the unit fail to start instead of just not getting that one
+/// extra write target. Returns an empty string when `owner` is `None` so the
+/// default unit is unaffected.
+fn owner_directives(paths: &Paths, owner: Option<&ServiceOwner>) -> String {
+    let Some(ServiceOwner { user, group }) = owner else {
+        return String::new();
+    };
+    let log_dir = paths.log_file.parent().unwrap_or(&paths.log_file);
+    format!(
+        "User={user}\n\
+Group={group}\n\
+AmbientCapabilities=CAP_NET_BIND_SERVICE\n\
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE\n\
+NoNewPrivileges=true\n\
+ProtectSystem=strict\n\
+ProtectHome=true\n\
+ReadWritePaths=-{data_dir} -{log_dir} -{document_root}\n",
+        data_dir = paths.data_dir.display(),
+        log_dir = log_dir.display(),
+        document_root = paths.document_root.display(),
+    )
+}
+
+/// Render the systemd unit file body. `owner` is `None` for the historical
+/// root-with-no-sandboxing unit (byte-identical to the pre-`--user` output)
+/// or `Some` to run the service as a dedicated non-root user/group — see
+/// [`owner_directives`].
+fn unit_body(paths: &Paths, owner: Option<&ServiceOwner>) -> String {
     format!(
         "[Unit]\n\
 Description=ePHPm — embedded PHP application server\n\
@@ -24,6 +67,7 @@ ExecStart={binary} serve --config {config}\n\
 Restart=on-failure\n\
 RestartSec=2s\n\
 LimitNOFILE=65536\n\
+{owner_directives}\
 StandardOutput=append:{log}\n\
 StandardError=append:{log}\n\
 \n\
@@ -32,15 +76,16 @@ WantedBy=multi-user.target\n",
         binary = paths.binary.display(),
         config = paths.config.display(),
         log = paths.log_file.display(),
+        owner_directives = owner_directives(paths, owner),
     )
 }
 
 /// Write the unit file and reload systemd so the new unit is visible.
-pub(super) fn register(paths: &Paths) -> Result<()> {
+pub(super) fn register(paths: &Paths, owner: Option<&ServiceOwner>) -> Result<()> {
     if let Some(parent) = paths.service_unit.parent() {
         std::fs::create_dir_all(parent).map_err(|e| ServiceError::io(parent, e))?;
     }
-    std::fs::write(&paths.service_unit, unit_body(paths))
+    std::fs::write(&paths.service_unit, unit_body(paths, owner))
         .map_err(|e| ServiceError::io(&paths.service_unit, e))?;
     run_systemctl(&["daemon-reload"])?;
     run_systemctl(&["enable", "ephpm.service"])?;
@@ -141,21 +186,58 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn unit_body_renders_paths() {
-        let paths = Paths {
+    fn test_paths() -> Paths {
+        Paths {
             binary: PathBuf::from("/usr/local/bin/ephpm"),
             config: PathBuf::from("/etc/ephpm/ephpm.toml"),
             service_unit: PathBuf::from("/etc/systemd/system/ephpm.service"),
             data_dir: PathBuf::from("/var/lib/ephpm"),
             document_root: PathBuf::from("/var/www/html"),
             log_file: PathBuf::from("/var/log/ephpm/ephpm.log"),
-        };
-        let body = unit_body(&paths);
+        }
+    }
+
+    #[test]
+    fn unit_body_renders_paths() {
+        let paths = test_paths();
+        let body = unit_body(&paths, None);
         assert!(
             body.contains("ExecStart=/usr/local/bin/ephpm serve --config /etc/ephpm/ephpm.toml")
         );
         assert!(body.contains("StandardOutput=append:/var/log/ephpm/ephpm.log"));
+        assert!(body.contains("WantedBy=multi-user.target"));
+    }
+
+    #[test]
+    fn unit_body_without_owner_omits_user_and_hardening() {
+        // Backward compatibility: no `--user` must produce exactly what
+        // pre-#XXX callers got — root, no `User=`/`Group=`, no sandboxing.
+        let paths = test_paths();
+        let body = unit_body(&paths, None);
+        assert!(!body.contains("User="));
+        assert!(!body.contains("Group="));
+        assert!(!body.contains("ProtectSystem"));
+        assert!(!body.contains("NoNewPrivileges"));
+        assert!(!body.contains("AmbientCapabilities"));
+    }
+
+    #[test]
+    fn unit_body_with_owner_sets_user_group_and_hardening() {
+        let paths = test_paths();
+        let owner = ServiceOwner { user: "ephpm-web".to_string(), group: "ephpm-web".to_string() };
+        let body = unit_body(&paths, Some(&owner));
+        assert!(body.contains("User=ephpm-web"));
+        assert!(body.contains("Group=ephpm-web"));
+        assert!(body.contains("AmbientCapabilities=CAP_NET_BIND_SERVICE"));
+        assert!(body.contains("CapabilityBoundingSet=CAP_NET_BIND_SERVICE"));
+        assert!(body.contains("NoNewPrivileges=true"));
+        assert!(body.contains("ProtectSystem=strict"));
+        assert!(body.contains("ProtectHome=true"));
+        assert!(body.contains("ReadWritePaths=-/var/lib/ephpm -/var/log/ephpm -/var/www/html"));
+        // Unaffected by the owner directives.
+        assert!(
+            body.contains("ExecStart=/usr/local/bin/ephpm serve --config /etc/ephpm/ephpm.toml")
+        );
         assert!(body.contains("WantedBy=multi-user.target"));
     }
 }

--- a/crates/ephpm/src/service/windows.rs
+++ b/crates/ephpm/src/service/windows.rs
@@ -25,7 +25,7 @@ use windows_service::service::{
 use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
 use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
-use super::{Paths, Result, ServiceError, StatusReport};
+use super::{Paths, Result, ServiceError, ServiceOwner, StatusReport};
 
 /// SCM service name.
 const SERVICE_NAME: &str = "ephpm";
@@ -69,7 +69,25 @@ pub fn is_elevated() -> bool {
     }
 }
 
-pub(super) fn register(paths: &Paths) -> Result<()> {
+/// Registers the service with the SCM, always as `LocalSystem`.
+///
+/// # Errors
+///
+/// Returns [`ServiceError::Other`] if `owner` is `Some` — the SCM requires a
+/// stored account password to run a service under a specific account, which
+/// this CLI has no secure way to collect or persist yet. Failing loudly here
+/// (instead of silently installing as `LocalSystem` anyway) keeps `--user` an
+/// honest cross-platform flag: a Windows caller finds out immediately that it
+/// isn't honored here, rather than discovering it later via `services.msc`.
+pub(super) fn register(paths: &Paths, owner: Option<&ServiceOwner>) -> Result<()> {
+    if let Some(ServiceOwner { user, group }) = owner {
+        return Err(ServiceError::Other(format!(
+            "ephpm install --user {user} --group {group} is not supported on Windows yet — the \
+             SCM requires a stored account password to run a service under a specific account, \
+             and there's no secure way to collect one from this CLI. Omit --user to install \
+             running as LocalSystem."
+        )));
+    }
     let manager = ServiceManager::local_computer(
         None::<&OsStr>,
         ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,


### PR DESCRIPTION
Adds `--user`/`--group` to `ephpm install` so the service unit can run as a **non-root** account. Needed for multi-tenant / preview deployments where the ePHPm process must not be root (kernel uid separation is the tenant boundary), and for `switchboard-infra`'s two-uid model.

## Why

Today `ephpm install` emits a systemd unit that runs **as root with no `User=`** — unusable when you need a dedicated service uid. The infra work was hand-rolling units to work around it; this makes the installer first-class instead.

## Changes (`crates/ephpm/src/service/{mod,systemd,launchd,windows}.rs`, `main.rs`)

- New `ServiceOwner { user, group }`, threaded through `install()`. `--group` requires `--user` and defaults to the same name.
- **systemd**: `User=`/`Group=` plus hardening — `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `AmbientCapabilities=CAP_NET_BIND_SERVICE`, and `ReadWritePaths=-data -log -document_root` (ignore-if-missing prefix).
- **Bug fixed along the way**: `install()` created the data/log dirs as root and never re-owned them, so a `User=` unit would come up unable to write its own log. Now `chown -R`s those dirs when `--user` is given (only — default behaviour untouched).
- **launchd** (macOS): `UserName`/`GroupName` mirror.
- **Windows**: `--user` is a hard error (SCM needs a stored password this CLI can't securely collect) — explicit, not a silent no-op.
- **Default (no `--user`) output is byte-identical** — pinned by a test.

## Verified
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test -p ephpm` on Windows; and again on Linux via WSL (exercises `systemd.rs`, which doesn't compile on Windows) — new systemd tests pass. `cargo +nightly fmt --check` clean.
- `launchd.rs` (macOS-only `cfg`) couldn't be compiled in this environment — reviewed by hand against the systemd pattern; flagged as the one unverified path.

Pairs with the `switchboard-infra` PR, whose StackScript calls `ephpm install --user ephpm-web`.
