### PR TITLE
feat(server): DNS-01 wildcard ACME (instant-acme + Cloudflare)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -260,10 +260,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -548,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +767,12 @@ dependencies = [
  "libc",
  "shlex 2.0.1",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1145,7 +1188,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1475,6 +1532,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "instant-acme",
  "ipnet",
  "libc",
  "libloading",
@@ -1487,7 +1545,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "quinn",
- "rcgen",
+ "rcgen 0.13.2",
  "reqwest",
  "rustls 0.23.37",
  "rustls-acme",
@@ -2180,6 +2238,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2441,6 +2500,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant-acme"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httpdate",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rcgen 0.14.9",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "intrusive-collections"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2605,50 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3232,7 +3361,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -3967,7 +4105,21 @@ dependencies = [
  "pem",
  "rustls-pki-types",
  "time",
- "yasna",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.1",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -4302,14 +4454,14 @@ dependencies = [
  "http",
  "log",
  "pem",
- "rcgen",
+ "rcgen 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "webpki-roots 1.0.6",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -4342,6 +4494,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4377,6 +4556,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "saturating"
@@ -5742,6 +5930,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5907,6 +6105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6058,11 +6265,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6071,7 +6287,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6085,19 +6301,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6107,9 +6344,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6125,9 +6374,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6137,9 +6398,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6286,14 +6559,32 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -6328,6 +6619,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,13 @@ quinn = { version = "0.11", default-features = false, features = ["runtime-tokio
 h3 = "0.0.8"
 h3-quinn = "0.0.10"
 rustls-acme = { version = "0.15", default-features = false, features = ["tokio", "aws-lc-rs", "tls12", "webpki-roots"] }
+# Lower-level ACME client for the DNS-01 wildcard lane (rustls-acme only speaks
+# TLS-ALPN-01). `default-features = false` + an explicit `aws-lc-rs` keeps it off
+# `ring`, the same single-provider discipline the rustls pin above enforces
+# (#241); `hyper-rustls` is its HTTPS transport to the ACME directory and
+# `rcgen` lets `Order::finalize` generate the CSR + certificate key pair. MSRV
+# 1.88, matching the workspace.
+instant-acme = { version = "0.8", default-features = false, features = ["aws-lc-rs", "hyper-rustls", "rcgen"] }
 tokio-stream = "0.1"
 tempfile = "3"
 rcgen = { version = "0.13", default-features = false, features = ["pem", "aws_lc_rs"] }

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1543,6 +1543,66 @@ pub struct TlsConfig {
     #[serde(default)]
     pub staging: bool,
 
+    // --- ACME challenge selection ---
+    /// ACME challenge type: `"tls-alpn-01"` (default) or `"dns-01"`.
+    ///
+    /// - `"tls-alpn-01"` — the zero-config default. The server answers the
+    ///   challenge inline on the TLS listener (via `rustls-acme`); no DNS
+    ///   credentials are needed, but **wildcard certificates are impossible**
+    ///   (the CA cannot prove wildcard control over a single hostname).
+    /// - `"dns-01"` — provisions the challenge as a `_acme-challenge` TXT
+    ///   record through a [`Self::dns_provider`]. This is the **only** way to
+    ///   obtain a wildcard certificate (`*.example.com`), and it works for
+    ///   hosts that never accept inbound TLS. Requires `dns_provider` and a
+    ///   provider credential (see [`Self::cloudflare_api_token_file`]).
+    ///
+    /// Default: `"tls-alpn-01"` (preserves the previous behaviour exactly).
+    /// Any other value is rejected at startup by `Config::validate`.
+    #[serde(default = "default_tls_challenge")]
+    pub challenge: String,
+
+    /// DNS provider used to satisfy `dns-01` challenges.
+    ///
+    /// Currently the only accepted value is `"cloudflare"`. Ignored unless
+    /// `challenge = "dns-01"`. `Config::validate` requires it in that mode and
+    /// rejects unknown providers rather than silently doing nothing.
+    #[serde(default)]
+    pub dns_provider: Option<String>,
+
+    /// Path to a file containing the Cloudflare API token (preferred).
+    ///
+    /// The token must be **zone-scoped** with the `Zone.DNS:Edit` permission on
+    /// the zone(s) that hold the challenge records. Keeping the secret in a
+    /// `0600` file (or a mounted secret) keeps it out of `ephpm.toml`.
+    ///
+    /// Precedence when both are present: this file wins over
+    /// [`Self::cloudflare_api_token`]. The token may instead be supplied
+    /// entirely via the environment as
+    /// `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN` (which populates
+    /// `cloudflare_api_token`). Only read when `dns_provider = "cloudflare"`.
+    #[serde(default)]
+    pub cloudflare_api_token_file: Option<PathBuf>,
+
+    /// Cloudflare API token supplied inline (discouraged).
+    ///
+    /// Prefer [`Self::cloudflare_api_token_file`] or the
+    /// `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN` environment variable so the
+    /// secret does not live in the config file. This field exists primarily as
+    /// the landing spot for that env var. Only read when
+    /// `dns_provider = "cloudflare"`; the token file takes precedence.
+    #[serde(default)]
+    pub cloudflare_api_token: Option<String>,
+
+    /// Explicit Cloudflare zone id for the challenge records.
+    ///
+    /// Optional. When absent, the zone is resolved from the challenge FQDN by
+    /// walking its parent domains against the Cloudflare `zones` API. Set it to
+    /// skip that lookup (one fewer API round-trip, and it removes the
+    /// `Zone:Read` requirement from the token). Only used when
+    /// `dns_provider = "cloudflare"`.
+    #[serde(default)]
+    pub cloudflare_zone_id: Option<String>,
+
     // --- Shared ---
     /// Optional separate listen address for HTTPS (e.g. `"0.0.0.0:443"`).
     ///
@@ -1570,6 +1630,22 @@ impl TlsConfig {
     #[must_use]
     pub fn is_acme(&self) -> bool {
         !self.domains.is_empty() && !self.is_manual()
+    }
+
+    /// Returns `true` if ACME is configured to use the `dns-01` challenge.
+    ///
+    /// This selects the [`crate::TlsConfig::dns_provider`]-driven wildcard lane
+    /// instead of the default TLS-ALPN-01 path. Only meaningful when
+    /// [`Self::is_acme`] is also `true`.
+    #[must_use]
+    pub fn is_dns01(&self) -> bool {
+        self.is_acme() && self.challenge.eq_ignore_ascii_case("dns-01")
+    }
+
+    /// Returns `true` if any configured domain is a wildcard (`*.example.com`).
+    #[must_use]
+    pub fn has_wildcard_domain(&self) -> bool {
+        self.domains.iter().any(|d| d.starts_with("*."))
     }
 }
 
@@ -3180,6 +3256,87 @@ impl Config {
                  entrypoint (default: [\"websocket.php\"])."
                     .to_string(),
             ));
+        }
+
+        // TLS / ACME challenge validation. All fail-closed: a wildcard cert
+        // that cannot be issued, or a dns-01 lane with no credential, must stop
+        // startup rather than come up serving no certificate.
+        if let Some(tls) = self.server.tls.as_ref() {
+            let challenge = tls.challenge.to_ascii_lowercase();
+            if challenge != "tls-alpn-01" && challenge != "dns-01" {
+                return Err(ConfigError::Validation(format!(
+                    "[server.tls] challenge must be \"tls-alpn-01\" or \"dns-01\", got \
+                     \"{}\". (tls-alpn-01 is the default; dns-01 is required for wildcard \
+                     certificates.)",
+                    tls.challenge,
+                )));
+            }
+
+            // A wildcard identifier can only be validated over DNS-01: the CA
+            // has no single host to answer a TLS-ALPN-01 or HTTP-01 challenge
+            // for `*.example.com`. Reject the combination loudly rather than
+            // let ACME fail opaquely at order time.
+            if tls.has_wildcard_domain() && challenge != "dns-01" {
+                return Err(ConfigError::Validation(
+                    "[server.tls] a wildcard domain (\"*.example.com\") requires \
+                     challenge = \"dns-01\". TLS-ALPN-01 cannot prove control of a \
+                     wildcard. Set challenge = \"dns-01\" and configure a dns_provider."
+                        .to_string(),
+                ));
+            }
+
+            // dns-01 needs somewhere to put the TXT record and something to
+            // request it for. Enforce the full triple: domains, a known
+            // provider, and a credential source.
+            if challenge == "dns-01" {
+                if tls.is_manual() {
+                    return Err(ConfigError::Validation(
+                        "[server.tls] challenge = \"dns-01\" is an ACME (automatic) mode \
+                         but cert/key were also provided. Remove cert/key to use ACME, or \
+                         drop the challenge setting to serve the static certificate."
+                            .to_string(),
+                    ));
+                }
+                if tls.domains.is_empty() {
+                    return Err(ConfigError::Validation(
+                        "[server.tls] challenge = \"dns-01\" requires at least one entry in \
+                         `domains` (e.g. [\"*.preview.example.com\"])."
+                            .to_string(),
+                    ));
+                }
+                match tls.dns_provider.as_deref() {
+                    Some(p) if p.eq_ignore_ascii_case("cloudflare") => {
+                        let has_token = tls.cloudflare_api_token_file.is_some()
+                            || tls
+                                .cloudflare_api_token
+                                .as_deref()
+                                .is_some_and(|t| !t.trim().is_empty());
+                        if !has_token {
+                            return Err(ConfigError::Validation(
+                                "[server.tls] dns_provider = \"cloudflare\" requires an API \
+                                 token: set `cloudflare_api_token_file` (a path to a file \
+                                 holding a zone-scoped Zone.DNS:Edit token) or provide it via \
+                                 the EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN environment \
+                                 variable."
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                    Some(other) => {
+                        return Err(ConfigError::Validation(format!(
+                            "[server.tls] dns_provider = \"{other}\" is not supported; the \
+                             only implemented provider is \"cloudflare\".",
+                        )));
+                    }
+                    None => {
+                        return Err(ConfigError::Validation(
+                            "[server.tls] challenge = \"dns-01\" requires `dns_provider` \
+                             (currently only \"cloudflare\")."
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
         }
 
         // Fail closed (issue #397): a `sites_domain_suffix` without a leading
@@ -5502,6 +5659,13 @@ fn default_cache_dir() -> PathBuf {
     PathBuf::from("certs")
 }
 
+/// Default ACME challenge type — TLS-ALPN-01, the zero-config path that
+/// predates the DNS-01 lane. Chosen so an existing `[server.tls]` with
+/// `domains` behaves exactly as before this knob existed.
+fn default_tls_challenge() -> String {
+    "tls-alpn-01".to_string()
+}
+
 fn default_max_execution_time() -> u32 {
     30
 }
@@ -5642,6 +5806,116 @@ mod tests {
                 .php_script(),
             None
         );
+    }
+
+    // ── [server.tls] DNS-01 challenge validation ────────────────────────
+
+    /// Load a config from TOML and validate, expecting success. Returns it.
+    fn load_ok(toml: &str) -> Config {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ephpm.toml");
+        std::fs::write(&file, toml).unwrap();
+        let config = Config::load(&file).unwrap();
+        config.validate().unwrap_or_else(|e| panic!("expected valid config, got: {e}\n{toml}"));
+        config
+    }
+
+    #[test]
+    fn tls_challenge_defaults_to_tls_alpn_01() {
+        let config = load_ok("[server.tls]\ndomains = [\"example.com\"]\n");
+        let tls = config.server.tls.expect("tls section present");
+        assert_eq!(tls.challenge, "tls-alpn-01");
+        assert!(tls.is_acme());
+        assert!(!tls.is_dns01(), "the default must not select the dns-01 lane");
+    }
+
+    #[test]
+    fn dns01_without_token_is_rejected() {
+        let err = validation_error(
+            "[server.tls]\n\
+             domains = [\"*.preview.example.com\"]\n\
+             challenge = \"dns-01\"\n\
+             dns_provider = \"cloudflare\"\n",
+        );
+        assert!(err.contains("requires an API token"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn dns01_without_provider_is_rejected() {
+        let err =
+            validation_error("[server.tls]\ndomains = [\"example.com\"]\nchallenge = \"dns-01\"\n");
+        assert!(err.contains("requires `dns_provider`"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn dns01_unknown_provider_is_rejected() {
+        let err = validation_error(
+            "[server.tls]\n\
+             domains = [\"example.com\"]\n\
+             challenge = \"dns-01\"\n\
+             dns_provider = \"route53\"\n\
+             cloudflare_api_token = \"x\"\n",
+        );
+        assert!(err.contains("not supported"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn unknown_challenge_is_rejected() {
+        let err = validation_error(
+            "[server.tls]\ndomains = [\"example.com\"]\nchallenge = \"http-01\"\n",
+        );
+        assert!(err.contains("challenge must be"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn wildcard_under_tls_alpn_01_is_rejected() {
+        let err = validation_error("[server.tls]\ndomains = [\"*.preview.example.com\"]\n");
+        assert!(err.contains("requires challenge = \"dns-01\""), "unexpected: {err}");
+    }
+
+    #[test]
+    fn dns01_wildcard_with_inline_token_validates() {
+        let config = load_ok(
+            "[server.tls]\n\
+             domains = [\"*.preview.example.com\", \"preview.example.com\"]\n\
+             challenge = \"dns-01\"\n\
+             dns_provider = \"cloudflare\"\n\
+             cloudflare_api_token = \"tok\"\n",
+        );
+        let tls = config.server.tls.expect("tls present");
+        assert!(tls.is_dns01());
+        assert!(tls.has_wildcard_domain());
+    }
+
+    #[test]
+    fn dns01_with_token_file_validates() {
+        // The file need not exist at validate() time — its readability is a
+        // runtime (fail-closed at startup) concern; presence of the path is
+        // what validate() checks.
+        let config = load_ok(
+            "[server.tls]\n\
+             domains = [\"example.com\"]\n\
+             challenge = \"dns-01\"\n\
+             dns_provider = \"cloudflare\"\n\
+             cloudflare_api_token_file = \"/run/secrets/cf-token\"\n",
+        );
+        assert!(config.server.tls.expect("tls present").is_dns01());
+    }
+
+    #[test]
+    fn dns01_token_via_env_satisfies_validation() {
+        // The env var lands in `cloudflare_api_token`, so no file/inline token
+        // is needed in the TOML.
+        let _env = EnvVars::set("EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN", "env-token");
+        let config = load_ok(
+            "[server.tls]\n\
+             domains = [\"example.com\"]\n\
+             challenge = \"dns-01\"\n\
+             dns_provider = \"cloudflare\"\n",
+        );
+        let tls = config.server.tls.expect("tls present");
+        assert_eq!(tls.cloudflare_api_token.as_deref(), Some("env-token"));
+        assert!(tls.is_dns01());
     }
 
     /// The whole tenant-isolation story rests on the path being joined onto the

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -46,6 +46,9 @@ rustls.workspace = true
 tokio-rustls.workspace = true
 rustls-pemfile.workspace = true
 rustls-acme.workspace = true
+# DNS-01 wildcard ACME lane (src/dns01.rs). instant-acme drives the ACME
+# protocol; the issued cert is wired into rustls via a hot-swappable resolver.
+instant-acme.workspace = true
 tokio-stream.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
@@ -69,13 +72,15 @@ opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
-# The exporter's HTTP client and its trust anchors. We build the
-# `rustls::ClientConfig` ourselves (see src/otlp.rs) so the exporter uses the
-# same crypto provider as the rest of the server; reqwest is therefore
-# compiled with no provider and no root store of its own.
-reqwest = { workspace = true, optional = true }
+# The Cloudflare DNS-01 API client (src/dns01.rs) and the OTLP exporter's HTTP
+# client (src/otlp.rs) both use reqwest. We build the `rustls::ClientConfig`
+# ourselves in each so they use the same crypto provider as the rest of the
+# server; reqwest is therefore compiled with no provider and no root store of
+# its own. `webpki-roots` supplies the trust anchors for both — hence both are
+# unconditional now that DNS-01 (a default-build feature) needs them.
+reqwest.workspace = true
+webpki-roots.workspace = true
 rustls-native-certs = { workspace = true, optional = true }
-webpki-roots = { workspace = true, optional = true }
 # The gRPC transport's TLS config type (`ClientTlsConfig`) and its root-store
 # switches. tonic is already in the graph via opentelemetry-proto; naming it
 # here is what enables the two `tls-*-roots` features — neither of which pulls
@@ -101,9 +106,10 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
     "dep:tracing-subscriber",
-    "dep:reqwest",
+    # reqwest + webpki-roots are unconditional now (the DNS-01 lane needs them),
+    # so they are no longer listed here; rustls-native-certs stays otlp-only
+    # because only the OTLP client blends the OS trust store with the bundle.
     "dep:rustls-native-certs",
-    "dep:webpki-roots",
     "dep:tonic",
     # The gRPC exporter is async; `otlp.rs` drives it on a dedicated
     # single-worker runtime built in `main`, before the server's own.

--- a/crates/ephpm-server/src/acme.rs
+++ b/crates/ephpm-server/src/acme.rs
@@ -177,9 +177,12 @@ async fn drive_acme_events<EC: Debug + 'static, EA: Debug + 'static>(mut state: 
 /// ACME leader key in the KV store.
 const ACME_LEADER_KEY: &str = "acme:leader";
 /// TTL for the ACME leader lock.
-const ACME_LEADER_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+pub(crate) const ACME_LEADER_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 /// Heartbeat interval for the ACME leader (must be less than TTL).
-const ACME_LEADER_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(10);
+///
+/// Shared with the DNS-01 renewal loop ([`crate::dns01`]) so both ACME lanes
+/// elect their leader on the same cadence.
+pub(crate) const ACME_LEADER_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(10);
 /// Consecutive confirmed heartbeats required before a node acts as leader.
 ///
 /// The gossip KV tier is eventually consistent, so during the second or so it
@@ -187,7 +190,7 @@ const ACME_LEADER_HEARTBEAT: std::time::Duration = std::time::Duration::from_sec
 /// Requiring the claim to survive another heartbeat gives the deterministic
 /// tie-break in [`try_acquire_acme_leadership`] time to settle before anything
 /// talks to Let's Encrypt.
-const ACME_LEADER_CONFIRMATIONS: u32 = 2;
+pub(crate) const ACME_LEADER_CONFIRMATIONS: u32 = 2;
 /// How often a follower re-checks the KV store for the leader's certificate
 /// while holding a `load_cert` open.
 const ACME_FOLLOWER_CERT_POLL: std::time::Duration = std::time::Duration::from_secs(5);
@@ -197,7 +200,10 @@ const ACME_CHALLENGE_PREFIX: &str = "acme:challenge:";
 const ACME_CERT_PREFIX: &str = "acme:cert:";
 
 /// Generate a unique node identifier for ACME leader election.
-fn acme_node_id() -> String {
+///
+/// Shared with [`crate::dns01`] so both ACME lanes derive their node identity
+/// (and therefore the lowest-id tie-break) the same way.
+pub(crate) fn acme_node_id() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
     let pid = std::process::id();
@@ -326,7 +332,7 @@ async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
 /// The caller additionally waits [`ACME_LEADER_CONFIRMATIONS`] heartbeats
 /// before acting on a claim, so the pre-convergence window cannot turn into
 /// duplicate certificate orders.
-fn try_acquire_acme_leadership(store: &Store, node_id: &str) -> bool {
+pub(crate) fn try_acquire_acme_leadership(store: &Store, node_id: &str) -> bool {
     let key = ACME_LEADER_KEY.to_string();
     let claim = node_id.as_bytes().to_vec();
 
@@ -1062,6 +1068,11 @@ mod tests {
             domains: vec!["example.com".into()],
             cache_dir: tmp.path().to_path_buf(),
             staging: true,
+            challenge: "tls-alpn-01".into(),
+            dns_provider: None,
+            cloudflare_api_token_file: None,
+            cloudflare_api_token: None,
+            cloudflare_zone_id: None,
             listen: None,
             redirect_http: false,
         };

--- a/crates/ephpm-server/src/dns01.rs
+++ b/crates/ephpm-server/src/dns01.rs
@@ -1,0 +1,1058 @@
+//! DNS-01 wildcard ACME provisioning.
+//!
+//! This is the **opt-in** ACME lane selected by `[server.tls] challenge =
+//! "dns-01"`. It exists alongside — never replacing — the default TLS-ALPN-01
+//! path in [`crate::acme`]. An operator picks exactly one; the default keeps
+//! the previous zero-config behaviour.
+//!
+//! ## Why DNS-01 at all
+//!
+//! TLS-ALPN-01 answers the challenge inline on the TLS socket, which is simple
+//! and needs no credentials — but a certificate authority cannot validate a
+//! **wildcard** identifier (`*.preview.ephpm.dev`) that way: there is no single
+//! hostname to connect to. Wildcards therefore *require* DNS-01, where control
+//! is proven by publishing a `_acme-challenge.<domain>` TXT record. One
+//! wildcard certificate also consolidates every ephemeral preview subdomain
+//! into a single order, sidestepping Let's Encrypt's "50 certificates per
+//! registered domain per week" rate limit that per-subdomain issuance would
+//! otherwise burn through.
+//!
+//! ## Architecture
+//!
+//! `rustls-acme` (the TLS-ALPN-01 engine) speaks only TLS-ALPN-01, so this lane
+//! is built on the lower-level [`instant_acme`] client, which drives the ACME
+//! protocol but owns neither TLS serving nor renewal. Those two jobs are ours:
+//!
+//! - **[`DnsProvider`]** is the `libdns`-equivalent seam. It has exactly two
+//!   operations — publish and retract a TXT record — so a new provider is a
+//!   ~150-line wrapper. [`CloudflareProvider`] is the first and only impl.
+//! - **[`Dns01CertResolver`]** is a hot-swappable [`rustls::server::ResolvesServerCert`].
+//!   The renewal task swaps a freshly issued certificate in with no restart and
+//!   no connection drop — which also closes the follower-can't-see-a-renewal
+//!   gap that the `rustls-acme` lane documents, because *this* resolver is ours
+//!   to mutate.
+//! - The **renewal + clustering machinery is reused from [`crate::acme`]**:
+//!   [`crate::acme::try_acquire_acme_leadership`] for leader election over the
+//!   same `acme:leader` KV key, and [`crate::acme::store_acme_cert`] /
+//!   [`crate::acme::get_acme_cert`] for cluster-wide certificate distribution.
+//!   Only the elected leader talks to Let's Encrypt; every other node installs
+//!   the leader's certificate out of the KV store. That reuse is deliberate —
+//!   duplicating a second, subtly different leader election is exactly how a
+//!   cluster ends up ordering five duplicate certificates and getting locked
+//!   out for a week.
+//!
+//! ## Live-validation status
+//!
+//! The order flow is exercised against a mocked [`DnsProvider`] and the request
+//! shaping against a captured HTTP server; a real end-to-end issuance needs a
+//! zone on Cloudflare plus a live token, which is pending. See the PR body for
+//! the exact live-validation steps.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, anyhow, bail};
+use async_trait::async_trait;
+use ephpm_config::TlsConfig;
+use ephpm_kv::store::Store;
+use instant_acme::{
+    Account, AuthorizationStatus, ChallengeType, Identifier, LetsEncrypt, NewAccount, NewOrder,
+    OrderStatus, RetryPolicy,
+};
+use rustls::ServerConfig;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use sha2::{Digest, Sha256};
+use tokio_rustls::TlsAcceptor;
+
+use crate::tls::crypto_provider;
+
+/// Renew when the certificate is this old. Let's Encrypt issues 90-day
+/// certificates; renewing at 60 days leaves a 30-day safety margin, matching
+/// the 2/3-of-validity policy `rustls-acme` hardcodes for the other lane.
+const RENEW_AFTER: Duration = Duration::from_secs(60 * 24 * 60 * 60);
+
+/// How long to wait after publishing the TXT records before telling the CA to
+/// validate. Cloudflare's authoritative edge is usually consistent within a
+/// couple of seconds; 15s is a conservative floor before we lean on the CA's
+/// own validation retries.
+const PROPAGATION_WAIT: Duration = Duration::from_secs(15);
+
+/// TXT record TTL requested from the provider. Short, because the record is
+/// deleted right after validation.
+const CHALLENGE_TXT_TTL_SECS: u32 = 60;
+
+/// Cloudflare API base URL. Overridable in tests via
+/// [`CloudflareProvider::with_api_base`].
+const CLOUDFLARE_API_BASE: &str = "https://api.cloudflare.com/client/v4";
+
+// ── DnsProvider seam ─────────────────────────────────────────────────────────
+
+/// A DNS provider capable of publishing and retracting the `_acme-challenge`
+/// TXT records a DNS-01 challenge requires.
+///
+/// This is intentionally tiny — the entire ACME/order state machine lives in
+/// [`instant_acme`] and this crate, so a provider is nothing more than "put a
+/// TXT record" and "take it away again". `set_txt` must **add** a record rather
+/// than replace: a wildcard order plus its bare apex produce two challenges at
+/// the *same* `_acme-challenge.<domain>` name with different values, and both
+/// must be live simultaneously. `delete_txt` therefore takes the value so it
+/// can retract precisely the record it published.
+#[async_trait]
+pub trait DnsProvider: Send + Sync {
+    /// Publish a `TXT` record at `fqdn` with the given `value`.
+    ///
+    /// Adds a record; it must not clobber an existing TXT record at the same
+    /// name (see the trait docs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record could not be created.
+    async fn set_txt(&self, fqdn: &str, value: &str) -> anyhow::Result<()>;
+
+    /// Retract the `TXT` record at `fqdn` whose content is exactly `value`.
+    ///
+    /// Best-effort cleanup: a failure here leaves a stale record but does not
+    /// invalidate the issued certificate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the lookup or deletion failed.
+    async fn delete_txt(&self, fqdn: &str, value: &str) -> anyhow::Result<()>;
+}
+
+// ── Cloudflare provider ──────────────────────────────────────────────────────
+
+/// A [`DnsProvider`] backed by the Cloudflare v4 API.
+///
+/// Authenticates with a **zone-scoped** API token (`Zone.DNS:Edit`, plus
+/// `Zone:Read` only when the zone id is resolved rather than configured). The
+/// token is never logged.
+pub struct CloudflareProvider {
+    client: reqwest::Client,
+    token: String,
+    /// Explicit zone id, or `None` to resolve it from the record FQDN.
+    zone_id: Option<String>,
+    api_base: String,
+}
+
+impl std::fmt::Debug for CloudflareProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render the token.
+        f.debug_struct("CloudflareProvider")
+            .field("zone_id", &self.zone_id)
+            .field("api_base", &self.api_base)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CloudflareProvider {
+    /// Build a Cloudflare provider from an API token and optional zone id.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTPS client cannot be constructed.
+    pub fn new(token: String, zone_id: Option<String>) -> anyhow::Result<Self> {
+        let client = build_cloudflare_http_client()?;
+        Ok(Self { client, token, zone_id, api_base: CLOUDFLARE_API_BASE.to_string() })
+    }
+
+    /// Override the API base URL. Test-only seam for a captured HTTP server.
+    #[must_use]
+    pub fn with_api_base(mut self, base: impl Into<String>) -> Self {
+        self.api_base = base.into();
+        self
+    }
+
+    /// Resolve the zone id for `fqdn`, using the configured id if present.
+    async fn zone_id_for(&self, fqdn: &str) -> anyhow::Result<String> {
+        if let Some(id) = &self.zone_id {
+            return Ok(id.clone());
+        }
+        for candidate in zone_candidates(fqdn) {
+            let url = format!("{}/zones?name={candidate}", self.api_base);
+            let resp = self
+                .client
+                .get(&url)
+                .bearer_auth(&self.token)
+                .send()
+                .await
+                .with_context(|| format!("Cloudflare GET zones?name={candidate} failed"))?;
+            let body = resp.bytes().await.context("reading Cloudflare zones response")?;
+            let parsed: CfList<Zone> =
+                serde_json::from_slice(&body).context("decoding Cloudflare zones response")?;
+            parsed.ensure_success("list zones")?;
+            if let Some(zone) = parsed.result.into_iter().next() {
+                return Ok(zone.id);
+            }
+        }
+        bail!(
+            "could not resolve a Cloudflare zone for {fqdn}: no parent domain is a zone on this \
+             account (set [server.tls] cloudflare_zone_id to skip resolution)"
+        )
+    }
+}
+
+#[async_trait]
+impl DnsProvider for CloudflareProvider {
+    async fn set_txt(&self, fqdn: &str, value: &str) -> anyhow::Result<()> {
+        let zone = self.zone_id_for(fqdn).await?;
+        let url = format!("{}/zones/{zone}/dns_records", self.api_base);
+        let body = serde_json::json!({
+            "type": "TXT",
+            "name": fqdn,
+            "content": value,
+            "ttl": CHALLENGE_TXT_TTL_SECS,
+        });
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.token)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&body).expect("serializing a static json object cannot fail"))
+            .send()
+            .await
+            .context("Cloudflare create TXT record request failed")?;
+        let bytes = resp.bytes().await.context("reading Cloudflare create-record response")?;
+        let parsed: CfStatus =
+            serde_json::from_slice(&bytes).context("decoding Cloudflare create-record response")?;
+        parsed.ensure_success("create TXT record")?;
+        tracing::debug!(fqdn, "published DNS-01 challenge TXT record via Cloudflare");
+        Ok(())
+    }
+
+    async fn delete_txt(&self, fqdn: &str, value: &str) -> anyhow::Result<()> {
+        let zone = self.zone_id_for(fqdn).await?;
+        // Find the record whose content matches, then delete by id.
+        let list_url = format!(
+            "{}/zones/{zone}/dns_records?type=TXT&name={fqdn}&content={value}",
+            self.api_base
+        );
+        let resp = self
+            .client
+            .get(&list_url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .context("Cloudflare list TXT records request failed")?;
+        let bytes = resp.bytes().await.context("reading Cloudflare list-records response")?;
+        let parsed: CfList<DnsRecord> =
+            serde_json::from_slice(&bytes).context("decoding Cloudflare list-records response")?;
+        parsed.ensure_success("list TXT records")?;
+        for record in parsed.result {
+            let del_url = format!("{}/zones/{zone}/dns_records/{}", self.api_base, record.id);
+            let resp = self
+                .client
+                .delete(&del_url)
+                .bearer_auth(&self.token)
+                .send()
+                .await
+                .context("Cloudflare delete TXT record request failed")?;
+            let bytes = resp.bytes().await.context("reading Cloudflare delete-record response")?;
+            let parsed: CfStatus = serde_json::from_slice(&bytes)
+                .context("decoding Cloudflare delete-record response")?;
+            parsed.ensure_success("delete TXT record")?;
+        }
+        tracing::debug!(fqdn, "retracted DNS-01 challenge TXT record via Cloudflare");
+        Ok(())
+    }
+}
+
+/// Build the reqwest client for Cloudflare with an explicit rustls config.
+///
+/// The workspace pins reqwest to `rustls-tls-manual-roots-no-provider` (so it
+/// never drags in `ring` — see [`crate::tls::crypto_provider`]), which means we
+/// must hand it a fully-built [`rustls::ClientConfig`]: the shared aws-lc-rs
+/// provider plus the bundled webpki roots.
+fn build_cloudflare_http_client() -> anyhow::Result<reqwest::Client> {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let tls = rustls::ClientConfig::builder_with_provider(crypto_provider())
+        .with_safe_default_protocol_versions()
+        .context("crypto provider does not support the default TLS versions")?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls)
+        .build()
+        .context("failed to build the Cloudflare API HTTP client")
+}
+
+/// Generate the candidate zone apexes for `fqdn`, longest first.
+///
+/// For `_acme-challenge.preview.ephpm.dev` this yields
+/// `["_acme-challenge.preview.ephpm.dev", "preview.ephpm.dev", "ephpm.dev"]`
+/// (stopping at two labels, since a single-label TLD is never an account
+/// zone). The caller queries each until one matches an actual zone, which
+/// avoids bundling a public-suffix list.
+fn zone_candidates(fqdn: &str) -> Vec<String> {
+    let fqdn = fqdn.trim_end_matches('.');
+    let labels: Vec<&str> = fqdn.split('.').collect();
+    let mut out = Vec::new();
+    // Keep suffixes with at least two labels.
+    for start in 0..labels.len().saturating_sub(1) {
+        out.push(labels[start..].join("."));
+    }
+    out
+}
+
+// ── Cloudflare API response envelopes ────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct CfList<T> {
+    success: bool,
+    #[serde(default)]
+    errors: Vec<CfError>,
+    #[serde(default = "Vec::new")]
+    result: Vec<T>,
+}
+
+/// A Cloudflare response envelope where we only care about success/errors
+/// (create and delete return a `result` we do not read).
+#[derive(serde::Deserialize)]
+struct CfStatus {
+    success: bool,
+    #[serde(default)]
+    errors: Vec<CfError>,
+}
+
+#[derive(serde::Deserialize)]
+struct CfError {
+    code: i64,
+    message: String,
+}
+
+#[derive(serde::Deserialize)]
+struct Zone {
+    id: String,
+}
+
+#[derive(serde::Deserialize)]
+struct DnsRecord {
+    id: String,
+}
+
+impl<T> CfList<T> {
+    fn ensure_success(&self, action: &str) -> anyhow::Result<()> {
+        ensure_cf_success(self.success, &self.errors, action)
+    }
+}
+
+impl CfStatus {
+    fn ensure_success(&self, action: &str) -> anyhow::Result<()> {
+        ensure_cf_success(self.success, &self.errors, action)
+    }
+}
+
+fn ensure_cf_success(success: bool, errors: &[CfError], action: &str) -> anyhow::Result<()> {
+    if success {
+        return Ok(());
+    }
+    let detail =
+        errors.iter().map(|e| format!("[{}] {}", e.code, e.message)).collect::<Vec<_>>().join("; ");
+    bail!("Cloudflare API {action} failed: {detail}")
+}
+
+// ── Hot-swappable rustls resolver ────────────────────────────────────────────
+
+/// A [`ResolvesServerCert`] whose certificate can be replaced at runtime.
+///
+/// The renewal task installs a freshly issued certificate here; in-flight and
+/// future handshakes pick it up on their next `resolve` call. Before the first
+/// certificate is installed (or loaded from cache), `resolve` returns `None` —
+/// a handshake attempted in that window fails, which is the honest signal that
+/// no certificate exists yet rather than serving a wrong one.
+#[derive(Debug)]
+pub struct Dns01CertResolver {
+    current: RwLock<Option<Arc<CertifiedKey>>>,
+}
+
+impl Dns01CertResolver {
+    /// Construct an empty resolver (no certificate installed yet).
+    #[must_use]
+    pub fn new() -> Self {
+        Self { current: RwLock::new(None) }
+    }
+
+    /// Install a certificate chain + private key (both PEM) as the resolver's
+    /// current certificate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the PEM cannot be parsed or the key does not match
+    /// what the crypto provider supports.
+    pub fn install(&self, cert_pem: &[u8], key_pem: &[u8]) -> anyhow::Result<()> {
+        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(cert_pem)
+            .collect::<Result<_, _>>()
+            .context("parsing DNS-01 certificate chain PEM")?;
+        anyhow::ensure!(!certs.is_empty(), "DNS-01 certificate PEM contained no certificates");
+        let key = PrivateKeyDer::from_pem_slice(key_pem)
+            .context("parsing DNS-01 certificate private key PEM")?;
+        let signing_key = crypto_provider()
+            .key_provider
+            .load_private_key(key)
+            .context("crypto provider rejected the DNS-01 certificate key")?;
+        let certified = CertifiedKey::new(certs, signing_key);
+        *self.current.write().unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Some(Arc::new(certified));
+        Ok(())
+    }
+
+    /// Whether a certificate is currently installed.
+    #[must_use]
+    pub fn has_cert(&self) -> bool {
+        self.current.read().unwrap_or_else(std::sync::PoisonError::into_inner).is_some()
+    }
+}
+
+impl Default for Dns01CertResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResolvesServerCert for Dns01CertResolver {
+    fn resolve(&self, _client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        self.current.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+    }
+}
+
+// ── Setup + lifecycle ────────────────────────────────────────────────────────
+
+/// The rustls acceptor for the DNS-01 lane, plus the resolver the renewal task
+/// mutates.
+pub struct Dns01Setup {
+    /// TLS acceptor whose cert resolver is hot-swapped by the renewal task.
+    pub acceptor: TlsAcceptor,
+}
+
+/// Everything the renewal loop needs, gathered once at startup.
+struct Dns01Context {
+    resolver: Arc<Dns01CertResolver>,
+    provider: Arc<dyn DnsProvider>,
+    domains: Vec<String>,
+    canonical: String,
+    contact: Vec<String>,
+    directory_url: String,
+    store: Option<Arc<Store>>,
+    cache_dir: PathBuf,
+}
+
+/// Resolve the Cloudflare API token from the config, honouring the file → env
+/// precedence.
+///
+/// The file (`cloudflare_api_token_file`) wins when present; otherwise the
+/// inline / env-populated `cloudflare_api_token` is used. The raw token is
+/// trimmed of trailing whitespace/newlines (a token file commonly ends in one).
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read or no token is available.
+pub fn resolve_cloudflare_token(tls: &TlsConfig) -> anyhow::Result<String> {
+    if let Some(path) = &tls.cloudflare_api_token_file {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("reading Cloudflare token file {}", path.display()))?;
+        let token = raw.trim().to_string();
+        anyhow::ensure!(!token.is_empty(), "Cloudflare token file {} is empty", path.display());
+        return Ok(token);
+    }
+    if let Some(token) = tls.cloudflare_api_token.as_deref() {
+        let token = token.trim().to_string();
+        if !token.is_empty() {
+            return Ok(token);
+        }
+    }
+    bail!(
+        "no Cloudflare API token available: set [server.tls] cloudflare_api_token_file or the \
+         EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN environment variable"
+    )
+}
+
+/// Start the DNS-01 ACME lane: build the hot-swap acceptor, seed it from any
+/// cached certificate, and spawn the renewal/leadership task.
+///
+/// When `store` is `Some`, the lane runs clustered: leadership election and
+/// certificate distribution reuse [`crate::acme`]'s KV machinery so only the
+/// leader talks to Let's Encrypt.
+///
+/// # Errors
+///
+/// Returns an error if the credential/provider cannot be constructed or the
+/// TLS acceptor cannot be built.
+pub fn start_dns01_acme(
+    tls_config: &TlsConfig,
+    store: Option<Arc<Store>>,
+) -> anyhow::Result<Dns01Setup> {
+    anyhow::ensure!(
+        tls_config.dns_provider.as_deref().is_some_and(|p| p.eq_ignore_ascii_case("cloudflare")),
+        "DNS-01 lane requires dns_provider = \"cloudflare\""
+    );
+    let token = resolve_cloudflare_token(tls_config)?;
+    let provider: Arc<dyn DnsProvider> =
+        Arc::new(CloudflareProvider::new(token, tls_config.cloudflare_zone_id.clone())?);
+
+    let resolver = Arc::new(Dns01CertResolver::new());
+    let cache_dir = tls_config.cache_dir.join("dns01");
+    std::fs::create_dir_all(&cache_dir)
+        .with_context(|| format!("creating DNS-01 cache directory {}", cache_dir.display()))?;
+
+    let canonical = canonical_domain_key(&tls_config.domains);
+
+    // Seed the resolver from cache so a restart serves TLS immediately instead
+    // of waiting for a fresh order. KV first (cluster-wide truth), then disk.
+    if let Some((cert, key)) = load_cached_cert(store.as_deref(), &cache_dir, &canonical) {
+        match resolver.install(&cert, &key) {
+            Ok(()) => {
+                tracing::info!(canonical, "DNS-01: seeded resolver from cached certificate");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "DNS-01: cached certificate unusable, will reorder");
+            }
+        }
+    }
+
+    // Build the acceptor around the hot-swap resolver.
+    let mut server_config = ServerConfig::builder_with_provider(crypto_provider())
+        .with_safe_default_protocol_versions()
+        .context("crypto provider does not support the default TLS versions")?
+        .with_no_client_auth()
+        .with_cert_resolver(Arc::clone(&resolver) as Arc<dyn ResolvesServerCert>);
+    server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    let contact =
+        tls_config.email.as_ref().map(|e| vec![format!("mailto:{e}")]).unwrap_or_default();
+    let directory_url = if tls_config.staging {
+        LetsEncrypt::Staging.url().to_owned()
+    } else {
+        LetsEncrypt::Production.url().to_owned()
+    };
+
+    let ctx = Dns01Context {
+        resolver: Arc::clone(&resolver),
+        provider,
+        domains: tls_config.domains.clone(),
+        canonical,
+        contact,
+        directory_url,
+        store,
+        cache_dir,
+    };
+
+    tracing::info!(
+        domains = ?tls_config.domains,
+        wildcard = tls_config.has_wildcard_domain(),
+        clustered = ctx.store.is_some(),
+        environment = if tls_config.staging { "staging" } else { "production" },
+        "DNS-01 ACME (Cloudflare) enabled"
+    );
+
+    tokio::spawn(run_dns01_lifecycle(ctx));
+
+    Ok(Dns01Setup { acceptor })
+}
+
+/// The renewal + leadership loop. Runs for the lifetime of the server.
+async fn run_dns01_lifecycle(ctx: Dns01Context) {
+    let node_id = crate::acme::acme_node_id();
+    let mut is_leader = false;
+    let mut confirmations: u32 = 0;
+    let mut last_issued: Option<SystemTime> =
+        read_issued_at(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical);
+    let mut installed_fp: Option<[u8; 32]> = if ctx.resolver.has_cert() {
+        load_cached_cert(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical)
+            .map(|(cert, _)| fingerprint(&cert))
+    } else {
+        None
+    };
+
+    let mut ticker = tokio::time::interval(crate::acme::ACME_LEADER_HEARTBEAT);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+
+        let standalone = ctx.store.is_none();
+        if let Some(store) = &ctx.store {
+            if crate::acme::try_acquire_acme_leadership(store, &node_id) {
+                confirmations = confirmations.saturating_add(1);
+            } else {
+                confirmations = 0;
+            }
+            let now_leader = confirmations >= crate::acme::ACME_LEADER_CONFIRMATIONS;
+            if now_leader != is_leader {
+                is_leader = now_leader;
+                if is_leader {
+                    // On promotion, trust the KV issuance timestamp the previous
+                    // leader wrote so we don't re-order a certificate that was
+                    // just issued — a needless trip toward the rate limit.
+                    last_issued =
+                        read_issued_at(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical);
+                    tracing::info!(node_id, "DNS-01: this node is now the ACME leader");
+                } else {
+                    tracing::info!(node_id, "DNS-01: this node is no longer the ACME leader");
+                }
+            }
+        }
+
+        if standalone || is_leader {
+            let due = match last_issued {
+                None => true,
+                Some(t) => t.elapsed().map_or(true, |age| age >= RENEW_AFTER),
+            };
+            if due {
+                match obtain_certificate(&ctx).await {
+                    Ok((cert_pem, key_pem)) => match ctx.resolver.install(&cert_pem, &key_pem) {
+                        Ok(()) => {
+                            let now = SystemTime::now();
+                            last_issued = Some(now);
+                            installed_fp = Some(fingerprint(&cert_pem));
+                            persist_cert(&ctx, &cert_pem, &key_pem, now);
+                            tracing::info!(
+                                canonical = ctx.canonical,
+                                "DNS-01: certificate issued and installed"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "DNS-01: freshly issued certificate would not install");
+                        }
+                    },
+                    Err(e) => {
+                        tracing::error!(error = %format!("{e:#}"), "DNS-01: issuance failed, will retry");
+                    }
+                }
+            }
+        } else if let Some(store) = &ctx.store
+            && let Some((cert_pem, key_pem)) = crate::acme::get_acme_cert(store, &ctx.canonical)
+        {
+            // Follower: pick up the leader's certificate from the KV store.
+            let fp = fingerprint(&cert_pem);
+            if installed_fp.as_ref() != Some(&fp) {
+                match ctx.resolver.install(&cert_pem, &key_pem) {
+                    Ok(()) => {
+                        installed_fp = Some(fp);
+                        tracing::info!(
+                            canonical = ctx.canonical,
+                            "DNS-01: follower installed the leader's certificate from KV"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "DNS-01: follower could not install the leader's certificate");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Run one full DNS-01 order and return `(cert_chain_pem, private_key_pem)`.
+async fn obtain_certificate(ctx: &Dns01Context) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+    let account = load_or_create_account(ctx).await?;
+
+    let identifiers: Vec<Identifier> =
+        ctx.domains.iter().map(|d| Identifier::Dns(d.clone())).collect();
+    let mut order = account
+        .new_order(&NewOrder::new(identifiers.as_slice()))
+        .await
+        .context("creating the ACME order")?;
+
+    // Pass 1: publish every challenge's TXT record. Track what we published so
+    // we can always retract it, even on the error paths.
+    let mut published: Vec<(String, String)> = Vec::new();
+    {
+        let mut authorizations = order.authorizations();
+        while let Some(result) = authorizations.next().await {
+            let mut authz = result.context("fetching an ACME authorization")?;
+            match authz.status {
+                AuthorizationStatus::Pending => {}
+                AuthorizationStatus::Valid => continue,
+                other => bail!("unexpected ACME authorization status: {other:?}"),
+            }
+            let challenge = authz
+                .challenge(ChallengeType::Dns01)
+                .ok_or_else(|| anyhow!("ACME authorization has no dns-01 challenge"))?;
+            let domain = challenge.identifier().to_string();
+            let fqdn = challenge_fqdn(&domain);
+            let value = challenge.key_authorization().dns_value();
+            published.push((fqdn.clone(), value.clone()));
+        }
+    }
+
+    // Publish outside the authorizations borrow so the provider calls don't
+    // hold the order borrowed across await points we don't need to.
+    let publish_result = publish_all(ctx.provider.as_ref(), &published).await;
+    if let Err(e) = publish_result {
+        retract_all(ctx.provider.as_ref(), &published).await;
+        return Err(e.context("publishing DNS-01 challenge records"));
+    }
+
+    tokio::time::sleep(PROPAGATION_WAIT).await;
+
+    // Pass 2: tell the CA each challenge is ready.
+    let ready = set_all_ready(&mut order).await;
+    if let Err(e) = ready {
+        retract_all(ctx.provider.as_ref(), &published).await;
+        return Err(e.context("signalling DNS-01 challenge readiness"));
+    }
+
+    // Poll to Ready, finalize, fetch the chain — then always retract records.
+    let outcome = finalize_order(&mut order).await;
+    retract_all(ctx.provider.as_ref(), &published).await;
+    outcome
+}
+
+/// Publish every `(fqdn, value)` challenge record.
+async fn publish_all(
+    provider: &dyn DnsProvider,
+    records: &[(String, String)],
+) -> anyhow::Result<()> {
+    for (fqdn, value) in records {
+        provider.set_txt(fqdn, value).await.with_context(|| format!("publishing TXT {fqdn}"))?;
+    }
+    Ok(())
+}
+
+/// Best-effort retraction of every published record.
+async fn retract_all(provider: &dyn DnsProvider, records: &[(String, String)]) {
+    for (fqdn, value) in records {
+        if let Err(e) = provider.delete_txt(fqdn, value).await {
+            tracing::warn!(fqdn, error = %e, "DNS-01: failed to retract challenge TXT record");
+        }
+    }
+}
+
+/// Signal readiness for every pending dns-01 challenge on the order.
+async fn set_all_ready(order: &mut instant_acme::Order) -> anyhow::Result<()> {
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let mut authz = result.context("re-fetching an ACME authorization")?;
+        match authz.status {
+            AuthorizationStatus::Pending => {}
+            AuthorizationStatus::Valid => continue,
+            other => bail!("unexpected ACME authorization status: {other:?}"),
+        }
+        let mut challenge = authz
+            .challenge(ChallengeType::Dns01)
+            .ok_or_else(|| anyhow!("ACME authorization has no dns-01 challenge"))?;
+        challenge.set_ready().await.context("marking dns-01 challenge ready")?;
+    }
+    Ok(())
+}
+
+/// Poll the order to Ready, finalize, and return `(cert_pem, key_pem)`.
+async fn finalize_order(order: &mut instant_acme::Order) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+    let status = order
+        .poll_ready(&RetryPolicy::default())
+        .await
+        .context("polling the ACME order to ready")?;
+    if status != OrderStatus::Ready {
+        bail!("ACME order did not reach Ready (status: {status:?})");
+    }
+    let key_pem = order.finalize().await.context("finalizing the ACME order")?;
+    let cert_pem = order
+        .poll_certificate(&RetryPolicy::default())
+        .await
+        .context("retrieving the ACME certificate chain")?;
+    Ok((cert_pem.into_bytes(), key_pem.into_bytes()))
+}
+
+/// Restore the ACME account from cached credentials, or create and cache one.
+async fn load_or_create_account(ctx: &Dns01Context) -> anyhow::Result<Account> {
+    if let Some(raw) = load_account_creds(ctx) {
+        match serde_json::from_slice::<instant_acme::AccountCredentials>(&raw) {
+            Ok(creds) => match Account::builder()?.from_credentials(creds).await {
+                Ok(account) => return Ok(account),
+                Err(e) => {
+                    tracing::warn!(error = %e, "DNS-01: cached account credentials unusable, creating a new account");
+                }
+            },
+            Err(e) => {
+                tracing::warn!(error = %e, "DNS-01: cached account credentials corrupt, creating a new account");
+            }
+        }
+    }
+    let contact: Vec<&str> = ctx.contact.iter().map(String::as_str).collect();
+    let (account, credentials) = Account::builder()?
+        .create(
+            &NewAccount {
+                contact: &contact,
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            ctx.directory_url.clone(),
+            None,
+        )
+        .await
+        .context("creating the ACME account")?;
+    if let Ok(bytes) = serde_json::to_vec(&credentials) {
+        persist_account_creds(ctx, &bytes);
+    }
+    Ok(account)
+}
+
+// ── Cache helpers (KV + disk) ────────────────────────────────────────────────
+
+/// KV key for the certificate issuance timestamp (unix seconds).
+fn issued_kv_key(canonical: &str) -> String {
+    format!("acme:cert:{canonical}:issued")
+}
+
+/// Build the `_acme-challenge.<domain>` FQDN, tolerating a wildcard prefix.
+fn challenge_fqdn(domain: &str) -> String {
+    let base = domain.strip_prefix("*.").unwrap_or(domain);
+    format!("_acme-challenge.{base}")
+}
+
+/// A canonical, stable key for a domain set: sorted, comma-joined.
+fn canonical_domain_key(domains: &[String]) -> String {
+    let mut sorted: Vec<String> = domains.to_vec();
+    sorted.sort();
+    sorted.join(",")
+}
+
+/// SHA-256 of a byte slice, for cheap change detection.
+fn fingerprint(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// Sanitise a canonical domain key into a filename-safe stem.
+fn cache_stem(canonical: &str) -> String {
+    canonical
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' { c } else { '_' })
+        .collect()
+}
+
+/// Load a cached cert `(cert_pem, key_pem)` — KV first, then disk.
+fn load_cached_cert(
+    store: Option<&Store>,
+    cache_dir: &Path,
+    canonical: &str,
+) -> Option<(Vec<u8>, Vec<u8>)> {
+    if let Some(store) = store
+        && let Some((cert, key)) = crate::acme::get_acme_cert(store, canonical)
+    {
+        return Some((cert, key));
+    }
+    let stem = cache_stem(canonical);
+    let cert = std::fs::read(cache_dir.join(format!("{stem}.crt"))).ok()?;
+    let key = std::fs::read(cache_dir.join(format!("{stem}.key"))).ok()?;
+    if cert.is_empty() || key.is_empty() {
+        return None;
+    }
+    Some((cert, key))
+}
+
+/// Read the issuance timestamp — KV first, then the on-disk sidecar.
+fn read_issued_at(store: Option<&Store>, cache_dir: &Path, canonical: &str) -> Option<SystemTime> {
+    if let Some(store) = store
+        && let Some(bytes) = store.get(&issued_kv_key(canonical))
+        && let Some(t) = parse_unix_secs(bytes.as_ref())
+    {
+        return Some(t);
+    }
+    let stem = cache_stem(canonical);
+    let bytes = std::fs::read(cache_dir.join(format!("{stem}.issued"))).ok()?;
+    parse_unix_secs(&bytes)
+}
+
+fn parse_unix_secs(bytes: &[u8]) -> Option<SystemTime> {
+    let secs: u64 = std::str::from_utf8(bytes).ok()?.trim().parse().ok()?;
+    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+}
+
+/// Persist the certificate to KV (cluster-wide) and disk (fast local restart).
+fn persist_cert(ctx: &Dns01Context, cert_pem: &[u8], key_pem: &[u8], issued: SystemTime) {
+    let secs =
+        issued.duration_since(SystemTime::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_default();
+    if let Some(store) = &ctx.store {
+        crate::acme::store_acme_cert(store, &ctx.canonical, cert_pem, key_pem);
+        store.set(issued_kv_key(&ctx.canonical), secs.to_string().into_bytes(), None);
+    }
+    let stem = cache_stem(&ctx.canonical);
+    write_file(&ctx.cache_dir.join(format!("{stem}.crt")), cert_pem);
+    write_file(&ctx.cache_dir.join(format!("{stem}.key")), key_pem);
+    write_file(&ctx.cache_dir.join(format!("{stem}.issued")), secs.to_string().as_bytes());
+}
+
+/// Load account credential JSON — KV first, then disk.
+fn load_account_creds(ctx: &Dns01Context) -> Option<Vec<u8>> {
+    if let Some(store) = &ctx.store
+        && let Some(bytes) = store.get(&account_kv_key(&ctx.directory_url))
+    {
+        return Some(bytes.to_vec());
+    }
+    std::fs::read(ctx.cache_dir.join("account.json")).ok()
+}
+
+/// Persist account credential JSON to KV (cluster-wide) and disk.
+fn persist_account_creds(ctx: &Dns01Context, bytes: &[u8]) {
+    if let Some(store) = &ctx.store {
+        store.set(account_kv_key(&ctx.directory_url), bytes.to_vec(), None);
+    }
+    write_file(&ctx.cache_dir.join("account.json"), bytes);
+}
+
+/// KV key for the ACME account credentials, namespaced by directory URL so
+/// staging and production accounts never collide.
+fn account_kv_key(directory_url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(directory_url.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(16);
+    for b in &digest[..8] {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    format!("acme:account:dns01:{hex}")
+}
+
+/// Write a file, logging (not propagating) any error — cache writes are
+/// best-effort and must never take TLS down.
+fn write_file(path: &Path, bytes: &[u8]) {
+    if let Err(e) = std::fs::write(path, bytes) {
+        tracing::warn!(path = %path.display(), error = %e, "DNS-01: cache write failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener as StdTcpListener;
+
+    use super::*;
+
+    #[test]
+    fn zone_candidates_walks_parents_longest_first() {
+        let got = zone_candidates("_acme-challenge.preview.ephpm.dev");
+        assert_eq!(
+            got,
+            vec![
+                "_acme-challenge.preview.ephpm.dev".to_string(),
+                "preview.ephpm.dev".to_string(),
+                "ephpm.dev".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn zone_candidates_stops_at_two_labels() {
+        assert_eq!(zone_candidates("ephpm.dev"), vec!["ephpm.dev".to_string()]);
+        assert_eq!(zone_candidates("dev"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn challenge_fqdn_strips_wildcard() {
+        assert_eq!(challenge_fqdn("*.preview.ephpm.dev"), "_acme-challenge.preview.ephpm.dev");
+        assert_eq!(challenge_fqdn("ephpm.dev"), "_acme-challenge.ephpm.dev");
+    }
+
+    #[test]
+    fn canonical_domain_key_is_order_independent() {
+        let a = canonical_domain_key(&["b.example".into(), "a.example".into()]);
+        let b = canonical_domain_key(&["a.example".into(), "b.example".into()]);
+        assert_eq!(a, b);
+        assert_eq!(a, "a.example,b.example");
+    }
+
+    #[test]
+    fn cache_stem_is_filename_safe() {
+        assert_eq!(cache_stem("*.preview.ephpm.dev,ephpm.dev"), "_.preview.ephpm.dev_ephpm.dev");
+    }
+
+    #[test]
+    fn resolver_starts_empty_and_installs() {
+        let resolver = Dns01CertResolver::new();
+        assert!(!resolver.has_cert());
+        // A self-signed pair proves the install/parse path without a CA.
+        let key = rcgen::KeyPair::generate().expect("keypair");
+        let params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).expect("params");
+        let cert = params.self_signed(&key).expect("self-sign");
+        assert!(resolver.install(cert.pem().as_bytes(), key.serialize_pem().as_bytes()).is_ok());
+        assert!(resolver.has_cert());
+    }
+
+    #[test]
+    fn account_kv_key_differs_by_directory() {
+        let staging = account_kv_key(LetsEncrypt::Staging.url());
+        let production = account_kv_key(LetsEncrypt::Production.url());
+        assert_ne!(staging, production);
+        assert!(staging.starts_with("acme:account:dns01:"));
+    }
+
+    /// A minimal one-shot HTTP server that captures the first request and
+    /// replies with a canned body. Enough to assert Cloudflare request shaping
+    /// without touching the network.
+    fn one_shot_http(response_body: &'static str) -> (String, std::thread::JoinHandle<String>) {
+        let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 4096];
+            let n = stream.read(&mut buf).expect("read");
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            // Read a fixed-size body if the headers announced one; the test
+            // payloads are tiny so the initial read already has everything.
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream.write_all(response.as_bytes()).expect("write");
+            stream.flush().ok();
+            request
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    #[tokio::test]
+    async fn cloudflare_set_txt_posts_the_right_record() {
+        let body = r#"{"success":true,"errors":[],"result":{"id":"rec123"}}"#;
+        let (base, handle) = one_shot_http(body);
+        let provider =
+            CloudflareProvider::new("tok-secret".to_string(), Some("zone999".to_string()))
+                .expect("provider")
+                .with_api_base(base);
+
+        provider
+            .set_txt("_acme-challenge.preview.ephpm.dev", "the-txt-value")
+            .await
+            .expect("set_txt");
+
+        let request = tokio::task::spawn_blocking(move || handle.join().expect("join"))
+            .await
+            .expect("captured request");
+
+        assert!(request.starts_with("POST /zones/zone999/dns_records"), "request line: {request}");
+        assert!(request.contains("authorization: Bearer tok-secret"), "missing bearer: {request}");
+        assert!(request.contains("content-type: application/json"), "missing content-type");
+        assert!(
+            request.contains("\"name\":\"_acme-challenge.preview.ephpm.dev\""),
+            "body: {request}"
+        );
+        assert!(request.contains("\"content\":\"the-txt-value\""), "body: {request}");
+        assert!(request.contains("\"type\":\"TXT\""), "body: {request}");
+    }
+
+    #[tokio::test]
+    async fn cloudflare_api_error_is_surfaced() {
+        let body = r#"{"success":false,"errors":[{"code":10000,"message":"Authentication error"}],"result":null}"#;
+        let (base, handle) = one_shot_http(body);
+        let provider = CloudflareProvider::new("bad".to_string(), Some("z".to_string()))
+            .expect("provider")
+            .with_api_base(base);
+
+        let err = provider
+            .set_txt("_acme-challenge.x.example", "v")
+            .await
+            .expect_err("must surface the API error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Authentication error"), "unexpected: {msg}");
+        let _ = tokio::task::spawn_blocking(move || handle.join().ok()).await;
+    }
+}

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod acme;
 pub mod body;
 pub mod db_health;
+pub mod dns01;
 pub mod file_cache;
 pub mod fpm_pool;
 pub mod http3;
@@ -518,6 +519,18 @@ async fn bind_listeners(
             );
             let acceptor = tls::build_tls_acceptor(cert, key)?;
             TlsMode::Manual(acceptor)
+        }
+        // DNS-01 wildcard lane (opt-in via `challenge = "dns-01"`). Checked
+        // before the general ACME arm because it is the more specific case.
+        // It shares the TLS *serving* path with manual mode: the resolver
+        // inside the acceptor is hot-swapped by the renewal task, so no ACME
+        // ClientHello inspection is needed (the challenge is answered over DNS,
+        // not on the TLS socket).
+        Some(tls_config) if tls_config.is_dns01() => {
+            let acme_store =
+                if config.cluster.enabled { Some(Arc::clone(&kv_store)) } else { None };
+            let setup = dns01::start_dns01_acme(tls_config, acme_store)?;
+            TlsMode::Manual(setup.acceptor)
         }
         Some(tls_config) if tls_config.is_acme() => {
             let acme_store =

--- a/site/content/guides/tls-acme.md
+++ b/site/content/guides/tls-acme.md
@@ -68,7 +68,7 @@ cache_dir = "/var/lib/ephpm/certs"
 
 ePHPm will:
 
-1. Solve a TLS-ALPN-01 challenge on the HTTPS listener itself — the only challenge type implemented. Port 443 must be reachable from the public internet for issuance; port 80 is never used for ACME.
+1. Solve a TLS-ALPN-01 challenge on the HTTPS listener itself — the default challenge type. Port 443 must be reachable from the public internet for issuance; port 80 is never used for ACME. (For wildcards, use the [DNS-01 challenge](#dns-01-challenge-wildcards) instead.)
 2. Save the issued certificate and account key under `cache_dir`.
 3. Renew automatically before expiry.
 
@@ -106,11 +106,38 @@ redirect_http = true
 
 The plain-HTTP listener only serves regular traffic (or 301-redirects when `redirect_http = true`). ACME challenges are always solved on the HTTPS listener via TLS-ALPN-01 — HTTP-01 is not implemented, so port 80 is never required for certificate issuance.
 
+## DNS-01 challenge (wildcards)
+
+TLS-ALPN-01 cannot obtain a **wildcard** certificate (`*.example.com`): the CA has no single hostname to connect to. For wildcards — and for hosts that never accept inbound TLS — set `challenge = "dns-01"`, which proves control by publishing a `_acme-challenge` TXT record through a DNS provider. Only **Cloudflare** is implemented today.
+
+```toml
+[server]
+listen = "0.0.0.0:443"
+
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email   = "admin@example.com"
+cache_dir = "/var/lib/ephpm/certs"
+challenge = "dns-01"
+dns_provider = "cloudflare"
+# Prefer a file or the environment over inlining the secret:
+cloudflare_api_token_file = "/run/secrets/cf-token"
+# ...or: EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN=<token>
+```
+
+The token must be a **zone-scoped Cloudflare API token** with the `Zone.DNS:Edit` permission on the zone that holds the records. If you also set `cloudflare_zone_id`, the token needs nothing more; otherwise ePHPm resolves the zone from the FQDN, which additionally needs `Zone:Read`.
+
+**Why wildcards matter here.** Let's Encrypt limits you to 50 certificates per registered domain per week. A fleet of ephemeral preview subdomains (`pr-123.preview.example.com`, …) would burn through that quickly with per-subdomain issuance; one `*.preview.example.com` certificate covers them all under a single order.
+
+For each order ePHPm publishes the challenge TXT records, waits for propagation, asks the CA to validate, then finalizes and retracts the records. The issued certificate is hot-swapped into the running TLS listener — no restart — and renewed automatically (~30 days before expiry). DNS-01 and TLS-ALPN-01 are mutually exclusive per server.
+
 ## Clustered ACME
 
-In a cluster, only one node should solve the challenge — the rest read the cert from the gossip-backed KV store. ePHPm does this automatically when `[cluster] enabled = true`. Each node points at the same `cache_dir` (or a shared store) and the leader publishes the cert; replicas pick it up. See [Clustering Setup](clustering-setup/).
+In a cluster, only one node should solve the challenge — the rest read the cert from the gossip-backed KV store. ePHPm does this automatically when `[cluster] enabled = true`. Each node points at the same `cache_dir` (or a shared store) and the leader publishes the cert; replicas pick it up. Both challenge lanes share the same `acme:leader` election and KV distribution. See [Clustering Setup](clustering-setup/).
 
-Two limitations you must plan around:
+The two limitations below apply to the **TLS-ALPN-01** lane. The **DNS-01** lane avoids both — the challenge is answered over DNS by the leader (nothing needs to reach a specific node), and its certificate resolver is hot-swappable, so a follower installs the leader's *renewed* certificate from the KV store without a restart. That makes DNS-01 the better fit for clustered deployments.
+
+Two limitations of the TLS-ALPN-01 lane you must plan around:
 
 - **Challenge traffic has to reach the ACME leader.** Sharing challenge
   tokens between nodes is **not implemented**. A follower can serve
@@ -119,12 +146,13 @@ Two limitations you must plan around:
   the leader's in-memory resolver. If your load balancer can send validation
   traffic to any node, issuance will fail intermittently.
 - **Followers do not pick up renewed certificates while running.** This is
-  **not implemented**: `rustls-acme` consults its certificate cache once per
-  state machine, so a renewal published by the leader is not injected into a
-  running follower. **A follower serves the certificate it loaded at startup
-  until it restarts.** On a 90-day Let's Encrypt cert this means a rolling
-  restart inside the renewal window, or followers will eventually serve an
-  expired certificate. Watch for it.
+  **not implemented** for TLS-ALPN-01: `rustls-acme` consults its certificate
+  cache once per state machine, so a renewal published by the leader is not
+  injected into a running follower. **A follower serves the certificate it
+  loaded at startup until it restarts.** On a 90-day Let's Encrypt cert this
+  means a rolling restart inside the renewal window, or followers will
+  eventually serve an expired certificate. Watch for it. (DNS-01 does not have
+  this limitation.)
 
 ## What's in `cache_dir`?
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -193,7 +193,7 @@ including explicit `0` = that limit off.
 
 ### `[server.tls]`
 
-Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If both are set, manual wins.
+Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If both are set, manual wins. ACME itself offers two challenge types via `challenge`: the default TLS-ALPN-01, and DNS-01 for **wildcard** certificates.
 
 > **Fixed in v0.6.2.** Manual `cert`+`key` mode panicked at startup on every
 > release from v0.1.0 through v0.6.1 — the process exited before binding a
@@ -209,8 +209,26 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `email` | string | (none) | Contact email for ACME registration. |
 | `cache_dir` | path | `"certs"` | Directory for ACME cert + account key cache. **Set this in production.** |
 | `staging` | bool | `false` | Use Let's Encrypt staging (untrusted certs, generous rate limits). |
+| `challenge` | string | `"tls-alpn-01"` | ACME challenge type: `"tls-alpn-01"` (default, zero-config, no wildcards) or `"dns-01"` (required for wildcards; needs `dns_provider` + a token). |
+| `dns_provider` | string | (none) | DNS provider for `dns-01`. Only `"cloudflare"` is implemented. Required when `challenge = "dns-01"`. |
+| `cloudflare_api_token_file` | path | (none) | Path to a file holding a zone-scoped `Zone.DNS:Edit` Cloudflare token. Preferred over inlining the secret; takes precedence over `cloudflare_api_token`. |
+| `cloudflare_api_token` | string | (none) | Cloudflare token inline (discouraged). Usually supplied via `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN` instead. |
+| `cloudflare_zone_id` | string | (none) | Explicit Cloudflare zone id. When absent, resolved from the challenge FQDN (adds a `Zone:Read` requirement to the token). |
 | `listen` | string | (none) | Separate HTTPS listener. When set, `[server] listen` serves HTTP and this serves HTTPS. |
 | `redirect_http` | bool | `false` | When `listen` is set, the HTTP listener redirects everything to HTTPS (301). |
+
+**DNS-01 wildcard example.** One wildcard cert covers every preview subdomain and stays under Let's Encrypt's 50-certs-per-registered-domain-per-week limit:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "cloudflare"
+cloudflare_api_token_file = "/run/secrets/cf-token"   # or EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN
+```
+
+The token is a **zone-scoped** Cloudflare API token with `Zone.DNS:Edit` on the challenge zone. In a cluster (`[cluster] enabled = true`) only the elected leader orders the certificate; every other node loads it from the KV store — the same leader-election and distribution machinery as the TLS-ALPN-01 lane. TLS-ALPN-01 and DNS-01 are mutually exclusive per server; wildcard domains **require** DNS-01.
 
 ### `[server.http3]`
 

--- a/site/content/reference/environment-variables.md
+++ b/site/content/reference/environment-variables.md
@@ -70,6 +70,13 @@ EPHPM_SERVER__TLS__DOMAINS='["example.com"]'
 EPHPM_SERVER__TLS__EMAIL=admin@example.com
 EPHPM_SERVER__TLS__CACHE_DIR=/data/certs
 
+# DNS-01 wildcard ACME (Cloudflare). The token is a secret, so this is the
+# preferred way to supply it — keep it out of ephpm.toml.
+EPHPM_SERVER__TLS__DOMAINS='["*.preview.example.com","preview.example.com"]'
+EPHPM_SERVER__TLS__CHALLENGE=dns-01
+EPHPM_SERVER__TLS__DNS_PROVIDER=cloudflare
+EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN=$CF_DNS_EDIT_TOKEN   # zone-scoped Zone.DNS:Edit
+
 # HTTP/3 (QUIC). Needs a static [server.tls] cert+key — enabling this with
 # ACME is a startup error, not a silent downgrade to TCP-only.
 EPHPM_SERVER__HTTP3__ENABLED=true


### PR DESCRIPTION
## DNS-01 wildcard ACME (instant-acme + Cloudflare)

Adds an **opt-in DNS-01 ACME lane** so ePHPm can obtain wildcard certificates (e.g. `*.preview.ephpm.dev`) itself — no certbot/lego sidecar. This is the "port Caddy/CertMagic's DNS-01 model to Rust" work from the [CertMagic analysis](https://ephpm.dev/analysis/certmagic/).

### Why wildcard / DNS-01
TLS-ALPN-01 cannot validate a wildcard identifier — there's no single hostname for the CA to connect to. DNS-01 proves control by publishing a `_acme-challenge` TXT record, which is the only path to a wildcard cert. One `*.preview.ephpm.dev` cert consolidates every ephemeral preview subdomain into a single order, staying under Let's Encrypt's **50 certs / registered domain / week** limit that per-subdomain issuance would otherwise burn through.

### Design (additive — TLS-ALPN-01 path untouched)
`rustls-acme` speaks only TLS-ALPN-01 and owns its whole state machine, so the new lane is built on the lower-level **`instant-acme`** client in the new `crates/ephpm-server/src/dns01.rs`. Both lanes coexist; an operator picks exactly one via `[server.tls] challenge`. The default (`"tls-alpn-01"`) preserves today's behaviour exactly.

- **`DnsProvider` trait** (the libdns equivalent): `set_txt(fqdn, value)` / `delete_txt(fqdn, value)`. First and only impl is **`CloudflareProvider`** — a zone-scoped `Zone.DNS:Edit` token against the Cloudflare v4 API. Zone id is resolved from the challenge FQDN (walking parent domains) unless `cloudflare_zone_id` is set. `delete_txt` takes the value so it retracts precisely the record it published (a wildcard + its apex produce two challenges at the same name).
- **Order flow** via `instant-acme`: new order → per-authorization dns-01 challenge → compute the key-authorization TXT value → publish all TXT records → propagation wait → `set_ready` → `poll_ready` → `finalize` (generates the cert key) → `poll_certificate` → **retract records** (always, even on error paths).
- **`Dns01CertResolver`** — a hot-swappable `rustls::server::ResolvesServerCert`. The renewal task swaps a freshly issued cert in with **no restart / no dropped connections**. This also closes the follower-can't-see-a-renewal gap the TLS-ALPN-01 lane documents, because this resolver is ours to mutate.

### Reusing `acme.rs`'s clustered machinery (not duplicating it)
The `rustls-acme` cache/renewal state machine can't be shared (it owns TLS-ALPN-01 end-to-end), but the **hard clustered parts are reused directly**:
- **Leader election** — `crate::acme::try_acquire_acme_leadership` over the same `acme:leader` KV key, same lowest-node-id tie-break and 2-heartbeat confirmation. Only the leader talks to Let's Encrypt.
- **Cert distribution** — `crate::acme::store_acme_cert` / `get_acme_cert`. The leader publishes to the KV store; followers install from it and hot-swap on change. Account credentials, cert, and issuance timestamp are cached in the KV store **and** on disk for fast restart and clean failover (a promoted follower reads the KV issuance time so it won't redundantly re-order).

To share the election helpers, `acme.rs` exposes `acme_node_id`, `try_acquire_acme_leadership`, and the leader TTL/heartbeat/confirmation constants as `pub(crate)`. No behavioural change to the existing lane.

**Design compromise (called out):** I did not refactor `rustls-acme`'s internal cache/renewal state machine into a shared abstraction — it's too coupled to that crate to share cleanly. Instead the DNS-01 lane owns its own resolver + renewal loop and **reuses the KV/leader primitives**, which are the genuinely hard, correctness-critical parts. Renewal timing is age-based (renew at 60 days, a 30-day margin on LE's 90-day certs, matching `rustls-acme`'s 2/3-of-validity policy) rather than parsing `notAfter`, to avoid pulling in a cert-parsing dependency on the hot path.

### Config (`[server.tls]`, additive, back-compatible)
| Key | Default | Notes |
|-----|---------|-------|
| `challenge` | `"tls-alpn-01"` | or `"dns-01"` |
| `dns_provider` | (none) | only `"cloudflare"` |
| `cloudflare_api_token_file` | (none) | **preferred**; a 0600 file with a zone-scoped token |
| `cloudflare_api_token` | (none) | inline (discouraged); the landing spot for `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN` |
| `cloudflare_zone_id` | (none) | optional; else resolved from the FQDN |

Token precedence: **file → env/inline**. `Config::validate` fails closed: `dns-01` requires `domains` + a known provider + a token; a **wildcard under `tls-alpn-01` is rejected**; unknown challenge or provider is rejected. (Followed the `add-config-knob` checklist: field + real enforcement + doc comments + reference-docs row + tests, no silent no-ops.)

### Dependencies / quality bar
- **`instant-acme` 0.8** (`default-features = false`, `aws-lc-rs` + `hyper-rustls` + `rcgen`) — MSRV 1.88, matches the workspace; stays off `ring` (the single-crypto-provider guard test still passes).
- **`reqwest` + `webpki-roots`** made unconditional in `ephpm-server` (were otlp-only) for the Cloudflare client, built with a preconfigured aws-lc-rs `ClientConfig` — the same discipline as `otlp.rs`, so no second crypto provider.
- `cargo clippy -p ephpm-server -p ephpm-config --all-targets -- -D warnings`: clean. `cargo +nightly fmt`: clean. **`cargo deny check`: advisories/licenses/bans/sources ok.**
- Everything is in `ephpm-server`, so it builds in normal (non-`php_linked`) mode — no cfg gating needed.

### Testing — what's verified vs. needs live E2E
**Unit / integration (passing):**
- TXT-value / zone-walk / challenge-FQDN / canonical-key helpers; resolver install parses a real cert+key.
- **Cloudflare request shaping** asserted against a captured in-process HTTP server: `POST /zones/<id>/dns_records`, `Authorization: Bearer …`, `application/json`, and the exact `{type,name,content}` body. A `success:false` API response is surfaced as an error.
- `ephpm-config` validation: default challenge, dns-01 requires token/provider/domains, wildcard rejected under tls-alpn-01, unknown challenge/provider rejected, token-via-env satisfies validation.

**Not yet exercised live (be honest):** a real end-to-end issuance against Let's Encrypt **staging** is *not* run here. `ephpm.dev` DNS is still on GoDaddy (Cloudflare migration pending) and there is no real zone-scoped token yet, so the CA round-trip and actual Cloudflare API calls are unverified against live services.

**Live-validation steps once `ephpm.dev` is on Cloudflare + a token exists:**
1. Create a zone-scoped Cloudflare API token (`Zone.DNS:Edit` on the `ephpm.dev` zone); put it in a 0600 file or `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN`.
2. Run single-node with `challenge = "dns-01"`, `domains = ["*.preview.ephpm.dev", "preview.ephpm.dev"]`, **`staging = true`**.
3. Confirm the `_acme-challenge.preview.ephpm.dev` TXT records appear then get retracted; confirm the staging cert installs and `https://<anything>.preview.ephpm.dev` serves it (browser warns — expected for staging).
4. Drop `staging`, clear the cache dir, re-issue against production; verify renewal by shortening `RENEW_AFTER` in a throwaway build.
5. Clustered: enable `[cluster]` on 2+ nodes, confirm only the leader orders (logs) and followers install the cert from KV; kill the leader and confirm a follower is promoted and re-orders/renews.

### Coexistence with TLS-ALPN-01
Unchanged and still the default zero-config path. DNS-01 is strictly opt-in; the two are mutually exclusive per server. HTTP/3 (which needs a static cert) is unaffected — it doesn't start under either ACME mode, same as before.

Do **not** merge — opened for review.
