### PR TITLE
feat(middleware): response-phase ABI hook + static-path request phase (#395, v0.8.0)

### DIFF
--- a/crates/ephpm-e2e/tests/middleware.rs
+++ b/crates/ephpm-e2e/tests/middleware.rs
@@ -131,26 +131,54 @@ async fn request_without_origin_is_untouched() {
     assert_eq!(header(&resp, "vary"), None);
 }
 
-/// Documented coverage boundary, pinned: in FPM mode the chain runs only for
-/// PHP-dispatched requests, so a static file does NOT pass through middleware.
-/// If that ever changes, this test should be updated deliberately rather than
-/// discovered by an operator whose CORS policy silently started applying to
-/// assets.
+/// Coverage boundary, updated for #395: the middleware chain now runs on the
+/// **static-file** path too, not just PHP-dispatched requests.
+///
+/// Why this is the correct behavior, not a loosened test: the whole point of
+/// #395 is that a gating module (`basic-auth`, `jwt`, `github-auth`, …) must be
+/// able to deny a *static asset* before its bytes leave disk — which requires
+/// running the request phase ahead of static serving. Once the chain runs on
+/// static, a `CONTINUE` module that appends response headers (CORS here,
+/// security headers, compression) necessarily applies to static responses as
+/// well. That is a feature, not a leak: a CORS policy SHOULD cover static
+/// assets a browser fetches cross-origin. This test therefore asserts the new
+/// behavior AND still proves the module makes a real decision on the static
+/// path (an unlisted origin gets nothing).
 #[tokio::test]
-async fn static_files_bypass_the_middleware_chain() {
+async fn middleware_chain_runs_on_static_files() {
     let base_url = required_env("EPHPM_URL");
+
+    // Allowed origin: the CORS module's request phase runs on the static file
+    // and appends its headers to the served asset.
     let resp = client()
         .get(format!("{base_url}/test.html"))
         .header("Origin", ALLOWED_ORIGIN)
         .send()
         .await
         .expect("request /test.html");
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        header(&resp, "access-control-allow-origin"),
+        Some(ALLOWED_ORIGIN),
+        "the chain now runs on static files (#395), so an allowed origin gets CORS headers — \
+         headers: {:?}",
+        resp.headers()
+    );
+    assert_eq!(header(&resp, "vary"), Some("Origin"));
 
+    // The decision is real on the static path too: an unlisted origin gets no
+    // CORS headers (a module unconditionally stamping headers would fail here).
+    let resp = client()
+        .get(format!("{base_url}/test.html"))
+        .header("Origin", "https://not-allowed.e2e.test")
+        .send()
+        .await
+        .expect("request /test.html");
     assert_eq!(resp.status(), 200);
     assert_eq!(
         header(&resp, "access-control-allow-origin"),
         None,
-        "static-file responses are documented as bypassing the middleware chain"
+        "an unlisted origin must not receive CORS headers, even on a static file"
     );
 }
 

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -10,7 +10,19 @@
 //!                                 ephpm_response_t* response_out);
 //! void    ephpm_middleware_shutdown(void);
 //! const char* ephpm_middleware_describe(void);   /* nullable */
+//!
+//! /* Optional, minor 1 — the response phase. A module that does not export
+//!    it is unaffected; the host skips it after generating the response. */
+//! int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
+//!                                          const ephpm_response_ctx_t* response,
+//!                                          ephpm_response_edit_t* edit_out);
 //! ```
+//!
+//! The request phase ([`EphpmResponse`]) fails **closed** — a broken gate must
+//! not fail open — while the response phase ([`EphpmResponseEdit`]) fails
+//! **safe**: an error or panic there leaves the already-authorized response
+//! untouched. Two phases, two policies. Response-phase modules are therefore
+//! transforms (compression, ETag, header injection), **not** security gates.
 //!
 //! The host callback table ([`EphpmHostV1`]) is passed BY POINTER at `init`
 //! (valid for the process lifetime) rather than having modules `dlsym` host
@@ -29,8 +41,33 @@
 
 use std::os::raw::{c_char, c_int};
 
-/// ABI version 1 (`0x01_00_00_00` — major byte gates compatibility).
-pub const ABI_V1: u32 = 0x0100_0000;
+/// Current ABI version (`0xMMmmmmmm`: major byte gates compatibility, the
+/// lower three bytes are an additive minor level).
+///
+/// `0x0100_0001` = major **1**, minor **1**. Minor 1 added the optional
+/// response phase (the [`SYM_INVOKE_RESPONSE`] symbol and the three appended
+/// `response_*` accessors on [`EphpmHostV1`]). The major byte is unchanged
+/// from minor 0, so **every** module built against major 1 still loads:
+/// growth is additive.
+pub const ABI_V1: u32 = 0x0100_0001;
+
+/// Major version — the compatibility gate. A module refuses to init when the
+/// host's major (`host.abi_version >> 24`) is newer than its own.
+pub const ABI_MAJOR: u32 = 1;
+
+/// Minor version — the additive feature level in the low three bytes of
+/// [`ABI_V1`]. A *response-capable* module checks the host's advertised minor
+/// (`host.abi_version & 0x00FF_FFFF`) is at least
+/// [`ABI_MINOR_RESPONSE_PHASE`] before calling any `response_*` accessor: an
+/// older host's table does not have those trailing fields, and reading past a
+/// shorter table is undefined behaviour.
+pub const ABI_MINOR: u32 = 1;
+
+/// The minor version that introduced the response phase — the three
+/// `response_*` accessors on [`EphpmHostV1`] and the [`SYM_INVOKE_RESPONSE`]
+/// symbol. A module needs `host.abi_version & 0x00FF_FFFF >=` this before
+/// using the response-side host callbacks.
+pub const ABI_MINOR_RESPONSE_PHASE: u32 = 1;
 
 /// Middleware verdicts for one request.
 pub const ACTION_CONTINUE: c_int = 0;
@@ -52,6 +89,17 @@ pub const LOG_DEBUG: c_int = 4;
 /// `ephpm_middleware_invoke` call; never store it.
 #[repr(C)]
 pub struct EphpmRequest {
+    _opaque: [u8; 0],
+}
+
+/// Opaque handle to the response being transformed, passed to
+/// `ephpm_middleware_invoke_response`. Read it through the host table's
+/// `response_status` / `response_headers` / `response_body` accessors; every
+/// pointer they return is borrowed and valid **only** for the duration of the
+/// one `ephpm_middleware_invoke_response` call — never store it. Mutate the
+/// response by filling the [`EphpmResponseEdit`] out-struct instead.
+#[repr(C)]
+pub struct EphpmResponseCtx {
     _opaque: [u8; 0],
 }
 
@@ -90,6 +138,42 @@ pub struct EphpmResponse {
     pub response_headers: *const EphpmHeaderKv,
     /// Number of entries in `response_headers`.
     pub response_headers_len: usize,
+}
+
+/// The response-phase edit, filled by `ephpm_middleware_invoke_response`. The
+/// host zero-initializes it before the call (`status = 0`, every pointer
+/// null, every length 0) — a module that touches nothing leaves the response
+/// exactly as it was.
+///
+/// Every pointer a module writes here must stay valid **until its
+/// `ephpm_middleware_invoke_response` returns**; the host applies the edit
+/// (copying out of module memory) before unwinding, exactly like the
+/// request-phase [`EphpmResponse`] contract.
+///
+/// The host applies the fields in a fixed order: `remove_headers` first, then
+/// `set_headers` (replace-or-add, case-insensitive), then `status`, then
+/// `body`. **When `body` is non-null the host also recomputes
+/// `Content-Length`** to the replacement length (dropping any stale value),
+/// so a transform can never desync framing.
+#[repr(C)]
+pub struct EphpmResponseEdit {
+    /// New HTTP status, or `0` to keep the existing one.
+    pub status: u16,
+    /// Replacement response body (`null` = keep the existing body). Valid
+    /// until `invoke_response` returns.
+    pub body: *const u8,
+    /// Length of `body`.
+    pub body_len: usize,
+    /// Headers to replace-or-add, case-insensitively (nullable). Each name
+    /// present in the response is overwritten; absent names are appended.
+    pub set_headers: *const EphpmHeaderKv,
+    /// Number of entries in `set_headers`.
+    pub set_headers_len: usize,
+    /// Header names to delete, case-insensitively (nullable). Each is a
+    /// NUL-terminated UTF-8 string.
+    pub remove_headers: *const *const c_char,
+    /// Number of entries in `remove_headers`.
+    pub remove_headers_len: usize,
 }
 
 /// Version-1 host callback table, passed to `ephpm_middleware_init` and valid
@@ -177,6 +261,26 @@ pub struct EphpmHostV1 {
         ttl_secs: i64,
         out: *mut i64,
     ) -> c_int,
+
+    // ── Response accessors (minor 1; valid only during `invoke_response`) ──
+    //
+    // Appended after `kv_incr_ttl`: a module built against minor 0 never
+    // reads these offsets, so the growth is ABI-compatible. A module that
+    // DOES read them must first confirm `abi_version & 0x00FF_FFFF >=
+    // ABI_MINOR_RESPONSE_PHASE`, otherwise it would read past a shorter
+    // (older-host) table.
+    /// Current response status for `invoke_response`.
+    pub response_status: unsafe extern "C" fn(*const EphpmResponseCtx) -> u16,
+    /// Borrow the response's header list. Writes the array base into
+    /// `*out_ptr` and returns its length; the array is valid only for the
+    /// duration of the call. Duplicate headers (e.g. `Set-Cookie`) appear as
+    /// separate entries.
+    pub response_headers:
+        unsafe extern "C" fn(*const EphpmResponseCtx, out_ptr: *mut *const EphpmHeaderKv) -> usize,
+    /// Borrow the response body. Writes the byte-slice base into `*out_ptr`
+    /// and returns its length; valid only for the duration of the call.
+    pub response_body:
+        unsafe extern "C" fn(*const EphpmResponseCtx, out_ptr: *mut *const u8) -> usize,
 }
 
 /// Symbol names the loader looks up.
@@ -187,11 +291,23 @@ pub const SYM_INVOKE: &[u8] = b"ephpm_middleware_invoke";
 pub const SYM_SHUTDOWN: &[u8] = b"ephpm_middleware_shutdown";
 /// Optional metadata symbol.
 pub const SYM_DESCRIBE: &[u8] = b"ephpm_middleware_describe";
+/// Optional response-phase entrypoint symbol (minor 1). A module that does
+/// not export it has no response phase and the host skips it in that phase.
+pub const SYM_INVOKE_RESPONSE: &[u8] = b"ephpm_middleware_invoke_response";
 
 /// `ephpm_middleware_init` signature.
 pub type InitFn = unsafe extern "C" fn(u32, *const c_char, *const EphpmHostV1) -> c_int;
 /// `ephpm_middleware_invoke` signature.
 pub type InvokeFn = unsafe extern "C" fn(*const EphpmRequest, *mut EphpmResponse) -> c_int;
+/// `ephpm_middleware_invoke_response` signature (optional; minor 1). Return
+/// `0` to apply the edit, non-zero to signal an error — on which the host
+/// leaves the response unchanged (fail-safe: a broken transform must not
+/// corrupt a good response).
+pub type InvokeResponseFn = unsafe extern "C" fn(
+    *const EphpmRequest,
+    *const EphpmResponseCtx,
+    *mut EphpmResponseEdit,
+) -> c_int;
 /// `ephpm_middleware_shutdown` signature.
 pub type ShutdownFn = unsafe extern "C" fn();
 /// `ephpm_middleware_describe` signature.

--- a/crates/ephpm-middleware/src/builtin.rs
+++ b/crates/ephpm-middleware/src/builtin.rs
@@ -16,8 +16,11 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
-use crate::host::{RequestCtx, host_table};
-use crate::{Middleware, Response, abi};
+use crate::host::{RequestCtx, ResponseCtx, host_table};
+use crate::{Middleware, Response, ResponseMiddleware, StagedEdit, abi};
+
+/// Boxed response-phase handler stored on a [`BuiltinModule`].
+type ResponseRunner = Box<dyn Fn(&RequestCtx, &mut ResponseCtx) + Send + Sync>;
 
 /// One middleware compiled into the host binary, adapted behind object-safe
 /// closures so a chain can hold heterogeneous modules.
@@ -26,6 +29,10 @@ use crate::{Middleware, Response, abi};
 /// trait a cdylib module implements; only the transport differs.
 pub struct BuiltinModule {
     run: Box<dyn Fn(&RequestCtx) -> Response + Send + Sync>,
+    /// Optional response-phase handler — present only for modules built via
+    /// [`BuiltinModule::init_response`] (the in-process equivalent of a module
+    /// that opted in with `declare!(Type, response)`).
+    run_response: Option<ResponseRunner>,
     stop: Box<dyn Fn() + Send + Sync>,
     description: &'static str,
 }
@@ -113,7 +120,57 @@ impl BuiltinModule {
             "" => std::any::type_name::<T>(),
             d => d,
         };
-        Ok(Self { run, stop, description })
+        Ok(Self { run, run_response: None, stop, description })
+    }
+
+    /// Construct a `T` that also implements [`ResponseMiddleware`], wiring up
+    /// the response-phase handler in addition to the request-phase one. The
+    /// in-process equivalent of `declare!(Type, response)`.
+    ///
+    /// # Errors
+    ///
+    /// As [`BuiltinModule::init`] — the module's `init` error, or a synthetic
+    /// message when `init` panicked.
+    pub fn init_response<T: ResponseMiddleware>(
+        config: &serde_json::Value,
+    ) -> Result<Self, String> {
+        let instance = catch_unwind(AssertUnwindSafe(|| T::init(config)))
+            .map_err(|_| "middleware init panicked".to_owned())??;
+        let instance = Arc::new(instance);
+        let run = {
+            let instance = Arc::clone(&instance);
+            Box::new(move |ctx: &RequestCtx| {
+                // SAFETY: `ctx` is live for this call; `host_table()` is 'static.
+                let req = unsafe { crate::Request::from_raw(ctx.as_abi(), host_table()) };
+                instance.invoke(&req)
+            }) as Box<dyn Fn(&RequestCtx) -> Response + Send + Sync>
+        };
+        let run_response = {
+            let instance = Arc::clone(&instance);
+            Box::new(move |req_ctx: &RequestCtx, resp: &mut ResponseCtx| {
+                // SAFETY: `req_ctx`/`resp` are live for this call and
+                // `host_table()` is 'static — the same invariants the dlopen
+                // lane provides. The read-through-`as_ptr` borrow ends before
+                // `resp` is mutated by `apply_staged_edit`.
+                let staged = {
+                    let req = unsafe { crate::Request::from_raw(req_ctx.as_abi(), host_table()) };
+                    let mut view =
+                        unsafe { crate::ResponseView::from_raw(resp.as_ptr(), host_table()) };
+                    instance.invoke_response(&req, &mut view);
+                    view.__into_parts()
+                };
+                apply_staged_edit(resp, staged);
+            }) as ResponseRunner
+        };
+        let stop = {
+            let instance = Arc::clone(&instance);
+            Box::new(move || instance.shutdown())
+        };
+        let description = match T::describe() {
+            "" => std::any::type_name::<T>(),
+            d => d,
+        };
+        Ok(Self { run, run_response: Some(run_response), stop, description })
     }
 
     /// Run the module for one request. A panic fails closed as a 500 —
@@ -127,6 +184,23 @@ impl BuiltinModule {
         }
     }
 
+    /// Whether this module has a response-phase handler (built via
+    /// [`BuiltinModule::init_response`]).
+    #[must_use]
+    pub fn has_response_phase(&self) -> bool {
+        self.run_response.is_some()
+    }
+
+    /// Run the module's response phase, mutating `resp` in place. A no-op when
+    /// the module has no response handler. A panic is caught and leaves `resp`
+    /// unchanged (fail-safe — a broken transform must not corrupt a good
+    /// response), matching the `declare!` glue's response contract.
+    pub fn invoke_response(&self, req_ctx: &RequestCtx, resp: &mut ResponseCtx) {
+        if let Some(run_response) = &self.run_response {
+            let _ = catch_unwind(AssertUnwindSafe(|| run_response(req_ctx, resp)));
+        }
+    }
+
     /// Call the module's `shutdown`; panics are swallowed (as in `declare!`).
     pub fn shutdown(&self) {
         let _ = catch_unwind(AssertUnwindSafe(|| (self.stop)()));
@@ -137,6 +211,26 @@ impl BuiltinModule {
     #[must_use]
     pub fn describe(&self) -> &'static str {
         self.description
+    }
+}
+
+/// Apply a drained [`ResponseView`](crate::ResponseView) edit to a
+/// [`ResponseCtx`] in the canonical order: remove headers, then set headers
+/// (replace-or-add), then status, then body. Shared by the in-process lane;
+/// the dlopen lane applies the same order in `ephpm-server`'s host driver.
+fn apply_staged_edit(resp: &mut ResponseCtx, staged: StagedEdit) {
+    let (status, body, set_headers, remove_headers) = staged;
+    for name in &remove_headers {
+        resp.remove_header(name);
+    }
+    for (name, value) in &set_headers {
+        resp.set_header(name, value);
+    }
+    if let Some(status) = status {
+        resp.set_status(status);
+    }
+    if let Some(body) = body {
+        resp.replace_body(body);
     }
 }
 

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_char, c_int};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use crate::abi::{self, EphpmHostV1, EphpmRequest};
+use crate::abi::{self, EphpmHeaderKv, EphpmHostV1, EphpmRequest, EphpmResponseCtx};
 
 /// Owned, C-string-backed request context. Built by the router per request;
 /// the opaque `EphpmRequest*` handed to modules is a pointer to this.
@@ -107,6 +107,176 @@ unsafe extern "C" fn request_body(_req: *const EphpmRequest, out_ptr: *mut *cons
         unsafe { *out_ptr = std::ptr::null() };
     }
     0
+}
+
+// ── Response context (response phase) ─────────────────────────────────────
+
+/// Host-owned, mutable representation of the response being transformed by the
+/// response phase. The opaque `EphpmResponseCtx*` handed to modules is a
+/// pointer to this; the host drives it across the reverse chain, applying each
+/// module's staged edit before handing it to the next module.
+///
+/// Headers are kept as owned Rust strings (easy case-insensitive mutation) and
+/// mirrored into a `CString`-backed [`EphpmHeaderKv`] array rebuilt on every
+/// mutation, so the `response_headers` accessor can hand back a stable
+/// borrowed pointer for the duration of a call.
+pub struct ResponseCtx {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+    body_replaced: bool,
+    kv_strs: Vec<CString>,
+    kvs: Vec<EphpmHeaderKv>,
+}
+
+impl ResponseCtx {
+    /// Build from the response the host just generated.
+    #[must_use]
+    pub fn new(status: u16, headers: Vec<(String, String)>, body: Vec<u8>) -> Self {
+        let mut ctx = Self {
+            status,
+            headers,
+            body,
+            body_replaced: false,
+            kv_strs: Vec::new(),
+            kvs: Vec::new(),
+        };
+        ctx.rebuild_kvs();
+        ctx
+    }
+
+    /// Rebuild the C-string mirror of `headers`. Interior-NUL header names or
+    /// values are dropped (invalid in HTTP anyway).
+    fn rebuild_kvs(&mut self) {
+        self.kv_strs.clear();
+        self.kvs.clear();
+        for (name, value) in &self.headers {
+            let (Ok(n), Ok(v)) = (CString::new(name.as_str()), CString::new(value.as_str())) else {
+                continue;
+            };
+            self.kv_strs.push(n);
+            self.kv_strs.push(v);
+            let len = self.kv_strs.len();
+            self.kvs.push(EphpmHeaderKv {
+                name: self.kv_strs[len - 2].as_ptr(),
+                value: self.kv_strs[len - 1].as_ptr(),
+            });
+        }
+    }
+
+    /// The opaque pointer to pass through the ABI. Valid while `self` lives.
+    #[must_use]
+    pub fn as_ptr(&self) -> *const EphpmResponseCtx {
+        std::ptr::from_ref(self).cast::<EphpmResponseCtx>()
+    }
+
+    /// Current status.
+    #[must_use]
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// Current headers.
+    #[must_use]
+    pub fn headers(&self) -> &[(String, String)] {
+        &self.headers
+    }
+
+    /// Current body.
+    #[must_use]
+    pub fn body(&self) -> &[u8] {
+        &self.body
+    }
+
+    /// Replace the status.
+    pub fn set_status(&mut self, status: u16) {
+        self.status = status;
+    }
+
+    /// Replace the body. Marks the response body as replaced so the host can
+    /// recompute `Content-Length`.
+    pub fn replace_body(&mut self, body: Vec<u8>) {
+        self.body = body;
+        self.body_replaced = true;
+    }
+
+    /// Whether any module replaced the body during the phase.
+    #[must_use]
+    pub fn body_replaced(&self) -> bool {
+        self.body_replaced
+    }
+
+    /// Replace-or-add a header (removes every case-insensitive occurrence,
+    /// then appends the new one).
+    pub fn set_header(&mut self, name: &str, value: &str) {
+        self.headers.retain(|(n, _)| !n.eq_ignore_ascii_case(name));
+        self.headers.push((name.to_owned(), value.to_owned()));
+        self.rebuild_kvs();
+    }
+
+    /// Remove every case-insensitive occurrence of `name`.
+    pub fn remove_header(&mut self, name: &str) {
+        let before = self.headers.len();
+        self.headers.retain(|(n, _)| !n.eq_ignore_ascii_case(name));
+        if self.headers.len() != before {
+            self.rebuild_kvs();
+        }
+    }
+
+    /// Consume the context back into owned response parts.
+    #[must_use]
+    pub fn into_parts(self) -> (u16, Vec<(String, String)>, Vec<u8>) {
+        (self.status, self.headers, self.body)
+    }
+}
+
+// SAFETY: the opaque pointer is only turned back into &ResponseCtx by the
+// accessors below, on the thread running the response phase, while it lives.
+unsafe fn resp_ctx<'a>(p: *const EphpmResponseCtx) -> Option<&'a ResponseCtx> {
+    // SAFETY: see above — `p` originates from ResponseCtx::as_ptr.
+    unsafe { p.cast::<ResponseCtx>().as_ref() }
+}
+
+unsafe extern "C" fn response_status(p: *const EphpmResponseCtx) -> u16 {
+    // SAFETY: ABI contract (pointer from as_ptr, live during invoke_response).
+    unsafe { resp_ctx(p) }.map_or(0, ResponseCtx::status)
+}
+
+unsafe extern "C" fn response_headers(
+    p: *const EphpmResponseCtx,
+    out_ptr: *mut *const EphpmHeaderKv,
+) -> usize {
+    // SAFETY: ABI contract.
+    let Some(ctx) = (unsafe { resp_ctx(p) }) else {
+        if !out_ptr.is_null() {
+            // SAFETY: module passes a valid out-pointer.
+            unsafe { *out_ptr = std::ptr::null() };
+        }
+        return 0;
+    };
+    if !out_ptr.is_null() {
+        let base = if ctx.kvs.is_empty() { std::ptr::null() } else { ctx.kvs.as_ptr() };
+        // SAFETY: module passes a valid out-pointer.
+        unsafe { *out_ptr = base };
+    }
+    ctx.kvs.len()
+}
+
+unsafe extern "C" fn response_body(p: *const EphpmResponseCtx, out_ptr: *mut *const u8) -> usize {
+    // SAFETY: ABI contract.
+    let Some(ctx) = (unsafe { resp_ctx(p) }) else {
+        if !out_ptr.is_null() {
+            // SAFETY: module passes a valid out-pointer.
+            unsafe { *out_ptr = std::ptr::null() };
+        }
+        return 0;
+    };
+    if !out_ptr.is_null() {
+        let base = if ctx.body.is_empty() { std::ptr::null() } else { ctx.body.as_ptr() };
+        // SAFETY: module passes a valid out-pointer.
+        unsafe { *out_ptr = base };
+    }
+    ctx.body.len()
 }
 
 // ── KV callbacks ─────────────────────────────────────────────────────────
@@ -286,6 +456,9 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     kv_free,
     log: host_log,
     kv_incr_ttl,
+    response_status,
+    response_headers,
+    response_body,
 };
 
 /// Wire the embedded KV store into the host table. Call once at startup,

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -1,9 +1,15 @@
 //! Native middleware for ePHPm: the C ABI plus a safe Rust authoring kit.
 //!
-//! ePHPm runs middleware per request **before PHP dispatch** — reject,
+//! ePHPm middleware runs in two phases. The **request phase**
+//! ([`Middleware::invoke`]) runs *before* a request is served — reject,
 //! rewrite, or annotate requests at native speed, with direct access to the
-//! embedded (cluster-replicated) KV store. See `site/content/` middleware
-//! docs for the operator view.
+//! embedded (cluster-replicated) KV store; it runs on the PHP path and the
+//! static-file path, and fails closed. The optional **response phase**
+//! ([`ResponseMiddleware::invoke_response`], opted into with
+//! `declare!(Type, response)`) runs *after* the response is generated, in
+//! reverse chain order, to transform it (compression, ETag, header
+//! injection); it fails safe and is not a security gate. See `site/content/`
+//! middleware docs for the operator view.
 //!
 //! There are two execution lanes for the same [`Middleware`] trait:
 //!
@@ -51,7 +57,7 @@ pub mod host;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
-use abi::{EphpmHostV1, EphpmRequest};
+use abi::{EphpmHeaderKv, EphpmHostV1, EphpmRequest, EphpmResponseCtx};
 
 /// The trait a Rust-authored middleware implements. [`declare!`] generates
 /// the C ABI exports around it.
@@ -79,6 +85,40 @@ pub trait Middleware: Sized + Send + Sync + 'static {
     fn describe() -> &'static str {
         ""
     }
+}
+
+/// The optional **response phase** of a middleware. A module implements this
+/// *in addition* to [`Middleware`] and opts in with `declare!(Type, response)`
+/// — the plain `declare!(Type)` does not export the response symbol, so the
+/// host skips such a module during the response phase.
+///
+/// The response phase runs **after** the response is generated (PHP output,
+/// a static file, an error page, or a request-phase `RESPOND` short-circuit),
+/// in **reverse** chain order, and — unlike the request phase — it runs on
+/// **static** responses too. Its purpose is to *transform* a response:
+/// compression, ETag / conditional-GET, response-header injection.
+///
+/// Two hard contracts, both consequences of where and how it runs:
+///
+/// - **It may run without a preceding [`Middleware::invoke`].** On the static
+///   path no request phase runs at all, and an upstream request-phase
+///   `RESPOND` can short-circuit before this module's `invoke`. A response
+///   handler must therefore not assume any per-request state its own `invoke`
+///   would have set.
+/// - **It is not a security gate.** The phase fails *safe*: a panic or an
+///   error leaves the response unchanged rather than failing closed. Gate
+///   requests in [`Middleware::invoke`] (which fails closed); use this only to
+///   transform an already-authorized response.
+///
+/// The phase applies to **buffered** responses only. A streamed response
+/// (worker-mode `send_response_stream`, large files served straight from
+/// disk) bypasses it entirely in this ABI version.
+pub trait ResponseMiddleware: Middleware {
+    /// Inspect and transform the generated response via `resp`. Staged edits
+    /// (status / body / header changes) are applied by the host after this
+    /// returns, in the documented order. Must not panic (a panic is caught
+    /// and the response is left unchanged).
+    fn invoke_response(&self, req: &Request<'_>, resp: &mut ResponseView<'_>);
 }
 
 // ── Safe request view ─────────────────────────────────────────────────────
@@ -343,6 +383,139 @@ impl<'a> Host<'a> {
     }
 }
 
+// ── Response view (response phase) ────────────────────────────────────────
+
+/// The edits a [`ResponseView`] staged, drained for the host to apply:
+/// `(new status, replacement body, set-or-replace headers, remove headers)`.
+#[doc(hidden)]
+pub type StagedEdit = (Option<u16>, Option<Vec<u8>>, Vec<(String, String)>, Vec<String>);
+
+/// Mutable view of the generated response, handed to
+/// [`ResponseMiddleware::invoke_response`]. Reads reflect the response as it
+/// stands on entry (already carrying any edits from later-in-reverse modules);
+/// writes are *staged* and applied by the host after `invoke_response`
+/// returns, in the order: remove headers, set headers, status, body.
+///
+/// Valid only inside `invoke_response`. Borrowed slices returned by
+/// [`body`](Self::body) / [`headers`](Self::headers) point into host memory
+/// live only for that call — never store them.
+pub struct ResponseView<'a> {
+    ctx: *const EphpmResponseCtx,
+    host: &'a EphpmHostV1,
+    new_status: Option<u16>,
+    new_body: Option<Vec<u8>>,
+    set_headers: Vec<(String, String)>,
+    remove_headers: Vec<String>,
+}
+
+impl ResponseView<'_> {
+    /// Wrap the raw response handle + host table. Used by [`declare!`] glue
+    /// and by unit tests that drive a module directly.
+    ///
+    /// # Safety
+    ///
+    /// `ctx` must be the live response handle passed to `invoke_response` and
+    /// `host` the table given at init, both outliving the returned view. The
+    /// host must advertise minor >= [`abi::ABI_MINOR_RESPONSE_PHASE`] so the
+    /// `response_*` accessors are present.
+    #[must_use]
+    pub unsafe fn from_raw(ctx: *const EphpmResponseCtx, host: &EphpmHostV1) -> ResponseView<'_> {
+        ResponseView {
+            ctx,
+            host,
+            new_status: None,
+            new_body: None,
+            set_headers: Vec::new(),
+            remove_headers: Vec::new(),
+        }
+    }
+
+    /// Current HTTP status of the response.
+    #[must_use]
+    pub fn status(&self) -> u16 {
+        // SAFETY: contract of `from_raw` — `ctx` is live for this call.
+        unsafe { (self.host.response_status)(self.ctx) }
+    }
+
+    /// Current response body bytes (borrowed; valid only for this call).
+    #[must_use]
+    pub fn body(&self) -> &[u8] {
+        let mut ptr: *const u8 = std::ptr::null();
+        // SAFETY: contract of `from_raw`; `ptr` points at a local.
+        let len = unsafe { (self.host.response_body)(self.ctx, &raw mut ptr) };
+        if ptr.is_null() || len == 0 {
+            return &[];
+        }
+        // SAFETY: the host returned a live `(ptr, len)` byte slice valid for
+        // the duration of this call.
+        unsafe { std::slice::from_raw_parts(ptr, len) }
+    }
+
+    /// Iterate the response headers as `(name, value)` (borrowed; valid only
+    /// for this call). Duplicate headers appear as separate items.
+    #[must_use]
+    pub fn headers(&self) -> Vec<(&str, &str)> {
+        let mut ptr: *const EphpmHeaderKv = std::ptr::null();
+        // SAFETY: contract of `from_raw`; `ptr` points at a local.
+        let len = unsafe { (self.host.response_headers)(self.ctx, &raw mut ptr) };
+        if ptr.is_null() || len == 0 {
+            return Vec::new();
+        }
+        // SAFETY: the host returned a live array of `len` header KVs valid for
+        // the duration of this call.
+        let kvs = unsafe { std::slice::from_raw_parts(ptr, len) };
+        kvs.iter()
+            .filter_map(|kv| {
+                if kv.name.is_null() || kv.value.is_null() {
+                    return None;
+                }
+                // SAFETY: non-null name/value are NUL-terminated per the ABI.
+                let name = unsafe { CStr::from_ptr(kv.name) }.to_str().ok()?;
+                // SAFETY: as above.
+                let value = unsafe { CStr::from_ptr(kv.value) }.to_str().ok()?;
+                Some((name, value))
+            })
+            .collect()
+    }
+
+    /// First value of `name` (case-insensitive), if present.
+    #[must_use]
+    pub fn header(&self, name: &str) -> Option<String> {
+        self.headers()
+            .into_iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.to_owned())
+    }
+
+    /// Stage a new HTTP status.
+    pub fn set_status(&mut self, status: u16) {
+        self.new_status = Some(status);
+    }
+
+    /// Stage a replacement body.
+    pub fn set_body(&mut self, body: impl Into<Vec<u8>>) {
+        self.new_body = Some(body.into());
+    }
+
+    /// Stage a header, replacing any existing occurrences (case-insensitive)
+    /// or adding it when absent.
+    pub fn set_header(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.set_headers.push((name.into(), value.into()));
+    }
+
+    /// Stage removal of every header named `name` (case-insensitive).
+    pub fn remove_header(&mut self, name: impl Into<String>) {
+        self.remove_headers.push(name.into());
+    }
+
+    /// Internal: drain the staged edits for the [`declare!`] glue to marshal.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn __into_parts(self) -> StagedEdit {
+        (self.new_status, self.new_body, self.set_headers, self.remove_headers)
+    }
+}
+
 // ── declare! ──────────────────────────────────────────────────────────────
 
 /// Generate the four C ABI exports around a [`Middleware`] implementation.
@@ -354,7 +527,17 @@ impl<'a> Host<'a> {
 /// fail-closed).
 #[macro_export]
 macro_rules! declare {
+    // Request phase only — no response symbol is exported, so the host skips
+    // this module during the response phase.
     ($ty:ty) => {
+        $crate::declare!(@inner $ty,);
+    };
+    // Request + response phase — also exports `ephpm_middleware_invoke_response`
+    // (requires `$ty: ResponseMiddleware`).
+    ($ty:ty, response) => {
+        $crate::declare!(@inner $ty, response);
+    };
+    (@inner $ty:ty, $($response:ident)?) => {
         mod __ephpm_mw_glue {
             #![allow(unsafe_code)]
             use super::*;
@@ -504,6 +687,93 @@ macro_rules! declare {
                     })
                     .as_ptr()
             }
+
+            // Optional response-phase export, emitted only for
+            // `declare!($ty, response)`. `$response` is the literal token
+            // `response`; referencing it in the doc attribute keeps the `?`
+            // repetition well-formed while gating the whole block.
+            $(
+                thread_local! {
+                    // Backing storage for the pointers handed to the host in
+                    // EphpmResponseEdit; alive until the next invoke_response
+                    // on this thread (the host applies the edit before then).
+                    static RESP_OUT: std::cell::RefCell<(
+                        Option<Vec<u8>>,
+                        Vec<CString>,
+                        Vec<abi::EphpmHeaderKv>,
+                        Vec<*const c_char>,
+                    )> = std::cell::RefCell::new((None, Vec::new(), Vec::new(), Vec::new()));
+                }
+
+                #[doc = concat!("Response phase (`", stringify!($response), "`) enabled.")]
+                #[unsafe(no_mangle)]
+                unsafe extern "C" fn ephpm_middleware_invoke_response(
+                    request: *const abi::EphpmRequest,
+                    response: *const abi::EphpmResponseCtx,
+                    edit_out: *mut abi::EphpmResponseEdit,
+                ) -> c_int {
+                    if edit_out.is_null() {
+                        return -1;
+                    }
+                    let (Some(instance), Some(host)) = (INSTANCE.get(), HOST.get()) else {
+                        return -1;
+                    };
+
+                    let parts = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        // SAFETY: `request`/`response` are live for this call;
+                        // `host` is the init-time table.
+                        let req = unsafe { $crate::Request::from_raw(request, host) };
+                        let mut view =
+                            unsafe { $crate::ResponseView::from_raw(response, host) };
+                        <$ty as $crate::ResponseMiddleware>::invoke_response(
+                            instance, &req, &mut view,
+                        );
+                        view.__into_parts()
+                    }));
+
+                    // Fail-safe: a panicking transform leaves the response
+                    // unchanged (rc != 0 => host applies no edit).
+                    let (status, body, set_headers, remove_headers) = match parts {
+                        Ok(p) => p,
+                        Err(_) => return -1,
+                    };
+
+                    RESP_OUT.with(|cell| {
+                        let mut out = cell.borrow_mut();
+                        let out = &mut *out;
+                        let ((body_ptr, body_len), set_kvs, remove_ptrs) =
+                            $crate::__marshal_edit(
+                                body,
+                                &set_headers,
+                                &remove_headers,
+                                &mut out.0,
+                                &mut out.1,
+                            );
+                        out.2 = set_kvs;
+                        out.3 = remove_ptrs;
+                        // SAFETY: edit_out is a valid, host-owned,
+                        // zero-initialised out-struct.
+                        unsafe {
+                            (*edit_out).status = status.unwrap_or(0);
+                            (*edit_out).body = body_ptr;
+                            (*edit_out).body_len = body_len;
+                            (*edit_out).set_headers = if out.2.is_empty() {
+                                std::ptr::null()
+                            } else {
+                                out.2.as_ptr()
+                            };
+                            (*edit_out).set_headers_len = out.2.len();
+                            (*edit_out).remove_headers = if out.3.is_empty() {
+                                std::ptr::null()
+                            } else {
+                                out.3.as_ptr()
+                            };
+                            (*edit_out).remove_headers_len = out.3.len();
+                        }
+                    });
+                    0
+                }
+            )?
         }
         pub use __ephpm_mw_glue::__ephpm_mw_host;
     };
@@ -602,4 +872,45 @@ fn marshal_headers(
         });
     }
     kvs
+}
+
+/// Internal marshaling helper for the [`declare!`] response-phase glue: stages
+/// the response edit into thread-local storage and returns the raw pointers
+/// for [`abi::EphpmResponseEdit`]. The body pointer is null when the module
+/// did not replace the body (`None`); a `Some(empty)` replacement yields a
+/// non-null pointer with length 0 (the host's length-0 guard never
+/// dereferences it), so "replace with empty body" is distinguishable from
+/// "keep body".
+///
+/// Every returned pointer borrows `body_buf` / `str_buf`, which the caller
+/// keeps alive in thread-local storage until the next `invoke_response` on the
+/// same thread — long enough for the host to apply the edit.
+#[doc(hidden)]
+#[must_use]
+pub fn __marshal_edit(
+    body: Option<Vec<u8>>,
+    set_headers: &[(String, String)],
+    remove_headers: &[String],
+    body_buf: &mut Option<Vec<u8>>,
+    str_buf: &mut Vec<CString>,
+) -> ((*const u8, usize), Vec<abi::EphpmHeaderKv>, Vec<*const c_char>) {
+    *body_buf = body;
+    let body_parts = match body_buf.as_ref() {
+        Some(b) => (b.as_ptr(), b.len()),
+        None => (std::ptr::null(), 0),
+    };
+
+    str_buf.clear();
+    let set_kvs = marshal_headers(set_headers, str_buf);
+
+    let mut remove_ptrs = Vec::with_capacity(remove_headers.len());
+    for name in remove_headers {
+        let Ok(n) = CString::new(name.as_str()) else {
+            continue;
+        };
+        str_buf.push(n);
+        remove_ptrs.push(str_buf[str_buf.len() - 1].as_ptr());
+    }
+
+    (body_parts, set_kvs, remove_ptrs)
 }

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -156,5 +156,18 @@ crate-type = ["cdylib"]
 name = "mw_probe_no_invoke"
 crate-type = ["cdylib"]
 
+# Response-phase proof module (tests/middleware_response_phase.rs). Opts into
+# the response phase via `declare!(Type, response)`, so it exports the optional
+# `ephpm_middleware_invoke_response` symbol the mw_probe_* fixtures do not.
+[[example]]
+name = "mw_response_gzip"
+crate-type = ["cdylib"]
+
+# Minimal header-injection response-phase module — used by the router
+# integration tests to prove the phase runs on the static-file path (#395).
+[[example]]
+name = "mw_response_header"
+crate-type = ["cdylib"]
+
 [lints]
 workspace = true

--- a/crates/ephpm-server/examples/mw_response_gzip.rs
+++ b/crates/ephpm-server/examples/mw_response_gzip.rs
@@ -1,0 +1,91 @@
+//! Proof module for the middleware **response phase**: a real gzip response
+//! compressor built through the `declare!(Type, response)` macro.
+//!
+//! It demonstrates the two-phase model end to end — the request phase is a
+//! no-op (`CONTINUE`), and the response phase transforms the *generated*
+//! response: it gzips the body, sets `Content-Encoding: gzip`, and drops the
+//! now-stale `Content-Length`/`ETag`. Because the host runs the response phase
+//! on **static** responses too, mounting this module compresses static assets
+//! (`.html`, `.css`, JSON) — something a request-phase-only module could never
+//! do.
+//!
+//! It is shipped here as a `crate-type = ["cdylib"]` example (like the
+//! `mw_probe_*` fixtures) so `cargo test -p ephpm-server` always leaves a
+//! loadable library on disk for `tests/middleware_response_phase.rs`, and so
+//! it can be dropped next to a real `ephpm` binary and driven with `curl`
+//! (see the middleware docs).
+//!
+//! Deliberately conservative — it compresses only when the client sent
+//! `Accept-Encoding: gzip`, the response is not already encoded, and the body
+//! is non-empty — because the response phase is a transform, not a gate: it
+//! must never turn a good response into a broken one.
+
+use std::io::Write;
+
+use ephpm_middleware::{Middleware, Request, Response, ResponseMiddleware, ResponseView};
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+/// gzip response compressor.
+pub struct Gzip {
+    /// Bodies at least this many bytes are compressed (smaller ones are left
+    /// alone — gzip framing can exceed the savings). Defaults to 32.
+    min_size: usize,
+}
+
+impl Middleware for Gzip {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let min_size = config
+            .get("min_size")
+            .and_then(serde_json::Value::as_u64)
+            .map_or(32, |n| usize::try_from(n).unwrap_or(usize::MAX));
+        Ok(Self { min_size })
+    }
+
+    // Request phase: nothing to gate — all the work is in the response phase.
+    fn invoke(&self, _req: &Request<'_>) -> Response {
+        Response::cont()
+    }
+
+    fn describe() -> &'static str {
+        "mw-response-gzip (ephpm-server proof module)"
+    }
+}
+
+impl ResponseMiddleware for Gzip {
+    fn invoke_response(&self, req: &Request<'_>, resp: &mut ResponseView<'_>) {
+        // Only when the client opted in.
+        let accepts_gzip = req
+            .header("Accept-Encoding")
+            .is_some_and(|v| v.split(',').any(|enc| enc.trim().eq_ignore_ascii_case("gzip")));
+        if !accepts_gzip {
+            return;
+        }
+        // Never double-encode a response another layer already compressed.
+        if resp.header("Content-Encoding").is_some() {
+            return;
+        }
+        let body = resp.body();
+        if body.len() < self.min_size {
+            return;
+        }
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        if encoder.write_all(body).is_err() {
+            return;
+        }
+        let Ok(compressed) = encoder.finish() else {
+            return;
+        };
+
+        resp.set_body(compressed);
+        resp.set_header("Content-Encoding", "gzip");
+        resp.set_header("Vary", "Accept-Encoding");
+        // The host recomputes Content-Length for the replaced body, but an
+        // ETag computed over the identity body no longer matches the encoded
+        // one — drop it rather than serve a wrong validator.
+        resp.remove_header("ETag");
+    }
+}
+
+ephpm_middleware::declare!(Gzip, response);

--- a/crates/ephpm-server/examples/mw_response_header.rs
+++ b/crates/ephpm-server/examples/mw_response_header.rs
@@ -1,0 +1,53 @@
+//! Minimal response-phase proof module: injects a configurable response header
+//! (default `X-Resp-Phase: 1`) during the response phase.
+//!
+//! Deliberately trivial and free of the built-in compression's competition, so
+//! the router integration tests can assert "the response phase ran on this
+//! response" by a single header check — including on the **static-file** path,
+//! which had no middleware at all before the response phase existed.
+//!
+//! Shipped as a `crate-type = ["cdylib"]` example so `cargo test -p
+//! ephpm-server` always leaves it loadable on disk.
+
+use ephpm_middleware::{Middleware, Request, Response, ResponseMiddleware, ResponseView};
+
+/// Injects one response header in the response phase.
+pub struct HeaderStamp {
+    name: String,
+    value: String,
+}
+
+impl Middleware for HeaderStamp {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        Ok(Self {
+            name: config
+                .get("header")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("X-Resp-Phase")
+                .to_owned(),
+            value: config
+                .get("value")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("1")
+                .to_owned(),
+        })
+    }
+
+    // Request phase: no-op. The header is added in the response phase, so its
+    // presence proves the response phase ran.
+    fn invoke(&self, _req: &Request<'_>) -> Response {
+        Response::cont()
+    }
+
+    fn describe() -> &'static str {
+        "mw-response-header (ephpm-server proof module)"
+    }
+}
+
+impl ResponseMiddleware for HeaderStamp {
+    fn invoke_response(&self, _req: &Request<'_>, resp: &mut ResponseView<'_>) {
+        resp.set_header(&self.name, &self.value);
+    }
+}
+
+ephpm_middleware::declare!(HeaderStamp, response);

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -16,18 +16,28 @@
 //!    stock release binaries on every platform (the Linux release is
 //!    glibc-dynamic).
 //!
-//! **Coverage:** the chain runs only for PHP-dispatched requests (inside
-//! `Router::handle_php`). Static-file responses and error responses (403/404
-//! from the router) do NOT pass through middleware, **in any mode**. This is
-//! true of worker mode too: a request for a file that exists on disk still
-//! takes the static branch and never reaches the worker (only a missing-file
-//! fallback is routed to PHP), so the chain does **not** see it. A middleware
-//! mount therefore cannot gate confidential static assets — media, JS/CSS
-//! bundles and their source maps, CSV/SQL/ZIP exports left in the document
-//! root are served without consulting the chain. To keep such files private,
-//! do not place them in a web-served document root. Making the chain gate the
-//! static branch is a separate, deliberate design decision (issue #395) and is
-//! not implemented.
+//! **Coverage (two phases):**
+//!
+//! - The **request phase** ([`MiddlewareChain::evaluate`], `CONTINUE`/
+//!   `RESPOND`/`REWRITE`) runs before a request is served. It runs on the PHP
+//!   path (inside `Router::handle_php`) **and**, as of the response-phase work
+//!   (issue #395), on the **static-file** path — before the file is read —
+//!   through `Router::static_request_phase`. A `RESPOND` there (e.g. an auth
+//!   denial) short-circuits, so a middleware mount CAN now gate confidential
+//!   static assets: the file's bytes never leave disk. It fails **closed**.
+//! - The **response phase** ([`MiddlewareChain::run_response_phase`]) runs
+//!   *after* the response is generated, in **reverse** chain order, letting
+//!   response-capable modules transform status/headers/body (compression,
+//!   ETag, header injection). It runs on PHP, static, worker-buffered, and
+//!   error responses alike, but only on **buffered** bodies — a streamed
+//!   response (worker `send_response_stream`, large files streamed from disk)
+//!   bypasses it. It fails **safe**: a broken transform leaves the response
+//!   unchanged. Only modules that export `ephpm_middleware_invoke_response`
+//!   (Rust: `declare!(Type, response)`) participate.
+//!
+//! Internal endpoints and the security gates that answer before routing
+//! (metrics/health/ACME, trusted-host/hidden-file/blocked-path 4xx) return
+//! ahead of both phases and are never seen by the chain.
 //!
 //! v1 chain semantics: `RESPOND` short-circuits the chain immediately.
 //! `REWRITE` accumulates a path override (last writer wins) and header
@@ -50,7 +60,7 @@ use anyhow::Context;
 use ephpm_config::MiddlewareMount;
 use ephpm_middleware::abi;
 use ephpm_middleware::builtin::{BuiltinModule, Verdict};
-use ephpm_middleware::host::RequestCtx;
+use ephpm_middleware::host::{RequestCtx, ResponseCtx};
 
 /// An ordered chain of loaded middleware modules.
 ///
@@ -82,11 +92,25 @@ enum Backend {
     Dynamic {
         /// Per-request entrypoint resolved from the library.
         invoke: abi::InvokeFn,
+        /// Optional response-phase entrypoint (`ephpm_middleware_invoke_response`).
+        /// `None` when the module does not export it — the host then skips this
+        /// module during the response phase (v1-module compatibility).
+        invoke_response: Option<abi::InvokeResponseFn>,
         /// Shutdown entrypoint resolved from the library.
         shutdown: abi::ShutdownFn,
         /// Keeps the library (and thus the fn pointers) alive.
         _lib: libloading::Library,
     },
+}
+
+impl Loaded {
+    /// Whether this module participates in the response phase.
+    fn has_response_phase(&self) -> bool {
+        match &self.backend {
+            Backend::Builtin(builtin) => builtin.has_response_phase(),
+            Backend::Dynamic { invoke_response, .. } => invoke_response.is_some(),
+        }
+    }
 }
 
 /// Constructor signature for a middleware compiled into this binary.
@@ -141,6 +165,20 @@ pub enum ChainVerdict {
         /// Extra response headers set by the module.
         headers: Vec<(String, String)>,
     },
+}
+
+/// Result of running the response phase over a generated response.
+pub struct ResponsePhaseOutcome {
+    /// Final HTTP status.
+    pub status: u16,
+    /// Final response headers (UTF-8-decodable set the router handed in,
+    /// after every module's edits).
+    pub headers: Vec<(String, String)>,
+    /// Final response body.
+    pub body: Vec<u8>,
+    /// Whether any module replaced the body — the router recomputes
+    /// `Content-Length` when true.
+    pub body_replaced: bool,
 }
 
 impl MiddlewareChain {
@@ -255,6 +293,66 @@ impl MiddlewareChain {
 
         ChainVerdict::Continue { rewrite_path, header_overrides, response_headers }
     }
+
+    /// Whether any loaded module participates in the response phase — the
+    /// router uses this to skip the whole response-phase machinery (including
+    /// the body collect) when no module can transform a response.
+    #[must_use]
+    pub fn has_response_phase(&self) -> bool {
+        self.modules.iter().any(Loaded::has_response_phase)
+    }
+
+    /// Run the **response phase** over an already-generated response.
+    ///
+    /// Response-capable modules whose `match` glob matches `path` run in
+    /// **reverse** chain order (onion unwind). Each transforms the response in
+    /// place — status, headers, body — via its staged edit, applied in the
+    /// order remove-headers → set-headers → status → body. A module that
+    /// replaced the body has `Content-Length` recomputed for it by the router
+    /// when the response is rebuilt.
+    ///
+    /// Unlike [`evaluate`](Self::evaluate) this runs even when no request phase
+    /// ran (the static-file path) or an upstream request-phase module
+    /// short-circuited — hence the documented contract that a response handler
+    /// must not assume paired per-request state. It fails **safe**: a module
+    /// error or panic leaves the response untouched.
+    #[must_use]
+    pub fn run_response_phase(
+        &self,
+        req_ctx: &RequestCtx,
+        path: &str,
+        status: u16,
+        headers: Vec<(String, String)>,
+        body: Vec<u8>,
+    ) -> ResponsePhaseOutcome {
+        let mut ctx = ResponseCtx::new(status, headers, body);
+        for module in self.modules.iter().rev() {
+            if !module.has_response_phase() {
+                continue;
+            }
+            if let Some(pattern) = &module.match_pattern
+                && !path_matches(pattern, path)
+            {
+                continue;
+            }
+            counter!(
+                "ephpm_middleware_response_invocations_total",
+                "module" => module.name.clone()
+            )
+            .increment(1);
+            match &module.backend {
+                Backend::Builtin(builtin) => builtin.invoke_response(req_ctx, &mut ctx),
+                Backend::Dynamic { invoke_response: Some(invoke_response), .. } => {
+                    invoke_response_dynamic(*invoke_response, req_ctx, &mut ctx, &module.name);
+                }
+                // Filtered out by `has_response_phase` above.
+                Backend::Dynamic { invoke_response: None, .. } => {}
+            }
+        }
+        let body_replaced = ctx.body_replaced();
+        let (status, headers, body) = ctx.into_parts();
+        ResponsePhaseOutcome { status, headers, body, body_replaced }
+    }
 }
 
 impl Drop for MiddlewareChain {
@@ -351,6 +449,89 @@ fn invoke_dynamic(invoke: abi::InvokeFn, ctx: &RequestCtx, name: &str) -> Verdic
             Verdict::Continue { response_headers: Vec::new() }
         }
     }
+}
+
+/// Call a dlopened module's `invoke_response`, copy its staged edit into owned
+/// host memory, and apply it to `ctx` in the canonical order (remove → set →
+/// status → body). Fails **safe**: a non-zero return leaves `ctx` untouched
+/// (a broken transform must not corrupt an already-authorized response).
+fn invoke_response_dynamic(
+    invoke_response: abi::InvokeResponseFn,
+    req_ctx: &RequestCtx,
+    ctx: &mut ResponseCtx,
+    name: &str,
+) {
+    // Zero-initialised edit: keep status, keep body, no header ops — the
+    // documented pre-call state.
+    let mut edit = abi::EphpmResponseEdit {
+        status: 0,
+        body: std::ptr::null(),
+        body_len: 0,
+        set_headers: std::ptr::null(),
+        set_headers_len: 0,
+        remove_headers: std::ptr::null(),
+        remove_headers_len: 0,
+    };
+    // SAFETY: `req_ctx.as_abi()` and `ctx.as_ptr()` are live for this call
+    // (`ctx` is only read through the const handle here — it is mutated below,
+    // strictly after the call returns), `edit` is a valid zero-initialised
+    // out-struct, and `invoke_response` points into a library kept alive by
+    // the owning `Backend::Dynamic`.
+    let rc = unsafe { invoke_response(req_ctx.as_abi(), ctx.as_ptr(), &raw mut edit) };
+    if rc != 0 {
+        tracing::warn!(
+            module = %name,
+            rc,
+            "response middleware returned an error — leaving the response unchanged"
+        );
+        return;
+    }
+
+    // Copy everything the module pointed at before it can reuse the buffers —
+    // the ABI only guarantees the edit pointers until invoke_response's caller
+    // returns, and we are still inside that window.
+    let status = (edit.status != 0).then_some(edit.status);
+    // SAFETY: a non-null `body` is valid for `body_len` bytes in this window.
+    let body = (!edit.body.is_null()).then(|| unsafe { copy_bytes(edit.body, edit.body_len) });
+    // SAFETY: `set_headers` is null or a live array of `set_headers_len` KVs.
+    let set_headers = unsafe { copy_headers(edit.set_headers, edit.set_headers_len) };
+    // SAFETY: `remove_headers` is null or a live array of `remove_headers_len`
+    // NUL-terminated name pointers.
+    let remove_headers =
+        unsafe { copy_remove_headers(edit.remove_headers, edit.remove_headers_len) };
+
+    for header in &remove_headers {
+        ctx.remove_header(header);
+    }
+    for (header, value) in &set_headers {
+        ctx.set_header(header, value);
+    }
+    if let Some(status) = status {
+        ctx.set_status(status);
+    }
+    if let Some(body) = body {
+        ctx.replace_body(body);
+    }
+}
+
+/// Copy a nullable module-owned array of NUL-terminated header-name pointers
+/// into host memory. Entries with a null pointer are skipped.
+///
+/// # Safety
+///
+/// `p` must be null or valid for reads of `len` `*const c_char` entries whose
+/// non-null members are NUL-terminated strings.
+unsafe fn copy_remove_headers(p: *const *const c_char, len: usize) -> Vec<String> {
+    if p.is_null() || len == 0 {
+        return Vec::new();
+    }
+    // SAFETY: caller contract — `(p, len)` is a live array of name pointers.
+    let names = unsafe { std::slice::from_raw_parts(p, len) };
+    names
+        .iter()
+        // SAFETY: caller contract — each non-null entry is a C string.
+        .filter_map(|&name| unsafe { copy_c_str(name) })
+        .collect()
 }
 
 /// Mounts sorted by ascending `order` (stable: equal orders keep declaration
@@ -456,6 +637,11 @@ fn load_module(mount: &MiddlewareMount, path: &Path) -> anyhow::Result<Loaded> {
     // SAFETY: as above. `describe` is optional — absence is not an error.
     let describe: Option<abi::DescribeFn> =
         unsafe { lib.get::<abi::DescribeFn>(abi::SYM_DESCRIBE) }.ok().map(|sym| *sym);
+    // SAFETY: as above. `invoke_response` is optional (minor 1) — a module
+    // that does not export it has no response phase and the host skips it
+    // there. This is the primary v1-module compatibility mechanism.
+    let invoke_response: Option<abi::InvokeResponseFn> =
+        unsafe { lib.get::<abi::InvokeResponseFn>(abi::SYM_INVOKE_RESPONSE) }.ok().map(|sym| *sym);
 
     // Serialise the mount's config table to JSON for the module's init.
     let config_json: Option<CString> = mount
@@ -509,7 +695,7 @@ fn load_module(mount: &MiddlewareMount, path: &Path) -> anyhow::Result<Loaded> {
     Ok(Loaded {
         name: mount.library.clone(),
         match_pattern: mount.match_pattern.clone(),
-        backend: Backend::Dynamic { invoke, shutdown, _lib: lib },
+        backend: Backend::Dynamic { invoke, invoke_response, shutdown, _lib: lib },
     })
 }
 
@@ -1011,5 +1197,194 @@ mod tests {
             ChainVerdict::Continue { .. } => panic!("preflight must short-circuit through dlopen"),
         }
         drop(chain);
+    }
+
+    // ── Response phase (builtin lane) ─────────────────────────────────────
+
+    use ephpm_middleware::{Middleware, Request, Response, ResponseMiddleware, ResponseView};
+
+    /// Appends its `id` to the running `X-Seq` header, so the final value
+    /// records the order the response phase visited modules in.
+    struct SeqTag {
+        id: String,
+    }
+    impl Middleware for SeqTag {
+        fn init(config: &serde_json::Value) -> Result<Self, String> {
+            Ok(Self { id: config["id"].as_str().unwrap_or("?").to_owned() })
+        }
+        fn invoke(&self, _req: &Request<'_>) -> Response {
+            Response::cont()
+        }
+    }
+    impl ResponseMiddleware for SeqTag {
+        fn invoke_response(&self, _req: &Request<'_>, resp: &mut ResponseView<'_>) {
+            let next = match resp.header("X-Seq") {
+                Some(cur) if !cur.is_empty() => format!("{cur},{}", self.id),
+                _ => self.id.clone(),
+            };
+            resp.set_header("X-Seq", next);
+        }
+    }
+
+    /// Rewrites status, body, and headers — the buffered transform surface.
+    struct Transformer;
+    impl Middleware for Transformer {
+        fn init(_config: &serde_json::Value) -> Result<Self, String> {
+            Ok(Self)
+        }
+        fn invoke(&self, _req: &Request<'_>) -> Response {
+            Response::cont()
+        }
+    }
+    impl ResponseMiddleware for Transformer {
+        fn invoke_response(&self, _req: &Request<'_>, resp: &mut ResponseView<'_>) {
+            resp.set_status(201);
+            let upper = resp.body().to_ascii_uppercase();
+            resp.set_body(upper);
+            resp.set_header("X-Transformed", "1");
+            resp.remove_header("X-Remove-Me");
+        }
+    }
+
+    /// Panics in the response phase — must be contained (fail-safe).
+    struct Panicker;
+    impl Middleware for Panicker {
+        fn init(_config: &serde_json::Value) -> Result<Self, String> {
+            Ok(Self)
+        }
+        fn invoke(&self, _req: &Request<'_>) -> Response {
+            Response::cont()
+        }
+    }
+    impl ResponseMiddleware for Panicker {
+        fn invoke_response(&self, _req: &Request<'_>, _resp: &mut ResponseView<'_>) {
+            panic!("boom in the response phase");
+        }
+    }
+
+    /// Request-phase only — no `ResponseMiddleware`, so no response phase.
+    struct RequestOnly;
+    impl Middleware for RequestOnly {
+        fn init(_config: &serde_json::Value) -> Result<Self, String> {
+            Ok(Self)
+        }
+        fn invoke(&self, _req: &Request<'_>) -> Response {
+            Response::cont()
+        }
+    }
+
+    fn loaded_response<T: ResponseMiddleware>(
+        name: &str,
+        pattern: Option<&str>,
+        config: serde_json::Value,
+    ) -> Loaded {
+        Loaded {
+            name: name.to_owned(),
+            match_pattern: pattern.map(str::to_owned),
+            backend: Backend::Builtin(BuiltinModule::init_response::<T>(&config).expect("init")),
+        }
+    }
+
+    fn loaded_request<T: Middleware>(name: &str) -> Loaded {
+        Loaded {
+            name: name.to_owned(),
+            match_pattern: None,
+            backend: Backend::Builtin(
+                BuiltinModule::init::<T>(&serde_json::Value::Null).expect("init"),
+            ),
+        }
+    }
+
+    fn resp_ctx() -> RequestCtx {
+        RequestCtx::new("GET", "/x", "", "203.0.113.9", "resp.test", &[])
+    }
+
+    #[test]
+    fn response_phase_runs_in_reverse_chain_order() {
+        // Chain order a, b -> response phase visits b then a (onion unwind).
+        let chain = MiddlewareChain {
+            modules: vec![
+                loaded_response::<SeqTag>("a", None, serde_json::json!({ "id": "a" })),
+                loaded_response::<SeqTag>("b", None, serde_json::json!({ "id": "b" })),
+            ],
+        };
+        let out = chain.run_response_phase(&resp_ctx(), "/x", 200, Vec::new(), Vec::new());
+        assert_eq!(
+            out.headers.iter().find(|(n, _)| n == "X-Seq").map(|(_, v)| v.as_str()),
+            Some("b,a"),
+            "last request-phase module (b) unwinds first"
+        );
+    }
+
+    #[test]
+    fn response_phase_transforms_status_body_and_headers() {
+        let chain = MiddlewareChain {
+            modules: vec![loaded_response::<Transformer>("t", None, serde_json::Value::Null)],
+        };
+        let headers = vec![
+            ("Content-Type".to_owned(), "text/plain".to_owned()),
+            ("X-Remove-Me".to_owned(), "gone".to_owned()),
+        ];
+        let out = chain.run_response_phase(&resp_ctx(), "/x", 200, headers, b"hello".to_vec());
+        assert_eq!(out.status, 201);
+        assert_eq!(out.body, b"HELLO");
+        assert!(out.body_replaced);
+        assert!(out.headers.iter().any(|(n, v)| n == "X-Transformed" && v == "1"));
+        assert!(!out.headers.iter().any(|(n, _)| n.eq_ignore_ascii_case("X-Remove-Me")));
+        // Untouched headers survive.
+        assert!(out.headers.iter().any(|(n, _)| n.eq_ignore_ascii_case("Content-Type")));
+    }
+
+    #[test]
+    fn response_phase_fails_safe_on_module_panic() {
+        let chain = MiddlewareChain {
+            modules: vec![loaded_response::<Panicker>("p", None, serde_json::Value::Null)],
+        };
+        let headers = vec![("X-Keep".to_owned(), "yes".to_owned())];
+        let out = chain.run_response_phase(&resp_ctx(), "/x", 200, headers, b"body".to_vec());
+        // A panicking transform leaves the response exactly as it was.
+        assert_eq!(out.status, 200);
+        assert_eq!(out.body, b"body");
+        assert!(!out.body_replaced);
+        assert_eq!(out.headers, vec![("X-Keep".to_owned(), "yes".to_owned())]);
+    }
+
+    #[test]
+    fn modules_without_a_response_phase_are_skipped() {
+        // A request-only module reports no response phase.
+        let request_only = MiddlewareChain { modules: vec![loaded_request::<RequestOnly>("r")] };
+        assert!(!request_only.has_response_phase());
+
+        // Mixed: the request-only module is skipped, the transformer still runs.
+        let mixed = MiddlewareChain {
+            modules: vec![
+                loaded_request::<RequestOnly>("r"),
+                loaded_response::<Transformer>("t", None, serde_json::Value::Null),
+            ],
+        };
+        assert!(mixed.has_response_phase());
+        let out = mixed.run_response_phase(&resp_ctx(), "/x", 200, Vec::new(), b"go".to_vec());
+        assert_eq!(out.body, b"GO");
+        assert!(out.body_replaced);
+    }
+
+    #[test]
+    fn response_phase_respects_the_match_glob() {
+        let chain = MiddlewareChain {
+            modules: vec![loaded_response::<Transformer>(
+                "t",
+                Some("/api/*"),
+                serde_json::Value::Null,
+            )],
+        };
+        // Off-glob: untouched.
+        let out =
+            chain.run_response_phase(&resp_ctx(), "/index.php", 200, Vec::new(), b"x".to_vec());
+        assert!(!out.body_replaced);
+        assert_eq!(out.body, b"x");
+        // On-glob: transformed.
+        let out = chain.run_response_phase(&resp_ctx(), "/api/v1", 200, Vec::new(), b"x".to_vec());
+        assert!(out.body_replaced);
+        assert_eq!(out.body, b"X");
     }
 }

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -28,6 +28,17 @@ use ipnet::IpNet;
 use crate::body::{self, ServerBody};
 use crate::{metrics, static_files};
 
+/// Outcome of running the middleware **request** phase ahead of a static-file
+/// response (issue #395, security half): either short-circuit with a module
+/// response, or continue serving the file with any appended response headers.
+enum StaticGate {
+    /// A request-phase module answered (e.g. a 401/403 auth denial); serve
+    /// this instead of the file — the file is never read.
+    Respond(Response<ServerBody>),
+    /// Serve the file; append these `CONTINUE`/`REWRITE` response headers.
+    Continue(Vec<(String, String)>),
+}
+
 /// Result of resolving a request through `fallback`.
 enum Resolved {
     /// A file on disk (static or PHP).
@@ -2212,6 +2223,15 @@ impl Router {
         // `handle_php` turns into `open_basedir` — see `SiteRoots`.
         let site_root = site_roots.document_root.clone();
 
+        // Snapshot the request headers for the middleware phases before `req`
+        // is consumed downstream: the static-path request phase (issue #395,
+        // security half) and the response phase (the choke point below) both
+        // build a `RequestCtx` from this. Only taken when a chain exists.
+        let mw_req_headers: Option<Vec<(String, String)>> = self
+            .middleware_chain
+            .as_ref()
+            .map(|_| extract_headers(req.headers(), &self.ingest_strip_headers));
+
         // WebSocket upgrade. Positioned deliberately:
         //
         // * AFTER the security gates above (trusted host, malformed host,
@@ -2338,21 +2358,39 @@ impl Router {
                         (error_response(StatusCode::FORBIDDEN, "403 Forbidden"), "error")
                     }
                 } else if let Some(canonical_root) = self.contained_canonical_root(&site_roots) {
-                    (
-                        static_files::serve_file(
-                            &canonical_root,
-                            &fs_path,
-                            accepts_gzip,
-                            accepts_br,
-                            &self.cache_control,
-                            self.compression,
-                            self.etag,
-                            if_none_match.as_deref(),
-                            self.file_cache.as_deref(),
-                        )
-                        .await,
-                        "static",
-                    )
+                    // #395 (security half): run the request phase (fail-closed)
+                    // BEFORE the file is read, so an auth/gate module can deny a
+                    // static asset — the sensitive bytes never leave disk. On
+                    // the PHP path this happens inside `handle_php`; the static
+                    // path had no request phase at all before this. A REWRITE's
+                    // path/header overrides are ignored here (the file is
+                    // already resolved and no PHP runs); only RESPOND and
+                    // appended response headers apply.
+                    match self.static_request_phase(
+                        mw_req_headers.as_deref(),
+                        method,
+                        &uri_path,
+                        &query_string,
+                        effective_addr,
+                        &host,
+                    ) {
+                        StaticGate::Respond(resp) => (resp, "middleware"),
+                        StaticGate::Continue(extra_headers) => {
+                            let resp = static_files::serve_file(
+                                &canonical_root,
+                                &fs_path,
+                                accepts_gzip,
+                                accepts_br,
+                                &self.cache_control,
+                                self.compression,
+                                self.etag,
+                                if_none_match.as_deref(),
+                                self.file_cache.as_deref(),
+                            )
+                            .await;
+                            (apply_response_headers(resp, &extra_headers), "static")
+                        }
+                    }
                 } else {
                     (error_response(StatusCode::NOT_FOUND, "404 Not Found"), "error")
                 }
@@ -2398,6 +2436,28 @@ impl Router {
 
         // Apply custom response headers to all responses.
         self.apply_response_headers(&mut response);
+
+        // Response phase: let response-capable middleware transform the
+        // generated response (compression, ETag, header injection) in reverse
+        // chain order. Runs on PHP, static, worker-buffered, and error
+        // responses alike — this is what makes those transforms (and #395's
+        // transform half) apply to static files, not just PHP. Buffered
+        // responses only; a streamed body bypasses it (see the method).
+        // Applied AFTER the server's configured headers so a module can see
+        // and override them.
+        if self.middleware_chain.as_ref().is_some_and(|c| c.has_response_phase()) {
+            response = self
+                .run_response_phase(
+                    response,
+                    mw_req_headers.as_deref(),
+                    method,
+                    &uri_path,
+                    &query_string,
+                    effective_addr,
+                    &host,
+                )
+                .await;
+        }
 
         Ok((response, handler))
     }
@@ -3713,6 +3773,159 @@ impl Router {
         }
     }
 
+    /// Run the middleware **request** phase for a static-file request, before
+    /// the file is read (issue #395, security half). Fail-closed, exactly like
+    /// the PHP path's request phase: a `RESPOND` verdict (e.g. an auth denial)
+    /// short-circuits and the file is never served. A `REWRITE`'s path/header
+    /// overrides are ignored on this branch (the file is already resolved and
+    /// no PHP runs); only its appended response headers are carried through.
+    #[allow(clippy::too_many_arguments)]
+    fn static_request_phase(
+        &self,
+        req_headers: Option<&[(String, String)]>,
+        method: &str,
+        path: &str,
+        query: &str,
+        remote_addr: SocketAddr,
+        server_name: &str,
+    ) -> StaticGate {
+        let Some(chain) = self.middleware_chain.as_ref() else {
+            return StaticGate::Continue(Vec::new());
+        };
+        let ctx = ephpm_middleware::host::RequestCtx::new(
+            method,
+            path,
+            query,
+            &remote_addr.ip().to_string(),
+            server_name,
+            req_headers.unwrap_or(&[]),
+        );
+        match chain.evaluate(&ctx, path) {
+            crate::middleware::ChainVerdict::Respond { status, body, headers } => {
+                StaticGate::Respond(middleware_response(status, body, &headers))
+            }
+            crate::middleware::ChainVerdict::Continue { response_headers, .. } => {
+                StaticGate::Continue(response_headers)
+            }
+        }
+    }
+
+    /// Run the middleware **response** phase over a generated response, letting
+    /// response-capable modules transform it (compression, ETag, header
+    /// injection) in reverse chain order.
+    ///
+    /// Only **buffered** responses are transformed: a streamed body
+    /// (worker-mode `send_response_stream`, large files streamed from disk)
+    /// has no exact `size_hint` — only a fully-in-memory `Full<Bytes>` reports
+    /// one — and bypasses the phase untouched, so a stream is never buffered
+    /// or corrupted. Header values that are not valid UTF-8 are invisible to
+    /// modules and pass through unchanged. When a module replaced the body,
+    /// `Content-Length` is recomputed here.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_response_phase(
+        &self,
+        response: Response<ServerBody>,
+        req_headers: Option<&[(String, String)]>,
+        method: &str,
+        path: &str,
+        query: &str,
+        remote_addr: SocketAddr,
+        server_name: &str,
+    ) -> Response<ServerBody> {
+        use hyper::body::Body as _;
+
+        let Some(chain) = self.middleware_chain.as_ref() else {
+            return response;
+        };
+        let (mut parts, body) = response.into_parts();
+
+        // Buffered-only: a streamed body has no exact size_hint. Bypass rather
+        // than risk buffering (or corrupting) a stream.
+        if body.size_hint().exact().is_none() {
+            static STREAM_BYPASS_LOG: std::sync::Once = std::sync::Once::new();
+            STREAM_BYPASS_LOG.call_once(|| {
+                tracing::debug!(
+                    "response-phase middleware skipped for streamed responses (v1: buffered only)"
+                );
+            });
+            return Response::from_parts(parts, body);
+        }
+
+        // The body's exact size_hint guarantees it is already in memory, so
+        // this collect resolves immediately without blocking.
+        let collected = match body.collect().await {
+            Ok(buf) => buf.to_bytes(),
+            Err(err) => {
+                // Unreachable for a buffered `Full<Bytes>` (uninhabited error
+                // type); handle defensively rather than panic.
+                tracing::error!(%err, "response-phase body collect failed; returning 500");
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "500 Internal Server Error",
+                );
+            }
+        };
+
+        // Split headers: UTF-8-decodable ones are visible to (and mutable by)
+        // modules; any non-decodable value passes through untouched so a rare
+        // binary header is never lost in the round-trip.
+        let mut decodable: Vec<(String, String)> = Vec::new();
+        let mut opaque: Vec<(hyper::header::HeaderName, hyper::header::HeaderValue)> = Vec::new();
+        for (name, value) in &parts.headers {
+            match value.to_str() {
+                Ok(text) => decodable.push((name.as_str().to_owned(), text.to_owned())),
+                Err(_) => opaque.push((name.clone(), value.clone())),
+            }
+        }
+
+        let ctx = ephpm_middleware::host::RequestCtx::new(
+            method,
+            path,
+            query,
+            &remote_addr.ip().to_string(),
+            server_name,
+            req_headers.unwrap_or(&[]),
+        );
+        let outcome = chain.run_response_phase(
+            &ctx,
+            path,
+            parts.status.as_u16(),
+            decodable,
+            collected.to_vec(),
+        );
+
+        parts.status = StatusCode::from_u16(outcome.status).unwrap_or(parts.status);
+        parts.headers.clear();
+        for (name, value) in &outcome.headers {
+            match (
+                hyper::header::HeaderName::from_bytes(name.as_bytes()),
+                hyper::header::HeaderValue::from_str(value),
+            ) {
+                (Ok(name), Ok(value)) => {
+                    parts.headers.append(name, value);
+                }
+                _ => tracing::warn!(
+                    header = %name,
+                    "response-phase header is not valid HTTP — skipped"
+                ),
+            }
+        }
+        for (name, value) in opaque {
+            parts.headers.append(name, value);
+        }
+        if outcome.body_replaced {
+            // The body changed — make Content-Length authoritative so a
+            // transform (compression, rewrite) can't desync framing.
+            parts.headers.remove(hyper::header::CONTENT_LENGTH);
+            if let Ok(value) = hyper::header::HeaderValue::from_str(&outcome.body.len().to_string())
+            {
+                parts.headers.insert(hyper::header::CONTENT_LENGTH, value);
+            }
+        }
+
+        Response::from_parts(parts, body::buffered(Full::new(Bytes::from(outcome.body))))
+    }
+
     /// Check if an IP address matches any trusted proxy CIDR.
     fn is_trusted_proxy(&self, ip: IpAddr) -> bool {
         self.trusted_proxies.iter().any(|net| net.contains(&ip))
@@ -4816,6 +5029,103 @@ mod tests {
             opcache: ephpm_config::OpcacheConfig::default(),
         };
         Router::new(&config, test_store(), None, None, None, None, None)
+    }
+
+    // ── Middleware response phase + static-path request phase (#395) ──────
+
+    /// Locate a built cdylib example (mirrors `tests/middleware_dlopen.rs`).
+    /// Fails loudly rather than skipping: `cargo test -p ephpm-server` builds
+    /// examples, so an absent artifact is a wiring regression.
+    fn example_lib(stem: &str) -> PathBuf {
+        let exe = std::env::current_exe().expect("test binary has a path");
+        let dir = exe
+            .parent()
+            .and_then(Path::parent)
+            .expect("test binary at <target>/<profile>/deps/<name>")
+            .join("examples");
+        let file =
+            format!("{}{stem}.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION);
+        let path = dir.join(&file);
+        assert!(
+            path.is_file(),
+            "example cdylib `{file}` missing at {} — build with \
+             `cargo build -p ephpm-server --examples`",
+            path.display()
+        );
+        path
+    }
+
+    fn chain_with(mounts: Vec<MiddlewareMount>) -> Arc<crate::middleware::MiddlewareChain> {
+        Arc::new(crate::middleware::MiddlewareChain::load(&mounts).expect("chain loads"))
+    }
+
+    /// The response phase MUST run on the **static-file** path, not just PHP —
+    /// that is half of #395's value. A header-injection module mounted on a
+    /// static site stamps its header onto a served `.html` file.
+    #[tokio::test]
+    async fn response_phase_runs_on_static_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("page.html"), b"<h1>hi</h1>").unwrap();
+        let mount = MiddlewareMount {
+            library: example_lib("mw_response_header").to_string_lossy().into_owned(),
+            match_pattern: None,
+            order: 10,
+            config: Some(serde_json::json!({ "header": "X-Resp-Phase", "value": "static" })),
+        };
+        let router = test_router(dir.path()).with_middleware_chain(Some(chain_with(vec![mount])));
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/page.html").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("x-resp-phase").and_then(|v| v.to_str().ok()),
+            Some("static"),
+            "the response phase must run on the static-file path (#395 transform half)"
+        );
+    }
+
+    /// The **request** phase (fail-closed) MUST run on the static path too, so
+    /// an auth module can deny a static asset *before the file is read* — the
+    /// security half of #395. A gated file is answered 401 and its bytes never
+    /// reach the client; an ungated sibling is served normally.
+    #[tokio::test]
+    async fn request_phase_gates_static_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("secret.txt"), b"TOPSECRET").unwrap();
+        std::fs::write(dir.path().join("public.txt"), b"public").unwrap();
+        // jwt (builtin) scoped to the secret asset; no response phase.
+        let jwt = MiddlewareMount {
+            library: "jwt".to_string(),
+            match_pattern: Some("/secret.txt".to_string()),
+            order: 10,
+            config: Some(serde_json::json!({ "secret": "s3cret" })),
+        };
+        let router = test_router(dir.path()).with_middleware_chain(Some(chain_with(vec![jwt])));
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        // Gated asset, no bearer token -> denied; the file is never served.
+        let req = Request::builder()
+            .method("GET")
+            .uri("/secret.txt")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_ne!(&body[..], b"TOPSECRET", "the gated file's bytes must never leave disk");
+
+        // Ungated sibling: served normally (glob does not match it).
+        let req = Request::builder()
+            .method("GET")
+            .uri("/public.txt")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"public");
     }
 
     // ── Ingest header hygiene (Finding 3) ────────────────────────────────

--- a/crates/ephpm-server/tests/middleware_response_phase.rs
+++ b/crates/ephpm-server/tests/middleware_response_phase.rs
@@ -1,0 +1,231 @@
+//! Coverage for the **response phase** across the dlopen C ABI — the optional
+//! `ephpm_middleware_invoke_response` symbol, the `EphpmResponseCtx` read
+//! accessors, and the `EphpmResponseEdit` write-back, driven through a real
+//! shared library built by `declare!(Type, response)`.
+//!
+//! The fixture is the `mw_response_gzip` cdylib example (a genuine gzip
+//! response compressor). Like the `mw_probe_*` fixtures it is a
+//! `crate-type = ["cdylib"]` example so `cargo test -p ephpm-server` always
+//! leaves a loadable library on disk — [`fixture`] hard-fails with the build
+//! command rather than skipping, so this lane can never go silently
+//! uncovered.
+//!
+//! The request-phase-only `mw_probe_v1` fixture (which does **not** export the
+//! response symbol) is reused here to prove the presence check: a v1 module is
+//! skipped by the response phase, and a chain of only such modules reports no
+//! response phase at all.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use ephpm_config::MiddlewareMount;
+use ephpm_middleware::host::RequestCtx;
+use ephpm_server::middleware::MiddlewareChain;
+use flate2::read::GzDecoder;
+
+/// Directory cargo drops example artifacts in (see `middleware_dlopen.rs`).
+fn examples_dir() -> PathBuf {
+    let exe = std::env::current_exe().expect("test binary has a path");
+    exe.parent()
+        .and_then(Path::parent)
+        .expect("test binary lives at <target>/<profile>/deps/<name>")
+        .join("examples")
+}
+
+/// A fixture library staged at a path unique to one test (private per-test
+/// load; see `middleware_dlopen.rs::Fixture` for why the copy matters).
+struct Fixture {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl Fixture {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Stage a fixture cdylib, or fail with the exact build command — never skip.
+fn fixture(stem: &str) -> Fixture {
+    let file =
+        format!("{}{stem}.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION);
+    let built = examples_dir().join(&file);
+    assert!(
+        built.is_file(),
+        "response-phase fixture `{file}` is missing at {} — build the cdylib examples with \
+         `cargo build -p ephpm-server --examples`.",
+        built.display()
+    );
+    let dir = tempfile::tempdir().expect("stage fixture");
+    let path = dir.path().join(&file);
+    std::fs::copy(&built, &path).expect("copy fixture into staging dir");
+    Fixture { _dir: dir, path }
+}
+
+fn mount(
+    path: &Path,
+    pattern: Option<&str>,
+    order: u32,
+    config: serde_json::Value,
+) -> MiddlewareMount {
+    MiddlewareMount {
+        library: path.to_string_lossy().into_owned(),
+        match_pattern: pattern.map(str::to_owned),
+        order,
+        config: Some(config),
+    }
+}
+
+fn find<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+    headers.iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.as_str())
+}
+
+fn gunzip(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    GzDecoder::new(bytes).read_to_end(&mut out).expect("valid gzip stream");
+    out
+}
+
+/// A request context that advertises gzip support.
+fn ctx_accepts_gzip() -> RequestCtx {
+    RequestCtx::new(
+        "GET",
+        "/page.html",
+        "",
+        "203.0.113.5",
+        "resp.example",
+        &[("Accept-Encoding".to_owned(), "gzip, deflate".to_owned())],
+    )
+}
+
+/// The full response-phase lifecycle over the C ABI: a gzip module reads the
+/// generated body through `EphpmResponseCtx`, replaces it, and rewrites the
+/// headers via `EphpmResponseEdit`. Proves the body round-trips (gunzip ==
+/// original), the encoding header is set, the stale ETag is dropped, and the
+/// host flagged the body as replaced.
+#[test]
+fn dynamic_response_module_gzips_a_buffered_response() {
+    let lib = fixture("mw_response_gzip");
+    let chain = MiddlewareChain::load(&[mount(lib.path(), None, 10, serde_json::json!({}))])
+        .expect("gzip module loads through dlopen");
+    assert!(chain.has_response_phase(), "the gzip module exports the response symbol");
+
+    let original = b"<html><body>".repeat(64);
+    let headers = vec![
+        ("Content-Type".to_owned(), "text/html".to_owned()),
+        ("Content-Length".to_owned(), original.len().to_string()),
+        ("ETag".to_owned(), "\"abc123\"".to_owned()),
+    ];
+
+    let outcome =
+        chain.run_response_phase(&ctx_accepts_gzip(), "/page.html", 200, headers, original.clone());
+
+    assert_eq!(outcome.status, 200);
+    assert!(outcome.body_replaced, "the gzip module replaced the body");
+    assert_eq!(find(&outcome.headers, "Content-Encoding"), Some("gzip"));
+    assert_eq!(find(&outcome.headers, "Vary"), Some("Accept-Encoding"));
+    assert!(find(&outcome.headers, "ETag").is_none(), "stale ETag must be dropped");
+    assert!(outcome.body.len() < original.len(), "gzip must shrink this repetitive body");
+    assert_eq!(gunzip(&outcome.body), original, "gunzip(body) round-trips to the original");
+}
+
+/// The module is conservative: with no `Accept-Encoding: gzip` on the request,
+/// it leaves the response untouched — proving the response phase can read the
+/// **request** context across the ABI and act on it.
+#[test]
+fn dynamic_response_module_skips_when_client_does_not_accept_gzip() {
+    let lib = fixture("mw_response_gzip");
+    let chain = MiddlewareChain::load(&[mount(lib.path(), None, 10, serde_json::json!({}))])
+        .expect("gzip module loads");
+
+    let original = b"<html><body>".repeat(64);
+    let ctx = RequestCtx::new("GET", "/page.html", "", "203.0.113.5", "resp.example", &[]);
+    let outcome = chain.run_response_phase(
+        &ctx,
+        "/page.html",
+        200,
+        vec![("Content-Type".to_owned(), "text/html".to_owned())],
+        original.clone(),
+    );
+
+    assert!(!outcome.body_replaced, "no Accept-Encoding: gzip -> body untouched");
+    assert_eq!(outcome.body, original);
+    assert!(find(&outcome.headers, "Content-Encoding").is_none());
+}
+
+/// A request-phase-only module (`mw_probe_v1`, no response symbol) is skipped
+/// by the response phase; a chain of only such modules reports none. Mixed
+/// with the gzip module, the transform still happens — the presence check is
+/// per module.
+#[test]
+fn modules_without_the_response_symbol_are_skipped() {
+    let probe = fixture("mw_probe_v1");
+    let gzip = fixture("mw_response_gzip");
+
+    // A chain of only request-phase modules has no response phase at all.
+    let probe_only =
+        MiddlewareChain::load(&[mount(probe.path(), None, 10, serde_json::json!({ "tag": "t" }))])
+            .expect("probe loads");
+    assert!(!probe_only.has_response_phase(), "a v1 module contributes no response phase");
+
+    // Mixed chain: the probe is skipped in the response phase, the gzip module
+    // still transforms.
+    let mixed = MiddlewareChain::load(&[
+        mount(probe.path(), None, 10, serde_json::json!({ "tag": "t" })),
+        mount(gzip.path(), None, 20, serde_json::json!({})),
+    ])
+    .expect("mixed chain loads");
+    assert!(mixed.has_response_phase());
+
+    let original = b"abcdefghij".repeat(16);
+    let outcome = mixed.run_response_phase(
+        &ctx_accepts_gzip(),
+        "/page.html",
+        200,
+        vec![("Content-Type".to_owned(), "text/plain".to_owned())],
+        original.clone(),
+    );
+    assert!(outcome.body_replaced, "the gzip module transformed despite the v1 probe in the chain");
+    assert_eq!(gunzip(&outcome.body), original);
+}
+
+/// A response module whose `match` glob does not match the request path is
+/// skipped in the response phase, exactly like the request phase.
+#[test]
+fn response_phase_respects_the_match_glob() {
+    let gzip = fixture("mw_response_gzip");
+    let chain =
+        MiddlewareChain::load(&[mount(gzip.path(), Some("/api/*"), 10, serde_json::json!({}))])
+            .expect("gzip module loads");
+
+    let original = b"x".repeat(256);
+
+    // Off-glob: untouched.
+    let outcome = chain.run_response_phase(
+        &ctx_accepts_gzip(),
+        "/page.html",
+        200,
+        vec![("Content-Type".to_owned(), "text/plain".to_owned())],
+        original.clone(),
+    );
+    assert!(!outcome.body_replaced, "off-glob request must not be compressed");
+
+    // On-glob: transformed. (Path is what the glob matches on.)
+    let ctx = RequestCtx::new(
+        "GET",
+        "/api/data",
+        "",
+        "203.0.113.5",
+        "resp.example",
+        &[("Accept-Encoding".to_owned(), "gzip".to_owned())],
+    );
+    let outcome = chain.run_response_phase(
+        &ctx,
+        "/api/data",
+        200,
+        vec![("Content-Type".to_owned(), "text/plain".to_owned())],
+        original.clone(),
+    );
+    assert!(outcome.body_replaced, "on-glob request must be compressed");
+    assert_eq!(gunzip(&outcome.body), original);
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,13 +170,14 @@ RUN mkdir -p \
     for d in ephpm-cluster ephpm-config ephpm-db ephpm-kv ephpm-middleware ephpm-middleware-builtins ephpm-middleware-cors ephpm-middleware-jwt ephpm-middleware-ratelimit ephpm-middleware-security-headers ephpm-php ephpm-query-stats ephpm-server ephpm-ws; do \
         touch crates/$d/src/lib.rs; \
     done && \
-    # ephpm-server declares three `[[example]] crate-type = ["cdylib"]` targets
-    # (the middleware-ABI probes added in #230). A named [[example]] must exist
-    # as a file or cargo hard-errors during this stub stage with
-    # "can't find 'mw_probe_abi_v2' example at examples/mw_probe_abi_v2.rs" --
-    # before a single dependency is fetched. Keep this list in sync with the
-    # [[example]] blocks in crates/ephpm-server/Cargo.toml.
-    for e in mw_probe_v1 mw_probe_abi_v2 mw_probe_no_invoke; do \
+    # ephpm-server declares several `[[example]] crate-type = ["cdylib"]`
+    # targets (the middleware-ABI probes added in #230, plus the response-phase
+    # proof modules). A named [[example]] must exist as a file or cargo
+    # hard-errors during this stub stage with "can't find 'mw_probe_abi_v2'
+    # example at examples/mw_probe_abi_v2.rs" -- before a single dependency is
+    # fetched. Keep this list in sync with the [[example]] blocks in
+    # crates/ephpm-server/Cargo.toml.
+    for e in mw_probe_v1 mw_probe_abi_v2 mw_probe_no_invoke mw_response_gzip mw_response_header; do \
         printf 'fn main() {}\n' > crates/ephpm-server/examples/$e.rs; \
     done && \
     # ephpm-php Cargo.toml declares `build = "build.rs"` explicitly, so cargo

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -176,21 +176,87 @@ v1 rules worth knowing:
   the body is read (rejecting before the transfer is the point);
   the ABI's body accessor currently always returns length 0.
 
-**Coverage.** The chain runs on **PHP-dispatched requests only**, **in every
-mode**: static-file responses and router error responses (403/404) do **not**
-pass through middleware. This includes worker mode — a request for a file that
-exists on disk still takes the static branch and is never routed to the worker
-(only a missing-file fallback reaches PHP), so the chain does not see it.
+**Coverage.** The request phase runs on **both** the PHP path and the
+**static-file** path, in every mode — so a `RESPOND` verdict gates a static
+asset just as it gates a PHP request, and it does so *before the file is read
+from disk*. Only the router's own pre-routing replies (internal
+`/_ephpm/*` and `/metrics` endpoints, ACME challenges, and the
+trusted-host / hidden-file / blocked-path 4xx gates) answer ahead of the chain
+and are never seen by it.
 
-> **Security note.** A middleware mount — including the `basic-auth`,
-> `session-cookie`, and `github-auth` gates — **does not protect static files**.
-> If confidential assets live in a web-served document root (media,
-> `wp-content/uploads/*`, JS/CSS bundles and their `.map` source maps, CSV/SQL/ZIP
-> exports), they are served to unauthenticated clients regardless of any mounted
-> middleware and regardless of `[php] mode`. Do not rely on the chain to gate
-> them: keep confidential files out of the document root, or enforce the rule in
-> a proxy in front of ePHPm. (Making the chain gate the static branch is tracked
-> as a separate design decision in issue #395 and is not implemented.)
+> **Static assets are gated too.** A gating mount (`basic-auth`,
+> `session-cookie`, `github-auth`, `jwt`, …) that matches a static asset's path
+> now denies it before the bytes leave disk — scope the mount's `match` glob to
+> cover the asset paths you mean to protect (e.g. `match = "/wp-content/uploads/*"`).
+> Defense in depth still applies: keep truly confidential files out of a
+> web-served document root where practical.
+
+See **[Response phase](#response-phase-transforming-the-response)** below for
+the *second* phase, which runs after the response is generated.
+
+## Response phase (transforming the response)
+
+The verdicts above are the **request phase** — they decide what to do *before*
+a request is served. A module may also implement an optional **response
+phase** that runs *after* the response is generated (PHP output, a static
+file, an error page, or a request-phase `RESPOND`), to **transform** it:
+compression, ETag / conditional-GET, response-header injection based on the
+body. This is the mechanism that lets those features be middleware at all, and
+it is what makes them apply to **static** files, not just PHP.
+
+Key properties:
+
+- **Runs in reverse chain order** (onion model): the last request-phase module
+  unwinds first.
+- **Buffered responses only.** A streamed response (worker-mode
+  `send_response_stream`, large files streamed from disk) bypasses the response
+  phase untouched — a stream is never buffered or corrupted to transform it.
+- **Fails safe.** Unlike the request phase (which fails *closed*), a response
+  handler that errors or panics leaves the response **unchanged**. A response
+  module is a transform, **not a security gate** — do your gating in the
+  request phase.
+- **May run without a request phase.** On the static path no request phase ran
+  for this module, and an upstream `RESPOND` can short-circuit before it — so a
+  response handler must not assume state its own request phase would have set.
+- **Opt-in per module.** Only modules that export the optional
+  `ephpm_middleware_invoke_response` symbol participate; every existing v1
+  module is unaffected (see [The C ABI](#the-c-abi-for-non-rust-modules)).
+
+In Rust, implement the `ResponseMiddleware` trait *in addition* to
+`Middleware`, and opt in with `declare!(Type, response)`:
+
+```rust
+use ephpm_middleware::{Middleware, Request, Response, ResponseMiddleware, ResponseView};
+
+struct Stamp;
+
+impl Middleware for Stamp {
+    fn init(_c: &serde_json::Value) -> Result<Self, String> { Ok(Self) }
+    fn invoke(&self, _req: &Request<'_>) -> Response { Response::cont() }
+}
+
+impl ResponseMiddleware for Stamp {
+    fn invoke_response(&self, req: &Request<'_>, resp: &mut ResponseView<'_>) {
+        // Read the generated response…
+        let _status = resp.status();
+        let _ctype = resp.header("Content-Type");
+        let _body: &[u8] = resp.body();
+        // …and stage edits (applied by the host: removes, then sets, then
+        // status, then body; Content-Length is recomputed if you replace the
+        // body).
+        resp.set_header("X-Served-By", "ephpm");
+        resp.remove_header("X-Powered-By");
+        // resp.set_status(203);
+        // resp.set_body(transformed);
+    }
+}
+
+declare!(Stamp, response);   // note the extra `, response`
+```
+
+A complete, real example — a gzip response compressor that runs on static
+files too — ships as
+[`crates/ephpm-server/examples/mw_response_gzip.rs`](https://github.com/ephpm/ephpm/blob/main/crates/ephpm-server/examples/mw_response_gzip.rs).
 
 ## The built-in modules
 
@@ -355,9 +421,11 @@ impl Middleware for MyAuth {
 declare!(MyAuth);
 ```
 
-`declare!` generates the four C ABI exports, the ABI major-version check,
-config JSON parsing, response marshaling, and panic containment (a panicking
-`invoke` becomes a fail-closed 500).
+`declare!(MyAuth)` generates the four C ABI exports, the ABI major-version
+check, config JSON parsing, response marshaling, and panic containment (a
+panicking `invoke` becomes a fail-closed 500). To add the optional response
+phase, implement `ResponseMiddleware` and write `declare!(MyAuth, response)` —
+see [Response phase](#response-phase-transforming-the-response).
 
 Inside `invoke`, `req.host()` exposes host services:
 
@@ -405,11 +473,22 @@ int32_t ephpm_middleware_invoke(const ephpm_request_t* request,
                                 ephpm_response_t* response_out);
 void    ephpm_middleware_shutdown(void);
 const char* ephpm_middleware_describe(void);   /* optional, nullable */
+
+/* Optional response phase (ABI minor 1). A module that does not export it is
+   unaffected; the host skips it after generating the response. Return 0 to
+   apply the edit, non-zero to leave the response unchanged (fail-safe). */
+int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
+                                         const ephpm_response_ctx_t* response,
+                                         ephpm_response_edit_t* edit_out);
 ```
 
-- `abi_version` is `0x01_00_00_00` for v1; the **major byte** gates
-  compatibility. Modules must refuse to init (return non-zero) when the
-  host's major is newer than they were built for.
+- `abi_version` is `0x01_00_00_01` — major **1**, minor **1**. The **major
+  byte** gates compatibility; modules must refuse to init (return non-zero)
+  when the host's major is newer than they were built for. The lower three
+  bytes are an additive **minor** level: growth (new host-table fields, the
+  optional response symbol) bumps the minor and keeps the major, so existing
+  major-1 modules keep loading. A module that uses a newer field must check
+  the host's advertised minor (`host->abi_version & 0x00FFFFFF`) first.
 - `config_json` is the mount's `config` table serialised to JSON (NULL when
   the mount has no config).
 - The host callback table is passed **by pointer at `init`** and is valid
@@ -417,24 +496,30 @@ const char* ephpm_middleware_describe(void);   /* optional, nullable */
   would need `-rdynamic` on Linux and has no clean Windows analogue). It
   contains request accessors (method, path, query, remote IP, header
   lookup, vhost id), the KV operations (`kv_get`/`kv_set`/`kv_set_nx`/
-  `kv_incr`/`kv_free`) and `log`.
+  `kv_incr`/`kv_incr_ttl`/`kv_free`), `log`, and — for the response phase
+  (minor 1) — the response accessors (`response_status`/`response_headers`/
+  `response_body`).
 - The request pointer is only valid during `invoke`; never store it.
   Everything a module writes into `response_out` must stay valid until its
-  `invoke` returns — the host copies before unwinding.
+  `invoke` returns — the host copies before unwinding. The same rule applies
+  to the response phase: the `ephpm_response_ctx_t*` and everything a module
+  writes into `ephpm_response_edit_t` are valid only until
+  `ephpm_middleware_invoke_response` returns.
 - New host capabilities append to the end of the table under the same major
-  version.
+  version (bumping the minor).
 
 The authoritative definition is
 [`crates/ephpm-middleware/src/abi.rs`](https://github.com/ephpm/ephpm/blob/main/crates/ephpm-middleware/src/abi.rs).
 
 ## Observability
 
-Each module invocation increments
+Each request-phase invocation increments
 `ephpm_middleware_invocations_total{module, action}` where `action` is the
 verdict (`continue` / `respond` / `rewrite`; module errors count as
-`respond` since they fail closed as 500s). Module `log` calls surface
-through the host's `tracing` subscriber under the `ephpm_middleware`
-target.
+`respond` since they fail closed as 500s). Each response-phase invocation
+increments `ephpm_middleware_response_invocations_total{module}`. Module `log`
+calls surface through the host's `tracing` subscriber under the
+`ephpm_middleware` target.
 
 ## Trust model
 


### PR DESCRIPTION
## What

Adds an optional **response phase** to the middleware ABI so a module can inspect/transform the HTTP response *after* PHP or static serving produces it (compression, ETag/conditional-GET, response-header injection) — the ABI was request-phase only. Also closes the **security half of #395** by running the request phase on the static-file path.

Targets **v0.8.0**. **Do not merge yet.**

## Which half of #395 each change fixes

#395 has two halves; this PR closes **both**, and the PR is precise about which is which:

- **Transform half** (compression/ETag/header transforms couldn't run on static responses): fixed by the **response phase**, invoked at the single response choke point in `dispatch` for PHP, static, worker-buffered and error responses alike.
- **Security half** (auth/gate middleware couldn't gate static assets): fixed by running the **request phase** (fail-closed) on the static path *before the file is read* (`Router::static_request_phase`). A `RESPOND` there denies the asset and its bytes never leave disk. This is a genuine gate — a response-phase module could not be one (it runs after the file is read, and it fails safe).

## ABI: additive, major stays 1 (minor 0 → 1)

- New **optional** exported symbol `ephpm_middleware_invoke_response`. The host `dlsym`s it per module; a module that doesn't export it is skipped in the response phase — this is the primary v1-module compatibility mechanism, so **every existing module keeps working with no major bump**.
- New `EphpmResponseCtx` (opaque; read via three **appended** host-table accessors `response_status` / `response_headers` / `response_body`) and `EphpmResponseEdit` (new status/body + `set_headers`/`remove_headers` ops).
- `ABI_V1` becomes `0x0100_0001`. The major byte is unchanged, so the major-only gate in `declare!` still accepts every v1 module. A minor was introduced so a response-capable module can detect an older host before touching the appended fields.
- Rust authoring: `ResponseMiddleware` trait + `declare!(Type, response)`. Plain `declare!(Type)` is unchanged and emits no response symbol.

## Semantics (the deliberate decisions)

- **Order:** response phase runs in **reverse** chain order (onion — last request-phase module unwinds first).
- **Phase policies (asymmetric, on purpose):** request phase fails **closed** (a broken gate must not fail open); response phase fails **safe** — a module error/panic leaves the response unchanged. Response-phase modules are transforms, **not security controls**.
- **Paired-state contract:** a response handler may run without a preceding `invoke` (static path, or an upstream `RESPOND`), so it must not assume state its own request phase would have set. This is forced by the static path, not a shortcut.
- **Streaming (v1 scope boundary):** buffered responses only. A streamed body (worker `send_response_stream`, large files streamed from disk) has no exact `size_hint` and **bypasses** the phase untouched — no half-transformed streams. Headers-only-on-streams is a documented future extension.
- **Body/Content-Length:** the host applies each edit `remove → set → status → body` and recomputes `Content-Length` when a module replaced the body. Header values that aren't valid UTF-8 are invisible to modules and pass through unchanged.

## Proof module + verification

`crates/ephpm-server/examples/mw_response_gzip.rs` — a real gzip response compressor. **Verified with `curl` under a live server** (PHP 8.5.7 ZTS, php-linked build) on **both**:

- static `.html`: `content-encoding: gzip`, body gunzips back to the 2401-byte original, `Content-Length` recomputed (2401→116), stale `ETag` dropped; uncompressed 2401 bytes with no `Accept-Encoding`.
- `index.php`: `x-powered-by: PHP/8.5.7` (PHP actually ran) + `content-encoding: gzip`, gunzips to the 2871-byte PHP output, `Content-Length` recomputed (2871→227); uncompressed when the client doesn't accept gzip.

## Tests

- **Unit (builtin lane):** reverse order, buffered transform (status/body/headers), fail-safe on panic, skip-without-symbol, match glob.
- **dlopen (C ABI):** gzip round-trip over the ABI, request-header gating from the response phase, presence check (v1 module skipped), match glob.
- **Router:** response phase runs on static files (#395 transform half); request phase gates a static asset — 401, file bytes never served (#395 security half).

Gates: `cargo clippy --workspace --all-targets -- -D warnings` clean (stub); `cargo +nightly fmt --all -- --check` clean; `cargo test -p ephpm-server` (421 lib + dlopen + response-phase) green; `cargo test -p ephpm-middleware --features host` green.

## Coordination

Kept the diff to the middleware ABI + its invocation points. Router footprint is small and localized: the response choke point in `dispatch`, one early request-header capture, the static-path request-phase call, and two helper methods. Did **not** touch `site_overrides.rs`/`static_files.rs` containment logic. Overlaps the concurrent reverse-proxy work in `router.rs`/`middleware.rs` — expect a rebase on whichever lands first.
