### PR TITLE
feat(middleware): ABI minor 2 — request scheme/is_secure/host + bounded request_body (stacks on #408)

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -407,6 +407,28 @@ pub struct RequestConfig {
     /// Default: `[]` (all hosts allowed).
     #[serde(default)]
     pub trusted_hosts: Vec<String>,
+
+    /// Maximum number of request-body bytes buffered and exposed to
+    /// **request-phase** native middleware through the `request_body` ABI
+    /// accessor.
+    ///
+    /// `0` (the default) **disables** body buffering: the middleware chain runs
+    /// before any body byte is read — so a `RESPOND` verdict (auth deny, rate
+    /// limit) never pays for the body transfer — and `request_body` returns
+    /// empty. This preserves the reject-before-transfer property by default.
+    ///
+    /// When `> 0` **and** a `[[middleware]]` chain is mounted, the request body
+    /// is buffered before the chain so middleware can inspect up to this many
+    /// bytes (a longer body is truncated to this limit *for the middleware
+    /// view only* — the complete body, subject to `max_body_size`, still
+    /// reaches PHP unchanged). Enables webhook/HMAC signature verification,
+    /// CSRF-with-body, and payload validation. Note: buffering the body up
+    /// front bypasses worker-mode request streaming for such requests.
+    ///
+    /// Independent of `max_body_size`, which remains the hard cap that 413s an
+    /// oversized body. Env override: `EPHPM_SERVER_REQUEST__MIDDLEWARE_BODY_LIMIT`.
+    #[serde(default = "default_middleware_body_limit")]
+    pub middleware_body_limit: u64,
 }
 
 /// Connection timeout configuration (`[server.timeouts]`).
@@ -3172,6 +3194,7 @@ impl Default for RequestConfig {
             max_body_size: default_max_body_size(),
             max_header_size: default_max_header_size(),
             trusted_hosts: Vec::new(),
+            middleware_body_limit: default_middleware_body_limit(),
         }
     }
 }
@@ -5050,6 +5073,13 @@ fn default_max_body_size() -> u64 {
     10 * 1024 * 1024 // 10 MiB
 }
 
+/// Request-body buffering for middleware is opt-in: `0` disables it, preserving
+/// the reject-before-body-transfer property. Operators that need `request_body`
+/// (webhook/HMAC, CSRF-with-body) set an explicit byte cap.
+fn default_middleware_body_limit() -> u64 {
+    0
+}
+
 /// Default `Alt-Svc` max-age: 24 hours, the value nginx and Caddy advertise.
 fn default_alt_svc_max_age() -> u64 {
     86400
@@ -6098,6 +6128,33 @@ config = { per_ip_rps = 50, burst = 100 }
         // The loader serialises this value back to JSON for the module's init.
         let json = serde_json::to_string(mount_config).unwrap();
         assert!(json.contains("per_ip_rps"));
+    }
+
+    #[test]
+    fn test_middleware_body_limit_defaults_to_disabled() {
+        // Opt-in by design: 0 preserves the reject-before-body-transfer
+        // property. Both the field default and the whole-section-absent path
+        // (RequestConfig::default) must land on 0.
+        assert_eq!(default_middleware_body_limit(), 0);
+        assert_eq!(RequestConfig::default().middleware_body_limit, 0);
+    }
+
+    #[test]
+    fn test_middleware_body_limit_parses_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(
+            &file,
+            r"
+[server.request]
+middleware_body_limit = 1048576
+",
+        )
+        .unwrap();
+
+        let config = Config::load(&file).unwrap();
+        config.validate().unwrap();
+        assert_eq!(config.server.request.middleware_body_limit, 1_048_576);
     }
 
     #[test]

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -44,30 +44,51 @@ use std::os::raw::{c_char, c_int};
 /// Current ABI version (`0xMMmmmmmm`: major byte gates compatibility, the
 /// lower three bytes are an additive minor level).
 ///
-/// `0x0100_0001` = major **1**, minor **1**. Minor 1 added the optional
-/// response phase (the [`SYM_INVOKE_RESPONSE`] symbol and the three appended
-/// `response_*` accessors on [`EphpmHostV1`]). The major byte is unchanged
-/// from minor 0, so **every** module built against major 1 still loads:
-/// growth is additive.
-pub const ABI_V1: u32 = 0x0100_0001;
+/// `0x0100_0002` = major **1**, minor **2**.
+///
+/// - Minor 1 added the optional response phase (the [`SYM_INVOKE_RESPONSE`]
+///   symbol and the three appended `response_*` accessors on [`EphpmHostV1`]).
+/// - Minor 2 added three appended request accessors — [`request_scheme`],
+///   [`request_is_secure`], and [`request_host`] — and gave the pre-existing
+///   [`request_body`] slot real (bounded, buffered) semantics.
+///
+/// The major byte is unchanged across every minor, so **every** module built
+/// against major 1 still loads: growth is additive.
+///
+/// [`request_scheme`]: EphpmHostV1::request_scheme
+/// [`request_is_secure`]: EphpmHostV1::request_is_secure
+/// [`request_host`]: EphpmHostV1::request_host
+/// [`request_body`]: EphpmHostV1::request_body
+pub const ABI_V1: u32 = 0x0100_0002;
 
 /// Major version — the compatibility gate. A module refuses to init when the
 /// host's major (`host.abi_version >> 24`) is newer than its own.
 pub const ABI_MAJOR: u32 = 1;
 
 /// Minor version — the additive feature level in the low three bytes of
-/// [`ABI_V1`]. A *response-capable* module checks the host's advertised minor
-/// (`host.abi_version & 0x00FF_FFFF`) is at least
-/// [`ABI_MINOR_RESPONSE_PHASE`] before calling any `response_*` accessor: an
-/// older host's table does not have those trailing fields, and reading past a
-/// shorter table is undefined behaviour.
-pub const ABI_MINOR: u32 = 1;
+/// [`ABI_V1`]. A module that reaches for a trailing accessor checks the host's
+/// advertised minor (`host.abi_version & 0x00FF_FFFF`) is at least the minor
+/// that introduced it before calling: an older host's table does not have
+/// those trailing fields, and reading past a shorter table is undefined
+/// behaviour. See [`ABI_MINOR_RESPONSE_PHASE`] and
+/// [`ABI_MINOR_REQUEST_ACCESSORS`].
+pub const ABI_MINOR: u32 = 2;
 
 /// The minor version that introduced the response phase — the three
 /// `response_*` accessors on [`EphpmHostV1`] and the [`SYM_INVOKE_RESPONSE`]
 /// symbol. A module needs `host.abi_version & 0x00FF_FFFF >=` this before
 /// using the response-side host callbacks.
 pub const ABI_MINOR_RESPONSE_PHASE: u32 = 1;
+
+/// The minor version that introduced the appended request accessors —
+/// [`EphpmHostV1::request_scheme`], [`EphpmHostV1::request_is_secure`], and
+/// [`EphpmHostV1::request_host`]. A module needs
+/// `host.abi_version & 0x00FF_FFFF >=` this before calling any of them: on an
+/// older host those trailing table fields are absent and reading them is
+/// undefined behaviour. ([`EphpmHostV1::request_body`] is **not** gated by
+/// this — its slot has existed since minor 0; only its buffered semantics are
+/// new — so a minor-0 module that already called it stays correct.)
+pub const ABI_MINOR_REQUEST_ACCESSORS: u32 = 2;
 
 /// Middleware verdicts for one request.
 pub const ACTION_CONTINUE: c_int = 0;
@@ -200,9 +221,21 @@ pub struct EphpmHostV1 {
     /// headers return the values pre-joined per HTTP list semantics.
     pub request_header:
         unsafe extern "C" fn(*const EphpmRequest, name: *const c_char) -> *const c_char,
-    /// Request body view. v1: bodies are not read before the middleware chain
-    /// runs (rejecting BEFORE the body transfer is the point), so this
-    /// returns length 0. Reserved for a future buffered-body option.
+    /// Bounded, read-only view of the buffered request body. Writes the byte
+    /// slice base into `*out_ptr` and returns its length; the slice is valid
+    /// only for the duration of the request (`invoke`) — never store it.
+    ///
+    /// The body is buffered by the host ONLY when the operator opts in with
+    /// `[server.request] middleware_body_limit > 0`; that knob also caps how
+    /// many bytes are exposed here (a longer body is truncated to the limit for
+    /// this view — PHP still receives the complete body). When the knob is `0`
+    /// (the default) the chain runs before any body byte is read — rejecting
+    /// BEFORE the body transfer is the point — and this returns length 0 with
+    /// `*out_ptr` set null. It is also 0 on the static-file and response-phase
+    /// paths, which carry no request body.
+    ///
+    /// This slot has existed since minor 0 (it returned 0 then); only the
+    /// buffered semantics are new in minor 2, so it needs no minor gate.
     pub request_body: unsafe extern "C" fn(*const EphpmRequest, out_ptr: *mut *const u8) -> usize,
     /// Identity of the vhost/site serving this request (server name).
     pub request_vhost_id: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
@@ -281,6 +314,30 @@ pub struct EphpmHostV1 {
     /// and returns its length; valid only for the duration of the call.
     pub response_body:
         unsafe extern "C" fn(*const EphpmResponseCtx, out_ptr: *mut *const u8) -> usize,
+
+    // ── Request accessors (minor 2; valid only during `invoke`) ───────────
+    //
+    // Appended after `response_body`: a module built against minor 0 or 1
+    // never reads these offsets, so the growth is ABI-compatible. A module
+    // that DOES read them must first confirm `abi_version & 0x00FF_FFFF >=
+    // ABI_MINOR_REQUEST_ACCESSORS`, otherwise it would read past a shorter
+    // (older-host) table.
+    /// Request URL scheme, authoritative from the connection: `"https"` when
+    /// the client's TLS terminated here, `"http"` otherwise. Derived from the
+    /// real connection TLS state (after trusted-proxy resolution), NOT from a
+    /// client-supplied `X-Forwarded-Proto` header — so a `force_https` gate can
+    /// trust it. Never null.
+    pub request_scheme: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
+    /// Whether the request arrived over a secure (HTTPS/TLS) connection — the
+    /// boolean form of [`request_scheme`](Self::request_scheme). `1` = secure,
+    /// `0` = plaintext.
+    pub request_is_secure: unsafe extern "C" fn(*const EphpmRequest) -> c_int,
+    /// Normalized request `Host` — port stripped, one trailing FQDN-root dot
+    /// stripped, lowercased (the same normalization the router uses to key a
+    /// vhost). Distinct from [`request_vhost_id`](Self::request_vhost_id),
+    /// which is the un-normalized server name. Empty (never null) when the
+    /// request carried no usable `Host`.
+    pub request_host: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
 }
 
 /// Symbol names the loader looks up.

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -17,13 +17,34 @@ pub struct RequestCtx {
     query: CString,
     remote_ip: CString,
     vhost: CString,
+    /// Normalized request host (port/trailing-dot stripped, lowercased) — the
+    /// `request_host` accessor. Empty when the request had no usable `Host`.
+    host: CString,
+    /// Whether the connection was secure (HTTPS/TLS) — drives `request_scheme`
+    /// and `request_is_secure`. Authoritative from the connection.
+    is_secure: bool,
+    /// Bounded, buffered request body exposed by `request_body`. Empty unless
+    /// the operator opted into body buffering (`[server.request]
+    /// middleware_body_limit`); already truncated to that limit by the caller.
+    body: Vec<u8>,
     /// Lower-cased name → value (values pre-joined per HTTP list semantics).
     headers: Vec<(CString, CString)>,
+}
+
+/// Convert a string to a C string, stripping interior NULs (invalid in HTTP
+/// metadata anyway) rather than failing.
+fn cstr(s: &str) -> CString {
+    CString::new(s.replace('\0', "")).unwrap_or_default()
 }
 
 impl RequestCtx {
     /// Build the context. Interior NULs are stripped (invalid in HTTP
     /// metadata anyway) rather than failing the request.
+    ///
+    /// The connection-derived extras — scheme/secure, normalized host, and the
+    /// buffered body — default to "insecure / empty / no body" and are set by
+    /// the router via [`with_scheme`](Self::with_scheme),
+    /// [`with_host`](Self::with_host), and [`with_body`](Self::with_body).
     #[must_use]
     pub fn new(
         method: &str,
@@ -33,17 +54,44 @@ impl RequestCtx {
         vhost: &str,
         headers: &[(String, String)],
     ) -> Self {
-        fn c(s: &str) -> CString {
-            CString::new(s.replace('\0', "")).unwrap_or_default()
-        }
         Self {
-            method: c(method),
-            path: c(path),
-            query: c(query),
-            remote_ip: c(remote_ip),
-            vhost: c(vhost),
-            headers: headers.iter().map(|(n, v)| (c(&n.to_ascii_lowercase()), c(v))).collect(),
+            method: cstr(method),
+            path: cstr(path),
+            query: cstr(query),
+            remote_ip: cstr(remote_ip),
+            vhost: cstr(vhost),
+            host: CString::default(),
+            is_secure: false,
+            body: Vec::new(),
+            headers: headers
+                .iter()
+                .map(|(n, v)| (cstr(&n.to_ascii_lowercase()), cstr(v)))
+                .collect(),
         }
+    }
+
+    /// Set the connection security (drives `request_scheme` /
+    /// `request_is_secure`). `true` = the request arrived over HTTPS/TLS.
+    #[must_use]
+    pub fn with_scheme(mut self, is_secure: bool) -> Self {
+        self.is_secure = is_secure;
+        self
+    }
+
+    /// Set the normalized request host (`request_host`). Pass the router's
+    /// canonical, already-normalized host key.
+    #[must_use]
+    pub fn with_host(mut self, host: &str) -> Self {
+        self.host = cstr(host);
+        self
+    }
+
+    /// Set the buffered request body exposed by `request_body`. The caller is
+    /// responsible for truncating `body` to the configured limit first.
+    #[must_use]
+    pub fn with_body(mut self, body: &[u8]) -> Self {
+        self.body = body.to_vec();
+        self
     }
 
     /// The opaque pointer to pass through the ABI. Valid while `self` lives.
@@ -99,14 +147,34 @@ unsafe extern "C" fn request_header(
     }
     std::ptr::null()
 }
-unsafe extern "C" fn request_body(_req: *const EphpmRequest, out_ptr: *mut *const u8) -> usize {
-    // v1: the chain runs BEFORE the body is read (rejecting before the
-    // transfer is the point) — no body view yet.
+unsafe extern "C" fn request_body(req: *const EphpmRequest, out_ptr: *mut *const u8) -> usize {
+    // The body is non-empty only when the operator opted into buffering
+    // (`[server.request] middleware_body_limit`); it is already bounded to
+    // that limit by the router. Empty otherwise (the chain ran before the body
+    // was read — rejecting before the transfer is the point) and on the
+    // static/response-phase paths, which carry no request body.
+    // SAFETY: ABI contract (pointer from as_abi, live during invoke).
+    let body = unsafe { ctx(req) }.map(|c| c.body.as_slice()).unwrap_or_default();
     if !out_ptr.is_null() {
+        let base = if body.is_empty() { std::ptr::null() } else { body.as_ptr() };
         // SAFETY: module passes a valid out-pointer.
-        unsafe { *out_ptr = std::ptr::null() };
+        unsafe { *out_ptr = base };
     }
-    0
+    body.len()
+}
+unsafe extern "C" fn request_scheme(req: *const EphpmRequest) -> *const c_char {
+    // SAFETY: ABI contract. Both branches point at 'static C-string literals.
+    unsafe { ctx(req) }.map_or(c"http".as_ptr(), |c| {
+        if c.is_secure { c"https".as_ptr() } else { c"http".as_ptr() }
+    })
+}
+unsafe extern "C" fn request_is_secure(req: *const EphpmRequest) -> c_int {
+    // SAFETY: ABI contract.
+    c_int::from(unsafe { ctx(req) }.is_some_and(|c| c.is_secure))
+}
+unsafe extern "C" fn request_host(req: *const EphpmRequest) -> *const c_char {
+    // SAFETY: ABI contract.
+    unsafe { ctx(req) }.map_or(std::ptr::null(), |c| c.host.as_ptr())
 }
 
 // ── Response context (response phase) ─────────────────────────────────────
@@ -459,6 +527,9 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     response_status,
     response_headers,
     response_body,
+    request_scheme,
+    request_is_secure,
+    request_host,
 };
 
 /// Wire the embedded KV store into the host table. Call once at startup,
@@ -471,4 +542,59 @@ pub fn set_kv_store(store: &Arc<ephpm_kv::store::Store>) {
 #[must_use]
 pub fn host_table() -> &'static EphpmHostV1 {
     &HOST_TABLE
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Request;
+    use crate::abi::{self, EphpmHostV1};
+    use crate::host::{RequestCtx, host_table};
+
+    fn ctx() -> RequestCtx {
+        RequestCtx::new("GET", "/hook", "", "203.0.113.4", "srv", &[])
+    }
+
+    #[test]
+    fn defaults_are_insecure_empty_host_no_body() {
+        let ctx = ctx();
+        // SAFETY: ctx and the real host table outlive the view.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert_eq!(req.scheme(), "http");
+        assert!(!req.is_secure());
+        assert_eq!(req.http_host(), "");
+        assert!(req.body().is_empty());
+    }
+
+    #[test]
+    fn builders_set_scheme_host_and_body() {
+        let ctx = ctx().with_scheme(true).with_host("blog.example").with_body(b"payload");
+        // SAFETY: as above.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert_eq!(req.scheme(), "https");
+        assert!(req.is_secure());
+        assert_eq!(req.http_host(), "blog.example");
+        assert_eq!(req.body(), b"payload");
+    }
+
+    /// A module built against minor 2 talking to a host advertising an OLDER
+    /// minor must NOT read the appended fields — the safe wrapper falls back.
+    /// (The `request_body` slot predates the gate, so it still works.)
+    #[test]
+    fn minor_gate_hides_appended_accessors_on_older_host() {
+        // A downgraded copy of the real table: every field identical, only the
+        // advertised minor rolled back below ABI_MINOR_REQUEST_ACCESSORS. All
+        // fields are Copy (fn pointers + u32), so struct-update copies them.
+        let old = EphpmHostV1 { abi_version: 0x0100_0001, ..*host_table() };
+        assert!((old.abi_version & 0x00FF_FFFF) < abi::ABI_MINOR_REQUEST_ACCESSORS);
+
+        let ctx = ctx().with_scheme(true).with_host("blog.example").with_body(b"payload");
+        // SAFETY: ctx and `old` outlive the view.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), &old) };
+        // Appended (minor-2) accessors fall back rather than read a short table.
+        assert_eq!(req.scheme(), "http");
+        assert!(!req.is_secure());
+        assert_eq!(req.http_host(), "");
+        // request_body has existed since minor 0 — not gated, still readable.
+        assert_eq!(req.body(), b"payload");
+    }
 }

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -186,6 +186,85 @@ impl Request<'_> {
         self.str_of(unsafe { (self.host.request_vhost_id)(self.raw) })
     }
 
+    /// The host's advertised ABI minor (low three bytes of `abi_version`).
+    /// Trailing accessors added in a later minor must be gated on this so a
+    /// module built against a newer ABI never reads past an older host's
+    /// (shorter) table.
+    fn host_minor(&self) -> u32 {
+        self.host.abi_version & 0x00FF_FFFF
+    }
+
+    /// Request URL scheme — `"https"` when TLS terminated at ePHPm for this
+    /// connection, `"http"` otherwise. Authoritative from the connection, not
+    /// from a forwarded header: the correct basis for a `force_https` redirect.
+    ///
+    /// Falls back to `"http"` on a host older than
+    /// [`abi::ABI_MINOR_REQUEST_ACCESSORS`] (the accessor is absent there).
+    #[must_use]
+    pub fn scheme(&self) -> &str {
+        if self.host_minor() < abi::ABI_MINOR_REQUEST_ACCESSORS {
+            return "http";
+        }
+        // SAFETY: contract of `from_raw`; the minor gate above guarantees the
+        // `request_scheme` field is present on this host's table.
+        self.str_of(unsafe { (self.host.request_scheme)(self.raw) })
+    }
+
+    /// Whether the request arrived over a secure (HTTPS/TLS) connection — the
+    /// boolean form of [`scheme`](Self::scheme).
+    ///
+    /// Falls back to `false` on a host older than
+    /// [`abi::ABI_MINOR_REQUEST_ACCESSORS`].
+    #[must_use]
+    pub fn is_secure(&self) -> bool {
+        if self.host_minor() < abi::ABI_MINOR_REQUEST_ACCESSORS {
+            return false;
+        }
+        // SAFETY: contract of `from_raw`; minor-gated as above.
+        (unsafe { (self.host.request_is_secure)(self.raw) }) != 0
+    }
+
+    /// Normalized request `Host` — port stripped, trailing dot stripped,
+    /// lowercased (the router's own vhost-key normalization). Distinct from
+    /// [`vhost_id`](Self::vhost_id) (the un-normalized server name); empty when
+    /// the request carried no usable `Host`.
+    ///
+    /// Falls back to `""` on a host older than
+    /// [`abi::ABI_MINOR_REQUEST_ACCESSORS`].
+    #[must_use]
+    pub fn http_host(&self) -> &str {
+        if self.host_minor() < abi::ABI_MINOR_REQUEST_ACCESSORS {
+            return "";
+        }
+        // SAFETY: contract of `from_raw`; minor-gated as above.
+        self.str_of(unsafe { (self.host.request_host)(self.raw) })
+    }
+
+    /// Bounded, read-only view of the buffered request body (borrowed; valid
+    /// only inside `invoke`).
+    ///
+    /// Non-empty only when the operator opted in with `[server.request]
+    /// middleware_body_limit > 0`, in which case up to that many body bytes are
+    /// exposed here (a longer body is truncated to the limit for this view —
+    /// PHP still receives the full body). Empty otherwise, and always empty on
+    /// the static-file path. Use it for webhook/HMAC signature checks,
+    /// CSRF-with-body, and payload validation.
+    ///
+    /// The `request_body` slot has existed since minor 0, so no minor gate is
+    /// needed.
+    #[must_use]
+    pub fn body(&self) -> &[u8] {
+        let mut ptr: *const u8 = std::ptr::null();
+        // SAFETY: contract of `from_raw`; `ptr` points at a local.
+        let len = unsafe { (self.host.request_body)(self.raw, &raw mut ptr) };
+        if ptr.is_null() || len == 0 {
+            return &[];
+        }
+        // SAFETY: the host returned a live `(ptr, len)` byte slice valid for
+        // the duration of this call (the request).
+        unsafe { std::slice::from_raw_parts(ptr, len) }
+    }
+
     /// Host services (KV store, logging) scoped to the table this request
     /// was invoked with. Equivalent to `Host::new(__ephpm_mw_host())` but
     /// also works in unit tests that build a [`Request`] by hand.

--- a/crates/ephpm-server/examples/mw_probe_v1.rs
+++ b/crates/ephpm-server/examples/mw_probe_v1.rs
@@ -44,6 +44,11 @@ impl Middleware for Probe {
             .response_header("X-Probe-Remote-Ip", req.remote_ip())
             .response_header("X-Probe-Vhost", req.vhost_id())
             .response_header("X-Probe-Accept", req.header("Accept").unwrap_or("<none>"))
+            // Minor-2 request accessors, echoed for the dlopen round-trip test.
+            .response_header("X-Probe-Scheme", req.scheme())
+            .response_header("X-Probe-Secure", if req.is_secure() { "1" } else { "0" })
+            .response_header("X-Probe-Host", req.http_host())
+            .response_header("X-Probe-Body", String::from_utf8_lossy(req.body()).into_owned())
     }
 
     fn describe() -> &'static str {

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -421,6 +421,10 @@ pub struct Router {
     fallback: Vec<String>,
     server_port: u16,
     max_body_size: u64,
+    /// `[server.request] middleware_body_limit` — max body bytes buffered and
+    /// exposed to request-phase middleware via `request_body`. `0` = disabled
+    /// (the chain runs before the body is read).
+    middleware_body_limit: u64,
     compression: CompressionSettings,
     hidden_files: String,
     cache_control: String,
@@ -980,6 +984,7 @@ impl Router {
             fallback: config.server.fallback.clone(),
             server_port: port,
             max_body_size: config.server.request.max_body_size,
+            middleware_body_limit: config.server.request.middleware_body_limit,
             compression: CompressionSettings {
                 enabled: config.server.response.compression,
                 level: config.server.response.compression_level,
@@ -2373,6 +2378,7 @@ impl Router {
                         &query_string,
                         effective_addr,
                         &host,
+                        is_https,
                     ) {
                         StaticGate::Respond(resp) => (resp, "middleware"),
                         StaticGate::Continue(extra_headers) => {
@@ -2455,6 +2461,7 @@ impl Router {
                     &query_string,
                     effective_addr,
                     &host,
+                    is_https,
                 )
                 .await;
         }
@@ -2841,14 +2848,59 @@ impl Router {
 
         let server_port = self.server_port;
 
-        // Native middleware chain — evaluated BEFORE any body bytes are read,
-        // so a RESPOND verdict (auth reject, rate limit, ...) never pays for
-        // the body transfer. v1: every module sees the original request;
+        // Content-Length (if declared) drives the worker-mode buffer-vs-stream
+        // decision below. Read here — before the body may be consumed for
+        // middleware buffering.
+        let content_length: Option<u64> = req
+            .headers()
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok());
+
+        // Optional request-body buffering for middleware (`[server.request]
+        // middleware_body_limit`). When enabled AND a chain is mounted, buffer
+        // the body up front so the chain's `request_body` accessor can inspect
+        // it (webhook/HMAC, CSRF-with-body); the SAME bytes are then handed to
+        // PHP, so the body still arrives intact. When disabled (the default)
+        // the chain runs before the body is read — a RESPOND never pays for the
+        // transfer — and `req` flows unbuffered to the dispatch below.
+        //
+        // `req` becomes an `Option` so it can be consumed conditionally: taken
+        // for buffering, or left intact for the streaming/buffered dispatch.
+        // WebSocket events (synthetic, codec-bounded bodies) skip this.
+        let mut req = Some(req);
+        let buffer_body =
+            self.middleware_body_limit > 0 && self.middleware_chain.is_some() && ws_event.is_none();
+        let mut prebuffered: Option<Vec<u8>> = if buffer_body {
+            let taken = req.take().expect("request present before body buffering");
+            match self.collect_body_capped(taken).await {
+                Ok(bytes) => {
+                    #[allow(clippy::cast_precision_loss)]
+                    histogram!("ephpm_http_request_body_bytes", "method" => method_label)
+                        .record(bytes.len() as f64);
+                    Some(bytes)
+                }
+                Err(()) => {
+                    counter!("ephpm_http_body_overflow_total").increment(1);
+                    return error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large");
+                }
+            }
+        } else {
+            None
+        };
+
+        // Native middleware chain. v1: every module sees the original request;
         // accumulated REWRITE overrides are applied here, after the chain.
         // CONTINUE/REWRITE response headers are appended to whatever response
-        // this request ultimately produces (PHP output or an error page).
+        // this request ultimately produces (PHP output or an error page). The
+        // `request_body` accessor exposes up to `middleware_body_limit` bytes of
+        // the buffered body (empty when buffering is off).
         let mut mw_response_headers: Vec<(String, String)> = Vec::new();
         if let Some(ref chain) = self.middleware_chain {
+            let body_view: &[u8] = prebuffered.as_deref().map_or(&[], |b| {
+                let cap = usize::try_from(self.middleware_body_limit).unwrap_or(usize::MAX);
+                &b[..b.len().min(cap)]
+            });
             let ctx = ephpm_middleware::host::RequestCtx::new(
                 &method,
                 &path,
@@ -2856,7 +2908,10 @@ impl Router {
                 &remote_addr.ip().to_string(),
                 &server_name,
                 &headers,
-            );
+            )
+            .with_scheme(is_https)
+            .with_host(&normalize_host_key(&server_name))
+            .with_body(body_view);
             match chain.evaluate(&ctx, &path) {
                 crate::middleware::ChainVerdict::Respond { status, body, headers } => {
                     return middleware_response(status, body, &headers);
@@ -2888,14 +2943,6 @@ impl Router {
             }
         }
 
-        // Content-Length (if declared) drives the worker-mode buffer-vs-stream
-        // decision below.
-        let content_length: Option<u64> = req
-            .headers()
-            .get("content-length")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse().ok());
-
         // Worker mode: dispatch to the persistent worker pool instead of the
         // spawn_blocking fpm path. The whole handler is already wrapped in the
         // outer request timeout, so a starved queue becomes a 504.
@@ -2903,43 +2950,54 @@ impl Router {
         // Large / unknown-length bodies STREAM into the worker (Phase 3): the
         // hyper `Incoming` body is read frame-by-frame by a task feeding a
         // bounded channel the worker drains, so ePHPm never holds the whole
-        // body in memory. Small bodies keep the cheaper buffered path.
+        // body in memory. Small bodies keep the cheaper buffered path. A body
+        // already buffered for middleware skips streaming and is handed over
+        // directly (its histogram was recorded when it was buffered).
         if let Some(pool) = self.worker_pool.clone() {
-            let should_stream = self.worker_stream_threshold > 0
-                && content_length.is_none_or(|len| len >= self.worker_stream_threshold);
-
-            let (worker_body, body_overflow) = if should_stream {
-                let (body, overflow) = stream_request_body(req, content_length, self.max_body_size);
-                (body, Some(overflow))
-            } else {
-                // The Content-Length pre-check already 413'd declared-large
-                // bodies; `Limited` catches chunked / lying clients on the
-                // buffered path (`Err` on exceeding the cap).
-                let bytes = if self.max_body_size > 0 {
-                    let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
-                    match http_body_util::Limited::new(req, cap).collect().await {
-                        Ok(collected) => collected.to_bytes().to_vec(),
-                        Err(_) => {
-                            counter!("ephpm_http_body_overflow_total").increment(1);
-                            return apply_response_headers(
-                                error_response(
-                                    StatusCode::PAYLOAD_TOO_LARGE,
-                                    "413 Payload Too Large",
-                                ),
-                                &mw_response_headers,
-                            );
-                        }
-                    }
-                } else {
-                    match req.collect().await {
-                        Ok(collected) => collected.to_bytes().to_vec(),
-                        Err(_) => Vec::new(),
-                    }
-                };
-                #[allow(clippy::cast_precision_loss)]
-                histogram!("ephpm_http_request_body_bytes", "method" => method_label)
-                    .record(bytes.len() as f64);
+            let (worker_body, body_overflow) = if let Some(bytes) = prebuffered.take() {
                 (ephpm_php::worker_bridge::WorkerBody::Buffered(bytes), None)
+            } else {
+                let should_stream = self.worker_stream_threshold > 0
+                    && content_length.is_none_or(|len| len >= self.worker_stream_threshold);
+                if should_stream {
+                    let (body, overflow) = stream_request_body(
+                        req.take().expect("request present for streaming"),
+                        content_length,
+                        self.max_body_size,
+                    );
+                    (body, Some(overflow))
+                } else {
+                    // The Content-Length pre-check already 413'd declared-large
+                    // bodies; `Limited` catches chunked / lying clients on the
+                    // buffered path (`Err` on exceeding the cap).
+                    let bytes = if self.max_body_size > 0 {
+                        let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
+                        let taken = req.take().expect("request present for buffered worker body");
+                        match http_body_util::Limited::new(taken, cap).collect().await {
+                            Ok(collected) => collected.to_bytes().to_vec(),
+                            Err(_) => {
+                                counter!("ephpm_http_body_overflow_total").increment(1);
+                                return apply_response_headers(
+                                    error_response(
+                                        StatusCode::PAYLOAD_TOO_LARGE,
+                                        "413 Payload Too Large",
+                                    ),
+                                    &mw_response_headers,
+                                );
+                            }
+                        }
+                    } else {
+                        let taken = req.take().expect("request present for buffered worker body");
+                        match taken.collect().await {
+                            Ok(collected) => collected.to_bytes().to_vec(),
+                            Err(_) => Vec::new(),
+                        }
+                    };
+                    #[allow(clippy::cast_precision_loss)]
+                    histogram!("ephpm_http_request_body_bytes", "method" => method_label)
+                        .record(bytes.len() as f64);
+                    (ephpm_php::worker_bridge::WorkerBody::Buffered(bytes), None)
+                }
             };
 
             let resp = self
@@ -2983,28 +3041,37 @@ impl Router {
         // fpm path buffers the whole body; cap chunked / lying clients the same
         // way the Content-Length pre-check caps declared bodies. A WebSocket
         // event's body was bounded by the codec, not by this knob (see the
-        // `check_body_size` skip above), so it takes the uncapped branch.
-        let body = if self.max_body_size > 0 && ws_event.is_none() {
-            let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
-            match http_body_util::Limited::new(req, cap).collect().await {
-                Ok(collected) => collected.to_bytes().to_vec(),
-                Err(_) => {
-                    counter!("ephpm_http_body_overflow_total").increment(1);
-                    return apply_response_headers(
-                        error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large"),
-                        &mw_response_headers,
-                    );
-                }
-            }
+        // `check_body_size` skip above), so it takes the uncapped branch. A body
+        // already buffered for middleware is reused as-is (its histogram was
+        // recorded when it was buffered).
+        let body = if let Some(bytes) = prebuffered.take() {
+            bytes
         } else {
-            match req.collect().await {
-                Ok(collected) => collected.to_bytes().to_vec(),
-                Err(_) => Vec::new(),
-            }
+            let bytes = if self.max_body_size > 0 && ws_event.is_none() {
+                let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
+                let taken = req.take().expect("request present for fpm body");
+                match http_body_util::Limited::new(taken, cap).collect().await {
+                    Ok(collected) => collected.to_bytes().to_vec(),
+                    Err(_) => {
+                        counter!("ephpm_http_body_overflow_total").increment(1);
+                        return apply_response_headers(
+                            error_response(StatusCode::PAYLOAD_TOO_LARGE, "413 Payload Too Large"),
+                            &mw_response_headers,
+                        );
+                    }
+                }
+            } else {
+                let taken = req.take().expect("request present for fpm body");
+                match taken.collect().await {
+                    Ok(collected) => collected.to_bytes().to_vec(),
+                    Err(_) => Vec::new(),
+                }
+            };
+            #[allow(clippy::cast_precision_loss)]
+            histogram!("ephpm_http_request_body_bytes", "method" => method_label)
+                .record(bytes.len() as f64);
+            bytes
         };
-        #[allow(clippy::cast_precision_loss)]
-        histogram!("ephpm_http_request_body_bytes", "method" => method_label)
-            .record(body.len() as f64);
 
         let multi_tenant_kv = self.multi_tenant_kv.clone();
         let vhost_open_basedir = self.sites_dir.is_some() && self.open_basedir;
@@ -3571,6 +3638,28 @@ impl Router {
         }
     }
 
+    /// Collect the full request body into a `Vec<u8>`, enforcing
+    /// `max_body_size` (the same cap the fpm/worker buffered paths apply):
+    /// `Err(())` when the cap is exceeded (the caller turns it into a 413),
+    /// `Ok` otherwise. Used to buffer the body up front for middleware
+    /// (`[server.request] middleware_body_limit`); the same bytes are then
+    /// handed to PHP, so the body still arrives intact.
+    async fn collect_body_capped<B>(&self, req: Request<B>) -> Result<Vec<u8>, ()>
+    where
+        B: RequestBody,
+    {
+        if self.max_body_size > 0 {
+            let cap = usize::try_from(self.max_body_size).unwrap_or(usize::MAX);
+            http_body_util::Limited::new(req, cap)
+                .collect()
+                .await
+                .map(|c| c.to_bytes().to_vec())
+                .map_err(|_| ())
+        } else {
+            req.collect().await.map(|c| c.to_bytes().to_vec()).map_err(|_| ())
+        }
+    }
+
     /// Return 413 if Content-Length exceeds the limit.
     fn check_body_size<B>(&self, req: &Request<B>) -> Option<Response<ServerBody>> {
         if self.max_body_size == 0 {
@@ -3788,10 +3877,14 @@ impl Router {
         query: &str,
         remote_addr: SocketAddr,
         server_name: &str,
+        is_https: bool,
     ) -> StaticGate {
         let Some(chain) = self.middleware_chain.as_ref() else {
             return StaticGate::Continue(Vec::new());
         };
+        // Static requests carry no buffered body, but scheme/host are still
+        // authoritative from the connection (a `force_https` gate on static
+        // assets needs the real scheme).
         let ctx = ephpm_middleware::host::RequestCtx::new(
             method,
             path,
@@ -3799,7 +3892,9 @@ impl Router {
             &remote_addr.ip().to_string(),
             server_name,
             req_headers.unwrap_or(&[]),
-        );
+        )
+        .with_scheme(is_https)
+        .with_host(&normalize_host_key(server_name));
         match chain.evaluate(&ctx, path) {
             crate::middleware::ChainVerdict::Respond { status, body, headers } => {
                 StaticGate::Respond(middleware_response(status, body, &headers))
@@ -3831,6 +3926,7 @@ impl Router {
         query: &str,
         remote_addr: SocketAddr,
         server_name: &str,
+        is_https: bool,
     ) -> Response<ServerBody> {
         use hyper::body::Body as _;
 
@@ -3885,7 +3981,9 @@ impl Router {
             &remote_addr.ip().to_string(),
             server_name,
             req_headers.unwrap_or(&[]),
-        );
+        )
+        .with_scheme(is_https)
+        .with_host(&normalize_host_key(server_name));
         let outcome = chain.run_response_phase(
             &ctx,
             path,

--- a/crates/ephpm-server/tests/middleware_dlopen.rs
+++ b/crates/ephpm-server/tests/middleware_dlopen.rs
@@ -126,9 +126,12 @@ fn dynamic_module_loads_and_round_trips_request_context() {
         "/app/index.php",
         "a=1&b=2",
         "198.51.100.9",
-        "probe.example",
+        "Probe.Example.:8443",
         &[("Accept".to_owned(), "text/html".to_owned())],
-    );
+    )
+    .with_scheme(true)
+    .with_host("probe.example")
+    .with_body(b"payload-bytes");
     match chain.evaluate(&ctx, "/app/index.php") {
         ChainVerdict::Continue { rewrite_path, header_overrides, response_headers } => {
             assert!(rewrite_path.is_none());
@@ -140,8 +143,15 @@ fn dynamic_module_loads_and_round_trips_request_context() {
             assert_eq!(find(&response_headers, "X-Probe-Path"), Some("/app/index.php"));
             assert_eq!(find(&response_headers, "X-Probe-Query"), Some("a=1&b=2"));
             assert_eq!(find(&response_headers, "X-Probe-Remote-Ip"), Some("198.51.100.9"));
-            assert_eq!(find(&response_headers, "X-Probe-Vhost"), Some("probe.example"));
+            // vhost_id is the un-normalized server name…
+            assert_eq!(find(&response_headers, "X-Probe-Vhost"), Some("Probe.Example.:8443"));
             assert_eq!(find(&response_headers, "X-Probe-Accept"), Some("text/html"));
+            // …minor-2 accessors: scheme/secure from the connection, normalized
+            // host, and the bounded buffered body — all across the C ABI.
+            assert_eq!(find(&response_headers, "X-Probe-Scheme"), Some("https"));
+            assert_eq!(find(&response_headers, "X-Probe-Secure"), Some("1"));
+            assert_eq!(find(&response_headers, "X-Probe-Host"), Some("probe.example"));
+            assert_eq!(find(&response_headers, "X-Probe-Body"), Some("payload-bytes"));
         }
         ChainVerdict::Respond { status, .. } => {
             panic!("expected CONTINUE from the probe fixture, got RESPOND {status}")

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -172,9 +172,13 @@ v1 rules worth knowing:
   non-zero, a Rust panic caught by the authoring kit, or a panicking
   built-in (caught by the host) all produce a plain 500, never a silent
   pass-through.
-- **Request bodies are not visible** to middleware. The chain runs before
-  the body is read (rejecting before the transfer is the point);
-  the ABI's body accessor currently always returns length 0.
+- **Request bodies are hidden by default.** The chain runs before the body is
+  read (rejecting before the transfer is the point), so `req.body()` is empty
+  unless the operator opts in with `[server.request] middleware_body_limit`
+  (bytes) `> 0`. When set, the body is buffered up front and `req.body()`
+  returns up to that many bytes — for webhook/HMAC signature checks,
+  CSRF-with-body, and payload validation — while the full body still reaches
+  PHP intact. See the [config reference](../../reference/config/).
 
 **Coverage.** The request phase runs on **both** the PHP path and the
 **static-file** path, in every mode — so a `RESPOND` verdict gates a static
@@ -441,6 +445,32 @@ host.log(ephpm_middleware::abi::LOG_INFO, "hello from middleware");
 The KV operations hit the same embedded store PHP sees through
 `ephpm_kv_*` — replicated across the cluster when clustering is enabled.
 
+The `Request` also exposes the connection and (optional) body:
+
+```rust
+fn invoke(&self, req: &Request<'_>) -> Response {
+    // Scheme is authoritative from the connection (ePHPm terminates TLS) —
+    // no X-Forwarded-Proto sniffing. This is the correct force-https basis.
+    if !req.is_secure() {
+        let target = format!("https://{}{}", req.http_host(), req.path());
+        return Response::respond(301, "").header("Location", target);
+    }
+    // req.body() is empty unless `[server.request] middleware_body_limit > 0`.
+    // Verify an HMAC signature over the buffered body:
+    let sig = req.header("X-Signature").unwrap_or("");
+    if !verify_hmac(req.body(), sig) {
+        return Response::respond(401, "bad signature");
+    }
+    Response::cont()
+}
+```
+
+`req.scheme()` returns `"http"`/`"https"`, `req.http_host()` the normalized
+`Host` (port/trailing-dot stripped, lowercased — distinct from
+`req.vhost_id()`, the raw server name), and `req.body()` the bounded buffered
+body. Against an older host that predates these (ABI minor < 2) they fall back
+to `"http"` / `false` / `""` rather than reading past a shorter table.
+
 ### Building modules on Linux
 
 The module must match the host binary's libc. The release binary is
@@ -482,23 +512,26 @@ int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
                                          ephpm_response_edit_t* edit_out);
 ```
 
-- `abi_version` is `0x01_00_00_01` — major **1**, minor **1**. The **major
+- `abi_version` is `0x01_00_00_02` — major **1**, minor **2**. The **major
   byte** gates compatibility; modules must refuse to init (return non-zero)
   when the host's major is newer than they were built for. The lower three
   bytes are an additive **minor** level: growth (new host-table fields, the
   optional response symbol) bumps the minor and keeps the major, so existing
   major-1 modules keep loading. A module that uses a newer field must check
-  the host's advertised minor (`host->abi_version & 0x00FFFFFF`) first.
+  the host's advertised minor (`host->abi_version & 0x00FFFFFF`) first —
+  minor **1** added the response phase, minor **2** the appended request
+  accessors (`request_scheme`/`request_is_secure`/`request_host`).
 - `config_json` is the mount's `config` table serialised to JSON (NULL when
   the mount has no config).
 - The host callback table is passed **by pointer at `init`** and is valid
   for the process lifetime — modules do not `dlsym` host symbols (that
   would need `-rdynamic` on Linux and has no clean Windows analogue). It
   contains request accessors (method, path, query, remote IP, header
-  lookup, vhost id), the KV operations (`kv_get`/`kv_set`/`kv_set_nx`/
-  `kv_incr`/`kv_incr_ttl`/`kv_free`), `log`, and — for the response phase
-  (minor 1) — the response accessors (`response_status`/`response_headers`/
-  `response_body`).
+  lookup, vhost id, and — minor 2 — scheme/`is_secure`, normalized host, and
+  the bounded buffered body), the KV operations (`kv_get`/`kv_set`/
+  `kv_set_nx`/`kv_incr`/`kv_incr_ttl`/`kv_free`), `log`, and — for the
+  response phase (minor 1) — the response accessors (`response_status`/
+  `response_headers`/`response_body`).
 - The request pointer is only valid during `invoke`; never store it.
   Everything a module writes into `response_out` must stay valid until its
   `invoke` returns — the host copies before unwinding. The same rule applies

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -35,6 +35,7 @@ All sections and keys are optional. Missing sections use defaults; `Config::defa
 | `max_body_size` | u64 (bytes) | `10_485_760` (10 MiB) | Max request body. `0` = unlimited. Exceeding sends 413. |
 | `max_header_size` | usize (bytes) | `8192` | Max total request header size. |
 | `trusted_hosts` | array of strings | `[]` | Allowed `Host` header values. Empty = allow all. Mismatched hosts get 421. `/_ephpm/health`, `/_ephpm/ready`, `/_ephpm/requests` (when the request timeline is enabled), and the metrics path are exempt (probes/scrapes address pods by IP). |
+| `middleware_body_limit` | u64 (bytes) | `0` (disabled) | Max request-body bytes buffered and exposed to **request-phase** native middleware via the `request_body` ABI accessor. `0` (default) disables buffering — the chain runs before the body is read, so a `RESPOND` never pays for the transfer. When `> 0` **and** a `[[middleware]]` chain is mounted, the body is buffered up front so middleware can inspect up to this many bytes (a longer body is truncated *for the middleware view only*; the full body, subject to `max_body_size`, still reaches PHP). Enables webhook/HMAC verification, CSRF-with-body, and payload validation. Buffering bypasses worker-mode request streaming for such requests. |
 
 ### `[server.timeouts]` (all in seconds)
 


### PR DESCRIPTION
## Summary

Extends the native-middleware host ABI (**major 1, additive**) with three new request accessors and gives the pre-existing `request_body` slot real, bounded semantics. Bumps `ABI_V1` `0x0100_0001 → 0x0100_0002` (minor **1 → 2**). Growth is append-only: the major byte is unchanged, so **every module built against major 1 still loads**, and older modules are unaffected.

These close real capability gaps the middleware modules hit: `force_https` had to sniff `X-Forwarded-Proto` (no scheme accessor), there was no host accessor, and `request_body` returned 0 — blocking webhook/HMAC verification, CSRF-with-body, and payload validation.

## ⚠️ Stacks on #408 (must merge after it)

This branch is cut from `origin/feat/middleware-response-phase` (#408, which introduced minor 1 — the response phase — and bumped the ABI to `0x0100_0001`). **#408 must merge first.** Once it lands, this branch rebases onto `main` down to just the accessor commit. If #408's branch is force-pushed (rebased) meanwhile, I'll re-base this onto its new head. Do **not** merge before #408.

## What's added

New host-table accessors, appended after `response_body` (minor 2 — a module reading them must first check `abi_version & 0x00FF_FFFF >= 2`):

| Accessor | Semantics |
|---|---|
| `request_scheme` | `"http"` / `"https"`, **authoritative from the connection** TLS state (ePHPm terminates TLS), not `X-Forwarded-Proto`. |
| `request_is_secure` | Boolean form of the above. |
| `request_host` | The router's **normalized** `Host` (port + trailing-dot stripped, lowercased) — distinct from `request_vhost_id`, the un-normalized server name. |

`request_body` — repurposed **in place** (no new slot, no reorder): a bounded, read-only buffered view. Opt-in via a new config knob:

- **`[server.request] middleware_body_limit`** (bytes, default **`0` = disabled**).
- `0` (default): the chain runs *before* the body is read — a `RESPOND` never pays for the transfer — and `request_body` returns empty. **Preserves the existing reject-before-body-transfer property; zero behavior change by default.**
- `> 0` **and** a chain mounted: the body is buffered up front so middleware can inspect up to that many bytes; a longer body is truncated **for the middleware view only** — the **full body (subject to `max_body_size`) still reaches PHP intact**. Buffering bypasses worker-mode request streaming for those requests.

> **Default-choice note:** the task suggested a default of ~1 MiB, but I defaulted to `0` (opt-in). Defaulting *on* would read (part of) every body before the chain for all middleware users — contradicting the module's own documented "rejecting before the body transfer is the point" design and the repo's config-knob guidance ("prefer 0 = disabled, opt into limits explicitly"). Flipping the default is a one-line change to `default_middleware_body_limit()` if you'd rather ship it on.

Safe authoring wrappers: `Request::scheme()`, `is_secure()`, `http_host()`, `body()` — all **minor-gated**, so a minor-2 module talking to an older host falls back to `"http"` / `false` / `""` rather than reading past a shorter table. (`request_body`'s slot predates the gate, so it stays readable.)

## Request-body passthrough (nothing deferred)

Fully implemented for the fpm and worker-buffered paths, which already reduce the body to a `Vec<u8>`: the buffered bytes are the exact bytes handed to PHP, so passthrough is correct by construction (no partial-stream surgery). The one tradeoff — worker-mode request *streaming* is bypassed when body buffering is engaged — is documented; operators who need streaming for huge uploads leave the knob at `0`.

## Version + back-compat

- `ABI_V1 = 0x0100_0002`, `ABI_MINOR = 2`, new `ABI_MINOR_REQUEST_ACCESSORS = 2`.
- Same presence/minor detection contract #408 uses; the major-version handshake is unchanged and still gates compatibility.

## Tests

- **host unit tests** (`ephpm-middleware`, `--features host`): defaults; builder round-trip; **minor-gate** hides the appended accessors on a downgraded host table while `request_body` still works.
- **dlopen host test** (`middleware_dlopen.rs`): the probe fixture now echoes scheme/secure/host/body; the round-trip asserts `scheme=https`, `secure=1`, normalized `host=probe.example` (from `Probe.Example.:8443`), and `body=payload-bytes` **across the C ABI**.
- **config**: default-disabled test (field default **and** whole-section-absent) + TOML parse test.
- `cargo check`, `cargo clippy --workspace --all-targets -- -D warnings` (plus `-p ephpm-middleware --features host`), and `cargo +nightly fmt --all -- --check` all clean.

## Docs

- `site/content/reference/config.md`: `middleware_body_limit` row.
- `site/content/guides/native-middleware.md`: ABI version/minor bump, the new accessors, a `force_https` + HMAC example, and the corrected "request bodies" note.

Do **not** merge — waiting on #408.
