### PR TITLE
fix(server): plain HTTP listener with a separate TLS port; cluster-wide ACME cert distribution

### DIFF
--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -328,6 +328,110 @@ impl ClusteredStore {
         ok
     }
 
+    /// Write a value that **every** node must hold a local copy of,
+    /// regardless of its size.
+    ///
+    /// Small values already behave this way — the gossip tier fans out to the
+    /// whole cluster — so this differs from [`set`](Self::set) only above
+    /// `small_key_threshold`, where `set` shards to `replication_factor`
+    /// nodes and this writes to every alive node instead.
+    ///
+    /// # Why a separate tier rather than a bigger threshold
+    ///
+    /// Raising `small_key_threshold` past the value's size is not an
+    /// equivalent fix: the gossip tier is chitchat over **UDP**, so a payload
+    /// that does not fit a datagram cannot ride it at all. The size threshold
+    /// exists to keep multi-kilobyte values off gossip, and it must keep
+    /// doing that. What was wrong is the assumption that "too big for gossip"
+    /// implies "shard it" — for cluster-wide state such as an ACME
+    /// certificate it implies the opposite.
+    ///
+    /// Unlike the sharded path, peer writes are **awaited**: a broadcast key
+    /// is written rarely (certificate issuance and renewal) and the caller
+    /// wants cluster-wide read-your-writes far more than it wants the write
+    /// to return quickly. A peer that is unreachable is logged and counted
+    /// ([`ClusteredStore::replica_write_failures`]) but does not fail the
+    /// write, matching the rest of this store: this is not a consensus
+    /// protocol.
+    ///
+    /// Returns whether **this node's** copy was written — the same
+    /// client-visible contract [`set`](Self::set) has.
+    ///
+    /// ## What this does not do
+    ///
+    /// Fan-out reaches the nodes that are alive *at write time*. A node that
+    /// joins later, or is down and comes back, does not receive the value
+    /// retroactively — there is no anti-entropy here any more than there is
+    /// on the sharded path. Readers that must tolerate that should use
+    /// [`get`](Self::get), whose miss path fetches from a peer.
+    pub async fn broadcast(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        if value.len() <= self.config.small_key_threshold {
+            // Gossip already means "every node"; nothing to widen.
+            self.cluster.gossip_set(&key, &value, ttl).await;
+            if self.config.hot_key_cache {
+                self.maybe_bump_hot_version(&key).await;
+            }
+            return true;
+        }
+
+        let ok = self.broadcast_large(&key, &value, ttl).await;
+        if ok && self.config.hot_key_cache {
+            self.maybe_bump_hot_version(&key).await;
+        }
+        ok
+    }
+
+    /// Write a large value to every alive node. See
+    /// [`broadcast`](Self::broadcast).
+    async fn broadcast_large(&self, key: &str, value: &[u8], ttl: Option<Duration>) -> bool {
+        // This node's own copy first: it must be able to serve the value out
+        // of its local store even if every peer write below fails.
+        let local_ok = self.store.set_local(key.to_string(), value.to_vec(), ttl);
+
+        let self_id = self.cluster.self_node().id;
+        let mut delivered = 0usize;
+        let mut peers = 0usize;
+        for node in self.alive_nodes().await {
+            if node.id == self_id {
+                continue;
+            }
+            peers += 1;
+            let Some(addr) = node_data_addr(&node, self.config.data_port) else {
+                self.replica_write_failures.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!(key, peer = %node.id, "broadcast peer has no parseable data address");
+                continue;
+            };
+            match crate::kv_data_plane::store_remote(addr, key, value, self.cipher.as_deref()).await
+            {
+                Ok(true) => delivered += 1,
+                Ok(false) => {
+                    self.replica_write_failures.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(key, peer = %node.id, %addr, "broadcast peer rejected the write");
+                }
+                Err(e) => {
+                    self.replica_write_failures.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(key, peer = %node.id, %addr, %e, "broadcast peer write failed");
+                }
+            }
+        }
+
+        if delivered < peers {
+            // Never silent: a partially-delivered broadcast means some nodes
+            // cannot read a value they are supposed to hold locally.
+            tracing::warn!(
+                key,
+                bytes = value.len(),
+                delivered,
+                peers,
+                "broadcast reached only some peers; the rest must fetch through on read"
+            );
+        } else {
+            tracing::debug!(key, bytes = value.len(), peers, "broadcast written to every peer");
+        }
+
+        local_ok
+    }
+
     /// Write a large value to its replica set. Returns whether the
     /// primary write succeeded (the client-visible result). See
     /// [`ClusteredStore::set`] for the replication semantics.
@@ -516,18 +620,29 @@ impl ClusteredStore {
     /// primary-first (the read/write fallback order). Returns an empty
     /// vector when only this node is alive (no clustering to do).
     async fn replica_nodes(&self, key: &str) -> Vec<NodeInfo> {
-        let nodes = self.cluster.nodes().await;
-        let mut alive: Vec<NodeInfo> =
-            nodes.into_iter().filter(|n| n.state == crate::NodeState::Alive).collect();
-        // `ClusterHandle::nodes` already sorts by id, but sort defensively
-        // so replica selection is stable regardless of caller.
-        alive.sort_by(|a, b| a.id.cmp(&b.id));
+        let alive = self.alive_nodes().await;
 
         if alive.len() <= 1 {
             return Vec::new(); // Only this node is alive.
         }
 
         replica_nodes_for(&alive, hash_key(key), self.config.replication_factor)
+    }
+
+    /// Every alive cluster node, including this one, sorted by id.
+    ///
+    /// `ClusterHandle::nodes` already sorts by id, but this sorts defensively
+    /// so replica selection is stable regardless of caller.
+    async fn alive_nodes(&self) -> Vec<NodeInfo> {
+        let mut alive: Vec<NodeInfo> = self
+            .cluster
+            .nodes()
+            .await
+            .into_iter()
+            .filter(|n| n.state == crate::NodeState::Alive)
+            .collect();
+        alive.sort_by(|a, b| a.id.cmp(&b.id));
+        alive
     }
 
     /// Number of replica writes that failed to reach or be accepted by a
@@ -803,6 +918,39 @@ impl ephpm_kv::store::Replicator for KvReplicator {
             }
         });
         true
+    }
+
+    fn replicate_broadcast(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        // Materialize this node's own copy synchronously at *every* size, not
+        // just below the gossip threshold as `replicate_set` does. A
+        // broadcast key's contract is "readable from every node's raw local
+        // Store", and the node that wrote it is one of those nodes — the
+        // caller (ACME certificate issuance) reads its own write back.
+        let local_ok = self.inner.store.set_local(key.clone(), value.clone(), ttl);
+        if value.len() <= self.inner.config.small_key_threshold {
+            // Same last-arrival-wins bookkeeping as `replicate_set`: stop a
+            // slow gossip echo of this write from clobbering a newer local
+            // overwrite.
+            self.applied.insert(key.clone(), current_write_ms());
+        }
+
+        let inner = Arc::clone(&self.inner);
+        self.handle.spawn(async move {
+            if !inner.broadcast(key.clone(), value, ttl).await {
+                tracing::warn!(key, "clustered broadcast returned false (local write rejected)");
+            }
+        });
+        local_ok
+    }
+
+    fn fetch_cluster<'a>(
+        &'a self,
+        key: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<Vec<u8>>> + Send + 'a>> {
+        // `ClusteredStore::get` is the cluster-aware read: gossip tier, local
+        // store, hot cache, then a data-plane fetch from the key's replica
+        // set. That last step is what a node which missed the write needs.
+        Box::pin(async move { self.inner.get(key).await })
     }
 
     fn replicate_remove(&self, key: &str) -> bool {

--- a/crates/ephpm-cluster/tests/broadcast_kv_replication.rs
+++ b/crates/ephpm-cluster/tests/broadcast_kv_replication.rs
@@ -1,0 +1,348 @@
+//! Broadcast-tier KV replication: values every node must hold **locally**.
+//!
+//! The sharded large-value tier is the right default for cache and session
+//! data: a multi-kilobyte value goes to `replication_factor` nodes and any
+//! other node fetches it through from an owner on a miss. It is the wrong
+//! default for cluster-wide state that every node reads out of its own raw
+//! [`Store`] with no round trip — an ACME certificate above all, because every
+//! node terminates TLS with it and `acme::get_acme_cert` reads the local map
+//! directly.
+//!
+//! That mismatch was a live outage: on a three-node cluster the ACME leader
+//! issued a 5140-byte chain against a 4096-byte `small_key_threshold`, so the
+//! certificate took the sharded tier, landed on two nodes, and the third
+//! answered every TLS handshake with `tlsv1 alert access denied`.
+//!
+//! These tests pin both halves of the fix, using the same in-process
+//! multi-node harness as `kv_replication.rs` (see its module docs for the
+//! `127.0.0.x` loopback-alias arrangement and why non-Linux platforms skip):
+//!
+//! 1. [`broadcast_reaches_a_node_outside_the_replica_set`] — a cert-sized
+//!    value written with `Store::set_broadcast` is readable from the raw local
+//!    store of the node that the sharded tier would have excluded.
+//! 2. [`sharded_set_is_invisible_to_a_non_replica_but_get_cluster_finds_it`] —
+//!    the regression control. The same value written with plain `Store::set`
+//!    is *never* local on that node, which is exactly the bug; and
+//!    `Store::get_cluster` still finds it, which is the read-side half of the
+//!    fix that covers a node which joined after the write.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ephpm_cluster::node::{ClusterHandle, NodeState, start_gossip};
+use ephpm_cluster::{ClusteredStore, KvReplicator};
+use ephpm_config::{ClusterConfig, ClusterKvConfig};
+use ephpm_kv::store::{Replicator, Store, StoreConfig};
+
+/// Size of the certificate chain from the live incident, so the test payload
+/// is the shape that actually broke rather than a round number.
+const CERT_SIZED: usize = 5140;
+
+/// The KV key an ACME certificate is stored under, so the test exercises the
+/// real key shape (nothing routes on the key text, but it keeps the failure
+/// message legible).
+const CERT_KEY: &str = "acme:cert:example.com:cert";
+
+/// Pick a currently-free TCP port on loopback, so concurrently-running tests
+/// never collide on a fixed data port.
+fn free_data_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Whether this platform can bind `127.0.0.2` (loopback aliases). Linux routes
+/// all of `127.0.0.0/8`; Windows and stock macOS do not.
+fn loopback_aliases_available() -> bool {
+    std::net::TcpListener::bind("127.0.0.2:0").is_ok()
+}
+
+/// One in-process cluster node: gossip, a local [`Store`] with the production
+/// [`KvReplicator`] installed, a data plane listener, and a [`ClusteredStore`].
+struct TestNode {
+    handle: Arc<ClusterHandle>,
+    /// The raw local store — what `acme::get_acme_cert` reads.
+    local: Arc<Store>,
+    clustered: Arc<ClusteredStore>,
+    data_plane: tokio::task::JoinHandle<()>,
+}
+
+impl TestNode {
+    fn id(&self) -> String {
+        self.handle.self_node().id
+    }
+
+    async fn shutdown(self) {
+        self.data_plane.abort();
+        // Order matters: the local store holds the replicator, the replicator
+        // holds the `ClusteredStore`, and that holds the `ClusterHandle`. Drop
+        // them front to back or the handle still has live `Arc`s.
+        self.local.set_replicator(None);
+        drop(self.clustered);
+        drop(self.local);
+        match Arc::try_unwrap(self.handle) {
+            Ok(handle) => handle.shutdown().await,
+            // Teardown only — a lingering `Arc` here would turn an unrelated
+            // failure into a confusing panic in the wrong test.
+            Err(_) => eprintln!("test node handle still shared at shutdown; skipping gossip stop"),
+        }
+    }
+}
+
+/// Start one node on `ip` (a `127.0.0.x` loopback), seeded at `seeds`.
+async fn start_test_node(ip: &str, data_port: u16, seeds: Vec<String>, node_id: &str) -> TestNode {
+    let gossip_sock =
+        tokio::net::UdpSocket::bind(format!("{ip}:0")).await.expect("bind gossip udp");
+    let gossip_port = gossip_sock.local_addr().expect("gossip local_addr").port();
+    drop(gossip_sock); // Release so chitchat can bind it.
+
+    let kv = ClusterKvConfig {
+        // Anything above a tiny threshold takes the large-value tier, so the
+        // cert-sized payload below exercises data-plane routing exactly as it
+        // does in production against a 4096-byte threshold.
+        small_key_threshold: 8,
+        replication_factor: 2,
+        replication_mode: "sync".to_string(),
+        // No hot-key cache: a read must reflect where the value really is, not
+        // a local cache of a previous remote fetch.
+        hot_key_cache: false,
+        data_port,
+        ..ClusterKvConfig::default()
+    };
+
+    let cluster_config = ClusterConfig {
+        enabled: true,
+        bind: format!("{ip}:{gossip_port}"),
+        join: seeds,
+        secret: String::new(),
+        allow_insecure_no_auth: false,
+        node_id: node_id.to_string(),
+        cluster_id: "broadcast-kv-test".to_string(),
+        kv: kv.clone(),
+        ..ClusterConfig::default()
+    };
+    let handle = Arc::new(
+        start_gossip(&cluster_config)
+            .await
+            .unwrap_or_else(|e| panic!("gossip start failed for {node_id}: {e}")),
+    );
+
+    let local = Store::new(StoreConfig::default());
+
+    let data_addr: SocketAddr = format!("{ip}:{data_port}").parse().expect("data addr");
+    let data_store = Arc::clone(&local);
+    let data_plane = tokio::spawn(async move {
+        if let Err(e) = ephpm_cluster::data_plane::serve_on(data_store, data_addr, None).await {
+            eprintln!("data plane serve_on failed on {data_addr}: {e}");
+        }
+    });
+
+    let clustered = ClusteredStore::new(Arc::clone(&local), Arc::clone(&handle), kv, None);
+
+    // Install the sync bridge, exactly as `serve()` does at startup — so the
+    // tests drive `Store::set` / `set_broadcast` / `get_cluster`, the same
+    // public entry points the ACME code calls, rather than reaching into
+    // `ClusteredStore` directly.
+    let replicator = KvReplicator::new(
+        Arc::clone(&clustered),
+        tokio::runtime::Handle::current(),
+        ephpm_cluster::clustered_store::new_applied_write_map(),
+    );
+    local.set_replicator(Some(replicator as Arc<dyn Replicator>));
+
+    TestNode { handle, local, clustered, data_plane }
+}
+
+/// Wait until every handle sees `expected` alive nodes.
+async fn wait_for_convergence(handles: &[&ClusterHandle], expected: usize, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        let mut all_ok = true;
+        for h in handles {
+            let alive = h.nodes().await.iter().filter(|n| n.state == NodeState::Alive).count();
+            if alive != expected {
+                all_ok = false;
+                break;
+            }
+        }
+        if all_ok {
+            return;
+        }
+        assert!(start.elapsed() <= timeout, "convergence timeout after {timeout:?}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Hash matching `clustered_store::hash_key` so the test computes the same
+/// replica set the production router does.
+fn hash_key(key: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// The id of the one node that the sharded tier leaves out: with three alive
+/// nodes and `replication_factor = 2`, the replica set is two consecutive
+/// nodes starting at `hash(key) % 3`, so the excluded node is the third.
+async fn non_replica_id(handle: &ClusterHandle, key: &str) -> String {
+    let mut alive = handle.nodes().await;
+    alive.retain(|n| n.state == NodeState::Alive);
+    alive.sort_by(|a, b| a.id.cmp(&b.id));
+    assert_eq!(alive.len(), 3, "expected a converged three-node cluster");
+    let primary = usize::try_from(hash_key(key) % 3).expect("index fits usize");
+    alive[(primary + 2) % 3].id.clone()
+}
+
+/// A converged three-node cluster.
+async fn three_nodes() -> [TestNode; 3] {
+    let data_port = free_data_port();
+    let n1 = start_test_node("127.0.0.1", data_port, vec![], "bcast-a").await;
+    let seed = n1.handle.self_node().gossip_addr.clone();
+    let n2 = start_test_node("127.0.0.2", data_port, vec![seed.clone()], "bcast-b").await;
+    let n3 = start_test_node("127.0.0.3", data_port, vec![seed], "bcast-c").await;
+
+    wait_for_convergence(
+        &[n1.handle.as_ref(), n2.handle.as_ref(), n3.handle.as_ref()],
+        3,
+        Duration::from_secs(15),
+    )
+    .await;
+
+    [n1, n2, n3]
+}
+
+/// Poll a node's **raw local** store until the key materialises.
+async fn await_local(node: &TestNode, key: &str, timeout: Duration) -> Option<Vec<u8>> {
+    let start = Instant::now();
+    loop {
+        if let Some(v) = node.local.get(key) {
+            return Some(v.to_vec());
+        }
+        if start.elapsed() > timeout {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// The fix: `set_broadcast` puts a cert-sized value on **every** node's local
+/// store, including the one the sharded tier would have excluded. That local
+/// copy is what `acme::get_acme_cert` reads, and what the node needs in order
+/// to answer a TLS handshake at all.
+#[tokio::test]
+async fn broadcast_reaches_a_node_outside_the_replica_set() {
+    if !loopback_aliases_available() {
+        eprintln!(
+            "skipping broadcast_reaches_a_node_outside_the_replica_set: platform lacks \
+             127.0.0.x loopback aliases (Linux-only in-process multi-node harness)"
+        );
+        return;
+    }
+
+    let [n1, n2, n3] = three_nodes().await;
+    let value = vec![0xACu8; CERT_SIZED];
+
+    // Written through the public `Store` seam, the same call `store_acme_cert`
+    // makes.
+    assert!(
+        n1.local.set_broadcast(CERT_KEY.to_string(), value.clone(), None),
+        "broadcast write must succeed on the writer"
+    );
+
+    let excluded = non_replica_id(n1.handle.as_ref(), CERT_KEY).await;
+    let nodes = [&n1, &n2, &n3];
+
+    // Every node — not just the replica set — must hold a local copy. The
+    // payload is 5 KB, so report presence and length rather than letting a
+    // failure dump the whole chain, then check the bytes separately.
+    for node in nodes {
+        let got = await_local(node, CERT_KEY, Duration::from_secs(15)).await;
+        let role = if node.id() == excluded { "non-replica" } else { "replica" };
+        assert_eq!(
+            got.as_ref().map(Vec::len),
+            Some(CERT_SIZED),
+            "node {} ({role}) must hold a local copy of a broadcast value",
+            node.id()
+        );
+        assert!(
+            got.as_deref() == Some(value.as_slice()),
+            "node {} ({role}) holds a local copy with the wrong contents",
+            node.id()
+        );
+    }
+
+    // Name the node the sharded tier would have missed, so a failure here
+    // reads as the regression it is rather than a generic replication flake.
+    assert!(
+        nodes.iter().any(|n| n.id() == excluded),
+        "the excluded node must be one of the three under test"
+    );
+
+    for node in [n1, n2, n3] {
+        node.shutdown().await;
+    }
+}
+
+/// The control, and the read-side half of the fix.
+///
+/// A plain `Store::set` of the same value is the pre-fix behaviour: the node
+/// outside the replica set never receives it, so a raw local read — which is
+/// all `acme::get_acme_cert` does — returns `None` forever. `get_cluster`
+/// nevertheless finds it, which is what lets a node that joined *after*
+/// issuance install the leader's certificate.
+#[tokio::test]
+async fn sharded_set_is_invisible_to_a_non_replica_but_get_cluster_finds_it() {
+    if !loopback_aliases_available() {
+        eprintln!(
+            "skipping sharded_set_is_invisible_to_a_non_replica_but_get_cluster_finds_it: \
+             platform lacks 127.0.0.x loopback aliases"
+        );
+        return;
+    }
+
+    let [n1, n2, n3] = three_nodes().await;
+    let value = vec![0xACu8; CERT_SIZED];
+
+    assert!(
+        n1.local.set(CERT_KEY.to_string(), value.clone(), None),
+        "sharded write must succeed on the writer"
+    );
+
+    let excluded_id = non_replica_id(n1.handle.as_ref(), CERT_KEY).await;
+    let excluded = [&n1, &n2, &n3]
+        .into_iter()
+        .find(|n| n.id() == excluded_id)
+        .expect("the excluded node must be one of the three under test");
+
+    // Generous settle time: `replication_mode = "sync"` awaits every reachable
+    // replica, so if this value were going to reach the non-replica node it
+    // would have by now.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(
+        excluded.local.get(CERT_KEY),
+        None,
+        "a sharded write must NOT be local on node {excluded_id} — if this starts passing, \
+         the replica set has changed and this control no longer reproduces the bug"
+    );
+
+    // ...but the cluster-aware read still resolves it, by fetching from a
+    // replica over the data plane.
+    let fetched = excluded
+        .local
+        .get_cluster(CERT_KEY)
+        .await
+        .expect("get_cluster must fetch a non-local value from the key's replica set");
+    assert_eq!(fetched.len(), CERT_SIZED, "get_cluster returned a truncated value");
+    assert!(
+        fetched.as_ref() == value.as_slice(),
+        "get_cluster returned the wrong bytes for {CERT_KEY}"
+    );
+
+    for node in [n1, n2, n3] {
+        node.shutdown().await;
+    }
+}

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1764,11 +1764,21 @@ pub struct TlsConfig {
     ///
     /// When set, `server.listen` serves HTTP and this address serves HTTPS.
     /// When omitted, `server.listen` serves HTTPS directly (no HTTP listener).
+    ///
+    /// "`server.listen` serves HTTP" holds unconditionally — it does not
+    /// depend on [`redirect_http`](Self::redirect_http). Setting this address
+    /// is what splits the two protocols across two ports; TLS is never
+    /// negotiated on `server.listen` while this is set.
     #[serde(default)]
     pub listen: Option<String>,
 
     /// When `true` and `listen` is set, the HTTP listener redirects
     /// all requests to HTTPS with a 301 Moved Permanently response.
+    ///
+    /// This chooses only what the plain-HTTP listener *says*. When `false`
+    /// that listener still serves plain HTTP — it answers requests normally
+    /// instead of redirecting. It never turns the HTTP listener into a
+    /// second HTTPS listener.
     ///
     /// Default: `false`.
     #[serde(default)]

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -169,6 +169,32 @@ pub trait Replicator: Send + Sync + std::fmt::Debug {
     /// Handle a public `expire`. Returns `true` if the key existed and the
     /// TTL was applied.
     fn replicate_expire(&self, key: &str, ttl: Duration) -> bool;
+
+    /// Handle a public [`Store::set_broadcast`]: put this value on **every**
+    /// node, whatever its size.
+    ///
+    /// A replicator that shards large values across a subset of the cluster
+    /// MUST override this — that is the whole point of the call. The default
+    /// delegates to [`replicate_set`](Self::replicate_set), which is correct
+    /// only for a replicator that already reaches every node (and for the
+    /// test doubles in this crate).
+    fn replicate_broadcast(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        self.replicate_set(key, value, ttl)
+    }
+
+    /// Fetch `key` from the rest of the cluster, for a node that has no local
+    /// copy. Returns `None` when the key is nowhere to be found, and for any
+    /// replicator with no cluster behind it.
+    ///
+    /// Boxed rather than `async fn` so the trait stays object-safe: it is
+    /// stored as `Arc<dyn Replicator>`.
+    fn fetch_cluster<'a>(
+        &'a self,
+        key: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<Vec<u8>>> + Send + 'a>> {
+        let _ = key;
+        Box::pin(std::future::ready(None))
+    }
 }
 
 /// Thread-safe in-memory KV store.
@@ -529,6 +555,57 @@ impl Store {
             return rep.replicate_set(key, value, ttl);
         }
         self.set_local(key, value, ttl)
+    }
+
+    /// Write a value that **every** node must hold a local copy of,
+    /// regardless of its size.
+    ///
+    /// # Why this is not just `set`
+    ///
+    /// [`Store::set`] hands the write to the [`Replicator`], which routes by
+    /// size: small values ride gossip (all nodes), large ones are *sharded* —
+    /// stored on `replication_factor` nodes and fetched through from an owner
+    /// on a miss. That is the right trade for cache and session data, and the
+    /// wrong one for cluster-wide state that every node must be able to read
+    /// out of its own local map with no round trip and no dependency on an
+    /// owner still being alive. An ACME certificate is the motivating case:
+    /// every node terminates TLS with it, and it is comfortably larger than
+    /// `small_key_threshold`, so plain `set` left it on a subset of the
+    /// cluster where the other nodes could never see it.
+    ///
+    /// Sharding is a capacity optimisation. Broadcast keys opt out of it, so
+    /// this is for a small, bounded set of keys — not a general-purpose write
+    /// path.
+    ///
+    /// Falls back to a local write when no replicator is installed, which is
+    /// already "every node" on a standalone node.
+    pub fn set_broadcast(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        if let Some(rep) = self.active_replicator() {
+            return rep.replicate_broadcast(key, value, ttl);
+        }
+        self.set_local(key, value, ttl)
+    }
+
+    /// Read a key, falling back to the rest of the cluster when this node has
+    /// no local copy.
+    ///
+    /// [`Store::get`] is local-only by design — it is on the hot path for
+    /// every RESP `GET` and every PHP `ephpm_kv_get`. This is the deliberate
+    /// slow path for the handful of callers that must not miss a value merely
+    /// because *this* node has not got it yet: a node that joined after the
+    /// write, or was down when it happened.
+    ///
+    /// The fetched value is **not** cached locally: it arrives with no TTL
+    /// information, so caching it would silently turn an expiring key into a
+    /// permanent one. Callers here poll on a timer, so a round trip per poll
+    /// is the cheaper mistake.
+    pub async fn get_cluster(&self, key: &str) -> Option<Bytes> {
+        if let Some(local) = self.get(key) {
+            return Some(local);
+        }
+        let replicator = self.active_replicator()?;
+        let value = replicator.fetch_cluster(key).await?;
+        Some(Bytes::from(value))
     }
 
     /// Local-only write — bypasses any installed [`Replicator`]. Used by a

--- a/crates/ephpm-server/src/acme.rs
+++ b/crates/ephpm-server/src/acme.rs
@@ -282,11 +282,15 @@ async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
                             deployed = true;
                         }
                         if is_leader {
-                            // The cache layer wired into AcmeConfig
-                            // pushes new certs into the KV store as part
-                            // of the rustls-acme state machine, so by
-                            // the time we see this event the cert is
-                            // already replicated cluster-wide.
+                            // The cache layer wired into AcmeConfig pushes new
+                            // certs into the KV store as part of the
+                            // rustls-acme state machine, via `set_broadcast`
+                            // so every node gets its own local copy rather
+                            // than `replication_factor` of them. Fan-out to
+                            // peers is spawned, so it is in flight — not
+                            // necessarily complete — by the time this event
+                            // arrives; a follower that has not received it yet
+                            // fetches through on its next `load_cert` poll.
                             tracing::info!(?ev, "ACME certificate event (leader, distributed via KV)");
                         } else {
                             tracing::info!(?ev, "ACME certificate event (follower, loaded from KV)");
@@ -392,23 +396,62 @@ pub fn get_acme_challenge(store: &Store, token: &str) -> Option<Vec<u8>> {
 ///
 /// The certificate is stored indefinitely (no TTL) — renewal replaces
 /// it with a fresh certificate.
+///
+/// # Why `set_broadcast` and not `set`
+///
+/// Every node in the cluster terminates TLS with this certificate, so every
+/// node needs its own local copy. [`Store::set`] would not give it one: in
+/// clustered mode it routes by size, and a certificate chain is several
+/// kilobytes — comfortably over `[cluster.kv] small_key_threshold` — so it
+/// takes the sharded large-value tier and lands on `replication_factor`
+/// nodes only (2 by default). The nodes outside that set then have no
+/// certificate at all, and their TLS handshakes fail outright.
+///
+/// This was live, not theoretical: on a three-node cluster the leader issued
+/// a 5140-byte chain against a 4096-byte threshold, and the two other nodes
+/// answered every handshake with `tlsv1 alert access denied` for as long as
+/// they were up. [`Store::set_broadcast`] is the fix — it puts the value on
+/// every node whatever its size. Raising `small_key_threshold` is *not* an
+/// alternative: the small-value tier is gossip over UDP and cannot carry a
+/// multi-kilobyte payload.
 pub fn store_acme_cert(store: &Store, domain: &str, cert_pem: &[u8], key_pem: &[u8]) {
     let cert_key = format!("{ACME_CERT_PREFIX}{domain}:cert");
     let key_key = format!("{ACME_CERT_PREFIX}{domain}:key");
-    store.set(cert_key, cert_pem.to_vec(), None);
-    store.set(key_key, key_pem.to_vec(), None);
-    tracing::info!(domain, "stored ACME certificate in KV store");
+    store.set_broadcast(cert_key, cert_pem.to_vec(), None);
+    store.set_broadcast(key_key, key_pem.to_vec(), None);
+    tracing::info!(domain, "stored ACME certificate in KV store (broadcast to every node)");
 }
 
-/// Retrieve a certificate and key from the KV store.
+/// Retrieve a certificate and key from this node's **local** KV store.
 ///
 /// Returns `None` if either the cert or key is missing.
+///
+/// Local-only, so it is safe to call from a non-async context (startup, before
+/// the runtime is driving the renewal loop). Nodes that were alive when
+/// [`store_acme_cert`] ran hold a local copy, so this normally hits. A node
+/// that joined afterwards does not — those callers want
+/// [`get_acme_cert_cluster`].
 #[must_use]
 pub fn get_acme_cert(store: &Store, domain: &str) -> Option<(Vec<u8>, Vec<u8>)> {
     let cert_key = format!("{ACME_CERT_PREFIX}{domain}:cert");
     let key_key = format!("{ACME_CERT_PREFIX}{domain}:key");
     let cert = store.get(&cert_key)?;
     let key = store.get(&key_key)?;
+    Some((cert.to_vec(), key.to_vec()))
+}
+
+/// [`get_acme_cert`], falling back to the rest of the cluster on a local miss.
+///
+/// [`store_acme_cert`] broadcasts to every node that is *alive at write time*.
+/// A node that joins later — a scale-up, a restart, a rolling deploy — has no
+/// local copy and would otherwise wait for the next renewal (up to 60 days) to
+/// get one. This is the read used by the polling loops that install the
+/// leader's certificate, so such a node converges on its next poll instead.
+pub async fn get_acme_cert_cluster(store: &Store, domain: &str) -> Option<(Vec<u8>, Vec<u8>)> {
+    let cert_key = format!("{ACME_CERT_PREFIX}{domain}:cert");
+    let key_key = format!("{ACME_CERT_PREFIX}{domain}:key");
+    let cert = store.get_cluster(&cert_key).await?;
+    let key = store.get_cluster(&key_key).await?;
     Some((cert.to_vec(), key.to_vec()))
 }
 
@@ -497,7 +540,9 @@ impl CertCache for KvCache {
         directory_url: &str,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
         let key = cert_key_for(domains, directory_url);
-        match self.store.get(&key) {
+        // Cluster-aware: a node that joined after the leader issued has no
+        // local copy, and this poll is its only chance to get one.
+        match self.store.get_cluster(&key).await {
             Some(bytes) => {
                 tracing::debug!(key = %key, len = bytes.len(), "ACME cert loaded from KV cache");
                 Ok(Some(bytes.to_vec()))
@@ -516,7 +561,9 @@ impl CertCache for KvCache {
         cert: &[u8],
     ) -> Result<(), Self::EC> {
         let key = cert_key_for(domains, directory_url);
-        let ok = self.store.set(key.clone(), cert.to_vec(), None);
+        // Broadcast, not `set`: see `store_acme_cert` for why a cert-sized
+        // value must not take the sharded large-value tier.
+        let ok = self.store.set_broadcast(key.clone(), cert.to_vec(), None);
         if ok {
             tracing::info!(
                 key = %key,
@@ -543,7 +590,7 @@ impl AccountCache for KvCache {
         directory_url: &str,
     ) -> Result<Option<Vec<u8>>, Self::EA> {
         let key = account_key_for(contact, directory_url);
-        match self.store.get(&key) {
+        match self.store.get_cluster(&key).await {
             Some(bytes) => {
                 tracing::debug!(key = %key, "ACME account loaded from KV cache");
                 Ok(Some(bytes.to_vec()))
@@ -562,7 +609,11 @@ impl AccountCache for KvCache {
         account: &[u8],
     ) -> Result<(), Self::EA> {
         let key = account_key_for(contact, directory_url);
-        let ok = self.store.set(key.clone(), account.to_vec(), None);
+        // Account material is the cluster's single ACME identity — every node
+        // must resolve the same one, or a promoted follower registers a second
+        // account and starts its own rate-limit budget. Same tier reasoning as
+        // the certificate: broadcast, never shard.
+        let ok = self.store.set_broadcast(key.clone(), account.to_vec(), None);
         if ok {
             tracing::info!(key = %key, "ACME account material published to KV store");
         } else {

--- a/crates/ephpm-server/src/dns01.rs
+++ b/crates/ephpm-server/src/dns01.rs
@@ -34,12 +34,24 @@
 //! - The **renewal + clustering machinery is reused from [`crate::acme`]**:
 //!   [`crate::acme::try_acquire_acme_leadership`] for leader election over the
 //!   same `acme:leader` KV key, and [`crate::acme::store_acme_cert`] /
-//!   [`crate::acme::get_acme_cert`] for cluster-wide certificate distribution.
-//!   Only the elected leader talks to Let's Encrypt; every other node installs
-//!   the leader's certificate out of the KV store. That reuse is deliberate —
-//!   duplicating a second, subtly different leader election is exactly how a
-//!   cluster ends up ordering five duplicate certificates and getting locked
-//!   out for a week.
+//!   [`crate::acme::get_acme_cert_cluster`] for cluster-wide certificate
+//!   distribution. Only the elected leader talks to Let's Encrypt; every other
+//!   node installs the leader's certificate out of the KV store. That reuse is
+//!   deliberate — duplicating a second, subtly different leader election is
+//!   exactly how a cluster ends up ordering five duplicate certificates and
+//!   getting locked out for a week.
+//!
+//!   "Every other node installs the leader's certificate" is a claim about the
+//!   KV tier the certificate is written to, and it was **false** until the
+//!   write moved to `Store::set_broadcast`. A certificate chain is bigger than
+//!   `[cluster.kv] small_key_threshold`, so a plain `set` sharded it across
+//!   `replication_factor` nodes; on a three-node cluster the other two served
+//!   no certificate at all. Distribution now has two halves, and both are load
+//!   bearing: the leader **broadcasts** to every node alive at issuance, and a
+//!   follower's poll below reads through
+//!   [`crate::acme::get_acme_cert_cluster`], which fetches from a peer when
+//!   this node has no local copy — the case for a node that joined after
+//!   issuance.
 //!
 //! ## Live-validation status
 //!
@@ -626,7 +638,8 @@ async fn run_dns01_lifecycle(ctx: Dns01Context) {
                 }
             }
         } else if let Some(store) = &ctx.store
-            && let Some((cert_pem, key_pem)) = crate::acme::get_acme_cert(store, &ctx.canonical)
+            && let Some((cert_pem, key_pem)) =
+                crate::acme::get_acme_cert_cluster(store, &ctx.canonical).await
         {
             // Follower: pick up the leader's certificate from the KV store.
             let fp = fingerprint(&cert_pem);
@@ -891,9 +904,14 @@ fn load_account_creds(ctx: &Dns01Context) -> Option<Vec<u8>> {
 }
 
 /// Persist account credential JSON to KV (cluster-wide) and disk.
+///
+/// Broadcast rather than `set` for the same reason the certificate is: the
+/// credential JSON carries a private key and is large enough to take the
+/// sharded large-value tier, which would leave it on a subset of nodes. Every
+/// node must resolve the *same* ACME account.
 fn persist_account_creds(ctx: &Dns01Context, bytes: &[u8]) {
     if let Some(store) = &ctx.store {
-        store.set(account_kv_key(&ctx.directory_url), bytes.to_vec(), None);
+        store.set_broadcast(account_kv_key(&ctx.directory_url), bytes.to_vec(), None);
     }
     write_file(&ctx.cache_dir.join("account.json"), bytes);
 }

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -1345,6 +1345,23 @@ impl Drop for InFlightGuard {
 }
 
 /// Dispatch a connection from the main listener.
+///
+/// # The main listener is plain HTTP whenever a separate TLS listener exists
+///
+/// `[server.tls] listen` means, per its documented contract, *"`server.listen`
+/// serves HTTP and this address serves HTTPS"*. So the moment a separate TLS
+/// listener is bound, this listener speaks plain HTTP — whatever [`TlsMode`]
+/// the server is in. `redirect_http` then chooses only what that plain-HTTP
+/// listener *says*: a 301 to HTTPS, or the site itself.
+///
+/// This used to be gated on `has_tls_listener && redirect_http`, and
+/// `redirect_http` defaults to `false`. A config with both `[server] listen`
+/// and `[server.tls] listen` but no redirect therefore fell through to the
+/// `tls_mode` match below and TLS-wrapped the *plain* listener: a plaintext
+/// `GET` got a TLS alert record (`15 03 03 ...`) instead of a response, so
+/// every plain-HTTP client — browsers, load-balancer health checks — failed to
+/// connect. Serving HTTPS on both listeners is never a valid reading of the
+/// contract, so there is no `tls_mode` arm here at all.
 fn dispatch_main_connection(
     stream: TcpStream,
     remote_addr: SocketAddr,
@@ -1359,10 +1376,16 @@ fn dispatch_main_connection(
     in_flight.fetch_add(1, Ordering::Relaxed);
     let flight_guard = InFlightGuard(Arc::clone(in_flight));
 
-    if has_tls_listener && redirect_http {
+    if has_tls_listener {
+        let router = Arc::clone(router);
         tokio::spawn(async move {
+            let _guard = guard; // held until connection closes
             let _flight = flight_guard;
-            serve_http_redirect(stream, remote_addr, conn).await;
+            if redirect_http {
+                serve_http_redirect(stream, remote_addr, conn).await;
+            } else {
+                serve_connection(stream, router, remote_addr, false, conn).await;
+            }
         });
         return;
     }
@@ -2453,6 +2476,186 @@ mod lib_tests {
         conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)", &[])
             .await
             .expect("execute through wrapper");
+    }
+
+    // ── Main-listener role when a separate TLS listener is configured ───
+    //
+    // `[server.tls] listen` documents: "server.listen serves HTTP and this
+    // address serves HTTPS". These tests pin that contract at
+    // `dispatch_main_connection` itself, over a real socket, by inspecting
+    // the first bytes the server writes back to a plaintext GET. The two
+    // answers are unambiguous on the wire: an HTTP response begins
+    // `HTTP/1.1`, whereas a TLS record begins with a content-type byte
+    // (0x16 handshake, 0x15 alert). The live bug was diagnosed exactly this
+    // way — `nc` to the plain port returned `15 03 03 00 02 02 32`.
+
+    /// A router serving one static file out of a temp document root.
+    fn dispatch_test_router(docroot: &std::path::Path) -> Arc<Router> {
+        let config = ephpm_config::Config {
+            server: ephpm_config::ServerConfig {
+                listen: "127.0.0.1:0".to_owned(),
+                document_root: docroot.to_path_buf(),
+                index_files: vec!["index.html".to_owned()],
+                ..ephpm_config::ServerConfig::default()
+            },
+            php: ephpm_config::PhpConfig::default(),
+            db: ephpm_config::DbConfig::default(),
+            kv: ephpm_config::KvConfig::default(),
+            cluster: ephpm_config::ClusterConfig::default(),
+            middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
+        };
+        let store = ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default());
+        Arc::new(Router::new(&config, store, None, None, None, None, None))
+    }
+
+    /// Manual TLS over a freshly generated self-signed cert.
+    fn dispatch_test_manual_tls(dir: &std::path::Path) -> TlsMode {
+        tls::tests_support::init_crypto();
+        let (cert, key) = tls::tests_support::generate_ec_cert(dir);
+        TlsMode::Manual(tls::build_tls_acceptor(&cert, &key).expect("build acceptor"))
+    }
+
+    /// ACME TLS mode over the same cert material, so the tests cover the
+    /// `TlsMode::Acme` arm too — the original bug hit both.
+    fn dispatch_test_acme_tls(dir: &std::path::Path) -> TlsMode {
+        tls::tests_support::init_crypto();
+        let (cert, key) = tls::tests_support::generate_ec_cert(dir);
+        let alpn = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        let build =
+            || Arc::new(tls::build_server_config(&cert, &key, &alpn).expect("build server config"));
+        TlsMode::Acme { challenge_config: build(), default_config: build() }
+    }
+
+    /// Send a plaintext `GET /` through `dispatch_main_connection` and
+    /// return the first bytes written back.
+    async fn plaintext_probe(
+        tls_mode: TlsMode,
+        has_tls_listener: bool,
+        redirect_http: bool,
+    ) -> Vec<u8> {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("index.html"), "hello").expect("write index");
+        let router = dispatch_test_router(dir.path());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind probe listener");
+        let addr = listener.local_addr().expect("probe local addr");
+        let in_flight = Arc::new(AtomicUsize::new(0));
+
+        let server = tokio::spawn(async move {
+            let (stream, remote) = listener.accept().await.expect("accept probe connection");
+            dispatch_main_connection(
+                stream,
+                remote,
+                &tls_mode,
+                has_tls_listener,
+                redirect_http,
+                ConnSettings {
+                    header_read_timeout: Duration::from_secs(5),
+                    max_header_size: 16 * 1024,
+                    idle_timeout: Duration::from_secs(5),
+                },
+                &router,
+                None,
+                &in_flight,
+            );
+            // `dispatch_main_connection` spawns the connection task with its
+            // own clones, so this task has nothing left to hold.
+        });
+
+        let mut client = tokio::net::TcpStream::connect(addr).await.expect("connect to probe");
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("write plaintext request");
+
+        let mut buf = vec![0u8; 512];
+        let read = tokio::time::timeout(Duration::from_secs(10), client.read(&mut buf))
+            .await
+            .expect("probe read timed out")
+            .expect("probe read failed");
+        buf.truncate(read);
+        server.await.expect("probe server task");
+        buf
+    }
+
+    /// Render the probe bytes for an assertion message: a TLS record is not
+    /// printable, so show the leading bytes in hex as well.
+    fn probe_debug(bytes: &[u8]) -> String {
+        let head: Vec<String> = bytes.iter().take(8).map(|b| format!("{b:02x}")).collect();
+        format!("{:?} (first bytes: {})", String::from_utf8_lossy(bytes), head.join(" "))
+    }
+
+    /// The regression: `[server] listen` plus `[server.tls] listen` with
+    /// `redirect_http` unset (its default, `false`) must leave the main
+    /// listener speaking plain HTTP. It used to fall through to the
+    /// `tls_mode` match and TLS-wrap the plain listener, so every
+    /// plain-HTTP client — including load-balancer health checks — got a
+    /// TLS alert and a failed connection.
+    #[tokio::test]
+    async fn main_listener_serves_plain_http_when_tls_listener_is_configured() {
+        let dir = tempfile::tempdir().expect("cert dir");
+        let got = plaintext_probe(dispatch_test_manual_tls(dir.path()), true, false).await;
+        assert!(
+            got.starts_with(b"HTTP/1.1 "),
+            "main listener must answer plain HTTP, got {}",
+            probe_debug(&got)
+        );
+        assert_ne!(
+            got.first(),
+            Some(&0x15),
+            "main listener wrote a TLS alert record instead of HTTP: {}",
+            probe_debug(&got)
+        );
+        assert_ne!(
+            got.first(),
+            Some(&0x16),
+            "main listener wrote a TLS handshake record instead of HTTP: {}",
+            probe_debug(&got)
+        );
+    }
+
+    /// Same contract in ACME mode: the bug was in the shared fall-through,
+    /// so both `TlsMode` variants have to be pinned.
+    #[tokio::test]
+    async fn acme_main_listener_serves_plain_http_when_tls_listener_is_configured() {
+        let dir = tempfile::tempdir().expect("cert dir");
+        let got = plaintext_probe(dispatch_test_acme_tls(dir.path()), true, false).await;
+        assert!(
+            got.starts_with(b"HTTP/1.1 "),
+            "ACME main listener must answer plain HTTP, got {}",
+            probe_debug(&got)
+        );
+    }
+
+    /// `redirect_http` keeps its only job: it decides what the plain-HTTP
+    /// listener *says*, not whether it is plain HTTP.
+    #[tokio::test]
+    async fn main_listener_redirects_when_redirect_http_is_enabled() {
+        let dir = tempfile::tempdir().expect("cert dir");
+        let got = plaintext_probe(dispatch_test_manual_tls(dir.path()), true, true).await;
+        assert!(
+            got.starts_with(b"HTTP/1.1 301"),
+            "redirect_http must 301 to HTTPS, got {}",
+            probe_debug(&got)
+        );
+    }
+
+    /// The other half of the contract, so the fix cannot regress into
+    /// "never terminate TLS on the main listener": with no separate TLS
+    /// listener, `server.listen` *is* the HTTPS listener, and a plaintext
+    /// GET must not be answered with HTTP.
+    #[tokio::test]
+    async fn main_listener_terminates_tls_when_it_is_the_only_listener() {
+        let dir = tempfile::tempdir().expect("cert dir");
+        let got = plaintext_probe(dispatch_test_manual_tls(dir.path()), false, false).await;
+        assert!(
+            !got.starts_with(b"HTTP/"),
+            "sole listener must terminate TLS, not answer plain HTTP: {}",
+            probe_debug(&got)
+        );
     }
 
     #[test]

--- a/site/content/guides/tls-acme.md
+++ b/site/content/guides/tls-acme.md
@@ -133,7 +133,9 @@ For each order ePHPm publishes the challenge TXT records, waits for propagation,
 
 ## Clustered ACME
 
-In a cluster, only one node should solve the challenge — the rest read the cert from the gossip-backed KV store. ePHPm does this automatically when `[cluster] enabled = true`. Each node points at the same `cache_dir` (or a shared store) and the leader publishes the cert; replicas pick it up. Both challenge lanes share the same `acme:leader` election and KV distribution. See [Clustering Setup](clustering-setup/).
+In a cluster, only one node should solve the challenge — the rest read the cert from the KV store. ePHPm does this automatically when `[cluster] enabled = true`. Each node points at the same `cache_dir` (or a shared store) and the leader publishes the cert; replicas pick it up. Both challenge lanes share the same `acme:leader` election and KV distribution. See [Clustering Setup](clustering-setup/).
+
+Certificates and ACME account material are written to the KV store's **broadcast** tier, so every node gets its own local copy. This is deliberate and distinct from an ordinary KV write: the clustered store routes values larger than `[cluster.kv] small_key_threshold` to a *sharded* tier held on `replication_factor` nodes, and a certificate chain is comfortably over that threshold. Every node terminates TLS, so every node needs the certificate — sharding it leaves the rest of the cluster unable to complete a handshake at all. A follower that missed the broadcast (it joined, or was down, after issuance) fetches the certificate from a peer on its next poll rather than waiting for the next renewal.
 
 The two limitations below apply to the **TLS-ALPN-01** lane. The **DNS-01** lane avoids both — the challenge is answered over DNS by the leader (nothing needs to reach a specific node), and its certificate resolver is hot-swappable, so a follower installs the leader's *renewed* certificate from the KV store without a restart. That makes DNS-01 the better fit for clustered deployments.
 


### PR DESCRIPTION
Two independent TLS/clustering bugs found by **live 3-node cluster testing**, both of which broke serving in production. Branched off `main`, independent of the in-flight per-site clustering work (#416).

Each bug is one commit. Both diagnoses were verified against the source before fixing, and one of them widened.

---

## Bug 1 — a configured `[server.tls] listen` TLS-wrapped the *plain* HTTP listener

**Symptom (live).** With `[server] listen = "0.0.0.0:8080"` plus `[server.tls] listen = "0.0.0.0:443"`, the `:8080` listener spoke **raw TLS**. A plaintext `GET` captured with `nc` came back as a TLS alert record:

```
15 03 03 00 02 02 32
```

Every plain-HTTP client got a connection failure. This took out a NodeBalancer HTTP health check and returned 503s to users.

> It also explains a previously-**misattributed "port 8080 connection refused"** symptom. The port was listening and accepting the whole time — it just was not speaking HTTP, so clients reported a connection-level failure and the port looked dead.

**Root cause (confirmed).** `dispatch_main_connection` gated plain-HTTP service on `has_tls_listener && redirect_http`. `[server.tls] redirect_http` defaults to `false`, so a separate TLS listener with no redirect fell straight through to `match tls_mode` and TLS-wrapped the main listener. Both `TlsMode::Manual` and `TlsMode::Acme` were affected.

The code contradicted its own documented contract, which was already correct in two places:

* `TlsConfig::listen` — *"When set, `server.listen` serves HTTP and this address serves HTTPS."*
* `site/content/architecture/http.md` modes table — *"HTTPS on `tls.listen`, HTTP on `server.listen`."*

**Fix.** Whenever a separate TLS listener is bound, the main listener serves plain HTTP regardless of TLS mode; `redirect_http` now decides only whether it 301s or serves normally. There is no `tls_mode` arm on that path any more, so the two modes cannot diverge again. The connection rate-limit guard is now held for the redirect case too, which it previously dropped early.

**Other paths checked, as requested:**

* **HTTP/3** — not affected. It binds its own UDP endpoint and already derives its address from `[server.tls] listen` when set, falling back to `[server] listen`.
* **ACME challenge dispatch** — not affected. TLS-ALPN-01 challenges arrive on the TLS listener, which is where a CA connects (:443). Nothing depended on the main listener terminating TLS.

**Tests.** Four tests drive the real `dispatch_main_connection` over a real socket and assert on the first bytes written back — the same signal the live diagnosis used (`HTTP/1.1` vs a `0x16`/`0x15` TLS record):

| Test | Pins |
|---|---|
| `main_listener_serves_plain_http_when_tls_listener_is_configured` | the regression: TLS listener + `redirect_http = false` gives plain HTTP |
| `acme_main_listener_serves_plain_http_when_tls_listener_is_configured` | same in `TlsMode::Acme` |
| `main_listener_redirects_when_redirect_http_is_enabled` | `redirect_http` still 301s |
| `main_listener_terminates_tls_when_it_is_the_only_listener` | the other half — no over-correction into "never terminate TLS" |

---

## Bug 2 — clustered ACME followers never installed the leader's certificate

**Symptom (live, 3 nodes).** node-1 won `acme:leader`, issued a valid certificate, and served it. Nodes 2 and 3 **never** installed it. 10+ minutes later they were still failing TLS handshakes with `tlsv1 alert access denied` — no certificate loaded at all.

**Root cause (confirmed, and wider than diagnosed).** `store_acme_cert` wrote via `Store::set`, which in clustered mode routes by size. The issued chain measured **5140 bytes** against a **4096-byte** `small_key_threshold`, so it took the **sharded** large-value tier and landed on `replication_factor` nodes (2 by default). `get_acme_cert` read it back with the raw, local-only `Store::get`, which has no fetch-from-owner path — only `ClusteredStore::get` does, and nothing on this path used it. On a 3-node cluster, one node could never see the certificate.

This falsified `dns01.rs`'s module docs: *"every other node installs the leader's certificate out of the KV store."*

**What the diagnosis missed:** the TLS-ALPN-01 lane has the *identical* defect independently. `KvCache::load_cert`/`store_cert` and `load_account`/`store_account` in `acme.rs` also went through raw `Store::get`/`set`, so fixing only `store_acme_cert`/`get_acme_cert` would have left that lane broken. Both lanes are fixed here.

**Fix — two halves, both load-bearing.**

Sharding is a *capacity* optimisation, and it is the wrong routing for state every node must hold locally: every node terminates TLS with this certificate.

1. **Write side** — `Store::set_broadcast` / `ClusteredStore::broadcast`: a tier that writes to every alive node whatever the value's size. Peer writes are **awaited** rather than fire-and-forget; a certificate is written twice a quarter, so cluster-wide read-your-writes matters far more than write latency. A partially-delivered broadcast warns rather than failing silently.
2. **Read side** — `Store::get_cluster` / `Replicator::fetch_cluster`: on a local miss, fetch through `ClusteredStore::get`, which already falls back to the key's replica set over the data plane.

Both are needed. Broadcast only reaches nodes alive *at write time*; the read fallback covers a node that joined, or was down, after issuance — which would otherwise wait up to 60 days for the next renewal to get a certificate.

**Deliberately not done:** raising `small_key_threshold`. Besides being a config workaround for a correctness bug, it does not even work — the small-value tier is chitchat gossip over **UDP**, so a multi-kilobyte payload cannot ride it. That is precisely why the threshold exists. The bug was never the threshold; it was the assumption that "too big for gossip" implies "shard it".

ACME **account material** moves to the broadcast tier too (both lanes). Every node must resolve the same ACME identity, or a promoted follower registers a second account and starts its own rate-limit budget.

**Tests.** New `crates/ephpm-cluster/tests/broadcast_kv_replication.rs`, using the existing in-process multi-node harness — three real gossip nodes on `127.0.0.x` with a real TCP data plane, driven through the public `Store` seam (`set_broadcast` / `set` / `get_cluster`) that the ACME code actually calls. Payload is 5140 bytes, the size from the incident.

* `broadcast_reaches_a_node_outside_the_replica_set` — the value is present in the **raw local store** of the node the sharded tier excludes. That is the exact read `get_acme_cert` performs, and the thing a node needs in order to answer a handshake at all.
* `sharded_set_is_invisible_to_a_non_replica_but_get_cluster_finds_it` — the control. A plain `set` is *never* local on that node (reproducing the bug), while `get_cluster` still resolves it.

**Negative control run:** reverting `set_broadcast` to route through `replicate_set` makes the first test fail with `left: None` on the non-replica node — i.e. it reproduces the live outage exactly, so the test has teeth.

---

## Also investigated: ACME leader tie-break re-firing every ~7 minutes

Reported: `"taking over ACME leadership (lower node id wins the tie-break)"` re-firing in steady state, not just at startup.

**No fix in this PR — the cause is not established, and I did not want to change election timing on a hunch inside a PR about two unrelated bugs.** Findings:

**Mechanically, the log line requires** that on the lowest-id node the key is present, held by a *different, higher-id* node. In steady state the lowest-id node *is* the holder, so some follower must first have won `set_nx` locally — which can only happen if `acme:leader` went **absent in that follower's local `Store`**. So the question is only ever "why does a follower lose its copy?"

**Ruled out.** The obvious suspect — chitchat's identical-value dedup (`state.rs:285-298`, which skips the version bump when the value is unchanged) — is **defeated**: `gossip_kv::encode_value` stamps a fresh `now_ms` into every payload, so each 10s heartbeat is a genuinely new version and does propagate. Also ruled out: chitchat key GC / `marked_for_deletion_grace_period` (ePHPm never creates real chitchat tombstones, so `last_gc_version` stays 0 and reset never runs), and any ~420s constant — none exists in the repo or in chitchat 0.10.0. The 7-minute cadence is emergent, not a timer.

**Real defects found, none proven to be the cause:**

1. **Thin TTL margin.** `ACME_LEADER_TTL` = 30s vs `ACME_LEADER_HEARTBEAT` = 10s — a 1:3 ratio, so a follower survives exactly two missed refreshes and the third kills it. `ACME_LEADER_CONFIRMATIONS = 2` then makes a node wait 20s (two-thirds of the lease) before acting.
2. **TTL is an absolute deadline on the origin's clock.** The wire format is `{expiry_ms}:{write_ms}:{b64}` with `expiry_ms = origin_now + ttl`. The peer computes `expiry_ms - peer_now`, so propagation delay *and* origin-to-peer clock skew are both silently subtracted from the 30s lease. Worse, a heartbeat that arrives already-expired is delivered as a **Tombstone** and the applier *deletes* the peer's copy rather than treating it as a stale no-op.
3. **`Store::set_local` is a non-atomic remove-then-insert** (`data.remove` … `ensure_memory` … `data.insert`), during which the key does not exist. This contradicts `set_nx`'s documented invariant ("the existence check and the insert are performed under the same per-key write lock") — atomic against other `set_nx` callers, but *not* against the gossip applier's `set_local`, which refreshes this very key on followers every 10s. Related: when `ensure_memory` fails, `set_local` has already removed the old entry and returns `false`, so a rejected write **destroys** the previous value.
4. **`acme:leader` is LRU-evictable.** Default policy is `AllKeysLru` over a 256 MiB budget, and `evict_lru` reaps without broadcasting.

**Why I do not think (3) explains the cadence,** despite it being the most attractive-looking race: the window between `remove` and `insert` is sub-microsecond absent memory pressure. Two 10s-period loops colliding in it gives roughly 1e-7 per tick — once per ~10^8 ticks, not once per 42. Even with `ensure_memory` doing real eviction work (~1ms) it is once per ~28 hours. It is a genuine bug worth fixing on its own merits; it is not a 7-minute cadence.

**Recommended next step:** log the *reason* a follower re-acquires — specifically whether `acme:leader` was absent versus expired at `set_nx` time, plus the observed `expiry_ms - peer_now` on arrival. That distinguishes (1)/(2) from (3)/(4) immediately. If a cheap hardening is wanted before that data exists, halving `ACME_LEADER_HEARTBEAT` to 5s (a 1:6 margin) is a one-constant change that costs nothing — but it will not help if the real cause is clock skew, which is why I have not bundled it.

Happy to file 1-4 as separate issues.

---

## Verification

Run from a worktree on this branch:

* `cargo clippy -p ephpm-server -p ephpm-cluster -p ephpm-kv -p ephpm-config --all-targets -- -D warnings` — clean
* `cargo test -p ephpm-server -p ephpm-cluster -p ephpm-kv -p ephpm-config` — **1170 passed, 0 failed, 10 ignored**
* `cargo +nightly fmt --all -- --check` (via WSL) — clean

The multi-node tests genuinely ran rather than skipping (`127.0.0.x` loopback aliases were available on the test host).

**One flake seen, not a regression:** the first full run had 3 failures in `tests/gossip.rs` with `failed to spawn chitchat gossip`. They pass in isolation and the identical command passed on re-run. Cause is pre-existing TOCTOU in that file's `random_udp_port()` — it binds `127.0.0.1:0`, reads the port, drops the socket, and chitchat re-binds it later, so a concurrently-running test binary can take the port in between. This PR adds a fourth multi-node test binary, which makes the existing race more likely to be observed. Worth fixing separately (hold the socket until bind, or retry).

## Docs

* `TlsConfig::listen` / `redirect_http` doc comments — spell out that "`server.listen` serves HTTP" is unconditional and that `redirect_http` only chooses what that listener *says*.
* `dns01.rs` module docs — the "every other node installs the leader's certificate" claim now states the mechanism that makes it true, and records that it was false before.
* `acme.rs` — the "already replicated cluster-wide" comment now describes the real timing (fan-out is in flight, followers fetch through on miss).
* `site/content/guides/tls-acme.md` — describes the broadcast tier and why certificates must not be sharded.

`site/content/architecture/http.md` needed no change: its modes table was already describing the correct Bug 1 behaviour.
