### PR TITLE
ci: linux-arm64 has a dedicated runner node - drop the stale build-macos serialization

### DIFF
--- a/.github/workflows/build-memory.yml
+++ b/.github/workflows/build-memory.yml
@@ -46,9 +46,9 @@ on:
         type: choice
         options: ["both", "linux-arm64", "windows"]
 
-# One probe at a time. linux-arm64 runs in the Apple Silicon host's embedded
-# Linux VM — the same physical machine as build-macos — so a concurrent probe
-# would contend for the very memory being measured and invalidate the number.
+# One probe at a time. linux-arm64 runs on the fleet's dedicated arm64 runner
+# node; a concurrent probe (or a second workflow run) on the same node would
+# contend for the very memory being measured and invalidate the number.
 concurrency:
   group: ephpm-build-memory
   cancel-in-progress: false

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -15,8 +15,8 @@ jobs:
     name: Build CI Image (${{ matrix.arch }})
     # Build each arch's image natively on a runner of that arch (no buildx /
     # cross-build, which would need --privileged). amd64 -> :latest,
-    # arm64 -> :latest-arm64. The arm64 runner is the Apple Silicon host's
-    # embedded linux VM (ephemerd dispatches `[self-hosted, linux, arm64]`).
+    # arm64 -> :latest-arm64. The arm64 runner is the fleet's dedicated
+    # arm64 node (ephemerd dispatches `[self-hosted, linux, arm64]`).
     runs-on: [self-hosted, linux, "${{ matrix.arch }}"]
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
   build-linux:
     name: Build (PHP ${{ matrix.php }}, ${{ matrix.arch.sdk }})
     # Built natively per arch: x64 on the WSL2 linux runner, arm64 on the
-    # Apple Silicon host's embedded linux VM (ephemerd dispatches
+    # fleet's dedicated arm64 runner node (ephemerd dispatches
     # `[self-hosted, linux, arm64]`). Each uses the matching CI image.
     runs-on: [self-hosted, linux, "${{ matrix.arch.runner }}"]
     container: "ephpm/ephpm-ci:${{ matrix.arch.image }}"
@@ -69,8 +69,8 @@ jobs:
           # Thin LTO is NOT enough here: release.yml tried it (#181) and
           # had to drop to off once the turso engine (#183) grew the
           # binary. Match release.yml so nightly and release build the
-          # arm64 artifact the same way. Revisit once the VM memory is
-          # raised.
+          # arm64 artifact the same way. Revisit once the arm64 node's
+          # memory is raised.
           CARGO_PROFILE_RELEASE_LTO: ${{ matrix.arch.lto }}
         run: cargo xtask release ${{ matrix.php }}
 
@@ -111,13 +111,13 @@ jobs:
     runs-on: [self-hosted, macos, arm64]
     strategy:
       fail-fast: false
-      # Cap at 2 to leave headroom on the Apple Silicon host. The same Mac
-      # also dispatches linux-aarch64 builds (via the embedded Linux VM),
-      # and ephemerd's per-host max_concurrent=4 was getting saturated when
-      # all 3 macos + 3 linux-aarch64 jobs hit at once -- the runner agent
-      # was reaped mid-build (observed: PHP 8.4 macos-aarch64 dying with no
-      # log activity after `actions/checkout`). 2 macos + ~2 linux-aarch64
-      # fits comfortably under the cap.
+      # Cap at 2 to leave headroom on the Apple Silicon host. linux-aarch64
+      # moved to its own dedicated node, so the Mac only runs macOS jobs now
+      # -- but 3 concurrent full release builds on one host is still a lot
+      # (the host has been reaped mid-build under saturation before:
+      # PHP 8.4 macos-aarch64 dying with no log activity after
+      # `actions/checkout`), and release.yml runs this same build at
+      # max-parallel: 1. Keep 2 until a nightly at 3 proves real headroom.
       max-parallel: 2
       matrix:
         php: ["8.3", "8.4", "8.5"]

--- a/.github/workflows/release-php-beta.yml
+++ b/.github/workflows/release-php-beta.yml
@@ -169,10 +169,16 @@ jobs:
           name: ephpm-beta-${{ needs.setup.outputs.safe_ref }}-php${{ matrix.php.full }}-macos-aarch64
           path: ${{ steps.pkg.outputs.archive }}
 
-  # -- Linux aarch64 (glibc, in the macOS host's linux VM) --------------------
+  # -- Linux aarch64 (glibc, dedicated arm64 runner node) ---------------------
   build-linux-arm64:
     name: Beta (PHP ${{ matrix.php.full }}, linux-aarch64)
-    needs: [build-macos, setup]
+    # arm64 runs on its own dedicated node now — it no longer shares the
+    # Apple Silicon host with build-macos, so no cross-job `needs:
+    # build-macos` serialization (that was copied from release.yml's old
+    # shared-Mac topology). max-parallel: 1 stays as a per-node guard on the
+    # arm64 box itself (disk/memory incidents under concurrent heavy links —
+    # see release.yml's build-linux-arm64).
+    needs: setup
     if: needs.setup.outputs.experimental_matrix != '[]'
     runs-on: [self-hosted, linux, arm64]
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,14 +225,16 @@ jobs:
   # -- Linux arm64 binaries ----------------------------------------------------
   build-linux-arm64:
     name: Build (PHP ${{ matrix.php.full }}, linux-aarch64)
-    # arm64 builds run in the Apple Silicon host's embedded linux VM
-    # (ephemerd dispatches `[self-hosted, linux, arm64]`) — the SAME
-    # physical machine that runs build-macos natively. `needs: build-macos`
-    # is the only cross-job serialization GitHub offers, and max-parallel: 1
-    # keeps the VM to one heavy link at a time. Without both, the v0.5.1
-    # release run put 6 concurrent release builds on that one host and every
-    # runner on it died mid-build.
-    needs: [build-macos, setup]
+    # arm64 builds run on a DEDICATED arm64 runner node (ephemerd dispatches
+    # `[self-hosted, linux, arm64]`) — it no longer shares hardware with
+    # build-macos, so there is no cross-job `needs: build-macos`
+    # serialization any more and the arm64 legs start as soon as setup is
+    # done. max-parallel: 1 stays as a per-node guard on the arm64 box's OWN
+    # capacity: it has had disk-full-mid-build and runner-death incidents
+    # under long jobs, and its memory is tight enough that even a single
+    # fat-LTO link OOMs (which is why LTO is off below). Raise only after a
+    # release proves real headroom on that node.
+    needs: setup
     if: github.event_name == 'push'
     runs-on: [self-hosted, linux, arm64]
     # No `container:` — de-containerized like build-linux (node24 JS actions on
@@ -251,7 +253,8 @@ jobs:
         # binary (libphp.a + ICU + everything, codegen-units=1 per #171) exceeds
         # the arm64 build host's memory -- rustc gets OOM-SIGKILLed even as the
         # only job (#181/#183). Disabling LTO cuts link-time memory the most for
-        # a low single-digit perf delta. Revisit once the VM memory is raised.
+        # a low single-digit perf delta. Revisit once the arm64 node's memory
+        # is raised.
         run: |
           set -eu
           docker run --rm -v "$PWD":/w -w /w \
@@ -299,9 +302,10 @@ jobs:
     runs-on: [self-hosted, macos, arm64]
     strategy:
       fail-fast: false
-      # One fat-LTO release build at a time on the Apple Silicon host — it
-      # also hosts the linux-arm64 build VM (see build-linux-arm64). Raise
-      # to 2 only after a release proves real headroom.
+      # One fat-LTO release build at a time on the Apple Silicon host.
+      # (linux-arm64 moved to its own dedicated node, so the Mac only runs
+      # macOS legs now.) Raise to 2 only after a release proves real
+      # headroom.
       max-parallel: 1
       matrix:
         # {minor, full} per supported PHP minor, from xtask::PHP_SDK_VERSIONS.


### PR DESCRIPTION
## What

linux-arm64 CI jobs no longer run in the Apple Silicon host's embedded Linux VM — the fleet has a **dedicated arm64 runner node** (confirmed by Luther, 2026-09-01). Three workflows (plus two comment-only stragglers) still encoded the old shared-Mac topology. Comments and job dependencies only — **no build flags, LTO settings, images, or runner labels change**.

### `release.yml`
- `build-linux-arm64`: `needs: [build-macos, setup]` → `needs: setup`. The arm64 legs now start as soon as `setup` finishes instead of waiting for all ~3 serialized macOS legs (`build-macos` is itself `max-parallel: 1`), cutting significant wall-clock from every release.
- Rewrote the job comment: the old text cited the v0.5.1 six-concurrent-builds-on-one-host incident and "the SAME physical machine that runs build-macos". **`max-parallel: 1` is kept deliberately**, re-justified on the arm64 node's own capacity: it has had disk-full-mid-build and runner-death incidents under long jobs, and its memory is tight enough that a single fat-LTO link OOMs (why LTO stays off there).
- `build-macos` comment no longer claims the Mac "also hosts the linux-arm64 build VM" (its `max-parallel: 1` is unchanged).

### `release-php-beta.yml`
- `build-linux-arm64`: same fix — `needs: [build-macos, setup]` → `needs: setup`, section header "(in the macOS host's linux VM)" corrected, `max-parallel: 1` kept with the per-node justification.

### `nightly.yml`
- `build-macos` `max-parallel: 2`: the setting stays, but the justification ("the same Mac also dispatches linux-aarch64 builds... per-host max_concurrent=4 saturated") was wrong either way. New rationale: 3 concurrent full release builds on one Mac is still plausibly too much (the host has been reaped mid-build under saturation before, and release.yml runs this same build at `max-parallel: 1`); raise to 3 only after a nightly proves headroom.
- `build-linux` arch comment: arm64 now described as the dedicated node. The fat-LTO OOM comment block and `lto: "off"` are **unchanged** — that history is about the arm64 machine's memory and still plausibly applies to the new node.

### Stale-claim sweep (comment-only)
- `build-memory.yml`: probe-serialization rationale reworded to the dedicated node (concurrency group unchanged — a memory probe still must run alone on its node).
- `ci-image.yml`: arm64 runner description corrected.
- `e2e.yml` quotes nightly's "to leave headroom on the Apple Silicon host" phrase; that wording was kept verbatim in the rewritten nightly comment, so the cross-reference stays accurate.

## Behavior change

Beyond starting earlier: with `needs: build-macos`, an arm64 release leg was **skipped whenever build-macos failed**. After this change the arm64 legs run independently of macOS outcomes — a red Mac no longer costs the release its linux-arm64 artifacts. That is the desired behavior; the `release` job still gates publication on all build legs directly, so nothing publishes with a missing leg.

## Validation

`actionlint` on all five touched workflows: clean (exit 0).

## Merge timing

**Do not merge yet** — a release rerun is currently in flight on `release.yml`. Leave this PR for merge after v0.8.7 publishes.

Closes #436
