### PR TITLE
feat(php): experimental PHP 8.6.0beta1 lane (non-gating)

### DIFF
--- a/.github/workflows/release-php-beta.yml
+++ b/.github/workflows/release-php-beta.yml
@@ -1,0 +1,365 @@
+name: Release (PHP beta, experimental)
+
+# EXPERIMENTAL, MANUAL-ONLY lane for building ephpm against an upstream PHP
+# PRE-RELEASE (beta/RC) SDK — today PHP 8.6.0beta1 (see xtask
+# EXPERIMENTAL_PHP_VERSIONS). This workflow is deliberately SEPARATE from
+# release.yml so that:
+#
+#   * a stable `v*` tag release never builds, gates on, or ships a beta binary;
+#   * the beta SDK not existing / not building can never block a real release;
+#   * the beta artifacts never enter release.yml's artifact collector or its
+#     SHA256SUMS (that collector sweeps every `ephpm-v*` artifact of a run — a
+#     beta job uploading into the same run would pollute the stable release).
+#
+# It is workflow_dispatch ONLY. A human cuts the first beta build. It builds the
+# four OS/arch targets against the pinned pre-release SDK and uploads them as
+# workflow artifacts; with `publish=true` from a tag ref it additionally
+# publishes a GitHub PRE-RELEASE (never promoted to "Latest").
+#
+# Prerequisite: the beta SDK must already be published at
+# github.com/ephpm/php-sdk (tag `v<full>`, e.g. v8.6.0beta1) for every target
+# `cargo xtask release` downloads. See php-sdk build.yml's beta handling.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish a GitHub pre-release from the built archives (requires dispatching from a v* tag). Off = build + upload workflow artifacts only."
+        type: boolean
+        default: false
+
+# Never run two beta builds at once, and queue behind (do not cancel) a stable
+# release — both draw on the same self-hosted fleet. Distinct group from
+# ephpm-release so a beta build cannot cancel a real release, only serialize.
+concurrency:
+  group: ephpm-release-php-beta
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Derive the experimental (pre-release) matrix from the single source of
+  # truth, xtask::EXPERIMENTAL_PHP_VERSIONS. Empty table => empty matrix =>
+  # every build job self-skips (zero matrix runs).
+  setup:
+    name: Derive experimental PHP matrix
+    runs-on: [self-hosted, linux, x64]
+    outputs:
+      experimental_matrix: ${{ steps.matrix.outputs.experimental_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Emit experimental matrix from xtask EXPERIMENTAL_PHP_VERSIONS
+        id: matrix
+        run: |
+          docker run --rm -v "$PWD":/w -w /w \
+            ephpm/ephpm-ci:latest \
+            cargo run --quiet -p xtask -- php-versions --github-matrix >> "$GITHUB_OUTPUT"
+
+  # -- Linux x86_64 (glibc 2.28 floor via ephpm-ci) ---------------------------
+  build-linux:
+    name: Beta (PHP ${{ matrix.php.full }}, linux-x86_64)
+    needs: setup
+    if: needs.setup.outputs.experimental_matrix != '[]'
+    runs-on: [self-hosted, linux, x64]
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ${{ fromJSON(needs.setup.outputs.experimental_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build ephpm in the ephpm-ci container
+        run: |
+          set -eu
+          docker run --rm -v "$PWD":/w -w /w \
+            -e EPHPM_RELEASE_VERSION="${GITHUB_REF_NAME#v}" \
+            -e CARGO_PROFILE_RELEASE_LTO="fat" \
+            -e CARGO_TERM_COLOR=always \
+            ephpm/ephpm-ci:latest \
+            sh -euc '
+              command -v clang >/dev/null 2>&1 \
+                || (apt-get update && apt-get install -y --no-install-recommends clang llvm) \
+                || echo "::warning::clang install failed; ebpf_policy will be stubbed"
+              cargo xtask release ${{ matrix.php.minor }}
+            '
+      - name: Package archive
+        id: pkg
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php.full }}
+        run: |
+          set -eu
+          name="ephpm-${VERSION}+php${PHP_FULL}-linux-x86_64"
+          mkdir -p "dist/${name}"
+          cp "target/x86_64-unknown-linux-gnu/release/ephpm" "dist/${name}/ephpm"
+          cp LICENSE "dist/${name}/LICENSE"
+          cp .github/release-readme.txt "dist/${name}/README.txt"
+          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
+          rm -rf "dist/${name}"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-linux-x86_64
+          path: ${{ steps.pkg.outputs.archive }}
+
+  # -- macOS aarch64 (native) -------------------------------------------------
+  build-macos:
+    name: Beta (PHP ${{ matrix.php.full }}, macos-aarch64)
+    needs: setup
+    if: needs.setup.outputs.experimental_matrix != '[]'
+    runs-on: [self-hosted, macos, arm64]
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        php: ${{ fromJSON(needs.setup.outputs.experimental_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Compute release version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -eu
+          echo "EPHPM_RELEASE_VERSION=${REF_NAME#v}" >> "$GITHUB_ENV"
+      - name: Pin libclang for bindgen
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          brew install llvm@17 || brew upgrade llvm@17 || true
+          LLVM_PREFIX=$(brew --prefix llvm@17)
+          LLVM_RESOURCE_DIR=$(ls -d "${LLVM_PREFIX}"/lib/clang/* | head -1)
+          echo "LIBCLANG_PATH=${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+          echo "BINDGEN_EXTRA_CLANG_ARGS=-resource-dir=${LLVM_RESOURCE_DIR}" >> "$GITHUB_ENV"
+      - name: Build ephpm
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
+        run: cargo xtask release ${{ matrix.php.minor }}
+      - name: Package archive
+        id: pkg
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php.full }}
+        run: |
+          set -eu
+          name="ephpm-${VERSION}+php${PHP_FULL}-macos-aarch64"
+          mkdir -p "dist/${name}"
+          cp target/aarch64-apple-darwin/release/ephpm "dist/${name}/ephpm"
+          cp LICENSE "dist/${name}/LICENSE"
+          cp .github/release-readme.txt "dist/${name}/README.txt"
+          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
+          rm -rf "dist/${name}"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-macos-aarch64
+          path: ${{ steps.pkg.outputs.archive }}
+
+  # -- Linux aarch64 (glibc, in the macOS host's linux VM) --------------------
+  build-linux-arm64:
+    name: Beta (PHP ${{ matrix.php.full }}, linux-aarch64)
+    needs: [build-macos, setup]
+    if: needs.setup.outputs.experimental_matrix != '[]'
+    runs-on: [self-hosted, linux, arm64]
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        php: ${{ fromJSON(needs.setup.outputs.experimental_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build ephpm in the ephpm-ci container
+        run: |
+          set -eu
+          docker run --rm -v "$PWD":/w -w /w \
+            -e EPHPM_RELEASE_VERSION="${GITHUB_REF_NAME#v}" \
+            -e CARGO_PROFILE_RELEASE_LTO="off" \
+            -e CARGO_TERM_COLOR=always \
+            ephpm/ephpm-ci:latest-arm64 \
+            sh -euc '
+              command -v clang >/dev/null 2>&1 \
+                || (apt-get update && apt-get install -y --no-install-recommends clang llvm) \
+                || echo "::warning::clang install failed; ebpf_policy will be stubbed"
+              cargo xtask release ${{ matrix.php.minor }}
+            '
+      - name: Package archive
+        id: pkg
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php.full }}
+        run: |
+          set -eu
+          name="ephpm-${VERSION}+php${PHP_FULL}-linux-aarch64"
+          mkdir -p "dist/${name}"
+          cp "target/aarch64-unknown-linux-gnu/release/ephpm" "dist/${name}/ephpm"
+          cp LICENSE "dist/${name}/LICENSE"
+          cp .github/release-readme.txt "dist/${name}/README.txt"
+          tar -C dist -czf "dist/${name}.tar.gz" "${name}"
+          rm -rf "dist/${name}"
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-linux-aarch64
+          path: ${{ steps.pkg.outputs.archive }}
+
+  # -- Windows x86_64 (native MSVC) -------------------------------------------
+  build-windows:
+    name: Beta (PHP ${{ matrix.php.full }}, windows-x86_64)
+    needs: setup
+    if: needs.setup.outputs.experimental_matrix != '[]'
+    runs-on: [self-hosted, windows, x64]
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        php: ${{ fromJSON(needs.setup.outputs.experimental_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        shell: powershell
+        run: |
+          $cargoBin = "$env:USERPROFILE\.cargo\bin"
+          if (-not (Test-Path "$cargoBin\rustup.exe")) {
+            Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+            .\rustup-init.exe -y --default-toolchain stable --profile minimal
+            Remove-Item rustup-init.exe
+          }
+          $env:PATH = "$cargoBin;$env:PATH"
+          $cargoBin | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & "$cargoBin\rustup.exe" show
+      - name: Install Visual Studio Build Tools
+        shell: powershell
+        run: |
+          $installPath = "C:\BuildTools"
+          $msbuild = "$installPath\MSBuild\Current\Bin\MSBuild.exe"
+          if (Test-Path $msbuild) {
+            Write-Host "VS Build Tools already present at $installPath"
+          } else {
+            Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_buildtools.exe" -OutFile vs_buildtools.exe
+            $proc = Start-Process -FilePath .\vs_buildtools.exe `
+              -ArgumentList @(
+                '--quiet', '--wait', '--norestart', '--nocache',
+                '--installPath', $installPath,
+                '--add', 'Microsoft.VisualStudio.Workload.VCTools',
+                '--add', 'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
+                '--includeRecommended'
+              ) -Wait -PassThru -NoNewWindow
+            Remove-Item vs_buildtools.exe
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while (-not (Test-Path $msbuild) -and $sw.Elapsed.TotalMinutes -lt 20) {
+              Start-Sleep -Seconds 30
+              Write-Host ("  ...waiting for VS install ({0:F0}s)" -f $sw.Elapsed.TotalSeconds)
+            }
+            if (-not (Test-Path $msbuild)) {
+              Write-Host "::error::VS install timed out - $msbuild never appeared"
+              exit 1
+            }
+          }
+      - name: Enter MSVC developer environment
+        shell: powershell
+        run: |
+          $vcvars = "C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { Write-Error "vcvars64.bat not found"; exit 1 }
+          $envBefore = @{}
+          foreach ($e in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+            $envBefore[$e.Key] = $e.Value
+          }
+          $cmdLine = 'call "' + $vcvars + '" >NUL & set'
+          $output = & cmd /c $cmdLine
+          foreach ($line in $output) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              if ($envBefore[$matches[1]] -ne $matches[2]) {
+                "$($matches[1])=$($matches[2])" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+              }
+            }
+          }
+          $libclangDir = "C:\BuildTools\VC\Tools\Llvm\x64\bin"
+          if (Test-Path "$libclangDir\libclang.dll") {
+            "LIBCLANG_PATH=$libclangDir" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          } else {
+            Write-Warning "libclang.dll not found at $libclangDir -- bindgen may panic"
+          }
+      - name: Compute release version
+        shell: powershell
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          $version = $env:REF_NAME -replace '^v',''
+          "EPHPM_RELEASE_VERSION=$version" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+      - name: Build ephpm.exe
+        shell: powershell
+        env:
+          CARGO_PROFILE_RELEASE_LTO: "off"
+          RUST_MIN_STACK: "33554432"
+        run: cargo xtask release ${{ matrix.php.minor }} --target windows
+      - name: Package archive
+        id: pkg
+        shell: powershell
+        env:
+          VERSION: ${{ github.ref_name }}
+          PHP_FULL: ${{ matrix.php.full }}
+        run: |
+          $name = "ephpm-$env:VERSION+php$env:PHP_FULL-windows-x86_64"
+          $stage = "dist\$name"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item target\x86_64-pc-windows-msvc\release\ephpm.exe "$stage\ephpm.exe"
+          Copy-Item LICENSE "$stage\LICENSE"
+          Copy-Item .github\release-readme.txt "$stage\README.txt"
+          tar -C dist -czf "dist\$name.tar.gz" $name
+          Remove-Item -Recurse -Force $stage
+          "archive=dist/$name.tar.gz" | Out-File -Append -FilePath $env:GITHUB_OUTPUT -Encoding utf8
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-windows-x86_64
+          path: ${{ steps.pkg.outputs.archive }}
+
+  # -- Optional pre-release publish -------------------------------------------
+  # Gathers whatever archives the (non-gating) build jobs produced and, only
+  # when dispatched from a v* tag with publish=true, attaches them to a GitHub
+  # PRE-RELEASE tagged v<ref>+php<beta>. Marked prerelease so it is never
+  # promoted to "Latest". Non-gating: `!cancelled()` + `always()`-style guard so
+  # a red OS leg still publishes the ones that succeeded.
+  publish:
+    name: Publish pre-release (optional)
+    needs: [build-linux, build-linux-arm64, build-macos, build-windows]
+    if: ${{ !cancelled() && inputs.publish && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: [self-hosted, linux, x64]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: ephpm-beta-*
+          merge-multiple: true
+      - name: Assemble archives + SHA256SUMS
+        id: collect
+        run: |
+          set -eu
+          mkdir -p release
+          find artifacts -type f -name '*.tar.gz' -exec cp {} release/ \;
+          if [ -z "$(ls -A release 2>/dev/null)" ]; then
+            echo "::error::no beta archives were produced by any OS leg"
+            exit 1
+          fi
+          (cd release && sha256sum *.tar.gz | sort > SHA256SUMS)
+          ls -lh release/
+      - name: Create GitHub pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          tag_name: ${{ github.ref_name }}
+          name: "${{ github.ref_name }} (PHP beta, experimental)"
+          prerelease: true
+          body: |
+            EXPERIMENTAL ephpm build linked against an upstream PHP pre-release
+            SDK. Not for production. See release-php-beta.yml.

--- a/site/content/developer/architecture-overview.md
+++ b/site/content/developer/architecture-overview.md
@@ -822,6 +822,7 @@ This is the same approach FrankenPHP uses.
 | PHP 8.3 | Active support (until Dec 2026) | **Supported — in CI (pinned 8.3.33)** |
 | PHP 8.4 | Active support (until Dec 2027) | **Supported — in CI (pinned 8.4.23)** |
 | PHP 8.5 | Active support | **Supported — in CI (pinned 8.5.7)** |
+| PHP 8.6 | Beta (8.6.0beta1, Aug 2026) | Experimental — pre-release, not GA. Built only by the manual `release-php-beta.yml` lane against a beta SDK; never part of a stable release. |
 
 ### Release Naming
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,26 @@ mod php_versions;
 /// resolver will accept it as-is.
 const PHP_SDK_VERSIONS: &[(&str, &str)] = &[("8.3", "8.3.33"), ("8.4", "8.4.23"), ("8.5", "8.5.7")];
 
+/// EXPERIMENTAL: PHP minors published only as an upstream pre-release (beta/RC).
+///
+/// Deliberately kept OUT of `PHP_SDK_VERSIONS`. Entries here:
+///   * carry a pre-release version string (e.g. "8.6.0beta1") that is not a
+///     valid `bump-php-pin` target (`bump::is_patch_of` rejects a non-numeric
+///     patch) and that `sdk-bump.yml`'s `("8.X", "8.X.Y")` pin regex does not
+///     match — so the nightly auto-bump and the `bump-php-pin --check` drift
+///     detector never touch them;
+///   * are absent from the gating release matrices (`php_matrix` /
+///     `docker_matrix`), so a beta SDK that is missing or fails to build can
+///     never block a stable `v*` release;
+///   * are built only by the manually-dispatched `release-php-beta.yml` lane,
+///     which reads the `experimental_matrix` from `cargo xtask php-versions`.
+///
+/// `resolve_php_version` accepts these minors so `cargo xtask release 8.6` and
+/// `cargo xtask php-sdk 8.6` resolve to the pinned beta once its SDK is
+/// published at github.com/ephpm/php-sdk. Not GA — do not document 8.6 as
+/// supported.
+const EXPERIMENTAL_PHP_VERSIONS: &[(&str, &str)] = &[("8.6", "8.6.0beta1")];
+
 /// Default PHP minor when no version is specified on the command line.
 const DEFAULT_PHP_MINOR: &str = "8.5";
 
@@ -450,9 +470,16 @@ fn release_windows(args: &[String]) -> ExitCode {
 /// in the table (in that case, the download will simply fail with a 404
 /// and the error message will point at the missing release tag).
 fn resolve_php_version(input: &str) -> Option<String> {
-    if let Some((_, full)) = PHP_SDK_VERSIONS.iter().find(|(short, _)| *short == input) {
+    if let Some((_, full)) = PHP_SDK_VERSIONS
+        .iter()
+        .chain(EXPERIMENTAL_PHP_VERSIONS.iter())
+        .find(|(short, _)| *short == input)
+    {
         return Some((*full).to_string());
     }
+    // A full version accepts two dots. Numeric patches ("8.5.2") and
+    // pre-release strings ("8.6.0beta1") both pass — the download simply 404s
+    // if no matching php-sdk release tag exists.
     if input.matches('.').count() == 2 {
         return Some(input.to_string());
     }
@@ -460,6 +487,9 @@ fn resolve_php_version(input: &str) -> Option<String> {
     eprintln!("       supported minors:");
     for (short, full) in PHP_SDK_VERSIONS {
         eprintln!("         {short}  → {full}");
+    }
+    for (short, full) in EXPERIMENTAL_PHP_VERSIONS {
+        eprintln!("         {short}  → {full}  (experimental, pre-release)");
     }
     eprintln!("       or pass a full version like 8.5.2 to use that release tag directly");
     None

--- a/xtask/src/php_versions.rs
+++ b/xtask/src/php_versions.rs
@@ -24,7 +24,7 @@
 
 use std::process::ExitCode;
 
-use crate::{DEFAULT_PHP_MINOR, PHP_SDK_VERSIONS, TAILCALL_MINORS};
+use crate::{DEFAULT_PHP_MINOR, EXPERIMENTAL_PHP_VERSIONS, PHP_SDK_VERSIONS, TAILCALL_MINORS};
 
 /// JSON array of every pinned `{minor, full}` pair.
 ///
@@ -52,6 +52,21 @@ fn tailcall_matrix_json() -> String {
     format!("[{}]", items.join(","))
 }
 
+/// JSON array of every EXPERIMENTAL (pre-release) `{minor, full}` pair.
+///
+/// The matrix for the manually-dispatched, non-gating `release-php-beta.yml`
+/// lane. Sourced from `EXPERIMENTAL_PHP_VERSIONS`, which is kept separate from
+/// `PHP_SDK_VERSIONS` so a beta never enters the gating release matrix, the
+/// docker matrix, or the auto-bump. Empty (`[]`) when no beta is pinned, which
+/// expands to zero matrix runs — the lane self-skips.
+fn experimental_matrix_json() -> String {
+    let items: Vec<String> = EXPERIMENTAL_PHP_VERSIONS
+        .iter()
+        .map(|(minor, full)| format!(r#"{{"minor":"{minor}","full":"{full}"}}"#))
+        .collect();
+    format!("[{}]", items.join(","))
+}
+
 /// JSON array of every pinned `{minor, full, default}` triple.
 ///
 /// The matrix for `docker-image`. `default` marks the minor whose images get
@@ -74,8 +89,9 @@ fn docker_matrix_json() -> String {
 
 /// Entry point for `cargo xtask php-versions [--github-matrix | --json]`.
 ///
-/// * `--github-matrix` prints the three `key=value` lines the `release.yml`
-///   `setup` job appends to `$GITHUB_OUTPUT`.
+/// * `--github-matrix` prints the `key=value` lines the release workflows'
+///   `setup` jobs append to `$GITHUB_OUTPUT` (`php_matrix`, `tailcall_matrix`,
+///   `experimental_matrix`, `docker_matrix`).
 /// * otherwise (or with `--json`) prints one combined JSON object — a
 ///   human/debug view and a stable contract for any other consumer.
 pub fn run(args: &[String]) -> ExitCode {
@@ -86,12 +102,14 @@ pub fn run(args: &[String]) -> ExitCode {
         // array (no newlines inside), so the plain `key=value` form is safe.
         println!("php_matrix={}", php_matrix_json());
         println!("tailcall_matrix={}", tailcall_matrix_json());
+        println!("experimental_matrix={}", experimental_matrix_json());
         println!("docker_matrix={}", docker_matrix_json());
     } else {
         println!(
-            r#"{{"php_matrix":{},"tailcall_matrix":{},"docker_matrix":{}}}"#,
+            r#"{{"php_matrix":{},"tailcall_matrix":{},"experimental_matrix":{},"docker_matrix":{}}}"#,
             php_matrix_json(),
             tailcall_matrix_json(),
+            experimental_matrix_json(),
             docker_matrix_json()
         );
     }
@@ -136,6 +154,30 @@ mod tests {
             );
         }
         assert_eq!(json.matches(r#""minor""#).count(), TAILCALL_MINORS.len(), "{json}");
+    }
+
+    /// `experimental_matrix` is exactly `EXPERIMENTAL_PHP_VERSIONS`, and none of
+    /// its (pre-release) minors leak into the gating `php_matrix` — that
+    /// separation is what keeps a beta from ever gating a stable release.
+    #[test]
+    fn experimental_matrix_is_disjoint_from_the_gating_matrix() {
+        let exp = experimental_matrix_json();
+        assert_eq!(
+            exp.matches(r#""minor""#).count(),
+            EXPERIMENTAL_PHP_VERSIONS.len(),
+            "experimental_matrix object count must equal the table length: {exp}"
+        );
+        let php = php_matrix_json();
+        for (minor, full) in EXPERIMENTAL_PHP_VERSIONS {
+            assert!(
+                exp.contains(&format!(r#"{{"minor":"{minor}","full":"{full}"}}"#)),
+                "experimental_matrix missing {minor} → {full}: {exp}"
+            );
+            assert!(
+                !php.contains(&format!(r#""minor":"{minor}""#)),
+                "experimental minor {minor} leaked into the gating php_matrix: {php}"
+            );
+        }
     }
 
     /// `docker_matrix` marks exactly the default minor `true` and every other


### PR DESCRIPTION
Adds an **experimental, non-gating** PHP 8.6.0beta1 build lane — additive to the stable 8.3/8.4/8.5 matrix, never blocks a `v*` release.

- `xtask`: new `EXPERIMENTAL_PHP_VERSIONS = [("8.6","8.6.0beta1")]`, kept **separate** from the gating `PHP_SDK_VERSIONS` (so `bump-php-pin --check`, `is_patch_of`, and lockstep gating are untouched); `resolve_php_version` accepts the `8.6` shorthand; a unit test proves the experimental matrix is disjoint from the gating one.
- `.github/workflows/release-php-beta.yml`: `workflow_dispatch`-only, all four OSes, `continue-on-error`, never in the stable release's `needs`/collector — mirrors the isolated TAILCALL lane.
- Docs: 8.6 row labeled experimental/pre-release.

Verified: `cargo test -p xtask` (green, incl. new test), clippy `-D warnings`, nightly fmt, and `bump-php-pin --check` all pass; stable 8.3/8.4/8.5 matrix output unchanged.

**Pairs with php-sdk beta-build support.** Nothing runs until `release-php-beta.yml` is dispatched. Windows 8.6 embed is unproven — expect the Windows leg to be the first thing to fail on a real build. Authored by a sub-agent; PR 1 is fully verified locally.