### PR TITLE
fix(php): gate zend_exception_restore() out on PHP 8.6

### DIFF
--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -1133,7 +1133,33 @@ static int ephpm_run_one_middleware(const char *path)
     }
 
     zend_execute(op_array, NULL);
+#if PHP_VERSION_ID < 80600
+    /* SAFETY (FFI/engine-state): PHP 8.6 removed zend_exception_save() and
+     * zend_exception_restore() outright, along with the EG(prev_exception)
+     * slot they shuttled a pending exception through — php-src commit
+     * 084e40969420 ("Remove zend_exception_save() and
+     * zend_exception_restore()", GH-20256), recorded at UPGRADING.INTERNALS
+     * line 53. There is no replacement API; the concept is gone.
+     *
+     * That same commit is also the migration pattern for THIS line. The two
+     * upstream sites that carry the loop body copied here — zend_execute_script()
+     * in Zend/zend.c and accel_preload() in ext/opcache/ZendAccelerator.c —
+     * were migrated by deleting the restore() call and changing nothing else
+     * (no rescue of a stranded exception, no substitute juggling). This gate
+     * reproduces that exactly: keep the call verbatim on <= 8.5 so those
+     * builds are behaviourally byte-identical, compile it out on >= 8.6.
+     *
+     * Dropping it on 8.6 cannot leak or clobber a pending exception.
+     * restore() was only ever a no-op-unless-EG(prev_exception)-is-set move,
+     * and the ONLY writer of that field was zend_exception_save(). In 8.6 the
+     * field does not exist and neither does the writer, so there is no second
+     * exception slot for a Throwable to be stranded in: once zend_execute()
+     * returns, EG(exception) is the entire pending-exception state, and it is
+     * read directly below. Nor does this interact with the bailout path — a
+     * zend_bailout longjmps past this line entirely, to the SETJMP in
+     * ephpm_execute_request, and never observed prev_exception either. */
     zend_exception_restore();
+#endif
 
     if (UNEXPECTED(EG(exception))) {
         if (zend_is_unwind_exit(EG(exception))) {


### PR DESCRIPTION
Fixes the single PHP 8.6 incompatibility in ePHPm. The stage-2 beta build ([run 33458581031](https://github.com/ephpm/ephpm/actions/runs/33458581031)) failed on **all four** targets at link with `undefined symbol: zend_exception_restore` (compile warning at `ephpm_wrapper.c:1136` in `ephpm_run_one_middleware`; the linker cites `ephpm_execute_request`, into which the static function inlines). Everything else in the workspace compiled clean against 8.6.

## What upstream did

PHP 8.6 removed `zend_exception_save()` / `zend_exception_restore()` **and** the `EG(prev_exception)` field they shuttled an exception through — php-src [`084e40969420`](https://github.com/php/php-src/commit/084e40969420) *"Remove zend_exception_save() and zend_exception_restore()"* (GH-20256, also fixes GH-20564), recorded at `UPGRADING.INTERNALS` line 53. There is no replacement API; the whole prev-exception concept is gone:

```diff
 -	zend_object *exception, *prev_exception;
 +	zend_object *exception;
```

Crucially, that commit is also the authoritative migration for *this exact call site*. `ephpm_run_one_middleware()` is a copy of upstream's `zend_execute_scripts()` loop body, and upstream migrated **both** of its own copies of that body — `zend_execute_script()` in `Zend/zend.c` and `accel_preload()` in `ext/opcache/ZendAccelerator.c` — by deleting the line and changing nothing else:

```diff
 	if (op_array) {
 		zend_execute(op_array, retval);
-		zend_exception_restore();
 		if (UNEXPECTED(EG(exception))) {
```

No rescue of a stranded exception, no substitute juggling. This PR reproduces that, and nothing more.

## The change

One hunk in `crates/ephpm-php/ephpm_wrapper.c`: wrap the existing call in `#if PHP_VERSION_ID < 80600`, with a `// SAFETY:`-style block documenting the reasoning. 8.3 / 8.4 / 8.5 keep the line verbatim and are behaviourally byte-identical. No Rust changes, so stub mode (no `PHP_SDK_PATH`) is untouched — the C file isn't compiled there at all.

### Why dropping it on 8.6 is safe

`zend_exception_restore()` was a no-op unless `EG(prev_exception)` was non-NULL, and the **only** writer of that field was `zend_exception_save()`. On 8.6 neither the field nor the writer exists, so there is no second exception slot for a `Throwable` to be stranded in: once `zend_execute()` returns, `EG(exception)` *is* the entire pending-exception state — and that is exactly what the block immediately below reads (`zend_is_unwind_exit` → `EPHPM_MW_EXIT`, else the user exception handler, else `zend_exception_error(..., E_ERROR)` → `EPHPM_MW_FATAL`). So the middleware chain's fail-closed classification is unchanged.

It also does not interact with the bailout path: a `zend_bailout` longjmps past this line entirely, to the `SETJMP` in `ephpm_execute_request`, and never observed `prev_exception` either.

(Related but not ours to act on: on 8.6, `zend_clear_exception()` no longer releases `prev_exception`, and `zend_exception_error()` is unaffected — our other two uses of it are fine.)

## Verification

Locally:

- `cargo check -p ephpm-php` (stub mode) — clean
- `cargo clippy -p ephpm-php --all-targets -- -D warnings` — clean
- **PHP-linked** `cargo check -p ephpm-php` against the 8.5.7 Windows SDK — clean, i.e. the retained `< 80600` branch still compiles through MSVC

The 8.6 branch **cannot** be verified on this host: no PHP 8.6 SDK exists for Windows. Real verification is a re-dispatch of `release-php-beta.yml`, which is triggered below.
