### PR TITLE
docs: PR preview bot guide, DNS-01 provider config, and roadmap reconciliation

### DIFF
--- a/site/content/analysis/certmagic.md
+++ b/site/content/analysis/certmagic.md
@@ -90,6 +90,14 @@ tokio::spawn(async move {
 
 **Primary: `rustls-acme`** for the core automatic HTTPS flow (TLS-ALPN-01 and HTTP-01 challenges). This covers 90% of use cases — single-domain and multi-domain certs with zero config.
 
+> **Update — shipped.** The DNS-01 lane described below as "secondary/future"
+> is now implemented. ePHPm runs its own ACME order state machine over
+> `instant-acme` with a `DnsProvider` trait and five provider wrappers
+> (Cloudflare, Linode, DigitalOcean, AWS Route 53, Google Cloud DNS), selected
+> by [`[server.tls] dns_provider`](/reference/config/#servertls). See the
+> [TLS / ACME guide](/guides/tls-acme/#dns-01-challenge-wildcards). The
+> paragraph below is the original design rationale, kept for context.
+
 **Secondary: `instant-acme`** for DNS-01 challenge support (needed for wildcard certs like `*.example.com`). DNS-01 requires calling DNS provider APIs (Cloudflare, Route53, etc.) to create TXT records. The Rust ecosystem doesn't have a `libdns` equivalent (Go's pluggable DNS provider library), so ePHPm would need thin wrappers for each provider:
 
 ```rust

--- a/site/content/architecture/security.md
+++ b/site/content/architecture/security.md
@@ -171,11 +171,19 @@ Both modes ship: manual `[server.tls] cert` + `key`, and ACME via
 
 - **No custom crypto.** Everything goes through `rustls` — no OpenSSL C code
   in the TLS path.
-- **ACME uses `rustls-acme` with TLS-ALPN-01 challenges only.** DNS-01 and
-  HTTP-01 are not implemented, so **wildcard certificates cannot be issued**
-  (wildcards require DNS-01). Name every host explicitly in `domains`.
+- **Two ACME challenge types ship.** The default `challenge = "tls-alpn-01"`
+  (via `rustls-acme`) answers inline on the TLS listener; HTTP-01 is not
+  implemented. `challenge = "dns-01"` publishes a `_acme-challenge` TXT record
+  through a DNS provider (Cloudflare, Linode, DigitalOcean, AWS Route 53, or
+  Google Cloud DNS) and is **the only lane that can issue a wildcard
+  certificate** (`*.example.com`). With TLS-ALPN-01 you must still name every
+  host explicitly in `domains`.
 
-Two gaps you must plan around in a cluster:
+Two gaps below apply to the **TLS-ALPN-01** lane in a cluster. The **DNS-01**
+lane avoids both — the leader answers the challenge over DNS (nothing has to
+reach a specific node) and its certificate resolver is hot-swappable, so a
+follower installs a renewed certificate from the KV store without a restart —
+which makes DNS-01 the better fit for clustered deployments:
 
 - **Challenge tokens are not shared between nodes.** A node can serve
   `/.well-known/acme-challenge/<token>` from the KV store, but nothing

--- a/site/content/guides/_index.md
+++ b/site/content/guides/_index.md
@@ -9,7 +9,8 @@ Task-oriented walkthroughs for common deployments.
 - **[WordPress](wordpress/)** — drop in a WordPress install with no PHP-FPM.
 - **[Laravel](laravel/)** — Laravel with embedded SQLite or MySQL passthrough.
 - **[Virtual Hosts](virtual-hosts/)** — multi-tenant directory-based hosting.
-- **[TLS / ACME](tls-acme/)** — automatic Let's Encrypt certificates.
+- **[TLS / ACME](tls-acme/)** — automatic Let's Encrypt certificates, including DNS-01 wildcards across five DNS providers.
+- **[PR Preview Bot](preview-bot/)** — per-PR preview URLs via the `switchboard` daemon + `switchboard-api` webhook receiver, running on ePHPm's multi-tenant runtime.
 - **[Clustering Setup](clustering-setup/)** — gossip-based HA with clustered SQLite.
 - **[Database from PHP](db-from-php/)** — the in-process `ephpm_db_*` bridge, and how it relates to the `pdo_mysql` wire path.
 - **[KV from PHP](kv-from-php/)** — the `ephpm_kv_*` SAPI functions.

--- a/site/content/guides/preview-bot.md
+++ b/site/content/guides/preview-bot.md
@@ -1,0 +1,320 @@
++++
+title = "PR Preview Bot"
+weight = 6
++++
+
+Every pull request gets a live preview URL — its own database, its own KV
+keyspace, deployed in seconds and torn down when the PR closes — and a sticky
+comment with the link. This is the same machinery that runs the previews on
+`ephpm/wordpress-sample`.
+
+The runtime half is ePHPm itself: multi-tenant [virtual hosts](/guides/virtual-hosts/),
+per-site Turso databases, per-site KV, and the `[server] preview` limits preset.
+The bot half is two separate open-source projects that sit on top of ePHPm:
+
+| Component | Repo | Language | Role |
+|-----------|------|----------|------|
+| **switchboard-api** | [`ephpm/switchboard-api`](https://github.com/ephpm/switchboard-api) | PHP (PSR-15) | The webhook receiver and GitHub App surface. Runs **on ePHPm** as a confined vhost. HMAC-verifies each webhook, dedups it, and publishes the desired preview state. |
+| **switchboard** | [`ephpm/switchboard`](https://github.com/ephpm/switchboard) | Rust | A daemon on every node. Claims deploy jobs, fetches the PR, runs the build, atomically swaps the checkout into `sites_dir`, health-gates, and posts/updates the sticky comment. |
+
+Both consume ePHPm; neither is part of the ePHPm binary. This guide covers how
+the pieces fit together and how to stand the system up on your own repo. Pull
+exact flag names and config values from each repo's README before you deploy —
+they are the authority, and the projects are young.
+
+## How it works
+
+```
+GitHub  ──pull_request webhook──►  switchboard-api (PHP, on ePHPm)
+                                        │  1. verify X-Hub-Signature-256 (HMAC-SHA256)
+                                        │  2. dedup by X-GitHub-Delivery GUID
+                                        │  3. publish desired state
+                                        ▼
+                        ┌─── single node ───┐   ┌──────── cluster ────────┐
+                        │ enqueue job file  │   │ write to gossip KV:      │
+                        │ into ./queue/     │   │  switchboard:preview:<l> │
+                        └─────────┬─────────┘   │  switchboard:index       │
+                                  │             │  switchboard:gen         │
+                                  │             └────────────┬────────────┘
+                                  │                          │  each node's daemon kicks
+                                  │                          │  GET /drain on its local
+                                  │                          │  switchboard-api, which
+                                  │                          │  materializes KV → ./queue/
+                                  ▼                          ▼
+                            switchboard daemon (Rust) consumes ./queue/
+                                  ├─ git fetch refs/pull/<N>/head
+                                  ├─ load ephpm.yaml (or synthesize from framework)
+                                  ├─ run build:  (sh -c)
+                                  ├─ atomic swap ──► <sites_dir>/<label>/
+                                  ├─ run seed:   (sh -c, gets $PREVIEW_URL/$PREVIEW_HOST/$PR)
+                                  ├─ poll health: until 200
+                                  ├─ POST a GitHub Deployment (state: success)
+                                  └─ post/update the sticky comment
+                                        │
+Browser ──► ephpm (:443, *.preview wildcard cert) ──► <label>.preview.<domain>
+```
+
+**The two boundaries never overlap.** switchboard-api talks to the daemon only
+through **files** (`./queue/`) — never a socket, never a shared library. The
+gossip KV carries *desired state between nodes*; each node's daemon then kicks
+its own local switchboard-api, which reads the KV and writes fresh queue files
+for the Rust daemon on that node. The daemon itself has **no KV awareness at
+all** — it only ever consumes queue files.
+
+### Single-node vs cluster
+
+- **Single node** — switchboard-api enqueues jobs directly into the daemon's
+  `./queue/` directory. No KV, no `/drain`. Run the daemon with
+  `--drain-interval-secs 0` to disable the drain kick.
+- **Cluster** — switchboard-api auto-detects that it is running on ePHPm (the
+  `ephpm_kv_*` SAPI functions exist) and publishes desired state into the
+  gossip-replicated KV instead of enqueueing locally. Every node runs both a
+  switchboard-api vhost and a switchboard daemon; each daemon periodically kicks
+  the localhost-only `GET /drain` on its node's switchboard-api, which
+  reconciles the KV against what has already been applied and writes any new
+  jobs into that node's local queue. **This cluster path is covered by
+  in-process tests only — it has not been validated against a live multi-node
+  cluster.**
+
+### The `/drain` endpoint
+
+`/drain` is a plain-HTTP `GET` the daemon kicks on `--drain-addr` (default
+`127.0.0.1:8080`), carrying a `Host:` header (`--drain-host`, which selects the
+switchboard-api vhost) and an `X-Drain-Token:` header (the trimmed contents of
+`--drain-token-file`, re-read on every kick so it rotates without a restart).
+switchboard-api gates it three ways, each failing closed with an identical
+`404`:
+
+1. `REMOTE_ADDR` must be `127.0.0.1` — **localhost only**.
+2. `X-Drain-Token` must `hash_equals` a line in the vhost's
+   `.switchboard/drain_secret`.
+3. A missing secret file, missing header, or wrong token → `404`.
+
+### Exactly-once: the hidden marker
+
+Every preview has exactly **one** PR comment, and it is deduplicated by a hidden
+HTML-comment marker — not by any shared-state coordination. Before posting, the
+daemon lists the PR's comments, scans for the marker string
+
+```
+<!-- switchboard-preview -->
+```
+
+and updates the existing comment if it finds one, else creates a new one. N
+nodes that all reconcile the same preview converge on the same single comment.
+There is **no RESP/redis coordination path** — the operator can leave ePHPm's
+RESP listener (`[kv.redis_compat]`) off entirely.
+
+The one honest limitation: the find-then-create is not atomic, so two nodes that
+both list *before* either has created can momentarily post two comments. It is a
+sub-second window and self-heals — the next push finds one by its marker and
+updates it in place.
+
+### Preview URL and label
+
+The host is `<label>.<preview-domain>`, e.g.
+`ephpm-wordpress-sample-pr-7.preview.ephpm.dev`, served by ePHPm on `:443`
+behind the `*.preview.<domain>` wildcard certificate. The **label** is
+`<owner>-<repo>-pr-<N>`, sanitized to a single DNS label: lowercased, every
+character outside `[a-z0-9-]` replaced with `-`, runs collapsed. If sanitizing
+changed nothing and the result is ≤ 63 characters it is used verbatim;
+otherwise a 6-hex-character hash of `owner/repo#N` is appended to keep it unique.
+
+Keeping the whole PR identity in a **single** DNS label is deliberate — a
+wildcard certificate for `*.preview.<domain>` covers exactly one label, so a
+multi-label host like `pr-42.my-blog.preview.<domain>` would need its own
+per-hostname certificate. The label is also the vhost directory name and
+therefore the [canonical site key](/guides/virtual-hosts/) that selects the
+site's database file, KV keyspace, and private temp/session root. The label is
+computed once by switchboard-api and travels in the job file; the daemon uses it
+verbatim.
+
+### Comment lifecycle
+
+- **On deploy** the comment shows **ready** once the health check passes, or
+  **deployed (health check pending)** if it has not, plus a table with the URL,
+  detected framework, PHP version, and deploy time, and the footer "Preview
+  updates automatically on each push to this PR."
+- **On each push** (`synchronize`) the deploy re-runs and the *same* comment is
+  updated in place.
+- **On PR close** the preview directory under `<sites_dir>/<label>/` is removed
+  and the sticky comment is rewritten to "Preview deployment has been torn
+  down." Note the per-site **database file is left in place** — teardown does
+  not delete it.
+
+### GitHub Deployment status
+
+Alongside the comment the daemon creates a GitHub Deployment
+(`environment: preview-pr-<N>`) and sets one status of **`success`** with the
+preview URL as its `environment_url`. This is a single terminal status — the
+daemon does **not** drive a `queued → in_progress → success/inactive`
+lifecycle, and it does not mark the deployment `inactive` on teardown. Unlike
+the comment, deployment records are **not** deduplicated across nodes, so a
+multi-node cluster may create more than one Deployment for the same PR. Failing
+to create the Deployment is non-fatal — the comment is what matters.
+
+## Install it on your repo
+
+### 1. Create and install the GitHub App
+
+Create a GitHub App and subscribe it to the **Pull requests** webhook event
+(`pull_request`). switchboard acts on `opened`, `synchronize`, and `reopened`
+(deploy) and `closed` (teardown). The App needs the permissions the operations
+below require:
+
+| Permission | Access | Why |
+|------------|--------|-----|
+| Pull requests | Read & write | Post and update the sticky PR comment. |
+| Deployments | Read & write | Create the Deployment and its status. |
+| Contents | Read | `git fetch refs/pull/<N>/head` from the repo. |
+| Metadata | Read | Mandatory for every GitHub App. |
+
+Set the App's **webhook URL** to your switchboard-api endpoint
+(`https://switchboard.<your-domain>/webhook`) and set a **webhook secret** — the
+same secret switchboard-api verifies against (below). Install the App on the
+repos you want previews for. (The reference deployment on `ephpm.dev` runs as
+the "ePHPm" App; you create your own for your own domain.)
+
+### 2. Wildcard DNS and TLS
+
+Point wildcard DNS at the node(s):
+
+```
+*.preview.<your-domain>.   A   <node IP>
+```
+
+and have ePHPm issue **one wildcard certificate** for `*.preview.<your-domain>`
+via a DNS-01 ACME challenge — this is exactly the case the
+[DNS-01 lane](/guides/tls-acme/#dns-01-challenge-wildcards) exists for. One cert
+covers every ephemeral preview subdomain and stays under Let's Encrypt's rate
+limit:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "cloudflare"          # or linode / digitalocean / route53 / google
+cloudflare_api_token_file = "/run/secrets/cf-token"
+```
+
+### 3. Deploy switchboard-api as an ePHPm vhost
+
+switchboard-api is a flat PHP app (front controller at `index.php`, no
+`public/`). Run it as a confined vhost under `sites_dir`. Its
+`examples/ephpm.toml` is the authoritative starting point; the load-bearing
+parts:
+
+```toml
+[server]
+sites_dir = "/var/www/sites"
+sites_domain_suffix = ".example.com"   # dir "switchboard/" serves Host switchboard.example.com
+
+[server.security]
+open_basedir = true
+hidden_files = "deny"
+# Only these pre-rewrite URIs may execute PHP. allowed_php_paths matches the URI
+# BEFORE routing, so every route must be listed — omitting one returns 403.
+allowed_php_paths = ["/index.php", "/webhook", "/healthz", "/drain"]
+blocked_paths = ["/vendor/*", "/src/*", "/tests/*", "/composer.*", "/worker.php"]
+```
+
+Set the webhook secret in the vhost's `.switchboard/webhook_secret` (one secret
+per line; multiple lines are accepted so you can rotate). A file is preferred
+over the `SWITCHBOARD_WEBHOOK_SECRET` env var, because env is shared across every
+vhost in the process. If no secret is configured the webhook fails closed with a
+`500`. In cluster mode also set the drain secret in `.switchboard/drain_secret`
+(matching the daemon's `--drain-token-file`).
+
+### 4. Deploy the switchboard daemon
+
+Run the Rust daemon on each node. It is configured entirely by flags, each with
+a `SWITCHBOARD_*` env fallback (designed for a systemd `EnvironmentFile=`). The
+repo ships **no** `.service` file — the unit below is illustrative:
+
+```ini
+# /etc/systemd/system/switchboard.service  (illustrative — no unit ships in-repo)
+[Unit]
+Description=ePHPm switchboard preview daemon
+After=network-online.target
+
+[Service]
+EnvironmentFile=/etc/switchboard/env
+ExecStart=/usr/local/bin/switchboard \
+  --state-dir /var/lib/switchboard \
+  --sites-dir /var/www/sites \
+  --preview-domain preview.example.com \
+  --app-id <APP_ID> \
+  --app-key /etc/switchboard/app-private-key.pem \
+  --drain-host switchboard.example.com \
+  --drain-token-file /var/www/sites/switchboard/.switchboard/drain_secret
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Flags worth calling out:
+
+- `--state-dir` is **required** (holds the queue and applied-markers).
+- `--app-id` and `--app-key` (the PEM path — not `--app-key-file`) must be given
+  **together**; the daemon mints installation tokens from them.
+- `--drain-host` and `--drain-token-file` are **required whenever the drain kick
+  is enabled** (`--drain-interval-secs` non-zero, the default). For a
+  single-node install, set `--drain-interval-secs 0` and omit both — the API
+  enqueues directly.
+- **There are no `--kv-*` flags.** The daemon needs no KV configuration; cluster
+  fan-out reaches it as queue files written by `/drain`.
+
+### 5. Add `ephpm.yaml` to your app repo
+
+An app repo describes its preview build in an `ephpm.yaml` at its root. The
+schema is owned by switchboard (`src/manifest.rs`); **ePHPm never reads it** —
+see [Virtual Hosts](/guides/virtual-hosts/) for why the runtime refuses to route
+on a file inside a tenant's checkout. `build:` and `seed:` steps run as `sh -c`
+children of the daemon; `seed:` additionally gets `$PREVIEW_URL`, `$PREVIEW_HOST`,
+and `$PR` in its environment. A representative manifest (the shape used by
+`ephpm/wordpress-sample`):
+
+```yaml
+version: 1                 # required; only version 1 is understood
+php: "8.5"
+docroot: "."
+build:                     # run in the checkout BEFORE the site goes live
+  - "./assemble.sh ."
+  - "composer install --no-dev --optimize-autoloader --no-interaction"
+services:
+  database: "turso"        # "turso" | false
+  kv: true
+  websocket: true
+seed:                      # run AFTER the site serves and its DB exists
+  - "wp core install --url=$PREVIEW_URL --title=\"Preview\" --admin_user=admin --admin_email=preview@example.com --skip-email"
+env:
+  WP_ENVIRONMENT_TYPE: "staging"
+health: "/"                # polled for a 200 before the deploy reports ready
+ini:
+  memory_limit: "256M"     # advisory — surfaced, not enforced in v1
+```
+
+A repo with no manifest is not rejected: switchboard synthesizes one from the
+detected framework (WordPress, Laravel, Symfony, Drupal, or generic).
+
+## Limitations to plan around
+
+- **Cluster mode is not live-validated.** The KV fan-out and `/drain`
+  reconciliation are covered by in-process tests only.
+- **Rare duplicate comment.** The sub-second find-then-create race can post two
+  comments momentarily; the next push self-heals to one.
+- **Deployment records are not deduped across nodes.** One PR can produce
+  multiple GitHub Deployments in a cluster (the *comment* is always single).
+- **The per-site database is not torn down** on PR close — only the checkout
+  directory is removed. Abandoned previews are not reaped automatically.
+- **`build:`/`seed:` run with the daemon's privileges** as plain `sh -c`
+  children (no container/namespace) — treat the whole system as trusted-tenant,
+  and see the isolation notes in [Virtual Hosts](/guides/virtual-hosts/).
+
+## See also
+
+- [Virtual Hosts](/guides/virtual-hosts/) — the multi-tenant runtime the bot writes into
+- [TLS / ACME → DNS-01 wildcards](/guides/tls-acme/#dns-01-challenge-wildcards)
+- [Preview Deployments roadmap](/roadmap/preview/) — what is still design, not shipped

--- a/site/content/guides/tls-acme.md
+++ b/site/content/guides/tls-acme.md
@@ -108,7 +108,19 @@ The plain-HTTP listener only serves regular traffic (or 301-redirects when `redi
 
 ## DNS-01 challenge (wildcards)
 
-TLS-ALPN-01 cannot obtain a **wildcard** certificate (`*.example.com`): the CA has no single hostname to connect to. For wildcards — and for hosts that never accept inbound TLS — set `challenge = "dns-01"`, which proves control by publishing a `_acme-challenge` TXT record through a DNS provider. Implemented providers: **Cloudflare** (`cloudflare`), **Linode** (`linode`), **DigitalOcean** (`digitalocean`), **AWS Route 53** (`route53`), and **Google Cloud DNS** (`google`) — each needs its own credential (an API token for Cloudflare/Linode/DigitalOcean, access-key/secret for Route 53, a service-account key + project for Google).
+TLS-ALPN-01 cannot obtain a **wildcard** certificate (`*.example.com`): the CA has no single hostname to connect to. For wildcards — and for hosts that never accept inbound TLS — set `challenge = "dns-01"`, which proves control by publishing a `_acme-challenge` TXT record through a DNS provider. Five providers ship, each selected by `dns_provider` and each needing its own credential:
+
+| `dns_provider` | Provider | Credential fields | Optional zone hint |
+|----------------|----------|-------------------|--------------------|
+| `"cloudflare"` | Cloudflare | `cloudflare_api_token_file` / `cloudflare_api_token` (zone-scoped, `Zone.DNS:Edit`) | `cloudflare_zone_id` |
+| `"linode"` | Linode | `linode_api_token_file` / `linode_api_token` (scope `domains:read_write`) | — |
+| `"digitalocean"` | DigitalOcean | `digitalocean_api_token_file` / `digitalocean_api_token` (write scope) | — |
+| `"route53"` | AWS Route 53 | `route53_access_key_id` + `route53_secret_access_key_file` / `route53_secret_access_key` | `route53_hosted_zone_id` |
+| `"google"` | Google Cloud DNS | `google_service_account_json_file` / `google_service_account_json` + `google_project` | `google_managed_zone` |
+
+For every provider the same rule holds: the `*_file` variant wins over the inline value, and either can be supplied from the environment as `EPHPM_SERVER__TLS__<FIELD>` (e.g. `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN`) so the secret stays out of `ephpm.toml`. ePHPm validates the selected provider's credentials at startup and refuses to start on a missing credential or an unknown `dns_provider`.
+
+### Cloudflare
 
 ```toml
 [server]
@@ -126,6 +138,71 @@ cloudflare_api_token_file = "/run/secrets/cf-token"
 ```
 
 The token must be a **zone-scoped Cloudflare API token** with the `Zone.DNS:Edit` permission on the zone that holds the records. If you also set `cloudflare_zone_id`, the token needs nothing more; otherwise ePHPm resolves the zone from the FQDN, which additionally needs `Zone:Read`.
+
+### Linode
+
+A Linode API v4 token scoped `domains:read_write`:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email   = "admin@example.com"
+cache_dir = "/var/lib/ephpm/certs"
+challenge = "dns-01"
+dns_provider = "linode"
+linode_api_token_file = "/run/secrets/linode-token"
+# ...or: EPHPM_SERVER__TLS__LINODE_API_TOKEN=<token>
+```
+
+### DigitalOcean
+
+A DigitalOcean API token with write scope:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email   = "admin@example.com"
+cache_dir = "/var/lib/ephpm/certs"
+challenge = "dns-01"
+dns_provider = "digitalocean"
+digitalocean_api_token_file = "/run/secrets/do-token"
+# ...or: EPHPM_SERVER__TLS__DIGITALOCEAN_API_TOKEN=<token>
+```
+
+### AWS Route 53
+
+An access-key/secret pair for an IAM identity allowed to change records in the hosted zone (`route53:ChangeResourceRecordSets` + `route53:ListResourceRecordSets`, plus `route53:ListHostedZonesByName` when you let ePHPm resolve the zone). On an account with more than ~100 hosted zones, set `route53_hosted_zone_id` explicitly — the zone lookup does not paginate.
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email   = "admin@example.com"
+cache_dir = "/var/lib/ephpm/certs"
+challenge = "dns-01"
+dns_provider = "route53"
+route53_access_key_id = "AKIA..."
+# ...or: EPHPM_SERVER__TLS__ROUTE53_ACCESS_KEY_ID=<id>
+route53_secret_access_key_file = "/run/secrets/aws-secret"
+# ...or: EPHPM_SERVER__TLS__ROUTE53_SECRET_ACCESS_KEY=<secret>
+route53_hosted_zone_id = "Z123EXAMPLE"   # optional — skips the zone lookup
+```
+
+### Google Cloud DNS
+
+A service-account JSON key with the `roles/dns.admin` role (or an equivalent custom role that can change record sets), plus the `google_project` that owns the Cloud DNS zone:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email   = "admin@example.com"
+cache_dir = "/var/lib/ephpm/certs"
+challenge = "dns-01"
+dns_provider = "google"
+google_service_account_json_file = "/run/secrets/gcp-sa.json"
+# ...or: EPHPM_SERVER__TLS__GOOGLE_SERVICE_ACCOUNT_JSON=<json>
+google_project = "my-gcp-project"        # required
+google_managed_zone = "preview-zone"     # optional — skips the zone lookup
+```
 
 **Why wildcards matter here.** Let's Encrypt limits you to 50 certificates per registered domain per week. A fleet of ephemeral preview subdomains (`pr-123.preview.example.com`, …) would burn through that quickly with per-subdomain issuance; one `*.preview.example.com` certificate covers them all under a single order.
 

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -514,7 +514,7 @@ memory_limit = "64M"
 memory_limit = "64MB"
 ```
 
-Put a reverse proxy (Caddy recommended — automatic HTTPS per domain) in front for TLS termination, or use ePHPm's built-in ACME with every hostname listed explicitly in `[server.tls] domains`. **Wildcard certificates are not possible** — ePHPm's ACME implementation uses TLS-ALPN-01 only, and wildcard issuance requires DNS-01, which is not implemented.
+Use ePHPm's built-in ACME for TLS. For a fixed set of hosts, the default TLS-ALPN-01 challenge issues per-host certificates with every hostname listed explicitly in `[server.tls] domains`. For **many** hosts under one parent — the typical multi-tenant / preview case — set `challenge = "dns-01"` with a `dns_provider` (Cloudflare, Linode, DigitalOcean, AWS Route 53, or Google Cloud DNS) and request a **wildcard** certificate such as `*.preview.example.com`: one cert covers every subdomain and stays under Let's Encrypt's rate limit. See [TLS / ACME → DNS-01](/guides/tls-acme/#dns-01-challenge-wildcards). A reverse proxy (Caddy, with automatic HTTPS per domain) in front is still an option if you prefer to terminate TLS elsewhere.
 
 **Capacity:**
 - 20 WordPress blogs

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -215,10 +215,26 @@ Two mutually exclusive modes — manual (`cert`+`key`) or ACME (`domains`). If b
 | `cloudflare_api_token_file` | path | (none) | Path to a file holding a zone-scoped `Zone.DNS:Edit` Cloudflare token. Preferred over inlining the secret; takes precedence over `cloudflare_api_token`. |
 | `cloudflare_api_token` | string | (none) | Cloudflare token inline (discouraged). Usually supplied via `EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN` instead. |
 | `cloudflare_zone_id` | string | (none) | Explicit Cloudflare zone id. When absent, resolved from the challenge FQDN (adds a `Zone:Read` requirement to the token). |
+| `linode_api_token_file` | path | (none) | Path to a file holding a Linode API v4 token (scope `domains:read_write`). Wins over `linode_api_token`. Only used when `dns_provider = "linode"`. |
+| `linode_api_token` | string | (none) | Linode token inline. Usually supplied via `EPHPM_SERVER__TLS__LINODE_API_TOKEN`. |
+| `digitalocean_api_token_file` | path | (none) | Path to a file holding a DigitalOcean API token (write scope). Wins over `digitalocean_api_token`. Only used when `dns_provider = "digitalocean"`. |
+| `digitalocean_api_token` | string | (none) | DigitalOcean token inline. Usually supplied via `EPHPM_SERVER__TLS__DIGITALOCEAN_API_TOKEN`. |
+| `route53_access_key_id` | string | (none) | AWS access key id. **Required** when `dns_provider = "route53"`. Usually supplied via `EPHPM_SERVER__TLS__ROUTE53_ACCESS_KEY_ID`. |
+| `route53_secret_access_key_file` | path | (none) | Path to a file holding the AWS secret access key. Wins over `route53_secret_access_key`. |
+| `route53_secret_access_key` | string | (none) | AWS secret access key inline. Usually supplied via `EPHPM_SERVER__TLS__ROUTE53_SECRET_ACCESS_KEY`. |
+| `route53_hosted_zone_id` | string | (none) | Explicit Route 53 hosted zone id. When absent, resolved from the challenge FQDN via `ListHostedZonesByName` (which does not paginate — set this on accounts with more than ~100 zones). |
+| `google_service_account_json_file` | path | (none) | Path to the GCP service-account JSON key file. Wins over `google_service_account_json`. Only used when `dns_provider = "google"`. |
+| `google_service_account_json` | string | (none) | Service-account JSON key **contents** inline. Usually supplied via `EPHPM_SERVER__TLS__GOOGLE_SERVICE_ACCOUNT_JSON`. |
+| `google_project` | string | (none) | GCP project id owning the Cloud DNS zone. **Required** when `dns_provider = "google"`. |
+| `google_managed_zone` | string | (none) | Explicit Cloud DNS managed-zone name. When absent, resolved from the challenge FQDN by listing the project's managed zones. |
 | `listen` | string | (none) | Separate HTTPS listener. When set, `[server] listen` serves HTTP and this serves HTTPS. |
 | `redirect_http` | bool | `false` | When `listen` is set, the HTTP listener redirects everything to HTTPS (301). |
 
-**DNS-01 wildcard example.** One wildcard cert covers every preview subdomain and stays under Let's Encrypt's 50-certs-per-registered-domain-per-week limit:
+Credentials follow one rule across every provider: the `*_file` variant wins over the inline value, and both can be supplied entirely from the environment (`EPHPM_SERVER__TLS__<FIELD>`) so no secret has to live in `ephpm.toml`. `Config::validate` requires the selected provider's credential(s) at startup and rejects an unknown `dns_provider` rather than silently doing nothing.
+
+**DNS-01 wildcard example.** One wildcard cert covers every preview subdomain and stays under Let's Encrypt's 50-certs-per-registered-domain-per-week limit. In a cluster (`[cluster] enabled = true`) only the elected leader orders the certificate; every other node loads it from the KV store — the same leader-election and distribution machinery as the TLS-ALPN-01 lane. TLS-ALPN-01 and DNS-01 are mutually exclusive per server; wildcard domains **require** DNS-01.
+
+*Cloudflare* — a **zone-scoped** token with `Zone.DNS:Edit` on the challenge zone (add `Zone:Read`, or set `cloudflare_zone_id`, to skip zone resolution):
 
 ```toml
 [server.tls]
@@ -229,7 +245,53 @@ dns_provider = "cloudflare"
 cloudflare_api_token_file = "/run/secrets/cf-token"   # or EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN
 ```
 
-The token is a **zone-scoped** Cloudflare API token with `Zone.DNS:Edit` on the challenge zone. In a cluster (`[cluster] enabled = true`) only the elected leader orders the certificate; every other node loads it from the KV store — the same leader-election and distribution machinery as the TLS-ALPN-01 lane. TLS-ALPN-01 and DNS-01 are mutually exclusive per server; wildcard domains **require** DNS-01.
+*Linode* — an API v4 token scoped `domains:read_write`:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "linode"
+linode_api_token_file = "/run/secrets/linode-token"   # or EPHPM_SERVER__TLS__LINODE_API_TOKEN
+```
+
+*DigitalOcean* — an API token with write scope:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "digitalocean"
+digitalocean_api_token_file = "/run/secrets/do-token"  # or EPHPM_SERVER__TLS__DIGITALOCEAN_API_TOKEN
+```
+
+*AWS Route 53* — an access-key/secret pair for an IAM identity allowed to change records in the hosted zone. Set `route53_hosted_zone_id` explicitly on accounts with more than ~100 zones (zone lookup does not paginate):
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "route53"
+route53_access_key_id = "AKIA..."                      # or EPHPM_SERVER__TLS__ROUTE53_ACCESS_KEY_ID
+route53_secret_access_key_file = "/run/secrets/aws-secret"  # or EPHPM_SERVER__TLS__ROUTE53_SECRET_ACCESS_KEY
+route53_hosted_zone_id = "Z123EXAMPLE"                 # optional
+```
+
+*Google Cloud DNS* — a service-account JSON key with the `roles/dns.admin` role and the owning `google_project`. Set `google_managed_zone` to skip zone resolution:
+
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "google"
+google_service_account_json_file = "/run/secrets/gcp-sa.json"  # or EPHPM_SERVER__TLS__GOOGLE_SERVICE_ACCOUNT_JSON
+google_project = "my-gcp-project"                      # required
+google_managed_zone = "preview-zone"                   # optional
+```
 
 ### `[server.http3]`
 

--- a/site/content/reference/environment-variables.md
+++ b/site/content/reference/environment-variables.md
@@ -76,6 +76,10 @@ EPHPM_SERVER__TLS__DOMAINS='["*.preview.example.com","preview.example.com"]'
 EPHPM_SERVER__TLS__CHALLENGE=dns-01
 EPHPM_SERVER__TLS__DNS_PROVIDER=cloudflare
 EPHPM_SERVER__TLS__CLOUDFLARE_API_TOKEN=$CF_DNS_EDIT_TOKEN   # zone-scoped Zone.DNS:Edit
+# Other providers use the analogous EPHPM_SERVER__TLS__* variables, e.g.
+# LINODE_API_TOKEN, DIGITALOCEAN_API_TOKEN, ROUTE53_ACCESS_KEY_ID +
+# ROUTE53_SECRET_ACCESS_KEY, or GOOGLE_SERVICE_ACCOUNT_JSON + GOOGLE_PROJECT.
+# See reference/config.md for the full per-provider field list.
 
 # HTTP/3 (QUIC). Needs a static [server.tls] cert+key — enabling this with
 # ACME is a startup error, not a silent downgrade to TCP-only.

--- a/site/content/roadmap/_index.md
+++ b/site/content/roadmap/_index.md
@@ -16,7 +16,7 @@ These pages describe targets, not currently-shipped behavior. For what works tod
 - **[Benchmarks as a Release Artifact](benchmarks/)** — in-tree bench recipes, per-release numbers, and a regression gate.
 - **[NTS Prefork Mode](nts-prefork/)** — trading features for pure per-request PHP speed, gated on a post-PGO measurement.
 - **[The Deploy Story](deploy-warmup/)** — post-invalidation warmup, `ephpm doctor <framework>`, `cache status`, thin deploy hooks.
-- **[Preview Deployments](preview/)** — instant per-PR preview URLs via a GitHub bot. The runtime half (per-site databases, per-site document roots, the `[server] preview` limits preset) **shipped**; the bot ([`ephpm/switchboard`](https://github.com/ephpm/switchboard), public) is young — the open contract gaps and the wildcard-certificate problem are the design content.
+- **[Preview Deployments](preview/)** — instant per-PR preview URLs via a GitHub bot. **Shipped end to end** — the runtime half plus the [`ephpm/switchboard`](https://github.com/ephpm/switchboard) daemon, the [`ephpm/switchboard-api`](https://github.com/ephpm/switchboard-api) webhook receiver, and in-process wildcard certs via DNS-01. See the [PR Preview Bot guide](/guides/preview-bot/) to install it; this roadmap page now holds only the remaining design items (multi-PHP routing, GC/quotas, sandboxed builds, scale-out).
 - **[OPcache Clustering & Per-Vhost Preload](opcache-clustering/)** — Phase 1 (cluster-wide invalidation) shipped in 0.4.0; per-vhost preload and worker-mode invalidation remain.
 - **[Symfony Runtime Adapter](symfony-runtime-driver/)** — native `ephpm` adapter under `symfony/runtime`, on top of the shipped worker-mode engine.
 - **[Kubernetes Operator](kubernetes/)** — first-class K8s deployment.

--- a/site/content/roadmap/preview.md
+++ b/site/content/roadmap/preview.md
@@ -1,7 +1,8 @@
 # Preview Deployments
 
-> **Status: PARTLY SHIPPED.** Every pull request gets a live preview URL with
-> its own database, deployed in seconds and torn down on merge.
+> **Status: SHIPPED — end to end.** Every pull request gets a live preview URL
+> with its own database, deployed in seconds and torn down on close, with a
+> sticky PR comment carrying the link.
 >
 > - **The ePHPm runtime half has shipped.** Per-site databases
 >   ([`[db.sqlite] dir`](/reference/config/#dbsqlite)), per-site document roots
@@ -9,17 +10,22 @@
 >   discovery, per-site KV keyspaces and the
 >   [`[server] preview`](/reference/config/#server) limits preset are all in the
 >   binary. See [Virtual Hosts](/guides/virtual-hosts/) for how they behave.
-> - **The bot exists and is public.** [`ephpm/switchboard`](https://github.com/ephpm/switchboard)
->   is a separate Rust project (not part of this workspace) that receives
->   GitHub webhooks, clones, builds, and writes into ePHPm's `sites_dir`. It is
->   young — several contract pieces below are open issues on that repo.
-> - **What is still design:** wildcard-certificate issuance from inside ePHPm,
->   multi-PHP-version routing, teardown/GC policy, and scale-out past one VM.
+> - **The bot has shipped and is public.** Two projects, both separate from this
+>   workspace: [`ephpm/switchboard`](https://github.com/ephpm/switchboard) (the
+>   Rust deploy daemon) and
+>   [`ephpm/switchboard-api`](https://github.com/ephpm/switchboard-api) (the PHP
+>   webhook receiver that runs *on* ePHPm). Proven on
+>   [`ephpm/wordpress-sample`](https://github.com/ephpm/wordpress-sample).
+> - **Wildcard-certificate issuance has shipped too.** ePHPm's own
+>   [DNS-01 ACME lane](/guides/tls-acme/#dns-01-challenge-wildcards) issues the
+>   `*.preview.<domain>` wildcard in-process — no out-of-band certbot/lego step.
+> - **What is still design:** multi-PHP-version routing, stale-preview GC and
+>   per-preview disk quotas, sandboxed (containerized) build steps, and
+>   scale-out past one VM. Cluster mode exists but is not live-validated.
 >
-> This page is the plan and the open questions. It is not a reference for the
-> shipped knobs — those live in [Configuration](/reference/config/) and
-> [Virtual Hosts](/guides/virtual-hosts/) — and it is not the app-developer
-> guide, which lives in switchboard alongside the schema it documents.
+> **How it works and how to install it now live in the
+> [PR Preview Bot guide](/guides/preview-bot/).** This page is the remaining
+> plan and the open questions only.
 
 ## The two halves
 
@@ -27,12 +33,13 @@
 |-----------|------|----------|------|
 | **ephpm** | `ephpm/ephpm` | Rust | Serves every preview as a vhost. Owns TLS, routing, per-site DB/KV/sessions. |
 | **switchboard** (daemon) | [`ephpm/switchboard`](https://github.com/ephpm/switchboard) | Rust | Clones the PR, runs `build:`, materializes env, atomically swaps the checkout into `sites_dir`, runs `seed:`, health-gates. |
-| **switchboard-api** | `ephpm/switchboard-api` | PHP | **In progress.** The webhook receiver and GitHub App surface, split out of the daemon so the HTTP/GitHub side is a PHP app running *on* ePHPm. |
+| **switchboard-api** | [`ephpm/switchboard-api`](https://github.com/ephpm/switchboard-api) | PHP | The webhook receiver and GitHub App surface, running *on* ePHPm. HMAC-verifies each webhook, dedups it by delivery GUID, and publishes desired preview state. |
 
-The daemon is being reduced to `deployer.rs` / `manifest.rs` / `secrets.rs` —
-the deployment mechanics — with the webhook, signature verification and PR
-commenting moving to the PHP API. Dogfooding: the thing that ships previews
-should itself be a PHP app on ePHPm.
+The webhook, signature verification, delivery dedup and desired-state publishing
+live in the PHP API; the daemon owns the deployment mechanics (fetch, build,
+atomic swap, health-gate, comment). Dogfooding: the thing that ships previews is
+itself a PHP app on ePHPm. See the
+[PR Preview Bot guide](/guides/preview-bot/) for the full split.
 
 Both halves share the filesystem. Switchboard writes a directory under
 `sites_dir`; ePHPm discovers it on the next request. No IPC, no reload signal,
@@ -208,32 +215,31 @@ Documented but unfiled:
   per-site `[php]` overrides — see the Phase 2 note in
   [Virtual Hosts](/guides/virtual-hosts/).
 
-## TLS: the wildcard certificate problem
+## TLS: the wildcard certificate — solved
 
 The settled architecture wants one wildcard certificate for
-`*.preview.ephpm.dev`, obtained via a DNS-01 challenge. **ePHPm cannot issue
-that itself today.** Its built-in ACME (`rustls-acme`) solves **TLS-ALPN-01
-only** — there is no DNS-01 solver, and without DNS-01 there is no wildcard.
-Worse for previews, the ACME domain set is the fixed
-[`[server.tls] domains`](/reference/config/#servertls) list read at startup, so
-a hostname invented by a webhook five minutes ago cannot get a certificate on
-demand.
+`*.preview.<domain>`, and **ePHPm now issues it itself.** The
+[DNS-01 ACME lane](/guides/tls-acme/#dns-01-challenge-wildcards) proves control
+by publishing a `_acme-challenge` TXT record through a DNS provider (Cloudflare,
+Linode, DigitalOcean, AWS Route 53, or Google Cloud DNS) — the only challenge
+type that can obtain a wildcard — and hot-swaps the renewed certificate into the
+running listener with no restart. Set it once and every ephemeral preview
+subdomain is covered by the single wildcard:
 
-So the shipped path is: obtain the wildcard out of band (certbot, lego, or any
-DNS-01 client), and point `[server.tls] cert` / `key` at the resulting PEMs —
-ePHPm's manual TLS mode. Two consequences to plan around:
+```toml
+[server.tls]
+domains = ["*.preview.example.com", "preview.example.com"]
+email = "ops@example.com"
+challenge = "dns-01"
+dns_provider = "cloudflare"
+cloudflare_api_token_file = "/run/secrets/cf-token"
+```
 
-- ePHPm does not watch those files, so a renewal needs a restart to take
-  effect.
-- Clustered ACME is not the answer either. Certificate *distribution* through
-  the gossip KV is implemented, but challenge-token propagation is not, and a
-  follower does not pick up a renewed certificate while running
-  ([TLS & ACME](/guides/tls-acme/)).
-
-**Planned — not yet implemented:** a DNS-01 solver behind a provider trait
-(Cloudflare first), which would make the wildcard self-service and remove the
-restart-on-renewal step. This is the single largest missing piece for a
-self-contained preview host.
+The out-of-band certbot/lego workaround the earlier design called for is no
+longer needed, and DNS-01 also side-steps the two clustered TLS-ALPN-01 gaps
+(challenge traffic must reach the leader; followers miss renewals until
+restart) — the leader answers over DNS and the resolver is hot-swappable. See
+[TLS & ACME](/guides/tls-acme/#clustered-acme).
 
 ## Deployment shape
 
@@ -298,15 +304,17 @@ non-default versions. That is strictly cheaper than a reverse proxy and keeps
 the "ePHPm terminates TLS" property.
 
 Two things would need solving first: certificate sharing across the instances
-(the same wildcard PEM can simply be pointed at by each, once the DNS-01 story
-lands), and the fact that each instance is a separate process with its own PHP
-memory footprint, which is what makes this a poor default for a small VM.
+(each can point at the same wildcard — now that the
+[DNS-01 lane](/guides/tls-acme/#dns-01-challenge-wildcards) issues it in-process
+this is a non-issue), and the fact that each instance is a separate process with
+its own PHP memory footprint, which is what makes this a poor default for a
+small VM.
 
 ## Security
 
 | Concern | Where it stands |
 |---------|-----------------|
-| Webhook spoofing | HMAC-SHA256 signature verification on every webhook (switchboard). |
+| Webhook spoofing | HMAC-SHA256 (`X-Hub-Signature-256`) verified over the raw body on every webhook, before parsing, fail-closed (switchboard-api). |
 | Malicious code in a PR | Previews run as the ePHPm process user. All tenants share one process and one uid — the isolation boundary is the per-site database file, KV keyspace and `open_basedir`, not an OS boundary. |
 | Cross-tenant data access | One Turso file per site; `ATTACH`/`DETACH`/`VACUUM`/path-`PRAGMA` rejected on the tenant path; unknown hosts get no database and no credentials. |
 | Tenant self-routing | ePHPm never reads routing config from inside a tenant's checkout; `site_overrides_dir` must be outside `sites_dir` or startup fails. |
@@ -326,7 +334,6 @@ limiting.
 2. **How does a seed step reach the database?** Handing it `DB_*` credentials
    is the smallest change; a "run this inside the site" primitive is the
    better one.
-3. **DNS-01 in ePHPm, or permanently out of band?** Out of band works and is
-   shipping; in-band removes a moving part and a restart.
-4. **What is the teardown policy for a PR that is never closed?** Nothing
-   currently reaps abandoned previews.
+3. **What is the teardown policy for a PR that is never closed?** Nothing
+   currently reaps abandoned previews, and PR-close teardown removes the
+   checkout but leaves the per-site database file behind.


### PR DESCRIPTION
Documents three now-shipped features and reconciles the docs that still described them as planned. Docs-only; every claim verified against source (`crates/ephpm-config/src/lib.rs` `TlsConfig`, `crates/ephpm-server/src/dns01_*.rs`, and the `ephpm/switchboard` + `ephpm/switchboard-api` code/READMEs).

## A. New guide — `guides/preview-bot.md`
How the PR preview system works and how to install it on your own repo:
- Flow: `pull_request` webhook -> `switchboard-api` (PHP on ePHPm) HMAC-verifies (`X-Hub-Signature-256`, raw body, fail-closed) + dedups by `X-GitHub-Delivery` -> publishes desired state (direct `./queue/` single-node, or gossip KV `switchboard:preview:*` / `:index` / `:gen` in a cluster) -> each node's daemon kicks localhost-only `GET /drain` -> `switchboard` (Rust) fetches, builds, atomic-swaps into `sites_dir`, health-gates, posts a sticky `<!-- switchboard-preview -->` comment.
- Exactly-once is the hidden marker (find-then-update), **no** RESP/redis coordination path.
- Install: GitHub App (permissions framed as required-by-operations, `pull_request` event), wildcard DNS + DNS-01 wildcard cert, `switchboard-api` as a confined vhost (`allowed_php_paths` matches pre-rewrite URIs), the `switchboard` daemon (illustrative systemd unit — no `.service` ships; `--app-id`/`--app-key`, `--drain-host`/`--drain-token-file`; **no `--kv-*` flags exist**), and the app's `ephpm.yaml`.
- Honest limits documented: cluster mode not live-validated, sub-second duplicate-comment race, Deployment status is **success-only** and **not deduped across nodes**, per-site DB not torn down.

## B. DNS-01 providers (shipped in #422)
`reference/config.md` `[server.tls]` table extended with all Linode / DigitalOcean / Route 53 / Google fields + a per-provider TOML example each (incl. `route53_hosted_zone_id`, `google_project`/`google_managed_zone`); `guides/tls-acme.md` gets a provider table and a `### <provider>` section each; `environment-variables.md` notes the other providers' `EPHPM_SERVER__TLS__*` vars.

## C. Stale roadmap/planned claims corrected
| File | Was | Now |
|------|-----|-----|
| `architecture/security.md` | "TLS-ALPN-01 only / DNS-01 & HTTP-01 not implemented / wildcards cannot be issued" | Both challenge lanes ship; five DNS providers; wildcards via DNS-01; DNS-01 avoids the two clustered TLS-ALPN-01 gaps |
| `guides/virtual-hosts.md` | "Wildcard certificates are not possible … DNS-01 not implemented" | Points to the DNS-01 wildcard path |
| `analysis/certmagic.md` | design-era "ePHPm would need DNS-01 provider wrappers" | "shipped" callout over the original rationale |
| `roadmap/preview.md` | PARTLY SHIPPED; "ePHPm cannot issue wildcard today / no DNS-01 solver / Planned"; DNS-01 open question | SHIPPED end-to-end; links the new guide; wildcard cert section rewritten as solved; resolved open question dropped |
| `roadmap/_index.md` | preview bullet "bot is young … wildcard-cert problem is design content" | shipped, links the guide |

Also added both new guides to `guides/_index.md`.

No merge — review requested.
