### PR TITLE
chore: pre-v0.8.7 tidy — CLAUDE.md tables, nightly serialization, beta artifact names

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -194,6 +194,11 @@ jobs:
     runs-on: [self-hosted, windows, x64]
     strategy:
       fail-fast: false
+      # One build per Windows worker at a time — same guard release.yml has
+      # carried since the v0.5.1 incident. Without it the three legs race
+      # the VS Build Tools bootstrapper and at most one survives (observed
+      # across four consecutive nightlies: exactly one leg green, rotating).
+      max-parallel: 1
       matrix:
         php: ["8.3", "8.4", "8.5"]
     steps:

--- a/.github/workflows/release-php-beta.yml
+++ b/.github/workflows/release-php-beta.yml
@@ -47,6 +47,11 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     outputs:
       experimental_matrix: ${{ steps.matrix.outputs.experimental_matrix }}
+      # github.ref_name with `/` flattened to `-`. Artifact names reject
+      # slashes, so a branch dispatch (fix/php86-...) otherwise builds
+      # successfully and then dies at "Upload archive" — observed on run
+      # 33460847551. Use this, never ref_name, in artifact names.
+      safe_ref: ${{ steps.safe_ref.outputs.safe_ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Emit experimental matrix from xtask EXPERIMENTAL_PHP_VERSIONS
@@ -55,6 +60,11 @@ jobs:
           docker run --rm -v "$PWD":/w -w /w \
             ephpm/ephpm-ci:latest \
             cargo run --quiet -p xtask -- php-versions --github-matrix >> "$GITHUB_OUTPUT"
+      - name: Slash-safe ref name for artifact names
+        id: safe_ref
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "safe_ref=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
   # -- Linux x86_64 (glibc 2.28 floor via ephpm-ci) ---------------------------
   build-linux:
@@ -101,7 +111,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-linux-x86_64
+          name: ephpm-beta-${{ needs.setup.outputs.safe_ref }}-php${{ matrix.php.full }}-linux-x86_64
           path: ${{ steps.pkg.outputs.archive }}
 
   # -- macOS aarch64 (native) -------------------------------------------------
@@ -156,7 +166,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-macos-aarch64
+          name: ephpm-beta-${{ needs.setup.outputs.safe_ref }}-php${{ matrix.php.full }}-macos-aarch64
           path: ${{ steps.pkg.outputs.archive }}
 
   # -- Linux aarch64 (glibc, in the macOS host's linux VM) --------------------
@@ -205,7 +215,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-linux-aarch64
+          name: ephpm-beta-${{ needs.setup.outputs.safe_ref }}-php${{ matrix.php.full }}-linux-aarch64
           path: ${{ steps.pkg.outputs.archive }}
 
   # -- Windows x86_64 (native MSVC) -------------------------------------------
@@ -318,7 +328,7 @@ jobs:
       - name: Upload archive
         uses: actions/upload-artifact@v4
         with:
-          name: ephpm-beta-${{ github.ref_name }}-php${{ matrix.php.full }}-windows-x86_64
+          name: ephpm-beta-${{ needs.setup.outputs.safe_ref }}-php${{ matrix.php.full }}-windows-x86_64
           path: ${{ steps.pkg.outputs.archive }}
 
   # -- Optional pre-release publish -------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,12 @@ The `ephpm-e2e` crate is **excluded from the workspace** and has different depen
 | `ephpm-cluster` | Clustering — SWIM gossip (chitchat), hashed large-value ownership (`hash(key)` mod sorted alive nodes — not a consistent-hash ring), KV replication, SQLite primary election |
 | `ephpm-query-stats` | Query observability — SQL normalization, digest tracking, slow query logging, Prometheus metrics |
 | `ephpm-ws` | Site-scoped WebSocket connection registry — connection/channel maps, bounded per-connection outbound queues, capability-style connection IDs. Protocol-free (no framing), so both `ephpm-php` and `ephpm-server` depend on it |
+| `ephpm-middleware` | Native middleware C ABI + safe Rust authoring kit. Two phases: **request** (`Middleware::invoke`, before serving — reject/rewrite/annotate, runs on both the PHP and static-file paths, **fails closed**) and optional **response** (`ResponseMiddleware::invoke_response`, reverse chain order — compression/ETag/headers, **fails safe, not a security gate**) |
+| `ephpm-middleware-builtins` | The ten in-tree official middleware modules as plain Rust — **no C ABI exports**, so `ephpm-server` links them all in and serves them through the static builtin registry (`library = "jwt"` works even in a fully static build with no `dlopen`) |
+| `ephpm-middleware-{cors,jwt,ratelimit,security-headers}` | Loadable **cdylib shells** over the matching `ephpm-middleware-builtins` module — they add only the `declare!` C ABI exports so the same module can be `dlopen`ed by dynamically linked builds. The implementation, docs, and tests live in builtins, not here. `security-headers` is also the guinea pig for `ephpm-server`'s dlopen round-trip test |
 | `xtask` | Build & test tooling — `release`, `php-sdk`, `e2e` (bare-process default), `k8s-e2e`/`k8s-e2e-up`/`k8s-e2e-down` (opt-in Kind path) |
+
+Workspace membership is `crates/*` + `examples/rust-middleware` + `xtask`, with `default-members = crates/*` and `crates/ephpm-e2e` **excluded**. `examples/rust-middleware` is a member on purpose — it's the worked example for the native-middleware C ABI, and keeping it in-tree means `cargo clippy --workspace` / `cargo +nightly fmt --all` catch ABI drift; it's out of `default-members` so a plain `cargo build` doesn't pay for it.
 
 ## External Dependencies
 
@@ -140,6 +145,9 @@ The `TrackedBackend` wrapper in `ephpm-server/src/tracked_backend.rs` wraps any 
 | `ephpm-server/src/tracked_backend.rs` | `TrackedBackend<B>` — wraps litewire `Backend` with query stats |
 | `ephpm-server/src/router.rs` | HTTP request routing, PHP dispatch, static file serving |
 | `ephpm-server/src/websocket.rs` | Native WebSocket upgrade + per-connection session task (`[server.websocket]`, experimental) |
+| `ephpm-server/src/middleware.rs` | Server-side middleware chain — resolves `library = "<name>"` against the static builtin registry first, else `dlopen`s a cdylib |
+| `ephpm-middleware/src/{abi,builtin,host}.rs` | `abi.rs` the C ABI + `declare!`; `builtin.rs` the static registry (no-`dlopen` builds); `host.rs` the host-side loader/invoker |
+| `ephpm-middleware-builtins/src/*.rs` | The ten official modules: `api_key`, `cors`, `header_transform`, `ip_allowlist`, `jwt`, `maintenance_mode`, `ratelimit`, `redirect`, `request_id`, `security_headers` |
 | `ephpm-php/src/ws_bridge.rs` | `ephpm_ws_*` native functions — per-thread site scope + current-connection context |
 | `ephpm-config/src/lib.rs` | All config structs: `SqliteConfig`, `ReplicationConfig`, `ClusterConfig`, `DbAnalysisConfig` |
 | `ephpm-cluster/src/sqlite_election.rs` | Primary election via gossip KV (lowest ordinal wins, TTL heartbeat); `hrw_owner()` + per-site election (`sqlite:primary:<site>`) for per-site clustered mode |
@@ -163,7 +171,7 @@ Quick-reference map of the **public** repos in the `github.com/ephpm` org (`orig
 | `litewire` | Rust wire-protocol proxy (MySQL/PG/TDS/Hrana → SQLite/Turso). | **Dependency** — git dep pinned by `rev` in workspace `Cargo.toml`; used as a library. |
 | `php-sdk` | Prebuilt PHP embed static libs (`libphp.a` / `php8embed.lib`) + headers, per OS/arch/PHP-version; built with static-php-cli. | **Dependency** — tarballs downloaded by `cargo xtask php-sdk`, pinned per-minor in `xtask/src/main.rs`. Separate build pipeline. |
 | `ephemerd` | Ephemeral GitHub Actions runner daemon (Go). Containers on Linux, Hyper-V on Windows, VMs on macOS. | **CI infra** — the self-hosted runner fleet that runs ePHPm's Actions (incl. Windows/macOS legs). Not linked into the binary. |
-| `db` | Base PHP library for the in-process DB bridge — typed `Connection`, exceptions, IDE stubs over `ephpm_db_*`. | **Consumer (PHP pkg)** — base dep of the DB-driver packages below. Requires ePHPm `main` (`ephpm_db_*` not in any tagged release ≤ v0.6.2). |
+| `db` | Base PHP library for the in-process DB bridge — typed `Connection`, exceptions, IDE stubs over `ephpm_db_*`. | **Consumer (PHP pkg)** — base dep of the DB-driver packages below. Requires ePHPm **≥ v0.6.3**, the first tag carrying the `ephpm_db_*` bridge (`ephpm_kv_*` has shipped since v0.1.0). |
 | `db-wordpress` | WordPress `wp-content/db.php` drop-in (wpdb) over `ephpm_db_*`. | **Consumer (PHP pkg)** — WordPress on per-site Turso, no mysqli/socket. Falls back to stock mysqli off-ePHPm. |
 | `db-laravel` | Laravel database driver (`'driver' => 'ephpm'`) over `ephpm_db_*`. | **Consumer (PHP pkg)** — Laravel query builder/Eloquent, no PDO/socket. |
 | `db-doctrine` | Doctrine DBAL 4 driver over `ephpm_db_*`. | **Consumer (PHP pkg)** — DBAL 4 only (not DBAL 3). |


### PR DESCRIPTION
Three small riders for v0.8.7:

1. **CLAUDE.md**: the six `ephpm-middleware*` crates were entirely missing from the Workspace Structure table (a whole subsystem invisible to agents reading the doc); Key Files gains the middleware entry points; the stale 'ephpm_db_* not in any tagged release ≤ v0.6.2' claim corrected to '≥ v0.6.3'.
2. **nightly.yml**: `max-parallel: 1` on Windows — same guard release.yml has had since v0.5.1; nightlies were racing the VS bootstrapper (one surviving leg per night, rotating).
3. **release-php-beta.yml**: slash-safe artifact names so branch dispatches don't die at upload (observed run 33460847551).