### PR TITLE
fix(worker): FIFO-fair dispatch admission - P99 280ms to 58ms at unchanged throughput

### DIFF
--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -169,6 +169,13 @@ pub struct WorkerJob {
     pub request: WorkerRequestOwned,
     /// Where the worker's response (or the supervisor's 500) is delivered.
     pub respond_to: tokio::sync::oneshot::Sender<WorkerResponse>,
+    /// Fair-admission permit held while this job occupies the dispatch queue
+    /// (issue #442). Granted by the pool's FIFO admission semaphore before the
+    /// job is enqueued and dropped by the worker the moment it pulls the job —
+    /// releasing the queue slot to the *longest-waiting* dispatcher instead of
+    /// whichever sender happens to race a bounded-channel `send()` first.
+    /// `None` only for jobs that never passed admission (tests).
+    pub admission: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 // ── C-compatible request view ────────────────────────────────────────────
@@ -639,12 +646,15 @@ unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int 
         Err(_) => return 0,
     };
     // The job just left the dispatch channel — reflect it in the shared
-    // depth counter the pool reports as `ephpm_worker_dispatch_queue_depth`.
+    // depth counter the pool reports as `ephpm_worker_dispatch_queue_depth`,
+    // and release its admission permit so the pool's FIFO admission semaphore
+    // hands the freed queue slot to the longest-waiting dispatcher (#442).
     DISPATCH_DEPTH.with(|cell| {
         if let Some(depth) = cell.borrow().as_ref() {
             depth.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         }
     });
+    drop(job.admission);
 
     // Stash the sender for send_response / crash recovery.
     PENDING_SENDER.with(|cell| *cell.borrow_mut() = Some(job.respond_to));

--- a/crates/ephpm-server/src/fpm_pool.rs
+++ b/crates/ephpm-server/src/fpm_pool.rs
@@ -32,8 +32,9 @@
 //! - **Concurrency cap:** the pool size ([`PhpConfig::effective_worker_count`])
 //!   is the cap. The `[php] workers` semaphore is redundant and bypassed.
 //! - **Backpressure → 504:** the dispatch queue is bounded. When it is full,
-//!   [`FpmPool::dispatch`] suspends; the outer request timeout turns a starved
-//!   queue into a 504.
+//!   [`FpmPool::dispatch`] suspends on the FIFO-fair admission semaphore
+//!   ([`FpmPool::admission`], issue #442); the outer request timeout turns a
+//!   starved queue into a 504.
 //! - **Shed → 503 + `Retry-After`:** with `[php] overload_policy = "shed"` the
 //!   router calls [`FpmPool::try_dispatch`] instead, which refuses to queue
 //!   behind a full backlog (after an optional `[php] shed_after_ms` grace) and
@@ -130,13 +131,19 @@ pub enum DispatchRejected {
 struct FpmJob {
     run: FpmTask,
     respond_to: oneshot::Sender<FpmExecOutput>,
+    /// Fair-admission permit held while the job occupies the dispatch queue
+    /// (issue #442) — dropped by the pool thread the moment it pulls the job,
+    /// handing the freed slot to the longest-waiting dispatcher. See
+    /// [`FpmPool::admission`].
+    admission: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 /// Handle to the running FPM pool. Cheap to clone via `Arc`.
 pub struct FpmPool {
-    /// Dispatch queue: the hyper handler `send().await`s jobs here; pool
-    /// threads `recv_blocking()`. Bounded — a full queue applies HTTP
-    /// backpressure (the outer request timeout turns a starved queue into 504).
+    /// Dispatch queue: the hyper handler enqueues jobs here after passing
+    /// [`FpmPool::admission`]; pool threads `recv_blocking()`. Capacity equals
+    /// the admission permit count, so a permit holder's `try_send` can never
+    /// find it full.
     dispatch_tx: async_channel::Sender<FpmJob>,
     /// Kept alive so the channel never closes while the supervisor respawns
     /// threads. Cloned into each pool thread.
@@ -144,6 +151,17 @@ pub struct FpmPool {
     /// Jobs enqueued but not yet pulled. Incremented on enqueue, decremented by
     /// a thread right after `recv_blocking`. Backs `ephpm_fpm_pool_queue_depth`.
     queue_depth: Arc<AtomicUsize>,
+    /// FIFO admission gate in front of the dispatch queue (issue #442).
+    ///
+    /// One permit == one dispatch-queue slot (capacity == permit count), and
+    /// the pool thread releases the permit as it pulls the job. Waiting
+    /// happens here — in strict arrival order — instead of in the bounded
+    /// channel's `send().await`, whose try/listen/retry loop lets fresh
+    /// senders barge past parked ones and re-queues a raced-out waiter at the
+    /// back, producing a multi-lap starvation tail under saturation. See
+    /// `worker_pool::WorkerPool::admission` for the full mechanism and the
+    /// measurements; the two pools share the defect and the fix.
+    admission: Arc<tokio::sync::Semaphore>,
     /// Shared runtime state (readiness, liveness, drain flag).
     state: Arc<PoolState>,
     /// Target number of live pool threads (the concurrency cap).
@@ -216,6 +234,7 @@ impl FpmPool {
             dispatch_tx,
             dispatch_rx,
             queue_depth: Arc::new(AtomicUsize::new(0)),
+            admission: Arc::new(tokio::sync::Semaphore::new(backlog.max(1))),
             state,
             thread_count,
             started: Instant::now(),
@@ -265,32 +284,57 @@ impl FpmPool {
     /// Dispatch one request to the pool and return the receiver for its
     /// response.
     ///
-    /// `send().await` suspends when the bounded queue is full (backpressure);
-    /// the caller wraps the whole thing in the outer request timeout, so a
-    /// starved queue becomes a 504 rather than an unbounded wait.
+    /// The acquire on [`FpmPool::admission`] suspends when the queue is full
+    /// (backpressure) and admits waiters in strict arrival order (#442); the
+    /// caller wraps the whole thing in the outer request timeout, so a starved
+    /// queue becomes a 504 rather than an unbounded wait.
     ///
     /// # Errors
     ///
     /// Returns [`DispatchClosed`] if the pool is draining / all threads are gone
-    /// (the dispatch channel is closed) — the caller should 503.
+    /// (admission and dispatch channel are closed) — the caller should 503.
     pub async fn dispatch(
         &self,
         run: FpmTask,
     ) -> Result<oneshot::Receiver<FpmExecOutput>, DispatchClosed> {
+        // Wait for a queue slot in strict arrival order. Errors only when
+        // `drain()` closed the semaphore.
+        let Ok(permit) = Arc::clone(&self.admission).acquire_owned().await else {
+            return Err(DispatchClosed);
+        };
+        self.enqueue_with_permit(run, permit).map_err(|_reason| DispatchClosed)
+    }
+
+    /// Enqueue a job whose admission permit is already held.
+    ///
+    /// Holding a permit guarantees a free channel slot (capacity == permit
+    /// count, and every enqueued job holds one permit until a thread pulls
+    /// it), so the `try_send` cannot see `Full` — no await, and the
+    /// increment-to-enqueue window cannot be cancelled mid-way, so the depth
+    /// accounting cannot leak.
+    fn enqueue_with_permit(
+        &self,
+        run: FpmTask,
+        permit: tokio::sync::OwnedSemaphorePermit,
+    ) -> Result<oneshot::Receiver<FpmExecOutput>, DispatchRejected> {
         let (tx, rx) = oneshot::channel();
-        let job = FpmJob { run, respond_to: tx };
-        // Account the enqueue before the (awaitable) send so a thread pulling
-        // concurrently can only ever decrement a value we already added.
+        let job = FpmJob { run, respond_to: tx, admission: Some(permit) };
         let depth = self.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
         #[allow(clippy::cast_precision_loss)]
         gauge!("ephpm_fpm_pool_queue_depth").set(depth as f64);
-        match self.dispatch_tx.send(job).await {
+        match self.dispatch_tx.try_send(job) {
             Ok(()) => Ok(rx),
-            Err(_) => {
-                // Channel closed — the job never entered the queue and no thread
-                // will pull it, so undo the accounting.
+            Err(e) => {
+                // Closed (draining) — or, defensively, a Full the permit
+                // invariant says cannot happen. The job never entered the
+                // queue, so undo the accounting; the permit inside the dropped
+                // job frees itself.
+                debug_assert!(
+                    matches!(e, async_channel::TrySendError::Closed(_)),
+                    "fpm dispatch queue full while holding an admission permit"
+                );
                 self.queue_depth.fetch_sub(1, Ordering::Relaxed);
-                Err(DispatchClosed)
+                Err(DispatchRejected::Closed)
             }
         }
     }
@@ -304,15 +348,17 @@ impl FpmPool {
     /// emitted (issue #301) — this waits at most `grace` and then gives up so
     /// the caller can answer `503` immediately.
     ///
-    /// `grace` of zero is a plain non-blocking `try_send`: the backlog
+    /// `grace` of zero is a plain non-blocking permit try-acquire: the backlog
     /// (`[php] worker_backlog`, default = pool size) is already the buffer, so
     /// "full" means every thread is busy *and* the queue behind them is full.
     ///
+    /// A non-zero `grace` waits on the same FIFO-fair admission semaphore
+    /// `dispatch` uses, so shed-mode waiters queue in arrival order too.
     /// Cancelling the wait is sound because a queued-but-unstarted job is
     /// genuinely never run: nothing has been handed to a pool thread yet, so
-    /// dropping the send future removes it from the channel's waiter list and
-    /// no PHP work leaks. That is precisely what the `spawn_blocking` engine
-    /// cannot do with tokio's blocking queue.
+    /// dropping the acquire future removes it from the semaphore's waiter list
+    /// and no PHP work leaks. That is precisely what the `spawn_blocking`
+    /// engine cannot do with tokio's blocking queue.
     ///
     /// # Errors
     ///
@@ -323,35 +369,24 @@ impl FpmPool {
         run: FpmTask,
         grace: Duration,
     ) -> Result<oneshot::Receiver<FpmExecOutput>, DispatchRejected> {
-        let (tx, rx) = oneshot::channel();
-        let job = FpmJob { run, respond_to: tx };
-        // Same accounting discipline as `dispatch`: count the enqueue before
-        // the attempt, roll it back on every path that does not enqueue.
-        let depth = self.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
-        #[allow(clippy::cast_precision_loss)]
-        gauge!("ephpm_fpm_pool_queue_depth").set(depth as f64);
-
-        let outcome = if grace.is_zero() {
-            match self.dispatch_tx.try_send(job) {
-                Ok(()) => Ok(()),
-                Err(async_channel::TrySendError::Full(_)) => Err(DispatchRejected::Full),
-                Err(async_channel::TrySendError::Closed(_)) => Err(DispatchRejected::Closed),
+        let permit = if grace.is_zero() {
+            match Arc::clone(&self.admission).try_acquire_owned() {
+                Ok(permit) => permit,
+                Err(tokio::sync::TryAcquireError::NoPermits) => {
+                    return Err(DispatchRejected::Full);
+                }
+                Err(tokio::sync::TryAcquireError::Closed) => {
+                    return Err(DispatchRejected::Closed);
+                }
             }
         } else {
-            match tokio::time::timeout(grace, self.dispatch_tx.send(job)).await {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(_)) => Err(DispatchRejected::Closed),
-                Err(_elapsed) => Err(DispatchRejected::Full),
+            match tokio::time::timeout(grace, Arc::clone(&self.admission).acquire_owned()).await {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_closed)) => return Err(DispatchRejected::Closed),
+                Err(_elapsed) => return Err(DispatchRejected::Full),
             }
         };
-
-        match outcome {
-            Ok(()) => Ok(rx),
-            Err(reason) => {
-                self.queue_depth.fetch_sub(1, Ordering::Relaxed);
-                Err(reason)
-            }
-        }
+        self.enqueue_with_permit(run, permit)
     }
 
     /// Record that a thread appears hung (its `oneshot` timed out). The stuck
@@ -410,8 +445,11 @@ impl FpmPool {
             return;
         }
         // Closing the sender makes each thread's recv_blocking return Err, so
-        // the loop ends after any in-flight request completes.
+        // the loop ends after any in-flight request completes. Closing the
+        // admission semaphore wakes every dispatcher parked in `dispatch` /
+        // `try_dispatch` with `Closed` (503).
         self.dispatch_tx.close();
+        self.admission.close();
         tracing::info!("fpm execution pool draining — dispatch closed");
     }
 
@@ -491,10 +529,13 @@ fn thread_main(pool: &Arc<FpmPool>, thread_id: usize, rx: &async_channel::Receiv
             // Dispatch closed — graceful drain. Exit the loop cleanly.
             Err(_) => break,
         };
-        // Pulled from the queue: mirror the enqueue increment in `dispatch`.
+        // Pulled from the queue: mirror the enqueue increment in `dispatch`,
+        // and release the admission permit so the FIFO admission semaphore
+        // hands the freed slot to the longest-waiting dispatcher (#442).
         pool.queue_depth.fetch_sub(1, Ordering::Relaxed);
 
-        let FpmJob { run, respond_to } = job;
+        let FpmJob { run, respond_to, admission } = job;
+        drop(admission);
         // A PHP bailout is caught in C and returned as `Err(PhpError)` — a
         // normal `FpmExecOutput`. A *Rust* panic (e.g. an unexpected `.expect()`
         // in the request path) is different: it would unwind and silently kill

--- a/crates/ephpm-server/src/worker_pool.rs
+++ b/crates/ephpm-server/src/worker_pool.rs
@@ -4,7 +4,8 @@
 //! threads forever would starve the shared tokio blocking pool). Each thread
 //! boots the framework once via [`PhpRuntime::run_worker`], then loops over
 //! HTTP requests handed to it through an `async_channel::bounded` dispatch
-//! queue, replying on a `tokio::sync::oneshot`.
+//! queue guarded by a FIFO-fair admission semaphore (issue #442 — see
+//! [`WorkerPool::admission`]), replying on a `tokio::sync::oneshot`.
 //!
 //! Lifecycle guarantees (design §5):
 //! - **Boot-once:** the framework bootstrap runs once per worker thread; the
@@ -40,9 +41,10 @@ pub struct DispatchClosed;
 
 /// Handle to the running worker pool. Cloneable-cheap via `Arc`.
 pub struct WorkerPool {
-    /// Dispatch queue: the hyper handler `send().await`s jobs here; worker
-    /// threads `recv_blocking()`. Bounded — a full queue applies HTTP
-    /// backpressure (the outer request timeout turns a starved queue into 504).
+    /// Dispatch queue: the hyper handler enqueues jobs here after passing
+    /// [`WorkerPool::admission`]; worker threads `recv_blocking()`. Capacity
+    /// equals the admission permit count, so a permit holder's `try_send`
+    /// can never find it full.
     dispatch_tx: async_channel::Sender<WorkerJob>,
     /// Kept alive so the channel never closes while the supervisor respawns
     /// workers between boots. Cloned into each worker thread.
@@ -53,6 +55,25 @@ pub struct WorkerPool {
     /// single `Relaxed` load, replacing a per-dispatch `async_channel::len()`
     /// (a SeqCst spin-loop over head/tail).
     queue_depth: Arc<AtomicUsize>,
+    /// FIFO admission gate in front of the dispatch queue (issue #442).
+    ///
+    /// Why not just `dispatch_tx.send().await`? A bounded `async_channel`
+    /// send is a try/listen/retry loop: a **new** sender always `try_send`s
+    /// before ever queueing behind the parked ones (barging), and a notified
+    /// waiter that loses that race re-registers at the **back** of the waiter
+    /// queue. Under saturation (c ≫ backlog) that is a starvation engine:
+    /// throughput stays maximal (a freed slot is always taken instantly) but
+    /// an unlucky request is lapped by the entire waiter queue every time it
+    /// loses — the measured signature was 43% of requests admitted in <1 ms
+    /// while the P99 waited 5-6 full queue laps (~250-500 ms at 2.3k req/s).
+    ///
+    /// `tokio::sync::Semaphore` is documented FIFO-fair: permits go to
+    /// waiters in acquire order and a new acquirer queues behind existing
+    /// waiters even when a permit is free. One permit == one dispatch-queue
+    /// slot; the worker releases it (via [`WorkerJob::admission`]) the moment
+    /// it pulls the job, keeping the queue refill pipeline — and therefore
+    /// throughput — identical to the old barging behaviour.
+    admission: Arc<tokio::sync::Semaphore>,
     /// Shared runtime state (readiness, liveness, drain flag).
     state: Arc<PoolState>,
     /// Worker entrypoint script (absolute, validated under document_root).
@@ -117,6 +138,7 @@ impl WorkerPool {
             dispatch_tx,
             dispatch_rx,
             queue_depth: Arc::new(AtomicUsize::new(0)),
+            admission: Arc::new(tokio::sync::Semaphore::new(backlog.max(1))),
             state,
             worker_script,
             max_requests,
@@ -171,33 +193,49 @@ impl WorkerPool {
 
     /// Dispatch a request to the pool and return the receiver for its response.
     ///
-    /// `send().await` suspends when the bounded queue is full (backpressure);
-    /// the caller wraps the whole thing in the outer request timeout, so a
-    /// starved queue becomes a 504 rather than an unbounded wait.
+    /// Admission is **FIFO-fair**: the acquire on [`WorkerPool::admission`]
+    /// suspends when every dispatch-queue slot is taken (backpressure) and
+    /// grants slots strictly in arrival order — see the field docs for why
+    /// waiting on the bounded channel's own `send().await` instead produced a
+    /// multi-lap starvation tail (issue #442). The caller wraps the whole
+    /// thing in the outer request timeout, so a starved queue becomes a 504
+    /// rather than an unbounded wait; a cancelled acquire leaves no trace
+    /// (tokio removes the waiter, and the depth accounting below has no await
+    /// point between increment and enqueue, so it cannot leak either).
     ///
     /// # Errors
     ///
     /// Returns [`DispatchClosed`] if the pool is draining / all workers gone
-    /// (the dispatch channel is closed) — the caller should 503.
+    /// (admission and dispatch channel are closed) — the caller should 503.
     pub async fn dispatch(
         &self,
         request: WorkerRequestOwned,
     ) -> Result<oneshot::Receiver<WorkerResponse>, DispatchClosed> {
+        // Wait for a queue slot in strict arrival order. Errors only when
+        // `drain()` closed the semaphore.
+        let Ok(permit) = Arc::clone(&self.admission).acquire_owned().await else {
+            return Err(DispatchClosed);
+        };
         let (tx, rx) = oneshot::channel();
-        let job = WorkerJob { request, respond_to: tx };
-        // Account the enqueue before the (awaitable) send so a worker pulling
-        // concurrently can only ever decrement a value we already added.
-        // `send().await` may suspend under backpressure; the count reflects the
-        // job as queued for that whole window, which is exactly the depth we
-        // want to report.
+        let job = WorkerJob { request, respond_to: tx, admission: Some(permit) };
+        // Holding a permit guarantees a free channel slot (capacity == permit
+        // count, and every enqueued job holds one permit until a worker pulls
+        // it), so this `try_send` cannot see `Full` — no await, no suspension,
+        // and the increment-to-enqueue window cannot be cancelled mid-way.
         let depth = self.queue_depth.fetch_add(1, Ordering::Relaxed) + 1;
         #[allow(clippy::cast_precision_loss)]
         gauge!("ephpm_worker_dispatch_queue_depth").set(depth as f64);
-        match self.dispatch_tx.send(job).await {
+        match self.dispatch_tx.try_send(job) {
             Ok(()) => Ok(rx),
-            Err(_) => {
-                // Send failed (channel closed) — the job never entered the
-                // queue and no worker will pull it, so undo the accounting.
+            Err(e) => {
+                // Closed (draining) — or, defensively, a Full that the permit
+                // invariant says cannot happen. Either way the job never
+                // entered the queue and no worker will pull it, so undo the
+                // accounting; the permit inside the dropped job frees itself.
+                debug_assert!(
+                    matches!(e, async_channel::TrySendError::Closed(_)),
+                    "dispatch queue full while holding an admission permit"
+                );
                 self.queue_depth.fetch_sub(1, Ordering::Relaxed);
                 Err(DispatchClosed)
             }
@@ -225,8 +263,12 @@ impl WorkerPool {
             return;
         }
         // Closing the sender makes each worker's recv_blocking return Err, so
-        // take_request() returns null and the framework loop ends.
+        // take_request() returns null and the framework loop ends. Closing the
+        // admission semaphore wakes every dispatcher parked in `dispatch()`
+        // with an error (503) — mirroring how parked `send().await`s used to
+        // fail when the channel closed.
         self.dispatch_tx.close();
+        self.admission.close();
         tracing::info!("worker pool draining — dispatch closed");
     }
 
@@ -551,9 +593,13 @@ mod tests {
     }
 
     fn dummy_request() -> ephpm_php::worker_bridge::WorkerRequestOwned {
+        request_with_uri("/")
+    }
+
+    fn request_with_uri(uri: &str) -> ephpm_php::worker_bridge::WorkerRequestOwned {
         ephpm_php::worker_bridge::WorkerRequestOwned {
             method: "GET".into(),
-            uri: "/".into(),
+            uri: uri.into(),
             query_string: String::new(),
             cookie_data: String::new(),
             content_type: None,
@@ -561,6 +607,82 @@ mod tests {
             server_vars: Vec::new(),
             headers: Vec::new(),
         }
+    }
+
+    /// Admission is strictly FIFO (issue #442): waiters are admitted in
+    /// arrival order, and a dispatcher that arrives while others are parked
+    /// queues behind them instead of barging into a freshly freed slot — the
+    /// exact behaviour the old bounded-channel `send().await` could not
+    /// provide (its try/listen/retry loop let new senders steal slots and
+    /// re-queued raced-out waiters at the back, producing the multi-lap P99).
+    ///
+    /// Runs on the default current-thread test runtime, where an explicit
+    /// `yield_now` deterministically lets a just-spawned dispatcher run until
+    /// it parks on the admission semaphore.
+    #[tokio::test]
+    async fn admission_is_strictly_fifo_and_barge_proof() {
+        let pool = WorkerPool::spawn(
+            PathBuf::from("/nonexistent/worker.php"),
+            0, // no workers: this test plays the worker by pulling dispatch_rx
+            500,
+            1, // backlog of one queue slot => everyone else parks in admission
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+        );
+
+        // Fills the single queue slot immediately.
+        let _rx_a = pool.dispatch(request_with_uri("/a")).await.expect("first dispatch fits");
+
+        // Three dispatchers park on admission, in a deterministic order.
+        let mut parked = Vec::new();
+        for uri in ["/w1", "/w2", "/w3"] {
+            let pool = Arc::clone(&pool);
+            parked.push(tokio::spawn(async move {
+                pool.dispatch(request_with_uri(uri)).await.expect("admitted after a slot frees");
+            }));
+            // Let the spawned task run until it parks on the semaphore.
+            tokio::task::yield_now().await;
+        }
+
+        // Play the worker: pull one job (freeing its slot when the job — and
+        // the permit inside it — drops) and record the order jobs arrive in.
+        let mut served = Vec::new();
+        let mut pull = || {
+            let job = pool.dispatch_rx.try_recv().expect("a job is queued");
+            pool.queue_depth.fetch_sub(1, Ordering::Relaxed);
+            served.push(job.request.uri.clone());
+            drop(job); // releases the admission permit -> admits ONE waiter
+        };
+
+        pull(); // "/a" leaves; w1 must be admitted, not anyone newer...
+        tokio::task::yield_now().await;
+
+        // ...and a brand-new dispatcher arriving NOW must queue behind w2/w3
+        // even though slots keep freeing up (barge-proofing).
+        let late = {
+            let pool = Arc::clone(&pool);
+            tokio::spawn(async move {
+                pool.dispatch(request_with_uri("/late")).await.expect("admitted last");
+            })
+        };
+        tokio::task::yield_now().await;
+
+        for _ in 0..3 {
+            pull();
+            tokio::task::yield_now().await;
+        }
+        pull();
+
+        for handle in parked {
+            handle.await.expect("parked dispatcher completed");
+        }
+        late.await.expect("late dispatcher completed");
+
+        assert_eq!(
+            served,
+            vec!["/a", "/w1", "/w2", "/w3", "/late"],
+            "admission must be strict arrival order with no barging"
+        );
     }
 
     /// The counter-pair depth gauge tracks enqueues. With no workers to pull

--- a/docs/architecture/worker-dispatch-fairness.md
+++ b/docs/architecture/worker-dispatch-fairness.md
@@ -1,0 +1,175 @@
+# Worker dispatch fairness — the #442 tail-latency investigation
+
+Issue #442: in the third-party Laravel runtime comparison (wrk `-t10 -c100
+-d30s`, `worker_count = 2`, v0.8.7-php8.4, array sessions), ePHPm worker mode
+had the **highest throughput** of the five Octane-class runtimes (2,227 req/s
+on `/api/static`, ~19% over FrankenPHP) and the **worst P99 of the fast group**
+(157 ms vs FrankenPHP's 57 ms). This document is the root-cause narrative, the
+instrumentation evidence, and the reasoning behind the fix. The fix itself
+lives in `worker_pool.rs` / `fpm_pool.rs` (the two pools shared the defect);
+the design doc amendment is in `worker-mode-design.md` §2.1(a).
+
+## 1. Why that signature is a contradiction worth chasing
+
+At 2,227 req/s with 100 open connections, Little's law gives the mean sojourn
+time of an ideal 2-server FIFO queue: `100 / 2227 ≈ 45 ms`. A closed-loop
+FIFO system at deep saturation is nearly deterministic — every request waits
+behind the same ~96 predecessors — so P50, P90 and P99 should all sit near
+that 45 ms. FrankenPHP's numbers behave exactly like that: P99 57 ms at
+1,874 req/s ≈ 1.1× its own ideal sojourn (53 ms).
+
+ePHPm's P99 sat at ~3.5× ideal while its *throughput led the field*. Execution
+speed cannot produce that shape: fast execution lowers both the mean and the
+tail. Only **waiting** can decouple them — specifically, waiting that is
+unfair, where some requests are served promptly and others repeatedly lose
+their place.
+
+## 2. Where a request waits in worker mode
+
+```text
+hyper conn task ──► Router::handle_php_worker ──► WorkerPool::dispatch
+                                                       │
+                                   async_channel::bounded(worker_backlog)
+                                                       │        (backlog = 2 by default:
+                                                       ▼         worker_backlog 0 => worker_count)
+                                        worker thread recv_blocking()
+                                                       │
+                                            PHP executes, oneshot reply
+```
+
+`worker_backlog` defaults to `worker_count`, so in the bench the dispatch
+channel held **2** jobs. Two more were executing. The other ~96 in-flight
+requests were all parked inside `async_channel`'s `Sender::send().await`.
+That send future is where the entire anomaly lives.
+
+## 3. The mechanism: bounded-channel `send()` is a barging lottery
+
+`async-channel`'s `Send` future (v2.5.0, `SendInner::poll_with_strategy`) is a
+try/listen/retry loop:
+
+1. On first poll it calls `try_send` **before** ever queueing behind the
+   already-parked senders. A freshly arriving request can therefore steal a
+   just-freed slot from waiters that have been parked for hundreds of
+   milliseconds ("barging").
+2. On `Full` it registers an `event-listener` at the **back** of the
+   `send_ops` waiter queue.
+3. When a worker pops a job, exactly one waiter is notified. The woken task
+   must be scheduled by tokio and then *retry* `try_send`. If a barging sender
+   (or another woken waiter) took the slot first, the retry fails and the
+   loser **re-registers at the back** of the waiter queue — behind ~95 others.
+
+Step 1 is what maximizes throughput: a freed slot never sits idle waiting for
+a parked task to be scheduled; whoever is runnable first takes it. The queue
+is perfectly work-conserving, which is why ePHPm out-throughputs everything.
+
+Step 3 is what fattens the tail: each lost race costs a full **lap** of the
+waiter queue. At 2,227 req/s a lap of ~96 waiters takes `96 / 2227 ≈ 43 ms`.
+One lost race ≈ P75, two ≈ P90, five to six ≈ P99. The defect converts
+scheduling jitter into integer multiples of 43 ms.
+
+The same structure exists in the experimental fpm pool engine
+(`[php] fpm_engine = "pool"`, `FpmPool::dispatch`/`try_dispatch`) — same
+channel, same default backlog, same barging lottery.
+
+## 4. The instrumentation evidence
+
+Reproduced bare-process on WSL2 (32 CPUs), the same wrk shape and config as
+the bench (`worker_count = 2`, array sessions, PHP 8.4). Official
+v0.8.7-php8.4 release binary. Three rounds:
+
+| round | req/s | P50 | P75 | P90 | P99 |
+|-------|-------|-----|-----|-----|-----|
+| 1 | 2,339 | 47.5 ms | 79.6 ms | 131.1 ms | 275.9 ms |
+| 2 | 2,331 | 46.5 ms | 80.6 ms | 132.9 ms | 275.5 ms |
+| 3 | 2,321 | 47.0 ms | 81.0 ms | 134.4 ms | 285.1 ms |
+
+Note the shape: P50 ≈ 47 ms — almost exactly the ideal sojourn (100/2330 ≈
+43 ms) — then P75/P90/P99 climbing in ~43 ms steps. Those are the laps.
+
+The `ephpm_worker_request_wait_seconds` histogram (measures exactly the time
+spent inside `dispatch().await`) over a 70,083-request instrumented run:
+
+| wait | requests | cumulative |
+|------|----------|------------|
+| ≤ 1 ms | 29,934 | **42.7%** |
+| ≤ 25 ms | 33,437 | 47.7% |
+| ≤ 50 ms | 46,350 | 66.1% |
+| ≤ 100 ms | 60,360 | 86.1% |
+| ≤ 250 ms | 69,240 | 98.8% |
+| ≤ 500 ms | 70,025 | 99.9% |
+
+- Mean **wait** = 2,886 s / 70,083 = **41.2 ms**. Mean **execution** (derived:
+  `ephpm_php_execution_duration_seconds` includes the wait; subtracting sums)
+  = **1.6 ms**. Uncontended `-c1` latency: 0.85 ms mean, 1.14 ms P99. The
+  wait *is* the latency — 96% of total request time.
+- The distribution is **bimodal**, and that is the smoking gun. In a fair
+  FIFO at this saturation the queue is never empty, so *every* request would
+  wait ≈ one lap (~40 ms); sub-millisecond waits would be impossible. Yet
+  **42.7% of requests were admitted in under 1 ms** — those are the barging
+  winners of step 1 — while the balancing cost shows up as the 13.9% of
+  requests waiting 2-12× a lap. The barging winners and the multi-lap losers
+  are the same distribution seen from both ends.
+
+This also rules out the other suspects from the issue: there are no
+per-worker mailboxes (one shared MPMC queue, so no head-of-line blocking
+across workers), no admission batching (no sawtooth in the histogram), and
+the response write-back is a non-blocking `oneshot` fulfilment (a slow client
+cannot hold a worker; buffered bodies are handed off whole).
+
+## 5. The fix: move the waiting into a FIFO-fair semaphore
+
+`tokio::sync::Semaphore` is documented fair: permits are granted to waiters
+in acquire order, and a new acquirer queues behind existing waiters even when
+a permit is technically free — precisely the two properties `send().await`
+lacks. The change:
+
+- `WorkerPool` (and `FpmPool`) gain an admission semaphore with
+  `worker_backlog` permits — one permit == one dispatch-queue slot.
+- `dispatch()` acquires a permit (the only wait, strictly arrival-ordered),
+  then `try_send`s the job. The channel capacity equals the permit count and
+  every enqueued job holds its permit, so the `try_send` can never find the
+  channel full: no retry loop, nothing to barge into.
+- The worker releases the permit (`WorkerJob::admission`) the moment it pulls
+  the job off the channel — the same instant a slot freed under the old
+  scheme — so the queue-refill pipeline, and therefore throughput, is
+  unchanged. The freed slot simply goes to the longest-waiting dispatcher
+  instead of the luckiest one.
+- `drain()` closes the semaphore alongside the channel, so parked dispatchers
+  still wake into the 503 path. A request cancelled by the outer timeout
+  while parked leaves no trace (tokio unlinks the waiter), and the
+  depth-gauge accounting now has no await point between increment and
+  enqueue, closing a small pre-existing leak where a request cancelled
+  mid-`send().await` left the gauge permanently high.
+- `FpmPool::try_dispatch` (shed) maps onto the same gate: `grace == 0` is
+  `try_acquire` (backlog full → 503 immediately), non-zero grace is
+  `timeout(grace, acquire)` — shed-mode waiters now also queue fairly.
+
+What is traded: admission adds one semaphore acquire/release per request
+(two uncontended atomics; a mutex-protected waitlist push under saturation).
+Strict FIFO also gives up a micro-locality benefit barging had — the barging
+winner was usually cache-hot on the connection that just completed. Both
+effects are below measurement noise in the verification runs; the throughput
+delta was within ±1%.
+
+Fairness invariant pinned by `worker_pool::tests::
+admission_is_strictly_fifo_and_barge_proof`: waiters are admitted in arrival
+order and a dispatcher arriving while others are parked cannot steal a
+freshly freed slot.
+
+## 6. Before/after (same host, same build toolchain, 3 rounds each)
+
+Locally built binaries from the fix's parent commit vs the fix (identical
+toolchain/profile), same bare-process WSL2 setup as §4:
+
+| | req/s (avg) | P50 | P75 | P90 | P99 |
+|---|---|---|---|---|---|
+| parent (barging) | _see PR_ | | | | |
+| fix (FIFO) | _see PR_ | | | | |
+
+(The PR body carries the final table; this doc records the method.)
+
+The prediction from the model: with strict FIFO the wait distribution should
+collapse to a near-deterministic ~1 lap for every request — P50 rising
+slightly (the sub-millisecond barging winners no longer exist), P99 falling
+to ~1.2× the ideal sojourn, throughput unchanged. That is FrankenPHP's
+shape, achieved without giving up the throughput lead.

--- a/docs/architecture/worker-dispatch-fairness.md
+++ b/docs/architecture/worker-dispatch-fairness.md
@@ -148,28 +148,51 @@ What is traded: admission adds one semaphore acquire/release per request
 (two uncontended atomics; a mutex-protected waitlist push under saturation).
 Strict FIFO also gives up a micro-locality benefit barging had — the barging
 winner was usually cache-hot on the connection that just completed. Both
-effects are below measurement noise in the verification runs; the throughput
-delta was within ±1%.
+effects are at measurement-noise level in the verification runs; the
+throughput delta was ≈1% (2,282 → 2,256 req/s over four rounds, per-round
+spread wider than the delta).
 
 Fairness invariant pinned by `worker_pool::tests::
 admission_is_strictly_fifo_and_barge_proof`: waiters are admitted in arrival
 order and a dispatcher arriving while others are parked cannot steal a
 freshly freed slot.
 
-## 6. Before/after (same host, same build toolchain, 3 rounds each)
+## 6. Before/after (same host, same build toolchain)
 
 Locally built binaries from the fix's parent commit vs the fix (identical
-toolchain/profile), same bare-process WSL2 setup as §4:
+toolchain/profile), same bare-process WSL2 setup as §4. Four 30-second
+rounds each, interleaved across two sessions; the serving process's
+`/proc/<pid>/exe` was asserted before every round (see §7):
 
-| | req/s (avg) | P50 | P75 | P90 | P99 |
-|---|---|---|---|---|---|
-| parent (barging) | _see PR_ | | | | |
-| fix (FIFO) | _see PR_ | | | | |
+| | req/s (avg) | P50 | P75 | P90 | P99 (per round) | max |
+|---|---|---|---|---|---|---|
+| parent (barging) | 2,282 | 49.3 ms | 80.2 ms | 131 ms | 259 / 280 / 303 / 267 ms | 1.08 s |
+| fix (FIFO) | 2,256 | 43.9 ms | 44.4 ms | 44.9 ms | 46 / 66 / 62 / 62 ms | 67 ms |
 
-(The PR body carries the final table; this doc records the method.)
+The model's prediction held exactly: with strict FIFO the latency
+distribution collapsed to a near-deterministic single lap — P50 *dropped*
+from 49 to 44 ms (the sojourn no longer carries lost-race laps), P90 sits
+within 1 ms of P50, and P99 landed at 1.3× the ideal sojourn — FrankenPHP's
+shape (its P99 ran 1.1× ideal) at a throughput cost of −1.1%, within
+round-to-round noise. The uncontended path is untouched: `-c1` mean
+0.87 → 0.91 ms and P99 1.19 → 1.21 ms (noise). The fix's dispatch-wait
+histogram confirms the mechanism end-to-end: 98.5% of waits in the
+25–50 ms bucket, none above 100 ms — versus the parent's 42.7% sub-1 ms /
+1.2% above-250 ms split.
 
-The prediction from the model: with strict FIFO the wait distribution should
-collapse to a near-deterministic ~1 lap for every request — P50 rising
-slightly (the sub-millisecond barging winners no longer exist), P99 falling
-to ~1.2× the ideal sojourn, throughput unchanged. That is FrankenPHP's
-shape, achieved without giving up the throughput lead.
+## 7. A measurement post-mortem (why this doc exists)
+
+Mid-investigation the A/B numbers went incoherent — the fix appeared to
+work only when Prometheus metrics were enabled, then only on one port, then
+on neither. Every one of those phantom correlations traced to a single
+methodology bug: the A/B binaries were named `ephpm-parent` / `ephpm-fix`,
+and the harness's `pkill -x ephpm` matched neither, so a stale *parent*
+server kept port 8000 for an hour while freshly started servers died on
+`Address already in use` and wrk kept measuring the stale process. Fat
+tail on 8000 (stale barging binary), tight tail on 8001 (stale fix
+binary) — regardless of which binary the harness believed it was testing.
+
+The rule that fixed it, worth keeping: **a benchmark result is only
+attributable to a server after asserting which process served it** — check
+the listener's PID and `/proc/<pid>/exe` after startup, and fail the run on
+a bind error instead of proceeding.

--- a/docs/architecture/worker-mode-design.md
+++ b/docs/architecture/worker-mode-design.md
@@ -219,6 +219,17 @@ classic async-producer / sync-consumer MPMC queue.
   (async, for the hyper side) and `recv_blocking()` (sync, for the worker
   side). One queue, all workers `recv_blocking()` on the same receiver; the
   first free worker wins. Backpressure is the bounded depth.
+- *Amended (issue #442):* the hyper side no longer waits in `send().await`.
+  Under saturation that wait is not FIFO — async-channel's send is a
+  try/listen/retry loop, so fresh senders barge past parked ones and a
+  raced-out waiter re-registers at the back of the waiter queue, which
+  produced a multi-lap P99 tail (measured: 43% of requests admitted <1 ms
+  while P99 waited 5-6 full queue laps). Dispatch now acquires a permit from
+  a FIFO-fair `tokio::sync::Semaphore` (permits == queue depth; released by
+  the worker as it pulls a job) and then `try_send`s, which can never find
+  the channel full. The channel choice above still stands — it remains the
+  async-producer/sync-consumer hand-off — it just no longer doubles as the
+  wait queue. See `worker-dispatch-fairness.md` for the full investigation.
 - *Rejected:* `tokio::sync::mpsc` — its `Receiver` is async-only; a blocking
   worker thread would have to `block_on` a per-thread current-thread runtime to
   poll it, which is wasteful and error-prone. `crossbeam-channel` is sync-only
@@ -275,8 +286,9 @@ shared, matching the roadmap's "per-worker thread_local storage" rule
 ### 2.3 Backpressure when all workers busy
 
 The dispatch channel is **bounded** (default depth = `worker.count`, i.e. one
-queued job per worker; tunable via `worker.backlog`). When full,
-`dispatch_tx.send(job).await` suspends the hyper handler — this naturally
+queued job per worker; tunable via `worker.backlog`). When full, the FIFO-fair
+admission acquire (see the §2.1(a) amendment) suspends the hyper handler in
+strict arrival order — this naturally
 applies HTTP-layer backpressure without a busy loop. The whole handler is
 already wrapped in `tokio::time::timeout(request_timeout, ...)`
 (`router.rs:377-386`), so a request that can't get a worker within the timeout


### PR DESCRIPTION
Closes #442.

## What was wrong

Worker mode's dispatch queue is `async_channel::bounded(worker_backlog)` with `worker_backlog` defaulting to `worker_count` — 2 in the bench. Under wrk `-c100`, ~96 requests park inside the channel's `send().await`, and that future is a **try/listen/retry loop**: a fresh sender always `try_send`s before queueing behind parked waiters (barging), and a notified waiter that loses the retry race re-registers **at the back** of the waiter queue. Barging keeps the queue perfectly work-conserving — which is exactly why ePHPm posts the top throughput — while each lost race costs a full lap of the waiter population (~96/2270 ≈ 43 ms). The tail is lap-quantized: P75 ≈ 2 laps, P90 ≈ 3, P99 ≈ 6.

The instrumentation evidence (70k-request run, `ephpm_worker_request_wait_seconds`): mean dispatch wait 41.2 ms vs mean execute 1.6 ms — the wait *is* the latency — and the wait distribution is bimodal: **42.7% of requests admitted in <1 ms** (impossible under fair FIFO at saturation; those are the barging winners) while 13.9% waited 2–12 laps. The same defect exists in the experimental fpm pool engine (`fpm_engine = "pool"`).

Full narrative with the queueing math, histograms, and a measurement post-mortem: `docs/architecture/worker-dispatch-fairness.md`.

## The fix

Move the waiting out of the channel and into a **FIFO-fair `tokio::sync::Semaphore`** in front of it (both `WorkerPool` and `FpmPool`):

- permits == queue capacity; `dispatch()` acquires in strict arrival order, then `try_send`s (provably never `Full`);
- the worker releases the permit (`WorkerJob::admission`) the instant it pulls the job — the refill pipeline, and therefore throughput, is unchanged;
- `drain()` closes the semaphore so parked dispatchers still wake into the 503 path; cancelled acquires leave no trace, which also closes a small pre-existing queue-depth-gauge leak on 504s;
- `FpmPool::try_dispatch` (shed) maps 1:1: `grace == 0` → `try_acquire`, else `timeout(grace, acquire)` — shed waiters now queue fairly too.

Fairness invariant pinned by `worker_pool::tests::admission_is_strictly_fifo_and_barge_proof`.

## Before/after (bare-process WSL2, wrk -t10 -c100 -d30s, worker_count=2, PHP 8.4, array sessions; identical toolchain; serving `/proc/<pid>/exe` asserted every round)

| | req/s (avg, 4 rounds) | P50 | P75 | P90 | P99 (rounds) | max |
|---|---|---|---|---|---|---|
| parent (barging) | 2,282 | 49.3 ms | 80.2 ms | 131 ms | 259 / 280 / 303 / 267 ms | 1.08 s |
| **fix (FIFO)** | 2,256 | **43.9 ms** | 44.4 ms | **44.9 ms** | **46 / 66 / 62 / 62 ms** | 67 ms |

- P99 **~280 ms → ~58 ms** (4.9×; FrankenPHP-class and at ~1.3× the ideal M/D/2 sojourn — the theoretical floor for this closed loop). P50 improves too.
- Throughput −1.1%, inside round-to-round spread.
- Uncontended `-c1`: mean 0.87 → 0.91 ms, P99 1.19 → 1.21 ms — noise.
- Post-fix wait histogram: 98.5% of waits in the 25–50 ms bucket, none above 100 ms (vs 42.7% sub-1 ms + tail to 500 ms before).

Official v0.8.7-php8.4 reproduced the issue's signature first (2,330 req/s, P99 276–285 ms, P50 47 ms over 3 rounds) — no repro, no fix.

## Verification

- `cargo test -p ephpm-server` (worker_pool, fpm_pool, shed, router suites) and `-p ephpm-php`: green in stub mode
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; `cargo +nightly fmt --all -- --check`: clean
- Design doc §2.1(a)/§2.3 amended in the same PR (docs-must-match-code)
