### PR TITLE
feat(server): built-in reverse proxy v1 — host+path routing to upstreams (v0.8.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ repository = "https://github.com/ephpm/ephpm"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
-hyper = { version = "1", features = ["http1", "http2", "server"] }
-hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
+hyper = { version = "1", features = ["http1", "http2", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "client-legacy", "http1"] }
 http-body-util = "0.1"
 http = "1"
 tower = { version = "0.5", features = ["full"] }

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -380,6 +380,230 @@ pub struct ServerConfig {
     /// Native WebSocket support (experimental, off by default).
     #[serde(default)]
     pub websocket: WebSocketConfig,
+
+    /// Built-in reverse-proxy rules (`[[server.proxy]]`), evaluated in order.
+    ///
+    /// Each rule matches on host and path and forwards a matched request to a
+    /// single upstream (a single-hop forwarder, **not** an edge load balancer).
+    /// Rules are tried top-to-bottom and the **first match wins**; a matched
+    /// rule short-circuits all local serving (static files, PHP, native
+    /// WebSocket termination). An empty list (the default) disables the feature
+    /// entirely — the request path pays one `slice::is_empty()`.
+    ///
+    /// See [`ProxyRuleConfig`] for the per-rule fields and their validation.
+    #[serde(default)]
+    pub proxy: Vec<ProxyRuleConfig>,
+}
+
+/// One reverse-proxy rule (`[[server.proxy]]`).
+///
+/// A rule matches on **host** and **path** and forwards the request to one
+/// **upstream**. Matching, precedence and the "single-hop forwarder, not a load
+/// balancer" scope are described on [`ServerConfig::proxy`].
+///
+/// # Host matcher (`host`)
+///
+/// One string, whose syntax selects the match kind (unambiguous on sight):
+///
+/// | `host` value            | matches                                            |
+/// |-------------------------|----------------------------------------------------|
+/// | `"app.example.com"`     | exact (case-insensitive; port/trailing-dot ignored)|
+/// | `"*.example.com"`       | wildcard — exactly one leftmost label              |
+/// | `".example.com"`        | suffix — the apex and any subdomain                |
+/// | `"*"` or omitted        | any host                                           |
+///
+/// # Path matcher (`path` + `path_exact`)
+///
+/// `path` is a **prefix** by default (`/api` matches `/api`, `/api/v1`, …); the
+/// default `"/"` matches every path. Set `path_exact = true` to require the
+/// request path to equal `path` exactly. Two explicit fields — never a marker
+/// smuggled into the string.
+///
+/// # Upstream (`upstream`)
+///
+/// A `http://host[:port]` URL — **scheme + authority only**. Validated at
+/// startup (fail-closed, so a mistake never becomes a silent no-op):
+///
+/// * `https://` upstreams are a **hard error in v1** — TLS to the upstream
+///   (client cert stores, SNI) is out of scope; v1 targets loopback plaintext
+///   backends. Terminate TLS at this instance and proxy plaintext.
+/// * A **path/query/fragment** in the URL is a **hard error in v1** — v1
+///   forwards the original request path unchanged and does **no** request-path
+///   rewriting (prefix strip/prepend). Give host+port only.
+///
+/// # Timeouts
+///
+/// `connect_timeout_secs` bounds the TCP connect to the upstream; a rule that
+/// matches an unreachable upstream returns `502 Bad Gateway` within this bound
+/// rather than hanging. `read_timeout_secs` bounds the time to receive the
+/// upstream **response head** (time-to-first-byte); it deliberately does **not**
+/// bound the streamed response body, so Server-Sent Events and long downloads
+/// are not cut off. The outer `[server.timeouts] request` ceiling still applies
+/// to the whole request exactly as it does to every handler.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProxyRuleConfig {
+    /// Host matcher. `None` (omitted) or `"*"` matches any host. See the type
+    /// docs for the exact/wildcard/suffix syntax.
+    #[serde(default)]
+    pub host: Option<String>,
+
+    /// Path matcher. A prefix by default (see [`path_exact`](Self::path_exact)).
+    ///
+    /// Default: `"/"` (every path). Must begin with `/`.
+    #[serde(default = "default_proxy_path")]
+    pub path: String,
+
+    /// When `true`, [`path`](Self::path) must equal the request path exactly
+    /// rather than being a prefix.
+    ///
+    /// Default: `false` (prefix match).
+    #[serde(default)]
+    pub path_exact: bool,
+
+    /// Upstream URL — `http://host[:port]`, scheme + authority only.
+    ///
+    /// Required. `https://` and any path/query/fragment are startup errors in
+    /// v1 (see the type docs).
+    pub upstream: String,
+
+    /// TCP connect timeout to the upstream, in seconds.
+    ///
+    /// A matched-but-unreachable upstream returns `502` within this bound. `0`
+    /// means no explicit connect deadline (the OS default applies).
+    ///
+    /// Default: 5 seconds.
+    #[serde(default = "default_proxy_connect_timeout")]
+    pub connect_timeout_secs: u64,
+
+    /// Time-to-first-byte timeout for the upstream response head, in seconds.
+    ///
+    /// Bounds how long ePHPm waits for the upstream to begin responding; it does
+    /// **not** bound the streamed body (so SSE/long downloads are unaffected).
+    /// `0` disables the head-read deadline (the outer `[server.timeouts] request`
+    /// ceiling still applies).
+    ///
+    /// Default: 60 seconds.
+    #[serde(default = "default_proxy_read_timeout")]
+    pub read_timeout_secs: u64,
+}
+
+impl ProxyRuleConfig {
+    /// Validate and normalize the [`upstream`](Self::upstream) URL, returning
+    /// the bare `host[:port]` authority ePHPm forwards to.
+    ///
+    /// This is the single source of truth for the v1 upstream rules; both
+    /// [`Config::validate`] (fail-closed at startup) and the server's rule
+    /// compiler call it, so they can never disagree about what a valid upstream
+    /// is.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message when the URL is not `http://`, uses
+    /// `https://`, carries a path/query/fragment or userinfo, or has an empty
+    /// or malformed authority — all of which are v1 scope errors, not no-ops.
+    pub fn upstream_authority(&self) -> Result<String, String> {
+        let raw = self.upstream.trim();
+        if raw.strip_prefix("https://").is_some() {
+            return Err(format!(
+                "upstream {raw:?} uses https:// — TLS to the upstream is not supported in v1 \
+                 (v1 targets loopback plaintext backends). Terminate TLS at this instance and \
+                 use an http:// upstream."
+            ));
+        }
+        let authority = raw.strip_prefix("http://").ok_or_else(|| {
+            format!(
+                "upstream {raw:?} must be an absolute http:// URL \
+                 (e.g. \"http://127.0.0.1:9000\")"
+            )
+        })?;
+        if authority.is_empty() {
+            return Err(format!("upstream {raw:?} has no host"));
+        }
+        if let Some(pos) = authority.find(['/', '?', '#']) {
+            return Err(format!(
+                "upstream {raw:?} has a path/query/fragment ({rest:?}) — request-path \
+                 rewriting (prefix strip/prepend) is not supported in v1; the original request \
+                 path is forwarded unchanged. Give scheme + host + port only.",
+                rest = &authority[pos..],
+            ));
+        }
+        if authority.contains('@') {
+            return Err(format!(
+                "upstream {raw:?} contains userinfo ('@'), which is not supported"
+            ));
+        }
+        // A lightweight authority sanity check (ephpm-config deliberately has no
+        // `http` dependency): non-empty host, and if a port is present it must be
+        // a valid `u16`. The server re-parses with `http::uri::Authority` as a
+        // strict second gate.
+        let host_part = if let Some(rest) = authority.strip_prefix('[') {
+            // IPv6 literal: `[::1]` or `[::1]:9000`.
+            let (inside, after) = rest
+                .split_once(']')
+                .ok_or_else(|| format!("upstream {raw:?} has an unterminated IPv6 literal"))?;
+            if inside.is_empty() {
+                return Err(format!("upstream {raw:?} has an empty IPv6 literal"));
+            }
+            if let Some(port) = after.strip_prefix(':') {
+                validate_proxy_port(raw, port)?;
+            } else if !after.is_empty() {
+                return Err(format!("upstream {raw:?} has trailing junk after the IPv6 literal"));
+            }
+            inside
+        } else if let Some((host, port)) = authority.rsplit_once(':') {
+            validate_proxy_port(raw, port)?;
+            host
+        } else {
+            authority
+        };
+        if host_part.is_empty() {
+            return Err(format!("upstream {raw:?} has an empty host"));
+        }
+        Ok(authority.to_string())
+    }
+
+    /// Validate the [`host`](Self::host) matcher syntax.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message when a wildcard host is not a single leftmost `*.`
+    /// label, or when the host is otherwise empty.
+    pub fn validate_host(&self) -> Result<(), String> {
+        let Some(host) = self.host.as_deref() else { return Ok(()) };
+        let host = host.trim();
+        if host.is_empty() {
+            return Err("host is empty — omit the key or use \"*\" to match any host".to_string());
+        }
+        if host == "*" || host.starts_with('.') {
+            return Ok(());
+        }
+        if let Some(rest) = host.strip_prefix("*.") {
+            if rest.is_empty() || rest.contains('*') {
+                return Err(format!(
+                    "host {host:?} is not a valid wildcard — a wildcard matches exactly one \
+                     leftmost label, so it must look like \"*.example.com\""
+                ));
+            }
+            return Ok(());
+        }
+        if host.contains('*') {
+            return Err(format!(
+                "host {host:?} contains a '*' that is not a leftmost \"*.\" label — the only \
+                 wildcard form is a single leftmost label (\"*.example.com\")"
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Validate a proxy upstream port component.
+fn validate_proxy_port(raw: &str, port: &str) -> Result<(), String> {
+    if port.is_empty() {
+        return Err(format!("upstream {raw:?} has an empty port after ':'"));
+    }
+    port.parse::<u16>()
+        .map(|_| ())
+        .map_err(|_| format!("upstream {raw:?} has an invalid port {port:?} (must be 0-65535)"))
 }
 
 /// Request limits configuration (`[server.request]`).
@@ -3061,6 +3285,22 @@ impl Config {
             )));
         }
 
+        // [[server.proxy]]: validate every rule at startup so a bad upstream,
+        // an out-of-scope-for-v1 URL (https/path), or a malformed host matcher
+        // fails closed rather than being silently dropped from the rule list.
+        for (i, rule) in self.server.proxy.iter().enumerate() {
+            if !rule.path.starts_with('/') {
+                return Err(ConfigError::Validation(format!(
+                    "[[server.proxy]] rule {i}: path {:?} must begin with '/'",
+                    rule.path,
+                )));
+            }
+            rule.validate_host()
+                .map_err(|e| ConfigError::Validation(format!("[[server.proxy]] rule {i}: {e}")))?;
+            rule.upstream_authority()
+                .map_err(|e| ConfigError::Validation(format!("[[server.proxy]] rule {i}: {e}")))?;
+        }
+
         Ok(())
     }
 
@@ -3184,6 +3424,7 @@ impl Default for ServerConfig {
             tls: None,
             http3: Http3Config::default(),
             websocket: WebSocketConfig::default(),
+            proxy: Vec::new(),
         }
     }
 }
@@ -5097,6 +5338,18 @@ fn default_request_timeout() -> u64 {
     300
 }
 
+fn default_proxy_path() -> String {
+    "/".to_string()
+}
+
+fn default_proxy_connect_timeout() -> u64 {
+    5
+}
+
+fn default_proxy_read_timeout() -> u64 {
+    60
+}
+
 fn default_shutdown_timeout() -> u64 {
     30
 }
@@ -5313,6 +5566,140 @@ alt_svc_max_age = 3600
         assert!(config.server.http3.enabled);
         assert_eq!(config.server.http3.listen.as_deref(), Some("0.0.0.0:8443"));
         assert_eq!(config.server.http3.alt_svc_max_age, 3600);
+    }
+
+    // ── [[server.proxy]] ─────────────────────────────────────────────
+
+    /// No `[[server.proxy]]` section: the rule list is empty (feature off).
+    #[test]
+    fn proxy_absent_defaults_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[server]\nlisten = \"0.0.0.0:8080\"\n").unwrap();
+
+        let config = Config::load(&file).unwrap();
+        assert!(config.server.proxy.is_empty(), "no proxy section means no rules");
+        assert!(ServerConfig::default().proxy.is_empty(), "the hand-written Default agrees");
+    }
+
+    /// A full rule parses every field; the per-rule field defaults hold for a
+    /// partial rule.
+    #[test]
+    fn proxy_rule_parses_fields_and_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r#"
+[[server.proxy]]
+host = "pr-a.example.com"
+path = "/api"
+path_exact = true
+upstream = "http://127.0.0.1:9084"
+connect_timeout_secs = 3
+read_timeout_secs = 45
+
+[[server.proxy]]
+upstream = "http://127.0.0.1:9085"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        config.validate().expect("valid proxy rules must pass validate()");
+        assert_eq!(config.server.proxy.len(), 2, "array-of-tables order preserved");
+
+        let first = &config.server.proxy[0];
+        assert_eq!(first.host.as_deref(), Some("pr-a.example.com"));
+        assert_eq!(first.path, "/api");
+        assert!(first.path_exact);
+        assert_eq!(first.connect_timeout_secs, 3);
+        assert_eq!(first.read_timeout_secs, 45);
+
+        // Partial rule: host/path/timeouts fall back to their field defaults.
+        let second = &config.server.proxy[1];
+        assert_eq!(second.host, None, "omitted host matches any");
+        assert_eq!(second.path, "/", "default path is the catch-all prefix");
+        assert!(!second.path_exact);
+        assert_eq!(second.connect_timeout_secs, 5);
+        assert_eq!(second.read_timeout_secs, 60);
+    }
+
+    #[test]
+    fn proxy_https_upstream_is_a_v1_startup_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[[server.proxy]]\nupstream = \"https://backend.example.com\"\n")
+            .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let err = config.validate().expect_err("https upstream must be rejected in v1");
+        assert!(err.to_string().contains("https"), "{err}");
+    }
+
+    #[test]
+    fn proxy_upstream_with_path_is_a_v1_startup_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, "[[server.proxy]]\nupstream = \"http://127.0.0.1:9000/api\"\n")
+            .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let err = config.validate().expect_err("a path in the upstream must be rejected in v1");
+        assert!(err.to_string().contains("rewriting"), "{err}");
+    }
+
+    #[test]
+    fn proxy_bad_host_wildcard_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            "[[server.proxy]]\nhost = \"a.*.example.com\"\nupstream = \"http://127.0.0.1:9000\"\n",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let err = config.validate().expect_err("a non-leftmost wildcard must be rejected");
+        assert!(err.to_string().contains("wildcard"), "{err}");
+    }
+
+    #[test]
+    fn proxy_relative_path_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            "[[server.proxy]]\npath = \"api\"\nupstream = \"http://127.0.0.1:9000\"\n",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        let err = config.validate().expect_err("a path not starting with / must be rejected");
+        assert!(err.to_string().contains("must begin with '/'"), "{err}");
+    }
+
+    #[test]
+    fn proxy_upstream_authority_forms() {
+        let ok = |u: &str| {
+            ProxyRuleConfig {
+                host: None,
+                path: "/".to_string(),
+                path_exact: false,
+                upstream: u.to_string(),
+                connect_timeout_secs: 5,
+                read_timeout_secs: 60,
+            }
+            .upstream_authority()
+        };
+
+        assert_eq!(ok("http://127.0.0.1:9000").unwrap(), "127.0.0.1:9000");
+        assert_eq!(ok("http://backend").unwrap(), "backend");
+        assert_eq!(ok("http://[::1]:9000").unwrap(), "[::1]:9000");
+        assert!(ok("ftp://x").is_err(), "non-http scheme");
+        assert!(ok("http://host:70000").is_err(), "port out of range");
+        assert!(ok("http://host:").is_err(), "empty port");
+        assert!(ok("http://").is_err(), "no host");
     }
 
     #[test]

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -11,6 +11,7 @@ pub mod opcache;
 #[cfg(feature = "otlp")]
 pub mod otlp;
 pub mod privdrop;
+pub mod proxy;
 pub mod rate_limit;
 pub mod router;
 pub mod screened_backend;

--- a/crates/ephpm-server/src/proxy.rs
+++ b/crates/ephpm-server/src/proxy.rs
@@ -1,0 +1,698 @@
+//! Built-in single-hop HTTP reverse proxy (`[[server.proxy]]`).
+//!
+//! # What this is
+//!
+//! An **ordered rule list**. Each rule matches on **host** and **path** and
+//! forwards a matched request to exactly **one** upstream. Rules are tried
+//! top-to-bottom and the **first match wins**. A matched rule short-circuits all
+//! local serving — [`Router::handle_inner`](crate::router::Router) consults the
+//! proxy *before* it resolves a vhost, serves a static file, runs PHP, or
+//! terminates a native WebSocket. So a proxied host/path is not served locally
+//! at all; it belongs to the backend.
+//!
+//! It is deliberately a **single-hop forwarder, not an edge load balancer**.
+//! There is one upstream per rule and no pool, health checks, retries, circuit
+//! breaking, or response rewriting. Those are v2+ (documented as out of scope in
+//! `site/content/`).
+//!
+//! # Why it exists
+//!
+//! The load-bearing case is **multi-PHP-version hosting**: ePHPm runs one PHP
+//! version per process, so an edge instance can route by host to
+//! version-pinned backends (`pr-a.preview → :9084` on PHP 8.4, `pr-b → :9085` on
+//! 8.5) with clean URLs, no ports in the URL, and TLS terminated once here. The
+//! secondary case is **strangler migration** — route `/api` to a legacy backend
+//! and move an app onto ePHPm route by route.
+//!
+//! # Streaming
+//!
+//! Both directions stream. The incoming request body is boxed and handed
+//! straight to hyper's client (no buffering — uploads stream up), and the
+//! upstream response body is boxed into a [`ServerBody`] (no buffering — SSE and
+//! large downloads stream down). `read_timeout_secs` bounds only the time to
+//! obtain the response **head**, never the streamed body.
+//!
+//! # WebSockets
+//!
+//! A matched rule whose request is an RFC 6455 upgrade is tunnelled: ePHPm opens
+//! a fresh HTTP/1.1 connection to the upstream (not the pooled client — an
+//! upgraded socket is single-use), relays the `101`, then copies bytes in both
+//! directions until either side closes. This is a raw tunnel — distinct from the
+//! native WebSocket *termination* in [`crate::websocket`], which parses frames
+//! and runs PHP per event.
+//!
+//! # Forwarded headers
+//!
+//! The original `Host` is preserved. `X-Forwarded-For` is set to the resolved
+//! client IP (the inbound proxy chain has already been collapsed to that IP by
+//! `[server.security] trusted_proxies`), `X-Forwarded-Proto` to the client-facing
+//! scheme, and `X-Forwarded-Host` to the original `Host`. Hop-by-hop headers are
+//! stripped in both directions (except the upgrade headers on the WebSocket
+//! path).
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use ephpm_config::ProxyRuleConfig;
+use http::uri::{Authority, PathAndQuery, Scheme};
+use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode, Uri};
+use http_body_util::combinators::UnsyncBoxBody;
+use http_body_util::{BodyExt, Empty, Full};
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use metrics::counter;
+
+use crate::body::{self, ServerBody};
+use crate::router::RequestBody;
+use crate::websocket::is_upgrade_request;
+
+/// The request-body type handed to the proxy client. The incoming body (hyper
+/// `Incoming` on TCP, `H3RequestBody` on HTTP/3) is boxed into this single type
+/// so one concrete [`Client`] can forward every transport's requests while still
+/// streaming the body through unbuffered.
+///
+/// Unsync (rather than `BoxBody`) because a [`RequestBody`] is `Send + Unpin`
+/// but not `Sync`; hyper's client requires only `Send`, so this suffices.
+type ProxyReqBody = UnsyncBoxBody<Bytes, std::io::Error>;
+
+/// Hop-by-hop headers (RFC 7230 §6.1) that must not be forwarded end-to-end.
+/// Stripped from both the forwarded request and the relayed response — except on
+/// the WebSocket path, which deliberately keeps `Connection`/`Upgrade`.
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
+/// How a request host is matched against a rule's `host`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HostMatcher {
+    /// `"*"` or omitted — matches any host.
+    Any,
+    /// Exact host (already lowercased).
+    Exact(String),
+    /// `"*.example.com"` — exactly one leftmost label over the stored base
+    /// (`example.com`).
+    Wildcard(String),
+    /// `".example.com"` — the apex (`example.com`) or any subdomain. Stores the
+    /// base without the leading dot.
+    Suffix(String),
+}
+
+impl HostMatcher {
+    /// Compile the config `host` string into a matcher. Assumes the syntax has
+    /// already passed [`ProxyRuleConfig::validate_host`].
+    fn compile(host: Option<&str>) -> Self {
+        match host.map(str::trim) {
+            None | Some("" | "*") => Self::Any,
+            Some(h) if h.starts_with("*.") => Self::Wildcard(h[2..].to_ascii_lowercase()),
+            Some(h) if h.starts_with('.') => Self::Suffix(h[1..].to_ascii_lowercase()),
+            Some(h) => Self::Exact(h.to_ascii_lowercase()),
+        }
+    }
+
+    /// Does `host` (already lowercased, port and trailing dot stripped) match?
+    fn matches(&self, host: &str) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Exact(want) => host == want,
+            Self::Wildcard(base) => host
+                .strip_suffix(base)
+                .and_then(|label| label.strip_suffix('.'))
+                .is_some_and(|label| !label.is_empty() && !label.contains('.')),
+            Self::Suffix(base) => {
+                host == base || host.strip_suffix(base).is_some_and(|p| p.ends_with('.'))
+            }
+        }
+    }
+}
+
+/// How a request path is matched against a rule's `path`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathMatcher {
+    /// Segment-aware prefix: `/api` matches `/api`, `/api/`, `/api/x` but not
+    /// `/apiary`. `/` matches everything.
+    Prefix(String),
+    /// The request path must equal this exactly.
+    Exact(String),
+}
+
+impl PathMatcher {
+    fn compile(path: &str, exact: bool) -> Self {
+        if exact { Self::Exact(path.to_string()) } else { Self::Prefix(path.to_string()) }
+    }
+
+    fn matches(&self, path: &str) -> bool {
+        match self {
+            Self::Exact(want) => path == want,
+            Self::Prefix(prefix) => {
+                let Some(rest) = path.strip_prefix(prefix.as_str()) else { return false };
+                // Match at a segment boundary only, so `/api` does not match
+                // `/apiary`. An empty remainder is an exact hit; a prefix that
+                // already ends in `/` needs no boundary check.
+                rest.is_empty() || prefix.ends_with('/') || rest.starts_with('/')
+            }
+        }
+    }
+}
+
+/// One compiled `[[server.proxy]]` rule: its matchers, its upstream, and its own
+/// pooled client (per-rule so `connect_timeout_secs` can differ between rules;
+/// each client pools connections to exactly this rule's one authority).
+struct CompiledRule {
+    host: HostMatcher,
+    path: PathMatcher,
+    /// The upstream authority (`host[:port]`), used to build the outgoing URI.
+    authority: Authority,
+    /// `host:port` for a manual `TcpStream::connect` on the WebSocket path, with
+    /// the default port 80 filled in when the config omitted it.
+    connect_target: String,
+    /// Time to obtain the upstream response head (`None` when disabled).
+    read_timeout: Option<Duration>,
+    /// TCP connect deadline for the WebSocket path (`None` when disabled). The
+    /// pooled `client` enforces the same bound via its connector.
+    connect_timeout: Option<Duration>,
+    /// Pooled HTTP client for the ordinary (non-upgrade) path.
+    client: Client<HttpConnector, ProxyReqBody>,
+}
+
+/// The reverse-proxy engine: the ordered, compiled rule list.
+///
+/// `None` on the [`Router`](crate::router::Router) when `[[server.proxy]]` is
+/// empty — the request path pays one `Option::is_none()`.
+pub struct ProxyEngine {
+    rules: Vec<CompiledRule>,
+}
+
+impl ProxyEngine {
+    /// Compile the config rules, or `None` when there are none.
+    ///
+    /// Every rule has already passed [`ephpm_config::Config::validate`] at
+    /// startup, so upstream/host parsing here cannot fail for the cases validate
+    /// checks; a defensive parse failure logs and skips the rule rather than
+    /// panicking.
+    #[must_use]
+    pub fn new(rules: &[ProxyRuleConfig]) -> Option<Self> {
+        if rules.is_empty() {
+            return None;
+        }
+        let compiled: Vec<CompiledRule> =
+            rules.iter().enumerate().filter_map(|(i, rule)| Self::compile_rule(i, rule)).collect();
+        if compiled.is_empty() {
+            return None;
+        }
+        tracing::info!(rules = compiled.len(), "built-in reverse proxy enabled");
+        Some(Self { rules: compiled })
+    }
+
+    /// Compile one rule, returning `None` (with an error log) if its upstream
+    /// somehow fails to parse despite startup validation.
+    fn compile_rule(index: usize, rule: &ProxyRuleConfig) -> Option<CompiledRule> {
+        let authority_str = match rule.upstream_authority() {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::error!(rule = index, "skipping invalid [[server.proxy]] upstream: {e}");
+                return None;
+            }
+        };
+        let authority = match authority_str.parse::<Authority>() {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::error!(
+                    rule = index,
+                    upstream = %authority_str,
+                    "skipping [[server.proxy]] rule — upstream is not a valid HTTP authority: {e}"
+                );
+                return None;
+            }
+        };
+        let connect_target = if authority.port_u16().is_some() {
+            authority_str.clone()
+        } else {
+            format!("{authority_str}:80")
+        };
+
+        let connect_timeout = non_zero_secs(rule.connect_timeout_secs);
+        let read_timeout = non_zero_secs(rule.read_timeout_secs);
+
+        let mut connector = HttpConnector::new();
+        connector.set_connect_timeout(connect_timeout);
+        connector.enforce_http(true);
+        let client: Client<HttpConnector, ProxyReqBody> =
+            Client::builder(TokioExecutor::new()).build(connector);
+
+        Some(CompiledRule {
+            host: HostMatcher::compile(rule.host.as_deref()),
+            path: PathMatcher::compile(&rule.path, rule.path_exact),
+            authority,
+            connect_target,
+            read_timeout,
+            connect_timeout,
+            client,
+        })
+    }
+
+    /// Index of the first rule matching `host` (already normalized: lowercased,
+    /// port and trailing dot stripped) and `path` (percent-decoded), or `None`
+    /// when no rule matches. Cheap and non-consuming: the caller checks this
+    /// first and only hands the request to [`forward`](Self::forward) on a hit,
+    /// so a non-match falls through to local serving without moving the request.
+    #[must_use]
+    pub fn match_index(&self, host: &str, path: &str) -> Option<usize> {
+        self.rules.iter().position(|r| r.host.matches(host) && r.path.matches(path))
+    }
+
+    /// Forward `req` to the rule at `idx` (from [`match_index`](Self::match_index))
+    /// and return the response, streaming both directions.
+    ///
+    /// `effective_addr`/`is_https` are the resolved client identity from
+    /// `[server.security] trusted_proxies`; `original_host_header` is the raw
+    /// client `Host` used for `X-Forwarded-Host`.
+    pub async fn forward<B: RequestBody>(
+        &self,
+        idx: usize,
+        req: Request<B>,
+        original_host_header: &str,
+        effective_addr: SocketAddr,
+        is_https: bool,
+    ) -> Response<ServerBody> {
+        let rule = &self.rules[idx];
+        counter!("ephpm_proxy_requests_total").increment(1);
+        if is_upgrade_request(&req) {
+            proxy_upgrade(rule, req, original_host_header, effective_addr, is_https).await
+        } else {
+            proxy_http(rule, req, original_host_header, effective_addr, is_https).await
+        }
+    }
+}
+
+/// `0` disables a timeout knob; anything else is seconds.
+fn non_zero_secs(secs: u64) -> Option<Duration> {
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// Build the outgoing upstream URI: `http://<upstream-authority><original path
+/// and query>`. v1 forwards the original path unchanged (no rewriting).
+fn upstream_uri<B>(req: &Request<B>, authority: &Authority) -> Uri {
+    let path_and_query =
+        req.uri().path_and_query().cloned().unwrap_or_else(|| PathAndQuery::from_static("/"));
+    Uri::builder()
+        .scheme(Scheme::HTTP)
+        .authority(authority.clone())
+        .path_and_query(path_and_query)
+        .build()
+        .expect("valid upstream URI from validated authority")
+}
+
+/// Copy the client headers to the upstream, dropping hop-by-hop headers, and add
+/// the `X-Forwarded-*` set. `keep_upgrade` keeps `Connection`/`Upgrade` for the
+/// WebSocket tunnel.
+fn build_forward_headers(
+    src: &HeaderMap,
+    original_host_header: &str,
+    effective_addr: SocketAddr,
+    is_https: bool,
+    keep_upgrade: bool,
+) -> HeaderMap {
+    let mut out = HeaderMap::with_capacity(src.len() + 3);
+    for (name, value) in src {
+        if is_hop_by_hop(name.as_str(), keep_upgrade) {
+            continue;
+        }
+        out.append(name.clone(), value.clone());
+    }
+
+    // X-Forwarded-For: the resolved client IP. The inbound proxy chain has
+    // already been collapsed to this IP by `trusted_proxies`, so ePHPm sets a
+    // single honest value rather than passing an untrusted client-supplied
+    // chain through.
+    insert_str(&mut out, "x-forwarded-for", &effective_addr.ip().to_string());
+    insert_str(&mut out, "x-forwarded-proto", if is_https { "https" } else { "http" });
+    if !original_host_header.is_empty() {
+        insert_str(&mut out, "x-forwarded-host", original_host_header);
+    }
+    out
+}
+
+/// Whether `name` is a hop-by-hop header. On the WebSocket path the two upgrade
+/// headers are kept so the tunnel can be negotiated end to end.
+fn is_hop_by_hop(name: &str, keep_upgrade: bool) -> bool {
+    if keep_upgrade
+        && (name.eq_ignore_ascii_case("connection") || name.eq_ignore_ascii_case("upgrade"))
+    {
+        return false;
+    }
+    HOP_BY_HOP.iter().any(|h| name.eq_ignore_ascii_case(h))
+}
+
+/// Insert a header, replacing any existing value, ignoring an unparseable value.
+fn insert_str(headers: &mut HeaderMap, name: &'static str, value: &str) {
+    if let Ok(v) = HeaderValue::from_str(value) {
+        headers.insert(HeaderName::from_static(name), v);
+    }
+}
+
+/// Forward an ordinary (non-upgrade) request and stream the response back.
+async fn proxy_http<B: RequestBody>(
+    rule: &CompiledRule,
+    req: Request<B>,
+    original_host_header: &str,
+    effective_addr: SocketAddr,
+    is_https: bool,
+) -> Response<ServerBody> {
+    let uri = upstream_uri(&req, &rule.authority);
+    let method = req.method().clone();
+    let headers =
+        build_forward_headers(req.headers(), original_host_header, effective_addr, is_https, false);
+
+    // Box the incoming body into `ProxyReqBody` — this streams the body through
+    // to the upstream without buffering it.
+    let body: ProxyReqBody = req.into_body().map_err(std::io::Error::other).boxed_unsync();
+
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(dst) = builder.headers_mut() {
+        *dst = headers;
+    }
+    let upstream_req = builder.body(body).expect("valid upstream request");
+
+    let send = rule.client.request(upstream_req);
+    let result = match rule.read_timeout {
+        Some(deadline) => match tokio::time::timeout(deadline, send).await {
+            Ok(r) => r,
+            Err(_) => {
+                counter!("ephpm_proxy_errors_total", "kind" => "read_timeout").increment(1);
+                return bad_gateway("upstream did not send a response head in time");
+            }
+        },
+        None => send.await,
+    };
+
+    let upstream = match result {
+        Ok(resp) => resp,
+        Err(e) => {
+            counter!("ephpm_proxy_errors_total", "kind" => "connect").increment(1);
+            tracing::debug!(%e, "reverse proxy upstream request failed");
+            return bad_gateway("upstream is unreachable");
+        }
+    };
+
+    // Relay status + headers (hop-by-hop stripped) and stream the body.
+    let (parts, incoming) = upstream.into_parts();
+    let mut response = Response::builder().status(parts.status);
+    if let Some(dst) = response.headers_mut() {
+        for (name, value) in &parts.headers {
+            if !is_hop_by_hop(name.as_str(), false) {
+                dst.append(name.clone(), value.clone());
+            }
+        }
+    }
+    let out_body: ServerBody = incoming.map_err(std::io::Error::other).boxed();
+    response.body(out_body).expect("valid proxied response")
+}
+
+/// Tunnel a WebSocket upgrade to the upstream over a fresh HTTP/1.1 connection.
+async fn proxy_upgrade<B: RequestBody>(
+    rule: &CompiledRule,
+    mut req: Request<B>,
+    original_host_header: &str,
+    effective_addr: SocketAddr,
+    is_https: bool,
+) -> Response<ServerBody> {
+    // Capture the downstream (client-facing) upgrade before the request is
+    // consumed.
+    let downstream = hyper::upgrade::on(&mut req);
+
+    let uri = upstream_uri(&req, &rule.authority);
+    let method = req.method().clone();
+    // Keep Connection/Upgrade so the upstream negotiates the same upgrade.
+    let headers =
+        build_forward_headers(req.headers(), original_host_header, effective_addr, is_https, true);
+
+    // Connect a dedicated TCP connection (not the pooled client — an upgraded
+    // socket is single-use).
+    let connect = tokio::net::TcpStream::connect(rule.connect_target.clone());
+    let stream = match rule.connect_timeout {
+        Some(d) => match tokio::time::timeout(d, connect).await {
+            Ok(Ok(s)) => s,
+            _ => {
+                counter!("ephpm_proxy_errors_total", "kind" => "ws_connect").increment(1);
+                return bad_gateway("upstream WebSocket backend is unreachable");
+            }
+        },
+        None => match connect.await {
+            Ok(s) => s,
+            Err(_) => {
+                counter!("ephpm_proxy_errors_total", "kind" => "ws_connect").increment(1);
+                return bad_gateway("upstream WebSocket backend is unreachable");
+            }
+        },
+    };
+
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) =
+        match hyper::client::conn::http1::handshake::<_, Empty<Bytes>>(io).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                counter!("ephpm_proxy_errors_total", "kind" => "ws_handshake").increment(1);
+                tracing::debug!(%e, "reverse proxy upstream WebSocket handshake failed");
+                return bad_gateway("upstream WebSocket handshake failed");
+            }
+        };
+    // Drive the client connection (with upgrade support) in the background.
+    tokio::spawn(async move {
+        if let Err(e) = conn.with_upgrades().await {
+            tracing::debug!(%e, "reverse proxy upstream WebSocket connection closed");
+        }
+    });
+
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(dst) = builder.headers_mut() {
+        *dst = headers;
+    }
+    let upstream_req = builder.body(Empty::<Bytes>::new()).expect("valid upstream upgrade request");
+
+    let upstream_resp = match sender.send_request(upstream_req).await {
+        Ok(r) => r,
+        Err(e) => {
+            counter!("ephpm_proxy_errors_total", "kind" => "ws_request").increment(1);
+            tracing::debug!(%e, "reverse proxy upstream WebSocket request failed");
+            return bad_gateway("upstream WebSocket request failed");
+        }
+    };
+
+    if upstream_resp.status() != StatusCode::SWITCHING_PROTOCOLS {
+        // The upstream refused the upgrade — relay its response verbatim.
+        let (parts, incoming) = upstream_resp.into_parts();
+        let mut response = Response::builder().status(parts.status);
+        if let Some(dst) = response.headers_mut() {
+            for (name, value) in &parts.headers {
+                if !is_hop_by_hop(name.as_str(), false) {
+                    dst.append(name.clone(), value.clone());
+                }
+            }
+        }
+        let out_body: ServerBody = incoming.map_err(std::io::Error::other).boxed();
+        return response.body(out_body).expect("valid proxied response");
+    }
+
+    // Build the 101 to hand back to the client, carrying the upstream's upgrade
+    // headers so the client completes the same handshake.
+    let mut response = Response::builder().status(StatusCode::SWITCHING_PROTOCOLS);
+    if let Some(dst) = response.headers_mut() {
+        for (name, value) in upstream_resp.headers() {
+            // Keep the upgrade headers; drop the rest of the hop-by-hop set.
+            if name.as_str().eq_ignore_ascii_case("connection")
+                || name.as_str().eq_ignore_ascii_case("upgrade")
+                || name.as_str().to_ascii_lowercase().starts_with("sec-websocket")
+            {
+                dst.append(name.clone(), value.clone());
+            }
+        }
+    }
+    let response = response
+        .body(body::buffered(Full::new(Bytes::new())))
+        .expect("valid 101 switching protocols response");
+
+    // Capture the upstream upgrade and tunnel bytes once both sides are upgraded.
+    let upstream_upgrade = hyper::upgrade::on(upstream_resp);
+    tokio::spawn(async move {
+        let (client_io, server_io) = match tokio::try_join!(downstream, upstream_upgrade) {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::debug!(%e, "reverse proxy WebSocket upgrade did not complete");
+                return;
+            }
+        };
+        let mut client_io = TokioIo::new(client_io);
+        let mut server_io = TokioIo::new(server_io);
+        match tokio::io::copy_bidirectional(&mut client_io, &mut server_io).await {
+            Ok((c2s, s2c)) => {
+                tracing::debug!(c2s, s2c, "reverse proxy WebSocket tunnel closed");
+            }
+            Err(e) => tracing::debug!(%e, "reverse proxy WebSocket tunnel error"),
+        }
+    });
+
+    counter!("ephpm_proxy_ws_tunnels_total").increment(1);
+    response
+}
+
+/// A `502 Bad Gateway` with a short plain-text body — never a hang.
+fn bad_gateway(reason: &'static str) -> Response<ServerBody> {
+    Response::builder()
+        .status(StatusCode::BAD_GATEWAY)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(body::buffered(Full::new(Bytes::from(format!("502 Bad Gateway: {reason}")))))
+        .expect("valid 502 response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_any_matches_everything() {
+        let m = HostMatcher::compile(None);
+        assert!(m.matches("anything.example.com"));
+        assert_eq!(HostMatcher::compile(Some("*")), HostMatcher::Any);
+    }
+
+    #[test]
+    fn host_exact() {
+        let m = HostMatcher::compile(Some("App.Example.com"));
+        assert!(m.matches("app.example.com"));
+        assert!(!m.matches("api.example.com"));
+        assert!(!m.matches("app.example.com.evil.com"));
+    }
+
+    #[test]
+    fn host_wildcard_is_one_leftmost_label() {
+        let m = HostMatcher::compile(Some("*.example.com"));
+        assert!(m.matches("pr-a.example.com"));
+        assert!(!m.matches("example.com"), "wildcard does not match the apex");
+        assert!(!m.matches("a.b.example.com"), "wildcard is one label only");
+        assert!(!m.matches("app.other.com"));
+    }
+
+    #[test]
+    fn host_suffix_matches_apex_and_subdomains() {
+        let m = HostMatcher::compile(Some(".example.com"));
+        assert!(m.matches("example.com"), "suffix matches the apex");
+        assert!(m.matches("a.example.com"));
+        assert!(m.matches("a.b.example.com"));
+        assert!(!m.matches("notexample.com"));
+        assert!(!m.matches("example.com.evil.com"));
+    }
+
+    #[test]
+    fn path_prefix_is_segment_aware() {
+        let m = PathMatcher::compile("/api", false);
+        assert!(m.matches("/api"));
+        assert!(m.matches("/api/"));
+        assert!(m.matches("/api/v1/users"));
+        assert!(!m.matches("/apiary"), "prefix must stop at a segment boundary");
+        assert!(!m.matches("/"));
+    }
+
+    #[test]
+    fn path_root_prefix_matches_all() {
+        let m = PathMatcher::compile("/", false);
+        assert!(m.matches("/"));
+        assert!(m.matches("/anything/here"));
+    }
+
+    #[test]
+    fn path_exact() {
+        let m = PathMatcher::compile("/healthz", true);
+        assert!(m.matches("/healthz"));
+        assert!(!m.matches("/healthz/"));
+        assert!(!m.matches("/healthz/sub"));
+    }
+
+    fn rule(host: Option<&str>, path: &str, exact: bool) -> ProxyRuleConfig {
+        ProxyRuleConfig {
+            host: host.map(str::to_string),
+            path: path.to_string(),
+            path_exact: exact,
+            upstream: "http://127.0.0.1:9000".to_string(),
+            connect_timeout_secs: 5,
+            read_timeout_secs: 60,
+        }
+    }
+
+    #[test]
+    fn first_match_wins_in_order() {
+        let engine = ProxyEngine::new(&[
+            rule(Some("app.example.com"), "/api", false),
+            rule(Some("app.example.com"), "/", false),
+            rule(None, "/", false),
+        ])
+        .expect("engine");
+
+        assert_eq!(engine.match_index("app.example.com", "/api/v1"), Some(0));
+        assert_eq!(engine.match_index("app.example.com", "/home"), Some(1));
+        assert_eq!(engine.match_index("other.example.com", "/home"), Some(2));
+    }
+
+    #[test]
+    fn empty_rules_disable_the_engine() {
+        assert!(ProxyEngine::new(&[]).is_none());
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let engine = ProxyEngine::new(&[rule(Some("app.example.com"), "/api", false)]).unwrap();
+        assert_eq!(engine.match_index("other.example.com", "/api"), None);
+        assert_eq!(engine.match_index("app.example.com", "/other"), None);
+    }
+
+    #[test]
+    fn hop_by_hop_detection_respects_the_upgrade_exception() {
+        assert!(is_hop_by_hop("Transfer-Encoding", false));
+        assert!(is_hop_by_hop("Connection", false));
+        assert!(is_hop_by_hop("Upgrade", false));
+        // On the WebSocket path the two upgrade headers are kept.
+        assert!(!is_hop_by_hop("Connection", true));
+        assert!(!is_hop_by_hop("Upgrade", true));
+        assert!(is_hop_by_hop("Transfer-Encoding", true));
+        assert!(!is_hop_by_hop("Content-Type", false));
+    }
+
+    #[test]
+    fn forward_headers_set_x_forwarded_and_preserve_host() {
+        let mut src = HeaderMap::new();
+        src.insert("host", HeaderValue::from_static("app.example.com"));
+        src.insert("connection", HeaderValue::from_static("keep-alive"));
+        src.insert("x-forwarded-for", HeaderValue::from_static("9.9.9.9"));
+        let addr: SocketAddr = "203.0.113.7:54321".parse().unwrap();
+
+        let out = build_forward_headers(&src, "app.example.com", addr, true, false);
+        assert_eq!(out.get("host").unwrap(), "app.example.com", "Host preserved");
+        assert!(out.get("connection").is_none(), "hop-by-hop stripped");
+        assert_eq!(
+            out.get("x-forwarded-for").unwrap(),
+            "203.0.113.7",
+            "XFF is the resolved client IP, not the spoofable inbound value"
+        );
+        assert_eq!(out.get("x-forwarded-proto").unwrap(), "https");
+        assert_eq!(out.get("x-forwarded-host").unwrap(), "app.example.com");
+    }
+
+    #[test]
+    fn ws_upgrade_kept_in_forward_headers() {
+        let mut src = HeaderMap::new();
+        src.insert("connection", HeaderValue::from_static("Upgrade"));
+        src.insert("upgrade", HeaderValue::from_static("websocket"));
+        let addr: SocketAddr = "203.0.113.7:1".parse().unwrap();
+        let out = build_forward_headers(&src, "h", addr, false, true);
+        assert_eq!(out.get("connection").unwrap(), "Upgrade");
+        assert_eq!(out.get("upgrade").unwrap(), "websocket");
+    }
+}

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -408,6 +408,11 @@ pub struct Router {
     /// disabled — in which case an upgrade request is routed like any other
     /// GET, exactly as before the feature existed.
     websocket: Option<Arc<crate::websocket::WsRuntime>>,
+    /// Built-in reverse-proxy engine (`[[server.proxy]]`), or `None` when no
+    /// rules are configured — in which case the proxy check on the request path
+    /// is one `Option::is_none()`. A matched rule short-circuits all local
+    /// serving.
+    proxy: Option<crate::proxy::ProxyEngine>,
     /// Weak self-reference, installed by [`Router::share`].
     ///
     /// A WebSocket session outlives the request that created it, and every
@@ -970,6 +975,7 @@ impl Router {
             sites,
             multi_site,
             websocket: None,
+            proxy: crate::proxy::ProxyEngine::new(&config.server.proxy),
             self_weak: std::sync::Weak::new(),
             websocket_files: config.server.websocket_files.clone(),
             sites_dir: config.server.sites_dir.clone(),
@@ -2206,6 +2212,40 @@ impl Router {
 
         // Resolve real client IP and HTTPS status from trusted proxy headers
         let (effective_addr, is_https) = self.resolve_proxy_info(&req, remote_addr, is_tls);
+
+        // Built-in reverse proxy (`[[server.proxy]]`). Positioned deliberately:
+        //
+        // * AFTER the host-validation gates (trusted host, malformed host) and
+        //   the hidden-file / blocked-path gates above — an operator's global
+        //   blocks still apply to proxied paths, so a proxy rule can never be a
+        //   way around them (documented precedence: gates outrank proxy).
+        // * AFTER `resolve_proxy_info`, so the `X-Forwarded-*` headers carry the
+        //   resolved client identity.
+        // * BEFORE `resolve_site` and the native WebSocket block, so a matched
+        //   rule short-circuits ALL local serving (static, PHP, native WS
+        //   termination) — a proxied host/path belongs to the backend.
+        //
+        // With no rules configured this is one `Option::is_none()`.
+        if let Some(ref proxy) = self.proxy {
+            let proxy_host = extract_server_name(&req).trim_end_matches('.').to_ascii_lowercase();
+            if let Some(idx) = proxy.match_index(&proxy_host, &uri_path) {
+                let original_host = req
+                    .headers()
+                    .get(http::header::HOST)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+                let mut resp =
+                    proxy.forward(idx, req, &original_host, effective_addr, is_https).await;
+                // Configured response headers belong on error/normal responses
+                // but not on a 101 — that hands the socket to the WS tunnel and
+                // anything appended would be read as frame bytes.
+                if resp.status() != StatusCode::SWITCHING_PROTOCOLS {
+                    self.apply_response_headers(&mut resp);
+                }
+                return Ok((resp, "proxy"));
+            }
+        }
 
         let accepts_br = self.compression.enabled && accepts_encoding(&req, "br");
         let accepts_gzip = self.compression.enabled && accepts_encoding(&req, "gzip");

--- a/crates/ephpm-server/tests/proxy_e2e.rs
+++ b/crates/ephpm-server/tests/proxy_e2e.rs
@@ -1,0 +1,286 @@
+//! End-to-end tests for the built-in reverse proxy (`[[server.proxy]]`) against
+//! **real** backends over real TCP.
+//!
+//! Rather than boot the whole `serve()` stack (which needs config, KV, TLS, …),
+//! these tests wrap [`ephpm_server::proxy::ProxyEngine`] in a minimal hyper
+//! HTTP/1.1 edge server. That is enough to exercise everything the proxy path
+//! actually does: real streaming through hyper's client, the `OnUpgrade`
+//! machinery (a request served with `.with_upgrades()` carries it, exactly as it
+//! does in `Router::handle_inner`), and the forwarded-header rewriting. The
+//! matcher logic itself is unit-tested in `proxy.rs`.
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use ephpm_config::ProxyRuleConfig;
+use ephpm_server::proxy::ProxyEngine;
+use futures::{SinkExt, StreamExt};
+use http::{Request, Response, StatusCode};
+use http_body_util::{BodyExt, Full};
+use hyper::body::Incoming;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
+use tokio::net::{TcpListener, TcpStream};
+
+/// Build a rule with sane defaults for a given host/path/upstream.
+fn rule(host: Option<&str>, path: &str, upstream: &str) -> ProxyRuleConfig {
+    ProxyRuleConfig {
+        host: host.map(str::to_string),
+        path: path.to_string(),
+        path_exact: false,
+        upstream: upstream.to_string(),
+        connect_timeout_secs: 2,
+        read_timeout_secs: 5,
+    }
+}
+
+/// A backend that echoes what it received as `key=value` lines, so a test can
+/// assert exactly which `Host`/`X-Forwarded-*`/path/body reached the upstream.
+async fn spawn_http_echo(tag: &'static str) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else { break };
+            tokio::spawn(async move {
+                let service = service_fn(move |req: Request<Incoming>| async move {
+                    let get = |name: &str| {
+                        req.headers()
+                            .get(name)
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("")
+                            .to_string()
+                    };
+                    let host = get("host");
+                    let xff = get("x-forwarded-for");
+                    let xfp = get("x-forwarded-proto");
+                    let xfh = get("x-forwarded-host");
+                    let method = req.method().to_string();
+                    let path = req.uri().path().to_string();
+                    let body = req
+                        .into_body()
+                        .collect()
+                        .await
+                        .map(http_body_util::Collected::to_bytes)
+                        .unwrap_or_default();
+                    let body = String::from_utf8_lossy(&body).into_owned();
+                    let out = format!(
+                        "tag={tag}\nhost={host}\nxff={xff}\nxfp={xfp}\nxfh={xfh}\nmethod={method}\npath={path}\nbody={body}\n"
+                    );
+                    Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(out))))
+                });
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+    addr
+}
+
+/// A WebSocket echo backend: accepts the upgrade and echoes every frame.
+async fn spawn_ws_echo() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else { break };
+            tokio::spawn(async move {
+                let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await else { return };
+                while let Some(Ok(msg)) = ws.next().await {
+                    if msg.is_text() || msg.is_binary() {
+                        if ws.send(msg).await.is_err() {
+                            break;
+                        }
+                    } else if msg.is_close() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// The edge: a hyper HTTP/1.1 server that routes every request through the
+/// engine, returning 404 when no rule matches (mirroring how the real router
+/// falls through to local serving on a miss).
+async fn spawn_edge(engine: ProxyEngine) -> SocketAddr {
+    let engine = Arc::new(engine);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, peer)) = listener.accept().await else { break };
+            let engine = engine.clone();
+            tokio::spawn(async move {
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let engine = engine.clone();
+                    async move {
+                        let host = req
+                            .headers()
+                            .get("host")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("")
+                            .split(':')
+                            .next()
+                            .unwrap_or("")
+                            .trim_end_matches('.')
+                            .to_ascii_lowercase();
+                        let original_host = req
+                            .headers()
+                            .get("host")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("")
+                            .to_string();
+                        let path = req.uri().path().to_string();
+                        let resp = if let Some(idx) = engine.match_index(&host, &path) {
+                            engine.forward(idx, req, &original_host, peer, false).await
+                        } else {
+                            Response::builder()
+                                .status(StatusCode::NOT_FOUND)
+                                .body(ephpm_server::body::buffered(Full::new(Bytes::from_static(
+                                    b"no proxy rule",
+                                ))))
+                                .unwrap()
+                        };
+                        Ok::<_, Infallible>(resp)
+                    }
+                });
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .with_upgrades()
+                    .await;
+            });
+        }
+    });
+    addr
+}
+
+/// Low-level HTTP/1.1 GET/POST with a fully controlled `Host` header (so the
+/// host-routing rules can be exercised without DNS).
+async fn send(
+    edge: SocketAddr,
+    host: &str,
+    path: &str,
+    body: &'static [u8],
+) -> (StatusCode, String) {
+    let stream = TcpStream::connect(edge).await.unwrap();
+    let (mut sender, conn) =
+        hyper::client::conn::http1::handshake(TokioIo::new(stream)).await.unwrap();
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    let method = if body.is_empty() { "GET" } else { "POST" };
+    let req = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("host", host)
+        .body(Full::new(Bytes::from_static(body)))
+        .unwrap();
+    let resp = sender.send_request(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[tokio::test]
+async fn proxies_http_and_preserves_host_and_sets_forwarded_headers() {
+    let backend = spawn_http_echo("A").await;
+    let engine =
+        ProxyEngine::new(&[rule(Some("app.example.com"), "/", &format!("http://{backend}"))])
+            .expect("engine");
+    let edge = spawn_edge(engine).await;
+
+    let (status, body) = send(edge, "app.example.com", "/widgets?x=1", b"").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("tag=A"), "reached backend A:\n{body}");
+    // Host is preserved end to end.
+    assert!(body.contains("host=app.example.com"), "Host must be preserved:\n{body}");
+    // X-Forwarded-* are set correctly.
+    assert!(body.contains("xfp=http"), "X-Forwarded-Proto:\n{body}");
+    assert!(body.contains("xfh=app.example.com"), "X-Forwarded-Host:\n{body}");
+    assert!(body.contains("xff=127.0.0.1"), "X-Forwarded-For is the client IP:\n{body}");
+    // The original path (and query) is forwarded unchanged (no v1 rewriting).
+    assert!(body.contains("path=/widgets"), "path forwarded unchanged:\n{body}");
+}
+
+#[tokio::test]
+async fn streams_request_body_to_the_upstream() {
+    let backend = spawn_http_echo("A").await;
+    let engine =
+        ProxyEngine::new(&[rule(None, "/", &format!("http://{backend}"))]).expect("engine");
+    let edge = spawn_edge(engine).await;
+
+    let (status, body) = send(edge, "anything", "/upload", b"payload-bytes").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("method=POST"), "{body}");
+    assert!(body.contains("body=payload-bytes"), "request body must reach the upstream:\n{body}");
+}
+
+#[tokio::test]
+async fn routes_by_host_and_path_to_distinct_backends() {
+    let a = spawn_http_echo("A").await;
+    let b = spawn_http_echo("B").await;
+    let engine = ProxyEngine::new(&[
+        rule(Some("a.test"), "/", &format!("http://{a}")),
+        rule(Some("b.test"), "/api", &format!("http://{b}")),
+    ])
+    .expect("engine");
+    let edge = spawn_edge(engine).await;
+
+    // Host a.test → backend A.
+    let (_, body_a) = send(edge, "a.test", "/", b"").await;
+    assert!(body_a.contains("tag=A"), "a.test must route to A:\n{body_a}");
+
+    // Host b.test + path /api → backend B.
+    let (_, body_b) = send(edge, "b.test", "/api/v1", b"").await;
+    assert!(body_b.contains("tag=B"), "b.test/api must route to B:\n{body_b}");
+
+    // Host b.test but a non-/api path matches no rule → 404 (falls through).
+    let (status, _) = send(edge, "b.test", "/other", b"").await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "unmatched path must not be proxied");
+
+    // Unknown host → no rule → 404.
+    let (status, _) = send(edge, "c.test", "/", b"").await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "unknown host must not be proxied");
+}
+
+#[tokio::test]
+async fn unreachable_upstream_returns_502_not_a_hang() {
+    // A port nothing listens on. connect_timeout bounds this to ~2s.
+    let engine = ProxyEngine::new(&[rule(None, "/", "http://127.0.0.1:1")]).expect("engine");
+    let edge = spawn_edge(engine).await;
+
+    let (status, body) = send(edge, "anything", "/", b"").await;
+    assert_eq!(status, StatusCode::BAD_GATEWAY, "unreachable upstream must 502");
+    assert!(body.contains("502"), "502 body:\n{body}");
+}
+
+#[tokio::test]
+async fn proxies_a_websocket_upgrade_end_to_end() {
+    let backend = spawn_ws_echo().await;
+    let engine =
+        ProxyEngine::new(&[rule(None, "/", &format!("http://{backend}"))]).expect("engine");
+    let edge = spawn_edge(engine).await;
+
+    // `connect_async` is behind tokio-tungstenite's `connect` feature (not
+    // enabled here), so connect the TCP stream ourselves and drive the client
+    // handshake with `client_async`.
+    let url = format!("ws://{edge}/socket");
+    let stream = TcpStream::connect(edge).await.unwrap();
+    let (mut ws, _resp) =
+        tokio_tungstenite::client_async(url, stream).await.expect("ws connect via proxy");
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Text("hello through proxy".into()))
+        .await
+        .unwrap();
+    let echoed = ws.next().await.expect("a reply").expect("no ws error");
+    assert_eq!(echoed.into_text().unwrap(), "hello through proxy");
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Binary(vec![1, 2, 3, 4])).await.unwrap();
+    let echoed = ws.next().await.expect("a reply").expect("no ws error");
+    assert_eq!(echoed.into_data(), vec![1, 2, 3, 4]);
+}

--- a/site/content/guides/reverse-proxy.md
+++ b/site/content/guides/reverse-proxy.md
@@ -1,0 +1,95 @@
++++
+title = "Reverse proxy"
+weight = 20
++++
+
+ePHPm has a **built-in HTTP reverse proxy**. An ordered list of rules matches a request on **host** and **path** and forwards it to a single upstream, streaming both directions. It is configured entirely in `[[server.proxy]]` — no nginx, no Caddy, one fewer moving part.
+
+It is deliberately a **single-hop forwarder, not an edge load balancer**: one upstream per rule, no pool, no health checks, no retries. Everything on this page is implemented and covered by tests; the "not in v1" list at the end says plainly what it does *not* do.
+
+## Why it exists
+
+**1. Multi-PHP-version hosting.** ePHPm runs one PHP version per process. Put an edge instance in front that routes **by host** to version-pinned backends, and you get multi-version hosting with clean URLs — no ports in the URL, no SNI hacks, TLS terminated once at the edge:
+
+```toml
+# The edge instance. It runs no app itself; it just routes.
+[server]
+listen = "0.0.0.0:443"
+
+[server.tls]
+cert = "/etc/ephpm/fullchain.pem"
+key  = "/etc/ephpm/privkey.pem"
+
+[[server.proxy]]
+host = "pr-a.preview.example.com"
+upstream = "http://127.0.0.1:9084"   # an ephpm built against PHP 8.4
+
+[[server.proxy]]
+host = "pr-b.preview.example.com"
+upstream = "http://127.0.0.1:9085"   # an ephpm built against PHP 8.5
+```
+
+Each backend is an ordinary ePHPm process listening on loopback; the edge terminates TLS and forwards plaintext to it.
+
+**2. Strangler migration.** Route **by path** to a legacy backend and move an app onto ePHPm one route at a time — the [strangler-fig pattern](https://martinfowler.com/bliki/StranglerFigApplication.html):
+
+```toml
+[[server.proxy]]
+path = "/api"                        # still served by the legacy app...
+upstream = "http://127.0.0.1:8000"
+# ...everything else falls through to local ePHPm serving (static + PHP).
+```
+
+Because a matched rule short-circuits local serving and an unmatched request falls through, you can migrate route by route: add local handlers for the paths you've ported, leave the `/api` rule pointing at the legacy backend until it's empty.
+
+## How matching works
+
+Rules are tried **top-to-bottom; the first match wins.** Put specific rules before general ones.
+
+* **`host`** — `"app.example.com"` (exact, case-insensitive), `"*.example.com"` (wildcard over exactly one leftmost label), `".example.com"` (suffix: the apex and any subdomain), or `"*"`/omitted (any host).
+* **`path`** — a segment-aware prefix by default: `/api` matches `/api`, `/api/`, and `/api/v1` but **not** `/apiary`. Set `path_exact = true` to require an exact match. The default `"/"` matches everything.
+
+A matched rule replaces **all** local serving for that request — static files, PHP execution, and native WebSocket termination.
+
+## Where the proxy sits relative to security
+
+The proxy is checked **after** the global security gates, so those gates always win:
+
+* `[server.request] trusted_hosts` (Host allow-list → `421`) runs first.
+* `[server.security]` hidden-file blocking and `blocked_paths` (→ `403`) run first.
+
+A proxy rule can therefore never be used to reach a path an operator has blocked. If you need the opposite precedence for a specific deployment, that is a documented v2 knob — not a v1 default.
+
+## Streaming, timeouts, and failures
+
+* **Streaming both ways.** Request bodies (uploads) stream to the upstream unbuffered; response bodies (SSE, large downloads) stream back unbuffered.
+* **`connect_timeout_secs`** (default 5) bounds the TCP connect. A rule that matches an **unreachable** upstream returns `502 Bad Gateway` within this bound — never a hang.
+* **`read_timeout_secs`** (default 60) bounds only the time to receive the response **head** (time-to-first-byte). It does **not** bound the streamed body, so SSE and long downloads are safe. The outer `[server.timeouts] request` ceiling still applies to the whole request.
+
+## WebSockets
+
+A WebSocket upgrade on a matched rule is **tunnelled** to the upstream — a raw bidirectional byte copy after the `101`. This is distinct from ePHPm's native WebSocket *termination* (`[server.websocket]`), which parses frames and runs PHP per event. Use the proxy tunnel when the upstream owns the WebSocket app; use native termination when *this* instance is the WebSocket app.
+
+## Forwarded headers
+
+The upstream sees a correct client view:
+
+| Header | Value |
+|--------|-------|
+| `Host` | **preserved** — the client's original `Host`, unchanged |
+| `X-Forwarded-For` | the resolved client IP (the inbound chain has been collapsed per `[server.security] trusted_proxies`) |
+| `X-Forwarded-Proto` | `https` or `http`, the client-facing scheme |
+| `X-Forwarded-Host` | the client's original `Host` |
+
+Hop-by-hop headers (`Connection`, `Transfer-Encoding`, …) are stripped in both directions, per RFC 7230.
+
+## Not in v1
+
+Out of scope, and enforced as such — these either error at startup or simply do not exist:
+
+* **Load balancing / multiple upstreams per rule**, health checks, retries, circuit breaking, dynamic upstreams, canary/percentage routing.
+* **Response-body or redirect rewriting** (`sub_filter`-style).
+* **`https://` upstreams.** A `https://` upstream is a **startup error**. Terminate TLS at the edge instance and proxy plaintext to a loopback backend.
+* **Request-path rewriting.** The original request path is forwarded **unchanged**; there is no prefix strip/prepend. A path/query/fragment in the `upstream` URL is a **startup error**. Strangler backends that serve under the same prefix (`/api` → a backend that also serves `/api`) work without rewriting.
+
+These are candidates for a future version.

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -247,6 +247,45 @@ With `enabled = false` (the default) an upgrade request routes exactly like any 
 
 Two ceilings are fixed rather than configurable: 64 channel subscriptions per connection and 256-byte channel names. They bound what one misbehaving script can pin.
 
+### `[[server.proxy]]` — built-in reverse proxy
+
+An **ordered rule list**. Each rule matches on host and path and forwards a matched request to **one** upstream. Rules are tried top-to-bottom and the **first match wins**. A matched rule **short-circuits all local serving** — static files, PHP, and native WebSocket termination — so a proxied host/path belongs entirely to the backend. An empty list (the default) turns the feature off.
+
+It is deliberately a **single-hop forwarder, not an edge load balancer**. See the [reverse-proxy guide](/guides/reverse-proxy/) for the multi-PHP-version and strangler-migration use cases.
+
+**Precedence:** the global host-validation gates (`[server.request] trusted_hosts`) and the `[server.security]` hidden-file / `blocked_paths` gates run **before** the proxy match, so an operator's blocks still apply to proxied paths — a proxy rule can never be used to bypass them.
+
+```toml
+# Route pr-A's host to the PHP 8.4 backend, pr-B's to the 8.5 backend.
+[[server.proxy]]
+host = "pr-a.preview.example.com"
+upstream = "http://127.0.0.1:9084"
+
+[[server.proxy]]
+host = "pr-b.preview.example.com"
+upstream = "http://127.0.0.1:9085"
+
+# Strangler migration: send /api to a legacy backend, keep the rest local.
+[[server.proxy]]
+path = "/api"
+upstream = "http://127.0.0.1:8000"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `host` | string | *(any)* | Host matcher. `"app.example.com"` = exact (case-insensitive; port/trailing-dot ignored); `"*.example.com"` = wildcard over exactly one leftmost label; `".example.com"` = suffix matching the apex and any subdomain; `"*"` or omitted = any host. A non-leftmost `*` is a **startup error**. |
+| `path` | string | `"/"` | Path matcher. A **segment-aware prefix** by default (`/api` matches `/api`, `/api/`, `/api/x` but not `/apiary`); `/` matches every path. Must begin with `/`. |
+| `path_exact` | bool | `false` | When `true`, `path` must equal the request path exactly rather than being a prefix. |
+| `upstream` | string | *(required)* | `http://host[:port]` — scheme + authority only. `https://` upstreams and any path/query/fragment are **startup errors in v1** (see below). |
+| `connect_timeout_secs` | u64 | `5` | TCP connect deadline to the upstream. A matched but unreachable upstream returns `502 Bad Gateway` within this bound rather than hanging. `0` = OS default. |
+| `read_timeout_secs` | u64 | `60` | Time to receive the upstream **response head** (time-to-first-byte). Deliberately does **not** bound the streamed response body, so SSE and long downloads are not cut off. `0` disables the head-read deadline. |
+
+**Streaming and WebSockets.** Both directions stream unbuffered (uploads, SSE, large downloads). An RFC 6455 WebSocket **upgrade** on a matched rule is tunnelled to the upstream (raw byte passthrough), distinct from the native WebSocket *termination* of `[server.websocket]`.
+
+**Forwarded headers.** The original `Host` is preserved. `X-Forwarded-For` is set to the resolved client IP (the inbound proxy chain has already been collapsed to that IP by `[server.security] trusted_proxies`), `X-Forwarded-Proto` to the client-facing scheme, and `X-Forwarded-Host` to the original `Host`. Hop-by-hop headers are stripped in both directions.
+
+**Not in v1 (documented as out of scope):** load balancing, multiple upstreams per route, health checks, retries, circuit breaking, dynamic upstreams, response-body/redirect rewriting, canary/percentage routing — and, specifically, **`https://` upstreams** (terminate TLS at this instance and proxy plaintext to a loopback backend) and **request-path rewriting** (the original request path is forwarded unchanged; there is no prefix strip/prepend). These are v2+.
+
 ```toml
 [server.tls]
 cert = "/etc/ephpm/fullchain.pem"


### PR DESCRIPTION
## What

A **built-in single-hop HTTP reverse proxy** (`[[server.proxy]]`), scoped to v1. An ordered rule list matches a request on **host** and **path** and forwards it to **one** upstream, streaming both directions. A matched rule short-circuits all local serving (static, PHP, native WebSocket termination); an unmatched request falls through unchanged. Target: **v0.8.0**.

Documented plainly as a **single-hop forwarder, not an edge load balancer**.

## Why (all three are real)

1. **Multi-PHP-version hosting** (the load-bearing one): ePHPm runs one PHP version per process. An edge instance routing **by host** to version-pinned loopback backends (`pr-a.preview → :9084` on 8.4, `pr-b → :9085` on 8.5) gives multi-version hosting with clean URLs, no ports-in-URL, TLS terminated once.
2. **Strangler migration**: route **by path** (`/api → legacy`) and adopt ePHPm route by route.
3. **FrankenPHP parity / one fewer moving part than nginx.**

## Design (RFC was reviewed and approved before implementation)

- **Config** — `[[server.proxy]]` array of tables, **first-match-wins**:
  - `host`: `"app.example.com"` exact / `"*.example.com"` wildcard (one leftmost label) / `".example.com"` suffix (apex + subdomains) / `"*"` or omitted (any).
  - `path`: segment-aware prefix (`/api` matches `/api`, `/api/x`, not `/apiary`) or `path_exact = true`. Default `"/"`.
  - `upstream`: `http://host[:port]`, authority only. `connect_timeout_secs` (5), `read_timeout_secs` (60).
  - **All rules validated at startup, fail-closed** (`add-config-knob`): `https://` upstreams and a path/query/fragment in the upstream are **hard errors** ("not supported in v1"), never silent no-ops. Empty list = feature off (one `Option::is_none()` on the hot path).
- **Placement** — slots into `Router::handle_inner` right after `resolve_proxy_info`, **after** the trusted-host / hidden-file / blocked-path gates (gates outrank proxy — documented precedence, so a rule can't bypass an operator's blocks) and **before** `resolve_site` and the native-WS block (so a matched rule owns the request).
- **Streaming** — request and response bodies stream unbuffered through hyper's client. `read_timeout` bounds only the response **head** (time-to-first-byte), never the streamed body, so SSE and long downloads are safe.
- **WebSockets** — an upgrade on a matched rule is **tunnelled** over a fresh one-shot HTTP/1.1 connection (not the pooled client — an upgraded socket is single-use), relaying the `101` then a raw bidirectional byte copy. Distinct from native WS *termination*.
- **Forwarded headers** — `Host` preserved; `X-Forwarded-For` = resolved client IP (inbound chain already collapsed per `[server.security] trusted_proxies`); `X-Forwarded-Proto`/`-Host` set; hop-by-hop headers stripped both directions (except upgrade on the WS path).
- **Unreachable upstream → `502`** within `connect_timeout`, never a hang.

## Explicitly OUT of v1 (documented as out)

Load balancing, multiple upstreams per route, health checks, retries, circuit breaking, dynamic upstreams, response-body/redirect rewriting, canary/percentage routing — **and** `https://` upstreams (terminate TLS here, proxy plaintext to loopback) and **request-path rewriting** (original path forwarded unchanged; no strip/prepend). These are v2+.

## Verified vs inferred

- **Verified end to end.** `proxy_e2e` integration suite drives a real hyper edge server + real HTTP and WebSocket echo backends over TCP: `Host`/`X-Forwarded-*` correctness, host-and-path routing to distinct backends, request-body streaming, `502`-on-unreachable, and WebSocket passthrough (text + binary echo). Also run against the **real `ephpm` binary with curl**: proxied requests reach the backend with the right headers, path routing works, unmatched host/path falls through to local serving, unreachable upstream returns `502`, and a spoofed `X-Forwarded-For` from an untrusted client is correctly overwritten with the real client IP.
- **Inferred (standard hyper patterns), then confirmed by the WS test.** The one-shot `hyper::client::conn::http1` handshake + `hyper::upgrade::on` + `copy_bidirectional` tunnel — the WS passthrough test exercises exactly this path.

## Tests / gates

- `cargo clippy -p ephpm-config -p ephpm-server --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo test -p ephpm-config` (incl. proxy validation) + `cargo test -p ephpm-server --lib` (427 pass, incl. matcher unit tests) + `--test proxy_e2e` (5 pass).
- `cargo deny check` — advisories/bans/licenses/sources ok. No new crate in the tree: the `hyper`/`hyper-util` client features activated code already present, and `Cargo.lock` is unchanged.

## Coordination

Kept the diff to a new `proxy.rs` module + config + one insertion block in `handle_inner` + one `Router` field. Did **not** touch `site_overrides.rs` / `static_files.rs` containment. Expect a rebase around the concurrent response-phase middleware hook (that work is in the response path; this is in the request path).

**Do not merge — reporting for review.**
