### PR TITLE
fix(acme): DNS-01 clustered cert distribution — republish on promotion + directory namespacing

### DIFF
--- a/crates/ephpm-server/src/acme.rs
+++ b/crates/ephpm-server/src/acme.rs
@@ -444,9 +444,35 @@ pub fn get_acme_challenge(store: &Store, token: &str) -> Option<Vec<u8>> {
 /// every node whatever its size. Raising `small_key_threshold` is *not* an
 /// alternative: the small-value tier is gossip over UDP and cannot carry a
 /// multi-kilobyte payload.
-pub fn store_acme_cert(store: &Store, domain: &str, cert_pem: &[u8], key_pem: &[u8]) {
-    let cert_key = format!("{ACME_CERT_PREFIX}{domain}:cert");
-    let key_key = format!("{ACME_CERT_PREFIX}{domain}:key");
+/// KV keys `(cert, key)` for a DNS-01 certificate, namespaced by the ACME
+/// directory URL.
+///
+/// The directory hash is what keeps a **staging** certificate from shadowing a
+/// **production** one (and vice-versa) for the same domain set. Without it, the
+/// key is only `acme:cert:<domain>:cert`, so flipping `[server.tls] staging`
+/// leaves the previous environment's certificate sitting in KV — and because
+/// `load_cached_cert` reads KV first and never inspects the issuer, every node
+/// would keep serving the stale cert instead of ordering a fresh one. The
+/// TLS-ALPN lane already namespaces this way via [`cert_key_for`]; this keeps
+/// the DNS-01 lane consistent.
+fn dns01_cert_keys(domain: &str, directory_url: &str) -> (String, String) {
+    let mut hasher = Sha256::new();
+    hasher.update(directory_url.as_bytes());
+    let dir_hash = hex_short(&hasher.finalize());
+    (
+        format!("{ACME_CERT_PREFIX}{domain}:cert:{dir_hash}"),
+        format!("{ACME_CERT_PREFIX}{domain}:key:{dir_hash}"),
+    )
+}
+
+pub fn store_acme_cert(
+    store: &Store,
+    domain: &str,
+    directory_url: &str,
+    cert_pem: &[u8],
+    key_pem: &[u8],
+) {
+    let (cert_key, key_key) = dns01_cert_keys(domain, directory_url);
     store.set_broadcast(cert_key, cert_pem.to_vec(), None);
     store.set_broadcast(key_key, key_pem.to_vec(), None);
     tracing::info!(domain, "stored ACME certificate in KV store (broadcast to every node)");
@@ -462,9 +488,12 @@ pub fn store_acme_cert(store: &Store, domain: &str, cert_pem: &[u8], key_pem: &[
 /// that joined afterwards does not — those callers want
 /// [`get_acme_cert_cluster`].
 #[must_use]
-pub fn get_acme_cert(store: &Store, domain: &str) -> Option<(Vec<u8>, Vec<u8>)> {
-    let cert_key = format!("{ACME_CERT_PREFIX}{domain}:cert");
-    let key_key = format!("{ACME_CERT_PREFIX}{domain}:key");
+pub fn get_acme_cert(
+    store: &Store,
+    domain: &str,
+    directory_url: &str,
+) -> Option<(Vec<u8>, Vec<u8>)> {
+    let (cert_key, key_key) = dns01_cert_keys(domain, directory_url);
     let cert = store.get(&cert_key)?;
     let key = store.get(&key_key)?;
     Some((cert.to_vec(), key.to_vec()))
@@ -477,9 +506,12 @@ pub fn get_acme_cert(store: &Store, domain: &str) -> Option<(Vec<u8>, Vec<u8>)> 
 /// local copy and would otherwise wait for the next renewal (up to 60 days) to
 /// get one. This is the read used by the polling loops that install the
 /// leader's certificate, so such a node converges on its next poll instead.
-pub async fn get_acme_cert_cluster(store: &Store, domain: &str) -> Option<(Vec<u8>, Vec<u8>)> {
-    let cert_key = format!("{ACME_CERT_PREFIX}{domain}:cert");
-    let key_key = format!("{ACME_CERT_PREFIX}{domain}:key");
+pub async fn get_acme_cert_cluster(
+    store: &Store,
+    domain: &str,
+    directory_url: &str,
+) -> Option<(Vec<u8>, Vec<u8>)> {
+    let (cert_key, key_key) = dns01_cert_keys(domain, directory_url);
     let cert = store.get_cluster(&cert_key).await?;
     let key = store.get_cluster(&key_key).await?;
     Some((cert.to_vec(), key.to_vec()))
@@ -806,6 +838,7 @@ impl AccountCache for LayeredCache {
 #[cfg(test)]
 mod tests {
     use ephpm_kv::store::StoreConfig;
+    use instant_acme::LetsEncrypt;
 
     use super::*;
 
@@ -867,20 +900,41 @@ mod tests {
     fn acme_cert_store_and_retrieve() {
         let store = test_store();
         let domain = "example.com";
+        let dir = LetsEncrypt::Staging.url();
         let cert_pem = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----";
         let key_pem = b"-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----";
 
-        store_acme_cert(&store, domain, cert_pem, key_pem);
+        store_acme_cert(&store, domain, dir, cert_pem, key_pem);
 
-        let (cert, key) = get_acme_cert(&store, domain).unwrap();
+        let (cert, key) = get_acme_cert(&store, domain, dir).unwrap();
         assert_eq!(cert, cert_pem);
         assert_eq!(key, key_pem);
     }
 
     #[test]
+    fn acme_cert_is_namespaced_by_directory() {
+        // A staging certificate must not be visible under the production
+        // directory for the same domain — otherwise flipping `staging` serves
+        // the stale cert forever instead of ordering a fresh one.
+        let store = test_store();
+        let domain = "example.com";
+        let staging_cert = b"STAGING-CERT";
+        let staging_key = b"STAGING-KEY";
+        store_acme_cert(&store, domain, LetsEncrypt::Staging.url(), staging_cert, staging_key);
+
+        assert!(
+            get_acme_cert(&store, domain, LetsEncrypt::Production.url()).is_none(),
+            "the staging cert must not be visible under the production directory"
+        );
+        let (cert, _) = get_acme_cert(&store, domain, LetsEncrypt::Staging.url())
+            .expect("staging cert visible");
+        assert_eq!(cert, staging_cert);
+    }
+
+    #[test]
     fn acme_cert_missing_returns_none() {
         let store = test_store();
-        assert!(get_acme_cert(&store, "missing.com").is_none());
+        assert!(get_acme_cert(&store, "missing.com", LetsEncrypt::Staging.url()).is_none());
     }
 
     #[test]

--- a/crates/ephpm-server/src/dns01.rs
+++ b/crates/ephpm-server/src/dns01.rs
@@ -614,6 +614,17 @@ async fn run_dns01_lifecycle(ctx: Dns01Context) {
                     // just issued — a needless trip toward the rate limit.
                     last_issued =
                         read_issued_at(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical);
+                    // Publish our cached certificate to the cluster if it isn't
+                    // there yet. A leader that loaded from disk (e.g. a full-
+                    // cluster restart) never issued, so it never broadcast, and
+                    // followers would serve nothing on :443 until the next
+                    // renewal. Idempotent — a no-op when KV already has it.
+                    if republish_cached_cert_on_promotion(&ctx, last_issued) {
+                        tracing::info!(
+                            canonical = ctx.canonical,
+                            "DNS-01: re-published cached certificate to the cluster on leadership acquisition"
+                        );
+                    }
                     tracing::info!(node_id, "DNS-01: this node is now the ACME leader");
                 } else {
                     tracing::info!(node_id, "DNS-01: this node is no longer the ACME leader");
@@ -904,6 +915,40 @@ fn persist_cert(ctx: &Dns01Context, cert_pem: &[u8], key_pem: &[u8], issued: Sys
     write_file(&ctx.cache_dir.join(format!("{stem}.issued")), secs.to_string().as_bytes());
 }
 
+/// On acquiring leadership, ensure this node's cached certificate is present in
+/// the cluster KV so followers can install it.
+///
+/// # The gap this closes
+///
+/// [`store_acme_cert`](crate::acme::store_acme_cert) only runs at *issuance*.
+/// A leader that loaded its certificate from the local disk cache — e.g. after
+/// a full-cluster restart, where the lowest-id node comes up holding a still-
+/// valid cert — never orders, so it never broadcasts. Followers then find KV
+/// empty (and their own disk empty) and serve nothing on `:443`. This is the
+/// "two of three nodes have no certificate" failure.
+///
+/// Re-publishing our cached certificate on promotion fixes that without waiting
+/// for the renewal window. It is **idempotent and cheap**: it does nothing when
+/// the cluster KV already holds the certificate, or when this node has no cached
+/// certificate to publish (a fresh node — the ordering path handles that).
+///
+/// Returns `true` when a re-publish actually happened (for logging).
+fn republish_cached_cert_on_promotion(ctx: &Dns01Context, last_issued: Option<SystemTime>) -> bool {
+    let Some(store) = ctx.store.as_deref() else {
+        return false; // standalone: no cluster to publish to
+    };
+    if crate::acme::get_acme_cert(store, &ctx.canonical).is_some() {
+        return false; // the cluster already has our certificate
+    }
+    let Some((cert_pem, key_pem)) = load_cached_cert(Some(store), &ctx.cache_dir, &ctx.canonical)
+    else {
+        return false; // nothing cached to publish — the ordering path will issue
+    };
+    let issued = last_issued.unwrap_or_else(SystemTime::now);
+    persist_cert(ctx, &cert_pem, &key_pem, issued);
+    true
+}
+
 /// Load account credential JSON — KV first, then disk.
 fn load_account_creds(ctx: &Dns01Context) -> Option<Vec<u8>> {
     if let Some(store) = &ctx.store
@@ -1004,6 +1049,95 @@ mod tests {
         let cert = params.self_signed(&key).expect("self-sign");
         assert!(resolver.install(cert.pem().as_bytes(), key.serialize_pem().as_bytes()).is_ok());
         assert!(resolver.has_cert());
+    }
+
+    /// A DNS provider that does nothing — the promotion re-publish path never
+    /// touches DNS, so a no-op is enough to build a [`Dns01Context`].
+    #[derive(Debug)]
+    struct NoopProvider;
+
+    #[async_trait]
+    impl DnsProvider for NoopProvider {
+        async fn set_txt(&self, _fqdn: &str, _value: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn delete_txt(&self, _fqdn: &str, _value: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Build a `Dns01Context` backed by a single-node store and the given cache
+    /// dir. Returns the context plus a self-signed `(cert_pem, key_pem)`.
+    fn ctx_with_store(cache_dir: PathBuf) -> (Dns01Context, Vec<u8>, Vec<u8>) {
+        let domains = vec!["*.preview.ephpm.dev".to_string(), "preview.ephpm.dev".to_string()];
+        let canonical = canonical_domain_key(&domains);
+        let store = ephpm_kv::store::Store::new(ephpm_kv::store::StoreConfig::default());
+        let key = rcgen::KeyPair::generate().expect("keypair");
+        let params =
+            rcgen::CertificateParams::new(vec!["preview.ephpm.dev".to_string()]).expect("params");
+        let cert = params.self_signed(&key).expect("self-sign");
+        let cert_pem = cert.pem().into_bytes();
+        let key_pem = key.serialize_pem().into_bytes();
+        let ctx = Dns01Context {
+            resolver: Arc::new(Dns01CertResolver::new()),
+            provider: Arc::new(NoopProvider) as Arc<dyn DnsProvider>,
+            domains,
+            canonical,
+            contact: Vec::new(),
+            directory_url: LetsEncrypt::Staging.url().to_string(),
+            store: Some(store),
+            cache_dir,
+            node_id: "node-1".to_string(),
+        };
+        (ctx, cert_pem, key_pem)
+    }
+
+    /// The regression: a leader that loaded its certificate from the local disk
+    /// cache (no fresh order → no broadcast) must re-publish it to the cluster
+    /// KV on promotion, so followers can install it. Without this a full-cluster
+    /// restart leaves every non-leader node serving nothing on `:443`.
+    #[test]
+    fn promotion_republishes_disk_cached_cert_to_kv() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (ctx, cert_pem, key_pem) = ctx_with_store(dir.path().to_path_buf());
+        let store = ctx.store.clone().expect("store");
+
+        // Simulate a leader that has the cert on disk only — nothing in KV.
+        let stem = cache_stem(&ctx.canonical);
+        std::fs::write(dir.path().join(format!("{stem}.crt")), &cert_pem).expect("write crt");
+        std::fs::write(dir.path().join(format!("{stem}.key")), &key_pem).expect("write key");
+        assert!(
+            crate::acme::get_acme_cert(&store, &ctx.canonical).is_none(),
+            "precondition: KV must not yet hold the certificate"
+        );
+
+        // Promotion re-publishes it.
+        assert!(
+            republish_cached_cert_on_promotion(&ctx, Some(SystemTime::now())),
+            "a disk-cached cert must be re-published on promotion"
+        );
+        let (kv_cert, kv_key) =
+            crate::acme::get_acme_cert(&store, &ctx.canonical).expect("cert now in KV");
+        assert_eq!(kv_cert, cert_pem, "the KV cert must match the disk cert");
+        assert_eq!(kv_key, key_pem, "the KV key must match the disk key");
+
+        // Idempotent: a second promotion is a no-op now that KV holds it.
+        assert!(
+            !republish_cached_cert_on_promotion(&ctx, Some(SystemTime::now())),
+            "re-publishing must be a no-op when KV already has the cert"
+        );
+    }
+
+    /// A node with no cached certificate at all (fresh join) must not claim to
+    /// have re-published anything — the ordering path handles issuance.
+    #[test]
+    fn promotion_without_cached_cert_is_a_noop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (ctx, _cert, _key) = ctx_with_store(dir.path().to_path_buf());
+        assert!(
+            !republish_cached_cert_on_promotion(&ctx, None),
+            "nothing to publish when there is no cached certificate"
+        );
     }
 
     #[test]

--- a/crates/ephpm-server/src/dns01.rs
+++ b/crates/ephpm-server/src/dns01.rs
@@ -520,10 +520,17 @@ pub fn start_dns01_acme(
         .with_context(|| format!("creating DNS-01 cache directory {}", cache_dir.display()))?;
 
     let canonical = canonical_domain_key(&tls_config.domains);
+    let directory_url = if tls_config.staging {
+        LetsEncrypt::Staging.url().to_owned()
+    } else {
+        LetsEncrypt::Production.url().to_owned()
+    };
 
     // Seed the resolver from cache so a restart serves TLS immediately instead
     // of waiting for a fresh order. KV first (cluster-wide truth), then disk.
-    if let Some((cert, key)) = load_cached_cert(store.as_deref(), &cache_dir, &canonical) {
+    if let Some((cert, key)) =
+        load_cached_cert(store.as_deref(), &cache_dir, &canonical, &directory_url)
+    {
         match resolver.install(&cert, &key) {
             Ok(()) => {
                 tracing::info!(canonical, "DNS-01: seeded resolver from cached certificate");
@@ -545,11 +552,6 @@ pub fn start_dns01_acme(
 
     let contact =
         tls_config.email.as_ref().map(|e| vec![format!("mailto:{e}")]).unwrap_or_default();
-    let directory_url = if tls_config.staging {
-        LetsEncrypt::Staging.url().to_owned()
-    } else {
-        LetsEncrypt::Production.url().to_owned()
-    };
 
     let ctx = Dns01Context {
         resolver: Arc::clone(&resolver),
@@ -584,9 +586,9 @@ async fn run_dns01_lifecycle(ctx: Dns01Context) {
     let mut is_leader = false;
     let mut confirmations: u32 = 0;
     let mut last_issued: Option<SystemTime> =
-        read_issued_at(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical);
+        read_issued_at(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical, &ctx.directory_url);
     let mut installed_fp: Option<[u8; 32]> = if ctx.resolver.has_cert() {
-        load_cached_cert(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical)
+        load_cached_cert(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical, &ctx.directory_url)
             .map(|(cert, _)| fingerprint(&cert))
     } else {
         None
@@ -612,8 +614,12 @@ async fn run_dns01_lifecycle(ctx: Dns01Context) {
                     // On promotion, trust the KV issuance timestamp the previous
                     // leader wrote so we don't re-order a certificate that was
                     // just issued — a needless trip toward the rate limit.
-                    last_issued =
-                        read_issued_at(ctx.store.as_deref(), &ctx.cache_dir, &ctx.canonical);
+                    last_issued = read_issued_at(
+                        ctx.store.as_deref(),
+                        &ctx.cache_dir,
+                        &ctx.canonical,
+                        &ctx.directory_url,
+                    );
                     // Publish our cached certificate to the cluster if it isn't
                     // there yet. A leader that loaded from disk (e.g. a full-
                     // cluster restart) never issued, so it never broadcast, and
@@ -661,7 +667,7 @@ async fn run_dns01_lifecycle(ctx: Dns01Context) {
             }
         } else if let Some(store) = &ctx.store
             && let Some((cert_pem, key_pem)) =
-                crate::acme::get_acme_cert_cluster(store, &ctx.canonical).await
+                crate::acme::get_acme_cert_cluster(store, &ctx.canonical, &ctx.directory_url).await
         {
             // Follower: pick up the leader's certificate from the KV store.
             let fp = fingerprint(&cert_pem);
@@ -830,9 +836,28 @@ async fn load_or_create_account(ctx: &Dns01Context) -> anyhow::Result<Account> {
 
 // ── Cache helpers (KV + disk) ────────────────────────────────────────────────
 
-/// KV key for the certificate issuance timestamp (unix seconds).
-fn issued_kv_key(canonical: &str) -> String {
-    format!("acme:cert:{canonical}:issued")
+/// Short, stable hash of an ACME directory URL. Used to namespace every cache
+/// entry — KV keys **and** on-disk filenames — by environment, so a staging
+/// certificate (or its issuance timestamp) never shadows a production one for
+/// the same domain set. Without this, flipping `[server.tls] staging` leaves the
+/// previous environment's material in the cache and `load_cached_cert` (which
+/// reads cache-first and never inspects the issuer) would serve it forever.
+fn directory_hash(directory_url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(directory_url.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(16);
+    for b in &digest[..8] {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// KV key for the certificate issuance timestamp (unix seconds), namespaced by
+/// the ACME directory URL — see [`directory_hash`].
+fn issued_kv_key(canonical: &str, directory_url: &str) -> String {
+    format!("acme:cert:{canonical}:issued:{}", directory_hash(directory_url))
 }
 
 /// Build the `_acme-challenge.<domain>` FQDN, tolerating a wildcard prefix.
@@ -863,18 +888,27 @@ fn cache_stem(canonical: &str) -> String {
         .collect()
 }
 
+/// On-disk filename stem, namespaced by ACME directory so staging and production
+/// certificates for the same domain set never share a file — see
+/// [`directory_hash`]. The KV keys are namespaced the same way, so cache-first
+/// reads stay consistent across the staging→production flip.
+fn cache_stem_for(canonical: &str, directory_url: &str) -> String {
+    format!("{}-{}", cache_stem(canonical), directory_hash(directory_url))
+}
+
 /// Load a cached cert `(cert_pem, key_pem)` — KV first, then disk.
 fn load_cached_cert(
     store: Option<&Store>,
     cache_dir: &Path,
     canonical: &str,
+    directory_url: &str,
 ) -> Option<(Vec<u8>, Vec<u8>)> {
     if let Some(store) = store
-        && let Some((cert, key)) = crate::acme::get_acme_cert(store, canonical)
+        && let Some((cert, key)) = crate::acme::get_acme_cert(store, canonical, directory_url)
     {
         return Some((cert, key));
     }
-    let stem = cache_stem(canonical);
+    let stem = cache_stem_for(canonical, directory_url);
     let cert = std::fs::read(cache_dir.join(format!("{stem}.crt"))).ok()?;
     let key = std::fs::read(cache_dir.join(format!("{stem}.key"))).ok()?;
     if cert.is_empty() || key.is_empty() {
@@ -884,14 +918,19 @@ fn load_cached_cert(
 }
 
 /// Read the issuance timestamp — KV first, then the on-disk sidecar.
-fn read_issued_at(store: Option<&Store>, cache_dir: &Path, canonical: &str) -> Option<SystemTime> {
+fn read_issued_at(
+    store: Option<&Store>,
+    cache_dir: &Path,
+    canonical: &str,
+    directory_url: &str,
+) -> Option<SystemTime> {
     if let Some(store) = store
-        && let Some(bytes) = store.get(&issued_kv_key(canonical))
+        && let Some(bytes) = store.get(&issued_kv_key(canonical, directory_url))
         && let Some(t) = parse_unix_secs(bytes.as_ref())
     {
         return Some(t);
     }
-    let stem = cache_stem(canonical);
+    let stem = cache_stem_for(canonical, directory_url);
     let bytes = std::fs::read(cache_dir.join(format!("{stem}.issued"))).ok()?;
     parse_unix_secs(&bytes)
 }
@@ -906,10 +945,14 @@ fn persist_cert(ctx: &Dns01Context, cert_pem: &[u8], key_pem: &[u8], issued: Sys
     let secs =
         issued.duration_since(SystemTime::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or_default();
     if let Some(store) = &ctx.store {
-        crate::acme::store_acme_cert(store, &ctx.canonical, cert_pem, key_pem);
-        store.set(issued_kv_key(&ctx.canonical), secs.to_string().into_bytes(), None);
+        crate::acme::store_acme_cert(store, &ctx.canonical, &ctx.directory_url, cert_pem, key_pem);
+        store.set(
+            issued_kv_key(&ctx.canonical, &ctx.directory_url),
+            secs.to_string().into_bytes(),
+            None,
+        );
     }
-    let stem = cache_stem(&ctx.canonical);
+    let stem = cache_stem_for(&ctx.canonical, &ctx.directory_url);
     write_file(&ctx.cache_dir.join(format!("{stem}.crt")), cert_pem);
     write_file(&ctx.cache_dir.join(format!("{stem}.key")), key_pem);
     write_file(&ctx.cache_dir.join(format!("{stem}.issued")), secs.to_string().as_bytes());
@@ -937,10 +980,11 @@ fn republish_cached_cert_on_promotion(ctx: &Dns01Context, last_issued: Option<Sy
     let Some(store) = ctx.store.as_deref() else {
         return false; // standalone: no cluster to publish to
     };
-    if crate::acme::get_acme_cert(store, &ctx.canonical).is_some() {
+    if crate::acme::get_acme_cert(store, &ctx.canonical, &ctx.directory_url).is_some() {
         return false; // the cluster already has our certificate
     }
-    let Some((cert_pem, key_pem)) = load_cached_cert(Some(store), &ctx.cache_dir, &ctx.canonical)
+    let Some((cert_pem, key_pem)) =
+        load_cached_cert(Some(store), &ctx.cache_dir, &ctx.canonical, &ctx.directory_url)
     else {
         return false; // nothing cached to publish — the ordering path will issue
     };
@@ -1103,11 +1147,11 @@ mod tests {
         let store = ctx.store.clone().expect("store");
 
         // Simulate a leader that has the cert on disk only — nothing in KV.
-        let stem = cache_stem(&ctx.canonical);
+        let stem = cache_stem_for(&ctx.canonical, &ctx.directory_url);
         std::fs::write(dir.path().join(format!("{stem}.crt")), &cert_pem).expect("write crt");
         std::fs::write(dir.path().join(format!("{stem}.key")), &key_pem).expect("write key");
         assert!(
-            crate::acme::get_acme_cert(&store, &ctx.canonical).is_none(),
+            crate::acme::get_acme_cert(&store, &ctx.canonical, &ctx.directory_url).is_none(),
             "precondition: KV must not yet hold the certificate"
         );
 
@@ -1117,7 +1161,8 @@ mod tests {
             "a disk-cached cert must be re-published on promotion"
         );
         let (kv_cert, kv_key) =
-            crate::acme::get_acme_cert(&store, &ctx.canonical).expect("cert now in KV");
+            crate::acme::get_acme_cert(&store, &ctx.canonical, &ctx.directory_url)
+                .expect("cert now in KV");
         assert_eq!(kv_cert, cert_pem, "the KV cert must match the disk cert");
         assert_eq!(kv_key, key_pem, "the KV key must match the disk key");
 
@@ -1146,6 +1191,37 @@ mod tests {
         let production = account_kv_key(LetsEncrypt::Production.url());
         assert_ne!(staging, production);
         assert!(staging.starts_with("acme:account:dns01:"));
+    }
+
+    /// The staging→production flip must not be shadowed by a stale cert. After a
+    /// staging cert is published, a node reading under the *production* directory
+    /// (i.e. after `staging = false`) must see nothing — so its ordering path
+    /// issues a fresh production cert instead of serving the staging one forever.
+    #[test]
+    fn staging_cert_does_not_shadow_production_across_the_flip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut ctx, cert_pem, key_pem) = ctx_with_store(dir.path().to_path_buf());
+        let store = ctx.store.clone().expect("store");
+
+        // A staging leader publishes its cert + issuance timestamp to KV.
+        ctx.directory_url = LetsEncrypt::Staging.url().to_string();
+        persist_cert(&ctx, &cert_pem, &key_pem, SystemTime::now());
+        assert!(
+            read_issued_at(Some(&store), &ctx.cache_dir, &ctx.canonical, &ctx.directory_url)
+                .is_some(),
+            "staging issuance timestamp must be readable under the staging directory"
+        );
+
+        // After the flip, the same node reads under the production directory.
+        let prod = LetsEncrypt::Production.url();
+        assert!(
+            crate::acme::get_acme_cert(&store, &ctx.canonical, prod).is_none(),
+            "the staging cert must not be visible to a production reader"
+        );
+        assert!(
+            read_issued_at(Some(&store), &ctx.cache_dir, &ctx.canonical, prod).is_none(),
+            "the staging issuance timestamp must not be visible to a production reader"
+        );
     }
 
     /// A minimal one-shot HTTP server that captures the first request and


### PR DESCRIPTION
Two related fixes to clustered DNS-01 certificate distribution, both found while bringing up TLS on the 3-node preview cluster.

## 1. Re-publish the cached cert to the cluster on leadership acquisition

`store_acme_cert` only broadcasts at **issuance**. A leader that comes up holding a still-valid cert in its local disk cache (normal after a full-cluster restart — lowest node id wins the election) seeds from disk *without ordering*, so it never broadcasts. Followers then find KV empty and serve **nothing on :443** — the 'two of three nodes have no certificate' failure, reproduced live this session.

Fix: on the leadership-acquisition transition, republish the cached cert to KV (idempotent — no-op when KV already has it, or when the node has no cached cert).

## 2. Namespace the DNS-01 cert cache by ACME directory (staging vs production)

The DNS-01 cert KV keys **and** on-disk cache files were keyed only by domain set, never by ACME directory — unlike the account key and the TLS-ALPN cert key, which already namespace by directory. So flipping `staging = false` left the staging cert in KV and on disk under the exact key/filename the production reader looks up; `load_cached_cert`/`read_issued_at` read cache-first and never inspect the issuer, so nodes would silently keep serving the untrusted staging cert and never order a production one.

Fix: namespace every DNS-01 cache entry (KV keys + disk filenames) by `directory_hash(directory_url)`.

## Tests
`promotion_republishes_disk_cached_cert_to_kv`, `promotion_without_cached_cert_is_a_noop`, `acme_cert_is_namespaced_by_directory`, `staging_cert_does_not_shadow_production_across_the_flip`. Full lib suite (493) + clippy `-D warnings` + nightly fmt all clean.

## Live validation
Fix #1 already validated on the preview cluster: after redeploy, node-1 logged `re-published cached certificate to the cluster on leadership acquisition` and all three nodes served the staging wildcard cert on :443 (was 1/3).