### PR TITLE
fix(test-infra): e2e port TOCTOU (#438), router test artifact dependency (#435), Windows xtask e2e (#367)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ cargo deny check                           # license/advisory audit
 
 IMPORTANT: Run single tests when possible, not the full suite. Use `cargo test -p <crate> <test_name>`. `cargo nextest` is preferred but may not be installed — fall back to `cargo test`.
 
+**The dlopen middleware tests need an explicit build first.** `cargo test` and `cargo nextest run` do **not** emit example artifacts (`cargo test --no-run` does; a plain `cargo test` does not — verified, issue #435), so `crates/ephpm-server/tests/middleware_dlopen.rs` and `tests/middleware_response_phase.rs` hard-fail on a missing cdylib unless you run `cargo build --workspace --lib --examples` first — the same step CI runs before its test step. This is platform-independent; it was reported as a Windows bug only because that is where someone ran a bare `cargo test` on a clean checkout.
+
 The `ephpm-e2e` crate is **excluded from the workspace** and has different dependencies — don't try to compile it with `cargo test --workspace`. It runs bare-process by default via `cargo xtask e2e` (spawns ephpm on 127.0.0.1, no Kind), or via `cargo xtask k8s-e2e` for opt-in Kind + Tilt cluster testing (dispatched from `.github/workflows/k8s-e2e.yml`).
 
 ## Workspace Structure

--- a/crates/ephpm-e2e/src/lib.rs
+++ b/crates/ephpm-e2e/src/lib.rs
@@ -61,13 +61,11 @@ impl SingleNodeFixture {
     /// `docroot` is the directory ephpm will serve — typically
     /// `crates/ephpm-e2e/tests/docroot` or its own scratch dir.
     pub async fn start(ephpm_binary: &Path, docroot: &Path) -> Result<Self> {
-        // Reserve loopback ports by opening + immediately closing a listener.
-        // Two ephpm instances started in quick succession could race for the
-        // same port; the OS may hand out the same port before ephpm binds it.
-        // That's acceptable for a test fixture — worst case, the health poll
-        // times out and the caller retries.
-        let http_port = reserve_loopback_port().await?;
-        let mysql_port = reserve_loopback_port().await?;
+        // Ports stay *held* by live probe sockets (see `PortReserver`) until
+        // the moment this fixture spawns its child, so nothing else on the box
+        // can be handed one in between.
+        let lease = PortReserver::new().lease(&[PortKind::Tcp, PortKind::Tcp]).await?;
+        let (http_port, mysql_port) = (lease.port(0), lease.port(1));
 
         let tmp = tempfile::Builder::new()
             .prefix("ephpm-e2e-single-")
@@ -88,6 +86,8 @@ impl SingleNodeFixture {
         let stdout = fs::File::create(tmp.path().join("stdout.log")).context("open stdout log")?;
         let stderr = fs::File::create(tmp.path().join("stderr.log")).context("open stderr log")?;
 
+        // Hand the ports off: release the probes and spawn in the same breath.
+        lease.release();
         let mut child = Command::new(ephpm_binary)
             .args(["serve", "--config"])
             .arg(&config_path)
@@ -160,7 +160,8 @@ impl ClusterFixture {
             return Err(anyhow!("cluster fixture needs at least 2 nodes, got {size}"));
         }
 
-        // Reserve all port sets before spawning so overlap is impossible.
+        // Reserve all port sets before spawning so overlap is impossible. Each
+        // set stays *held* by its own probe sockets until that node spawns.
         let port_sets = reserve_cluster_ports(size).await?;
 
         let join_addrs: Vec<String> =
@@ -172,7 +173,7 @@ impl ClusterFixture {
             .context("create tempdir")?;
 
         let mut nodes = Vec::with_capacity(size);
-        for (i, ports) in port_sets.iter().enumerate() {
+        for (i, ports) in port_sets.into_iter().enumerate() {
             let node_dir = tmp.path().join(format!("node-{i}"));
             fs::create_dir_all(&node_dir).context("create node dir")?;
             let data_dir = node_dir.join("data");
@@ -204,6 +205,9 @@ impl ClusterFixture {
             let stderr =
                 fs::File::create(node_dir.join("stderr.log")).context("open stderr log")?;
 
+            // Hand this node's ports off: release its probes, spawn at once.
+            let http_port = ports.http;
+            ports.lease.release();
             let child = Command::new(ephpm_binary)
                 .args(["serve", "--config"])
                 .arg(&config_path)
@@ -214,7 +218,7 @@ impl ClusterFixture {
 
             nodes.push(ClusterFixtureNode {
                 child: Some(child),
-                base_url: format!("http://127.0.0.1:{}", ports.http),
+                base_url: format!("http://127.0.0.1:{http_port}"),
             });
         }
 
@@ -267,28 +271,8 @@ struct ClusterPorts {
     mysql: u16,
     gossip: u16,
     kv_data: u16,
-}
-
-// ── helpers ────────────────────────────────────────────────────────────────
-
-/// Ask the kernel for a free loopback port by binding to `127.0.0.1:0` and
-/// then dropping the listener.
-///
-/// There is an inherent TOCTOU here — the port may be re-issued before ephpm
-/// binds it — and unlike the in-process proxy tests (which now bind once and
-/// hand the live listener to `run_on`) it cannot be engineered away: the
-/// ports cross a process boundary through a generated config file, and
-/// `ephpm serve` has no way to inherit an already-bound socket. The race
-/// fails closed rather than cross-wired: a stolen port makes the child's own
-/// bind fail and the child exit, which `wait_for_health` detects and reports
-/// immediately instead of health-probing a port someone else may now own.
-/// For a fixture that runs one topology at a time this is acceptable in
-/// practice.
-async fn reserve_loopback_port() -> Result<u16> {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.context("bind :0")?;
-    let port = listener.local_addr().context("local_addr")?.port();
-    drop(listener);
-    Ok(port)
+    /// Probes holding this node's ports until it is spawned. See [`PortLease`].
+    lease: PortLease,
 }
 
 /// Ports past `[cluster] bind` that a node claims without anyone reserving
@@ -322,38 +306,171 @@ struct PortProbes {
     udp: Vec<tokio::net::UdpSocket>,
 }
 
-/// Reserve a non-overlapping port set per node.
+/// What a reserved loopback port will actually be bound as by the child.
 ///
-/// Two things here are easy to get wrong, and both did (issue #239):
+/// The protocol matters: a port that accepts a TCP bind can still refuse a UDP
+/// one — on Windows, Hyper-V/WinNAT reserve large UDP-only ranges and the bind
+/// fails with `WSAEACCES` (issue #239) — so a gossip port has to be probed with
+/// a real UDP socket, not a TCP one.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PortKind {
+    /// A TCP listener: HTTP, MySQL, Hrana, KV data plane, cluster channel.
+    Tcp,
+    /// A UDP socket: gossip, where the cluster-channel port is configured
+    /// explicitly (`[cluster.channel] listen`) rather than derived.
+    Udp,
+    /// A gossip (UDP) port whose **derived** cluster-channel port is claimed
+    /// alongside it.
+    ///
+    /// `ephpm-cluster` derives the channel listener from the gossip bind
+    /// address as `gossip_socket_addr().port() + 2` (see `cluster_channel.rs`),
+    /// so a node with gossip on `G` also owns `G + 2`. Nobody configures that
+    /// port, so nobody would otherwise probe it — and the kernel hands out
+    /// ephemeral ports consecutively, which is how node 0's `G + 2` once landed
+    /// on node 1's HTTP port and killed it with EADDRINUSE (issue #239). Use
+    /// this variant when the node's channel port is derived; use [`Self::Udp`]
+    /// when it is pinned explicitly.
+    GossipWithDerivedChannel,
+}
+
+/// A set of loopback ports **held open** by live probe sockets until the child
+/// that will bind them is spawned.
 ///
-/// - **Protocol.** Gossip is **UDP**; every other listener is TCP. A port that
-///   accepts a TCP bind can still refuse a UDP one — on Windows, Hyper-V/WinNAT
-///   reserve large UDP-only ranges and the bind fails with `WSAEACCES`. So the
-///   gossip port is probed with a real UDP socket.
-/// - **Derived ports.** The cluster channel is never configured, only derived
-///   (`gossip + 2`), so it has to be probed and claimed explicitly or a sibling
-///   node gets handed it.
+/// This is the whole point of the type. Asking the kernel for a port by binding
+/// `127.0.0.1:0`, reading the number and *closing the socket* leaves a TOCTOU
+/// window in which the port goes straight back into the ephemeral pool — and a
+/// live ephpm cluster churning gossip, CDC and MySQL connections drains that
+/// pool continuously. That is how a port reserved for a node reached
+/// `Address already in use` before the node ever spawned, reported as "node N
+/// never became healthy" ~1 run in 25 (issue #438). The window is proportional
+/// to reserve→spawn distance, and a fixture that reserves every node's ports up
+/// front but spawns one of them ~100s later has a *very* wide one.
+///
+/// Holding the probe closes the window instead of narrowing it: the port cannot
+/// be re-issued to anything while the probe lives. Call [`release`](Self::release)
+/// immediately before `Command::spawn` so the handoff gap is a few
+/// instructions rather than the length of a test phase.
+///
+/// A held TCP probe accepts nothing and a held UDP probe reads nothing; peers
+/// dialing a not-yet-spawned node see a connection that is reset (or datagrams
+/// dropped) when the probe is released, which is indistinguishable from the
+/// closed port they would have seen anyway.
+pub struct PortLease {
+    ports: Vec<u16>,
+    probes: PortProbes,
+}
+
+impl PortLease {
+    /// The `index`-th port of this lease, in the order the kinds were requested.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `index` is past the number of ports requested.
+    #[must_use]
+    pub fn port(&self, index: usize) -> u16 {
+        self.ports[index]
+    }
+
+    /// Every port in this lease, in request order.
+    #[must_use]
+    pub fn ports(&self) -> &[u16] {
+        &self.ports
+    }
+
+    /// Release the probe sockets, handing the ports to the child.
+    ///
+    /// Consuming `self` is deliberate: it makes "the ports are no longer
+    /// protected" a state you cannot use by accident, and puts the release at
+    /// the exact statement it belongs next to — the `spawn`.
+    pub fn release(self) {
+        drop(self.probes);
+    }
+}
+
+/// Hands out loopback ports that stay reserved until they are handed off.
+///
+/// One reserver serves a whole topology: ports it has already issued are
+/// remembered forever, so a port released by an earlier [`PortLease`] (whose
+/// node is by then binding it) is never offered to a later one.
+#[derive(Default)]
+pub struct PortReserver {
+    claimed: BTreeSet<u16>,
+}
+
+impl PortReserver {
+    /// A reserver with nothing claimed yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reserve one port per entry in `kinds`, returning a lease that **holds**
+    /// them until [`PortLease::release`].
+    ///
+    /// # Errors
+    ///
+    /// Fails when the kernel cannot produce a bindable, not-already-claimed
+    /// port of the requested kind within [`MAX_PORT_ATTEMPTS`] tries.
+    pub async fn lease(&mut self, kinds: &[PortKind]) -> Result<PortLease> {
+        let mut probes = PortProbes::default();
+        let mut ports = Vec::with_capacity(kinds.len());
+        for kind in kinds {
+            let port = match kind {
+                PortKind::Tcp => claim_tcp_port(&mut probes, &mut self.claimed).await?,
+                PortKind::Udp => claim_udp_port(&mut probes, &mut self.claimed).await?,
+                PortKind::GossipWithDerivedChannel => {
+                    claim_gossip_port(&mut probes, &mut self.claimed).await?
+                }
+            };
+            ports.push(port);
+        }
+        Ok(PortLease { ports, probes })
+    }
+}
+
+/// Reserve a non-overlapping port set per node, each set held by its own lease
+/// until that node spawns.
 async fn reserve_cluster_ports(size: usize) -> Result<Vec<ClusterPorts>> {
-    let mut probes = PortProbes::default();
-    let mut claimed: BTreeSet<u16> = BTreeSet::new();
+    let mut reserver = PortReserver::new();
     let mut sets = Vec::with_capacity(size);
 
     for _ in 0..size {
-        let http = claim_tcp_port(&mut probes, &mut claimed).await?;
-        let mysql = claim_tcp_port(&mut probes, &mut claimed).await?;
-        let kv_data = claim_tcp_port(&mut probes, &mut claimed).await?;
-        let gossip = claim_gossip_port(&mut probes, &mut claimed).await?;
-        sets.push(ClusterPorts { http, mysql, gossip, kv_data });
+        let lease = reserver
+            .lease(&[
+                PortKind::Tcp,
+                PortKind::Tcp,
+                PortKind::Tcp,
+                PortKind::GossipWithDerivedChannel,
+            ])
+            .await?;
+        sets.push(ClusterPorts {
+            http: lease.port(0),
+            mysql: lease.port(1),
+            kv_data: lease.port(2),
+            gossip: lease.port(3),
+            lease,
+        });
     }
 
-    // Release every probe now that the assignment is fixed; the children bind
-    // these ports themselves a moment later.
-    drop(probes);
     Ok(sets)
 }
 
 /// Number of attempts any single port claim gets before giving up.
-const MAX_PORT_ATTEMPTS: usize = 64;
+pub const MAX_PORT_ATTEMPTS: usize = 64;
+
+/// Claim one unclaimed loopback **UDP** port, for a gossip listener whose
+/// cluster-channel port is configured explicitly rather than derived.
+async fn claim_udp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
+    for _ in 0..MAX_PORT_ATTEMPTS {
+        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.context("bind udp :0")?;
+        let port = socket.local_addr().context("local_addr")?.port();
+        probes.udp.push(socket);
+        if claimed.insert(port) {
+            return Ok(port);
+        }
+    }
+    Err(anyhow!("could not reserve a free loopback UDP port in {MAX_PORT_ATTEMPTS} attempts"))
+}
 
 /// Claim one unclaimed loopback TCP port.
 async fn claim_tcp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
@@ -407,10 +524,11 @@ async fn claim_gossip_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>)
 /// Poll `child`'s health endpoint until it answers 200, the child exits, or
 /// `timeout` elapses.
 ///
-/// The child-exit check is load-bearing for the reserved-port TOCTOU (see
-/// [`reserve_loopback_port`]): a stolen port makes the child fail its bind
-/// and exit, and without the check the poll could get a 200 from whatever
-/// *else* is listening there and hand the test a stranger's server.
+/// The child-exit check is a backstop for a port that got taken anyway (see
+/// [`PortLease`], which is what stops that happening): a stolen port makes the
+/// child fail its bind and exit, and without the check the poll could get a 200
+/// from whatever *else* is listening there and hand the test a stranger's
+/// server.
 async fn wait_for_health(child: &mut Child, port: u16, timeout: Duration) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let mut last_err = String::from("no attempts made");

--- a/crates/ephpm-e2e/src/lib.rs
+++ b/crates/ephpm-e2e/src/lib.rs
@@ -64,7 +64,7 @@ impl SingleNodeFixture {
         // Ports stay *held* by live probe sockets (see `PortReserver`) until
         // the moment this fixture spawns its child, so nothing else on the box
         // can be handed one in between.
-        let lease = PortReserver::new().lease(&[PortKind::Tcp, PortKind::Tcp]).await?;
+        let lease = PortReserver::new().lease(&[PortKind::Tcp, PortKind::Tcp])?;
         let (http_port, mysql_port) = (lease.port(0), lease.port(1));
 
         let tmp = tempfile::Builder::new()
@@ -162,7 +162,7 @@ impl ClusterFixture {
 
         // Reserve all port sets before spawning so overlap is impossible. Each
         // set stays *held* by its own probe sockets until that node spawns.
-        let port_sets = reserve_cluster_ports(size).await?;
+        let port_sets = reserve_cluster_ports(size)?;
 
         let join_addrs: Vec<String> =
             port_sets.iter().map(|p| format!("127.0.0.1:{}", p.gossip)).collect();
@@ -300,10 +300,22 @@ const GOSSIP_PORT_SPAN: u16 = CLUSTER_CHANNEL_PORT_OFFSET + 1;
 /// ephemeral pool, and the kernel walks that pool in order, so an early
 /// release is exactly how a rejected port comes back as the answer to the
 /// next request.
+///
+/// **`std::net`, not `tokio::net`, and that is not incidental.** A probe never
+/// does any I/O — it exists to occupy a port — so it has no use for the
+/// reactor; but more importantly, tokio's sockets come from mio, and mio
+/// creates Windows sockets with `WSASocketW(..., WSA_FLAG_OVERLAPPED)` **without**
+/// `WSA_FLAG_NO_HANDLE_INHERIT`, which `std` does pass. An inheritable socket
+/// is duplicated into every child `Command::spawn` starts (stdio redirection
+/// implies `bInheritHandles = TRUE`), so a probe held across one node's spawn
+/// leaks into *that node's process* and stays bound there after this process
+/// drops it — and the next node dies with `os error 10048` on a port nothing
+/// visibly holds. `std` sockets are `HANDLE_FLAG_INHERIT`-clear on Windows and
+/// `SOCK_CLOEXEC` on Unix, so they vanish from the child exactly as intended.
 #[derive(Default)]
 struct PortProbes {
-    tcp: Vec<tokio::net::TcpListener>,
-    udp: Vec<tokio::net::UdpSocket>,
+    tcp: Vec<std::net::TcpListener>,
+    udp: Vec<std::net::UdpSocket>,
 }
 
 /// What a reserved loopback port will actually be bound as by the child.
@@ -411,15 +423,15 @@ impl PortReserver {
     ///
     /// Fails when the kernel cannot produce a bindable, not-already-claimed
     /// port of the requested kind within [`MAX_PORT_ATTEMPTS`] tries.
-    pub async fn lease(&mut self, kinds: &[PortKind]) -> Result<PortLease> {
+    pub fn lease(&mut self, kinds: &[PortKind]) -> Result<PortLease> {
         let mut probes = PortProbes::default();
         let mut ports = Vec::with_capacity(kinds.len());
         for kind in kinds {
             let port = match kind {
-                PortKind::Tcp => claim_tcp_port(&mut probes, &mut self.claimed).await?,
-                PortKind::Udp => claim_udp_port(&mut probes, &mut self.claimed).await?,
+                PortKind::Tcp => claim_tcp_port(&mut probes, &mut self.claimed)?,
+                PortKind::Udp => claim_udp_port(&mut probes, &mut self.claimed)?,
                 PortKind::GossipWithDerivedChannel => {
-                    claim_gossip_port(&mut probes, &mut self.claimed).await?
+                    claim_gossip_port(&mut probes, &mut self.claimed)?
                 }
             };
             ports.push(port);
@@ -430,19 +442,17 @@ impl PortReserver {
 
 /// Reserve a non-overlapping port set per node, each set held by its own lease
 /// until that node spawns.
-async fn reserve_cluster_ports(size: usize) -> Result<Vec<ClusterPorts>> {
+fn reserve_cluster_ports(size: usize) -> Result<Vec<ClusterPorts>> {
     let mut reserver = PortReserver::new();
     let mut sets = Vec::with_capacity(size);
 
     for _ in 0..size {
-        let lease = reserver
-            .lease(&[
-                PortKind::Tcp,
-                PortKind::Tcp,
-                PortKind::Tcp,
-                PortKind::GossipWithDerivedChannel,
-            ])
-            .await?;
+        let lease = reserver.lease(&[
+            PortKind::Tcp,
+            PortKind::Tcp,
+            PortKind::Tcp,
+            PortKind::GossipWithDerivedChannel,
+        ])?;
         sets.push(ClusterPorts {
             http: lease.port(0),
             mysql: lease.port(1),
@@ -460,9 +470,9 @@ pub const MAX_PORT_ATTEMPTS: usize = 64;
 
 /// Claim one unclaimed loopback **UDP** port, for a gossip listener whose
 /// cluster-channel port is configured explicitly rather than derived.
-async fn claim_udp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
+fn claim_udp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
     for _ in 0..MAX_PORT_ATTEMPTS {
-        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.context("bind udp :0")?;
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").context("bind udp :0")?;
         let port = socket.local_addr().context("local_addr")?.port();
         probes.udp.push(socket);
         if claimed.insert(port) {
@@ -473,9 +483,9 @@ async fn claim_udp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) ->
 }
 
 /// Claim one unclaimed loopback TCP port.
-async fn claim_tcp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
+fn claim_tcp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
     for _ in 0..MAX_PORT_ATTEMPTS {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.context("bind :0")?;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").context("bind :0")?;
         let port = listener.local_addr().context("local_addr")?.port();
         probes.tcp.push(listener);
         if claimed.insert(port) {
@@ -490,9 +500,9 @@ async fn claim_tcp_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) ->
 ///
 /// Claims the whole `G..G + GOSSIP_PORT_SPAN` window so no other node can be
 /// handed the channel port.
-async fn claim_gossip_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
+fn claim_gossip_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>) -> Result<u16> {
     for _ in 0..MAX_PORT_ATTEMPTS {
-        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.context("bind udp :0")?;
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").context("bind udp :0")?;
         let port = socket.local_addr().context("local_addr")?.port();
         probes.udp.push(socket);
 
@@ -507,7 +517,7 @@ async fn claim_gossip_port(probes: &mut PortProbes, claimed: &mut BTreeSet<u16>)
         // The channel port is TCP and nobody probes it but us. If it is taken
         // (or excluded), this whole gossip port is unusable — try another.
         let channel = port + CLUSTER_CHANNEL_PORT_OFFSET;
-        let Ok(listener) = tokio::net::TcpListener::bind(("127.0.0.1", channel)).await else {
+        let Ok(listener) = std::net::TcpListener::bind(("127.0.0.1", channel)) else {
             continue;
         };
         probes.tcp.push(listener);
@@ -610,8 +620,20 @@ unsafe fn libc_kill(pid: i32, sig: i32) -> i32 {
 }
 
 fn escape_toml(path: &Path) -> String {
-    let mut out = String::new();
-    for ch in path.to_string_lossy().chars() {
+    escape_toml_str(&path.to_string_lossy())
+}
+
+/// Escape `value` for use inside a TOML basic (double-quoted) string.
+///
+/// Mandatory for any **path** written into a generated config: a Windows path
+/// interpolated raw makes `C:\Users\...` a TOML parse error (`\U` starts an
+/// 8-digit unicode escape), so the server never even reaches the behaviour the
+/// test is about — it dies on "invalid unicode 8-digit hex code" and the
+/// assertion failure names the wrong thing entirely.
+#[must_use]
+pub fn escape_toml_str(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
         match ch {
             '\\' => out.push_str("\\\\"),
             '"' => out.push_str("\\\""),

--- a/crates/ephpm-e2e/tests/middleware.rs
+++ b/crates/ephpm-e2e/tests/middleware.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use ephpm_e2e::required_env;
+use ephpm_e2e::{escape_toml_str, required_env};
 
 /// The origin the mounted CORS module is configured to allow.
 const ALLOWED_ORIGIN: &str = "https://allowed.e2e.test";
@@ -232,7 +232,13 @@ fn serve_and_watch(config: &str, label: &str, budget: Duration) -> (bool, String
 }
 
 /// Minimal config with one `[[middleware]]` mount pointing at `library`.
+///
+/// Both interpolated values are paths, so both go through [`escape_toml_str`]:
+/// a raw Windows path turns the generated TOML into a parse error before
+/// `ephpm serve` ever looks at the mount.
 fn config_with_mount(library: &str, port: u16, dir: &str) -> String {
+    let library = escape_toml_str(library);
+    let dir = escape_toml_str(dir);
     format!(
         "[server]\n\
          listen = \"127.0.0.1:{port}\"\n\
@@ -290,7 +296,7 @@ fn garbage_library_file_fails_startup() {
 /// broken in some unrelated way and exited immediately on every config.
 #[test]
 fn valid_module_mount_does_not_abort_startup() {
-    let lib = required_env("EPHPM_MIDDLEWARE_LIB");
+    let lib = escape_toml_str(&required_env("EPHPM_MIDDLEWARE_LIB"));
     let dir = tempfile::Builder::new().prefix("ephpm-mw-ok-").tempdir().expect("tempdir");
     let cfg = format!(
         "[server]\n\
@@ -301,7 +307,7 @@ fn valid_module_mount_does_not_abort_startup() {
          library = \"{lib}\"\n\
          order = 10\n\
          config = {{ allow_origins = [\"{ALLOWED_ORIGIN}\"] }}\n",
-        dir.path().to_string_lossy()
+        escape_toml_str(&dir.path().to_string_lossy())
     );
     // Reuse the failure harness, then invert the expectation: a healthy mount
     // means the process is STILL RUNNING when the budget expires.

--- a/crates/ephpm-e2e/tests/turso_cdc.rs
+++ b/crates/ephpm-e2e/tests/turso_cdc.rs
@@ -57,7 +57,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
-use ephpm_e2e::ephpm_binary_env;
+use ephpm_e2e::{PortKind, PortLease, PortReserver, ephpm_binary_env};
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -119,6 +119,12 @@ struct NodePorts {
     /// from the kernel and collided under parallelism (issue #383).
     channel: u16,
     kv_data: u16,
+    /// Probe sockets holding this node's six ports until it is spawned.
+    ///
+    /// `None` once the node has been spawned (or, defensively, if a caller ever
+    /// spawns twice). Holding is what makes reserving ports for a node that
+    /// starts ~100s later safe — see [`ephpm_e2e::PortLease`] and issue #438.
+    lease: Option<PortLease>,
 }
 
 /// How a node's `[db.sqlite.replication]` block is written.
@@ -150,6 +156,18 @@ impl CdcCluster {
     /// the scratch layout. Ports for *every* node — including ones spawned
     /// later — are reserved up front so each node's `join` list can name the
     /// full eventual membership.
+    ///
+    /// Reserved here means **held**: each node keeps its probe sockets open
+    /// until [`Self::spawn`] releases them a few instructions before
+    /// `Command::spawn`. This suite is the reason that matters —
+    /// [`a_joining_node_must_not_steal_an_established_primary`] does not start
+    /// node 3 until ~100s after `prepare`, and for all of that time a live
+    /// 3-node cluster is churning gossip, CDC and MySQL connections through the
+    /// ephemeral range. With the old bind-read-close reservation the kernel
+    /// re-issued node 3's port to one of those connections roughly 1 run in 25,
+    /// and the node died on `Address already in use` — surfacing as "node 3
+    /// never became healthy within 90s", which reads like a cluster regression
+    /// and burns a whole e2e leg (issue #438).
     async fn prepare(binary: &Path, total: usize) -> Result<Self> {
         let tempdir =
             tempfile::Builder::new().prefix("ephpm-e2e-cdc-").tempdir().context("tempdir")?;
@@ -157,15 +175,29 @@ impl CdcCluster {
         fs::create_dir_all(&docroot).context("create docroot")?;
         fs::write(docroot.join("index.html"), "cdc-e2e").context("write index.html")?;
 
+        // Gossip is UDP; the channel port is pinned explicitly here (not
+        // derived as `gossip + 2`), so it is reserved as an ordinary TCP port.
+        let mut reserver = PortReserver::new();
         let mut ports = Vec::with_capacity(total);
         for _ in 0..total {
+            let lease = reserver
+                .lease(&[
+                    PortKind::Tcp, // http
+                    PortKind::Tcp, // mysql
+                    PortKind::Tcp, // hrana
+                    PortKind::Udp, // gossip
+                    PortKind::Tcp, // cluster channel
+                    PortKind::Tcp, // kv data plane
+                ])
+                .await?;
             ports.push(NodePorts {
-                http: reserve_port().await?,
-                mysql: reserve_port().await?,
-                hrana: reserve_port().await?,
-                gossip: reserve_port().await?,
-                channel: reserve_port().await?,
-                kv_data: reserve_port().await?,
+                http: lease.port(0),
+                mysql: lease.port(1),
+                hrana: lease.port(2),
+                gossip: lease.port(3),
+                channel: lease.port(4),
+                kv_data: lease.port(5),
+                lease: Some(lease),
             });
         }
 
@@ -227,7 +259,13 @@ impl CdcCluster {
         let stdout = fs::File::create(node_dir.join("stdout.log")).context("stdout log")?;
         let stderr = fs::File::create(node_dir.join("stderr.log")).context("stderr log")?;
 
-        eprintln!("[cdc-e2e] spawning node {i} (http 127.0.0.1:{})", p.http);
+        let http_port = self.ports[i].http;
+        eprintln!("[cdc-e2e] spawning node {i} (http 127.0.0.1:{http_port})");
+        // Hand the ports off: release this node's probes and spawn in the same
+        // breath, so nothing else can be issued one in between (issue #438).
+        if let Some(lease) = self.ports[i].lease.take() {
+            lease.release();
+        }
         let child = Command::new(&self.binary)
             .args(["serve", "--config"])
             .arg(&config_path)
@@ -425,13 +463,6 @@ impl Drop for CdcCluster {
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────────
-
-/// Ask the kernel for a free loopback port. Inherent TOCTOU, acceptable for a
-/// fixture that spawns immediately after reserving.
-async fn reserve_port() -> Result<u16> {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.context("bind :0")?;
-    Ok(listener.local_addr().context("local_addr")?.port())
-}
 
 fn escape_toml(path: &Path) -> String {
     let mut out = String::new();

--- a/crates/ephpm-e2e/tests/turso_cdc.rs
+++ b/crates/ephpm-e2e/tests/turso_cdc.rs
@@ -180,16 +180,14 @@ impl CdcCluster {
         let mut reserver = PortReserver::new();
         let mut ports = Vec::with_capacity(total);
         for _ in 0..total {
-            let lease = reserver
-                .lease(&[
-                    PortKind::Tcp, // http
-                    PortKind::Tcp, // mysql
-                    PortKind::Tcp, // hrana
-                    PortKind::Udp, // gossip
-                    PortKind::Tcp, // cluster channel
-                    PortKind::Tcp, // kv data plane
-                ])
-                .await?;
+            let lease = reserver.lease(&[
+                PortKind::Tcp, // http
+                PortKind::Tcp, // mysql
+                PortKind::Tcp, // hrana
+                PortKind::Udp, // gossip
+                PortKind::Tcp, // cluster channel
+                PortKind::Tcp, // kv data plane
+            ])?;
             ports.push(NodePorts {
                 http: lease.port(0),
                 mysql: lease.port(1),

--- a/crates/ephpm-server/Cargo.toml
+++ b/crates/ephpm-server/Cargo.toml
@@ -160,13 +160,19 @@ mysql_async = { version = "0.34", default-features = false, features = ["minimal
 
 # Loadable middleware fixtures for the dlopen lane (tests/middleware_dlopen.rs).
 #
-# These are `examples` rather than workspace crates on purpose: cargo emits an
-# example's declared crate-types during an ordinary `cargo test -p
-# ephpm-server`, whereas a library crate's `cdylib` output is produced only by
-# an explicit `cargo build -p <crate>` — not by `cargo test --workspace`, and
-# not by a dev-dependency edge (both verified). That gap is why the dlopen
-# loader had no enforced coverage: the one test that touched it skipped
-# whenever the artifact was absent, which in CI was always.
+# These are `examples` rather than workspace crates on purpose: `cargo build
+# --examples` emits an example's declared crate-types, whereas a library
+# crate's `cdylib` output needs a per-crate `cargo build -p <crate>` — it is
+# produced by neither `cargo test --workspace` nor a dev-dependency edge (both
+# verified). That gap is why the dlopen loader had no enforced coverage: the one
+# test that touched it skipped whenever the artifact was absent, which in CI was
+# always.
+#
+# NOTE: `cargo test` does NOT build examples either (`cargo test --no-run` does;
+# a plain `cargo test` does not — verified on Windows, issue #435). CI therefore
+# runs `cargo build --workspace --lib --examples` before its test step, and a
+# local `cargo test -p ephpm-server` needs the same command first or the dlopen
+# tests fail on a missing artifact.
 [[example]]
 name = "mw_probe_v1"
 crate-type = ["cdylib"]

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -5555,28 +5555,6 @@ mod tests {
 
     // ── Middleware response phase + static-path request phase (#395) ──────
 
-    /// Locate a built cdylib example (mirrors `tests/middleware_dlopen.rs`).
-    /// Fails loudly rather than skipping: `cargo test -p ephpm-server` builds
-    /// examples, so an absent artifact is a wiring regression.
-    fn example_lib(stem: &str) -> PathBuf {
-        let exe = std::env::current_exe().expect("test binary has a path");
-        let dir = exe
-            .parent()
-            .and_then(Path::parent)
-            .expect("test binary at <target>/<profile>/deps/<name>")
-            .join("examples");
-        let file =
-            format!("{}{stem}.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION);
-        let path = dir.join(&file);
-        assert!(
-            path.is_file(),
-            "example cdylib `{file}` missing at {} — build with \
-             `cargo build -p ephpm-server --examples`",
-            path.display()
-        );
-        path
-    }
-
     fn chain_with(mounts: Vec<MiddlewareMount>) -> Arc<crate::middleware::MiddlewareChain> {
         Arc::new(crate::middleware::MiddlewareChain::load(&mounts).expect("chain loads"))
     }
@@ -5584,15 +5562,29 @@ mod tests {
     /// The response phase MUST run on the **static-file** path, not just PHP —
     /// that is half of #395's value. A header-injection module mounted on a
     /// static site stamps its header onto a served `.html` file.
+    ///
+    /// The module is the compiled-in `header-transform` **builtin**, not the
+    /// `mw_response_header` cdylib example this test used to `dlopen`. Nothing
+    /// in a test build puts that example on disk — `cargo test` and `cargo
+    /// nextest` do not emit example artifacts (which is why CI runs an explicit
+    /// `cargo build --workspace --lib --examples` first, see `ci.yml`) — so the
+    /// artifact assertion turned a bare `cargo test` on a clean checkout into a
+    /// hard failure on every platform (issue #435, reported from Windows). What
+    /// this test is *about* is the router calling the response phase on the
+    /// static path; which lane the module was loaded through is irrelevant
+    /// here, and the dlopen lane keeps its own coverage in
+    /// `tests/middleware_dlopen.rs` and `tests/middleware_response_phase.rs`.
     #[tokio::test]
     async fn response_phase_runs_on_static_files() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("page.html"), b"<h1>hi</h1>").unwrap();
         let mount = MiddlewareMount {
-            library: example_lib("mw_response_header").to_string_lossy().into_owned(),
+            library: "header-transform".to_string(),
             match_pattern: None,
             order: 10,
-            config: Some(serde_json::json!({ "header": "X-Resp-Phase", "value": "static" })),
+            config: Some(serde_json::json!({
+                "response": { "set": { "X-Resp-Phase": "static" } }
+            })),
         };
         let router = test_router(dir.path()).with_middleware_chain(Some(chain_with(vec![mount])));
         let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();

--- a/crates/ephpm-server/tests/middleware_dlopen.rs
+++ b/crates/ephpm-server/tests/middleware_dlopen.rs
@@ -13,9 +13,14 @@
 //! fired every time.
 //!
 //! The fixtures are `crate-type = ["cdylib"]` examples of this crate
-//! (`examples/mw_probe_*.rs`), which cargo *does* build during `cargo test -p
-//! ephpm-server`. [`fixture`] hard-fails with the build command when one is
-//! missing — a skip here is indistinguishable from the bug this file closes.
+//! (`examples/mw_probe_*.rs`). **Producing them is an explicit build step**:
+//! `cargo test` / `cargo nextest run` do not emit example artifacts (verified
+//! — `cargo test --no-run` does, a plain `cargo test` does not), which is why
+//! CI runs `cargo build --workspace --lib --examples` before the test step (see
+//! `.github/workflows/ci.yml`). Run that yourself before `cargo test -p
+//! ephpm-server` locally, on any platform. [`fixture`] hard-fails with the
+//! build command when an artifact is missing — a skip here is
+//! indistinguishable from the bug this file closes.
 //!
 //! End-to-end coverage of a *shipped* module (`ephpm-middleware-cors`) mounted
 //! by path in a real server's `[[middleware]]` config lives in the E2E suite,

--- a/crates/ephpm-server/tests/middleware_response_phase.rs
+++ b/crates/ephpm-server/tests/middleware_response_phase.rs
@@ -5,10 +5,11 @@
 //!
 //! The fixture is the `mw_response_gzip` cdylib example (a genuine gzip
 //! response compressor). Like the `mw_probe_*` fixtures it is a
-//! `crate-type = ["cdylib"]` example so `cargo test -p ephpm-server` always
-//! leaves a loadable library on disk — [`fixture`] hard-fails with the build
-//! command rather than skipping, so this lane can never go silently
-//! uncovered.
+//! `crate-type = ["cdylib"]` example, and like them it has to be **built
+//! explicitly** — `cargo build --workspace --lib --examples`, which CI runs
+//! before its test step; `cargo test` alone does not emit example artifacts
+//! (see `middleware_dlopen.rs`). [`fixture`] hard-fails with that build command
+//! rather than skipping, so this lane can never go silently uncovered.
 //!
 //! The request-phase-only `mw_probe_v1` fixture (which does **not** export the
 //! response symbol) is reused here to prove the presence check: a v1 module is

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -693,8 +693,15 @@ fn resolve_ephpm_binary(args: &[String], php_version: &str) -> Option<PathBuf> {
 /// alternative (a bare `--release`) would recompile the dependency graph into
 /// a second output directory for no benefit.
 fn build_middleware_cdylib() -> Option<PathBuf> {
+    // Every host needs its own branch here. Falling through to the linux-gnu
+    // triple on Windows asked cargo to cross-compile to a target that is not
+    // installed, and the suite died on `can't find crate for core` (issue
+    // #367) — a rustup message, in the middle of an e2e run, for a build that
+    // was only ever meant to be native.
     let host_target = if cfg!(target_os = "macos") {
         format!("{}-apple-darwin", std::env::consts::ARCH)
+    } else if cfg!(windows) {
+        format!("{}-pc-windows-msvc", std::env::consts::ARCH)
     } else {
         format!("{}-unknown-linux-gnu", std::env::consts::ARCH)
     };

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -24,7 +24,7 @@ use std::process::{Child, Command, ExitCode, Stdio};
 use std::time::{Duration, Instant};
 use std::{fs, io, thread};
 
-use crate::{DEFAULT_PHP_MINOR, release, workspace_root};
+use crate::{DEFAULT_PHP_MINOR, canonicalize_portable, release, workspace_root};
 
 /// Test suites that need a 3-node cluster (rather than a single node).
 ///
@@ -326,7 +326,11 @@ pub fn run(args: &[String]) -> ExitCode {
         eprintln!("error: docroot not found at {}", docroot.display());
         return ExitCode::FAILURE;
     }
-    let docroot = match docroot.canonicalize() {
+    // `canonicalize_portable`, not `Path::canonicalize`: on Windows the latter
+    // yields a `\\?\`-prefixed path, which PHP's `open_basedir` check rejects —
+    // every script under the docroot then 500s and the whole suite is
+    // unrunnable on a Windows host (issue #367).
+    let docroot = match canonicalize_portable(&docroot) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("error: failed to canonicalize {}: {e}", docroot.display());
@@ -339,7 +343,7 @@ pub fn run(args: &[String]) -> ExitCode {
     // document_root). Resolved eagerly so a missing fixture fails before any
     // node is spawned.
     let worker_docroot = root.join("tests").join("worker-docroot");
-    let worker_docroot = match worker_docroot.canonicalize() {
+    let worker_docroot = match canonicalize_portable(&worker_docroot) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("error: worker docroot {} unusable: {e}", worker_docroot.display());
@@ -639,6 +643,12 @@ fn resolve_ephpm_binary(args: &[String], php_version: &str) -> Option<PathBuf> {
 
     // The release build lands under target/<triple>/release/ephpm, but the
     // top-level target/release/ephpm symlink is what people typically look for.
+    //
+    // The windows-msvc triple is in this list for the same reason as the other
+    // two: `cargo xtask release --target windows` is the only way to produce a
+    // Windows binary, it writes to `target/x86_64-pc-windows-msvc/release/`, and
+    // without this entry a Windows host never finds a binary it just built and
+    // falls through to a redundant `cargo xtask release` (issue #367).
     let candidates = [
         root.join("target").join("release").join(bin_name),
         root.join("target")
@@ -649,6 +659,7 @@ fn resolve_ephpm_binary(args: &[String], php_version: &str) -> Option<PathBuf> {
             .join(format!("{}-apple-darwin", std::env::consts::ARCH))
             .join("release")
             .join(bin_name),
+        root.join("target").join("x86_64-pc-windows-msvc").join("release").join(bin_name),
     ];
     for c in &candidates {
         if c.exists() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
-use std::{env, fs};
+use std::{env, fs, io};
 
 mod bump;
 mod cli_conformance;
@@ -1546,6 +1546,58 @@ fn container_engine() -> String {
 
 // ── workspace + platform helpers ─────────────────────────────────────────────
 
+/// Resolve a path to its real location **without** Windows' extended-length
+/// (`\\?\`) prefix, so the result can be handed to another program.
+///
+/// `std::fs::canonicalize` on Windows returns the verbatim form —
+/// `\\?\C:\Users\...\tests\docroot`. That is a perfectly good path to Rust and
+/// to the Win32 API, but it is not a path an unrelated program necessarily
+/// understands: PHP normalises and compares paths itself, and a
+/// `\\?\`-prefixed `document_root` fails its `open_basedir` check, so **every**
+/// script under that root 500s. That is what made `cargo xtask e2e` unrunnable
+/// on a Windows host (issue #367) — environmental, identical on every suite,
+/// and looking nothing like a path bug.
+///
+/// On non-Windows this is exactly `fs::canonicalize`.
+///
+/// # Errors
+///
+/// Same as [`std::fs::canonicalize`] — the path must exist and be reachable.
+fn canonicalize_portable(path: &Path) -> io::Result<PathBuf> {
+    Ok(strip_verbatim_prefix(path.canonicalize()?))
+}
+
+/// Rewrite `\\?\C:\dir` as `C:\dir` when that spelling is equivalent.
+///
+/// Only a **verbatim drive** prefix is unwrapped. `\\?\UNC\server\share` and
+/// verbatim device paths (`\\?\PhysicalDrive0`) are left alone: they have no
+/// shorter spelling that means the same thing. A result at or past `MAX_PATH`
+/// keeps its prefix too — there the prefix is what makes the path usable at
+/// all, and a docroot that long is not a case worth breaking to be pretty.
+#[cfg(windows)]
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    use std::path::{Component, Prefix};
+
+    /// Windows' classic path-length limit; `\\?\` exists to exceed it.
+    const MAX_PATH: usize = 260;
+
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix)) = components.next() else { return path };
+    let Prefix::VerbatimDisk(letter) = prefix.kind() else { return path };
+
+    // What follows the prefix is `RootDir` then the rest; collected that is
+    // `\dir\file`, and pushing a rooted-but-prefixless path onto `C:` keeps the
+    // prefix and replaces the rest — i.e. yields `C:\dir\file`.
+    let mut out = PathBuf::from(format!("{}:", letter as char));
+    out.push(components.collect::<PathBuf>());
+    if out.as_os_str().len() >= MAX_PATH { path } else { out }
+}
+
+#[cfg(not(windows))]
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    path
+}
+
 /// Find the workspace root (directory containing the root Cargo.toml).
 fn workspace_root() -> PathBuf {
     let mut dir = env::current_dir().expect("cannot read current directory");
@@ -1881,4 +1933,46 @@ fn download_and_extract_zip(url: &str, dest_dir: &Path, file_name: &str) -> bool
     let dest_path = dest_dir.join(file_name);
     make_executable(&dest_path);
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A canonicalized path handed to a spawned ephpm must not carry Windows'
+    /// verbatim prefix — PHP's `open_basedir` rejects it and every script under
+    /// the docroot 500s (issue #367).
+    #[test]
+    fn canonicalize_portable_has_no_verbatim_prefix() {
+        let here = canonicalize_portable(Path::new(".")).expect("cwd canonicalizes");
+        assert!(
+            !here.as_os_str().to_string_lossy().starts_with(r"\\?\"),
+            "canonicalize_portable leaked a verbatim prefix: {}",
+            here.display()
+        );
+        assert!(here.is_dir(), "the stripped path must still resolve: {}", here.display());
+    }
+
+    /// Only a verbatim *drive* prefix is unwrapped; a verbatim UNC path has no
+    /// equivalent shorter spelling and must survive untouched.
+    #[cfg(windows)]
+    #[test]
+    fn strip_verbatim_prefix_leaves_unc_alone() {
+        let unc = PathBuf::from(r"\\?\UNC\server\share\dir");
+        assert_eq!(strip_verbatim_prefix(unc.clone()), unc);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_verbatim_prefix_unwraps_a_drive() {
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\C:\Users\ci\ephpm\tests\docroot")),
+            PathBuf::from(r"C:\Users\ci\ephpm\tests\docroot")
+        );
+        // Already plain: unchanged.
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"C:\Users\ci")),
+            PathBuf::from(r"C:\Users\ci")
+        );
+    }
 }


### PR DESCRIPTION
Three test-infrastructure fixes. They are unrelated in code but share a shape: each one made a test signal lie — a flaky e2e leg that reads as a cluster regression, a unit test that fails on a clean checkout, and an e2e harness that cannot run at all on one platform.

Closes #438
Closes #435
Closes #367

---

## #438 — e2e port reservation was TOCTOU, now holds until handoff

`reserve_loopback_port()` (`crates/ephpm-e2e/src/lib.rs`) and the CDC harness's private `reserve_port()` (`crates/ephpm-e2e/tests/turso_cdc.rs`) both bound `127.0.0.1:0`, read the port, closed the socket and handed out a bare number. That returns the port to the ephemeral pool immediately — and a live ephpm cluster churning gossip, CDC and MySQL connections drains that pool continuously, so the kernel could re-issue a reserved port before the node that owned it ever spawned. The node died on `Address already in use`, the fixture said "node N never became healthy within 90s", and a ~15 minute e2e leg burned looking like a cluster regression. Observed ~1 run in 25.

The window is proportional to reserve→spawn distance, and `a_joining_node_must_not_steal_an_established_primary` has the worst possible one: `CdcCluster::prepare(4)` reserves every node's ports up front (each node's `join` list has to name the full eventual membership) but does not spawn node 3 until ~100s later, with three live nodes running the whole time.

**Fix** — generalise the safe pattern that already existed in the same file (`claim_tcp_port` + `PortProbes`, which *holds* its listeners) into a small public API:

- `PortReserver` hands out `PortLease`s and remembers every port it has ever issued, so a port released by an earlier lease is never offered to a later one.
- A `PortLease` keeps its probe sockets open — the port cannot be re-issued to anything while it lives. `PortLease::release` consumes the lease and is called immediately before `Command::spawn`, so the handoff gap is a few instructions instead of a whole test phase.
- `PortKind` makes the protocol explicit: `Tcp`, `Udp` (gossip with an explicitly pinned `[cluster.channel] listen`), and `GossipWithDerivedChannel` (also claims the derived `gossip + 2` port that nothing else probes). A TCP-bindable port can still refuse a UDP bind — WinNAT reserves UDP-only ranges — which is why this distinction is load-bearing (#239).

Both racy helpers are **deleted**, not deprecated, so neither can be reintroduced. All three fixtures (`SingleNodeFixture`, `ClusterFixture`, `CdcCluster`) now release at spawn. Repo-wide check: those were the only two such helpers; the xtask bare harness uses fixed ports (18100…) and is unaffected.

Note on holding a probe for ~100s: a held TCP listener accepts nothing and a held UDP socket reads nothing, so peers dialling a not-yet-spawned node see a connection reset (or dropped datagrams) when the probe is released — indistinguishable from the closed port they would otherwise have seen.

**Probes are `std::net`, not `tokio::net`, and that is load-bearing** (second commit — this was caught by running the suite on Windows, where the first version regressed `bare_process_smoke` 100% of the time). mio creates Windows sockets without `WSA_FLAG_NO_HANDLE_INHERIT`, which `std` passes; stdio redirection makes `Command::spawn` inherit handles, so a held probe was duplicated into the *previously spawned* node's process and stayed bound there after this process dropped it. The fix for "a port that looks free and isn't" had introduced a port that looks free and isn't — invisibly on Linux, where mio does set `SOCK_CLOEXEC`. A probe does no I/O and never needed the reactor. `PortReserver::lease` and the claim helpers are sync as a result. See the PR comment for the full write-up.

## #435 — the router test depended on a build artifact nothing in a test build produces

**This is not a Windows bug**, and not a behaviour difference in the static-file response phase. `response_phase_runs_on_static_files` asserted that `target/<profile>/examples/mw_response_header.<dll|so>` exists, and **nothing in a test build puts it there**.

Verified on this host: `cargo test --no-run` builds example targets, a plain `cargo test` does not. Touching `examples/mw_response_header.rs` and running `cargo test -p ephpm-server <filter>` leaves the artifact untouched and does not recompile it; moving the `.dll` aside reproduces the reported failure exactly. CI is green only because `.github/workflows/ci.yml` runs `cargo build --workspace --lib --examples` before its test step — and its comment says so explicitly. The doc comment on the (now deleted) `example_lib` helper claimed the opposite: "`cargo test -p ephpm-server` builds examples, so an absent artifact is a wiring regression". That contradiction is what sent this to triage as a platform bug. It reproduces on Linux and macOS too, on any clean checkout.

**Fix** — make the test hermetic. What it is *about* is the router invoking the response phase on the static-file path; which lane the module was loaded through is incidental. It now mounts the compiled-in `header-transform` builtin (which has a response phase) and needs no artifact at all. Verified by moving `mw_response_header.dll` out of `target/debug/examples` entirely and running the test — it passes.

The dlopen lane keeps its own coverage in `tests/middleware_dlopen.rs` and `tests/middleware_response_phase.rs`. Those genuinely need the cdylibs and still hard-fail (never skip) with the exact build command. Their module docs, and the comment in `crates/ephpm-server/Cargo.toml`, are corrected to state the real rule, and CLAUDE.md now documents the prerequisite so a local `cargo test` is a trustworthy signal.

## #367 — `cargo xtask e2e` can now run on Windows

Four blockers, all found by actually running it:

1. **The `\\?\` docroot.** The harness canonicalises `tests/docroot` before writing it into the generated `document_root`. On Windows `Path::canonicalize` returns the extended-length form, PHP's `open_basedir` check rejects that spelling, and every script under the docroot 500s. New `canonicalize_portable` canonicalises and then unwraps a verbatim **drive** prefix when the result is expressible without it. Verbatim UNC and device paths are left alone (no shorter spelling means the same thing), and so is a result at or past `MAX_PATH` (there the prefix is what makes the path usable at all). On non-Windows it is `fs::canonicalize` verbatim.

   Hand-rolled rather than adding `dunce`: xtask has **no dependencies at all** today and that seemed worth more than the twenty lines saved. `cargo deny` is therefore untouched. Three unit tests cover it, including that a verbatim UNC path survives.

2. **The binary was never found.** `resolve_ephpm_binary` knew the linux-gnu and apple-darwin triples but not `x86_64-pc-windows-msvc`, which is where `cargo xtask release --target windows` actually writes — so a Windows host never found the binary it had just built and fell through to a redundant release build.

3. **The middleware cdylib was cross-compiled to a target that isn't installed.** `build_middleware_cdylib` branched on macOS and fell through to `<arch>-unknown-linux-gnu` for everything else, so on Windows the run died mid-suite on rustc's `can't find crate for core` for a build that was only ever meant to be native. Windows gets its own branch.

4. **`tests/middleware.rs` generated unparseable TOML.** Both interpolated values are paths, and a raw Windows path makes `document_root = "C:\Users\..."` a TOML error (`\U` begins an 8-digit unicode escape) — so three startup tests failed on "invalid unicode 8-digit hex code" long before reaching the middleware mount they were about. Both now go through a new public `escape_toml_str`.

**Verification (the acceptance test):** on this Windows 11 host, `cargo xtask e2e --tests basic` — the exact control experiment named in the issue, which previously 500'd on every request — now spawns the node, runs the suite, and reports `4 passed`. A **full** `cargo xtask e2e` gets **48 of 51 suites passing**, from "cannot run at all". The three that still fail (`crash_containment`, one test in `middleware`, one in `opcache_invalidation`) are documented precisely in the comment below and are **not** claimed fixed here — including the caveat that the server binary used was built from `main`, not this branch.

---

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean. (`crates/ephpm-e2e` is excluded from the workspace and is *not* covered by that gate — it has never been formatted to the workspace style — so it is deliberately left alone rather than reformatted wholesale in this PR.)
- `cargo test -p xtask --bin xtask` — 41 passed, including the three new path tests
- `cargo test -p ephpm-server --lib response_phase_runs_on_static_files` — passes with no cdylib on disk
- `cargo test --manifest-path crates/ephpm-e2e/Cargo.toml --no-run --tests` — the e2e crate (not in the workspace, so not built by CI's test job) compiles
- `cargo xtask e2e` on Windows 11 / PHP 8.5.7 ZTS — 48 of 51 suites pass (see comment); `bare_process_smoke` run standalone 3× to confirm the probe-socket fix
- Stub mode throughout — nothing here touches `#[cfg(php_linked)]` code

## Overlap with open PRs

- **#444** (router `/_ephpm/*` internal-route dispatch) — this touches `crates/ephpm-server/src/router.rs`, but only inside `mod tests`, and only the one test plus a deleted test helper. No production router code changed.
- **#443** (worker/fpm dispatch) — no overlap.
