### PR TITLE
fix(otlp): report export failures, export SERVER spans, attribute spans to a site

### DIFF
--- a/crates/ephpm-server/src/otlp.rs
+++ b/crates/ephpm-server/src/otlp.rs
@@ -357,6 +357,203 @@ fn build_http_client() -> anyhow::Result<(reqwest::blocking::Client, String)> {
     Ok((client, description))
 }
 
+/// How long a continuously failing exporter stays quiet between summary lines.
+///
+/// The batch processor's scheduled delay is 5s, so an unreachable collector
+/// produces a failed export roughly every 5s — 720 an hour. One line a minute
+/// is enough to prove the condition is ongoing without burying the rest of the
+/// log, and short enough that an operator tailing it sees the problem quickly.
+const EXPORT_FAILURE_SUMMARY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// What [`ExportHealth`] decided should be said about one export result.
+///
+/// Separating the decision from the `tracing` call is what makes the
+/// rate-limiting testable without a subscriber or a real clock.
+#[derive(Debug, PartialEq, Eq)]
+enum ExportReport {
+    /// Say nothing — either a success with nothing to recover from, or a
+    /// repeat failure inside the summary window.
+    Silent,
+    /// The first failure of a run. Log it in full, at WARN.
+    FirstFailure,
+    /// The run is still going and the summary interval has elapsed.
+    StillFailing { consecutive: u64, elapsed: Duration },
+    /// An export succeeded after a run of failures. Log at INFO.
+    Recovered { consecutive: u64, elapsed: Duration },
+}
+
+/// Rate-limiting state machine over the exporter's success/failure stream.
+///
+/// Issue #378: a misconfigured or unreachable collector used to be completely
+/// silent. The naive fix — let every failed batch log — replaces silence with
+/// 720 identical lines an hour, which is its own way of telling an operator
+/// nothing. So the contract is: **first failure, periodic summary, recovery**.
+///
+/// The clock is a parameter rather than read from [`std::time::Instant::now`]
+/// so the window logic can be tested deterministically.
+#[derive(Debug, Default)]
+struct ExportHealth {
+    /// Failures since the last success. `0` means the last export succeeded.
+    consecutive: u64,
+    /// When the current failure run started. `Some` iff `consecutive > 0`.
+    failing_since: Option<std::time::Instant>,
+    /// When the last line was emitted for the current run, so the summary
+    /// interval is measured from what the operator last saw.
+    last_reported_at: Option<std::time::Instant>,
+}
+
+impl ExportHealth {
+    /// Fold one export outcome into the run, returning what to log.
+    fn observe(&mut self, failed: bool, now: std::time::Instant) -> ExportReport {
+        if !failed {
+            let Some(since) = self.failing_since.take() else {
+                return ExportReport::Silent;
+            };
+            let report = ExportReport::Recovered {
+                consecutive: self.consecutive,
+                elapsed: now.saturating_duration_since(since),
+            };
+            self.consecutive = 0;
+            self.last_reported_at = None;
+            return report;
+        }
+
+        self.consecutive += 1;
+        let Some(since) = self.failing_since else {
+            self.failing_since = Some(now);
+            self.last_reported_at = Some(now);
+            return ExportReport::FirstFailure;
+        };
+
+        // `last_reported_at` is always `Some` once a run has started (set on
+        // the branch above), but treating `None` as "due now" keeps the state
+        // machine total rather than relying on that invariant.
+        let due = self
+            .last_reported_at
+            .is_none_or(|at| now.saturating_duration_since(at) >= EXPORT_FAILURE_SUMMARY_INTERVAL);
+        if !due {
+            return ExportReport::Silent;
+        }
+
+        self.last_reported_at = Some(now);
+        ExportReport::StillFailing {
+            consecutive: self.consecutive,
+            elapsed: now.saturating_duration_since(since),
+        }
+    }
+}
+
+/// Reports export health through `tracing`, and rate-limits it.
+///
+/// Wraps whichever exporter [`init_layer`] built. Every batch's outcome passes
+/// through [`ExportHealth`], which decides between silence, a first-failure
+/// WARN, a once-a-minute summary WARN, and a recovery INFO.
+///
+/// # Why the error is not propagated
+///
+/// `export` returns `Ok(())` even when the inner exporter failed, because
+/// `opentelemetry_sdk`'s batch processor does exactly two things with an
+/// `Err`: it emits `otel_error!(name: "BatchSpanProcessor.ExportError", …)`,
+/// and it returns the value to a caller that discards it on the periodic path
+/// (`opentelemetry_sdk-0.31.0/src/trace/span_processor.rs`, the `match` at
+/// `:509` and the `let _ =` at `:345`/`:397`). There is no retry and no
+/// backoff keyed on it. Propagating it therefore buys nothing and costs the
+/// one thing this wrapper exists to prevent: a second, un-rate-limited line
+/// per failed batch, defeating the summary window.
+///
+/// The rest of the SDK's `internal-logs` output is untouched — notably
+/// `BatchSpanProcessor.SpanDroppingStarted`, which reports a full queue and is
+/// self-limiting (emitted only on the first drop). This wrapper deliberately
+/// suppresses one specific duplicate, not the SDK's diagnostics.
+///
+/// **On upgrading `opentelemetry_sdk`:** re-check those call sites. If a
+/// future version acts on the `Err` — retry, backoff, circuit-breaking — this
+/// must stop swallowing it and the duplicate must be handled another way.
+#[derive(Debug)]
+struct ReportingExporter<E> {
+    inner: E,
+    health: std::sync::Mutex<ExportHealth>,
+}
+
+impl<E> ReportingExporter<E> {
+    fn new(inner: E) -> Self {
+        Self { inner, health: std::sync::Mutex::new(ExportHealth::default()) }
+    }
+
+    /// Fold one outcome into the health state and log whatever it decides.
+    ///
+    /// `error` is `None` on success. Poisoning is impossible (nothing panics
+    /// while the lock is held) but is recovered from anyway rather than
+    /// turning an export into a panic.
+    fn report(&self, error: Option<&str>) {
+        let report = {
+            let mut health = self.health.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            health.observe(error.is_some(), std::time::Instant::now())
+        };
+
+        match report {
+            ExportReport::Silent => {}
+            ExportReport::FirstFailure => tracing::warn!(
+                error = error.unwrap_or_default(),
+                summary_interval_secs = EXPORT_FAILURE_SUMMARY_INTERVAL.as_secs(),
+                "OTLP span export failed; traces are not reaching the collector. \
+                 Requests are unaffected. Repeats are summarized rather than \
+                 logged individually."
+            ),
+            ExportReport::StillFailing { consecutive, elapsed } => tracing::warn!(
+                error = error.unwrap_or_default(),
+                consecutive_failures = consecutive,
+                failing_for_secs = elapsed.as_secs(),
+                "OTLP span export is still failing"
+            ),
+            ExportReport::Recovered { consecutive, elapsed } => tracing::info!(
+                consecutive_failures = consecutive,
+                was_failing_for_secs = elapsed.as_secs(),
+                "OTLP span export recovered"
+            ),
+        }
+    }
+}
+
+impl<E: opentelemetry_sdk::trace::SpanExporter> opentelemetry_sdk::trace::SpanExporter
+    for ReportingExporter<E>
+{
+    fn export(
+        &self,
+        batch: Vec<opentelemetry_sdk::trace::SpanData>,
+    ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        let export = self.inner.export(batch);
+        async move {
+            match export.await {
+                Ok(()) => {
+                    self.report(None);
+                }
+                Err(e) => {
+                    self.report(Some(&e.to_string()));
+                }
+            }
+            // See the type docs: swallowing is what keeps the SDK from
+            // emitting a second, un-rate-limited line per failed batch.
+            Ok(())
+        }
+    }
+
+    fn shutdown_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
+    }
+
+    fn force_flush(&mut self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(resource);
+    }
+}
+
 /// Adapts an async [`SpanExporter`] to the SDK's synchronous batch thread.
 ///
 /// [`opentelemetry_sdk::trace::BatchSpanProcessor`] runs on a plain
@@ -630,11 +827,15 @@ where
 
     // The two transports produce different exporter types, so each branch
     // builds its own provider and they converge on `SdkTracerProvider`.
+    //
+    // Both wrap their exporter in `ReportingExporter` — that is what turns a
+    // failing export from silence (issue #378) into a rate-limited
+    // first-failure / periodic-summary / recovery story in the ePHPm log.
     let (provider, grpc_runtime, transport_description) = match transport {
         Transport::Grpc => {
             let (exporter, runtime, description) = build_grpc_exporter(builder_endpoint)?;
             let provider = SdkTracerProvider::builder()
-                .with_batch_exporter(exporter)
+                .with_batch_exporter(ReportingExporter::new(exporter))
                 .with_resource(resource)
                 .build();
             (provider, Some(runtime), description)
@@ -652,7 +853,7 @@ where
             }
             let exporter = builder.build().context("failed to build the OTLP span exporter")?;
             let provider = SdkTracerProvider::builder()
-                .with_batch_exporter(exporter)
+                .with_batch_exporter(ReportingExporter::new(exporter))
                 .with_resource(resource)
                 .build();
             (provider, None, description)
@@ -864,6 +1065,156 @@ mod tests {
 
         assert!(!first.contains("already installed"), "first: {first}");
         assert!(!second.contains("already installed"), "second: {second}");
+    }
+
+    /// The #378 contract, end to end on the state machine: a collector that
+    /// goes away logs **once**, then at most once per summary interval, then
+    /// once more when it comes back.
+    ///
+    /// The clock is synthetic so the 60s window is exercised without the test
+    /// taking 60s, and so the assertion is on the boundary rather than on
+    /// whatever the machine's scheduler did.
+    #[test]
+    fn export_failures_are_reported_once_then_summarized_then_recovered() {
+        let t0 = std::time::Instant::now();
+        let mut health = ExportHealth::default();
+
+        // A healthy exporter says nothing at all — no per-batch chatter.
+        assert_eq!(health.observe(false, t0), ExportReport::Silent);
+
+        // The collector goes away. The first failure is the loud one.
+        assert_eq!(health.observe(true, t0), ExportReport::FirstFailure);
+
+        // Every batch for the next minute fails, and none of them may log:
+        // the batch delay is 5s, so this is the 720-lines-an-hour case.
+        for i in 1..12 {
+            assert_eq!(
+                health.observe(true, t0 + Duration::from_secs(5 * i)),
+                ExportReport::Silent,
+                "a repeat failure inside the summary window must stay silent (t+{}s)",
+                5 * i
+            );
+        }
+
+        // At the window boundary exactly one summary comes out, carrying the
+        // count so the operator can see it is ongoing rather than new.
+        let at_window = t0 + EXPORT_FAILURE_SUMMARY_INTERVAL;
+        assert_eq!(
+            health.observe(true, at_window),
+            ExportReport::StillFailing {
+                consecutive: 13,
+                elapsed: EXPORT_FAILURE_SUMMARY_INTERVAL
+            }
+        );
+        // ...and the window restarts from the line just emitted, not from the
+        // start of the run, so the next summary is a full interval away.
+        assert_eq!(health.observe(true, at_window + Duration::from_secs(59)), ExportReport::Silent);
+
+        // Recovery is worth a line: "no traces" and "traces again" are both
+        // states an operator needs to see the transition into.
+        let recovered_at = at_window + EXPORT_FAILURE_SUMMARY_INTERVAL;
+        assert_eq!(
+            health.observe(false, recovered_at),
+            ExportReport::Recovered {
+                consecutive: 14,
+                elapsed: recovered_at.saturating_duration_since(t0)
+            }
+        );
+
+        // Back to steady state: a success after a success is silent, and the
+        // next outage is a fresh FirstFailure rather than a summary.
+        assert_eq!(health.observe(false, recovered_at), ExportReport::Silent);
+        assert_eq!(health.observe(true, recovered_at), ExportReport::FirstFailure);
+    }
+
+    /// The wrapper itself, not just its state machine: a failing exporter
+    /// produces exactly **one** `tracing` event for a run of failures, and
+    /// [`ReportingExporter::export`] reports success upward so the SDK does not
+    /// emit its own un-rate-limited duplicate.
+    ///
+    /// This is the actual #378 regression guard — the reproduction in the issue
+    /// is an unreachable collector, and the observable symptom was zero log
+    /// lines. A stub exporter stands in for the collector so the test needs no
+    /// network and no timing.
+    #[tokio::test]
+    async fn a_failing_exporter_logs_once_and_does_not_propagate_the_error() {
+        use opentelemetry_sdk::trace::SpanExporter as _;
+
+        /// Stands in for a collector that is down / rejecting TLS / 404ing.
+        #[derive(Debug)]
+        struct AlwaysFails;
+
+        impl opentelemetry_sdk::trace::SpanExporter for AlwaysFails {
+            fn export(
+                &self,
+                _batch: Vec<opentelemetry_sdk::trace::SpanData>,
+            ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send
+            {
+                std::future::ready(Err(opentelemetry_sdk::error::OTelSdkError::InternalFailure(
+                    "tcp connect error: Connection refused".to_string(),
+                )))
+            }
+        }
+
+        /// Counts events by level so the assertion is on "how many lines did
+        /// the operator get", which is the whole contract.
+        #[derive(Clone, Default)]
+        struct EventCounter(std::sync::Arc<std::sync::Mutex<Vec<(tracing::Level, String)>>>);
+
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for EventCounter {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push((*event.metadata().level(), event.metadata().target().to_string()));
+            }
+        }
+
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        let events = EventCounter::default();
+        let subscriber = tracing_subscriber::registry().with(events.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let exporter = ReportingExporter::new(AlwaysFails);
+
+        // Three failed batches in quick succession — the shape of a collector
+        // that has just gone away.
+        for _ in 0..3 {
+            assert!(
+                exporter.export(Vec::new()).await.is_ok(),
+                "the wrapper must report success upward so the SDK does not log \
+                 its own line per failed batch; see the type docs"
+            );
+        }
+
+        let lines = events.0.lock().unwrap().clone();
+        assert_eq!(
+            lines.len(),
+            1,
+            "a run of failures must produce exactly one line until the summary \
+             interval elapses: {lines:?}"
+        );
+        assert_eq!(lines[0].0, tracing::Level::WARN, "{lines:?}");
+        assert_eq!(lines[0].1, "ephpm_server::otlp", "{lines:?}");
+    }
+
+    /// A single failed batch that recovers immediately still produces exactly
+    /// two lines — the failure and the recovery — never a summary.
+    #[test]
+    fn a_transient_failure_reports_the_failure_and_the_recovery() {
+        let t0 = std::time::Instant::now();
+        let mut health = ExportHealth::default();
+
+        assert_eq!(health.observe(true, t0), ExportReport::FirstFailure);
+        assert_eq!(
+            health.observe(false, t0 + Duration::from_secs(5)),
+            ExportReport::Recovered { consecutive: 1, elapsed: Duration::from_secs(5) }
+        );
     }
 
     /// The client must speak plaintext exactly as before TLS was added.

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -2092,12 +2092,36 @@ impl Router {
         // the callsite disabled — the span only materializes when a layer
         // opts in (the OTLP layer's Targets filter, or RUST_LOG=debug).
         // Timing-wise it brackets the same region as `start`/`elapsed`.
+        //
+        // Field names follow the OpenTelemetry HTTP semantic conventions (HTTP
+        // spans, stable since semconv v1.23.0): `http.request.method`,
+        // `url.path`, `http.response.status_code`, `error.type`. The three
+        // `otel.*` names are not attributes — `tracing-opentelemetry` consumes
+        // them to set the span's *kind* and *status* (see `SPAN_KIND_FIELD` /
+        // `SPAN_STATUS_CODE_FIELD` in that crate's `layer.rs`).
+        //
+        // Deliberately absent (issue #380): the raw `Host` header, under
+        // `server.address` or any other name. It is attacker-controlled and
+        // arrives before any tenancy decision; `ephpm.site` below carries the
+        // *resolved* tenant instead. Also absent: the query string, which
+        // routinely carries tokens (`url.path` excludes it by construction).
         let span = tracing::debug_span!(
             target: crate::OTEL_TRACE_TARGET,
             "http.request",
+            // An inbound HTTP request is a SERVER span. Backends key service
+            // graphs and RED metrics off this (issue #379); as INTERNAL, ePHPm
+            // never appeared as a trace's entry point.
+            otel.kind = "server",
             http.request.method = %req.method(),
             url.path = req.uri().path(),
             http.response.status_code = tracing::field::Empty,
+            // Recorded below once the response status is known — see
+            // `server_span_status_is_error`.
+            otel.status_code = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+            // Recorded by `handle_inner` once `resolve_site` has run, and only
+            // when a known vhost matched (issue #380).
+            ephpm.site = tracing::field::Empty,
         );
         // W3C trace-context propagation: parent the request span to an
         // incoming `traceparent` header. Only compiled with the `otlp`
@@ -2139,7 +2163,20 @@ impl Router {
             self.apply_alt_svc(resp, is_tls);
             self.apply_preview_marker(resp);
 
-            span.record("http.response.status_code", resp.status().as_u16());
+            let status = resp.status();
+            span.record("http.response.status_code", status.as_u16());
+            // OTel HTTP semconv, span status: on a SERVER span a 5xx (or any
+            // code the server could not interpret) is an Error and a 4xx is
+            // deliberately left Unset — a 404 is a normal outcome of serving,
+            // not a fault of the server. `error.type` is Conditionally
+            // Required when the span status is Error, and the status code is
+            // its canonical value when the failure is fully described by that
+            // code. No status *description* is set: semconv says not to
+            // duplicate what the status code already conveys. Issue #379.
+            if server_span_status_is_error(status) {
+                span.record("otel.status_code", "error");
+                span.record("error.type", status.as_str());
+            }
 
             // Timeline entry: reuse the values already measured — `elapsed`
             // (the histogram measurement below) plus the PHP-path timings the
@@ -2362,6 +2399,33 @@ impl Router {
             fallback: site_fallback,
             websocket_files: site_websocket_files,
         } = self.resolve_site(&host);
+
+        // Tenant attribution on the request span (issue #380).
+        //
+        // The value is the canonical key `resolve_site` just returned, never
+        // the `Host` header — the same rule the database filename, the KV
+        // keyspace and the wire credential follow, so a span names the same
+        // tenant as the data it touched (see `ResolvedSite`). Reading the
+        // header here instead would export an attacker-controlled string and
+        // reintroduce exactly the class of bug the one-canonical-key invariant
+        // exists to prevent.
+        //
+        // A host that matched no known vhost has no key and therefore gets no
+        // attribute: an absent value is the honest representation of "no
+        // tenant", and it keeps unknown hosts off the wire entirely.
+        //
+        // `ephpm.site` is a deliberately ePHPm-owned name. OTel semconv has no
+        // multi-tenant attribute, and no reserved namespace (`service.*`,
+        // `server.*`, `host.*`) means "which of this process's vhosts served
+        // this", so squatting on one would be wrong.
+        //
+        // Cost: `None` in single-site mode (`resolve_site` returns
+        // `default_site()` for every request), so this is one `Option` check
+        // and nothing else unless multi-site is actually configured.
+        if let Some(key) = site_key.as_deref() {
+            tracing::Span::current().record("ephpm.site", key);
+        }
+
         // Everything below routes against the WEB root: index files, the
         // fallback chain, static-file containment and PHP-script containment.
         // The container travels separately inside `site_roots` and is what
@@ -4487,6 +4551,29 @@ fn method_metric_label(method: &hyper::Method) -> &'static str {
     }
 }
 
+/// Whether a response status makes the request's **server** span an OTel
+/// `Error`.
+///
+/// From the OpenTelemetry HTTP semantic conventions (HTTP spans; stable since
+/// semconv v1.23.0 and unchanged through the current 1.3x line):
+///
+/// > For HTTP status codes in the 5xx range, as well as any other code the
+/// > client failed to interpret, span status MUST be set to `Error`. For HTTP
+/// > status codes in the 4xx range span status MUST be left unset in case of
+/// > `SpanKind.SERVER` and MUST be set to `Error` in case of `SpanKind.CLIENT`.
+///
+/// ePHPm's `http.request` span is a SERVER span, so this is a pure
+/// status-class check and not a judgement call: a 404 or a 401 is a normal
+/// outcome of serving and must NOT paint the trace red, while a 500 from PHP
+/// or a 504 from the request deadline must.
+///
+/// Kept as a named function rather than an inline `is_server_error()` so the
+/// rule — and specifically the 4xx exclusion, which is the part people get
+/// wrong — is unit-testable and has somewhere to cite the spec.
+fn server_span_status_is_error(status: StatusCode) -> bool {
+    status.is_server_error()
+}
+
 /// Map an HTTP status code to a `&'static str` metrics label.
 ///
 /// The `metrics` macros require label values to be `'static`; returning a
@@ -6121,6 +6208,319 @@ mod tests {
                 .and_then(|pid| ctx.span(&pid).map(|s| s.name().to_string()));
             self.0.lock().unwrap().push((attrs.metadata().name().to_string(), parent));
         }
+    }
+
+    /// One `http.request` span's attributes, as a collector would receive them.
+    type SpanAttrs = std::collections::BTreeMap<String, String>;
+
+    /// Test layer capturing the **attributes** of the router's `http.request`
+    /// spans — creation-time fields and values recorded later (the status code,
+    /// the span status, the site key) alike.
+    ///
+    /// [`SpanTree`] answers "what shape is the trace?". This answers "what does
+    /// a collector actually receive?", which is what issues #379 and #380 are
+    /// about. Everything is stringified because that is how these values reach
+    /// the wire anyway, and it keeps the assertions readable.
+    #[derive(Clone, Default)]
+    struct SpanAttrCollector(Arc<std::sync::Mutex<Vec<(u64, SpanAttrs)>>>);
+
+    impl SpanAttrCollector {
+        /// Attributes of every captured `http.request` span, in creation order.
+        fn snapshot(&self) -> Vec<SpanAttrs> {
+            self.0.lock().unwrap().iter().map(|(_, attrs)| attrs.clone()).collect()
+        }
+
+        /// The single captured span, when a test drove exactly one request.
+        fn only(&self) -> SpanAttrs {
+            let spans = self.snapshot();
+            assert_eq!(spans.len(), 1, "expected exactly one http.request span: {spans:?}");
+            spans.into_iter().next().unwrap()
+        }
+    }
+
+    /// Flattens any `tracing` field value into a `String`.
+    struct AttrVisitor<'a>(&'a mut SpanAttrs);
+
+    impl tracing::field::Visit for AttrVisitor<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+
+        /// Covers the `%`-sigil (`Display`) fields — `tracing` wraps those in a
+        /// `DisplayValue` whose `Debug` forwards to `Display`, so
+        /// `http.request.method` lands here as `GET`, not `"GET"`.
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for SpanAttrCollector
+    where
+        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            id: &tracing::span::Id,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if attrs.metadata().target() != crate::OTEL_TRACE_TARGET
+                || attrs.metadata().name() != "http.request"
+            {
+                return;
+            }
+            let mut fields = SpanAttrs::new();
+            attrs.record(&mut AttrVisitor(&mut fields));
+            self.0.lock().unwrap().push((id.into_u64(), fields));
+        }
+
+        fn on_record(
+            &self,
+            id: &tracing::span::Id,
+            values: &tracing::span::Record<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut spans = self.0.lock().unwrap();
+            if let Some((_, fields)) = spans.iter_mut().find(|(sid, _)| *sid == id.into_u64()) {
+                values.record(&mut AttrVisitor(fields));
+            }
+        }
+    }
+
+    /// Install a `SpanAttrCollector` collector for the duration of a test.
+    fn collect_span_attrs() -> (SpanAttrCollector, tracing::subscriber::DefaultGuard) {
+        enable_span_callsites();
+        let attrs = SpanAttrCollector::default();
+        let subscriber = tracing_subscriber::registry().with(attrs.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        (attrs, guard)
+    }
+
+    /// The OTel HTTP semconv span-status rule for a **server** span, pinned as
+    /// a table: 5xx is an error, 4xx explicitly is not, 2xx/3xx are not.
+    ///
+    /// The 4xx row is the one worth a test — treating a 404 as an error is the
+    /// intuitive-but-wrong reading, and it would paint every bot probe red.
+    #[test]
+    fn only_5xx_makes_a_server_span_an_error() {
+        for code in [200u16, 201, 204, 301, 304, 400, 401, 403, 404, 429, 499] {
+            let status = StatusCode::from_u16(code).unwrap();
+            assert!(
+                !server_span_status_is_error(status),
+                "{code} must leave the server span status unset"
+            );
+        }
+        for code in [500u16, 502, 503, 504] {
+            let status = StatusCode::from_u16(code).unwrap();
+            assert!(server_span_status_is_error(status), "{code} must mark the server span Error");
+        }
+    }
+
+    /// Issue #379: `http.request` exports as a SERVER span carrying the current
+    /// OTel HTTP semantic-convention attributes, and a successful response
+    /// leaves the span status unset.
+    #[tokio::test]
+    async fn request_span_is_a_server_span_with_semconv_attributes() {
+        let (attrs, _guard) = collect_span_attrs();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        let router = test_router(dir.path());
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/a.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let span = attrs.only();
+        // The whole point of #379: an inbound request is a SERVER span, so
+        // service graphs and RED-metric connectors see ePHPm as a trace's
+        // entry point instead of an orphan internal span.
+        assert_eq!(span.get("otel.kind").map(String::as_str), Some("server"), "{span:?}");
+
+        // Current semconv names. The deprecated `http.method` / `http.url`
+        // spellings must not appear.
+        assert_eq!(span.get("http.request.method").map(String::as_str), Some("GET"), "{span:?}");
+        assert_eq!(span.get("url.path").map(String::as_str), Some("/a.txt"), "{span:?}");
+        assert_eq!(span.get("http.response.status_code").map(String::as_str), Some("200"));
+        assert!(!span.contains_key("http.method"), "deprecated name leaked: {span:?}");
+        assert!(!span.contains_key("http.url"), "deprecated name leaked: {span:?}");
+
+        // A 200 is not an error, and single-site mode names no tenant.
+        assert!(!span.contains_key("otel.status_code"), "a 200 must leave status unset: {span:?}");
+        assert!(!span.contains_key("error.type"), "{span:?}");
+        assert!(!span.contains_key("ephpm.site"), "single-site mode has no tenant: {span:?}");
+
+        // The `Host` header and the query string stay off the wire.
+        assert!(!span.contains_key("server.address"), "{span:?}");
+        assert!(!span.contains_key("url.query"), "{span:?}");
+        assert!(!span.contains_key("url.full"), "{span:?}");
+    }
+
+    /// Issue #379, the 4xx half: semconv says a 4xx on a SERVER span is NOT an
+    /// error. A 404 must leave the span status unset — otherwise every bot
+    /// probe shows up red and error-rate dashboards are useless.
+    #[tokio::test]
+    async fn four_xx_leaves_the_server_span_status_unset() {
+        let (attrs, _guard) = collect_span_attrs();
+
+        let dir = tempfile::tempdir().unwrap();
+        let router = test_router_with_404(dir.path());
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/nope.txt").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let span = attrs.only();
+        assert_eq!(span.get("http.response.status_code").map(String::as_str), Some("404"));
+        assert!(
+            !span.contains_key("otel.status_code"),
+            "a 4xx must not mark a server span as an error: {span:?}"
+        );
+        assert!(!span.contains_key("error.type"), "{span:?}");
+    }
+
+    /// Issue #379, the 5xx half: a server error sets the span status to ERROR
+    /// and records `error.type`, so a failed request is distinguishable from a
+    /// healthy one in the UI and in span-derived metrics.
+    ///
+    /// The 504 from the request deadline is the deterministic 5xx available in
+    /// stub mode: a zero-worker pool accepts the dispatch and never answers.
+    #[tokio::test(start_paused = true)]
+    async fn five_xx_marks_the_server_span_as_an_error() {
+        let (attrs, _guard) = collect_span_attrs();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.php"), b"<?php echo 1;").unwrap();
+        let mut config = Config {
+            server: ServerConfig {
+                listen: "0.0.0.0:8080".to_string(),
+                document_root: dir.path().to_path_buf(),
+                index_files: vec!["index.php".to_string()],
+                fallback: vec!["$uri".to_string(), "=404".to_string()],
+                ..ServerConfig::default()
+            },
+            php: PhpConfig::default(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+            middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
+        };
+        config.server.timeouts.request = 1;
+        let pool = crate::worker_pool::WorkerPool::spawn(
+            dir.path().join("worker.php"),
+            0, // zero workers: dispatch queues, nobody answers
+            500,
+            4,
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+        );
+        let router = Router::new(&config, test_store(), None, None, None, None, Some(pool));
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/index.php").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+
+        let span = attrs.only();
+        assert_eq!(span.get("http.response.status_code").map(String::as_str), Some("504"));
+        // `tracing-opentelemetry` turns this field into the OTel span status;
+        // it is not exported as an attribute of its own.
+        assert_eq!(
+            span.get("otel.status_code").map(String::as_str),
+            Some("error"),
+            "a 5xx must set the span status to ERROR: {span:?}"
+        );
+        // Conditionally required by semconv when the status is Error; the
+        // status code is its canonical value for an HTTP failure.
+        assert_eq!(span.get("error.type").map(String::as_str), Some("504"), "{span:?}");
+    }
+
+    /// Issue #380: in multi-site mode the span carries the **resolved**
+    /// canonical site key, and a host that matched no vhost carries nothing.
+    ///
+    /// The second half is the security-relevant one. `ephpm.site` must never be
+    /// a re-spelling of the `Host` header — an unknown host has no tenant, and
+    /// an absent attribute is the honest representation of that. Recording the
+    /// header instead would put an attacker-controlled string on the wire and
+    /// re-open the #290/#291 class of bug from the trace side.
+    #[tokio::test]
+    async fn span_carries_the_resolved_site_key_and_nothing_for_an_unknown_host() {
+        let (attrs, _guard) = collect_span_attrs();
+
+        let dir = tempfile::tempdir().unwrap();
+        let sites = dir.path().join("sites");
+        fs::create_dir_all(sites.join("alpha")).unwrap();
+        std::fs::write(sites.join("alpha").join("index.html"), b"alpha").unwrap();
+
+        let config = Config {
+            server: ServerConfig {
+                listen: "0.0.0.0:8080".to_string(),
+                document_root: dir.path().to_path_buf(),
+                sites_dir: Some(sites),
+                index_files: vec!["index.html".to_string()],
+                fallback: vec!["$uri".to_string(), "$uri/".to_string(), "=404".to_string()],
+                ..ServerConfig::default()
+            },
+            php: PhpConfig::default(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+            middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
+        };
+        let router = Router::new(&config, test_store(), None, None, None, None, None);
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/")
+            .header("host", "alpha")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "the alpha vhost must serve its index");
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/")
+            .header("host", "evil.example.com")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "an unknown host matches no vhost");
+
+        let spans = attrs.snapshot();
+        assert_eq!(spans.len(), 2, "{spans:?}");
+        assert_eq!(
+            spans[0].get("ephpm.site").map(String::as_str),
+            Some("alpha"),
+            "the span must carry the canonical key resolve_site returned: {spans:?}"
+        );
+        assert!(
+            !spans[1].contains_key("ephpm.site"),
+            "an unknown host has no tenant, so no attribute — and certainly not \
+             the raw Host header: {spans:?}"
+        );
+        // Belt and braces: the attacker-supplied host must not appear under
+        // ANY attribute name on that span.
+        assert!(
+            !spans[1].values().any(|v| v.contains("evil.example.com")),
+            "the Host header must not reach the wire under any name: {spans:?}"
+        );
     }
 
     async fn fetch_timeline(router: &Router) -> Vec<serde_json::Value> {

--- a/site/content/architecture/_index.md
+++ b/site/content/architecture/_index.md
@@ -22,7 +22,7 @@ This document describes the full vision for ePHPm. The matrix below tracks what 
 | Signal handling | Partial | Ctrl+C only; no SIGHUP reload |
 | Observability — logging | **Implemented** | `tracing` crate, structured logs, request lifecycle events |
 | Observability — query stats | **Implemented** | `ephpm-query-stats`: SQL normalization, digest tracking, slow query log, Prometheus metrics |
-| Observability — OTLP export | **Implemented** | Request spans (`http.request` / `worker.queue_wait` / `php.execute`) over OTLP gRPC or http/protobuf, W3C `traceparent` continuation. Auto-instrumentation of PHP code, and an OTLP *receiver*, are still planned |
+| Observability — OTLP export | **Implemented** | Request spans (`http.request` as `SERVER` / `worker.queue_wait` / `php.execute`) over OTLP gRPC or http/protobuf, OTel HTTP semconv attributes with 5xx→`ERROR` span status, per-tenant `ephpm.site` in multi-site mode, W3C `traceparent` continuation, rate-limited export-failure reporting. Auto-instrumentation of PHP code, and an OTLP *receiver*, are still planned |
 | DB proxy (MySQL) | **Implemented** | Wire protocol, connection pooling, transparent forwarding to upstream MySQL |
 | DB proxy (PostgreSQL) | **Implemented** | Wire protocol, connection pooling, trust/md5/SCRAM auth, R/W splitting |
 | Read/write splitting | **Implemented** | `ephpm-db` routes reads to replicas, writes to primary |

--- a/site/content/guides/otlp-tracing.md
+++ b/site/content/guides/otlp-tracing.md
@@ -25,11 +25,11 @@ stitched into a trace that continues from whatever called you.
 
 ## What ePHPm exports
 
-| Span | Emitted | Attributes |
-|------|---------|------------|
-| `http.request` | every request | `http.request.method`, `url.path`, `http.response.status_code` |
-| `php.execute` | requests that run PHP | none |
-| `worker.queue_wait` | worker mode only | none |
+| Span | Kind | Emitted | Attributes |
+|------|------|---------|------------|
+| `http.request` | `SERVER` | every request | `http.request.method`, `url.path`, `http.response.status_code`; `error.type` on a 5xx; `ephpm.site` in multi-site mode |
+| `php.execute` | `INTERNAL` | requests that run PHP | none |
+| `worker.queue_wait` | `INTERNAL` | worker mode only | none |
 
 `php.execute` and `worker.queue_wait` are children of `http.request`. On the
 default fpm path there is no dispatch queue, so you get a two-span tree; in
@@ -37,11 +37,53 @@ worker mode (`[php] mode = "worker"`) `worker.queue_wait` appears as a sibling
 of `php.execute` and measures how long the request waited for a free worker.
 A static file or a 404 produces `http.request` alone.
 
-Note what is **not** on a span: no `Host` header, no query string, and no
-site/vhost identifier. Query strings routinely carry tokens, so their absence
-is deliberate. The consequence in multi-tenant mode (`[server] sites_dir`) is
-that traces from different vhosts are currently indistinguishable — see
-[Known rough edges](#known-rough-edges).
+Attribute names follow the [OpenTelemetry HTTP semantic
+conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
+(HTTP spans, stable since semconv **v1.23.0**). ePHPm has never used the
+deprecated `http.method` / `http.url` spellings, so there is nothing to
+migrate.
+
+**Span status.** A 5xx sets the span status to `ERROR` and records
+`error.type` (the status code). A **4xx does not** — semconv is explicit that
+on a `SERVER` span a 4xx is left unset, because a 404 or a 401 is a normal
+outcome of serving rather than a server fault. Without that rule every bot
+probe would show up red.
+
+**Span name.** `http.request`, not the semconv-preferred `{method} {route}`.
+ePHPm has no route concept, so the only thing it could substitute is the raw
+path — which explodes cardinality on any app with IDs in its URLs. The method
+and path are both available as attributes.
+
+Note what is **not** on a span: no `Host` header (under `server.address` or any
+other name), and no query string. Both are deliberate. The `Host` header is
+attacker-controlled and arrives before any tenancy decision, so what is
+exported instead is `ephpm.site` — see below. Query strings routinely carry
+tokens and PII; `url.path` excludes the query by construction.
+
+### Per-tenant attribution (`ephpm.site`)
+
+In multi-site mode (`[server] sites_dir`) the `http.request` span carries
+`ephpm.site`: the **canonical site key** ePHPm resolved for the request — the
+same key that selects the vhost's database file, its KV keyspace and its
+`pdo_mysql` credential. Filter or group by it to get per-tenant traces,
+latency and error rates out of one process.
+
+Two properties worth knowing:
+
+- It is the *resolved* key, never a re-spelling of the `Host` header. With
+  `sites_domain_suffix = ".local"`, `Host: shop.local` and `Host: shop` both
+  export `ephpm.site="shop"`, because they are one tenant.
+- A request whose `Host` matched **no** vhost carries **no** `ephpm.site` at
+  all. An absent attribute is the honest representation of "no tenant", and it
+  keeps unknown, attacker-supplied hostnames off the wire entirely.
+
+In single-site mode the attribute is absent — there is one tenant and
+`OTEL_SERVICE_NAME` already distinguishes the deployment.
+
+`ephpm.` is a deliberately ePHPm-owned namespace. OTel semantic conventions
+have no multi-tenant attribute, and no reserved namespace (`service.*`,
+`server.*`, `host.*`) means "which of this process's vhosts served this", so
+squatting on one would be wrong.
 
 ## Choosing a transport
 
@@ -234,6 +276,49 @@ correct behaviour and the most common cause of "my traces stopped appearing
 after I put a load balancer in front" — the symptom is indistinguishable from
 a broken exporter.
 
+## When export fails
+
+A wrong endpoint, an unreachable collector, or a certificate ePHPm does not
+trust used to be **completely silent**: the startup line appeared, no spans
+arrived, and nothing in the log said why
+([#378](https://github.com/ephpm/ephpm/issues/378)). Now the failure is
+reported — and deliberately rate-limited, because a collector that is down for
+an hour must not produce hundreds of identical lines.
+
+The first failed batch is loud:
+
+```text
+WARN ephpm_server::otlp: OTLP span export failed; traces are not reaching the
+     collector. Requests are unaffected. Repeats are summarized rather than
+     logged individually.
+     error="Operation failed: ... tcp connect error ... Connection refused"
+     summary_interval_secs=60
+```
+
+While it keeps failing you get one summary a minute, carrying how bad it is:
+
+```text
+WARN ephpm_server::otlp: OTLP span export is still failing
+     consecutive_failures=13 failing_for_secs=60 error="..."
+```
+
+And the recovery is logged too, so "traces came back" is not something you
+have to infer:
+
+```text
+INFO ephpm_server::otlp: OTLP span export recovered
+     consecutive_failures=14 was_failing_for_secs=120
+```
+
+Read the `error=` value first — it distinguishes the four failure modes that
+otherwise look identical from the collector side: a refused connection (wrong
+port, collector down), a TLS error (`unknown certificate authority` → see
+[HTTPS collectors](#https-collectors)), an HTTP status from the collector
+(wrong path, or gRPC pointed at an http/protobuf receiver), and a timeout.
+
+**Serving is never affected.** A failing exporter does not slow, block or fail
+requests; export runs on the SDK's own batch thread.
+
 ## HTTPS collectors
 
 An `https://` endpoint works with no extra configuration, on **both**
@@ -298,10 +383,9 @@ set the endpoint in `ephpm.toml` anyway, so this costs you nothing.
 
 If the Traces tab stays empty, work down this list: is the startup line
 present and does it say `grpc`; does it name 17011; is *Use fixed OTLP server
-port* actually enabled; and is there an `ERROR ... BatchSpanProcessor.
-ExportError` in the ePHPm log (a refused connection means the IDE is not
-listening on that port). Export failures are logged — see
-[Known rough edges](#known-rough-edges).
+port* actually enabled; and is there a `WARN ... OTLP span export failed` line
+in the ePHPm log (a refused connection means the IDE is not listening on that
+port). See [When export fails](#when-export-fails).
 
 Jaeger in a browser tab remains a perfectly good alternative, and is what to
 fall back to if the plugin misbehaves.
@@ -398,32 +482,12 @@ flushes the batch queue before exiting — verified. `SIGKILL` does not, and the
 last few seconds of spans are gone. If your last request never shows up, check
 how you stopped the server before you check anything else.
 
-**Export failures are logged, and repeat.** A wrong endpoint, an unreachable
-collector or an untrusted certificate produces an error line naming the cause,
-on the `opentelemetry_sdk` target:
-
-```text
-ERROR opentelemetry_sdk: name="BatchSpanProcessor.ExportError"
-      error="Operation failed: ... tcp connect error ... Connection refused"
-```
-
-This was silent before ([#378](https://github.com/ephpm/ephpm/issues/378)).
-Two things to know: the message is emitted **once per failed batch**, so a
-collector that stays down produces a steady trickle of error lines rather than
-one; and a `[server.logging] level` / `RUST_LOG` filter strict enough to
-exclude the `opentelemetry_sdk` target will hide it again. Serving is never
-affected — requests keep returning normally while export fails.
-
-**Spans are `SPAN_KIND_INTERNAL`, including `http.request`.** Backends that
-build service graphs or RED metrics from span kind will not recognise ePHPm as
-a server. A 5xx response also leaves the span status `UNSET`, so failed
-requests are not highlighted as errors — the `http.response.status_code`
-attribute is correct, but nothing else marks them. Tracked in
-[#379](https://github.com/ephpm/ephpm/issues/379).
-
-**No per-tenant attribution.** In multi-site mode every span looks the same
-regardless of which vhost served the request. Tracked in
-[#380](https://github.com/ephpm/ephpm/issues/380).
+**`busy_ns` and `idle_ns` are `0` on `php.execute` and `worker.queue_wait`.**
+Those spans are created and dropped but never *entered*, so
+`tracing-opentelemetry`'s busy/idle accounting sees nothing to attribute. The
+span durations themselves are correct (a span records create→close), and
+`http.request` carries real values. Cosmetic, but do not read the zeros as
+"this took no time".
 
 ## See also
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -155,7 +155,7 @@ Per-vhost kernel network policy via eBPF. **Linux-only, multi-tenant-only, exper
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `request_log` | bool | (mode default) | Per-request timeline: the last 256 completed requests (method, path, status, total/queue-wait/PHP durations in ms, response bytes, timestamp) served as JSON at `GET /_ephpm/requests`, newest first. Unset resolves per mode: **on** under `ephpm dev` / bare `ephpm`, **off** under `ephpm serve`. `queue_wait_ms` is `null` outside worker mode (there is no dispatch queue on the fpm path); in worker mode `php_ms` includes the queue wait, matching `ephpm_php_execution_duration_seconds`. Requests to `/_ephpm/*` and the metrics path are not recorded. When off, `/_ephpm/requests` is not registered and the path falls through to normal routing. Env override: `EPHPM_SERVER__DIAGNOSTICS__REQUEST_LOG`. |
-| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"`. The transport is chosen by `OTEL_EXPORTER_OTLP_PROTOCOL` — **http/protobuf** by default (`/v1/traces` appended when missing, conventional port 4318) or **grpc** (used as-is, no path appended, conventional port 4317). Exports one `http.request` span per request (attrs: method, path, status) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. Requires a binary built with the `otlp` cargo feature. **Official release binaries and the Docker image have it** (`cargo xtask release` builds with it); a plain `cargo build` does not, and there a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs (verified — thread count is identical to a binary without the feature). Both `http://` and `https://` endpoints are supported on both transports — see the notes below. |
+| `otlp_endpoint` | string | (none) | OTLP trace-export endpoint, e.g. `"http://127.0.0.1:4318"`. The transport is chosen by `OTEL_EXPORTER_OTLP_PROTOCOL` — **http/protobuf** by default (`/v1/traces` appended when missing, conventional port 4318) or **grpc** (used as-is, no path appended, conventional port 4317). Exports one `http.request` **server** span per request (attrs: `http.request.method`, `url.path`, `http.response.status_code`, plus `error.type` on a 5xx and `ephpm.site` in multi-site mode) with `worker.queue_wait` and `php.execute` children, and honors an incoming W3C `traceparent` header. A 5xx sets the span status to `ERROR`; a 4xx does not, per OTel HTTP semantic conventions for server spans. Requires a binary built with the `otlp` cargo feature. **Official release binaries and the Docker image have it** (`cargo xtask release` builds with it); a plain `cargo build` does not, and there a set value only logs a startup warning. The standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` env vars take precedence over this knob, and `OTEL_SERVICE_NAME` overrides the default service name `ephpm`. Unset (and no env vars): no exporter is built and no background export thread runs (verified — thread count is identical to a binary without the feature). Both `http://` and `https://` endpoints are supported on both transports — see the notes below. |
 | `otlp_protocol` | string | (none → `http/protobuf`) | OTLP wire protocol for `otlp_endpoint`: `"grpc"` or `"http/protobuf"`. `"http/json"` is rejected at startup. The standard `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `OTEL_EXPORTER_OTLP_PROTOCOL` env vars take precedence over this knob. Setting it without an endpoint logs a startup warning and does nothing. Env override: `EPHPM_SERVER__DIAGNOSTICS__OTLP_PROTOCOL`. |
 
 **OTLP transport selection.** `OTEL_EXPORTER_OTLP_PROTOCOL` (or
@@ -170,10 +170,18 @@ port (4317 vs 4318) ePHPm logs a WARN naming both, since that mix-up otherwise
 presents as silence; it is a warning rather than an error because running
 either transport on any port is legal.
 
-**OTLP export failures are logged**, once per failed batch, on the
-`opentelemetry_sdk` target (`name="BatchSpanProcessor.ExportError"`). Serving
-is never affected by a failing exporter. A `[server.logging] level` or
-`RUST_LOG` filter that excludes that target will hide them.
+**OTLP export failures are logged, and rate-limited.** A wrong endpoint, an
+unreachable collector or an untrusted certificate produces:
+
+- one **WARN** naming the cause on the first failed batch;
+- one **WARN** summary per minute while the failure continues, carrying the
+  consecutive-failure count and how long it has been failing (the batch delay
+  is ~5s, so an unfiltered line per batch would be ~720 an hour);
+- one **INFO** when export recovers.
+
+All three are on ePHPm's own `ephpm_server::otlp` target, so a `[server.logging]
+level` of `info` or lower shows them. Serving is never affected by a failing
+exporter — requests keep returning normally.
 
 **OTLP over HTTPS.** An `https://` endpoint works with no extra configuration,
 on either transport.


### PR DESCRIPTION
Three OTLP defects, fixed together because they all produce the same
operator experience: a trace backend that is technically receiving data but
cannot tell you anything useful with it.

Closes #378
Closes #379
Closes #380

## #378 — export failures were silent

**What was wrong.** `opentelemetry-otlp`'s `internal-logs` feature was
already enabled by #385, but that alone replaces silence with noise: the SDK
emits one `otel_error!` per failed batch and the scheduled delay is ~5s, so
a collector that is down for an hour produces ~720 identical lines. That is
its own way of telling an operator nothing.

**The fix.** `ReportingExporter` (new, in `otlp.rs`) wraps whichever exporter
`init_layer` builds — both transports — and turns the outcome stream into a
rate-limited story on ePHPm's own `ephpm_server::otlp` target:

| Event | Level | Content |
|---|---|---|
| First failure of a run | `WARN` | the full error, plus a note that repeats are summarized |
| Still failing, once per 60s | `WARN` | consecutive-failure count + how long it has been failing + latest error |
| First success after failures | `INFO` | how many failures, over how long |

The decision is a pure state machine (`ExportHealth::observe`) over a
caller-supplied `Instant`, so the 60s window is unit-tested at its boundary
without the test taking 60s.

**One thing worth reviewing carefully:** `ReportingExporter::export` returns
`Ok(())` even when the inner exporter failed. That is deliberate and
verified against the pinned SDK — `opentelemetry_sdk-0.31.0`'s batch
processor does exactly two things with an `Err`: emits
`BatchSpanProcessor.ExportError`, and returns it to a caller that discards
it on the periodic path (`src/trace/span_processor.rs`, the `match` at
`:509`, the `let _ =` at `:345`/`:397`). There is no retry and no backoff
keyed on it. Propagating it buys nothing and costs the one thing the wrapper
exists to provide — the summary window would be defeated by an
un-rate-limited duplicate per batch. The rest of the SDK's `internal-logs`
output is untouched, notably `BatchSpanProcessor.SpanDroppingStarted` (which
is self-limiting anyway). The type docs say to re-check those call sites on
an SDK bump.

**`cargo deny`:** no dependency or feature-flag changes at all in this PR,
so nothing new entered the graph. Re-run anyway — `advisories ok, bans ok,
licenses ok, sources ok`.

## #379 — SPAN_KIND_INTERNAL, and 5xx left the status UNSET

**Semconv version targeted:** [OpenTelemetry HTTP semantic conventions, HTTP
spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) —
**stable since semconv v1.23.0**, and unchanged on these points through the
current 1.3x line.

**What was wrong.** `http.request` exported as `SPAN_KIND_INTERNAL` with
status `UNSET`, including for 5xx. Two consequences: ePHPm never appeared as
a trace's entry point (Tempo's `service-graphs` / `span-metrics` connectors
and Jaeger's dependency graph key off `SPAN_KIND_SERVER`), and a request
where PHP died was indistinguishable from a healthy one.

**The fix.**

- `otel.kind = "server"` on `http.request`. The two children are genuinely
  internal and stay that way.
- On a 5xx: `otel.status_code = "error"` plus `error.type` (the status code
  — semconv makes it Conditionally Required when the span status is Error,
  and the status code is its canonical value for an HTTP failure). No status
  *description* is set; semconv says not to duplicate what the status code
  already conveys.
- A **4xx deliberately does not** set the status. Semconv is explicit that a
  4xx is left unset on a `SpanKind.SERVER` span (and only set to Error on
  CLIENT). This is the part that is easy to get wrong, and getting it wrong
  paints every bot probe red and makes error-rate dashboards useless — so the
  rule lives in a named `server_span_status_is_error` function with the spec
  quoted above it, tested as a table.

### Breaking attribute renames: **none**

Checked the existing attribute names against current semconv, and they were
already correct: `http.request.method`, `url.path`,
`http.response.status_code`. ePHPm has never emitted the deprecated
`http.method` / `http.url` spellings, so no dashboard breaks. A test asserts
the deprecated names do not appear.

`server.address` was **not** added, deliberately. Its only available source
is the raw `Host` header, which is attacker-controlled and arrives before
any tenancy decision — exporting it is precisely what #380 says not to do.
`ephpm.site` (below) carries the legitimate "which host was this for"
signal, resolved rather than echoed.

### Span name: left as `http.request`, on purpose

Semconv prefers `{method} {route}` for server spans. ePHPm has no route
concept, so the only substitute available is the raw path, which explodes
cardinality on any app with IDs in its URLs. Method and path are both
present as attributes. Documented in the guide as a decision rather than an
oversight.

### `busy_ns` / `idle_ns`: documented, not fixed

They read `0` on `php.execute` and `worker.queue_wait` because those spans
are created and dropped but never *entered*. The durations themselves are
correct and `http.request` carries real values. Fixing it means
instrumenting the dispatch futures — the region #443/#444 are rewriting — so
it is now written down under "Known rough edges" instead of silently
misleading.

## #380 — no tenant attribution

**What was wrong.** In multi-site mode the `alpha` span, the `beta` span and
an unknown-host 404 were indistinguishable. Nothing to filter, group or
alert on per site.

**The fix.** `http.request` carries `ephpm.site`.

The tenancy trap the issue flagged is handled exactly as it asks: the span
is created in `handle`, *before* `resolve_site` runs in `handle_inner`, so
the field is declared `field::Empty` and recorded later from
`ResolvedSite.key` — the one canonical derivation, per CLAUDE.md's "one
canonical site key" invariant. The `Host` header is never read for this.

A host that matched **no** vhost has no key and therefore gets **no
attribute**. An absent value is the honest representation of "no tenant",
and it keeps attacker-supplied hostnames off the wire. A test asserts the
unknown-host span contains that hostname under *no* attribute name at all,
not merely that `ephpm.site` is absent.

**Attribute name.** `ephpm.site` — an ePHPm-owned namespace, chosen
deliberately. Semconv has no multi-tenant attribute, and no reserved
namespace (`service.*`, `server.*`, `host.*`) means "which of this process's
vhosts served this request", so squatting on one would be wrong. Documented
in the guide with the resolved-vs-header property spelled out.

Cost when the feature is off: `resolve_site` returns `key: None` for every
request in single-site mode, so this is one `Option` check and nothing else.

## Tests

Eight new tests, all offline and deterministic.

`otlp.rs`:
- `export_failures_are_reported_once_then_summarized_then_recovered` — the
  full contract on a synthetic clock: silent when healthy, one line on the
  first failure, silent for 11 more batches, exactly one summary at the 60s
  boundary, window restarts from the line emitted (not from the run start),
  recovery line, back to steady state.
- `a_transient_failure_reports_the_failure_and_the_recovery` — one failure
  and an immediate recovery produce two lines, never a summary.
- `a_failing_exporter_logs_once_and_does_not_propagate_the_error` — the
  wrapper itself, not just the state machine: a stub always-failing exporter
  through a real `tracing` subscriber, asserting exactly one WARN on the
  right target across three failed batches, and that `export` returns `Ok`.

`router.rs` (new `SpanAttrCollector` test layer capturing creation-time
*and* later-recorded span fields, i.e. what a collector actually receives):
- `only_5xx_makes_a_server_span_an_error` — the semconv rule as a table,
  including the 4xx row.
- `request_span_is_a_server_span_with_semconv_attributes` — SERVER kind,
  current attribute names, deprecated names absent, no status on a 200, no
  `ephpm.site` in single-site mode, no `server.address` / `url.query` /
  `url.full`.
- `four_xx_leaves_the_server_span_status_unset` — a 404 stays unset.
- `five_xx_marks_the_server_span_as_an_error` — a deterministic 504 (request
  deadline against a zero-worker pool) sets `otel.status_code=error` and
  `error.type=504`.
- `span_carries_the_resolved_site_key_and_nothing_for_an_unknown_host` —
  both halves of #380 in one test.

**Not verified here:** there is no end-to-end OTLP assertion — no harness in
this repo receives spans from a live server. What is *not* covered by unit
tests is therefore the last hop: that `tracing-opentelemetry` translates
`otel.kind` / `otel.status_code` into the protobuf `SPAN_KIND_SERVER` and
`STATUS_CODE_ERROR`. That translation is read off
`tracing-opentelemetry-0.32.1/src/layer.rs` (`SPAN_KIND_FIELD` /
`SPAN_STATUS_CODE_FIELD` at `:30-31`, `str_to_span_kind` / `str_to_status`
at `:174-191`, applied in `record_str` at `:526-527`) and the tests assert
the fields carry the exact values that mapping consumes — but confirming it
against a real collector is a lab step, the same way the issues were
reproduced.

## Overlap with open PRs

`handle` / `handle_inner` are also touched by #443 (`ephpm-php` dispatch)
and #444 (router internal-route dispatch). The edits here were kept
deliberately surgical and are confined to three spots: the `debug_span!`
field list, the status-recording block right after `apply_preview_marker`,
and six lines immediately after the `resolve_site` destructure. Nothing in
the dispatch or internal-route regions was touched.

## Checks

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets --features ephpm/otlp -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- Stub mode compiles (the whole workspace check above is stub mode)
- `cargo test -p ephpm-server --features otlp` — 548 pass. Two `otlp::`
  gRPC crypto-provider tests fail *locally* under plain `cargo test` because
  the whole suite shares one process and `CryptoProvider::install_default`
  is a process-wide one-shot; **the same two fail identically on the base
  commit with this branch stashed**, and CI runs `cargo nextest`
  (process-per-test) where they pass.

## Docs

- `site/content/guides/otlp-tracing.md` — span table now carries kind and
  the new attributes; new sections on span status, span-name rationale, and
  `ephpm.site` including the resolved-not-echoed property; new **When export
  fails** section with the three real log lines and how to read `error=`;
  the three "Known rough edges" entries for #378/#379/#380 are gone (fixed),
  leaving the hard-kill and `busy_ns` ones.
- `site/content/reference/config.md` — `otlp_endpoint` description updated
  for SERVER kind and the new attributes; the export-failure paragraph
  rewritten for the rate-limited behaviour and the new target.
- `site/content/architecture/_index.md` — status row updated.
