### PR TITLE
fix(examples): drop the stale reset_strategy = always workaround (#425)

### DIFF
--- a/crates/ephpm-db/tests/proxy_integration.rs
+++ b/crates/ephpm-db/tests/proxy_integration.rs
@@ -285,9 +285,17 @@ async fn transaction_integrity() {
 
 // ── Smart reset_strategy tests ───────────────────────────────────────────────
 //
-// These exercise the `proxy_routing_loop` path (per-query routing + dirty
-// tracking). The `Always` tests above run through `proxy_bidirectional`, so
-// without these the Smart code path is never integration-tested.
+// These exercise the dirty-tracking half of `Smart`: the strategy is consulted
+// once per session, when the backend goes back to the pool, and only a session
+// the client dirtied pays for a `COM_RESET_CONNECTION`.
+//
+// They deliberately use `start_proxy` (no replicas), which is what every
+// `[db.mysql]` deployment without `[db.read_write_split]` gets. On that path
+// `Smart` and `Always` relay identical bytes through
+// `proxy_bidirectional_sniff` and differ *only* in whether the reset is sent on
+// return — see `MySqlProxy::handle_client`. Before #97 `Smart` alone selected
+// `proxy_routing_loop`, which is what made it hang; `start_proxy_rw_split`
+// below is now the only way to reach that per-command path.
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "requires MYSQL_TEST_URL — see .github/workflows/db-integration.yml"]
@@ -571,4 +579,114 @@ async fn multi_result_call_does_not_desync_the_pooled_backend() {
     .await;
 
     result.expect("a multi-result CALL desynchronised the proxy (timed out)");
+}
+
+// ── The WordPress bootstrap query on the Smart default (issues #97, #425) ────
+
+/// `WordPress` opens with `SELECT @@max_allowed_packet, @@wait_timeout` — a
+/// two-column, one-row result set — and before #97 that hung on the shipped
+/// `reset_strategy = "smart"` default. `examples/wordpress-compose/ephpm.toml`
+/// pinned `"always"` to dodge it and kept the warning for two months after the
+/// fix landed; #425 is the ticket that removed it, and this is the test that
+/// keeps the claim from having to be re-verified by hand.
+///
+/// The shape matters more than the query text. The original failure was
+/// `forward_mysql_response` returning at the *intermediate* EOF that closes the
+/// column-definition block, so the row packets stayed on the backend socket —
+/// which only bites when a result set has both column definitions and rows.
+/// `SELECT 1` does not exercise it; two columns and a row do.
+///
+/// `max_connections = 1` is load-bearing twice over: every session provably
+/// draws the same backend, and the sessions alternate between the two `Smart`
+/// return branches — a pure-read session (returned *without* a reset) and a
+/// dirtied one (returned with `COM_RESET_CONNECTION`). Leftover bytes from
+/// either branch would desynchronise the next session, and a desynchronised
+/// session hangs rather than errors, so the whole body is bounded.
+///
+/// Scope, so nobody over-reads this: the client here is `mysql_async`, not
+/// `pdo_mysql`. Nothing in CI drives the `[db.mysql]` proxy from PHP — the one
+/// `pdo_mysql` e2e suite (`rw_split`) points at the embedded SQLite listener,
+/// not a real MySQL backend — so the `pdo_mysql` half of #425 was verified by
+/// hand (WordPress on `examples/wordpress-compose`) and is not regression-
+/// guarded. What *is* guarded here is the wire shape that actually broke.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires MYSQL_TEST_URL — see .github/workflows/db-integration.yml"]
+async fn wordpress_bootstrap_query_smart_survives_session_churn() {
+    let Some(url) = mysql_url() else {
+        println!("MYSQL_TEST_URL not set — skipping");
+        return;
+    };
+
+    let config = PoolConfig {
+        min_connections: 1,
+        max_connections: 1,
+        idle_timeout: Duration::from_secs(60),
+        max_lifetime: Duration::from_secs(300),
+        pool_timeout: Duration::from_secs(5),
+        health_check_interval: Duration::from_secs(30),
+    };
+    let addr = start_proxy(&url, config, ResetStrategy::Smart).await;
+
+    let result = tokio::time::timeout(Duration::from_secs(30), async {
+        for round in 0..6 {
+            // A pure-read session: `Smart` returns this backend to the pool
+            // *without* a reset, so anything left behind survives into the
+            // next iteration.
+            {
+                let pool = mysql_async::Pool::new(proxy_opts(&addr));
+                let mut conn = pool.get_conn().await.unwrap();
+
+                let rows: Vec<(u64, u64)> =
+                    conn.query("SELECT @@max_allowed_packet, @@wait_timeout").await.unwrap();
+                assert_eq!(rows.len(), 1, "round {round}: expected exactly one row");
+                assert!(rows[0].0 > 0, "round {round}: @@max_allowed_packet must be non-zero");
+                assert!(rows[0].1 > 0, "round {round}: @@wait_timeout must be non-zero");
+
+                // A second command on the same session proves the first
+                // response was consumed to its last byte.
+                let echo: Vec<(i32,)> = conn.query("SELECT 7").await.unwrap();
+                assert_eq!(echo[0].0, 7, "round {round}: follow-up command read the wrong bytes");
+
+                drop(conn);
+                pool.disconnect().await.unwrap();
+            }
+
+            // A dirtied session on the same single backend: `Smart` resets this
+            // one on return, which is the other half of the branch.
+            {
+                let pool = mysql_async::Pool::new(proxy_opts(&addr));
+                let mut conn = pool.get_conn().await.unwrap();
+                conn.query_drop(format!("SET @_ephpm_i425 = {round}")).await.unwrap();
+                let rows: Vec<(Option<i64>,)> = conn.query("SELECT @_ephpm_i425").await.unwrap();
+                assert_eq!(
+                    rows[0].0,
+                    Some(i64::from(round)),
+                    "round {round}: session continuity broken — the backend was swapped mid-session"
+                );
+                drop(conn);
+                pool.disconnect().await.unwrap();
+            }
+
+            // Let the proxy finish parking (and resetting) the backend before
+            // the next round draws it again.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // The dirtied sessions above must not have leaked into a fresh one.
+        let pool = mysql_async::Pool::new(proxy_opts(&addr));
+        let mut conn = pool.get_conn().await.unwrap();
+        let rows: Vec<(Option<i64>,)> = conn.query("SELECT @_ephpm_i425").await.unwrap();
+        assert_eq!(
+            rows[0].0, None,
+            "@_ephpm_i425 leaked across sessions — Smart skipped a reset it owed"
+        );
+        drop(conn);
+        pool.disconnect().await.unwrap();
+    })
+    .await;
+
+    result.expect(
+        "the WordPress bootstrap query hung on reset_strategy = \"smart\" (timed out) — \
+         this is the #97 regression that #425 verified was gone",
+    );
 }

--- a/examples/wordpress-compose/ephpm.toml
+++ b/examples/wordpress-compose/ephpm.toml
@@ -10,22 +10,19 @@ document_root = "/app/wordpress"
 url             = "mysql://wordpress:wordpress@mysql:3306/wordpress"
 listen          = "127.0.0.1:3306"
 max_connections = 20
-# NOT the default. The shipped default is "smart" (reset after any non-SELECT);
-# this example overrides it to "always".
+# reset_strategy is deliberately not set — this example runs the shipped
+# default, "smart" (reset the pooled backend only after a session that issued
+# something other than a SELECT).
 #
-# Provenance: the override was added in #94 (2026-06-19) against v0.2.x-era
-# proxy code, with a note that "smart" hung when pdo_mysql was the client and a
-# promise to file an issue that was never filed. The proxy has changed
-# substantially since, and the claim has NOT been re-verified against current
-# code — treat it as unconfirmed history, not a known-current defect. The Smart
-# path does now have integration coverage
-# (crates/ephpm-db/tests/proxy_integration.rs::basic_query_roundtrip_smart and
-# ::session_isolation_smart), but those drive the proxy with mysql_async rather
-# than pdo_mysql, so the exact combination named above is still uncovered.
-#
-# TODO: run this stack with the line below removed; either fix the hang or drop
-# the override so the example demonstrates the shipped default.
-reset_strategy  = "always"
+# History, because this line used to say the opposite: #94 (2026-06-19) pinned
+# "always" here to dodge a hang that "smart" hit on WordPress's very first
+# query. #97 (2026-06-23) fixed it — `forward_mysql_response` was stopping at
+# the intermediate EOF that ends the column-definition block, so a two-column
+# result set left its rows on the backend socket and the client waited forever.
+# The override outlived the fix by two months. #425 re-verified the current
+# proxy against this exact stack (WordPress installed and served over
+# pdo_mysql, "smart" vs "always" vs "never", concurrent load): no hang, and
+# "smart" isolates sessions exactly as "always" does.
 
 # Note: no [kv.redis_compat] either. WordPress's Redis Object Cache talks
 # directly to the standalone `redis` container (see wp-config.php), not to


### PR DESCRIPTION
## Verdict: the hang is gone

`examples/wordpress-compose/ephpm.toml` has pinned `reset_strategy = "always"` since #94 (2026-06-19), carrying a comment that the shipped `"smart"` default "has a known hang when pdo_mysql is the client (issue TBD)". The issue was never filed, so nothing tracked it.

It was fixed four days later. #97 (2026-06-23) — *"MySQL Smart reset hangs on multi-column result sets"* — names this exact example in its own commit message and ends with *"With this in, `examples/wordpress-compose/ephpm.toml` can drop the `reset_strategy = "always"` workaround in a follow-up."* That follow-up is this PR, two months late.

### Why it could not still be true

Before #97, `Smart` was the only strategy that selected `proxy_routing_loop`, and `forward_mysql_response` returned at the *intermediate* EOF closing the column-definition block — so a two-column result set left its rows on the backend socket and the client blocked forever. WordPress's first query is `SELECT @@max_allowed_packet, @@wait_timeout`: two columns, one row.

Today, `MySqlProxy::handle_client` gates the routing loop on `self.rw_split.enabled && !self.replica_pools.is_empty()`. The compose example configures no replicas, so `"smart"` and `"always"` relay **identical bytes** through `proxy_bidirectional_sniff` and differ only in whether `COM_RESET_CONNECTION` is sent when the backend is parked.

### Empirical verification

Run against `ephpm/ephpm:v0.8.6-php8.5.7` with a real `mysql:8.4` container, ePHPm's own PHP as the client, `pdo_mysql` → `127.0.0.1:3306` → proxy → MySQL. `crates/ephpm-db` is byte-identical between `v0.8.5` and this branch's base, so the image's proxy is the code under review.

**1. Real WordPress on the `"smart"` default** (`reset_strategy` removed entirely):

| Step | Result |
|---|---|
| `GET /wp-admin/install.php` | `200`, `WordPress › Installation` |
| `POST /wp-admin/install.php?step=2` (full schema + seed) | `200`, install success |
| Front page, `/wp-login.php`, `/wp-json/`, `/?feed=rss2` | all `200` |

The installer page is exactly where the original hang fired.

**2. A 13-step `pdo_mysql` probe**, run against all three strategies with a 4-connection pool and a hard 120s host-side timeout (a hang would have been a truncated transcript, not a stuck harness):

```
STEP 01 SELECT @@max_allowed_packet,@@wait_timeout   STEP 07 SET @v / SELECT @v (session continuity)
STEP 02 8 cols x 50 rows                             STEP 08 abandon mid-transaction x8
STEP 03 SET NAMES / SHOW VARIABLES / DATABASE()      STEP 09 reconnect, pool must be clean
STEP 04 DDL + INSERT + SELECT                        STEP 10 abandon mid-result-set x8
STEP 05 prepared statement lifecycle                 STEP 11 120 short sessions, mixed read/write
STEP 06 transaction commit + rollback                STEP 12 cross-session isolation
                                                     STEP 13 multi-result CALL
```

| strategy | verdict | elapsed | `@churn` on a fresh session |
|---|---|---|---|
| `smart` (default) | all 13 steps pass | 0.46s | `NULL` |
| `always` | all 13 steps pass | 0.38s | `NULL` |
| `never` | all 13 steps pass | 0.37s | **`118` (leaked)** |

The `never` column is the control: the knob is live, and `"smart"` really does issue the resets it owes. Uncommitted rows from the eight abandoned transactions were invisible afterwards under every strategy.

**3. Concurrent load**, 8 workers × 30 requests over WordPress front page / login / REST / feed:

| strategy | elapsed | requests >5s | proxy warnings or errors |
|---|---|---|---|
| `smart` | 62.7s | 9 | none |
| `always` | 61.1s | 5 | none |

Within noise of each other on a Windows/WSL bind-mount rig. (The `slow` tail is the 9p filesystem, not the proxy — serial latency is ~1–4s for *every* path under both strategies, and the proxy logged nothing.)

## What this PR changes

- **`examples/wordpress-compose/ephpm.toml`** — drops the `reset_strategy = "always"` override so the example demonstrates the shipped default. The replacement comment records the history compactly (why it was there, that #97 fixed it, that #425 re-verified it) rather than leaving a bare deletion for the next reader to re-litigate.

- **`crates/ephpm-db/tests/proxy_integration.rs`** — adds `wordpress_bootstrap_query_smart_survives_session_churn`. The shape is the point, not the query text: `max_connections = 1` so every session provably draws the same backend, and rounds alternate a pure-read session (Smart returns it *without* a reset) with a dirtied one (Smart resets it), so both return branches get exercised against a single shared connection. Bounded at 30s, because a desync hangs rather than errors. Runs in CI via `.github/workflows/db-integration.yml` against a real `mysql:8.0`.

  Verified locally against `mysql:8.0` with default `caching_sha2_password`:

  ```
  running 10 tests
  test basic_query_roundtrip ... ok
  test basic_query_roundtrip_smart ... ok
  test connection_pool_reuse ... ok
  test multi_result_call_does_not_desync_the_pooled_backend ... ok
  test prepared_statement_lifecycle ... ok
  test prepared_statement_lifecycle_smart ... ok
  test session_isolation ... ok
  test session_isolation_smart ... ok
  test transaction_integrity ... ok
  test wordpress_bootstrap_query_smart_survives_session_churn ... ok

  test result: ok. 10 passed; 0 failed
  ```

- Corrects the section header above the Smart tests, which claimed they "exercise the `proxy_routing_loop` path". That stopped being true in #97 — `start_proxy_rw_split` is now the only way to reach that path.

## Residual gap, stated rather than papered over

**Nothing in CI drives the `[db.mysql]` proxy from PHP.** The one `pdo_mysql` e2e suite (`rw_split`) points at the embedded SQLite listener, not a real MySQL backend, and `xtask`'s bare-process e2e rig provisions no MySQL server. So the `pdo_mysql` half of this verification was done by hand and is **not** regression-guarded; the new test guards the wire shape that actually broke, with `mysql_async` as the client. That limitation is written into the test's doc comment so it cannot be quietly over-read later.

Closing that gap properly means a real-MySQL e2e leg with PHP in front of it — worth its own issue, not a silent rider on this one.

Closes #425
