### PR TITLE
feat(middleware): compile all official modules into the builtin registry (v0.8.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ The project has a working Cargo workspace. PHP embedding is fully implemented an
 
 ZTS PHP runs concurrently: each `spawn_blocking` thread auto-registers with TSRM and gets its own PHP context — no dedicated worker pool. Shipped subsystems beyond core embedding: in-process MySQL DB proxy with pooling, in-process KV store (RESP + SETNX), SWIM gossip clustering, single-node and clustered embedded Turso (litewire + the in-process Turso engine; clustered replicates via the in-process Turso CDC path — no sqld sidecar), primary election + failover, query stats with Prometheus metrics, and a native PHP session handler backed by the KV tier. As of v0.7.0 the rusqlite backend and sqld were removed — Turso is the only embedded SQLite-family engine.
 
-Native middleware shipped: a static builtin registry (`jwt`, `cors`, `ratelimit`, `security-headers` compiled into every binary) plus a dlopen C-ABI lane for out-of-tree modules — the Linux release binary is glibc-dynamic, so the dlopen lane (and `[php] extensions` shared-extension loading) works out of the box. Implementations live in `ephpm-middleware-builtins`; the `ephpm-middleware-*` crates are cdylib shells (their `declare!` exports collide if linked into one binary — never add them as server deps). Active roadmap items (specs landed, no code yet): OPcache clustering with per-vhost preload.
+Native middleware shipped: a static builtin registry (ten official modules — `jwt`, `cors`, `ratelimit`, `security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, `header-transform` — compiled into every binary; `request-id`/`header-transform` also run the response phase via `BuiltinModule::init_response`) plus a dlopen C-ABI lane for out-of-tree modules — the Linux release binary is glibc-dynamic, so the dlopen lane (and `[php] extensions` shared-extension loading) works out of the box. Implementations live in `ephpm-middleware-builtins`; the in-repo `ephpm-middleware-{jwt,cors,ratelimit,security-headers}` crates are cdylib shells kept as the cross-platform dlopen CI fixtures (their `declare!` exports collide if linked into one binary — never add them as server deps), and cdylib shells for the other six live in the `ephpm/middleware` (examples) repo. Active roadmap items (specs landed, no code yet): OPcache clustering with per-vhost preload.
 
 ## Repository Structure
 
@@ -208,8 +208,8 @@ crates/
 │                       # two-tier KV replication, SQLite primary election
 ├── ephpm-query-stats/  # SQL normalizer + digest tracking + Prometheus metrics
 ├── ephpm-middleware/   # Middleware C ABI + Rust authoring kit + host table + builtin adapter
-├── ephpm-middleware-builtins/  # The four in-tree middleware implementations (rlib, linked into the server)
-├── ephpm-middleware-{jwt,cors,ratelimit,security-headers}/  # cdylib shells for the dlopen lane
+├── ephpm-middleware-builtins/  # The ten official middleware implementations (rlib, linked into the server)
+├── ephpm-middleware-{jwt,cors,ratelimit,security-headers}/  # cdylib shells kept as the dlopen CI fixtures (other six shells live in the examples repo)
 ├── ephpm-e2e/          # E2E test suite — excluded from workspace; runs bare-process via `cargo xtask e2e` (opt-in Kind path is `cargo xtask k8s-e2e`)
 └── xtask/              # Build tooling — release, php-sdk, e2e (bare-process default), k8s-e2e/k8s-e2e-up/k8s-e2e-down (opt-in)
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,8 +1365,10 @@ dependencies = [
  "ephpm-kv",
  "ephpm-middleware",
  "hmac 0.12.1",
+ "ipnetwork",
  "serde_json",
  "sha2 0.10.9",
+ "subtle",
 ]
 
 [[package]]
@@ -2453,6 +2455,12 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "ipnetwork"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "iri-string"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,13 @@ flate2 = "1"
 brotli = "7"
 zstd = "0.13"
 ipnet = "2"
+# CIDR membership for the `ip-allowlist` builtin middleware (IPv4 + IPv6).
+# Default features only (`serde` is opt-in and not enabled), so no extra
+# transitive deps beyond std IP parsing.
+ipnetwork = "0.21"
+# Constant-time key comparison for the `api-key` builtin middleware. Tiny,
+# no_std, no transitive deps.
+subtle = "2"
 tracing-appender = "0.2"
 # ONE rustls crypto provider for the whole tree: aws-lc-rs (issue #241).
 #

--- a/crates/ephpm-middleware-builtins/Cargo.toml
+++ b/crates/ephpm-middleware-builtins/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "The in-tree ePHPm middleware implementations (jwt, cors, ratelimit, security-headers) as plain Rust types — compiled into every ePHPm binary via the static registry"
+description = "The in-tree ePHPm official middleware implementations (jwt, cors, ratelimit, security-headers, api-key, ip-allowlist, maintenance-mode, redirect, request-id, header-transform) as plain Rust types — compiled into every ePHPm binary via the static registry"
 
 # Deliberately rlib-only and free of C ABI exports: `ephpm-server` links this
 # crate into the (possibly fully static) binary. The loadable cdylib shells
@@ -20,6 +20,12 @@ serde_json.workspace = true
 hmac.workspace = true
 sha2.workspace = true
 base64ct.workspace = true
+# ip-allowlist: CIDR containment for v4+v6. Tiny, MIT/Apache-2.0; std handles
+# IP parsing, ipnetwork only does the network-membership test.
+ipnetwork.workspace = true
+# api-key: constant-time key comparison (no_std, no transitive deps) — closes
+# the timing oracle a naive `==` would open.
+subtle.workspace = true
 
 [dev-dependencies]
 ephpm-middleware = { workspace = true, features = ["host"] }

--- a/crates/ephpm-middleware-builtins/src/api_key.rs
+++ b/crates/ephpm-middleware-builtins/src/api_key.rs
@@ -1,0 +1,420 @@
+//! `api-key` — ePHPm native middleware validating an API key on the request
+//! before PHP runs, then forwarding the resolved **consumer identity** to PHP.
+//!
+//! Analogous to Kong's `key-auth`, AWS API Gateway API keys / usage plans, and
+//! Tyk: a request carrying a recognised key is admitted and tagged with the
+//! consumer it belongs to; a request with a missing or unrecognised key is
+//! short-circuited with `401` and PHP never runs.
+//!
+//! The key is read from a configurable request header (default `X-Api-Key`)
+//! and, only when explicitly enabled, from a query parameter (default off —
+//! see the security note). It is validated against either a static
+//! `key → consumer-id` map baked into the config, a KV lookup (`kv_get` on a
+//! `kv_key_template` like `apikey:<key>` whose value is the consumer id), or
+//! both (the static map is consulted first). On success the module `REWRITE`s
+//! the request, injecting the consumer id in a header (default
+//! `X-Consumer-Id`) that PHP reads — the exact mechanism `jwt` uses to forward
+//! claims. The injected header **overwrites** any same-named header the client
+//! sent (the host's `override_header` replaces, not appends), so a client
+//! cannot spoof its consumer identity.
+//!
+//! ## Security
+//!
+//! * **Constant-time comparison.** Static keys are compared with a
+//!   constant-time equality check (`subtle::ConstantTimeEq`) so the match does
+//!   not leak how many leading bytes were correct — closing the timing oracle
+//!   that a naive `==` would open. All configured keys are compared on every
+//!   request (no early return on the first match). Only the *lengths* of keys
+//!   can differ in timing, which is not a practical attack surface. The KV
+//!   path is an exact-key store lookup and does not compare secrets in Rust.
+//! * **The key value is never logged.** This module emits no logs containing
+//!   the presented key.
+//! * **Query parameter is off by default.** Query strings routinely end up in
+//!   access logs, proxy logs, browser history and `Referer` headers, so a key
+//!   in the URL leaks far more readily than one in a header. Enable
+//!   `query_param` only when a client genuinely cannot set a header.
+//! * **Composes with `ratelimit`.** Point the `ratelimit` module's
+//!   `key_headers` at the same header (e.g. `["X-Api-Key"]`) to get per-key
+//!   rate limiting in front of, or alongside, this auth gate.
+//!
+//! Configuration (`[[middleware]] config = { ... }`):
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `header` (string) | `"X-Api-Key"` | request header carrying the key |
+//! | `query_param` (string) | unset (disabled) | also accept the key from this query parameter — see the security note |
+//! | `keys` (object) | unset | static `key → consumer-id` map |
+//! | `kv_key_template` (string) | unset | KV lookup key with a `<key>` placeholder, e.g. `apikey:<key>`; the value is the consumer id |
+//! | `consumer_header` (string) | `"X-Consumer-Id"` | header injected for PHP with the resolved consumer id |
+//!
+//! At least one of `keys` / `kv_key_template` must be configured.
+
+use ephpm_middleware::{Middleware, Request, Response};
+use subtle::ConstantTimeEq;
+
+/// The literal replaced with the presented key in `kv_key_template`.
+const KEY_PLACEHOLDER: &str = "<key>";
+
+/// API-key validation policy, built once at `init`.
+pub struct ApiKey {
+    header: String,
+    query_param: Option<String>,
+    consumer_header: String,
+    /// Static `key → consumer-id` entries. Keys are stored as bytes for the
+    /// constant-time comparison.
+    keys: Vec<(Vec<u8>, String)>,
+    /// KV lookup template containing [`KEY_PLACEHOLDER`], e.g. `apikey:<key>`.
+    kv_key_template: Option<String>,
+}
+
+/// Constant-time byte-slice equality. Wraps [`subtle::ConstantTimeEq`] so the
+/// comparison does not short-circuit on the first differing byte (unequal
+/// lengths still return `false` fast, leaking only length). This is the helper
+/// the static-key match uses; it is unit-tested directly.
+#[must_use]
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    a.ct_eq(b).into()
+}
+
+/// URL-decode a query-string component (`+` → space, `%XX` → byte). Invalid
+/// escapes are passed through literally rather than failing the lookup.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(hi), Some(lo)) = (hi, lo) {
+                    out.push((hi * 16 + lo) as u8);
+                    i += 3;
+                } else {
+                    out.push(b'%');
+                    i += 1;
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Return the (decoded) value of query parameter `name` in `query`, if present.
+fn query_value(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        (k == name).then(|| percent_decode(v))
+    })
+}
+
+impl ApiKey {
+    /// Extract the presented key: the configured header first, then the query
+    /// parameter when enabled. Empty values count as absent.
+    fn extract_key(&self, req: &Request<'_>) -> Option<String> {
+        if let Some(v) = req.header(&self.header) {
+            let v = v.trim();
+            if !v.is_empty() {
+                return Some(v.to_owned());
+            }
+        }
+        if let Some(param) = &self.query_param
+            && let Some(v) = query_value(req.query(), param)
+            && !v.is_empty()
+        {
+            return Some(v);
+        }
+        None
+    }
+
+    /// Constant-time match of `presented` against the static key map. Every
+    /// entry is compared (no early return) so the number of matching leading
+    /// bytes is not observable via timing.
+    fn match_static(&self, presented: &[u8]) -> Option<&str> {
+        let mut matched: Option<&str> = None;
+        for (key, consumer) in &self.keys {
+            if ct_eq(presented, key) {
+                matched = Some(consumer.as_str());
+            }
+        }
+        matched
+    }
+
+    /// Look the presented key up in the KV store via `kv_key_template`. The
+    /// stored value (UTF-8, non-empty) is the consumer id.
+    fn match_kv(&self, req: &Request<'_>, presented: &str) -> Option<String> {
+        let template = self.kv_key_template.as_ref()?;
+        let lookup = template.replace(KEY_PLACEHOLDER, presented);
+        let value = req.host().kv_get(&lookup)?;
+        let consumer = String::from_utf8(value).ok()?;
+        (!consumer.is_empty()).then_some(consumer)
+    }
+
+    /// Admit the request, injecting the consumer id for PHP (mirrors how `jwt`
+    /// forwards its claims via a request header).
+    fn grant(&self, consumer: &str) -> Response {
+        Response::rewrite().header(self.consumer_header.as_str(), consumer)
+    }
+
+    /// `401` with a `WWW-Authenticate`-style hint naming the expected header.
+    /// The key value is deliberately absent from the body.
+    fn unauthorized(&self, body: &'static str) -> Response {
+        Response::respond(401, body)
+            .header("WWW-Authenticate", format!("ApiKey header=\"{}\"", self.header))
+    }
+}
+
+impl Middleware for ApiKey {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let opt_str = |key: &str| -> Result<Option<String>, String> {
+            match config.get(key) {
+                Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
+                None | Some(serde_json::Value::Null | serde_json::Value::String(_)) => Ok(None),
+                Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+            }
+        };
+
+        let header = opt_str("header")?.unwrap_or_else(|| "X-Api-Key".to_owned());
+        let query_param = opt_str("query_param")?;
+        let consumer_header =
+            opt_str("consumer_header")?.unwrap_or_else(|| "X-Consumer-Id".to_owned());
+
+        let keys = match config.get("keys") {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(v) => {
+                let map = v.as_object().ok_or("`keys` must be an object of key -> consumer-id")?;
+                map.iter()
+                    .map(|(key, consumer)| {
+                        if key.is_empty() {
+                            return Err("`keys` entries must have a non-empty key".to_owned());
+                        }
+                        let consumer = consumer.as_str().ok_or_else(|| {
+                            format!("`keys[\"{key}\"]` must be a string consumer-id")
+                        })?;
+                        Ok((key.as_bytes().to_vec(), consumer.to_owned()))
+                    })
+                    .collect::<Result<Vec<_>, String>>()?
+            }
+        };
+
+        let kv_key_template = opt_str("kv_key_template")?;
+        if let Some(template) = &kv_key_template
+            && !template.contains(KEY_PLACEHOLDER)
+        {
+            return Err(format!(
+                "`kv_key_template` must contain the `{KEY_PLACEHOLDER}` placeholder"
+            ));
+        }
+
+        if keys.is_empty() && kv_key_template.is_none() {
+            return Err("at least one of `keys` or `kv_key_template` must be configured".into());
+        }
+
+        Ok(Self { header, query_param, consumer_header, keys, kv_key_template })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        let Some(key) = self.extract_key(req) else {
+            return self.unauthorized("missing api key");
+        };
+        if let Some(consumer) = self.match_static(key.as_bytes()) {
+            return self.grant(consumer);
+        }
+        if let Some(consumer) = self.match_kv(req, &key) {
+            return self.grant(&consumer);
+        }
+        self.unauthorized("invalid api key")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use ephpm_middleware::abi::{ACTION_RESPOND, ACTION_REWRITE};
+    use ephpm_middleware::host::{RequestCtx, host_table, set_kv_store};
+
+    use super::*;
+
+    fn api_key(config: serde_json::Value) -> ApiKey {
+        ApiKey::init(&config).expect("init")
+    }
+
+    /// Invoke with headers and an optional query string against a fresh ctx.
+    fn invoke_q(mw: &ApiKey, query: &str, headers: &[(String, String)]) -> Response {
+        let ctx = RequestCtx::new("GET", "/api/x", query, "203.0.113.9", "example.test", headers);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn invoke(mw: &ApiKey, headers: &[(String, String)]) -> Response {
+        invoke_q(mw, "", headers)
+    }
+
+    fn hdr(name: &str, value: &str) -> Vec<(String, String)> {
+        vec![(name.to_owned(), value.to_owned())]
+    }
+
+    /// Wire a real in-memory Store into the host table (first call wins; all
+    /// tests in this binary share it) and seed one `apikey:*` entry via the
+    /// host's own `kv_set`.
+    fn setup_kv_with(entries: &[(&str, &str)]) {
+        set_kv_store(&ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default()));
+        let ctx = RequestCtx::new("GET", "/", "", "127.0.0.1", "seed", &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        for (k, v) in entries {
+            assert!(req.host().kv_set(k, v.as_bytes(), 0), "seed kv_set failed for {k}");
+        }
+    }
+
+    fn consumer_header(resp: &Response) -> Option<String> {
+        resp.__headers()
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("X-Consumer-Id"))
+            .map(|(_, v)| v.clone())
+    }
+
+    fn assert_401(resp: &Response, body: &str) {
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 401);
+        assert_eq!(resp.__body(), body.as_bytes());
+        // Never leak the key; always hint via WWW-Authenticate.
+        assert!(
+            resp.__headers().iter().any(|(n, _)| n.eq_ignore_ascii_case("WWW-Authenticate")),
+            "401 must carry a WWW-Authenticate hint",
+        );
+    }
+
+    #[test]
+    fn ct_eq_is_correct() {
+        assert!(ct_eq(b"correct-key", b"correct-key"));
+        assert!(!ct_eq(b"correct-key", b"correct-keZ"));
+        assert!(!ct_eq(b"correct-key", b"correct-ke")); // length mismatch
+        assert!(ct_eq(b"", b""));
+        assert!(!ct_eq(b"a", b""));
+    }
+
+    #[test]
+    fn init_requires_a_store() {
+        // No keys and no KV template → misconfiguration.
+        assert!(ApiKey::init(&serde_json::json!({})).is_err());
+        assert!(ApiKey::init(&serde_json::json!({ "header": "X-Api-Key" })).is_err());
+        // `keys` must be an object; entries must be string consumer-ids.
+        assert!(ApiKey::init(&serde_json::json!({ "keys": "nope" })).is_err());
+        assert!(ApiKey::init(&serde_json::json!({ "keys": { "k": 42 } })).is_err());
+        // `kv_key_template` must contain the placeholder.
+        assert!(ApiKey::init(&serde_json::json!({ "kv_key_template": "apikey:" })).is_err());
+        // Valid minimal configs.
+        assert!(ApiKey::init(&serde_json::json!({ "keys": { "k": "c" } })).is_ok());
+        assert!(ApiKey::init(&serde_json::json!({ "kv_key_template": "apikey:<key>" })).is_ok());
+    }
+
+    #[test]
+    fn valid_static_key_rewrites_with_consumer() {
+        let mw = api_key(serde_json::json!({ "keys": { "secret-abc": "consumer-7" } }));
+        let resp = invoke(&mw, &hdr("X-Api-Key", "secret-abc"));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(consumer_header(&resp).as_deref(), Some("consumer-7"));
+    }
+
+    #[test]
+    fn invalid_static_key_is_401() {
+        let mw = api_key(serde_json::json!({ "keys": { "secret-abc": "consumer-7" } }));
+        assert_401(&invoke(&mw, &hdr("X-Api-Key", "wrong")), "invalid api key");
+    }
+
+    #[test]
+    fn missing_key_is_401() {
+        let mw = api_key(serde_json::json!({ "keys": { "secret-abc": "consumer-7" } }));
+        assert_401(&invoke(&mw, &[]), "missing api key");
+        // Present-but-empty header also counts as missing.
+        assert_401(&invoke(&mw, &hdr("X-Api-Key", "   ")), "missing api key");
+    }
+
+    #[test]
+    fn custom_header_and_consumer_header() {
+        let mw = api_key(serde_json::json!({
+            "header": "X-Key",
+            "consumer_header": "X-Who",
+            "keys": { "k1": "alice" },
+        }));
+        let resp = invoke(&mw, &hdr("X-Key", "k1"));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        let who = resp
+            .__headers()
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("X-Who"))
+            .map(|(_, v)| v.as_str());
+        assert_eq!(who, Some("alice"));
+    }
+
+    #[test]
+    fn query_param_disabled_by_default() {
+        let mw = api_key(serde_json::json!({ "keys": { "qk": "qc" } }));
+        // Key only in the query string, but query_param is off → 401 missing.
+        assert_401(&invoke_q(&mw, "api_key=qk", &[]), "missing api key");
+    }
+
+    #[test]
+    fn query_param_when_enabled() {
+        let mw = api_key(serde_json::json!({
+            "query_param": "api_key",
+            "keys": { "qk": "qc" },
+        }));
+        let resp = invoke_q(&mw, "foo=1&api_key=qk&bar=2", &[]);
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(consumer_header(&resp).as_deref(), Some("qc"));
+        // Header still takes precedence over the query param.
+        let resp = invoke_q(&mw, "api_key=wrong", &hdr("X-Api-Key", "qk"));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(consumer_header(&resp).as_deref(), Some("qc"));
+        // URL-encoded value round-trips.
+        let mw2 = api_key(serde_json::json!({
+            "query_param": "api_key",
+            "keys": { "a b": "spaced" },
+        }));
+        let resp = invoke_q(&mw2, "api_key=a%20b", &[]);
+        assert_eq!(consumer_header(&resp).as_deref(), Some("spaced"));
+    }
+
+    #[test]
+    fn kv_backed_valid_and_invalid() {
+        setup_kv_with(&[("apikey:live-key", "kv-consumer-1")]);
+        let mw = api_key(serde_json::json!({ "kv_key_template": "apikey:<key>" }));
+        // Valid: value in the store is the consumer id.
+        let resp = invoke(&mw, &hdr("X-Api-Key", "live-key"));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(consumer_header(&resp).as_deref(), Some("kv-consumer-1"));
+        // Absent key → 401 invalid.
+        assert_401(&invoke(&mw, &hdr("X-Api-Key", "no-such-key")), "invalid api key");
+    }
+
+    #[test]
+    fn static_map_takes_precedence_then_kv() {
+        setup_kv_with(&[("apikey:kv-only", "from-kv")]);
+        let mw = api_key(serde_json::json!({
+            "keys": { "static-only": "from-static" },
+            "kv_key_template": "apikey:<key>",
+        }));
+        // Static hit.
+        assert_eq!(
+            consumer_header(&invoke(&mw, &hdr("X-Api-Key", "static-only"))).as_deref(),
+            Some("from-static"),
+        );
+        // Falls through to KV.
+        assert_eq!(
+            consumer_header(&invoke(&mw, &hdr("X-Api-Key", "kv-only"))).as_deref(),
+            Some("from-kv"),
+        );
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/header_transform.rs
+++ b/crates/ephpm-middleware-builtins/src/header_transform.rs
@@ -1,0 +1,302 @@
+//! `header-transform` — ePHPm native middleware that rewrites request headers
+//! seen by PHP and response headers sent to the client.
+//!
+//! Analogous to Traefik's `headers` (`customRequestHeaders` /
+//! `customResponseHeaders`), Kong's request/response transformer, or nginx's
+//! `proxy_set_header` / `add_header` / `more_clear_headers`.
+//!
+//! # Two phases
+//!
+//! - **Request phase** ([`Middleware::invoke`]) — set request headers before
+//!   PHP runs (PHP reads them as `$_SERVER['HTTP_<NAME>']`).
+//! - **Response phase** ([`ResponseMiddleware::invoke_response`]) — set or
+//!   remove response headers on the way out, on **every** response (PHP,
+//!   static file, error page).
+//!
+//! Configuration (`[[middleware]] config = { ... }`), all optional:
+//!
+//! ```toml
+//! [middleware.config.request]
+//! set = { "X-Env" = "prod", "X-Tenant" = "acme" }
+//!
+//! [middleware.config.response]
+//! set    = { "X-Served-By" = "ephpm" }
+//! remove = ["Server", "X-Powered-By"]
+//! ```
+//!
+//! | section | key | effect |
+//! |---------|-----|--------|
+//! | `request` | `set` (object) | replace-or-add each request header PHP sees |
+//! | `response` | `set` (object) | replace-or-add each response header |
+//! | `response` | `remove` (array) | delete each response header (case-insensitive) |
+//!
+//! # v1 ABI scope (why there is no `add` or request `remove`)
+//!
+//! The host applies both request-header overrides and response `set` as
+//! **replace-or-add** (one occurrence, case-insensitive) — there is no
+//! duplicate-append primitive in the v1 middleware ABI, so `add` and `set`
+//! would be identical; only `set` is offered. And the request phase can only
+//! *override* a request header, not delete one, so request-side `remove` is
+//! not offered (it would be a silent no-op). Header **removal is response-side
+//! only**, where the ABI supports it. Both are honest reflections of the ABI,
+//! not omissions.
+
+use ephpm_middleware::{Middleware, Request, Response, ResponseMiddleware, ResponseView};
+
+/// A parsed set of `(name, value)` header assignments, order preserved.
+type Assignments = Vec<(String, String)>;
+
+/// Header rewrite policy, built once at `init`.
+pub struct HeaderTransform {
+    request_set: Assignments,
+    response_set: Assignments,
+    response_remove: Vec<String>,
+}
+
+/// Parse an optional `{ name: value, ... }` object into ordered string pairs.
+/// Rejects non-string values and empty names.
+fn parse_set(section: &serde_json::Value, path: &str) -> Result<Assignments, String> {
+    match section.get("set") {
+        None | Some(serde_json::Value::Null) => Ok(Vec::new()),
+        Some(serde_json::Value::Object(map)) => {
+            let mut out = Vec::with_capacity(map.len());
+            for (name, value) in map {
+                if name.is_empty() {
+                    return Err(format!("`{path}.set` has an empty header name"));
+                }
+                let v = value.as_str().ok_or_else(|| {
+                    format!("`{path}.set` values must be strings, got {value} for `{name}`")
+                })?;
+                out.push((name.clone(), v.to_owned()));
+            }
+            Ok(out)
+        }
+        Some(other) => Err(format!("`{path}.set` must be an object, got {other}")),
+    }
+}
+
+/// Parse an optional `["Name", ...]` array of header names to remove.
+fn parse_remove(section: &serde_json::Value, path: &str) -> Result<Vec<String>, String> {
+    match section.get("remove") {
+        None | Some(serde_json::Value::Null) => Ok(Vec::new()),
+        Some(serde_json::Value::Array(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                let name = item.as_str().ok_or_else(|| {
+                    format!("`{path}.remove` entries must be strings, got {item}")
+                })?;
+                if name.is_empty() {
+                    return Err(format!("`{path}.remove` has an empty header name"));
+                }
+                out.push(name.to_owned());
+            }
+            Ok(out)
+        }
+        Some(other) => Err(format!("`{path}.remove` must be an array, got {other}")),
+    }
+}
+
+/// Fetch a top-level section object (`request` / `response`), defaulting to a
+/// JSON null (an empty section) when absent. Rejects a non-object section.
+fn section<'a>(config: &'a serde_json::Value, key: &str) -> Result<&'a serde_json::Value, String> {
+    const NULL: serde_json::Value = serde_json::Value::Null;
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(&NULL),
+        Some(v @ serde_json::Value::Object(_)) => Ok(v),
+        Some(other) => Err(format!("`{key}` must be an object, got {other}")),
+    }
+}
+
+impl Middleware for HeaderTransform {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let request = section(config, "request")?;
+        let response = section(config, "response")?;
+
+        // `request.remove` cannot be honored (see module docs); reject it loudly
+        // rather than silently ignore it.
+        if request.get("remove").is_some_and(|v| !v.is_null()) {
+            return Err("`request.remove` is not supported: the v1 ABI request phase can \
+                 only set/override request headers, not delete them"
+                .into());
+        }
+
+        Ok(Self {
+            request_set: parse_set(request, "request")?,
+            response_set: parse_set(response, "response")?,
+            response_remove: parse_remove(response, "response")?,
+        })
+    }
+
+    fn invoke(&self, _req: &Request<'_>) -> Response {
+        if self.request_set.is_empty() {
+            return Response::cont();
+        }
+        let mut r = Response::rewrite();
+        for (name, value) in &self.request_set {
+            r = r.header(name.clone(), value.clone());
+        }
+        r
+    }
+}
+
+impl ResponseMiddleware for HeaderTransform {
+    fn invoke_response(&self, _req: &Request<'_>, resp: &mut ResponseView<'_>) {
+        for name in &self.response_remove {
+            resp.remove_header(name.clone());
+        }
+        for (name, value) in &self.response_set {
+            resp.set_header(name.clone(), value.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request / Response views by hand.
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_REWRITE};
+    use ephpm_middleware::host::{RequestCtx, ResponseCtx, host_table};
+
+    use super::*;
+
+    fn init(config: serde_json::Value) -> HeaderTransform {
+        HeaderTransform::init(&config).expect("init")
+    }
+
+    fn hdr(name: &str, value: &str) -> (String, String) {
+        (name.to_owned(), value.to_owned())
+    }
+
+    fn invoke(mw: &HeaderTransform) -> Response {
+        let ctx = RequestCtx::new("GET", "/index.php", "", "203.0.113.9", "example.test", &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn invoke_response(
+        mw: &HeaderTransform,
+        resp_headers: Vec<(String, String)>,
+    ) -> Vec<(String, String)> {
+        let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", "example.test", &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        let mut rctx = ResponseCtx::new(200, resp_headers, b"body".to_vec());
+        {
+            // SAFETY: `rctx` outlives the view; host_table() is 'static.
+            let mut view = unsafe { ResponseView::from_raw(rctx.as_ptr(), host_table()) };
+            mw.invoke_response(&req, &mut view);
+            let (status, body, set, remove) = view.__into_parts();
+            for name in remove {
+                rctx.remove_header(&name);
+            }
+            for (n, v) in set {
+                rctx.set_header(&n, &v);
+            }
+            if let Some(s) = status {
+                rctx.set_status(s);
+            }
+            if let Some(b) = body {
+                rctx.replace_body(b);
+            }
+        }
+        let (_status, headers, _body) = rctx.into_parts();
+        headers
+    }
+
+    fn get<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        headers.iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.as_str())
+    }
+
+    // ── request phase ─────────────────────────────────────────────────────
+
+    #[test]
+    fn request_set_injects_headers() {
+        let mw = init(serde_json::json!({
+            "request": { "set": { "X-Env": "prod", "X-Tenant": "acme" } }
+        }));
+        let resp = invoke(&mw);
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(get(resp.__headers(), "X-Env"), Some("prod"));
+        assert_eq!(get(resp.__headers(), "X-Tenant"), Some("acme"));
+    }
+
+    #[test]
+    fn no_request_config_continues() {
+        let mw = init(serde_json::json!({
+            "response": { "set": { "X-A": "b" } }
+        }));
+        assert_eq!(invoke(&mw).__action(), ACTION_CONTINUE);
+    }
+
+    // ── response phase ────────────────────────────────────────────────────
+
+    #[test]
+    fn response_set_replaces_or_adds() {
+        let mw = init(serde_json::json!({
+            "response": { "set": { "X-Served-By": "ephpm", "Content-Type": "text/plain" } }
+        }));
+        let out = invoke_response(&mw, vec![hdr("Content-Type", "text/html")]);
+        assert_eq!(get(&out, "X-Served-By"), Some("ephpm"));
+        // Replace, not duplicate.
+        assert_eq!(get(&out, "Content-Type"), Some("text/plain"));
+        assert_eq!(out.iter().filter(|(n, _)| n.eq_ignore_ascii_case("Content-Type")).count(), 1);
+    }
+
+    #[test]
+    fn response_remove_deletes() {
+        let mw = init(serde_json::json!({
+            "response": { "remove": ["Server", "X-Powered-By"] }
+        }));
+        let out = invoke_response(
+            &mw,
+            vec![hdr("Server", "nginx"), hdr("X-Powered-By", "PHP/8.5"), hdr("X-Keep", "1")],
+        );
+        assert_eq!(get(&out, "Server"), None);
+        assert_eq!(get(&out, "X-Powered-By"), None);
+        assert_eq!(get(&out, "X-Keep"), Some("1"));
+    }
+
+    #[test]
+    fn remove_then_set_same_header_nets_set() {
+        let mw = init(serde_json::json!({
+            "response": { "set": { "Server": "ephpm" }, "remove": ["Server"] }
+        }));
+        let out = invoke_response(&mw, vec![hdr("Server", "nginx")]);
+        assert_eq!(get(&out, "Server"), Some("ephpm"));
+        assert_eq!(out.iter().filter(|(n, _)| n.eq_ignore_ascii_case("Server")).count(), 1);
+    }
+
+    // ── config validation ─────────────────────────────────────────────────
+
+    #[test]
+    fn request_remove_is_rejected() {
+        assert!(
+            HeaderTransform::init(&serde_json::json!({
+                "request": { "remove": ["X-Foo"] }
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn bad_config_fails_init() {
+        assert!(
+            HeaderTransform::init(&serde_json::json!({ "request": { "set": { "X": 1 } } }))
+                .is_err()
+        );
+        assert!(
+            HeaderTransform::init(&serde_json::json!({ "response": { "remove": [42] } })).is_err()
+        );
+        assert!(HeaderTransform::init(&serde_json::json!({ "request": "nope" })).is_err());
+        assert!(HeaderTransform::init(&serde_json::json!({ "response": { "set": [] } })).is_err());
+    }
+
+    #[test]
+    fn empty_config_is_a_noop() {
+        let mw = init(serde_json::Value::Null);
+        assert_eq!(invoke(&mw).__action(), ACTION_CONTINUE);
+        let out = invoke_response(&mw, vec![hdr("X-A", "b")]);
+        assert_eq!(get(&out, "X-A"), Some("b"));
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/ip_allowlist.rs
+++ b/crates/ephpm-middleware-builtins/src/ip_allowlist.rs
@@ -1,0 +1,268 @@
+//! `ip-allowlist` — ePHPm native middleware that allows or denies requests by
+//! client IP against CIDR lists. The analog of Traefik's `ipallowlist`, Kong's
+//! `ip-restriction`, and nginx `allow`/`deny`.
+//!
+//! The client IP is taken from [`Request::remote_ip`], which the host has
+//! already resolved through the trusted-proxy configuration — this module
+//! never parses `X-Forwarded-For` itself.
+//!
+//! Decision order (a request is evaluated exactly once):
+//!
+//! 1. If the client IP matches any `deny` CIDR → **`403`** (deny wins over
+//!    allow, always).
+//! 2. Else if it matches any `allow` CIDR → **`CONTINUE`**.
+//! 3. Else apply the `default` policy (`"allow"` → CONTINUE, `"deny"` → 403).
+//!
+//! **Fail-closed security gate.** This is an access-control filter, so it fails
+//! closed, in two senses:
+//!
+//! * **Config errors fail startup.** A malformed CIDR, a non-array `allow`/
+//!   `deny`, or an unknown `default` value makes `init` return `Err`, which the
+//!   host treats as a hard startup failure — the module never loads half-parsed.
+//! * **An unparseable client IP is denied.** If `remote_ip()` is empty or not a
+//!   valid address it cannot match `allow`, so it is rejected with `403` unless
+//!   `default = "allow"` explicitly opens the gate.
+//!
+//! Request-phase only: the verdict is decided before PHP runs and this module
+//! touches no response-phase API.
+//!
+//! ## Configuration (`[[middleware]] config = { ... }`)
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `allow` (array of CIDR strings) | `[]` | client IPs allowed through; v4 and v6, e.g. `"10.0.0.0/8"`, `"2001:db8::/32"`. A bare address is a `/32` (v4) or `/128` (v6). |
+//! | `deny` (array of CIDR strings) | `[]` | client IPs rejected with `403`; takes precedence over `allow`. |
+//! | `default` (string) | `"deny"` | verdict when no rule matches: `"allow"` or `"deny"`. |
+//!
+//! ### Scope
+//!
+//! Configuration is per `[[middleware]]` block. Like the sibling modules
+//! (`cors`, `security-headers`), the policy is read once at `init` and applied
+//! to every request the block sees; the module does not itself branch on
+//! [`Request::vhost_id`]. Per-site policies are expressed the same way per-site
+//! behaviour is expressed for the other modules — by scoping the `[[middleware]]`
+//! block to a site in the host configuration — not by a per-vhost config map
+//! inside this module (v1).
+
+use std::net::IpAddr;
+
+use ephpm_middleware::{Middleware, Request, Response};
+use ipnetwork::IpNetwork;
+
+/// Plain-text body returned on a `403` denial.
+const DENIED_BODY: &str = "Forbidden: your IP address is not permitted.";
+
+/// The verdict applied when a client IP matches neither list.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum DefaultPolicy {
+    /// Continue to PHP.
+    Allow,
+    /// Reject with `403`.
+    Deny,
+}
+
+/// IP allow/deny policy, built once at `init`.
+pub struct IpAllowlist {
+    allow: Vec<IpNetwork>,
+    deny: Vec<IpNetwork>,
+    default: DefaultPolicy,
+}
+
+/// Parse an optional array-of-CIDR config key into networks. A missing or null
+/// key is an empty list; any non-array, non-string, or unparseable entry is a
+/// hard error (fail-closed at startup).
+fn parse_cidrs(config: &serde_json::Value, key: &str) -> Result<Vec<IpNetwork>, String> {
+    let arr = match config.get(key) {
+        None | Some(serde_json::Value::Null) => return Ok(Vec::new()),
+        Some(serde_json::Value::Array(a)) => a,
+        Some(other) => {
+            return Err(format!("`{key}` must be an array of CIDR strings, got {other}"));
+        }
+    };
+    arr.iter()
+        .map(|v| {
+            let s = v
+                .as_str()
+                .ok_or_else(|| format!("`{key}` entries must be CIDR strings, got {v}"))?;
+            s.parse::<IpNetwork>()
+                .map_err(|e| format!("`{key}` entry {s:?} is not a valid CIDR: {e}"))
+        })
+        .collect()
+}
+
+impl IpAllowlist {
+    /// True when `ip` falls inside any network in `nets`.
+    fn matches(nets: &[IpNetwork], ip: IpAddr) -> bool {
+        nets.iter().any(|n| n.contains(ip))
+    }
+}
+
+impl Middleware for IpAllowlist {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let allow = parse_cidrs(config, "allow")?;
+        let deny = parse_cidrs(config, "deny")?;
+        let default = match config.get("default") {
+            None | Some(serde_json::Value::Null) => DefaultPolicy::Deny,
+            Some(serde_json::Value::String(s)) => match s.as_str() {
+                "allow" => DefaultPolicy::Allow,
+                "deny" => DefaultPolicy::Deny,
+                other => {
+                    return Err(format!("`default` must be \"allow\" or \"deny\", got {other:?}"));
+                }
+            },
+            Some(other) => {
+                return Err(format!("`default` must be \"allow\" or \"deny\", got {other}"));
+            }
+        };
+        Ok(Self { allow, deny, default })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        // The host has already applied trusted-proxy resolution; parse the
+        // client address. An unparseable/empty IP cannot match `allow`, so it
+        // is treated as unmatched and subject to the fail-closed default below.
+        let parsed = req.remote_ip().parse::<IpAddr>().ok();
+
+        if let Some(ip) = parsed {
+            // Deny always wins.
+            if Self::matches(&self.deny, ip) {
+                return denied();
+            }
+            if Self::matches(&self.allow, ip) {
+                return Response::cont();
+            }
+        }
+
+        match self.default {
+            DefaultPolicy::Allow => Response::cont(),
+            DefaultPolicy::Deny => denied(),
+        }
+    }
+}
+
+/// The `403` response with a small plain-text body.
+fn denied() -> Response {
+    Response::respond(403, DENIED_BODY).header("Content-Type", "text/plain; charset=utf-8")
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+
+    use super::*;
+
+    fn build(config: serde_json::Value) -> IpAllowlist {
+        IpAllowlist::init(&config).expect("init")
+    }
+
+    fn invoke(mw: &IpAllowlist, ip: &str) -> Response {
+        let ctx = RequestCtx::new("GET", "/index.php", "", ip, "example.test", &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    #[test]
+    fn ipv4_allow_and_default_deny() {
+        let mw = build(serde_json::json!({ "allow": ["10.0.0.0/8"] }));
+        // In-range → continue.
+        assert_eq!(invoke(&mw, "10.1.2.3").__action(), ACTION_CONTINUE);
+        // Out-of-range → default deny → 403.
+        let resp = invoke(&mw, "192.168.1.1");
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 403);
+        assert_eq!(resp.__body(), DENIED_BODY.as_bytes());
+    }
+
+    #[test]
+    fn ipv6_allow_matches() {
+        let mw = build(serde_json::json!({ "allow": ["2001:db8::/32"] }));
+        assert_eq!(invoke(&mw, "2001:db8::dead:beef").__action(), ACTION_CONTINUE);
+        assert_eq!(invoke(&mw, "2001:dead::1").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn cidr_boundary_is_respected() {
+        // /24 covers .0–.255 only.
+        let mw = build(serde_json::json!({ "allow": ["203.0.113.0/24"], "default": "deny" }));
+        assert_eq!(invoke(&mw, "203.0.113.255").__action(), ACTION_CONTINUE);
+        assert_eq!(invoke(&mw, "203.0.114.0").__action(), ACTION_RESPOND);
+        // A /32 host route: exact match only.
+        let host = mw2_host();
+        assert_eq!(invoke(&host, "198.51.100.7").__action(), ACTION_CONTINUE);
+        assert_eq!(invoke(&host, "198.51.100.8").__action(), ACTION_RESPOND);
+    }
+
+    fn mw2_host() -> IpAllowlist {
+        build(serde_json::json!({ "allow": ["198.51.100.7/32"] }))
+    }
+
+    #[test]
+    fn deny_takes_precedence_over_allow() {
+        // Same address is in both lists — deny must win.
+        let mw = build(serde_json::json!({
+            "allow": ["10.0.0.0/8"],
+            "deny": ["10.6.6.6/32"],
+            "default": "allow",
+        }));
+        assert_eq!(invoke(&mw, "10.6.6.6").__action(), ACTION_RESPOND);
+        // A different in-allow address still continues.
+        assert_eq!(invoke(&mw, "10.6.6.7").__action(), ACTION_CONTINUE);
+        // A broader deny range wins over a narrower allow.
+        let broad = build(serde_json::json!({
+            "allow": ["192.168.1.0/24"],
+            "deny": ["192.168.0.0/16"],
+        }));
+        assert_eq!(invoke(&broad, "192.168.1.50").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn default_allow_lets_unmatched_through() {
+        let mw = build(serde_json::json!({ "deny": ["10.0.0.0/8"], "default": "allow" }));
+        // Not denied, not in any allow list → default allow.
+        assert_eq!(invoke(&mw, "8.8.8.8").__action(), ACTION_CONTINUE);
+        // Still denied when in the deny list.
+        assert_eq!(invoke(&mw, "10.0.0.1").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn default_deny_is_the_default_when_unset() {
+        // No allow, no deny, no default: everything is denied (fail-closed).
+        let mw = build(serde_json::json!({}));
+        assert_eq!(invoke(&mw, "8.8.8.8").__action(), ACTION_RESPOND);
+        assert_eq!(invoke(&mw, "10.0.0.1").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn unparseable_client_ip_is_denied_by_default() {
+        let mw = build(serde_json::json!({ "allow": ["0.0.0.0/0"] }));
+        // A valid any-v4 address is allowed…
+        assert_eq!(invoke(&mw, "1.2.3.4").__action(), ACTION_CONTINUE);
+        // …but a garbage/empty IP cannot match allow → fail closed.
+        assert_eq!(invoke(&mw, "not-an-ip").__action(), ACTION_RESPOND);
+        assert_eq!(invoke(&mw, "").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn unparseable_client_ip_follows_default_allow() {
+        // With default=allow, an unparseable IP that hits no deny rule passes.
+        let mw = build(serde_json::json!({ "deny": ["10.0.0.0/8"], "default": "allow" }));
+        assert_eq!(invoke(&mw, "not-an-ip").__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn malformed_config_fails_init_closed() {
+        // Bad CIDR string.
+        assert!(IpAllowlist::init(&serde_json::json!({ "allow": ["10.0.0.0/999"] })).is_err());
+        assert!(IpAllowlist::init(&serde_json::json!({ "deny": ["nonsense"] })).is_err());
+        // Wrong types.
+        assert!(IpAllowlist::init(&serde_json::json!({ "allow": "10.0.0.0/8" })).is_err());
+        assert!(IpAllowlist::init(&serde_json::json!({ "allow": [42] })).is_err());
+        // Unknown default policy.
+        assert!(IpAllowlist::init(&serde_json::json!({ "default": "maybe" })).is_err());
+        assert!(IpAllowlist::init(&serde_json::json!({ "default": true })).is_err());
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/lib.rs
+++ b/crates/ephpm-middleware-builtins/src/lib.rs
@@ -1,4 +1,5 @@
-//! The four in-tree ePHPm middleware modules as plain Rust library code.
+//! The ten in-tree official ePHPm middleware modules as plain Rust library
+//! code.
 //!
 //! Each module here is an ordinary [`ephpm_middleware::Middleware`]
 //! implementation with **no C ABI exports** — that is what lets
@@ -6,15 +7,31 @@
 //! through the static builtin registry (`library = "jwt"` works even in a
 //! custom fully static build, where `dlopen` does not exist).
 //!
-//! The sibling `ephpm-middleware-{jwt,cors,ratelimit,security-headers}`
-//! crates are thin cdylib shells: they re-export these types and add the
-//! `declare!` C ABI glue, producing the loadable `.so`/`.dylib`/`.dll`
-//! artifacts for the dynamic (dlopen) lane. The shells cannot be merged into
-//! one binary — four copies of the same `ephpm_middleware_*` export symbols
-//! collide at link time — which is exactly why the implementations live
-//! here instead.
+//! The modules, by phase:
+//!
+//! - **Request phase** ([`ephpm_middleware::Middleware`]): [`jwt`], [`cors`],
+//!   [`ratelimit`], [`security_headers`], [`api_key`], [`ip_allowlist`],
+//!   [`maintenance_mode`], [`redirect`].
+//! - **Request + response phase** (also
+//!   [`ephpm_middleware::ResponseMiddleware`], registered in the server via
+//!   [`ephpm_middleware::builtin::BuiltinModule::init_response`]):
+//!   [`request_id`], [`header_transform`].
+//!
+//! The sibling `ephpm-middleware-<name>` crates in the `ephpm/middleware`
+//! (examples) repository are thin cdylib shells: they re-export these types
+//! and add the `declare!` C ABI glue, producing the loadable
+//! `.so`/`.dylib`/`.dll` artifacts for the dynamic (dlopen) lane. The shells
+//! cannot be merged into one binary — many copies of the same
+//! `ephpm_middleware_*` export symbols collide at link time — which is exactly
+//! why the implementations live here instead.
 
+pub mod api_key;
 pub mod cors;
+pub mod header_transform;
+pub mod ip_allowlist;
 pub mod jwt;
+pub mod maintenance_mode;
 pub mod ratelimit;
+pub mod redirect;
+pub mod request_id;
 pub mod security_headers;

--- a/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
+++ b/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
@@ -1,0 +1,405 @@
+//! `maintenance-mode` — ePHPm native middleware that flips a tenant into a
+//! 503 holding page the instant a per-site flag appears in the embedded
+//! (cluster-replicated) KV store — no redeploy, no restart. The flagship demo
+//! of the KV store as a control plane: analogous to Cloudflare's maintenance
+//! mode or an HAProxy `monitor-uri`, but driven by a single KV key you can set
+//! from PHP (`ephpm_kv_set`) or the RESP interface.
+//!
+//! Per request the module builds a per-site key from a configurable template
+//! (default `mw:maintenance:<vhost>`, with `<vhost>` replaced by the request's
+//! vhost id) and `kv_get`s it. If the key is present and *truthy* the request
+//! is short-circuited with a `503` holding page carrying a `Retry-After`
+//! header. If the key is absent the request `CONTINUE`s to PHP untouched.
+//!
+//! **Bypass.** Operators need to verify a site while it is "down". Two escape
+//! hatches let a request `CONTINUE` even during maintenance:
+//! - `bypass_ips` — exact IPs or CIDR ranges (client IP is taken *after*
+//!   trusted-proxy resolution, so it is the real client, not the proxy).
+//! - `bypass_paths` — path prefixes kept live (e.g. `/healthz` so the load
+//!   balancer's health check still passes and the tenant is not evicted).
+//!
+//! Bypass is checked *before* the KV lookup, so a health check never even
+//! touches the KV store.
+//!
+//! **Fail-OPEN by design.** The embedded `kv_get` accessor returns `None` for
+//! both "key absent" and "KV store unavailable" — and both paths `CONTINUE`.
+//! That is deliberate: a KV blip must **not** take *every* tenant down. A
+//! maintenance flag is a soft, operator-driven signal; failing closed here
+//! would turn a transient KV hiccup into a fleet-wide outage. This is the
+//! **opposite** of an IP-allowlist / auth gate (which must fail *closed* — see
+//! the `jwt` module): there, availability must never beat correctness; here it
+//! must. Choose this module only for maintenance signalling, never for access
+//! control.
+//!
+//! Configuration (`[[middleware]] config = { ... }`), all optional:
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `key_template` (string) | `"mw:maintenance:<vhost>"` | KV key checked per request; `<vhost>` is replaced with the request's vhost id |
+//! | `retry_after` (integer seconds) | `300` | value of the `Retry-After` header on the 503 |
+//! | `body` (string) | built-in minimal HTML | holding-page body served with the 503 |
+//! | `content_type` (string) | `"text/html; charset=utf-8"` | `Content-Type` of the holding page |
+//! | `bypass_ips` (array of strings) | unset | exact IPs or CIDR ranges whose requests continue during maintenance |
+//! | `bypass_paths` (array of strings) | unset | path prefixes that stay live during maintenance |
+
+use std::net::IpAddr;
+
+use ephpm_middleware::abi::LOG_DEBUG;
+use ephpm_middleware::{Middleware, Request, Response};
+
+/// Default KV key template. `<vhost>` is substituted per request.
+const DEFAULT_KEY_TEMPLATE: &str = "mw:maintenance:<vhost>";
+/// Placeholder replaced with the request's vhost id in the key template.
+const VHOST_PLACEHOLDER: &str = "<vhost>";
+/// Default `Retry-After` (seconds).
+const DEFAULT_RETRY_AFTER: u64 = 300;
+/// Default holding-page `Content-Type`.
+const DEFAULT_CONTENT_TYPE: &str = "text/html; charset=utf-8";
+/// Minimal built-in holding page.
+const DEFAULT_BODY: &str = "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n<title>Down for maintenance</title>\n</head>\n<body>\n<h1>We&rsquo;ll be right back</h1>\n<p>This site is temporarily down for maintenance. Please try again shortly.</p>\n</body>\n</html>\n";
+
+/// One entry from `bypass_ips`: a single address or a CIDR range.
+enum IpMatcher {
+    /// Exact IP match.
+    Exact(IpAddr),
+    /// CIDR: network address plus prefix length (bits).
+    Cidr { network: IpAddr, prefix: u8 },
+}
+
+impl IpMatcher {
+    /// Parse an exact IP (`203.0.113.4`, `2001:db8::1`) or CIDR
+    /// (`203.0.113.0/24`, `2001:db8::/32`).
+    fn parse(spec: &str) -> Result<Self, String> {
+        if let Some((net, bits)) = spec.split_once('/') {
+            let network: IpAddr = net
+                .parse()
+                .map_err(|_| format!("`bypass_ips`: invalid CIDR network in {spec:?}"))?;
+            let prefix: u8 =
+                bits.parse().map_err(|_| format!("`bypass_ips`: invalid prefix in {spec:?}"))?;
+            let max = if network.is_ipv4() { 32 } else { 128 };
+            if prefix > max {
+                return Err(format!("`bypass_ips`: prefix /{prefix} too large in {spec:?}"));
+            }
+            Ok(IpMatcher::Cidr { network, prefix })
+        } else {
+            let ip: IpAddr =
+                spec.parse().map_err(|_| format!("`bypass_ips`: invalid IP {spec:?}"))?;
+            Ok(IpMatcher::Exact(ip))
+        }
+    }
+
+    /// Does `ip` fall within this matcher?
+    fn matches(&self, ip: IpAddr) -> bool {
+        match self {
+            IpMatcher::Exact(want) => *want == ip,
+            IpMatcher::Cidr { network, prefix } => cidr_contains(*network, *prefix, ip),
+        }
+    }
+}
+
+/// Compare the high `prefix` bits of two same-family addresses.
+fn cidr_contains(network: IpAddr, prefix: u8, ip: IpAddr) -> bool {
+    match (network, ip) {
+        (IpAddr::V4(net), IpAddr::V4(addr)) => prefix_match(&net.octets(), &addr.octets(), prefix),
+        (IpAddr::V6(net), IpAddr::V6(addr)) => prefix_match(&net.octets(), &addr.octets(), prefix),
+        // Mixed families never match.
+        _ => false,
+    }
+}
+
+/// True when `a` and `b` agree on the first `prefix` bits.
+fn prefix_match(a: &[u8], b: &[u8], prefix: u8) -> bool {
+    let mut bits = usize::from(prefix);
+    for (x, y) in a.iter().zip(b.iter()) {
+        if bits == 0 {
+            break;
+        }
+        if bits >= 8 {
+            if x != y {
+                return false;
+            }
+            bits -= 8;
+        } else {
+            // Compare the top `bits` bits of this byte.
+            let mask = 0xFFu8 << (8 - bits);
+            return (x & mask) == (y & mask);
+        }
+    }
+    true
+}
+
+/// A KV maintenance value is "on" unless it is empty or an explicit falsey
+/// marker. This lets an operator disable maintenance by *setting* the flag to
+/// `0`/`false`/`off` without having to delete the key.
+fn is_truthy(value: &[u8]) -> bool {
+    let s = std::str::from_utf8(value).unwrap_or("").trim();
+    if s.is_empty() {
+        return false;
+    }
+    !matches!(s.to_ascii_lowercase().as_str(), "0" | "false" | "off" | "no")
+}
+
+/// Maintenance-mode policy, built once at `init`.
+pub struct MaintenanceMode {
+    key_template: String,
+    retry_after: u64,
+    body: String,
+    content_type: String,
+    bypass_ips: Vec<IpMatcher>,
+    bypass_paths: Vec<String>,
+}
+
+impl MaintenanceMode {
+    /// Build the per-request KV key by substituting the vhost id.
+    fn key_for(&self, vhost: &str) -> String {
+        self.key_template.replace(VHOST_PLACEHOLDER, vhost)
+    }
+
+    /// Does this request qualify for a bypass (path prefix or client IP)?
+    fn is_bypassed(&self, req: &Request<'_>) -> bool {
+        let path = req.path();
+        if self.bypass_paths.iter().any(|p| path.starts_with(p.as_str())) {
+            return true;
+        }
+        if !self.bypass_ips.is_empty()
+            && let Ok(ip) = req.remote_ip().parse::<IpAddr>()
+            && self.bypass_ips.iter().any(|m| m.matches(ip))
+        {
+            return true;
+        }
+        false
+    }
+}
+
+/// Read an optional array-of-strings config key.
+fn opt_string_array(config: &serde_json::Value, key: &str) -> Result<Vec<String>, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(Vec::new()),
+        Some(v) => v
+            .as_array()
+            .ok_or_else(|| format!("`{key}` must be an array of strings"))?
+            .iter()
+            .map(|e| {
+                e.as_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| format!("`{key}` entries must be strings, got {e}"))
+            })
+            .collect(),
+    }
+}
+
+/// Read an optional string config key with a default.
+fn opt_string(config: &serde_json::Value, key: &str, default: &str) -> Result<String, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default.to_owned()),
+        Some(serde_json::Value::String(s)) => Ok(s.clone()),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+impl Middleware for MaintenanceMode {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let key_template = opt_string(config, "key_template", DEFAULT_KEY_TEMPLATE)?;
+        if key_template.is_empty() {
+            return Err("`key_template` must not be empty".into());
+        }
+        let retry_after = match config.get("retry_after") {
+            None | Some(serde_json::Value::Null) => DEFAULT_RETRY_AFTER,
+            Some(v) => v
+                .as_u64()
+                .ok_or_else(|| format!("`retry_after` must be a non-negative integer, got {v}"))?,
+        };
+        let body = opt_string(config, "body", DEFAULT_BODY)?;
+        let content_type = opt_string(config, "content_type", DEFAULT_CONTENT_TYPE)?;
+        let bypass_ips = opt_string_array(config, "bypass_ips")?
+            .iter()
+            .map(|s| IpMatcher::parse(s))
+            .collect::<Result<_, _>>()?;
+        let bypass_paths = opt_string_array(config, "bypass_paths")?;
+
+        Ok(Self { key_template, retry_after, body, content_type, bypass_ips, bypass_paths })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        // Bypass first — a health check must never depend on the KV store.
+        if self.is_bypassed(req) {
+            return Response::cont();
+        }
+
+        let key = self.key_for(req.vhost_id());
+        let host = req.host();
+        // `kv_get` returns None for BOTH "absent" and "KV unavailable" — both
+        // fall through to CONTINUE. That is the fail-OPEN choice (see the
+        // module docs): a KV blip must not black-hole every tenant.
+        match host.kv_get(&key) {
+            Some(value) if is_truthy(&value) => Response::respond(503, self.body.clone())
+                .header("Retry-After", self.retry_after.to_string())
+                .header("Content-Type", self.content_type.clone()),
+            _ => {
+                host.log(LOG_DEBUG, &format!("maintenance-mode: {key} not set — continuing"));
+                Response::cont()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+    use ephpm_middleware::host::{RequestCtx, host_table, set_kv_store};
+
+    use super::*;
+
+    /// Wire a real in-memory Store into the host table (first call wins; all
+    /// tests in this binary share it, so each uses a unique vhost).
+    fn setup_kv() {
+        set_kv_store(&ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default()));
+    }
+
+    fn invoke(mw: &MaintenanceMode, path: &str, ip: &str, vhost: &str) -> Response {
+        let ctx = RequestCtx::new("GET", path, "", ip, vhost, &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    /// Turn maintenance on for a vhost via the same KV key the module reads.
+    fn set_flag(vhost: &str, value: &[u8]) {
+        let key = format!("mw:maintenance:{vhost}");
+        let ctx = RequestCtx::new("GET", "/", "", "127.0.0.1", vhost, &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert!(req.host().kv_set(&key, value, 0), "kv_set failed");
+    }
+
+    #[test]
+    fn init_defaults_and_validation() {
+        let mw = MaintenanceMode::init(&serde_json::Value::Null).expect("init");
+        assert_eq!(mw.key_template, DEFAULT_KEY_TEMPLATE);
+        assert_eq!(mw.retry_after, DEFAULT_RETRY_AFTER);
+        assert_eq!(mw.key_for("acme.test"), "mw:maintenance:acme.test");
+        // Bad config is rejected.
+        assert!(MaintenanceMode::init(&serde_json::json!({ "key_template": "" })).is_err());
+        assert!(MaintenanceMode::init(&serde_json::json!({ "retry_after": "soon" })).is_err());
+        assert!(
+            MaintenanceMode::init(&serde_json::json!({ "bypass_ips": ["not-an-ip"] })).is_err()
+        );
+        assert!(
+            MaintenanceMode::init(&serde_json::json!({ "bypass_ips": ["10.0.0.0/40"] })).is_err()
+        );
+        assert!(MaintenanceMode::init(&serde_json::json!({ "bypass_paths": "/healthz" })).is_err());
+    }
+
+    #[test]
+    fn flag_unset_continues() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::Value::Null).expect("init");
+        let resp = invoke(&mw, "/", "198.51.100.1", "vhost-unset");
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn flag_set_returns_503_with_retry_after_and_body() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::json!({ "retry_after": 120 })).expect("init");
+        set_flag("vhost-503", b"1");
+        let resp = invoke(&mw, "/anything", "198.51.100.2", "vhost-503");
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 503);
+        assert_eq!(resp.__body(), DEFAULT_BODY.as_bytes());
+        let find = |name: &str| {
+            resp.__headers()
+                .iter()
+                .find(|(n, _)| n.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(find("Retry-After"), Some("120"));
+        assert_eq!(find("Content-Type"), Some(DEFAULT_CONTENT_TYPE));
+    }
+
+    #[test]
+    fn falsey_flag_value_continues() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::Value::Null).expect("init");
+        set_flag("vhost-falsey", b"0");
+        assert_eq!(invoke(&mw, "/", "198.51.100.3", "vhost-falsey").__action(), ACTION_CONTINUE);
+        set_flag("vhost-falsey", b"off");
+        assert_eq!(invoke(&mw, "/", "198.51.100.3", "vhost-falsey").__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn custom_body_is_served() {
+        setup_kv();
+        let mw =
+            MaintenanceMode::init(&serde_json::json!({ "body": "gone fishing" })).expect("init");
+        set_flag("vhost-body", b"true");
+        let resp = invoke(&mw, "/", "198.51.100.4", "vhost-body");
+        assert_eq!(resp.__body(), b"gone fishing");
+    }
+
+    #[test]
+    fn bypass_exact_ip_continues_during_maintenance() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::json!({
+            "bypass_ips": ["203.0.113.7"],
+        }))
+        .expect("init");
+        set_flag("vhost-ip", b"1");
+        // Operator's IP sails through.
+        assert_eq!(invoke(&mw, "/", "203.0.113.7", "vhost-ip").__action(), ACTION_CONTINUE);
+        // Everyone else gets the 503.
+        assert_eq!(invoke(&mw, "/", "203.0.113.8", "vhost-ip").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn bypass_cidr_continues_during_maintenance() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::json!({
+            "bypass_ips": ["10.0.0.0/8", "2001:db8::/32"],
+        }))
+        .expect("init");
+        set_flag("vhost-cidr", b"1");
+        assert_eq!(invoke(&mw, "/", "10.4.5.6", "vhost-cidr").__action(), ACTION_CONTINUE);
+        assert_eq!(invoke(&mw, "/", "2001:db8::dead", "vhost-cidr").__action(), ACTION_CONTINUE);
+        // Outside the range → still down.
+        assert_eq!(invoke(&mw, "/", "11.0.0.1", "vhost-cidr").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn bypass_path_continues_during_maintenance() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::json!({
+            "bypass_paths": ["/healthz", "/status"],
+        }))
+        .expect("init");
+        set_flag("vhost-path", b"1");
+        assert_eq!(
+            invoke(&mw, "/healthz", "198.51.100.9", "vhost-path").__action(),
+            ACTION_CONTINUE
+        );
+        assert_eq!(
+            invoke(&mw, "/status/live", "198.51.100.9", "vhost-path").__action(),
+            ACTION_CONTINUE
+        );
+        // A normal path is still down.
+        assert_eq!(invoke(&mw, "/", "198.51.100.9", "vhost-path").__action(), ACTION_RESPOND);
+    }
+
+    #[test]
+    fn custom_key_template_is_used() {
+        setup_kv();
+        let mw = MaintenanceMode::init(&serde_json::json!({
+            "key_template": "flags:down:<vhost>",
+        }))
+        .expect("init");
+        // Set the flag under the CUSTOM key.
+        let key = "flags:down:vhost-tmpl";
+        let ctx = RequestCtx::new("GET", "/", "", "127.0.0.1", "vhost-tmpl", &[]);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert!(req.host().kv_set(key, b"1", 0));
+        assert_eq!(invoke(&mw, "/", "198.51.100.10", "vhost-tmpl").__action(), ACTION_RESPOND);
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/redirect.rs
+++ b/crates/ephpm-middleware-builtins/src/redirect.rs
@@ -1,0 +1,541 @@
+//! `redirect` — ePHPm native middleware that enforces canonical URLs with a
+//! single `301`/`308` redirect **before** PHP runs.
+//!
+//! Analogous to Traefik's `redirectscheme`/`redirectregex`, Caddy's `redir`,
+//! Cloudflare redirect rules, or an nginx `return 301`. It composes several
+//! canonicalization rules — scheme, host, trailing slash — computes the final
+//! canonical URL **once**, and redirects a single time only when the request
+//! is not already canonical (so it can never loop).
+//!
+//! Configuration (`[[middleware]] config = { ... }`), all optional:
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `force_https` (bool) | `false` | redirect `http` → `https` |
+//! | `canonical_host` (string) | unset | `"www"` forces the apex → `www.`; `"apex"` (alias `"non-www"`) strips a leading `www.` |
+//! | `host_map` (object) | unset | explicit `source-host` → `canonical-host` map (exact, case-insensitive key); wins over `canonical_host` on a match |
+//! | `trailing_slash` (string) | unset | `"add"` appends a `/` (except the root and paths whose last segment looks like a file, i.e. contains a `.`); `"strip"` removes trailing `/` (except the root) |
+//! | `status` (integer) | `308` | redirect status — `301` or `308`; `308` preserves the request method |
+//! | `forwarded_proto_header` (string) | `"X-Forwarded-Proto"` | header the current scheme is derived from |
+//!
+//! **Scheme derivation.** The v1 middleware ABI exposes no request scheme or
+//! "is secure" flag, so the current scheme is read from
+//! `forwarded_proto_header` (default `X-Forwarded-Proto`); a request with no
+//! such header is treated as `http`. Behind a TLS-terminating proxy the proxy
+//! **must** set that header, or `force_https` would redirect an
+//! already-secure request and loop — the same requirement nginx/Traefik place
+//! on the operator.
+//!
+//! **Scope.** Config is per-mount (there is no per-vhost config idiom in the
+//! ABI). Use `host_map` to canonicalize several hosts from one mount; the
+//! request's own `Host` header is what every rule is computed against.
+
+use ephpm_middleware::{Middleware, Request, Response};
+
+/// The canonical-host policy.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HostPolicy {
+    /// Force the apex form to `www.` (`example.com` → `www.example.com`).
+    Www,
+    /// Strip a leading `www.` (`www.example.com` → `example.com`).
+    Apex,
+}
+
+/// The trailing-slash policy.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SlashPolicy {
+    /// Append a trailing `/` (except the root and file-like paths).
+    Add,
+    /// Remove trailing `/` (except the root).
+    Strip,
+}
+
+/// Redirect policy, built once at `init`.
+pub struct Redirect {
+    force_https: bool,
+    canonical_host: Option<HostPolicy>,
+    /// Exact source→canonical host map; keys are stored lower-cased.
+    host_map: Vec<(String, String)>,
+    trailing_slash: Option<SlashPolicy>,
+    status: u16,
+    forwarded_proto_header: String,
+}
+
+/// Read an optional boolean config key with a default.
+fn opt_bool(config: &serde_json::Value, key: &str, default: bool) -> Result<bool, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("`{key}` must be a boolean, got {other}")),
+    }
+}
+
+/// Read an optional string config key with a default.
+fn opt_string(config: &serde_json::Value, key: &str, default: &str) -> Result<String, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default.to_owned()),
+        Some(serde_json::Value::String(s)) => Ok(s.clone()),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+/// True when `host` begins with a `www.` label (case-insensitive).
+fn has_www_prefix(host: &str) -> bool {
+    host.len() > 4 && host[..4].eq_ignore_ascii_case("www.")
+}
+
+/// The host with a leading `www.` removed, or `None` when there is no such
+/// prefix (or removing it would leave the host empty).
+fn strip_www_prefix(host: &str) -> Option<&str> {
+    if has_www_prefix(host) {
+        let rest = &host[4..];
+        (!rest.is_empty()).then_some(rest)
+    } else {
+        None
+    }
+}
+
+/// Split a `Host` header value into `(host, Option<port>)`. Handles bracketed
+/// IPv6 literals (`[::1]:8080`) and only treats an all-digit tail after the
+/// last `:` as a port.
+fn split_host(value: &str) -> (&str, Option<&str>) {
+    if value.starts_with('[') {
+        // Bracketed IPv6 literal: the host is everything through `]`.
+        if let Some(idx) = value.find(']') {
+            let host = &value[..=idx];
+            let port = value[idx + 1..].strip_prefix(':').filter(|p| !p.is_empty());
+            return (host, port);
+        }
+        return (value, None);
+    }
+    match value.rsplit_once(':') {
+        Some((host, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => {
+            (host, Some(port))
+        }
+        _ => (value, None),
+    }
+}
+
+/// True when the last path segment looks like a file (contains a `.`).
+fn last_segment_has_dot(path: &str) -> bool {
+    path.rsplit('/').next().is_some_and(|seg| seg.contains('.'))
+}
+
+impl Redirect {
+    /// The canonical host for `host` (case preserved when nothing applies).
+    fn canonical_host(&self, host: &str) -> String {
+        for (src, dst) in &self.host_map {
+            if host.eq_ignore_ascii_case(src) {
+                return dst.clone();
+            }
+        }
+        match self.canonical_host {
+            Some(HostPolicy::Www) => {
+                if has_www_prefix(host) {
+                    host.to_owned()
+                } else {
+                    format!("www.{host}")
+                }
+            }
+            Some(HostPolicy::Apex) => strip_www_prefix(host).unwrap_or(host).to_owned(),
+            None => host.to_owned(),
+        }
+    }
+
+    /// The canonical path for `path` under the trailing-slash policy.
+    fn canonical_path(&self, path: &str) -> String {
+        match self.trailing_slash {
+            Some(SlashPolicy::Strip) => {
+                if path.len() > 1 && path.ends_with('/') {
+                    let trimmed = path.trim_end_matches('/');
+                    if trimmed.is_empty() { "/".to_owned() } else { trimmed.to_owned() }
+                } else {
+                    path.to_owned()
+                }
+            }
+            Some(SlashPolicy::Add) => {
+                if path.ends_with('/') || last_segment_has_dot(path) {
+                    path.to_owned()
+                } else {
+                    format!("{path}/")
+                }
+            }
+            None => path.to_owned(),
+        }
+    }
+
+    /// The current request scheme, derived from `forwarded_proto_header`
+    /// (first value of a comma list); `http` when the header is absent.
+    fn current_scheme<'a>(&self, req: &'a Request<'_>) -> &'a str {
+        match req.header(&self.forwarded_proto_header) {
+            Some(v) => {
+                let first = v.split(',').next().unwrap_or(v).trim();
+                if first.eq_ignore_ascii_case("https") { "https" } else { "http" }
+            }
+            None => "http",
+        }
+    }
+}
+
+impl Middleware for Redirect {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let canonical_host = match config.get("canonical_host") {
+            None | Some(serde_json::Value::Null) => None,
+            Some(serde_json::Value::String(s)) => match s.to_ascii_lowercase().as_str() {
+                "www" => Some(HostPolicy::Www),
+                "apex" | "non-www" => Some(HostPolicy::Apex),
+                other => {
+                    return Err(format!(
+                        "`canonical_host` must be \"www\" or \"apex\", got \"{other}\""
+                    ));
+                }
+            },
+            Some(other) => return Err(format!("`canonical_host` must be a string, got {other}")),
+        };
+
+        let host_map = match config.get("host_map") {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(serde_json::Value::Object(map)) => {
+                let mut out = Vec::with_capacity(map.len());
+                for (k, v) in map {
+                    let dst = v.as_str().ok_or_else(|| {
+                        format!("`host_map` values must be strings, got {v} for key `{k}`")
+                    })?;
+                    if dst.is_empty() {
+                        return Err(format!("`host_map` value for key `{k}` must not be empty"));
+                    }
+                    out.push((k.to_ascii_lowercase(), dst.to_owned()));
+                }
+                out
+            }
+            Some(other) => return Err(format!("`host_map` must be an object, got {other}")),
+        };
+
+        let trailing_slash = match config.get("trailing_slash") {
+            None | Some(serde_json::Value::Null) => None,
+            Some(serde_json::Value::String(s)) => match s.to_ascii_lowercase().as_str() {
+                "add" => Some(SlashPolicy::Add),
+                "strip" => Some(SlashPolicy::Strip),
+                other => {
+                    return Err(format!(
+                        "`trailing_slash` must be \"add\" or \"strip\", got \"{other}\""
+                    ));
+                }
+            },
+            Some(other) => return Err(format!("`trailing_slash` must be a string, got {other}")),
+        };
+
+        let status = match config.get("status") {
+            None | Some(serde_json::Value::Null) => 308,
+            Some(v) => {
+                let n =
+                    v.as_u64().ok_or_else(|| format!("`status` must be 301 or 308, got {v}"))?;
+                if n != 301 && n != 308 {
+                    return Err(format!("`status` must be 301 or 308, got {n}"));
+                }
+                u16::try_from(n).unwrap_or(308)
+            }
+        };
+
+        let forwarded_proto_header =
+            opt_string(config, "forwarded_proto_header", "X-Forwarded-Proto")?;
+        if forwarded_proto_header.is_empty() {
+            return Err("`forwarded_proto_header` must not be empty".into());
+        }
+
+        Ok(Self {
+            force_https: opt_bool(config, "force_https", false)?,
+            canonical_host,
+            host_map,
+            trailing_slash,
+            status,
+            forwarded_proto_header,
+        })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        // Without an authority we cannot build an absolute Location; pass through.
+        let Some(host_hdr) = req.header("Host").filter(|h| !h.is_empty()) else {
+            return Response::cont();
+        };
+        let (host, port) = split_host(host_hdr);
+
+        let scheme_cur = self.current_scheme(req);
+        let scheme_can = if self.force_https { "https" } else { scheme_cur };
+
+        let host_can = self.canonical_host(host);
+
+        let path_cur = {
+            let p = req.path();
+            if p.is_empty() { "/" } else { p }
+        };
+        let path_can = self.canonical_path(path_cur);
+
+        let changed = scheme_cur != scheme_can
+            || !host.eq_ignore_ascii_case(&host_can)
+            || path_cur != path_can;
+        if !changed {
+            return Response::cont();
+        }
+
+        let query = req.query();
+        let mut location = String::with_capacity(
+            scheme_can.len() + 3 + host_can.len() + path_can.len() + query.len() + 8,
+        );
+        location.push_str(scheme_can);
+        location.push_str("://");
+        location.push_str(&host_can);
+        if let Some(p) = port {
+            location.push(':');
+            location.push_str(p);
+        }
+        location.push_str(&path_can);
+        if !query.is_empty() {
+            location.push('?');
+            location.push_str(query);
+        }
+
+        Response::respond(self.status, "").header("Location", location)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+
+    use super::*;
+
+    fn redirect(config: serde_json::Value) -> Redirect {
+        Redirect::init(&config).expect("init")
+    }
+
+    fn invoke(
+        mw: &Redirect,
+        method: &str,
+        path: &str,
+        query: &str,
+        headers: &[(String, String)],
+    ) -> Response {
+        let ctx = RequestCtx::new(method, path, query, "203.0.113.9", "example.test", headers);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn hdr(name: &str, value: &str) -> (String, String) {
+        (name.to_owned(), value.to_owned())
+    }
+
+    fn location(resp: &Response) -> Option<&str> {
+        resp.__headers()
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("Location"))
+            .map(|(_, v)| v.as_str())
+    }
+
+    // ── force_https ────────────────────────────────────────────────────────
+
+    #[test]
+    fn force_https_redirects_http_to_https() {
+        let mw = redirect(serde_json::json!({ "force_https": true }));
+        let resp = invoke(&mw, "GET", "/page", "", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 308);
+        assert_eq!(location(&resp), Some("https://example.com/page"));
+    }
+
+    #[test]
+    fn force_https_is_a_noop_when_already_https() {
+        let mw = redirect(serde_json::json!({ "force_https": true }));
+        let resp = invoke(
+            &mw,
+            "GET",
+            "/page",
+            "",
+            &[hdr("Host", "example.com"), hdr("X-Forwarded-Proto", "https")],
+        );
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn scheme_read_from_first_forwarded_proto_value() {
+        let mw = redirect(serde_json::json!({ "force_https": true }));
+        // A list "https, http" means the edge saw https — no redirect.
+        let resp = invoke(
+            &mw,
+            "GET",
+            "/",
+            "",
+            &[hdr("Host", "example.com"), hdr("X-Forwarded-Proto", "https, http")],
+        );
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn custom_forwarded_proto_header_is_honored() {
+        let mw = redirect(serde_json::json!({
+            "force_https": true,
+            "forwarded_proto_header": "X-Scheme",
+        }));
+        let resp =
+            invoke(&mw, "GET", "/", "", &[hdr("Host", "example.com"), hdr("X-Scheme", "https")]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    // ── canonical host ─────────────────────────────────────────────────────
+
+    #[test]
+    fn www_to_apex() {
+        let mw = redirect(serde_json::json!({ "canonical_host": "apex" }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "www.example.com")]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(location(&resp), Some("http://example.com/p"));
+    }
+
+    #[test]
+    fn apex_already_canonical_continues() {
+        let mw = redirect(serde_json::json!({ "canonical_host": "apex" }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn apex_to_www_other_direction() {
+        let mw = redirect(serde_json::json!({ "canonical_host": "www" }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(location(&resp), Some("http://www.example.com/p"));
+    }
+
+    #[test]
+    fn www_already_canonical_continues() {
+        let mw = redirect(serde_json::json!({ "canonical_host": "www" }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "www.example.com")]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn host_map_exact_match_wins() {
+        let mw = redirect(serde_json::json!({
+            "host_map": { "old.example.com": "new.example.com" },
+        }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "Old.Example.com")]);
+        assert_eq!(location(&resp), Some("http://new.example.com/p"));
+    }
+
+    #[test]
+    fn host_case_only_difference_does_not_redirect() {
+        // No policy → an uppercase Host is not forced to lowercase (no loop-y
+        // cosmetic redirect).
+        let mw = redirect(serde_json::json!({ "force_https": false }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "Example.COM")]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    // ── trailing slash ─────────────────────────────────────────────────────
+
+    #[test]
+    fn trailing_slash_add() {
+        let mw = redirect(serde_json::json!({ "trailing_slash": "add" }));
+        let resp = invoke(&mw, "GET", "/blog", "", &[hdr("Host", "example.com")]);
+        assert_eq!(location(&resp), Some("http://example.com/blog/"));
+    }
+
+    #[test]
+    fn trailing_slash_add_skips_file_like_and_root() {
+        let mw = redirect(serde_json::json!({ "trailing_slash": "add" }));
+        assert_eq!(
+            invoke(&mw, "GET", "/style.css", "", &[hdr("Host", "example.com")]).__action(),
+            ACTION_CONTINUE
+        );
+        assert_eq!(
+            invoke(&mw, "GET", "/", "", &[hdr("Host", "example.com")]).__action(),
+            ACTION_CONTINUE
+        );
+    }
+
+    #[test]
+    fn trailing_slash_strip() {
+        let mw = redirect(serde_json::json!({ "trailing_slash": "strip" }));
+        let resp = invoke(&mw, "GET", "/blog/", "", &[hdr("Host", "example.com")]);
+        assert_eq!(location(&resp), Some("http://example.com/blog"));
+    }
+
+    #[test]
+    fn trailing_slash_strip_keeps_root() {
+        let mw = redirect(serde_json::json!({ "trailing_slash": "strip" }));
+        let resp = invoke(&mw, "GET", "/", "", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    // ── query preservation, status, combined rules ─────────────────────────
+
+    #[test]
+    fn query_string_is_preserved() {
+        let mw = redirect(serde_json::json!({ "force_https": true }));
+        let resp = invoke(&mw, "GET", "/s", "q=1&x=2", &[hdr("Host", "example.com")]);
+        assert_eq!(location(&resp), Some("https://example.com/s?q=1&x=2"));
+    }
+
+    #[test]
+    fn status_301_selection() {
+        let mw = redirect(serde_json::json!({ "force_https": true, "status": 301 }));
+        let resp = invoke(&mw, "GET", "/", "", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__status(), 301);
+    }
+
+    #[test]
+    fn default_status_is_308() {
+        let mw = redirect(serde_json::json!({ "force_https": true }));
+        let resp = invoke(&mw, "GET", "/", "", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__status(), 308);
+    }
+
+    #[test]
+    fn all_rules_collapse_into_one_redirect() {
+        let mw = redirect(serde_json::json!({
+            "force_https": true,
+            "canonical_host": "apex",
+            "trailing_slash": "add",
+        }));
+        let resp = invoke(&mw, "GET", "/blog", "page=2", &[hdr("Host", "www.example.com")]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(location(&resp), Some("https://example.com/blog/?page=2"));
+    }
+
+    #[test]
+    fn port_is_preserved() {
+        let mw = redirect(serde_json::json!({ "canonical_host": "apex" }));
+        let resp = invoke(&mw, "GET", "/p", "", &[hdr("Host", "www.example.com:8080")]);
+        assert_eq!(location(&resp), Some("http://example.com:8080/p"));
+    }
+
+    #[test]
+    fn already_canonical_no_config_continues() {
+        let mw = redirect(serde_json::Value::Null);
+        let resp = invoke(&mw, "GET", "/p", "a=1", &[hdr("Host", "example.com")]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn missing_host_header_passes_through() {
+        let mw = redirect(serde_json::json!({ "force_https": true }));
+        let resp = invoke(&mw, "GET", "/p", "", &[]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    // ── config validation ──────────────────────────────────────────────────
+
+    #[test]
+    fn bad_config_fails_init() {
+        assert!(Redirect::init(&serde_json::json!({ "status": 302 })).is_err());
+        assert!(Redirect::init(&serde_json::json!({ "canonical_host": "root" })).is_err());
+        assert!(Redirect::init(&serde_json::json!({ "trailing_slash": "keep" })).is_err());
+        assert!(Redirect::init(&serde_json::json!({ "force_https": "yes" })).is_err());
+        assert!(Redirect::init(&serde_json::json!({ "host_map": { "a": 1 } })).is_err());
+        assert!(Redirect::init(&serde_json::json!({ "forwarded_proto_header": "" })).is_err());
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/request_id.rs
+++ b/crates/ephpm-middleware-builtins/src/request_id.rs
@@ -1,0 +1,388 @@
+//! `request-id` — ePHPm native middleware that gives every request a stable
+//! correlation id, injects it for PHP, and echoes it on the response.
+//!
+//! Analogous to Caddy's `request_id`, Kong's `correlation-id`, Traefik's
+//! request-id plugins, or nginx's `$request_id`. One id per request ties the
+//! access log, the PHP application log, and the client's copy of the header
+//! together.
+//!
+//! # Two phases
+//!
+//! - **Request phase** ([`Middleware::invoke`]) — resolve the id (honor a
+//!   trusted inbound header, otherwise generate a fresh UUIDv4), inject it as a
+//!   request header so PHP sees `$_SERVER['HTTP_<HEADER>']`, and stage the same
+//!   value as a response header so the dynamic response carries exactly the id
+//!   PHP logged.
+//! - **Response phase** ([`ResponseMiddleware::invoke_response`]) — guarantee
+//!   the header on responses the request phase never touched (the static-file
+//!   path runs **no** request phase) and stay idempotent on the PHP path.
+//!
+//! # Why the request phase also stages the response header
+//!
+//! The v1 response phase cannot see state its own request phase set — it is
+//! handed a request view rebuilt from the *original* inbound headers, and it
+//! may run with no preceding `invoke` at all (static files, an upstream
+//! short-circuit). So a *generated* id known only to the request phase could
+//! not be re-derived in the response phase; regenerating there would echo a
+//! different id than PHP received. The request phase therefore carries the id
+//! to the response itself (`response_header`), and the response phase only
+//! *fills in* the header when it is absent — never overwrites it.
+//!
+//! Configuration (`[[middleware]] config = { ... }`), all optional:
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `header` (string) | `"X-Request-Id"` | the request/response header name carrying the id |
+//! | `trust_inbound` (bool) | `false` | when true, reuse a well-formed inbound `header` value instead of generating; when false, always generate (the inbound value is ignored) |
+//!
+//! An inbound id is only trusted when it is a short, printable ASCII token
+//! (no control characters, no whitespace, ≤ 200 bytes). A trusted value that
+//! fails that check is replaced with a generated id rather than reflected — a
+//! client must not be able to smuggle CR/LF or oversized junk into logs and
+//! downstream headers through a "trusted" correlation id.
+
+use std::cell::Cell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ephpm_middleware::{Middleware, Request, Response, ResponseMiddleware, ResponseView};
+
+/// Max length of an inbound id we are willing to reflect.
+const MAX_INBOUND_LEN: usize = 200;
+
+/// Resolved request-id policy, built once at `init`.
+pub struct RequestId {
+    /// Header name carrying the id (as configured; used verbatim on the wire).
+    header: String,
+    /// Whether a well-formed inbound value is reused instead of generated.
+    trust_inbound: bool,
+}
+
+/// Read an optional string config key with a default.
+fn opt_string(config: &serde_json::Value, key: &str, default: &str) -> Result<String, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default.to_owned()),
+        Some(serde_json::Value::String(s)) => Ok(s.clone()),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+/// Read an optional boolean config key with a default.
+fn opt_bool(config: &serde_json::Value, key: &str, default: bool) -> Result<bool, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("`{key}` must be a boolean, got {other}")),
+    }
+}
+
+/// True when `id` is a safe correlation token: non-empty, ≤ [`MAX_INBOUND_LEN`]
+/// bytes, and every byte a printable ASCII graphic (no controls, no spaces).
+fn is_safe_id(id: &str) -> bool {
+    !id.is_empty() && id.len() <= MAX_INBOUND_LEN && id.bytes().all(|b| b.is_ascii_graphic())
+}
+
+/// Per-process entropy mixed into every generated id, so two processes (or two
+/// restarts) do not produce the same id stream. Seeded once from wall-clock
+/// nanos and the address of a stack local.
+static SEED: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    /// Per-thread SplitMix64 state. Lazily seeded from the process seed, the
+    /// thread identity, and a monotonic counter so distinct threads never
+    /// walk the same sequence.
+    static RNG: Cell<u64> = const { Cell::new(0) };
+}
+
+/// SplitMix64 — a tiny, fast, well-distributed 64-bit generator. Not
+/// cryptographic; request ids need collision resistance, not unpredictability.
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Initialise the process seed exactly once.
+fn ensure_seed() {
+    if SEED.load(Ordering::Relaxed) == 0 {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0x1234_5678, |d| d.as_nanos() as u64);
+        let local = 0u8;
+        let addr = std::ptr::from_ref(&local) as u64;
+        let mut s = nanos ^ addr.rotate_left(17) ^ 0xA5A5_5A5A_1234_ABCD;
+        if s == 0 {
+            s = 0xDEAD_BEEF_CAFE_F00D;
+        }
+        // Racy is fine: any winner leaves a usable non-zero seed.
+        SEED.store(s, Ordering::Relaxed);
+    }
+}
+
+/// Draw the next two 64-bit words of randomness from the thread-local RNG.
+fn next_u128() -> (u64, u64) {
+    ensure_seed();
+    RNG.with(|cell| {
+        let mut state = cell.get();
+        if state == 0 {
+            static THREAD_COUNTER: AtomicU64 = AtomicU64::new(1);
+            let tc = THREAD_COUNTER.fetch_add(1, Ordering::Relaxed);
+            state = SEED
+                .load(Ordering::Relaxed)
+                .wrapping_mul(0x2545_F491_4F6C_DD1D)
+                .wrapping_add(tc.rotate_left(32));
+            if state == 0 {
+                state = 0x1;
+            }
+        }
+        let hi = splitmix64(&mut state);
+        let lo = splitmix64(&mut state);
+        cell.set(state);
+        (hi, lo)
+    })
+}
+
+/// Generate a random UUIDv4 string (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`).
+fn generate_id() -> String {
+    let (mut hi, mut lo) = next_u128();
+    // Version 4 in the high nibble of byte 6.
+    hi = (hi & 0xFFFF_FFFF_FFFF_0FFF) | 0x0000_0000_0000_4000;
+    // Variant 10xx in the two high bits of byte 8.
+    lo = (lo & 0x3FFF_FFFF_FFFF_FFFF) | 0x8000_0000_0000_0000;
+    let b = |v: u64, shift: u32| ((v >> shift) & 0xFF) as u8;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        b(hi, 56),
+        b(hi, 48),
+        b(hi, 40),
+        b(hi, 32),
+        b(hi, 24),
+        b(hi, 16),
+        b(hi, 8),
+        b(hi, 0),
+        b(lo, 56),
+        b(lo, 48),
+        b(lo, 40),
+        b(lo, 32),
+        b(lo, 24),
+        b(lo, 16),
+        b(lo, 8),
+        b(lo, 0),
+    )
+}
+
+impl RequestId {
+    /// The id to use for this request: a trusted, well-formed inbound value
+    /// when `trust_inbound` is on, otherwise a freshly generated UUIDv4.
+    fn resolve(&self, inbound: Option<&str>) -> String {
+        if self.trust_inbound
+            && let Some(v) = inbound
+            && is_safe_id(v)
+        {
+            return v.to_owned();
+        }
+        generate_id()
+    }
+}
+
+impl Middleware for RequestId {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let header = opt_string(config, "header", "X-Request-Id")?;
+        if header.is_empty() {
+            return Err("`header` must not be empty".into());
+        }
+        Ok(Self { header, trust_inbound: opt_bool(config, "trust_inbound", false)? })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        let id = self.resolve(req.header(&self.header));
+        // Inject the request header (PHP sees $_SERVER['HTTP_...']) AND echo the
+        // same value on the response, so the dynamic path carries exactly the
+        // id PHP logged. The response phase fills the header in only when it is
+        // still absent (e.g. the static-file path, which runs no request phase).
+        Response::rewrite()
+            .header(self.header.clone(), id.clone())
+            .response_header(self.header.clone(), id)
+    }
+}
+
+impl ResponseMiddleware for RequestId {
+    fn invoke_response(&self, req: &Request<'_>, resp: &mut ResponseView<'_>) {
+        // Idempotent: if the header is already present (request phase echoed it,
+        // or PHP set its own), leave it untouched — never overwrite or duplicate.
+        if resp.header(&self.header).is_some() {
+            return;
+        }
+        // No request phase ran for this response (static file / short-circuit),
+        // so honor a trusted inbound value or generate a fresh id.
+        let id = self.resolve(req.header(&self.header));
+        resp.set_header(self.header.clone(), id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request / Response views by hand.
+
+    use ephpm_middleware::abi::ACTION_REWRITE;
+    use ephpm_middleware::host::{RequestCtx, ResponseCtx, host_table};
+
+    use super::*;
+
+    fn init(config: serde_json::Value) -> RequestId {
+        RequestId::init(&config).expect("init")
+    }
+
+    fn hdr(name: &str, value: &str) -> (String, String) {
+        (name.to_owned(), value.to_owned())
+    }
+
+    fn invoke(mw: &RequestId, headers: &[(String, String)]) -> Response {
+        let ctx = RequestCtx::new("GET", "/index.php", "", "203.0.113.9", "example.test", headers);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    /// Drive the response phase against a fabricated response, returning the
+    /// resulting `(status, headers, body)`.
+    fn invoke_response(
+        mw: &RequestId,
+        req_headers: &[(String, String)],
+        resp_status: u16,
+        resp_headers: Vec<(String, String)>,
+        resp_body: &[u8],
+    ) -> (u16, Vec<(String, String)>, Vec<u8>) {
+        let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", "example.test", req_headers);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        let mut rctx = ResponseCtx::new(resp_status, resp_headers, resp_body.to_vec());
+        {
+            // SAFETY: `rctx` outlives the view; host_table() is 'static.
+            let mut view = unsafe { ResponseView::from_raw(rctx.as_ptr(), host_table()) };
+            mw.invoke_response(&req, &mut view);
+            let (status, body, set, remove) = view.__into_parts();
+            for name in remove {
+                rctx.remove_header(&name);
+            }
+            for (n, v) in set {
+                rctx.set_header(&n, &v);
+            }
+            if let Some(s) = status {
+                rctx.set_status(s);
+            }
+            if let Some(b) = body {
+                rctx.replace_body(b);
+            }
+        }
+        rctx.into_parts()
+    }
+
+    fn get<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        headers.iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.as_str())
+    }
+
+    fn looks_like_uuid(v: &str) -> bool {
+        v.len() == 36 && v.as_bytes()[14] == b'4' && v.chars().filter(|c| *c == '-').count() == 4
+    }
+
+    // ── request phase ─────────────────────────────────────────────────────
+
+    #[test]
+    fn generates_and_injects_when_absent() {
+        let mw = init(serde_json::Value::Null);
+        let resp = invoke(&mw, &[]);
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        // Request header override (PHP-visible).
+        let req_id = get(resp.__headers(), "X-Request-Id").expect("request header");
+        assert!(looks_like_uuid(req_id), "{req_id}");
+        // Response echo — same value.
+        let resp_id = get(resp.__response_headers(), "X-Request-Id").expect("response header");
+        assert_eq!(req_id, resp_id, "PHP and the client must see the same id");
+    }
+
+    #[test]
+    fn ignores_inbound_when_not_trusted() {
+        let mw = init(serde_json::Value::Null);
+        let resp = invoke(&mw, &[hdr("X-Request-Id", "client-supplied-123")]);
+        let id = get(resp.__headers(), "X-Request-Id").unwrap();
+        assert_ne!(id, "client-supplied-123");
+        assert!(looks_like_uuid(id), "{id}");
+    }
+
+    #[test]
+    fn honors_trusted_inbound() {
+        let mw = init(serde_json::json!({ "trust_inbound": true }));
+        let resp = invoke(&mw, &[hdr("X-Request-Id", "abc-123-DEF")]);
+        assert_eq!(get(resp.__headers(), "X-Request-Id"), Some("abc-123-DEF"));
+        assert_eq!(get(resp.__response_headers(), "X-Request-Id"), Some("abc-123-DEF"));
+    }
+
+    #[test]
+    fn trusted_but_unsafe_inbound_is_regenerated() {
+        let mw = init(serde_json::json!({ "trust_inbound": true }));
+        // CR/LF injection attempt — must not be reflected.
+        let resp = invoke(&mw, &[hdr("X-Request-Id", "bad\r\nInjected: 1")]);
+        let id = get(resp.__headers(), "X-Request-Id").unwrap();
+        assert!(looks_like_uuid(id), "{id}");
+    }
+
+    #[test]
+    fn custom_header_name() {
+        let mw = init(serde_json::json!({ "header": "X-Correlation-Id", "trust_inbound": true }));
+        let resp = invoke(&mw, &[hdr("X-Correlation-Id", "corr-1")]);
+        assert_eq!(get(resp.__headers(), "X-Correlation-Id"), Some("corr-1"));
+    }
+
+    #[test]
+    fn generated_ids_are_unique() {
+        let mw = init(serde_json::Value::Null);
+        let a = get(invoke(&mw, &[]).__headers(), "X-Request-Id").unwrap().to_owned();
+        let b = get(invoke(&mw, &[]).__headers(), "X-Request-Id").unwrap().to_owned();
+        assert_ne!(a, b);
+    }
+
+    // ── response phase ────────────────────────────────────────────────────
+
+    #[test]
+    fn response_phase_adds_header_when_absent() {
+        // Static-file path: no request phase ran, response has no id yet.
+        let mw = init(serde_json::Value::Null);
+        let (_status, headers, _body) = invoke_response(&mw, &[], 200, vec![], b"body");
+        let id = get(&headers, "X-Request-Id").expect("id added");
+        assert!(looks_like_uuid(id), "{id}");
+    }
+
+    #[test]
+    fn response_phase_is_idempotent_when_present() {
+        // PHP path: the request phase already echoed the id — do not overwrite.
+        let mw = init(serde_json::Value::Null);
+        let (_status, headers, _body) =
+            invoke_response(&mw, &[], 200, vec![hdr("X-Request-Id", "existing-id-42")], b"body");
+        assert_eq!(get(&headers, "X-Request-Id"), Some("existing-id-42"));
+        // Exactly one occurrence — no duplicate.
+        assert_eq!(
+            headers.iter().filter(|(n, _)| n.eq_ignore_ascii_case("X-Request-Id")).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn response_phase_honors_trusted_inbound_on_static_path() {
+        let mw = init(serde_json::json!({ "trust_inbound": true }));
+        let (_status, headers, _body) =
+            invoke_response(&mw, &[hdr("X-Request-Id", "inbound-77")], 200, vec![], b"body");
+        assert_eq!(get(&headers, "X-Request-Id"), Some("inbound-77"));
+    }
+
+    // ── config validation ─────────────────────────────────────────────────
+
+    #[test]
+    fn bad_config_fails_init() {
+        assert!(RequestId::init(&serde_json::json!({ "header": "" })).is_err());
+        assert!(RequestId::init(&serde_json::json!({ "header": 5 })).is_err());
+        assert!(RequestId::init(&serde_json::json!({ "trust_inbound": "yes" })).is_err());
+    }
+}

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -7,10 +7,11 @@
 //!
 //! Each mount resolves through two lanes, in order:
 //!
-//! 1. **Builtin registry** ([`builtin`]) — the four in-tree modules compiled
-//!    into this binary and invoked in-process (no FFI, no dlopen). Works in
-//!    every binary, including custom fully static builds where `dlopen` does
-//!    not exist.
+//! 1. **Builtin registry** ([`builtin`]) — the ten in-tree official modules
+//!    compiled into this binary and invoked in-process (no FFI, no dlopen).
+//!    Works in every binary, including custom fully static builds where
+//!    `dlopen` does not exist. Two of them (`request-id`, `header-transform`)
+//!    also run in the response phase, via [`BuiltinModule::init_response`].
 //! 2. **Shared library** — everything else goes through the dlopen path and
 //!    the versioned C ABI host table, for out-of-tree modules. Works with the
 //!    stock release binaries on every platform (the Linux release is
@@ -139,6 +140,29 @@ pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
         }
         "security-headers" | "ephpm-middleware-security-headers" => {
             BuiltinModule::init::<ephpm_middleware_builtins::security_headers::SecurityHeaders>
+        }
+        "api-key" | "ephpm-middleware-api-key" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::api_key::ApiKey>
+        }
+        "ip-allowlist" | "ephpm-middleware-ip-allowlist" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::ip_allowlist::IpAllowlist>
+        }
+        "maintenance-mode" | "ephpm-middleware-maintenance-mode" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::maintenance_mode::MaintenanceMode>
+        }
+        "redirect" | "ephpm-middleware-redirect" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::redirect::Redirect>
+        }
+        // Response-phase modules: registered via `init_response` so the
+        // static-registry lane runs their response phase too (mirrors a
+        // dlopened module built with `declare!(Type, response)`).
+        "request-id" | "ephpm-middleware-request-id" => {
+            BuiltinModule::init_response::<ephpm_middleware_builtins::request_id::RequestId>
+        }
+        "header-transform" | "ephpm-middleware-header-transform" => {
+            BuiltinModule::init_response::<
+                ephpm_middleware_builtins::header_transform::HeaderTransform,
+            >
         }
         _ => return None,
     })
@@ -908,6 +932,24 @@ mod tests {
             "ephpm_middleware_ratelimit",
             "ephpm-middleware-security-headers",
             "ephpm_middleware_security_headers",
+            "api-key",
+            "api_key",
+            "ephpm-middleware-api-key",
+            "ephpm_middleware_api_key",
+            "ip-allowlist",
+            "ip_allowlist",
+            "ephpm-middleware-ip-allowlist",
+            "maintenance-mode",
+            "maintenance_mode",
+            "ephpm-middleware-maintenance-mode",
+            "redirect",
+            "ephpm-middleware-redirect",
+            "request-id",
+            "request_id",
+            "ephpm-middleware-request-id",
+            "header-transform",
+            "header_transform",
+            "ephpm-middleware-header-transform",
         ] {
             assert!(builtin(name).is_some(), "\"{name}\" should resolve as builtin");
         }
@@ -1386,5 +1428,37 @@ mod tests {
         let out = chain.run_response_phase(&resp_ctx(), "/api/v1", 200, Vec::new(), b"x".to_vec());
         assert!(out.body_replaced);
         assert_eq!(out.body, b"X");
+    }
+
+    /// The compiled-in `header-transform` module, loaded purely from the static
+    /// registry (no cdylib on disk, no dlopen), runs its RESPONSE phase and
+    /// mutates the outgoing response. This proves the builtin lane — not just
+    /// the dlopen lane — drives `ephpm_middleware_invoke_response`-equivalent
+    /// behaviour end to end, which the fully static release binary relies on.
+    #[test]
+    fn builtin_response_phase_runs_via_registry() {
+        let mounts = vec![builtin_mount(
+            "header-transform",
+            None,
+            10,
+            serde_json::json!({
+                "response": { "set": { "X-Served-By": "ephpm" }, "remove": ["X-Powered-By"] }
+            }),
+        )];
+        let chain = MiddlewareChain::load(&mounts).expect("builtin header-transform loads");
+        assert_eq!(chain.len(), 1);
+        // The registry registered it as a response-phase module.
+        assert!(chain.has_response_phase(), "header-transform must expose a response phase");
+
+        let headers = vec![
+            ("Content-Type".to_owned(), "text/html".to_owned()),
+            ("X-Powered-By".to_owned(), "PHP/8.5".to_owned()),
+        ];
+        let out =
+            chain.run_response_phase(&resp_ctx(), "/index.php", 200, headers, b"body".to_vec());
+        // set → header added; remove → header stripped; untouched header kept.
+        assert_eq!(find_header(&out.headers, "X-Served-By"), Some("ephpm"));
+        assert!(!out.headers.iter().any(|(n, _)| n.eq_ignore_ascii_case("X-Powered-By")));
+        assert_eq!(find_header(&out.headers, "Content-Type"), Some("text/html"));
     }
 }

--- a/docs/architecture/build-compose-design.md
+++ b/docs/architecture/build-compose-design.md
@@ -66,8 +66,10 @@ they are not this document's subject.
 
 ### 2.2 The static middleware registry (PR #123, this branch)
 
-- `ephpm-middleware-builtins` holds the four in-tree middleware as plain
-  Rust types; `ephpm-server` links it as an rlib and maps names via
+- `ephpm-middleware-builtins` holds the ten official middleware as plain
+  Rust types (`request-id` / `header-transform` also implement the response
+  phase, registered via `BuiltinModule::init_response`); `ephpm-server` links
+  it as an rlib and maps names via
   `fn builtin(name) -> Option<BuiltinBuilder>`; execution goes through
   `ephpm_middleware::builtin::BuiltinModule` (no FFI, works fully static).
 - **Hard-won constraint:** the C-ABI `declare!` exports

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -16,10 +16,12 @@ counter is a single `kv_incr`.
 
 There are **two ways a module runs**:
 
-- **Built-in (static registry).** Four modules — `jwt`, `cors`,
-  `ratelimit`, `security-headers` — are compiled into **every** ePHPm
-  binary. `library = "jwt"` just works: no shared library on disk, no
-  `dlopen`, no special build.
+- **Built-in (static registry).** Ten official modules — `jwt`, `cors`,
+  `ratelimit`, `security-headers`, `api-key`, `ip-allowlist`,
+  `maintenance-mode`, `redirect`, `request-id`, and `header-transform` — are
+  compiled into **every** ePHPm binary. `library = "jwt"` just works: no
+  shared library on disk, no `dlopen`, no special build. Two of them
+  (`request-id`, `header-transform`) also run in the **response phase**.
 - **Dynamic (shared library).** Custom out-of-tree modules are `.so` /
   `.dylib` / `.dll` files speaking a small, versioned C ABI, loaded once at
   startup via `dlopen` (`LoadLibrary` on Windows). This works out of the
@@ -121,8 +123,10 @@ the mount.
 The `library` value is checked against the **builtin registry first**.
 Each built-in answers to its short name and its crate name, with `-` and
 `_` interchangeable: `jwt`, `cors`, `ratelimit` (also `rate-limit`),
-`security-headers`, and the `ephpm-middleware-*` / `ephpm_middleware_*`
-long forms. Builtin mounts never touch the filesystem.
+`security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`,
+`redirect`, `request-id`, `header-transform`, and the
+`ephpm-middleware-*` / `ephpm_middleware_*` long forms. Builtin mounts
+never touch the filesystem.
 
 Anything else is resolved as a shared library. A value containing a path
 separator or a file extension is used as-is. A bare name tries, in each
@@ -260,9 +264,12 @@ files too — ships as
 
 ## The built-in modules
 
-All four are compiled into every ePHPm binary and run in-process — the
-sections below apply identically whether you mount them by short name
-(built-in) or dlopen their cdylib builds on a dynamic binary.
+All ten are compiled into every ePHPm binary and run in-process — mount
+them by short name (`library = "jwt"`) with no shared library on disk.
+`request-id` and `header-transform` additionally run in the response phase.
+Loadable cdylib builds of the same implementations (for the dlopen lane, or
+as authoring templates) live in the
+[`ephpm/middleware-examples`](https://github.com/ephpm/middleware) repo.
 
 ### `security-headers`
 
@@ -351,6 +358,111 @@ Note this is a *fixed-window* limiter (a full window's allowance can be
 consumed instantly at a window boundary), and it is distinct from the
 built-in connection-level limiter in `[server.limits]` — the two are
 independent.
+
+### `api-key`
+
+Validates an API key on the request before PHP runs, then forwards the
+resolved **consumer identity** to PHP. A recognised key `REWRITE`s the
+request, injecting the consumer id in a header PHP reads; a missing or
+unrecognised key short-circuits with `401` (PHP never runs). Static keys are
+compared **constant-time** (`subtle`), and the presented key is never logged.
+At least one of `keys` / `kv_key_template` must be configured.
+
+| key | default | meaning |
+|-----|---------|---------|
+| `header` (string) | `"X-Api-Key"` | request header carrying the key |
+| `query_param` (string) | unset (disabled) | also accept the key from this query parameter — off by default, since URLs leak into logs |
+| `keys` (object) | unset | static `key → consumer-id` map |
+| `kv_key_template` (string) | unset | KV lookup key with a `<key>` placeholder (e.g. `apikey:<key>`); the stored value is the consumer id |
+| `consumer_header` (string) | `"X-Consumer-Id"` | header injected for PHP with the resolved consumer id |
+
+### `ip-allowlist`
+
+Allows or denies requests by client IP against CIDR lists (IPv4 + IPv6).
+The client IP is taken from the host's trusted-proxy-resolved value — this
+module never parses `X-Forwarded-For` itself. **Fail-closed:** a malformed
+CIDR fails startup, and an unparseable client IP is denied unless
+`default = "allow"`. `deny` always wins over `allow`.
+
+| key | default | meaning |
+|-----|---------|---------|
+| `allow` (array of CIDR strings) | `[]` | client IPs allowed through; a bare address is `/32` (v4) or `/128` (v6) |
+| `deny` (array of CIDR strings) | `[]` | client IPs rejected with `403`; takes precedence over `allow` |
+| `default` (string) | `"deny"` | verdict when no rule matches: `"allow"` or `"deny"` |
+
+### `maintenance-mode`
+
+Flips a tenant into a `503` holding page the instant a per-site flag appears
+in the embedded (cluster-replicated) KV store — no redeploy. Per request it
+builds a per-site key from `key_template` (default `mw:maintenance:<vhost>`)
+and reads it; a truthy value serves the holding page. **Fail-open by
+design:** a KV blip means CONTINUE, so a transient hiccup can't black-hole
+every tenant. Never use it as an access-control gate.
+
+| key | default | meaning |
+|-----|---------|---------|
+| `key_template` (string) | `"mw:maintenance:<vhost>"` | KV key checked per request; `<vhost>` is substituted |
+| `retry_after` (integer seconds) | `300` | `Retry-After` header on the 503 |
+| `body` (string) | built-in minimal HTML | holding-page body |
+| `content_type` (string) | `"text/html; charset=utf-8"` | holding-page `Content-Type` |
+| `bypass_ips` (array of strings) | unset | exact IPs or CIDR ranges whose requests continue during maintenance |
+| `bypass_paths` (array of strings) | unset | path prefixes kept live (e.g. `/healthz`) |
+
+### `redirect`
+
+Enforces canonical URLs with a single `301`/`308` **before** PHP runs.
+Composes scheme, host, and trailing-slash rules, computes the canonical URL
+once, and redirects only when the request is not already canonical (so it
+can never loop). Since the v1 ABI exposes no request scheme, the current
+scheme is read from `forwarded_proto_header` (default `X-Forwarded-Proto`).
+
+| key | default | meaning |
+|-----|---------|---------|
+| `force_https` (bool) | `false` | redirect `http` → `https` |
+| `canonical_host` (string) | unset | `"www"` forces apex → `www.`; `"apex"` (alias `"non-www"`) strips a leading `www.` |
+| `host_map` (object) | unset | explicit `source-host` → `canonical-host` map; wins over `canonical_host` |
+| `trailing_slash` (string) | unset | `"add"` or `"strip"` (root and file-like paths are left alone) |
+| `status` (integer) | `308` | redirect status — `301` or `308` |
+| `forwarded_proto_header` (string) | `"X-Forwarded-Proto"` | header the current scheme is derived from |
+
+### `request-id`
+
+**Request + response phase.** Gives every request a stable correlation id,
+injects it for PHP (`$_SERVER['HTTP_X_REQUEST_ID']`), and echoes it on the
+response — so the access log, the application log, and the client all share
+one id. The response phase guarantees the header even on responses no request
+phase touched (static files), and is idempotent on the PHP path. An inbound
+id is trusted only when `trust_inbound` is on **and** it is a short, printable
+ASCII token (no CR/LF smuggling).
+
+| key | default | meaning |
+|-----|---------|---------|
+| `header` (string) | `"X-Request-Id"` | request/response header carrying the id |
+| `trust_inbound` (bool) | `false` | reuse a well-formed inbound value instead of generating |
+
+### `header-transform`
+
+**Request + response phase.** Sets request headers PHP sees (before PHP runs)
+and sets/removes response headers on the way out — on **every** response (PHP,
+static file, error page). Both request and response `set` are replace-or-add;
+header **removal is response-side only** (the v1 ABI request phase can only
+override a request header, not delete one — a request-side `remove` is
+rejected at `init` rather than silently ignored).
+
+```toml
+[middleware.config.request]
+set = { "X-Env" = "prod" }
+
+[middleware.config.response]
+set    = { "X-Served-By" = "ephpm" }
+remove = ["Server", "X-Powered-By"]
+```
+
+| section | key | effect |
+|---------|-----|--------|
+| `request` | `set` (object) | replace-or-add each request header PHP sees |
+| `response` | `set` (object) | replace-or-add each response header |
+| `response` | `remove` (array) | delete each response header (case-insensitive) |
 
 ## The dynamic lane
 
@@ -453,9 +565,11 @@ cargo build --release -p my-auth
 
 The artifact lands at `target/release/lib<crate_name>.so`; a bare
 `library = "<crate_name>"` mount finds the `lib<name>.so` form through
-the search path. The four in-tree modules build exactly the same way
-(`-p ephpm-middleware-jwt -p ephpm-middleware-cors
--p ephpm-middleware-ratelimit -p ephpm-middleware-security-headers`).
+the search path. The ten official modules are already compiled into every
+ePHPm binary (mount them by short name); loadable cdylib builds of the same
+implementations, useful as authoring templates, live in the
+[`ephpm/middleware-examples`](https://github.com/ephpm/middleware) repo and
+build exactly the same way.
 
 Build on a distro whose glibc is not newer than the deployment target's
 (the usual glibc forward-compatibility rule — a module built on Debian 12
@@ -539,6 +653,5 @@ naming the faulting `.so` and function before it dies — see
 Planned — not yet implemented: request-body access from middleware, an
 async `invoke` variant, hot reload of modules, per-vhost mounts, a WASM
 loader for sandboxed modules, and the wider module catalog (basic-auth,
-IP lists, webhook signatures, GeoIP, response cache, OpenTelemetry,
-request-id). The design notes live in the git history of the roadmap page
-this guide replaced.
+webhook signatures, GeoIP, response cache, OpenTelemetry). The design notes
+live in the git history of the roadmap page this guide replaced.

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -593,9 +593,12 @@ and the membership check is per-host and trusts the TCP source address.
 ## `[[middleware]]`
 
 Native middleware mounts — repeatable array-of-tables. Each mount resolves
-against the **builtin registry first**: the four in-tree modules (`jwt`,
-`cors`, `ratelimit`, `security-headers`) are compiled into every binary and
-run in-process — no shared library on disk, no `dlopen`. Any other name
+against the **builtin registry first**: the ten official modules (`jwt`,
+`cors`, `ratelimit`, `security-headers`, `api-key`, `ip-allowlist`,
+`maintenance-mode`, `redirect`, `request-id`, `header-transform`) are
+compiled into every binary and run in-process — no shared library on disk,
+no `dlopen`. `request-id` and `header-transform` also run in the response
+phase. Any other name
 loads a shared library (`.so`/`.dylib`/`.dll`) at startup. Loading is
 fail-fast: a builtin rejecting its config, an unresolvable library, a
 missing ABI symbol, or a failing module `init` aborts server startup. The
@@ -614,7 +617,7 @@ at startup) — see the guide's
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
+| `library` | string | **required** | Builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, `header-transform`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
 | `match` | string | (none) | Glob the request path must match for the mount to run. `*` matches any character sequence, including `/`. Unset = every PHP-bound request. |
 | `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. |
 | `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init`. |


### PR DESCRIPTION
﻿## What

Brings the six remaining **official** middleware modules in-tree so that **all ten** are compiled into every ePHPm binary via the static builtin registry. `library = "api-key"` (etc.) now resolves with **no dlopen and no loose files** — the self-contained model.

New in-tree modules (ported from the `ephpm/middleware` repo's `ephpm-middleware-modules` crate, with their unit tests):

| Module | Phase |
|--------|-------|
| `api-key` | request |
| `ip-allowlist` | request |
| `maintenance-mode` | request |
| `redirect` | request |
| `request-id` | request + **response** |
| `header-transform` | request + **response** |

Together with the existing `jwt`, `cors`, `ratelimit`, `security-headers`, that's the full set of ten.

## Why compile-in

The owner's chosen model: **official modules are built into the single self-contained binary** — they work in every build, including a custom fully-static (musl) binary where `dlopen` does not exist. Custom, out-of-tree middleware continues to use the documented C ABI + dlopen lane. The `ephpm/middleware` repo (being renamed to `ephpm/middleware-examples`) keeps the loadable cdylib shells as authoring templates; the four original shells stay in this repo as the cross-platform dlopen CI fixtures (`load_real_module_end_to_end`).

This is the opposite of the now-closed #402 (which would have removed the builtins).

## Response phase (builtin lane)

`request-id` and `header-transform` use the response phase added in #408. The `BuiltinModule` adapter already supported the response phase (`init_response` / `has_response_phase` / `invoke_response`) and the server's `run_response_phase` already drives `Backend::Builtin` — so **no adapter change was needed**. The only wiring required was registering those two modules via `BuiltinModule::init_response::<T>` in `fn builtin`. A new test, `builtin_response_phase_runs_via_registry`, loads `header-transform` purely from the registry (no cdylib, no dlopen) and asserts its response phase sets/removes response headers end to end.

## Changes

- `ephpm-middleware-builtins`: 6 new module impls + tests; `lib.rs` exports all ten; deps `ipnetwork` (ip-allowlist) + `subtle` (api-key, constant-time key compare).
- Workspace `Cargo.toml`: add `ipnetwork` / `subtle`.
- `ephpm-server/src/middleware.rs`: register the six in `fn builtin` (two via `init_response`); extend the spelling test; add the registry response-phase test.
- Docs (docs-must-match-code): middleware guide, config reference, `AGENTS.md`, `build-compose-design.md` all enumerate the ten builtins and mark the two response-phase ones.

## Verification

- `cargo build`, `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo +nightly fmt --all -- --check` → clean
- `cargo test -p ephpm-middleware-builtins` → 98 passed (incl. all six new modules)
- `cargo test -p ephpm-server` middleware lib tests → 22 passed (incl. new registry response-phase test); `middleware_dlopen` (8) + `middleware_response_phase` (4) → pass
