### PR TITLE
fix(acme): elect the leader on the configured cluster node id

### DIFF
--- a/crates/ephpm-server/src/acme.rs
+++ b/crates/ephpm-server/src/acme.rs
@@ -72,7 +72,15 @@ pub struct AcmeSetup {
 /// # Errors
 ///
 /// Returns an error if the cache directory cannot be created.
-pub fn start_acme(tls_config: &TlsConfig, store: Option<Arc<Store>>) -> anyhow::Result<AcmeSetup> {
+/// `cluster_node_id` is the configured `[cluster] node_id`; see
+/// [`acme_node_id`] for why a stable identity is required for the leader
+/// election to converge.
+pub fn start_acme(
+    tls_config: &TlsConfig,
+    store: Option<Arc<Store>>,
+    cluster_node_id: Option<&str>,
+) -> anyhow::Result<AcmeSetup> {
+    let node_id = acme_node_id(cluster_node_id);
     let domains = &tls_config.domains;
     let production = !tls_config.staging;
 
@@ -119,7 +127,7 @@ pub fn start_acme(tls_config: &TlsConfig, store: Option<Arc<Store>>) -> anyhow::
             if let Some(cfg) = Arc::get_mut(&mut default_config) {
                 cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
             }
-            tokio::spawn(drive_clustered_acme_events(state, kv_store, leader_flag));
+            tokio::spawn(drive_clustered_acme_events(state, kv_store, leader_flag, node_id));
             (challenge_config, default_config)
         }
         None => {
@@ -199,11 +207,33 @@ const ACME_CHALLENGE_PREFIX: &str = "acme:challenge:";
 /// KV key prefix for stored certificates.
 const ACME_CERT_PREFIX: &str = "acme:cert:";
 
-/// Generate a unique node identifier for ACME leader election.
+/// Resolve this node's identifier for ACME leader election.
 ///
 /// Shared with [`crate::dns01`] so both ACME lanes derive their node identity
 /// (and therefore the lowest-id tie-break) the same way.
-pub(crate) fn acme_node_id() -> String {
+///
+/// # Why the configured `[cluster] node_id` must win
+///
+/// The tie-break is "lowest id wins", so the id has to be **stable across
+/// restarts** for leadership to converge. The fallback below is not: it is
+/// derived from the wall clock and pid, so every process start mints a new
+/// identity and "lowest id" degenerates into "whichever process happened to
+/// boot earliest". On a live three-node cluster that produced a permanent
+/// takeover cycle — each node reclaiming the key every heartbeat — so no node
+/// ever held leadership long enough to finish a DNS-01 order (which takes
+/// ~60s waiting for TXT propagation). Two of three nodes never obtained a
+/// certificate at all, and the churn looked like unexplained "leader flapping".
+///
+/// When `[cluster] node_id` is set (the normal clustered configuration, and
+/// the same identity gossip advertises) it is used verbatim, so the election is
+/// deterministic and survives restarts.
+///
+/// The ephemeral fallback is retained only for a node with no configured id —
+/// a single-node deployment, where there is nothing to elect against.
+pub(crate) fn acme_node_id(configured: Option<&str>) -> String {
+    if let Some(id) = configured.map(str::trim).filter(|id| !id.is_empty()) {
+        return id.to_string();
+    }
     use std::time::{SystemTime, UNIX_EPOCH};
     let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
     let pid = std::process::id();
@@ -241,8 +271,8 @@ async fn drive_clustered_acme_events<EC: Debug + 'static, EA: Debug + 'static>(
     mut state: AcmeState<EC, EA>,
     store: Arc<Store>,
     leader_flag: Arc<AtomicBool>,
+    node_id: String,
 ) {
-    let node_id = acme_node_id();
     let mut is_leader = false;
     let mut confirmations: u32 = 0;
     // Set once this node has a certificate installed in its resolver.
@@ -947,11 +977,51 @@ mod tests {
 
     #[test]
     fn acme_node_id_is_unique() {
-        let id1 = acme_node_id();
+        // With no configured id, each call mints a fresh one. That is only
+        // acceptable for a single node — see the clustered test below.
+        let id1 = acme_node_id(None);
         // Sleep briefly to ensure different timestamp.
         std::thread::sleep(std::time::Duration::from_millis(1));
-        let id2 = acme_node_id();
+        let id2 = acme_node_id(None);
         assert_ne!(id1, id2);
+    }
+
+    /// The election tie-break is "lowest id wins", so a configured
+    /// `[cluster] node_id` must be used verbatim and be **stable across
+    /// restarts**. Regression guard: the ephemeral fallback made every process
+    /// start mint a new identity, so three live nodes reclaimed leadership from
+    /// each other every heartbeat and none held it long enough to finish a
+    /// ~60s DNS-01 order — two of three never got a certificate at all.
+    #[test]
+    fn configured_cluster_node_id_is_stable_and_wins() {
+        // Same configured id across "restarts" → same election identity.
+        let first = acme_node_id(Some("node-1"));
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let second = acme_node_id(Some("node-1"));
+        assert_eq!(first, "node-1");
+        assert_eq!(first, second, "a configured node id must not change between starts");
+
+        // Distinct nodes stay distinct, and order deterministically for the
+        // lowest-id tie-break.
+        let mut ids = [acme_node_id(Some("node-3")), acme_node_id(Some("node-1"))];
+        ids.sort_unstable();
+        assert_eq!(ids, ["node-1", "node-3"]);
+
+        // Blank / whitespace-only is treated as "not configured" so a
+        // misconfiguration can't collapse every node onto one shared identity
+        // (which would make them all believe they hold the same claim).
+        for blank in ["", "   "] {
+            let generated = acme_node_id(Some(blank));
+            assert_ne!(generated, blank);
+            assert!(
+                generated.contains('-'),
+                "blank config must fall back to the generated form, got {generated:?}"
+            );
+        }
+
+        // Surrounding whitespace is trimmed rather than making two nodes that
+        // configured the same name look different.
+        assert_eq!(acme_node_id(Some("  node-2  ")), "node-2");
     }
 
     // ── KvCache / LayeredCache tests ────────────────────────────────────────
@@ -1127,7 +1197,8 @@ mod tests {
             listen: None,
             redirect_http: false,
         };
-        let setup = rt.block_on(async { start_acme(&cfg, None).expect("single-node start_acme") });
+        let setup =
+            rt.block_on(async { start_acme(&cfg, None, None).expect("single-node start_acme") });
         // Sanity-check that the returned configs are real rustls
         // configs and not the same Arc.
         assert!(

--- a/crates/ephpm-server/src/dns01.rs
+++ b/crates/ephpm-server/src/dns01.rs
@@ -451,6 +451,10 @@ struct Dns01Context {
     directory_url: String,
     store: Option<Arc<Store>>,
     cache_dir: PathBuf,
+    /// This node's ACME leader-election identity — the configured
+    /// `[cluster] node_id` when set. See [`crate::acme::acme_node_id`] for why
+    /// it must be stable across restarts.
+    node_id: String,
 }
 
 /// Resolve the Cloudflare API token from the config, honouring the file → env
@@ -494,9 +498,13 @@ pub fn resolve_cloudflare_token(tls: &TlsConfig) -> anyhow::Result<String> {
 ///
 /// Returns an error if the credential/provider cannot be constructed or the
 /// TLS acceptor cannot be built.
+/// `cluster_node_id` is the configured `[cluster] node_id`; see
+/// [`crate::acme::acme_node_id`] for why a stable identity is required for the
+/// leader election to converge.
 pub fn start_dns01_acme(
     tls_config: &TlsConfig,
     store: Option<Arc<Store>>,
+    cluster_node_id: Option<&str>,
 ) -> anyhow::Result<Dns01Setup> {
     anyhow::ensure!(
         tls_config.dns_provider.as_deref().is_some_and(|p| p.eq_ignore_ascii_case("cloudflare")),
@@ -552,12 +560,15 @@ pub fn start_dns01_acme(
         directory_url,
         store,
         cache_dir,
+        node_id: crate::acme::acme_node_id(cluster_node_id),
     };
 
     tracing::info!(
         domains = ?tls_config.domains,
         wildcard = tls_config.has_wildcard_domain(),
         clustered = ctx.store.is_some(),
+        node_id = %ctx.node_id,
+        stable_node_id = cluster_node_id.map(str::trim).is_some_and(|id| !id.is_empty()),
         environment = if tls_config.staging { "staging" } else { "production" },
         "DNS-01 ACME (Cloudflare) enabled"
     );
@@ -569,7 +580,7 @@ pub fn start_dns01_acme(
 
 /// The renewal + leadership loop. Runs for the lifetime of the server.
 async fn run_dns01_lifecycle(ctx: Dns01Context) {
-    let node_id = crate::acme::acme_node_id();
+    let node_id = ctx.node_id.clone();
     let mut is_leader = false;
     let mut confirmations: u32 = 0;
     let mut last_issued: Option<SystemTime> =

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -626,13 +626,14 @@ async fn bind_listeners(
         Some(tls_config) if tls_config.is_dns01() => {
             let acme_store =
                 if config.cluster.enabled { Some(Arc::clone(&kv_store)) } else { None };
-            let setup = dns01::start_dns01_acme(tls_config, acme_store)?;
+            let setup =
+                dns01::start_dns01_acme(tls_config, acme_store, Some(&config.cluster.node_id))?;
             TlsMode::Manual(setup.acceptor)
         }
         Some(tls_config) if tls_config.is_acme() => {
             let acme_store =
                 if config.cluster.enabled { Some(Arc::clone(&kv_store)) } else { None };
-            let setup = acme::start_acme(tls_config, acme_store)?;
+            let setup = acme::start_acme(tls_config, acme_store, Some(&config.cluster.node_id))?;
             TlsMode::Acme {
                 challenge_config: setup.challenge_config,
                 default_config: setup.default_config,

--- a/crates/ephpm-server/src/privdrop.rs
+++ b/crates/ephpm-server/src/privdrop.rs
@@ -300,24 +300,46 @@ fn resolve_group(spec: &str) -> anyhow::Result<u32> {
 
 #[cfg(all(test, unix))]
 mod tests {
+    use std::sync::Mutex;
+
     use ephpm_config::Config;
 
     use super::*;
 
+    /// Serializes the tests that perform a *name* lookup.
+    ///
+    /// `getpwnam`/`getgrnam` return a pointer into libc's shared static buffer.
+    /// Production upholds the invariant in [`resolve_user`]'s SAFETY note — the
+    /// drop happens once, at startup, before other threads exist — but the test
+    /// harness runs these concurrently, where one lookup overwrites another's
+    /// buffer. That surfaced as `resolve_user("root")` returning the *current*
+    /// user's uid, and it is timing-dependent: it appears and disappears as
+    /// unrelated tests change the scheduling.
+    ///
+    /// Locking here makes the tests honour the same single-lookup-at-a-time
+    /// contract the production caller does. Removing the invariant entirely
+    /// (switching to the reentrant `getpwnam_r`/`getgrnam_r`) is the more
+    /// thorough fix and is left as follow-up work — it changes unsafe FFI and
+    /// is unrelated to whatever change happens to be in flight.
+    static NAME_LOOKUP: Mutex<()> = Mutex::new(());
+
     #[test]
     fn numeric_user_and_group_parse_without_lookup() {
+        // Numeric specs short-circuit before any libc call, so no lock needed.
         assert_eq!(resolve_user("1000").unwrap(), (1000, None));
         assert_eq!(resolve_group("2000").unwrap(), 2000);
     }
 
     #[test]
     fn unknown_name_is_an_error_not_a_panic() {
+        let _guard = NAME_LOOKUP.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         assert!(resolve_user("definitely-no-such-user-zzz").is_err());
         assert!(resolve_group("definitely-no-such-group-zzz").is_err());
     }
 
     #[test]
     fn root_user_and_group_resolve() {
+        let _guard = NAME_LOOKUP.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         // root exists on every Unix; getpwnam/getgrnam must find it.
         let (uid, gid) = resolve_user("root").unwrap();
         assert_eq!(uid, 0);


### PR DESCRIPTION
## The bug

ACME leader election minted its own node identity per process:

```
1787985979173-22749-173895959
└─ epoch millis ─┘ └pid┘ └random┘
```

The tie-break is *"lowest id wins"*, so with an identity that is regenerated on
every boot it actually means **"whichever process started earliest"** — which
reshuffles on every restart.

## What that did on a live 3-node cluster

All three nodes independently `acquired ACME leadership`, then took it back from
each other on a ~70s cycle:

```
node-1  acquired ACME leadership node_id="1787985979173-..."
node-2  acquired ACME leadership node_id="1787986064600-..."
node-3  acquired ACME leadership node_id="1787986130867-..."
node-1  taking over ACME leadership (lower node id wins the tie-break) ...
node-2  taking over ACME leadership (lower node id wins the tie-break) ...
```

No node held leadership long enough to complete a DNS-01 order (~60s waiting on
TXT propagation), so **two of three nodes never obtained a certificate at all**
and served no TLS. The third only had one because it loaded a cached cert from
disk.

This is also the *"~7 minute leader flapping"* previously investigated and left
unexplained — the cadence is emergent from restart timing, not a timer, which is
why it resisted a timing-based explanation.

## The fix

Use the configured `[cluster] node_id` — the same stable identity gossip already
advertises — so the election is deterministic and survives restarts. The
generated form remains only as a fallback for a node with no configured id (a
single-node deployment, where there is nothing to elect against).

Blank/whitespace-only config falls back to the generated form rather than
collapsing every node onto one shared identity, which would have every node
believe it holds the same claim.

Threaded through **both** lanes (`start_dns01_acme` and `start_acme`) so DNS-01 and
TLS-ALPN-01 elect identically, and the DNS-01 startup log now reports the id and
whether it is stable.

## Also in this PR

Serialized the two `privdrop` name-lookup tests. `getpwnam`/`getgrnam` return a
pointer into libc's shared static buffer; production upholds the documented
startup-only invariant, but the parallel test harness does not, so
`resolve_user("root")` could return the *current* user's uid depending on
scheduling. This was latent and surfaced when the new test above shifted
scheduling. Switching to the reentrant `_r` variants would remove the invariant
entirely and is left as follow-up (unsafe FFI, unrelated to this change).

## Verification

- `cargo test -p ephpm-server --lib`: **489 passed, 0 failed**, three consecutive runs (was intermittently 1 failure).
- clippy (`ephpm-server`/`ephpm-cluster`/`ephpm-kv`/`ephpm-config`, `--all-targets -D warnings`): clean.
- `cargo +nightly fmt --all -- --check`: clean.
- New test `configured_cluster_node_id_is_stable_and_wins` pins: stability across calls, deterministic ordering for the tie-break, blank-config fallback, and whitespace trimming.

Found by attempting to move wildcard TLS termination onto the cluster nodes; that migration is blocked until this lands. Not yet validated end-to-end on the cluster — issuance against Let's Encrypt **staging** is the next step, deliberately before production to protect the wildcard rate limit.