### PR TITLE
fix: derive three per-tenant values from the canonical site key (#366, #390, #376)

### DIFF
--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -895,8 +895,11 @@ pub struct PhpETagCacheConfig {
     /// # Via RESP CLI (if redis_compat enabled):
     /// redis-cli DEL "etag:*"
     ///
-    /// # Via native PHP function:
-    /// ephpm_kv_del("etag:GET:/api/endpoint");
+    /// # Via native PHP function (single-site — note the empty site component):
+    /// ephpm_kv_del("etag::GET:/api/endpoint");
+    ///
+    /// # Multi-tenant (`sites_dir`): the vhost's canonical site key is in the key.
+    /// ephpm_kv_del("etag:blog:GET:/api/endpoint");
     /// ```
     ///
     /// Default: `300` (5 minutes).
@@ -905,8 +908,18 @@ pub struct PhpETagCacheConfig {
 
     /// Key prefix for `ETag` entries in the KV store.
     ///
-    /// `ETag`s are stored with keys like `{prefix}{method}:{path}?{query}`.
+    /// `ETag`s are stored with keys like `{prefix}{site}:{method}:{path}?{query}`.
     /// This allows organizing `ETag` data separately from other KV entries.
+    ///
+    /// `{site}` is the request's **canonical site key** — the vhost directory
+    /// name [`crate`]'s router resolved, the same identity that selects the
+    /// per-site database and KV keyspace. It is **empty** for a request that
+    /// matched no virtual host, which is every request on a single-site node
+    /// (so the key reads `etag::GET:/index.php` there). The site component
+    /// exists because this cache lives in the process-wide store: without it,
+    /// two vhosts serving the same path shared one entry and one tenant's
+    /// content hash could answer another tenant's `If-None-Match` with a
+    /// `304` (issue #366).
     ///
     /// Default: `"etag:"`.
     #[serde(default = "default_php_etag_cache_prefix")]

--- a/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
+++ b/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
@@ -11,6 +11,15 @@
 //! is short-circuited with a `503` holding page carrying a `Retry-After`
 //! header. If the key is absent the request `CONTINUE`s to PHP untouched.
 //!
+//! `<vhost>` is the **canonical site key** the router resolved, not the `Host`
+//! header (issue #390): one flag per tenant, covering every name that resolves
+//! to it, rather than one flag per spelling. A request that matched no vhost
+//! has no tenant identity and reads the single
+//! [`ephpm_middleware::UNMATCHED_VHOST`] flag. The lookup goes to that vhost's
+//! own KV keyspace on a multi-tenant node (issue #376) — the same keyspace the
+//! site's PHP and its RESP credential use — so a site can flip its own flag
+//! with `ephpm_kv_set('mw:maintenance:<key>', 1)`.
+//!
 //! **Bypass.** Operators need to verify a site while it is "down". Two escape
 //! hatches let a request `CONTINUE` even during maintenance:
 //! - `bypass_ips` — exact IPs or CIDR ranges (client IP is taken *after*

--- a/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
+++ b/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
@@ -15,7 +15,12 @@
 //! header (issue #390): one flag per tenant, covering every name that resolves
 //! to it, rather than one flag per spelling. A request that matched no vhost
 //! has no tenant identity and reads the single
-//! [`ephpm_middleware::UNMATCHED_VHOST`] flag. The lookup goes to that vhost's
+//! [`ephpm_middleware::UNMATCHED_VHOST`] flag — which is **every** request on a
+//! single-site node, where no vhost is ever matched, so the key there is always
+//! `mw:maintenance:_UNMATCHED`. Upgrading a single-site deployment from ABI
+//! minor ≤ 2 renames its flag from `mw:maintenance:<Host>`; an active
+//! maintenance flag must be re-set under the new name or the site comes back
+//! up. The lookup goes to that vhost's
 //! own KV keyspace on a multi-tenant node (issue #376) — the same keyspace the
 //! site's PHP and its RESP credential use — so a site can flip its own flag
 //! with `ephpm_kv_set('mw:maintenance:<key>', 1)`.

--- a/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
+++ b/crates/ephpm-middleware-builtins/src/maintenance_mode.rs
@@ -226,7 +226,11 @@ impl Middleware for MaintenanceMode {
             return Response::cont();
         }
 
-        let key = self.key_for(req.vhost_id());
+        // The canonical site key, not the raw `Host` (issue #390): one flag per
+        // tenant, no matter which of that vhost's names the client used. A host
+        // that matched no vhost has no tenant identity, so it shares the single
+        // `UNMATCHED_VHOST` flag rather than minting one per header value.
+        let key = self.key_for(req.vhost_id().unwrap_or(ephpm_middleware::UNMATCHED_VHOST));
         let host = req.host();
         // `kv_get` returns None for BOTH "absent" and "KV unavailable" — both
         // fall through to CONTINUE. That is the fail-OPEN choice (see the

--- a/crates/ephpm-middleware-builtins/src/ratelimit.rs
+++ b/crates/ephpm-middleware-builtins/src/ratelimit.rs
@@ -89,7 +89,13 @@ impl Middleware for RateLimit {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
         let window = now / WINDOW_SECS;
         let client = self.client_key(req);
-        let key = format!("mw:rl:{}:{}:{}", req.vhost_id(), client, window);
+        // The canonical site key, not the raw `Host` (issue #390). A
+        // `Host`-derived component was a bypass: every spelling of one tenant
+        // got its own budget, and an unmatched host got a fresh budget per
+        // header value. `UNMATCHED_VHOST` is unspellable as a site key, so
+        // every unmatched request now shares one bucket.
+        let vhost = req.vhost_id().unwrap_or(ephpm_middleware::UNMATCHED_VHOST);
+        let key = format!("mw:rl:{vhost}:{client}:{window}");
 
         let host = req.host();
         // Atomically bump the counter, applying the window TTL only when this

--- a/crates/ephpm-middleware-builtins/src/ratelimit.rs
+++ b/crates/ephpm-middleware-builtins/src/ratelimit.rs
@@ -11,6 +11,19 @@
 //! is on. Over the limit the client gets `429` with a `Retry-After` for the
 //! seconds left in the window.
 //!
+//! **The budget is per tenant, and a client cannot mint a new one.**
+//! `{vhost}` is the canonical site key the router resolved, not the `Host`
+//! header — before that (issue #390) every spelling of one vhost got its own
+//! counter and, worse, any unmatched `Host` value got a fresh budget on
+//! demand, which is a bypass rather than a cosmetic key change. A request that
+//! matched no vhost now shares the single
+//! [`ephpm_middleware::UNMATCHED_VHOST`] bucket, a sentinel no vhost directory
+//! can spell. On a multi-tenant node the counter additionally lands in that
+//! vhost's own KV store (issue #376), so two tenants cannot spend each other's
+//! budget even given an identical key. For a deliberately node-wide edge
+//! limiter — one budget for the whole node — a module would use
+//! `kv_incr_ttl_global` instead; this module is per-tenant on purpose.
+//!
 //! **Fail-open by design:** when the KV store is unavailable (`kv_incr`
 //! errors), the request is allowed through with a warning log. For a rate
 //! limiter, availability beats strictness — dropping every request because

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -61,8 +61,11 @@ use std::os::raw::{c_char, c_int};
 ///     store (issue #376), with the global store still reachable through the
 ///     appended `kv_*_global` slots ([`ABI_MINOR_GLOBAL_KV`]).
 ///
-///   Both redefinitions are no-ops on a single-site node, where there is one
-///   tenant and one store. See [`ABI_MINOR_GLOBAL_KV`] for the migration note.
+///   The `kv_*` redefinition is a no-op on a single-site node (one tenant, one
+///   store). **`request_vhost_id` is not** — a single-site node matches no
+///   vhost, so it returns NULL on *every* request there, where it used to
+///   return the `Host`. C modules must null-check it. See
+///   [`ABI_MINOR_GLOBAL_KV`] for the migration note.
 ///
 /// The major byte is unchanged across every minor, so **every** module built
 /// against major 1 still loads: growth is additive.
@@ -111,21 +114,41 @@ pub const ABI_MINOR_REQUEST_ACCESSORS: u32 = 2;
 ///
 /// # What changed for an existing module
 ///
-/// Nothing at all on a single-site node: there is one tenant and one store, so
-/// both redefinitions are identity.
+/// ## [`EphpmHostV1::request_vhost_id`] — changes on **every** node (#390)
 ///
-/// On a multi-tenant node (`[server] sites_dir`):
+/// It returns the router's canonical site key rather than the raw `Host`, and
+/// **NULL** rather than a client-supplied string when no vhost matched.
 ///
-/// * [`EphpmHostV1::request_vhost_id`] returns the router's canonical site key
-///   rather than the raw `Host`, and NULL rather than a client-supplied string
-///   for a host that matched no vhost (issue #390). A key built from it changes
-///   name once, at upgrade.
-/// * The `kv_*` slots resolve **this request's** per-vhost keyspace rather
-///   than the process-global store (issue #376). A module that was relying on
-///   node-wide `kv_*` state — an edge-wide rate limiter, an operator-owned
-///   config key — must move those calls to the matching `kv_*_global` slot.
-///   Everything per-tenant should stay where it is and simply becomes
-///   isolated, and now shares a keyspace with the tenant's `ephpm_kv_*`.
+/// The NULL is not a rare edge case. The router's `resolve_site`
+/// short-circuits to its no-site branch whenever neither `sites_dir` nor any
+/// `[[site]]` is configured, so on a **single-site node — the most common
+/// deployment shape — this slot returns NULL on every single request**, where
+/// in minor ≤ 2 it returned the `Host` and was never NULL.
+///
+/// **A C module MUST null-check it.** `strcmp(host->request_vhost_id(req), …)`
+/// was safe against every prior minor and segfaults now. Rust modules get a
+/// compile error instead: the safe wrapper returns `Option<&str>`.
+///
+/// The behaviour is deliberate — no vhost matched means no tenant, and
+/// inventing one from a client-supplied header is exactly the bug #390 fixed.
+/// [`EphpmHostV1::request_host`] still gives the host as sent, for the cases
+/// that genuinely want it.
+///
+/// Note this also renames keys built from the vhost id, once, at upgrade — on
+/// a single-site node to whatever the module substitutes for "no tenant"
+/// (the stock modules use `ephpm_middleware::UNMATCHED_VHOST`).
+///
+/// ## The `kv_*` slots — change only on a multi-tenant node (#376)
+///
+/// They resolve **this request's** per-vhost keyspace rather than the
+/// process-global store. A module that was relying on node-wide `kv_*` state —
+/// an edge-wide rate limiter, an operator-owned config key — must move those
+/// calls to the matching `kv_*_global` slot. Everything per-tenant should stay
+/// where it is and simply becomes isolated, and now shares a keyspace with the
+/// tenant's `ephpm_kv_*`.
+///
+/// This half genuinely *is* a no-op on a single-site node: there is one store,
+/// and both the scoped and global slots reach it.
 pub const ABI_MINOR_GLOBAL_KV: u32 = 3;
 
 /// Middleware verdicts for one request.
@@ -296,6 +319,13 @@ pub struct EphpmHostV1 {
     /// no vhost is an arbitrary client-supplied string; returning NULL is what
     /// lets a gate tell "tenant `foo`" from "someone sent `Host: foo`" and
     /// fail closed instead of keying policy on attacker input.
+    ///
+    /// **NULL-check this, always.** It is not a rare edge case: a **single-site
+    /// node matches no vhost at all**, so this returns NULL on *every* request
+    /// there — and that is the most common deployment shape. In minor ≤ 2 the
+    /// slot was never NULL, so a C module doing
+    /// `strcmp(host->request_vhost_id(req), …)` was safe then and crashes now.
+    /// See [`ABI_MINOR_GLOBAL_KV`] for the full migration note.
     ///
     /// Changed in **minor 3** (issue #390). Before that this returned the raw
     /// `Host` header with only the port stripped — un-normalized, never NULL.

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -60,6 +60,7 @@ use std::os::raw::{c_char, c_int};
 ///     on a multi-tenant node instead of always hitting the process-global
 ///     store (issue #376), with the global store still reachable through the
 ///     appended `kv_*_global` slots ([`ABI_MINOR_GLOBAL_KV`]).
+///
 ///   Both redefinitions are no-ops on a single-site node, where there is one
 ///   tenant and one store. See [`ABI_MINOR_GLOBAL_KV`] for the migration note.
 ///
@@ -101,6 +102,31 @@ pub const ABI_MINOR_RESPONSE_PHASE: u32 = 1;
 /// this — its slot has existed since minor 0; only its buffered semantics are
 /// new — so a minor-0 module that already called it stays correct.)
 pub const ABI_MINOR_REQUEST_ACCESSORS: u32 = 2;
+
+/// The minor version that introduced the appended process-global KV
+/// accessors — [`EphpmHostV1::kv_get_global`] and its four siblings — and, in
+/// the same pass, **redefined** two pre-existing surfaces for multi-tenant
+/// correctness. A module needs `host.abi_version & 0x00FF_FFFF >=` this before
+/// calling any `kv_*_global` slot.
+///
+/// # What changed for an existing module
+///
+/// Nothing at all on a single-site node: there is one tenant and one store, so
+/// both redefinitions are identity.
+///
+/// On a multi-tenant node (`[server] sites_dir`):
+///
+/// * [`EphpmHostV1::request_vhost_id`] returns the router's canonical site key
+///   rather than the raw `Host`, and NULL rather than a client-supplied string
+///   for a host that matched no vhost (issue #390). A key built from it changes
+///   name once, at upgrade.
+/// * The `kv_*` slots resolve **this request's** per-vhost keyspace rather
+///   than the process-global store (issue #376). A module that was relying on
+///   node-wide `kv_*` state — an edge-wide rate limiter, an operator-owned
+///   config key — must move those calls to the matching `kv_*_global` slot.
+///   Everything per-tenant should stay where it is and simply becomes
+///   isolated, and now shares a keyspace with the tenant's `ephpm_kv_*`.
+pub const ABI_MINOR_GLOBAL_KV: u32 = 3;
 
 /// Middleware verdicts for one request.
 pub const ACTION_CONTINUE: c_int = 0;
@@ -215,6 +241,13 @@ pub struct EphpmResponseEdit {
 /// KV operations hit the embedded, gossip-replicated store — the same data
 /// PHP sees through `ephpm_kv_*` — which is what makes a cluster-wide rate
 /// limiter a single `kv_incr_ttl` call.
+///
+/// Since minor 3 the `kv_*` slots resolve **the keyspace of the vhost serving
+/// the current request**, so "the same data PHP sees" holds per tenant on a
+/// multi-tenant node rather than only on a single-site one. The process-global
+/// store — where operator-owned state lives, out of reach of any tenant's
+/// PHP — is reachable through the appended `kv_*_global` slots. See
+/// [`ABI_MINOR_GLOBAL_KV`].
 #[repr(C)]
 pub struct EphpmHostV1 {
     /// Host ABI version (== [`ABI_V1`] for this table).
@@ -367,10 +400,62 @@ pub struct EphpmHostV1 {
     pub request_is_secure: unsafe extern "C" fn(*const EphpmRequest) -> c_int,
     /// Normalized request `Host` — port stripped, one trailing FQDN-root dot
     /// stripped, lowercased (the same normalization the router uses to key a
-    /// vhost). Distinct from [`request_vhost_id`](Self::request_vhost_id),
-    /// which is the un-normalized server name. Empty (never null) when the
+    /// vhost). **Not a tenant identity**: it is what the client sent, not what
+    /// the router matched, and it is populated even for a host that names no
+    /// vhost. Use [`request_vhost_id`](Self::request_vhost_id) for tenancy
+    /// decisions and this only when you genuinely want the request host (a
+    /// canonical-host redirect, a log line). Empty (never null) when the
     /// request carried no usable `Host`.
     pub request_host: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
+
+    // ── Process-global KV (minor 3) ───────────────────────────────────────
+    //
+    // Appended after `request_host`. A module that reads these must first
+    // confirm `abi_version & 0x00FF_FFFF >= ABI_MINOR_GLOBAL_KV`.
+    //
+    // The same five operations as the `kv_*` slots above, against the
+    // **process-wide** store instead of this request's per-site keyspace. Use
+    // them only for state that is genuinely node-scoped: operator-owned
+    // configuration, which must live where no tenant's PHP can rewrite it, or
+    // a deliberately node-wide edge counter. Anything belonging to the tenant
+    // being served belongs in the request-scoped `kv_*` slots — which is where
+    // PHP's `ephpm_kv_*` puts it, so the two lanes meet there by default.
+    //
+    // On a single-site node these reach the same store as `kv_*`.
+    /// Global-store `kv_get`. Same return contract; free with `kv_free`.
+    pub kv_get_global: unsafe extern "C" fn(
+        key: *const u8,
+        key_len: usize,
+        out: *mut *mut u8,
+        out_len: *mut usize,
+    ) -> c_int,
+    /// Global-store `kv_set`.
+    pub kv_set_global: unsafe extern "C" fn(
+        key: *const u8,
+        key_len: usize,
+        value: *const u8,
+        value_len: usize,
+        ttl_secs: i64,
+    ) -> c_int,
+    /// Global-store `kv_set_nx`.
+    pub kv_set_nx_global: unsafe extern "C" fn(
+        key: *const u8,
+        key_len: usize,
+        value: *const u8,
+        value_len: usize,
+        ttl_secs: i64,
+    ) -> c_int,
+    /// Global-store `kv_incr`.
+    pub kv_incr_global:
+        unsafe extern "C" fn(key: *const u8, key_len: usize, by: i64, out: *mut i64) -> c_int,
+    /// Global-store `kv_incr_ttl`.
+    pub kv_incr_ttl_global: unsafe extern "C" fn(
+        key: *const u8,
+        key_len: usize,
+        by: i64,
+        ttl_secs: i64,
+        out: *mut i64,
+    ) -> c_int,
 }
 
 /// Symbol names the loader looks up.

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -44,13 +44,24 @@ use std::os::raw::{c_char, c_int};
 /// Current ABI version (`0xMMmmmmmm`: major byte gates compatibility, the
 /// lower three bytes are an additive minor level).
 ///
-/// `0x0100_0002` = major **1**, minor **2**.
+/// `0x0100_0003` = major **1**, minor **3**.
 ///
 /// - Minor 1 added the optional response phase (the [`SYM_INVOKE_RESPONSE`]
 ///   symbol and the three appended `response_*` accessors on [`EphpmHostV1`]).
 /// - Minor 2 added three appended request accessors — [`request_scheme`],
 ///   [`request_is_secure`], and [`request_host`] — and gave the pre-existing
 ///   [`request_body`] slot real (bounded, buffered) semantics.
+/// - Minor 3 is the multi-tenancy correctness pass. It **redefines** two
+///   pre-existing surfaces rather than only appending to them:
+///   * [`request_vhost_id`] now returns the router's **canonical site key**
+///     (NULL when the host matched no vhost) instead of the raw `Host`
+///     header (issue #390);
+///   * the `kv_*` callbacks now resolve **this request's per-site keyspace**
+///     on a multi-tenant node instead of always hitting the process-global
+///     store (issue #376), with the global store still reachable through the
+///     appended `kv_*_global` slots ([`ABI_MINOR_GLOBAL_KV`]).
+///   Both redefinitions are no-ops on a single-site node, where there is one
+///   tenant and one store. See [`ABI_MINOR_GLOBAL_KV`] for the migration note.
 ///
 /// The major byte is unchanged across every minor, so **every** module built
 /// against major 1 still loads: growth is additive.
@@ -59,7 +70,8 @@ use std::os::raw::{c_char, c_int};
 /// [`request_is_secure`]: EphpmHostV1::request_is_secure
 /// [`request_host`]: EphpmHostV1::request_host
 /// [`request_body`]: EphpmHostV1::request_body
-pub const ABI_V1: u32 = 0x0100_0002;
+/// [`request_vhost_id`]: EphpmHostV1::request_vhost_id
+pub const ABI_V1: u32 = 0x0100_0003;
 
 /// Major version — the compatibility gate. A module refuses to init when the
 /// host's major (`host.abi_version >> 24`) is newer than its own.
@@ -72,7 +84,7 @@ pub const ABI_MAJOR: u32 = 1;
 /// those trailing fields, and reading past a shorter table is undefined
 /// behaviour. See [`ABI_MINOR_RESPONSE_PHASE`] and
 /// [`ABI_MINOR_REQUEST_ACCESSORS`].
-pub const ABI_MINOR: u32 = 2;
+pub const ABI_MINOR: u32 = 3;
 
 /// The minor version that introduced the response phase — the three
 /// `response_*` accessors on [`EphpmHostV1`] and the [`SYM_INVOKE_RESPONSE`]
@@ -237,7 +249,28 @@ pub struct EphpmHostV1 {
     /// This slot has existed since minor 0 (it returned 0 then); only the
     /// buffered semantics are new in minor 2, so it needs no minor gate.
     pub request_body: unsafe extern "C" fn(*const EphpmRequest, out_ptr: *mut *const u8) -> usize,
-    /// Identity of the vhost/site serving this request (server name).
+    /// The **canonical site key** of the vhost serving this request, or NULL
+    /// when the request matched no known virtual host.
+    ///
+    /// This is the value the router's one host→tenant derivation produced —
+    /// the same identity that selects this request's per-site database file,
+    /// KV keyspace and OPcache vhost. It is suffix-stripped, port-stripped,
+    /// lowercased and allowlist-validated, so `Host: Site.Example`,
+    /// `site.example:8080` and `site.example.` all yield one key.
+    ///
+    /// **NULL means "no tenant", and a module must not invent one.** ePHPm
+    /// does not reject unrecognised hosts by default, so any host that matched
+    /// no vhost is an arbitrary client-supplied string; returning NULL is what
+    /// lets a gate tell "tenant `foo`" from "someone sent `Host: foo`" and
+    /// fail closed instead of keying policy on attacker input.
+    ///
+    /// Changed in **minor 3** (issue #390). Before that this returned the raw
+    /// `Host` header with only the port stripped — un-normalized, never NULL.
+    /// Three separate modules had each re-normalized it locally, one of them
+    /// with an auth bypass (a `Host` differing only in letter case missed its
+    /// credential entry). For the un-normalized/raw view use
+    /// [`request_host`](Self::request_host), which is the normalized request
+    /// host and is explicitly *not* a tenant identity.
     pub request_vhost_id: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
 
     // ── KV store ─────────────────────────────────────────────────────────

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -4,6 +4,7 @@
 
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
 use std::os::raw::{c_char, c_int};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
@@ -414,8 +415,19 @@ thread_local! {
 /// tokio worker from carrying one tenant's scope into the next request it
 /// picks up — the same stale-per-thread-state hazard the PHP lane's eBPF tag
 /// guard exists for.
+/// It is deliberately **`!Send`**. The guard names thread-local state, so
+/// holding one across an `.await` would let a task resume on a different tokio
+/// worker with the scope installed on the old one — a silent cross-tenant
+/// leak, and exactly the class of bug this type exists to prevent. The
+/// `PhantomData<*const ()>` makes rustc enforce that instead of a comment: a
+/// future holding this across an await stops being `Send` and fails to compile
+/// where hyper requires `Send`. It costs nothing at the current call sites,
+/// since rustc only stores locals that are *live across* an await in the
+/// generator, and all three scopes close before their next await.
 pub struct SiteKvScope {
     previous: Option<Arc<ephpm_kv::store::Store>>,
+    /// `!Send` marker — see the type docs. Carries no data.
+    _not_send: PhantomData<*const ()>,
 }
 
 impl Drop for SiteKvScope {
@@ -437,8 +449,12 @@ impl Drop for SiteKvScope {
 /// suspended task can resume on a different worker.
 #[must_use]
 pub fn enter_site_kv(store: Option<Arc<ephpm_kv::store::Store>>) -> SiteKvScope {
-    let previous = KV_SITE_STORE.with(|s| s.replace(store));
-    SiteKvScope { previous }
+    // `try_with`, matching the read side and `Drop`: during thread teardown the
+    // slot may be gone. Unreachable today (the chain never runs at teardown),
+    // but a panic here would take down a request thread for nothing, and an
+    // uninstalled scope simply leaves the callbacks on the global store.
+    let previous = KV_SITE_STORE.try_with(|s| s.replace(store)).unwrap_or(None);
+    SiteKvScope { previous, _not_send: PhantomData }
 }
 
 /// The store for the request being evaluated: this thread's site store when a

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -16,7 +16,12 @@ pub struct RequestCtx {
     path: CString,
     query: CString,
     remote_ip: CString,
-    vhost: CString,
+    /// The request's **canonical site key** — the value `Router::resolve_site`
+    /// matched, which also selects the per-site database, the KV keyspace and
+    /// the OPcache vhost. Empty when the request matched no known virtual host;
+    /// the `request_vhost_id` accessor turns that into a NULL return so a
+    /// module can tell "tenant `foo`" from "someone sent `Host: foo`".
+    site_key: CString,
     /// Normalized request host (port/trailing-dot stripped, lowercased) — the
     /// `request_host` accessor. Empty when the request had no usable `Host`.
     host: CString,
@@ -41,6 +46,14 @@ impl RequestCtx {
     /// Build the context. Interior NULs are stripped (invalid in HTTP
     /// metadata anyway) rather than failing the request.
     ///
+    /// `site_key` is the request's **canonical site key** — pass exactly what
+    /// `Router::resolve_site` returned, and the **empty string** when it
+    /// returned `None` (the host matched no known virtual host). Never pass a
+    /// raw `Host` header here: that was issue #390, and modules read this value
+    /// as a tenant identity in authorization decisions. The normalized request
+    /// host stays available separately through
+    /// [`with_host`](Self::with_host) / the `request_host` accessor.
+    ///
     /// The connection-derived extras — scheme/secure, normalized host, and the
     /// buffered body — default to "insecure / empty / no body" and are set by
     /// the router via [`with_scheme`](Self::with_scheme),
@@ -51,7 +64,7 @@ impl RequestCtx {
         path: &str,
         query: &str,
         remote_ip: &str,
-        vhost: &str,
+        site_key: &str,
         headers: &[(String, String)],
     ) -> Self {
         Self {
@@ -59,7 +72,7 @@ impl RequestCtx {
             path: cstr(path),
             query: cstr(query),
             remote_ip: cstr(remote_ip),
-            vhost: cstr(vhost),
+            site_key: cstr(site_key),
             host: CString::default(),
             is_secure: false,
             body: Vec::new(),
@@ -125,8 +138,14 @@ unsafe extern "C" fn request_remote_ip(req: *const EphpmRequest) -> *const c_cha
     unsafe { ctx(req) }.map_or(std::ptr::null(), |c| c.remote_ip.as_ptr())
 }
 unsafe extern "C" fn request_vhost_id(req: *const EphpmRequest) -> *const c_char {
+    // NULL — not `""` — for a request that matched no known vhost. An empty
+    // C string is still a tenant-shaped answer a module would happily use as a
+    // lookup key; NULL is the one value that cannot be mistaken for a tenant,
+    // so a module can fail closed on it (issue #390).
     // SAFETY: ABI contract.
-    unsafe { ctx(req) }.map_or(std::ptr::null(), |c| c.vhost.as_ptr())
+    unsafe { ctx(req) }.map_or(std::ptr::null(), |c| {
+        if c.site_key.is_empty() { std::ptr::null() } else { c.site_key.as_ptr() }
+    })
 }
 unsafe extern "C" fn request_header(
     req: *const EphpmRequest,
@@ -563,6 +582,40 @@ mod tests {
         assert!(!req.is_secure());
         assert_eq!(req.http_host(), "");
         assert!(req.body().is_empty());
+    }
+
+    /// Issue #390: the vhost accessor is a *tenant identity*, so "no tenant"
+    /// must be distinguishable from a tenant. An empty site key crosses the
+    /// ABI as NULL and surfaces as `None`, never as `Some("")` — otherwise a
+    /// module keys its policy on a string an unauthenticated client chose.
+    #[test]
+    fn unmatched_host_has_no_vhost_identity() {
+        let matched = RequestCtx::new("GET", "/x", "", "203.0.113.4", "blog", &[]);
+        // SAFETY: ctx and the real host table outlive the view.
+        let req = unsafe { Request::from_raw(matched.as_abi(), host_table()) };
+        assert_eq!(req.vhost_id(), Some("blog"));
+
+        let unmatched = RequestCtx::new("GET", "/x", "", "203.0.113.4", "", &[]);
+        // SAFETY: as above.
+        let req = unsafe { Request::from_raw(unmatched.as_abi(), host_table()) };
+        assert_eq!(req.vhost_id(), None, "no matched vhost must read as no tenant");
+        // SAFETY: the raw accessor is the C-ABI surface modules see; NULL is
+        // the contract, and an empty non-null string would defeat the point.
+        assert!(unsafe { (host_table().request_vhost_id)(unmatched.as_abi()) }.is_null());
+    }
+
+    /// The tenant identity and the request host are deliberately two different
+    /// values: one is what the router resolved, the other is what the client
+    /// sent. A module must be able to reach both without confusing them.
+    #[test]
+    fn vhost_id_and_http_host_stay_distinct() {
+        // A suffixed request: `Host: blog.localhost` resolves to site `blog`.
+        let ctx = RequestCtx::new("GET", "/x", "", "203.0.113.4", "blog", &[])
+            .with_host("blog.localhost");
+        // SAFETY: ctx and the real host table outlive the view.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert_eq!(req.vhost_id(), Some("blog"));
+        assert_eq!(req.http_host(), "blog.localhost");
     }
 
     #[test]

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -2,6 +2,7 @@
 //! process-wide [`abi::EphpmHostV1`] callback table. Used by `ephpm-server`
 //! (feature `host`); middleware authors never touch this module.
 
+use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
 use std::sync::{Arc, OnceLock};
@@ -367,11 +368,92 @@ unsafe extern "C" fn response_body(p: *const EphpmResponseCtx, out_ptr: *mut *co
 }
 
 // ── KV callbacks ─────────────────────────────────────────────────────────
+//
+// Two scopes, deliberately (issue #376):
+//
+// * `kv_*` resolves **this request's** keyspace — the per-vhost store on a
+//   multi-tenant node, which is the same physically-separate `DashMap` PHP's
+//   `ephpm_kv_*` reaches for that vhost. So a rate limiter is per-tenant by
+//   default and a module can read a key PHP wrote, without either side having
+//   to hand-prefix anything.
+// * `kv_*_global` resolves the process-wide store, which is where
+//   *operator*-owned state belongs precisely because no tenant's PHP can
+//   reach it (see #384: a per-site credential map must not be writable by the
+//   site it authorizes).
+//
+// On a single-site node there is one store and the two are the same thing.
 
+/// The process-wide store. Also the fallback for a request that matched no
+/// vhost: such a request has no tenant, so there is no per-site keyspace it
+/// could legitimately be given. (PHP's `kv` identity instead falls back to the
+/// normalized `Host`, which suits a catch-all document root serving many
+/// names. The middleware chain runs on *every* request — static files
+/// included — so minting a store per `Host` value here would be a cheap way to
+/// grow the site map without bound.)
 static KV_STORE: OnceLock<Arc<ephpm_kv::store::Store>> = OnceLock::new();
 
-fn kv() -> Option<&'static Arc<ephpm_kv::store::Store>> {
-    KV_STORE.get()
+thread_local! {
+    /// The store the `kv_*` callbacks resolve for the request currently being
+    /// evaluated on this thread. `None` = fall back to [`KV_STORE`].
+    ///
+    /// Thread-local rather than an argument because the KV slots on
+    /// [`EphpmHostV1`] take no `EphpmRequest*` — changing that would break the
+    /// ABI, and modules built against major 1 must keep loading. The chain is
+    /// invoked synchronously and never across an `.await`, so "the request on
+    /// this thread" is well defined for the duration of a scope. Mirrors
+    /// `ephpm_php::kv_bridge`'s per-thread site store, which is what gives the
+    /// two lanes the same keyspace.
+    static KV_SITE_STORE: RefCell<Option<Arc<ephpm_kv::store::Store>>> =
+        const { RefCell::new(None) };
+}
+
+/// RAII scope binding the `kv_*` callbacks to one request's site store.
+///
+/// Restoring the **previous** value on drop rather than clearing is what makes
+/// the guard safe to nest, and clearing on drop at all is what stops a pooled
+/// tokio worker from carrying one tenant's scope into the next request it
+/// picks up — the same stale-per-thread-state hazard the PHP lane's eBPF tag
+/// guard exists for.
+pub struct SiteKvScope {
+    previous: Option<Arc<ephpm_kv::store::Store>>,
+}
+
+impl Drop for SiteKvScope {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        // `try_with`: during thread teardown the slot may already be gone, and
+        // failing to restore it then is harmless (nothing will read it again).
+        let _ = KV_SITE_STORE.try_with(|s| {
+            *s.borrow_mut() = previous;
+        });
+    }
+}
+
+/// Bind the `kv_*` callbacks to `store` for as long as the returned guard
+/// lives. Pass `None` to leave them on the process-global store.
+///
+/// The host calls this immediately around a synchronous chain invocation. It
+/// must not be held across an `.await`: the guard is thread-local state and a
+/// suspended task can resume on a different worker.
+#[must_use]
+pub fn enter_site_kv(store: Option<Arc<ephpm_kv::store::Store>>) -> SiteKvScope {
+    let previous = KV_SITE_STORE.with(|s| s.replace(store));
+    SiteKvScope { previous }
+}
+
+/// The store for the request being evaluated: this thread's site store when a
+/// scope is active, the process-global store otherwise.
+fn kv() -> Option<Arc<ephpm_kv::store::Store>> {
+    KV_SITE_STORE
+        .try_with(|s| s.borrow().clone())
+        .ok()
+        .flatten()
+        .or_else(|| KV_STORE.get().cloned())
+}
+
+/// The process-global store, whatever request is in flight.
+fn kv_global_store() -> Option<Arc<ephpm_kv::store::Store>> {
+    KV_STORE.get().cloned()
 }
 
 unsafe fn key_str<'a>(key: *const u8, key_len: usize) -> Option<&'a str> {
@@ -382,7 +464,14 @@ unsafe fn key_str<'a>(key: *const u8, key_len: usize) -> Option<&'a str> {
     std::str::from_utf8(unsafe { std::slice::from_raw_parts(key, key_len) }).ok()
 }
 
-unsafe extern "C" fn kv_get(
+/// Shared body of `kv_get` / `kv_get_global`; `store` picks the scope.
+///
+/// # Safety
+///
+/// ABI contract: `(key, key_len)` is a valid slice for the call, and
+/// `out`/`out_len` are writable out-params.
+unsafe fn kv_get_in(
+    store: Option<Arc<ephpm_kv::store::Store>>,
     key: *const u8,
     key_len: usize,
     out: *mut *mut u8,
@@ -392,7 +481,7 @@ unsafe extern "C" fn kv_get(
         return -1;
     }
     // SAFETY: ABI contract.
-    let (Some(store), Some(k)) = (kv(), unsafe { key_str(key, key_len) }) else {
+    let (Some(store), Some(k)) = (store, unsafe { key_str(key, key_len) }) else {
         return -1;
     };
     match store.get(k) {
@@ -417,6 +506,26 @@ unsafe extern "C" fn kv_get(
     }
 }
 
+unsafe extern "C" fn kv_get(
+    key: *const u8,
+    key_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_get_in(kv(), key, key_len, out, out_len) }
+}
+
+unsafe extern "C" fn kv_get_global(
+    key: *const u8,
+    key_len: usize,
+    out: *mut *mut u8,
+    out_len: *mut usize,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_get_in(kv_global_store(), key, key_len, out, out_len) }
+}
+
 unsafe extern "C" fn kv_free(ptr: *mut u8, len: usize) {
     if ptr.is_null() {
         return;
@@ -438,7 +547,14 @@ fn ttl_of(ttl_secs: i64) -> Option<Duration> {
     (ttl_secs > 0).then(|| Duration::from_secs(ttl_secs.unsigned_abs()))
 }
 
-unsafe extern "C" fn kv_set(
+/// Shared body of `kv_set` / `kv_set_global`.
+///
+/// # Safety
+///
+/// ABI contract: `(key, key_len)` and `(value, value_len)` are valid slices
+/// for the duration of the call.
+unsafe fn kv_set_in(
+    store: Option<Arc<ephpm_kv::store::Store>>,
     key: *const u8,
     key_len: usize,
     value: *const u8,
@@ -446,12 +562,56 @@ unsafe extern "C" fn kv_set(
     ttl_secs: i64,
 ) -> c_int {
     // SAFETY: ABI contract.
-    let (Some(store), Some(k)) = (kv(), unsafe { key_str(key, key_len) }) else {
+    let (Some(store), Some(k)) = (store, unsafe { key_str(key, key_len) }) else {
         return -1;
     };
     // SAFETY: ABI contract.
     let v = unsafe { kv_value(value, value_len) };
     if store.set(k.to_string(), v.to_vec(), ttl_of(ttl_secs)) { 0 } else { -2 }
+}
+
+unsafe extern "C" fn kv_set(
+    key: *const u8,
+    key_len: usize,
+    value: *const u8,
+    value_len: usize,
+    ttl_secs: i64,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_set_in(kv(), key, key_len, value, value_len, ttl_secs) }
+}
+
+unsafe extern "C" fn kv_set_global(
+    key: *const u8,
+    key_len: usize,
+    value: *const u8,
+    value_len: usize,
+    ttl_secs: i64,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_set_in(kv_global_store(), key, key_len, value, value_len, ttl_secs) }
+}
+
+/// Shared body of `kv_set_nx` / `kv_set_nx_global`.
+///
+/// # Safety
+///
+/// As [`kv_set_in`].
+unsafe fn kv_set_nx_in(
+    store: Option<Arc<ephpm_kv::store::Store>>,
+    key: *const u8,
+    key_len: usize,
+    value: *const u8,
+    value_len: usize,
+    ttl_secs: i64,
+) -> c_int {
+    // SAFETY: ABI contract.
+    let (Some(store), Some(k)) = (store, unsafe { key_str(key, key_len) }) else {
+        return -1;
+    };
+    // SAFETY: ABI contract.
+    let v = unsafe { kv_value(value, value_len) };
+    i32::from(!store.set_nx(k.to_string(), v.to_vec(), ttl_of(ttl_secs)))
 }
 
 unsafe extern "C" fn kv_set_nx(
@@ -461,24 +621,86 @@ unsafe extern "C" fn kv_set_nx(
     value_len: usize,
     ttl_secs: i64,
 ) -> c_int {
-    // SAFETY: ABI contract.
-    let (Some(store), Some(k)) = (kv(), unsafe { key_str(key, key_len) }) else {
-        return -1;
-    };
-    // SAFETY: ABI contract.
-    let v = unsafe { kv_value(value, value_len) };
-    i32::from(!store.set_nx(k.to_string(), v.to_vec(), ttl_of(ttl_secs)))
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_set_nx_in(kv(), key, key_len, value, value_len, ttl_secs) }
 }
 
-unsafe extern "C" fn kv_incr(key: *const u8, key_len: usize, by: i64, out: *mut i64) -> c_int {
+unsafe extern "C" fn kv_set_nx_global(
+    key: *const u8,
+    key_len: usize,
+    value: *const u8,
+    value_len: usize,
+    ttl_secs: i64,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_set_nx_in(kv_global_store(), key, key_len, value, value_len, ttl_secs) }
+}
+
+/// Shared body of `kv_incr` / `kv_incr_global`.
+///
+/// # Safety
+///
+/// ABI contract: `(key, key_len)` is a valid slice and `out` is writable.
+unsafe fn kv_incr_in(
+    store: Option<Arc<ephpm_kv::store::Store>>,
+    key: *const u8,
+    key_len: usize,
+    by: i64,
+    out: *mut i64,
+) -> c_int {
     if out.is_null() {
         return -1;
     }
     // SAFETY: ABI contract.
-    let (Some(store), Some(k)) = (kv(), unsafe { key_str(key, key_len) }) else {
+    let (Some(store), Some(k)) = (store, unsafe { key_str(key, key_len) }) else {
         return -1;
     };
     match store.incr_by(k, by) {
+        Ok(v) => {
+            // SAFETY: out checked non-null above.
+            unsafe { *out = v };
+            0
+        }
+        Err(_) => -2,
+    }
+}
+
+unsafe extern "C" fn kv_incr(key: *const u8, key_len: usize, by: i64, out: *mut i64) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_incr_in(kv(), key, key_len, by, out) }
+}
+
+unsafe extern "C" fn kv_incr_global(
+    key: *const u8,
+    key_len: usize,
+    by: i64,
+    out: *mut i64,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_incr_in(kv_global_store(), key, key_len, by, out) }
+}
+
+/// Shared body of `kv_incr_ttl` / `kv_incr_ttl_global`.
+///
+/// # Safety
+///
+/// As [`kv_incr_in`].
+unsafe fn kv_incr_ttl_in(
+    store: Option<Arc<ephpm_kv::store::Store>>,
+    key: *const u8,
+    key_len: usize,
+    by: i64,
+    ttl_secs: i64,
+    out: *mut i64,
+) -> c_int {
+    if out.is_null() {
+        return -1;
+    }
+    // SAFETY: ABI contract.
+    let (Some(store), Some(k)) = (store, unsafe { key_str(key, key_len) }) else {
+        return -1;
+    };
+    match store.incr_by_with_ttl(k, by, ttl_of(ttl_secs)) {
         Ok(v) => {
             // SAFETY: out checked non-null above.
             unsafe { *out = v };
@@ -495,21 +717,19 @@ unsafe extern "C" fn kv_incr_ttl(
     ttl_secs: i64,
     out: *mut i64,
 ) -> c_int {
-    if out.is_null() {
-        return -1;
-    }
-    // SAFETY: ABI contract.
-    let (Some(store), Some(k)) = (kv(), unsafe { key_str(key, key_len) }) else {
-        return -1;
-    };
-    match store.incr_by_with_ttl(k, by, ttl_of(ttl_secs)) {
-        Ok(v) => {
-            // SAFETY: out checked non-null above.
-            unsafe { *out = v };
-            0
-        }
-        Err(_) => -2,
-    }
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_incr_ttl_in(kv(), key, key_len, by, ttl_secs, out) }
+}
+
+unsafe extern "C" fn kv_incr_ttl_global(
+    key: *const u8,
+    key_len: usize,
+    by: i64,
+    ttl_secs: i64,
+    out: *mut i64,
+) -> c_int {
+    // SAFETY: ABI contract, forwarded unchanged.
+    unsafe { kv_incr_ttl_in(kv_global_store(), key, key_len, by, ttl_secs, out) }
 }
 
 unsafe extern "C" fn host_log(level: c_int, msg: *const u8, msg_len: usize) {
@@ -549,10 +769,20 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     request_scheme,
     request_is_secure,
     request_host,
+    kv_get_global,
+    kv_set_global,
+    kv_set_nx_global,
+    kv_incr_global,
+    kv_incr_ttl_global,
 };
 
-/// Wire the embedded KV store into the host table. Call once at startup,
+/// Wire the process-global KV store into the host table. Call once at startup,
 /// before loading any middleware. Subsequent calls are ignored.
+///
+/// This is the store the `kv_*_global` callbacks always reach, and the one the
+/// request-scoped `kv_*` callbacks fall back to outside a
+/// [`enter_site_kv`] scope (single-site mode, and any request that matched no
+/// vhost).
 pub fn set_kv_store(store: &Arc<ephpm_kv::store::Store>) {
     let _ = KV_STORE.set(Arc::clone(store));
 }
@@ -565,12 +795,30 @@ pub fn host_table() -> &'static EphpmHostV1 {
 
 #[cfg(test)]
 mod tests {
-    use crate::Request;
+    use std::sync::Arc;
+
+    use ephpm_kv::store::{Store, StoreConfig};
+
     use crate::abi::{self, EphpmHostV1};
-    use crate::host::{RequestCtx, host_table};
+    use crate::host::{KV_STORE, RequestCtx, enter_site_kv, host_table, set_kv_store};
+    use crate::{Host, Request};
 
     fn ctx() -> RequestCtx {
         RequestCtx::new("GET", "/hook", "", "203.0.113.4", "srv", &[])
+    }
+
+    /// The process-global store as the callbacks see it.
+    ///
+    /// `KV_STORE` is a `OnceLock`, so whichever test in this binary calls
+    /// [`set_kv_store`] first wins; every test must therefore read back what
+    /// the table actually resolved rather than assuming its own handle won.
+    fn global_store() -> Arc<Store> {
+        set_kv_store(&Store::new(StoreConfig::default()));
+        KV_STORE.get().expect("global store is set by now").clone()
+    }
+
+    fn site_store() -> Arc<Store> {
+        Store::new(StoreConfig::default())
     }
 
     #[test]
@@ -649,5 +897,130 @@ mod tests {
         assert_eq!(req.http_host(), "");
         // request_body has existed since minor 0 — not gated, still readable.
         assert_eq!(req.body(), b"payload");
+    }
+
+    // ── KV scoping (issue #376) ──────────────────────────────────────────
+
+    /// THE isolation guard: two sites, one key name, no bleed. Middleware
+    /// running for `tenant-a` must not see, overwrite, or be counted against
+    /// `tenant-b`'s value — the same physical-store separation PHP's
+    /// `ephpm_kv_*` already has.
+    #[test]
+    fn two_sites_never_share_a_middleware_kv_key() {
+        let global = global_store();
+        let a = site_store();
+        let b = site_store();
+        let host = Host::new(host_table());
+
+        {
+            let _scope = enter_site_kv(Some(Arc::clone(&a)));
+            assert!(host.kv_set("shared-name", b"from-a", 0));
+        }
+        {
+            let _scope = enter_site_kv(Some(Arc::clone(&b)));
+            // B does not see A's write...
+            assert_eq!(host.kv_get("shared-name"), None, "tenant B must not read tenant A's key");
+            assert!(host.kv_set("shared-name", b"from-b", 0));
+        }
+        {
+            let _scope = enter_site_kv(Some(Arc::clone(&a)));
+            // ...and B's write did not clobber A's.
+            assert_eq!(host.kv_get("shared-name").as_deref(), Some(&b"from-a"[..]));
+        }
+
+        // Neither tenant's write leaked into the process-global store, which is
+        // where operator-owned state lives.
+        assert_eq!(global.get("shared-name"), None);
+
+        // A counter is per-tenant too — the rate-limiter case from #376.
+        for store in [&a, &b] {
+            let _scope = enter_site_kv(Some(Arc::clone(store)));
+            assert_eq!(host.kv_incr_ttl("counter", 1, 60), Some(1), "each site counts from zero");
+        }
+    }
+
+    /// The scope is per-request state on a pooled thread, so it must not
+    /// outlive the request. Dropping the guard restores whatever was there
+    /// before — nothing, for a top-level scope — or the next request served on
+    /// this thread would inherit the previous tenant's keyspace.
+    #[test]
+    fn the_site_scope_does_not_outlive_its_guard() {
+        let global = global_store();
+        let site = site_store();
+        let host = Host::new(host_table());
+
+        {
+            let _scope = enter_site_kv(Some(Arc::clone(&site)));
+            assert!(host.kv_set("scoped-key", b"tenant", 0));
+        }
+        // Out of scope: writes land in the global store again.
+        assert!(host.kv_set("unscoped-key", b"node", 0));
+        assert_eq!(global.get("unscoped-key").as_deref(), Some(&b"node"[..]));
+        assert_eq!(global.get("scoped-key"), None, "the tenant write must not have leaked");
+        assert_eq!(host.kv_get("scoped-key"), None, "the scope must not persist past its guard");
+    }
+
+    /// Nesting restores the outer scope rather than clearing it, so a scope
+    /// entered around an inner call cannot silently unscope the outer one.
+    #[test]
+    fn nested_scopes_restore_the_outer_store() {
+        let _global = global_store();
+        let outer = site_store();
+        let inner = site_store();
+        let host = Host::new(host_table());
+
+        let _outer_scope = enter_site_kv(Some(Arc::clone(&outer)));
+        {
+            let _inner_scope = enter_site_kv(Some(Arc::clone(&inner)));
+            assert!(host.kv_set("k", b"inner", 0));
+        }
+        assert!(host.kv_set("k", b"outer", 0));
+        assert_eq!(inner.get("k").as_deref(), Some(&b"inner"[..]));
+        assert_eq!(outer.get("k").as_deref(), Some(&b"outer"[..]));
+    }
+
+    /// The deliberate escape hatch (#384): operator-level state stays reachable
+    /// on the process-global store from inside a tenant's scope, and a tenant's
+    /// own keyspace can never shadow it. This is what keeps "readable by
+    /// middleware, unwritable by any tenant's PHP" expressible.
+    #[test]
+    fn global_kv_reaches_the_process_store_from_inside_a_site_scope() {
+        let global = global_store();
+        let site = site_store();
+        let host = Host::new(host_table());
+        global.set("operator:flag".into(), b"on".to_vec(), None);
+
+        let _scope = enter_site_kv(Some(Arc::clone(&site)));
+        // Site-scoped read misses; global read hits.
+        assert_eq!(host.kv_get("operator:flag"), None);
+        assert_eq!(host.kv_get_global("operator:flag").as_deref(), Some(&b"on"[..]));
+
+        // A tenant writing the same name shadows nothing.
+        assert!(host.kv_set("operator:flag", b"tenant-says-off", 0));
+        assert_eq!(host.kv_get_global("operator:flag").as_deref(), Some(&b"on"[..]));
+
+        // The global write path targets the process store, not the scope.
+        assert!(host.kv_set_global("operator:written", b"1", 0));
+        assert_eq!(global.get("operator:written").as_deref(), Some(&b"1"[..]));
+        assert_eq!(site.get("operator:written"), None);
+    }
+
+    /// A module built against minor 3 talking to a minor-2 host must not read
+    /// the appended `kv_*_global` slots — they are past the end of that host's
+    /// table. The safe wrapper degrades instead.
+    #[test]
+    fn minor_gate_hides_global_kv_on_an_older_host() {
+        let _global = global_store();
+        let old = EphpmHostV1 { abi_version: 0x0100_0002, ..*host_table() };
+        assert!((old.abi_version & 0x00FF_FFFF) < abi::ABI_MINOR_GLOBAL_KV);
+
+        let host = Host::new(&old);
+        assert_eq!(host.kv_get_global("anything"), None);
+        assert!(!host.kv_set_global("anything", b"v", 0));
+        assert!(!host.kv_set_nx_global("anything", b"v", 0));
+        assert_eq!(host.kv_incr_global("anything", 1), None);
+        assert_eq!(host.kv_incr_ttl_global("anything", 1, 60), None);
+        // The un-suffixed slots predate minor 3 and still work.
+        assert!(host.kv_set("anything", b"v", 0));
     }
 }

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -59,6 +59,21 @@ use std::os::raw::c_char;
 
 use abi::{EphpmHeaderKv, EphpmHostV1, EphpmRequest, EphpmResponseCtx};
 
+/// Key component a module should substitute when [`Request::vhost_id`] is
+/// `None` — the request matched no known virtual host.
+///
+/// Deliberately **uppercase**, which makes it unspellable as a site key: the
+/// router lowercases every host before matching and `is_valid_site_key`
+/// accepts only `[a-z0-9._-]`, so no vhost directory can ever produce it. That
+/// matters because the alternative — keying on the raw `Host` for an unmatched
+/// request — hands an attacker a fresh keyspace per header value. For a rate
+/// limiter that is a bypass: vary `Host`, get a fresh budget. Collapsing every
+/// unmatched host into one bucket is the fail-closed direction.
+///
+/// A module that must *deny* rather than bucket unmatched requests should
+/// branch on `None` directly instead of using this.
+pub const UNMATCHED_VHOST: &str = "_UNMATCHED";
+
 /// The trait a Rust-authored middleware implements. [`declare!`] generates
 /// the C ABI exports around it.
 pub trait Middleware: Sized + Send + Sync + 'static {
@@ -151,6 +166,18 @@ impl Request<'_> {
         unsafe { CStr::from_ptr(p) }.to_str().unwrap_or("")
     }
 
+    /// Like [`str_of`](Self::str_of) but keeps NULL distinguishable from an
+    /// empty string. Used for accessors where "absent" is a decision a module
+    /// must be able to make — [`vhost_id`](Self::vhost_id) is the one that
+    /// matters: `""` would read as a usable tenant key.
+    fn opt_str_of(&self, p: *const c_char) -> Option<&str> {
+        if p.is_null() {
+            return None;
+        }
+        // SAFETY: as `str_of`.
+        unsafe { CStr::from_ptr(p) }.to_str().ok().filter(|s| !s.is_empty())
+    }
+
     /// HTTP method.
     #[must_use]
     pub fn method(&self) -> &str {
@@ -179,11 +206,25 @@ impl Request<'_> {
         self.str_of(unsafe { (self.host.request_remote_ip)(self.raw) })
     }
 
-    /// Vhost / server-name identity for this request.
+    /// The request's **canonical site key** — the tenant identity the router
+    /// resolved, and the same value that selects this request's per-site
+    /// database, KV keyspace and OPcache vhost.
+    ///
+    /// `None` when the request matched no known virtual host. That is not a
+    /// missing value to paper over: ePHPm serves unrecognised hosts from the
+    /// default document root by default, so the `Host` there is arbitrary
+    /// client input. A gate should treat `None` as "no tenant" and fail closed
+    /// rather than substituting the header (issue #390).
+    ///
+    /// Normalization is the router's, not the header's: `Site.Example`,
+    /// `site.example:8080` and `site.example.` all resolve to one key, and a
+    /// configured `sites_domain_suffix` is stripped. For the request host as
+    /// sent — normalized but *not* a tenant identity — use
+    /// [`http_host`](Self::http_host).
     #[must_use]
-    pub fn vhost_id(&self) -> &str {
+    pub fn vhost_id(&self) -> Option<&str> {
         // SAFETY: contract of `from_raw`.
-        self.str_of(unsafe { (self.host.request_vhost_id)(self.raw) })
+        self.opt_str_of(unsafe { (self.host.request_vhost_id)(self.raw) })
     }
 
     /// The host's advertised ABI minor (low three bytes of `abi_version`).

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -431,7 +431,24 @@ impl<'a> Host<'a> {
         Self { table }
     }
 
-    /// Get a key from the embedded KV store (`None` = absent or error).
+    /// The host's advertised ABI minor (low three bytes of `abi_version`).
+    /// Trailing table slots must be gated on this so a module built against a
+    /// newer ABI never reads past an older host's shorter table.
+    fn minor(&self) -> u32 {
+        self.table.abi_version & 0x00FF_FFFF
+    }
+
+    /// Get a key from **this request's** KV keyspace (`None` = absent or
+    /// error).
+    ///
+    /// On a multi-tenant node that is the serving vhost's own store — the same
+    /// physically separate map the tenant's PHP reaches through
+    /// `ephpm_kv_set()`, so a module and the app it fronts can share a key
+    /// without either hand-prefixing anything, and two tenants cannot see each
+    /// other's. On a single-site node, and for a request that matched no
+    /// vhost, it is the process-global store. Use
+    /// [`kv_get_global`](Self::kv_get_global) when you specifically want
+    /// node-wide state.
     #[must_use]
     pub fn kv_get(&self, key: &str) -> Option<Vec<u8>> {
         let mut ptr: *mut u8 = std::ptr::null_mut();
@@ -492,6 +509,115 @@ impl<'a> Host<'a> {
         // SAFETY: valid key slice; out-param points at a local.
         let rc = unsafe {
             (self.table.kv_incr_ttl)(key.as_ptr(), key.len(), by, ttl_secs, &raw mut out)
+        };
+        (rc == 0).then_some(out)
+    }
+
+    // ── Process-global KV (ABI minor 3) ───────────────────────────────────
+    //
+    // For node-scoped state only: operator-owned configuration that no
+    // tenant's PHP may rewrite, or a deliberately node-wide counter. Anything
+    // belonging to the tenant being served goes through the request-scoped
+    // methods above. Each falls back to a safe no-op/`None` on a host older
+    // than `abi::ABI_MINOR_GLOBAL_KV`, where the slot is absent — reading it
+    // would be a read past a shorter table.
+
+    /// [`kv_get`](Self::kv_get) against the **process-global** store.
+    ///
+    /// `None` on a host older than [`abi::ABI_MINOR_GLOBAL_KV`].
+    #[must_use]
+    pub fn kv_get_global(&self, key: &str) -> Option<Vec<u8>> {
+        if self.minor() < abi::ABI_MINOR_GLOBAL_KV {
+            return None;
+        }
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        let mut len: usize = 0;
+        // SAFETY: valid key slice; out-params point at locals; minor-gated
+        // above so the slot exists on this host's table.
+        let rc = unsafe {
+            (self.table.kv_get_global)(key.as_ptr(), key.len(), &raw mut ptr, &raw mut len)
+        };
+        if rc != 0 || ptr.is_null() {
+            return None;
+        }
+        // SAFETY: rc==0 means the host allocated `len` bytes at `ptr`.
+        let out = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+        // SAFETY: `ptr`/`len` came from `kv_get_global` above; `kv_free` is
+        // scope-independent (the allocation, not the store, is what it frees).
+        unsafe { (self.table.kv_free)(ptr, len) };
+        Some(out)
+    }
+
+    /// [`kv_set`](Self::kv_set) against the **process-global** store.
+    ///
+    /// `false` on a host older than [`abi::ABI_MINOR_GLOBAL_KV`].
+    #[must_use]
+    pub fn kv_set_global(&self, key: &str, value: &[u8], ttl_secs: i64) -> bool {
+        if self.minor() < abi::ABI_MINOR_GLOBAL_KV {
+            return false;
+        }
+        // SAFETY: valid slices for the call; minor-gated as above.
+        let rc = unsafe {
+            (self.table.kv_set_global)(
+                key.as_ptr(),
+                key.len(),
+                value.as_ptr(),
+                value.len(),
+                ttl_secs,
+            )
+        };
+        rc == 0
+    }
+
+    /// [`kv_set_nx`](Self::kv_set_nx) against the **process-global** store.
+    ///
+    /// `false` on a host older than [`abi::ABI_MINOR_GLOBAL_KV`].
+    #[must_use]
+    pub fn kv_set_nx_global(&self, key: &str, value: &[u8], ttl_secs: i64) -> bool {
+        if self.minor() < abi::ABI_MINOR_GLOBAL_KV {
+            return false;
+        }
+        // SAFETY: valid slices for the call; minor-gated as above.
+        let rc = unsafe {
+            (self.table.kv_set_nx_global)(
+                key.as_ptr(),
+                key.len(),
+                value.as_ptr(),
+                value.len(),
+                ttl_secs,
+            )
+        };
+        rc == 0
+    }
+
+    /// [`kv_incr`](Self::kv_incr) against the **process-global** store.
+    ///
+    /// `None` on a host older than [`abi::ABI_MINOR_GLOBAL_KV`].
+    #[must_use]
+    pub fn kv_incr_global(&self, key: &str, by: i64) -> Option<i64> {
+        if self.minor() < abi::ABI_MINOR_GLOBAL_KV {
+            return None;
+        }
+        let mut out: i64 = 0;
+        // SAFETY: valid key slice; out-param points at a local; minor-gated.
+        let rc = unsafe { (self.table.kv_incr_global)(key.as_ptr(), key.len(), by, &raw mut out) };
+        (rc == 0).then_some(out)
+    }
+
+    /// [`kv_incr_ttl`](Self::kv_incr_ttl) against the **process-global** store
+    /// — the primitive for a deliberately node-wide fixed-window counter, e.g.
+    /// an edge rate limiter that must not give each tenant its own budget.
+    ///
+    /// `None` on a host older than [`abi::ABI_MINOR_GLOBAL_KV`].
+    #[must_use]
+    pub fn kv_incr_ttl_global(&self, key: &str, by: i64, ttl_secs: i64) -> Option<i64> {
+        if self.minor() < abi::ABI_MINOR_GLOBAL_KV {
+            return None;
+        }
+        let mut out: i64 = 0;
+        // SAFETY: valid key slice; out-param points at a local; minor-gated.
+        let rc = unsafe {
+            (self.table.kv_incr_ttl_global)(key.as_ptr(), key.len(), by, ttl_secs, &raw mut out)
         };
         (rc == 0).then_some(out)
     }

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -72,6 +72,12 @@ use abi::{EphpmHeaderKv, EphpmHostV1, EphpmRequest, EphpmResponseCtx};
 ///
 /// A module that must *deny* rather than bucket unmatched requests should
 /// branch on `None` directly instead of using this.
+///
+/// Note this is the **only** bucket a single-site node ever uses: with no
+/// `sites_dir` and no `[[site]]`, the router matches no vhost, so every request
+/// has `vhost_id() == None`. A single-site deployment therefore sees keys like
+/// `mw:maintenance:_UNMATCHED` — that is the expected shape there, not a
+/// degraded one.
 pub const UNMATCHED_VHOST: &str = "_UNMATCHED";
 
 /// The trait a Rust-authored middleware implements. [`declare!`] generates
@@ -215,6 +221,12 @@ impl Request<'_> {
     /// default document root by default, so the `Host` there is arbitrary
     /// client input. A gate should treat `None` as "no tenant" and fail closed
     /// rather than substituting the header (issue #390).
+    ///
+    /// **`None` is the normal case on a single-site node.** With neither
+    /// `sites_dir` nor any `[[site]]` configured the router matches no vhost at
+    /// all, so this is `None` on every request there — treat it as "one
+    /// tenant", not as an error. [`UNMATCHED_VHOST`] is the conventional key
+    /// component for that bucket.
     ///
     /// Normalization is the router's, not the header's: `Site.Example`,
     /// `site.example:8080` and `site.example.` all resolve to one key, and a

--- a/crates/ephpm-server/examples/mw_probe_v1.rs
+++ b/crates/ephpm-server/examples/mw_probe_v1.rs
@@ -42,7 +42,9 @@ impl Middleware for Probe {
             .response_header("X-Probe-Path", req.path())
             .response_header("X-Probe-Query", req.query())
             .response_header("X-Probe-Remote-Ip", req.remote_ip())
-            .response_header("X-Probe-Vhost", req.vhost_id())
+            // Minor 3: the canonical site key, `<none>` when the request
+            // matched no known vhost (the accessor returns NULL there).
+            .response_header("X-Probe-Vhost", req.vhost_id().unwrap_or("<none>"))
             .response_header("X-Probe-Accept", req.header("Accept").unwrap_or("<none>"))
             // Minor-2 request accessors, echoed for the dlopen round-trip test.
             .response_header("X-Probe-Scheme", req.scheme())

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -2442,6 +2442,7 @@ impl Router {
                         if is_cacheable && let Some(client_tag) = &if_none_match {
                             let key = php_etag_cache_key(
                                 &self.php_etag_cache_config.key_prefix,
+                                site_key.as_deref(),
                                 method,
                                 &uri_path,
                                 &query_string,
@@ -2483,6 +2484,7 @@ impl Router {
                         {
                             let key = php_etag_cache_key(
                                 &self.php_etag_cache_config.key_prefix,
+                                site_key.as_deref(),
                                 method,
                                 &uri_path,
                                 &query_string,
@@ -5369,12 +5371,40 @@ pub fn brotli_compress(
 
 /// Build the KV store key for caching a PHP response's `ETag`.
 ///
-/// Format: `{prefix}{method}:{path}` or `{prefix}{method}:{path}?{query}` if query string is present.
-fn php_etag_cache_key(prefix: &str, method: &str, path: &str, query: &str) -> String {
+/// Format: `{prefix}{site}:{method}:{path}`, with `?{query}` appended when a
+/// query string is present.
+///
+/// # Why the site key is in there (issue #366)
+///
+/// The cache lives in the process-wide [`Store`], so on a multi-tenant node
+/// every vhost shares one keyspace. Without a site component
+/// `tenant-a.example/index.php` and `tenant-b.example/index.php` normalize to
+/// the *same* key, and one tenant's content hash decides whether the other
+/// tenant gets a `304 Not Modified` — a cross-tenant boundary crossing, not
+/// merely a stale cache. The site key is the same canonical value
+/// [`Router::resolve_site`] produced for this request (never re-derived from
+/// the `Host` header), so it names the same tenant as the database file, the
+/// KV keyspace and the OPcache vhost. Same model as
+/// [`opcache_vhost_key`]: global store, tenant baked into the key.
+///
+/// `site_key` is `None` for a host that matched no known vhost, which renders
+/// as the **empty** site component (`etag::GET:/x`). Empty is deliberately not
+/// a spellable site key — [`is_valid_site_key`] rejects it outright — so the
+/// unmatched-host bucket can never be reached by naming a site, and no named
+/// site can land in it. (`_default`, the sentinel OPcache uses, would be
+/// collidable here: it is a legal `sites_dir` directory name.)
+fn php_etag_cache_key(
+    prefix: &str,
+    site_key: Option<&str>,
+    method: &str,
+    path: &str,
+    query: &str,
+) -> String {
+    let site = site_key.unwrap_or("");
     if query.is_empty() {
-        format!("{prefix}{method}:{path}")
+        format!("{prefix}{site}:{method}:{path}")
     } else {
-        format!("{prefix}{method}:{path}?{query}")
+        format!("{prefix}{site}:{method}:{path}?{query}")
     }
 }
 
@@ -7206,14 +7236,14 @@ mod tests {
 
     #[test]
     fn test_php_etag_cache_key_without_query() {
-        let key = php_etag_cache_key("etag:", "GET", "/api/data", "");
-        assert_eq!(key, "etag:GET:/api/data");
+        let key = php_etag_cache_key("etag:", None, "GET", "/api/data", "");
+        assert_eq!(key, "etag::GET:/api/data");
     }
 
     #[test]
     fn test_php_etag_cache_key_with_query() {
-        let key = php_etag_cache_key("etag:", "POST", "/api/users", "id=42");
-        assert_eq!(key, "etag:POST:/api/users?id=42");
+        let key = php_etag_cache_key("etag:", None, "POST", "/api/users", "id=42");
+        assert_eq!(key, "etag::POST:/api/users?id=42");
     }
 
     #[test]
@@ -7555,32 +7585,76 @@ mod tests {
 
     #[test]
     fn etag_cache_key_without_query() {
-        let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
-        assert_eq!(key, "etag:GET:/index.php");
+        let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
+        assert_eq!(key, "etag::GET:/index.php");
     }
 
     #[test]
     fn etag_cache_key_with_query() {
-        let key = php_etag_cache_key("etag:", "GET", "/api/data", "page=1&sort=name");
-        assert_eq!(key, "etag:GET:/api/data?page=1&sort=name");
+        let key = php_etag_cache_key("etag:", None, "GET", "/api/data", "page=1&sort=name");
+        assert_eq!(key, "etag::GET:/api/data?page=1&sort=name");
     }
 
     #[test]
     fn etag_cache_key_head_method() {
-        let key = php_etag_cache_key("etag:", "HEAD", "/status", "");
-        assert_eq!(key, "etag:HEAD:/status");
+        let key = php_etag_cache_key("etag:", None, "HEAD", "/status", "");
+        assert_eq!(key, "etag::HEAD:/status");
     }
 
     #[test]
     fn etag_cache_key_custom_prefix() {
-        let key = php_etag_cache_key("cache:", "GET", "/page", "");
-        assert_eq!(key, "cache:GET:/page");
+        let key = php_etag_cache_key("cache:", None, "GET", "/page", "");
+        assert_eq!(key, "cache::GET:/page");
+    }
+
+    /// Two vhosts requesting the identical path must never share an ETag cache
+    /// entry (issue #366). Before the site component existed, both sites keyed
+    /// `etag:GET:/index.php` and tenant A's content hash could 304 tenant B.
+    #[test]
+    fn etag_cache_key_two_sites_same_path_never_collide() {
+        let a = php_etag_cache_key("etag:", Some("tenant-a"), "GET", "/index.php", "");
+        let b = php_etag_cache_key("etag:", Some("tenant-b"), "GET", "/index.php", "");
+        assert_ne!(a, b, "two tenants must not share one ETag cache entry");
+        assert_eq!(a, "etag:tenant-a:GET:/index.php");
+        assert_eq!(b, "etag:tenant-b:GET:/index.php");
+    }
+
+    /// The unmatched-host bucket is unreachable by naming a site. The empty
+    /// site component is not a spellable key — `is_valid_site_key("")` is
+    /// false — so no vhost can be created that lands in it, and it cannot
+    /// collide with a named site the way a `_default`-style sentinel could.
+    #[test]
+    fn etag_cache_key_unmatched_host_bucket_is_unspellable() {
+        let none = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
+        assert_eq!(none, "etag::GET:/index.php");
+        assert!(!is_valid_site_key(""), "empty must stay an unspellable site key");
+        // A site literally named `_default` (a legal `sites_dir` directory)
+        // gets its own bucket rather than the unmatched-host one.
+        let sentinel_named_site =
+            php_etag_cache_key("etag:", Some("_default"), "GET", "/index.php", "");
+        assert_ne!(none, sentinel_named_site);
+    }
+
+    /// A site key that differs only in the vhost dimension still separates
+    /// every other dimension of the key — method and query keep working.
+    #[test]
+    fn etag_cache_key_site_is_orthogonal_to_method_and_query() {
+        let a_get = php_etag_cache_key("etag:", Some("a"), "GET", "/x", "");
+        let a_head = php_etag_cache_key("etag:", Some("a"), "HEAD", "/x", "");
+        let b_get = php_etag_cache_key("etag:", Some("b"), "GET", "/x", "");
+        let a_get_q = php_etag_cache_key("etag:", Some("a"), "GET", "/x", "v=2");
+        let all = [&a_get, &a_head, &b_get, &a_get_q];
+        for (i, left) in all.iter().enumerate() {
+            for right in all.iter().skip(i + 1) {
+                assert_ne!(left, right, "cache keys must be pairwise distinct");
+            }
+        }
     }
 
     #[test]
     fn etag_store_and_retrieve() {
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/test.php", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/test.php", "");
 
         // Store an ETag.
         store.set(key.clone(), b"\"v1\"".to_vec(), None);
@@ -7594,7 +7668,7 @@ mod tests {
     #[test]
     fn etag_store_overwrites_previous() {
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/test.php", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/test.php", "");
 
         store.set(key.clone(), b"\"v1\"".to_vec(), None);
         store.set(key.clone(), b"\"v2\"".to_vec(), None);
@@ -7628,7 +7702,7 @@ mod tests {
     #[test]
     fn etag_cache_respects_ttl_zero_as_indefinite() {
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/page", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/page", "");
 
         // TTL of None means indefinite storage.
         store.set(key.clone(), b"\"forever\"".to_vec(), None);
@@ -7641,8 +7715,8 @@ mod tests {
     #[test]
     fn etag_cache_different_methods_different_keys() {
         let store = test_store();
-        let get_key = php_etag_cache_key("etag:", "GET", "/page", "");
-        let head_key = php_etag_cache_key("etag:", "HEAD", "/page", "");
+        let get_key = php_etag_cache_key("etag:", None, "GET", "/page", "");
+        let head_key = php_etag_cache_key("etag:", None, "HEAD", "/page", "");
 
         store.set(get_key.clone(), b"\"get-v1\"".to_vec(), None);
         store.set(head_key.clone(), b"\"head-v1\"".to_vec(), None);
@@ -7654,8 +7728,8 @@ mod tests {
     #[test]
     fn etag_cache_different_paths_different_keys() {
         let store = test_store();
-        let key_a = php_etag_cache_key("etag:", "GET", "/page-a", "");
-        let key_b = php_etag_cache_key("etag:", "GET", "/page-b", "");
+        let key_a = php_etag_cache_key("etag:", None, "GET", "/page-a", "");
+        let key_b = php_etag_cache_key("etag:", None, "GET", "/page-b", "");
 
         store.set(key_a.clone(), b"\"a-v1\"".to_vec(), None);
         store.set(key_b.clone(), b"\"b-v1\"".to_vec(), None);
@@ -7667,8 +7741,8 @@ mod tests {
     #[test]
     fn etag_cache_query_string_differentiates() {
         let store = test_store();
-        let key_no_qs = php_etag_cache_key("etag:", "GET", "/api", "");
-        let key_with_qs = php_etag_cache_key("etag:", "GET", "/api", "v=2");
+        let key_no_qs = php_etag_cache_key("etag:", None, "GET", "/api", "");
+        let key_with_qs = php_etag_cache_key("etag:", None, "GET", "/api", "v=2");
 
         store.set(key_no_qs.clone(), b"\"no-qs\"".to_vec(), None);
         store.set(key_with_qs.clone(), b"\"with-qs\"".to_vec(), None);
@@ -7680,7 +7754,7 @@ mod tests {
     #[test]
     fn etag_cache_304_logic_matches_stored() {
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
         store.set(key.clone(), b"\"cached-v1\"".to_vec(), None);
 
         // Simulate the cache lookup that happens in handle().
@@ -7697,7 +7771,7 @@ mod tests {
     #[test]
     fn etag_cache_304_logic_no_match() {
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
         store.set(key.clone(), b"\"cached-v1\"".to_vec(), None);
 
         let stored_bytes = store.get(&key).unwrap();
@@ -7711,7 +7785,7 @@ mod tests {
     #[test]
     fn etag_cache_miss_returns_none() {
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/nonexistent.php", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/nonexistent.php", "");
 
         // No entry → cache miss → execute PHP.
         assert!(store.get(&key).is_none());
@@ -7722,7 +7796,7 @@ mod tests {
         use std::time::Duration;
 
         let store = test_store();
-        let key = php_etag_cache_key("etag:", "GET", "/page.php", "");
+        let key = php_etag_cache_key("etag:", None, "GET", "/page.php", "");
 
         // Store with 1-second TTL.
         store.set(key.clone(), b"\"ttl-v1\"".to_vec(), Some(Duration::from_secs(1)));
@@ -7793,7 +7867,7 @@ echo "content here";
             assert_eq!(etag, Some("\"test-v1\""));
 
             // ETag should be stored in the KV store
-            let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
+            let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
             let stored = store.get(&key);
             assert!(stored.is_some());
             assert_eq!(stored.unwrap(), b"\"test-v1\"");
@@ -7815,7 +7889,7 @@ echo "should not see this";
             let router = test_router_with_store(dir.path(), Arc::clone(&store));
 
             // Pre-seed the store with an ETag
-            let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
+            let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
             store.set(key, b"\"test-v2\"".to_vec(), None);
 
             // Make request with matching If-None-Match
@@ -7843,7 +7917,7 @@ echo "new content";
             let router = test_router_with_store(dir.path(), Arc::clone(&store));
 
             // Pre-seed the store with a different ETag
-            let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
+            let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
             store.set(key.clone(), b"\"old-version\"".to_vec(), None);
 
             // Make request with different If-None-Match
@@ -7883,7 +7957,7 @@ echo "no etag";
             assert!(resp.headers().get("etag").is_none());
 
             // KV store should not have an entry for this path
-            let key = php_etag_cache_key("etag:", "GET", "/index.php", "");
+            let key = php_etag_cache_key("etag:", None, "GET", "/index.php", "");
             assert!(store.get(&key).is_none());
         }
 
@@ -7908,7 +7982,7 @@ echo "post response";
             assert_eq!(resp.status(), StatusCode::OK);
 
             // POST responses should NOT be cached in KV store (only GET/HEAD)
-            let key = php_etag_cache_key("etag:", "POST", "/index.php", "");
+            let key = php_etag_cache_key("etag:", None, "POST", "/index.php", "");
             assert!(store.get(&key).is_none());
         }
     }
@@ -8991,6 +9065,12 @@ echo "post response";
             kv: String,
             /// The OPcache invalidation vhost.
             opcache: String,
+            /// (5) the PHP response's `ETag` cache key for a fixed
+            /// method+path+query. Joined the invariant in #366: it lives in the
+            /// process-wide store, so without the canonical key in it two
+            /// vhosts serving the same path share one entry and tenant A's
+            /// content hash can 304 tenant B.
+            etag_cache_key: String,
         }
 
         /// Run every derivation for `host` exactly the way a request does.
@@ -9019,6 +9099,13 @@ echo "post response";
                 wire_password: env.get("DB_PASSWORD").cloned(),
                 kv: ids.kv,
                 opcache: ids.opcache,
+                etag_cache_key: php_etag_cache_key(
+                    "etag:",
+                    resolved.key.as_deref(),
+                    "GET",
+                    "/index.php",
+                    "",
+                ),
             }
         }
 
@@ -9057,6 +9144,7 @@ echo "post response";
             assert_eq!(expected.wire_user.as_deref(), Some("shop"));
             assert_eq!(expected.kv, "shop");
             assert_eq!(expected.opcache, "shop");
+            assert_eq!(expected.etag_cache_key, "etag:shop:GET:/index.php");
 
             for host in spellings {
                 assert_eq!(
@@ -9174,6 +9262,57 @@ echo "post response";
             assert_ne!(bare.db_path, dotted.db_path);
             assert_ne!(bare.state_root, dotted.state_root);
             assert_ne!(bare.wire_password, dotted.wire_password);
+            // Issue #366: the same URL path on two vhosts must not resolve to
+            // one ETag cache entry — that entry decides a 304, so sharing it
+            // lets one tenant's content hash answer for the other's.
+            assert_ne!(
+                bare.etag_cache_key, dotted.etag_cache_key,
+                "two tenants requesting the same path must not share an ETag cache entry — #366"
+            );
+        }
+
+        /// The whole point of #366, stated directly: two *different* vhosts
+        /// asking for the identical method+path+query never collide, and every
+        /// spelling of one vhost always does. The suffix is configured here so
+        /// `shop.local` and `shop` are the SAME tenant while `blog` is not —
+        /// which is exactly the discrimination a `Host`-derived key gets wrong.
+        #[tokio::test]
+        async fn etag_cache_key_isolates_two_sites_on_the_same_path() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = dir.path().join("sites");
+            let dbdir = dir.path().join("dbs");
+            for name in ["shop", "blog"] {
+                fs::create_dir_all(sites.join(name)).unwrap();
+            }
+
+            let backends =
+                SiteBackends::new(dbdir.clone(), 8, stats(), tokio::runtime::Handle::current())
+                    .expect("registry");
+            let auth = SiteWireAuth::new(backends.clone()).expect("secret");
+            let router = router_with(dir.path(), &sites, &dbdir, Some(".local"), &auth);
+
+            let shop = derive(&router, &backends, "shop.local").etag_cache_key;
+            let blog = derive(&router, &backends, "blog.local").etag_cache_key;
+            let unknown = derive(&router, &backends, "nobody.example.com").etag_cache_key;
+
+            assert_eq!(shop, "etag:shop:GET:/index.php");
+            assert_eq!(blog, "etag:blog:GET:/index.php");
+            // A host that matched no vhost lands in the unspellable bucket, so
+            // it can neither read nor poison a real tenant's entry.
+            assert_eq!(unknown, "etag::GET:/index.php");
+            for (a, b) in [(&shop, &blog), (&shop, &unknown), (&blog, &unknown)] {
+                assert_ne!(a, b, "tenant ETag cache keys must be pairwise distinct — #366");
+            }
+
+            // ...while every legal spelling of ONE tenant still shares its own
+            // entry, or the cache would simply never hit.
+            for spelling in ["shop", "shop.local", "SHOP.LOCAL", "shop.local:8080", "shop."] {
+                assert_eq!(
+                    derive(&router, &backends, spelling).etag_cache_key,
+                    shop,
+                    "`{spelling}` is the same tenant and must share its ETag cache entry"
+                );
+            }
         }
 
         /// The wire path applies [`normalize_host_key`] to the client-asserted

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -1978,6 +1978,37 @@ impl Router {
         }
     }
 
+    /// The KV store the native-middleware chain should see for this request
+    /// (issue #376).
+    ///
+    /// Scoped to the **canonical site key** on a multi-tenant node, so a
+    /// module's `kv_get`/`kv_incr_ttl` reaches the same physically separate
+    /// store this vhost's PHP reaches through `ephpm_kv_*` — a rate limiter is
+    /// per-tenant by default, and a module can read a key PHP wrote.
+    ///
+    /// `None` (the process-global store) in two cases, both deliberate:
+    ///
+    /// * single-site mode, where there is one store and nothing to isolate;
+    /// * a request that matched **no** vhost, which has no tenant identity to
+    ///   scope to. Note this is the one place the middleware lane deliberately
+    ///   differs from [`SiteIdentities::kv`], which falls back to the
+    ///   normalized `Host` so a catch-all document root keeps per-hostname
+    ///   keyspaces. The chain runs on *every* request, static files included,
+    ///   and site stores are created lazily and never evicted — so minting one
+    ///   per `Host` value here would be a cheap way to grow the site map
+    ///   without bound. A module that wants to bucket unmatched requests has
+    ///   [`ephpm_middleware::UNMATCHED_VHOST`] for the key, in the global
+    ///   store where operator state already lives.
+    fn middleware_kv_store(
+        &self,
+        site_key: Option<&str>,
+    ) -> Option<std::sync::Arc<ephpm_kv::store::Store>> {
+        let key = site_key?;
+        // `get_site_store` treats the empty string as "the default store", but
+        // `site_key` is `Some` here so the key is a real, validated vhost name.
+        Some(self.multi_tenant_kv.as_ref()?.get_site_store(key))
+    }
+
     /// Resolve, and lazily create, this vhost's private temp + session
     /// directories, returning the paths to inject into the per-request PHP
     /// sandbox.
@@ -3061,7 +3092,18 @@ impl Router {
             .with_scheme(is_https)
             .with_host(&normalize_host_key(&server_name))
             .with_body(body_view);
-            match chain.evaluate(&ctx, &path) {
+            // Scope the chain's KV callbacks to this request's vhost keyspace
+            // (issue #376) — the same store PHP gets below. The guard is held
+            // across the synchronous `evaluate` only and dropped before any
+            // `.await`: it is thread-local state, and a suspended task can
+            // resume on a different tokio worker.
+            let verdict = {
+                let _kv_scope = ephpm_middleware::host::enter_site_kv(
+                    self.middleware_kv_store(site_key.as_deref()),
+                );
+                chain.evaluate(&ctx, &path)
+            };
+            match verdict {
                 crate::middleware::ChainVerdict::Respond { status, body, headers } => {
                     return middleware_response(status, body, &headers);
                 }
@@ -4160,6 +4202,9 @@ impl Router {
         )
         .with_scheme(is_https)
         .with_host(&normalize_host_key(server_name));
+        // Per-vhost KV scope, exactly as on the PHP path (issue #376). This
+        // method is synchronous throughout, so the guard never spans an await.
+        let _kv_scope = ephpm_middleware::host::enter_site_kv(self.middleware_kv_store(site_key));
         match chain.evaluate(&ctx, path) {
             crate::middleware::ChainVerdict::Respond { status, body, headers } => {
                 StaticGate::Respond(middleware_response(status, body, &headers))
@@ -4250,13 +4295,20 @@ impl Router {
         )
         .with_scheme(is_https)
         .with_host(&normalize_host_key(server_name));
-        let outcome = chain.run_response_phase(
-            &ctx,
-            path,
-            parts.status.as_u16(),
-            decodable,
-            collected.to_vec(),
-        );
+        // Per-vhost KV scope for the response phase too (issue #376). Scoped
+        // to the synchronous call: the body `.collect().await` above is
+        // already done, and nothing awaits between here and the drop.
+        let outcome = {
+            let _kv_scope =
+                ephpm_middleware::host::enter_site_kv(self.middleware_kv_store(site_key));
+            chain.run_response_phase(
+                &ctx,
+                path,
+                parts.status.as_u16(),
+                decodable,
+                collected.to_vec(),
+            )
+        };
 
         parts.status = StatusCode::from_u16(outcome.status).unwrap_or(parts.status);
         parts.headers.clear();
@@ -9348,6 +9400,187 @@ echo "post response";
                 assert_eq!(normalize_host_key(&key), key, "`{key}` must normalize to itself");
                 assert!(is_valid_site_key(&key), "`{key}` must pass the allowlist gate");
             }
+        }
+    }
+
+    /// Issue #376 — which KV store the native-middleware chain is handed.
+    ///
+    /// The chain's `kv_*` callbacks take no request pointer, so the store is
+    /// bound per request via a thread-local scope. These tests pin the
+    /// *selection* — the part that decides tenancy — rather than the FFI
+    /// plumbing (covered by `ephpm_middleware::host`'s own tests).
+    mod middleware_kv_scope {
+        use super::*;
+
+        /// A multi-tenant router sharing one `MultiTenantStore`, exactly as
+        /// `start_kv_service` builds it for the RESP listener and the PHP path.
+        fn multi_tenant_router(
+            dir: &Path,
+            sites: &Path,
+        ) -> (Router, Arc<Store>, ephpm_kv::multi_tenant::MultiTenantStore) {
+            let config = Config {
+                server: ServerConfig {
+                    listen: "0.0.0.0:8080".to_string(),
+                    document_root: dir.to_path_buf(),
+                    sites_dir: Some(sites.to_path_buf()),
+                    sites_domain_suffix: Some(".local".to_string()),
+                    ..ServerConfig::default()
+                },
+                php: PhpConfig::default(),
+                db: DbConfig::default(),
+                kv: KvConfig::default(),
+                cluster: ClusterConfig::default(),
+                middleware: Vec::new(),
+                opcache: ephpm_config::OpcacheConfig::default(),
+            };
+            let global = test_store();
+            let mt = ephpm_kv::multi_tenant::MultiTenantStore::new(
+                Arc::clone(&global),
+                StoreConfig::default(),
+            );
+            let router =
+                Router::new(&config, Arc::clone(&global), Some(mt.clone()), None, None, None, None);
+            (router, global, mt)
+        }
+
+        /// Two vhosts get two physically separate stores, and each is the same
+        /// `Arc` PHP's `ephpm_kv_*` resolves for that vhost — so a module and
+        /// the app it fronts share a keyspace, and two tenants never do.
+        #[tokio::test]
+        async fn each_site_gets_its_own_store_and_it_is_phps_store() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = dir.path().join("sites");
+            for name in ["shop", "blog"] {
+                fs::create_dir_all(sites.join(name)).unwrap();
+            }
+            let (router, global, mt) = multi_tenant_router(dir.path(), &sites);
+
+            let shop = router
+                .middleware_kv_store(router.resolve_site("shop.local").key.as_deref())
+                .expect("a matched vhost gets its own store");
+            let blog = router
+                .middleware_kv_store(router.resolve_site("blog.local").key.as_deref())
+                .expect("a matched vhost gets its own store");
+
+            assert!(!Arc::ptr_eq(&shop, &blog), "two tenants must not share one store");
+            assert!(!Arc::ptr_eq(&shop, &global), "a tenant must not be handed the global store");
+
+            // The same handle the PHP bridge is given for that vhost — this is
+            // what makes "middleware reads a key PHP wrote" true (#376 case 1).
+            assert!(Arc::ptr_eq(&shop, &mt.get_site_store("shop")));
+            assert!(Arc::ptr_eq(&blog, &mt.get_site_store("blog")));
+
+            // And the separation is physical, not a key prefix.
+            shop.set("same-name".into(), b"shop".to_vec(), None);
+            assert_eq!(blog.get("same-name"), None);
+            assert_eq!(global.get("same-name"), None);
+        }
+
+        /// Every legal spelling of one tenant lands on one store, or a module's
+        /// per-tenant state would fragment the way #390's raw `Host` key did.
+        #[tokio::test]
+        async fn every_spelling_of_one_tenant_resolves_the_same_store() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = dir.path().join("sites");
+            fs::create_dir_all(sites.join("shop")).unwrap();
+            let (router, ..) = multi_tenant_router(dir.path(), &sites);
+
+            let expected = router
+                .middleware_kv_store(router.resolve_site("shop.local").key.as_deref())
+                .expect("known site");
+            for spelling in ["shop", "shop.local", "SHOP.LOCAL", "shop.local:8080", "shop."] {
+                let got = router
+                    .middleware_kv_store(router.resolve_site(spelling).key.as_deref())
+                    .expect("known site");
+                assert!(Arc::ptr_eq(&expected, &got), "`{spelling}` must reach one store");
+            }
+        }
+
+        /// A host that matched no vhost has no tenant identity, so it gets the
+        /// process-global store (`None` = no override) rather than a keyspace
+        /// minted from the header. The chain runs on every request, static
+        /// files included, and site stores are never evicted — a `Host`-derived
+        /// store here would grow the site map without bound.
+        #[tokio::test]
+        async fn an_unmatched_host_gets_no_site_store() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = dir.path().join("sites");
+            fs::create_dir_all(sites.join("shop")).unwrap();
+            let (router, _global, mt) = multi_tenant_router(dir.path(), &sites);
+
+            for host in ["nobody.example.com", "127.0.0.1:8080", "not-a-site"] {
+                let resolved = router.resolve_site(host);
+                assert_eq!(resolved.key, None, "`{host}` names no vhost");
+                assert!(
+                    router.middleware_kv_store(resolved.key.as_deref()).is_none(),
+                    "`{host}` must not mint a keyspace"
+                );
+            }
+            assert_eq!(mt.site_count(), 0, "no site store may be created by an unknown Host");
+        }
+
+        /// Single-site mode has one store and nothing to isolate, so the scope
+        /// is never overridden — the pre-#376 behaviour, unchanged.
+        #[tokio::test]
+        async fn single_site_mode_never_overrides_the_global_store() {
+            let dir = tempfile::tempdir().unwrap();
+            let router = test_router(dir.path());
+            assert!(router.middleware_kv_store(None).is_none());
+            assert!(router.middleware_kv_store(Some("anything")).is_none());
+        }
+
+        /// Selecting the right store is only half of it — the router has to
+        /// actually *enter* the scope around the chain. This drives a real
+        /// mounted module end to end through `static_request_phase` (the one
+        /// chain-invoking path with no PHP runtime in it) and reads the effect
+        /// out of the store: a per-tenant counter must land in the tenant's own
+        /// store and nowhere else.
+        #[tokio::test]
+        async fn the_router_enters_the_site_scope_around_the_chain() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = dir.path().join("sites");
+            for name in ["shop", "blog"] {
+                fs::create_dir_all(sites.join(name)).unwrap();
+            }
+            let (router, global, mt) = multi_tenant_router(dir.path(), &sites);
+            // A generous budget: this test is about *where* the counter lands,
+            // not about tripping the limit.
+            let chain =
+                crate::middleware::MiddlewareChain::load(&[ephpm_config::MiddlewareMount {
+                    library: "ratelimit".to_string(),
+                    match_pattern: None,
+                    order: 10,
+                    config: Some(serde_json::json!({ "per_ip_rps": 1000 })),
+                }])
+                .expect("load builtin ratelimit");
+            let router = router.with_middleware_chain(Some(Arc::new(chain)));
+
+            let addr: SocketAddr = "198.51.100.20:5000".parse().unwrap();
+            let gate = |site: Option<&str>| {
+                router.static_request_phase(None, "GET", "/a.css", "", addr, site, "ignored", false)
+            };
+            assert!(matches!(gate(Some("shop")), StaticGate::Continue(_)));
+            assert!(matches!(gate(Some("blog")), StaticGate::Continue(_)));
+
+            // The module writes `mw:rl:<vhost>:<client>:<window>`. Find it in
+            // each tenant's own store, and confirm the counter is per-tenant.
+            let shop_store = mt.get_site_store("shop");
+            let blog_store = mt.get_site_store("blog");
+            let count_in = |store: &Arc<Store>, vhost: &str| -> Option<i64> {
+                store
+                    .keys(&format!("mw:rl:{vhost}:*"))
+                    .first()
+                    .and_then(|k| store.get(k))
+                    .and_then(|v| String::from_utf8_lossy(&v).parse().ok())
+            };
+            assert_eq!(count_in(&shop_store, "shop"), Some(1), "shop counted in shop's store");
+            assert_eq!(count_in(&blog_store, "blog"), Some(1), "blog counted in blog's store");
+            assert_eq!(count_in(&shop_store, "blog"), None, "no cross-tenant key in shop's store");
+            assert_eq!(count_in(&blog_store, "shop"), None, "no cross-tenant key in blog's store");
+            // And nothing leaked into the process-global store, which is where
+            // operator-owned middleware state lives (#384).
+            assert_eq!(count_in(&global, "shop"), None);
+            assert_eq!(count_in(&global, "blog"), None);
         }
     }
 

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -2519,6 +2519,7 @@ impl Router {
                         &uri_path,
                         &query_string,
                         effective_addr,
+                        site_key.as_deref(),
                         &host,
                         is_https,
                     ) {
@@ -2602,6 +2603,7 @@ impl Router {
                     &uri_path,
                     &query_string,
                     effective_addr,
+                    site_key.as_deref(),
                     &host,
                     is_https,
                 )
@@ -3043,12 +3045,17 @@ impl Router {
                 let cap = usize::try_from(self.middleware_body_limit).unwrap_or(usize::MAX);
                 &b[..b.len().min(cap)]
             });
+            // The vhost identity handed to modules is the CANONICAL site key
+            // (`""` = matched no vhost, which the accessor turns into NULL) —
+            // never the raw `Host`. Modules use it as a tenant identity in
+            // authorization decisions, so it has to be the same derivation the
+            // database file and KV keyspace use (issue #390).
             let ctx = ephpm_middleware::host::RequestCtx::new(
                 &method,
                 &path,
                 &query_string,
                 &remote_addr.ip().to_string(),
-                &server_name,
+                site_key.as_deref().unwrap_or(""),
                 &headers,
             )
             .with_scheme(is_https)
@@ -4132,6 +4139,7 @@ impl Router {
         path: &str,
         query: &str,
         remote_addr: SocketAddr,
+        site_key: Option<&str>,
         server_name: &str,
         is_https: bool,
     ) -> StaticGate {
@@ -4140,13 +4148,14 @@ impl Router {
         };
         // Static requests carry no buffered body, but scheme/host are still
         // authoritative from the connection (a `force_https` gate on static
-        // assets needs the real scheme).
+        // assets needs the real scheme). The vhost identity is the canonical
+        // site key, exactly as on the PHP path (issue #390).
         let ctx = ephpm_middleware::host::RequestCtx::new(
             method,
             path,
             query,
             &remote_addr.ip().to_string(),
-            server_name,
+            site_key.unwrap_or(""),
             req_headers.unwrap_or(&[]),
         )
         .with_scheme(is_https)
@@ -4181,6 +4190,7 @@ impl Router {
         path: &str,
         query: &str,
         remote_addr: SocketAddr,
+        site_key: Option<&str>,
         server_name: &str,
         is_https: bool,
     ) -> Response<ServerBody> {
@@ -4235,7 +4245,7 @@ impl Router {
             path,
             query,
             &remote_addr.ip().to_string(),
-            server_name,
+            site_key.unwrap_or(""),
             req_headers.unwrap_or(&[]),
         )
         .with_scheme(is_https)

--- a/crates/ephpm-server/tests/middleware_dlopen.rs
+++ b/crates/ephpm-server/tests/middleware_dlopen.rs
@@ -126,7 +126,9 @@ fn dynamic_module_loads_and_round_trips_request_context() {
         "/app/index.php",
         "a=1&b=2",
         "198.51.100.9",
-        "Probe.Example.:8443",
+        // The canonical site key, as the router resolves it — already
+        // normalized, never the raw `Host` (issue #390).
+        "probe.example",
         &[("Accept".to_owned(), "text/html".to_owned())],
     )
     .with_scheme(true)
@@ -143,8 +145,8 @@ fn dynamic_module_loads_and_round_trips_request_context() {
             assert_eq!(find(&response_headers, "X-Probe-Path"), Some("/app/index.php"));
             assert_eq!(find(&response_headers, "X-Probe-Query"), Some("a=1&b=2"));
             assert_eq!(find(&response_headers, "X-Probe-Remote-Ip"), Some("198.51.100.9"));
-            // vhost_id is the un-normalized server name…
-            assert_eq!(find(&response_headers, "X-Probe-Vhost"), Some("Probe.Example.:8443"));
+            // vhost_id is the canonical site key (minor 3, issue #390)…
+            assert_eq!(find(&response_headers, "X-Probe-Vhost"), Some("probe.example"));
             assert_eq!(find(&response_headers, "X-Probe-Accept"), Some("text/html"));
             // …minor-2 accessors: scheme/secure from the connection, normalized
             // host, and the bounded buffered body — all across the C ABI.
@@ -167,6 +169,22 @@ fn dynamic_module_loads_and_round_trips_request_context() {
             assert_eq!(find(&headers, "X-Probe-Action"), Some("respond"));
         }
         ChainVerdict::Continue { .. } => panic!("/__probe/deny must short-circuit"),
+    }
+
+    // A request that matched NO virtual host has no tenant identity, and that
+    // has to survive the C boundary as a NULL — not as `""`, which a module
+    // would happily use as a lookup key (issue #390). The probe renders the
+    // module-side `Option::None` as `<none>`.
+    let ctx = RequestCtx::new("GET", "/app/index.php", "", "198.51.100.9", "", &[]);
+    match chain.evaluate(&ctx, "/app/index.php") {
+        ChainVerdict::Continue { response_headers, .. } => {
+            assert_eq!(
+                find(&response_headers, "X-Probe-Vhost"),
+                Some("<none>"),
+                "an unmatched host must reach the module as NULL, not an empty tenant key"
+            );
+        }
+        ChainVerdict::Respond { status, .. } => panic!("expected CONTINUE, got RESPOND {status}"),
     }
 
     // Dropping runs `shutdown` through the ABI, then dlclose.

--- a/examples/rust-middleware/README.md
+++ b/examples/rust-middleware/README.md
@@ -218,11 +218,13 @@ reads the same literal key through the host table's `kv_get`, and the next
 request is rejected in native code with no restart and no config reload. TTL
 is in **seconds** on both surfaces.
 
-> **Single-site only.** With `[server] sites_dir` set, PHP is rebound per
-> request to a per-vhost KV store while the middleware host table holds one
-> process-wide store, so PHP and middleware would no longer meet on the same
-> key. The rate limiter is unaffected (it only talks to the middleware side);
-> the PHP-driven revocation demo is what would break.
+> **Multi-tenant too, since ABI minor 3** (issue #376). The middleware host
+> table's `kv_*` callbacks are now bound per request to the *serving vhost's*
+> store — the same one PHP is rebound to — so this demo works unchanged with
+> `[server] sites_dir` set: `revoke.php` on `tenant-a.example` revokes for
+> `tenant-a.example` and nowhere else. The rate-limit counter becomes
+> per-tenant for free. For node-wide state (operator-owned config a tenant
+> must not be able to rewrite) use the explicit `kv_*_global` accessors.
 
 > `revoke.php` has no authentication. It is a demo, not a pattern.
 

--- a/examples/rust-middleware/src/lib.rs
+++ b/examples/rust-middleware/src/lib.rs
@@ -220,7 +220,11 @@ impl Middleware for ApiGate {
         // ── RESPOND: fixed-window rate limit (fail-open) ──────────────────
         let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
         let window = now / WINDOW_SECS;
-        let key = Self::window_key(req.vhost_id(), tenant, window);
+        // `vhost_id()` is the canonical site key, `None` when the request
+        // matched no vhost. Bucket those together rather than trusting the
+        // header — otherwise varying `Host` mints a fresh budget.
+        let vhost = req.vhost_id().unwrap_or(ephpm_middleware::UNMATCHED_VHOST);
+        let key = Self::window_key(vhost, tenant, window);
 
         // One atomic call: increment, and stamp the TTL only if this call
         // created the key. A counter can therefore never exist without an

--- a/examples/rust-middleware/src/lib.rs
+++ b/examples/rust-middleware/src/lib.rs
@@ -131,7 +131,11 @@ impl ApiGate {
     }
 
     /// KV key holding this tenant's counter for the current window. The vhost
-    /// is part of the key so two sites in one process cannot share a budget.
+    /// is part of the key so two sites in one process cannot share a budget —
+    /// and it is the router's canonical site key, never the `Host` header,
+    /// which a caller could vary to mint a fresh budget (issue #390). On a
+    /// multi-tenant node the counter also lands in that vhost's own KV store
+    /// (issue #376), so the key component is belt-and-braces.
     fn window_key(vhost: &str, tenant: &str, window: u64) -> String {
         format!("apigate:rl:{vhost}:{tenant}:{window}")
     }

--- a/site/content/architecture/http.md
+++ b/site/content/architecture/http.md
@@ -195,7 +195,9 @@ Rejecting `%2F` / `%5C` is what keeps percent encoding from being used to sneak 
 
 The static file `ETag` support only covers non-PHP assets. PHP frameworks (WordPress, Laravel) generate their own `ETag` headers for dynamic content, but without help every request still hits PHP to compute whether the content changed.
 
-**Implemented:** the ETag-based 304 short-circuit. Configured via `[server.php_etag_cache]` (enabled by default; see `Router::handle` in `crates/ephpm-server/src/router.rs`). When PHP sets an `ETag` on a GET/HEAD response, the server stores it in the KV store keyed by method + path + query string. A repeat request with a matching `If-None-Match` returns `304 Not Modified` without executing PHP at all. In clustered mode the KV entries replicate via gossip, so the short-circuit works across nodes.
+**Implemented:** the ETag-based 304 short-circuit. Configured via `[server.php_etag_cache]` (**disabled by default** — `enabled = false`; see `Router::handle` in `crates/ephpm-server/src/router.rs`). When PHP sets an `ETag` on a GET/HEAD response, the server stores it in the KV store keyed by the request's canonical site key + method + path + query string. A repeat request with a matching `If-None-Match` returns `304 Not Modified` without executing PHP at all. In clustered mode the KV entries replicate via gossip, so the short-circuit works across nodes.
+
+The site key is load-bearing on a multi-tenant node. The cache lives in the process-wide KV store, so before the key carried a site component (issue #366) `tenant-a.example/index.php` and `tenant-b.example/index.php` shared one entry — and that entry decides a `304`, so one tenant's content hash could answer the other's conditional request. The key is the canonical value `Router::resolve_site` returned, never re-derived from the `Host` header, so it names the same tenant as the per-site database, the KV keyspace and the OPcache vhost. A host that matched no vhost gets an **empty** site component, which is deliberately not a spellable vhost name — so the unmatched-host bucket can never be reached by naming a site.
 
 **Future work:** full-response caching (serving the cached body on requests without `If-None-Match`), which would turn ePHPm into an edge cache — see the design decisions below.
 
@@ -204,7 +206,8 @@ The static file `ETag` support only covers non-PHP assets. PHP frameworks (WordP
 ```
 1. First request: /blog/hello
    → PHP executes, returns response with ETag: "abc123"
-   → Server stores in KV: <key_prefix><method>:<path>?<query> → "abc123" (with TTL)
+   → Server stores in KV: <key_prefix><site>:<method>:<path>?<query> → "abc123" (with TTL)
+     (<site> = canonical site key; empty on a single-site node, e.g. `etag::GET:/blog/hello`)
    → Response sent to client
 
 2. Repeat request: /blog/hello + If-None-Match: "abc123"

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -113,8 +113,10 @@ config  = { api_key = "..." }
 | `config` | no | Arbitrary table, serialised to JSON and handed to the module's `init`. |
 
 Mounts are **global** — they apply to every vhost. A module that needs
-per-tenant behavior reads the request's vhost id (the server name) and
-decides itself.
+per-tenant behavior reads the request's canonical site key (`req.vhost_id()`,
+`None` for a host that matched no vhost) and decides itself. Its KV state is
+already per-tenant by default — see
+[KV scope](#kv-scope-per-tenant-by-default).
 
 Loading is **fail-fast**: a builtin whose `init` rejects its config, a
 library that can't be found, a missing ABI symbol, or a dynamic module
@@ -406,9 +408,17 @@ and reads it; a truthy value serves the holding page. **Fail-open by
 design:** a KV blip means CONTINUE, so a transient hiccup can't black-hole
 every tenant. Never use it as an access-control gate.
 
+`<vhost>` is the request's **canonical site key** — the vhost directory name,
+not the `Host` header — so one flag covers every name that resolves to that
+tenant (`blog`, `blog.localhost`, `BLOG.`). The key is read from that vhost's
+own KV keyspace, which is the keyspace the site's PHP and its RESP credential
+already use, so `ephpm_kv_set('mw:maintenance:blog', 1)` from the site's own
+code flips it. A request that matched no vhost reads the single
+`mw:maintenance:_UNMATCHED` flag in the process-global store.
+
 | key | default | meaning |
 |-----|---------|---------|
-| `key_template` (string) | `"mw:maintenance:<vhost>"` | KV key checked per request; `<vhost>` is substituted |
+| `key_template` (string) | `"mw:maintenance:<vhost>"` | KV key checked per request; `<vhost>` is substituted with the canonical site key |
 | `retry_after` (integer seconds) | `300` | `Retry-After` header on the 503 |
 | `body` (string) | built-in minimal HTML | holding-page body |
 | `content_type` (string) | `"text/html; charset=utf-8"` | holding-page `Content-Type` |
@@ -565,6 +575,38 @@ host.log(ephpm_middleware::abi::LOG_INFO, "hello from middleware");
 The KV operations hit the same embedded store PHP sees through
 `ephpm_kv_*` — replicated across the cluster when clustering is enabled.
 
+#### KV scope: per-tenant by default
+
+`kv_get`/`kv_set`/`kv_set_nx`/`kv_incr`/`kv_incr_ttl` resolve **the keyspace of
+the vhost serving the current request**. On a multi-tenant node
+(`[server] sites_dir`) that is the site's own store — a physically separate
+map, not a key prefix — and it is the *same* store that vhost's PHP reaches
+through `ephpm_kv_set()`. Two consequences worth designing around:
+
+- A counter, session, or flag your module writes is **per tenant** already.
+  You do not need to prefix keys with the vhost, and one tenant's traffic
+  cannot spend another tenant's budget.
+- A module and the PHP app it fronts can **share a key**. Writing
+  `ephpm_kv_set('revoked:'.$id, 1)` from PHP is visible to the module's
+  `kv_get` on the next request, with no bridging.
+
+For state that is genuinely node-scoped there are `kv_*_global` variants
+(`host.kv_get_global(...)`, ABI minor 3), which always resolve the
+process-wide store:
+
+```rust
+// Operator-owned config: written out of band, readable here, and NOT
+// writable by any tenant's PHP — which is the point.
+let policy = host.kv_get_global("operator:policy");
+// A deliberately node-wide edge counter, one budget for the whole node:
+let n = host.kv_incr_ttl_global("edge:rl:global", 1, 60);
+```
+
+Single-site nodes have exactly one store, so the two sets are the same thing
+there and nothing changes. A request whose `Host` matched **no** vhost has no
+tenant identity and gets the process-global store; bucket such requests under
+`ephpm_middleware::UNMATCHED_VHOST` rather than keying on the header.
+
 The `Request` also exposes the connection and (optional) body:
 
 ```rust
@@ -586,10 +628,36 @@ fn invoke(&self, req: &Request<'_>) -> Response {
 ```
 
 `req.scheme()` returns `"http"`/`"https"`, `req.http_host()` the normalized
-`Host` (port/trailing-dot stripped, lowercased — distinct from
-`req.vhost_id()`, the raw server name), and `req.body()` the bounded buffered
-body. Against an older host that predates these (ABI minor < 2) they fall back
-to `"http"` / `false` / `""` rather than reading past a shorter table.
+`Host` (port/trailing-dot stripped, lowercased), and `req.body()` the bounded
+buffered body. Against an older host that predates these (ABI minor < 2) they
+fall back to `"http"` / `false` / `""` rather than reading past a shorter table.
+
+#### `vhost_id()` is the tenant identity; `http_host()` is not
+
+`req.vhost_id()` returns `Option<&str>`: the **canonical site key** the router
+resolved — the same identity that selects the request's per-site database, KV
+keyspace and OPcache vhost. It is normalized by the router, not by the header,
+so `Site.Example`, `site.example:8080` and `site.example.` all yield one key,
+and a configured `sites_domain_suffix` is already stripped.
+
+`None` means the request matched **no** known virtual host. That is a decision,
+not a missing value: ePHPm serves unrecognised hosts from the default document
+root, so `http_host()` there is arbitrary client input. Use `None` to fail
+closed, or bucket it under `ephpm_middleware::UNMATCHED_VHOST` — never
+substitute the header, or a caller gets a fresh keyspace (and a fresh rate-limit
+budget) per `Host` value they invent.
+
+```rust
+// Fail closed: no tenant, no policy.
+let Some(site) = req.vhost_id() else {
+    return Response::respond(404, "unknown host");
+};
+let creds = host.kv_get_global(&format!("basicauth:{site}"));
+```
+
+Reach for `http_host()` only when you genuinely want the host as sent — a
+canonical-host redirect, a log line — never as a lookup key for per-tenant
+policy.
 
 ### Building modules on Linux
 
@@ -634,7 +702,7 @@ int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
                                          ephpm_response_edit_t* edit_out);
 ```
 
-- `abi_version` is `0x01_00_00_02` — major **1**, minor **2**. The **major
+- `abi_version` is `0x01_00_00_03` — major **1**, minor **3**. The **major
   byte** gates compatibility; modules must refuse to init (return non-zero)
   when the host's major is newer than they were built for. The lower three
   bytes are an additive **minor** level: growth (new host-table fields, the
@@ -642,7 +710,18 @@ int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
   major-1 modules keep loading. A module that uses a newer field must check
   the host's advertised minor (`host->abi_version & 0x00FFFFFF`) first —
   minor **1** added the response phase, minor **2** the appended request
-  accessors (`request_scheme`/`request_is_secure`/`request_host`).
+  accessors (`request_scheme`/`request_is_secure`/`request_host`), minor
+  **3** the appended process-global KV slots (`kv_get_global` and its four
+  siblings).
+- **Minor 3 also redefined two existing surfaces** (issues #390 and #376).
+  Both are no-ops on a single-site node; on a multi-tenant node:
+  `request_vhost_id` returns the canonical site key and **NULL** for an
+  unmatched host, where it used to return the raw `Host`; and the `kv_*`
+  slots resolve the request's per-vhost keyspace, where they used to always
+  hit the process-global store. A module relying on node-wide `kv_*` state
+  should move those calls to the matching `kv_*_global` slot; anything
+  per-tenant should stay put and simply becomes isolated. Keys built from
+  the vhost id change name once, at upgrade.
 - `config_json` is the mount's `config` table serialised to JSON (NULL when
   the mount has no config).
 - The host callback table is passed **by pointer at `init`** and is valid
@@ -650,10 +729,13 @@ int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
   would need `-rdynamic` on Linux and has no clean Windows analogue). It
   contains request accessors (method, path, query, remote IP, header
   lookup, vhost id, and — minor 2 — scheme/`is_secure`, normalized host, and
-  the bounded buffered body), the KV operations (`kv_get`/`kv_set`/
-  `kv_set_nx`/`kv_incr`/`kv_incr_ttl`/`kv_free`), `log`, and — for the
+  the bounded buffered body), the request-scoped KV operations (`kv_get`/
+  `kv_set`/`kv_set_nx`/`kv_incr`/`kv_incr_ttl`/`kv_free`), `log`, — for the
   response phase (minor 1) — the response accessors (`response_status`/
-  `response_headers`/`response_body`).
+  `response_headers`/`response_body`), and — minor 3 — the process-global KV
+  operations (`kv_get_global`/`kv_set_global`/`kv_set_nx_global`/
+  `kv_incr_global`/`kv_incr_ttl_global`; `kv_free` is shared, since it frees
+  the allocation rather than touching a store).
 - The request pointer is only valid during `invoke`; never store it.
   Everything a module writes into `response_out` must stay valid until its
   `invoke` returns — the host copies before unwinding. The same rule applies

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -414,7 +414,12 @@ tenant (`blog`, `blog.localhost`, `BLOG.`). The key is read from that vhost's
 own KV keyspace, which is the keyspace the site's PHP and its RESP credential
 already use, so `ephpm_kv_set('mw:maintenance:blog', 1)` from the site's own
 code flips it. A request that matched no vhost reads the single
-`mw:maintenance:_UNMATCHED` flag in the process-global store.
+`mw:maintenance:_UNMATCHED` flag in the process-global store — and note that
+**on a single-site node no vhost is ever matched**, so the key there is always
+`mw:maintenance:_UNMATCHED`, not the server name. Upgrading a single-site
+deployment from ≤ minor 2 therefore renames its flag from
+`mw:maintenance:<Host>` to `mw:maintenance:_UNMATCHED`; an active maintenance
+flag must be re-set under the new name or the site quietly comes back up.
 
 | key | default | meaning |
 |-----|---------|---------|
@@ -647,6 +652,14 @@ closed, or bucket it under `ephpm_middleware::UNMATCHED_VHOST` — never
 substitute the header, or a caller gets a fresh keyspace (and a fresh rate-limit
 budget) per `Host` value they invent.
 
+**`None` is the normal case on a single-site node**, not an edge case. With
+neither `sites_dir` nor any `[[site]]` configured there are no vhosts to match,
+so `vhost_id()` is `None` on every request. Handle it as "one tenant", not as
+an error — the stock modules bucket it under `UNMATCHED_VHOST`, which is why a
+single-site `maintenance-mode` flag lives at `mw:maintenance:_UNMATCHED`. (C
+modules get a raw NULL here and **must** null-check; Rust's `Option` makes it a
+compile error.)
+
 ```rust
 // Fail closed: no tenant, no policy.
 let Some(site) = req.vhost_id() else {
@@ -713,15 +726,27 @@ int32_t ephpm_middleware_invoke_response(const ephpm_request_t* request,
   accessors (`request_scheme`/`request_is_secure`/`request_host`), minor
   **3** the appended process-global KV slots (`kv_get_global` and its four
   siblings).
-- **Minor 3 also redefined two existing surfaces** (issues #390 and #376).
-  Both are no-ops on a single-site node; on a multi-tenant node:
-  `request_vhost_id` returns the canonical site key and **NULL** for an
-  unmatched host, where it used to return the raw `Host`; and the `kv_*`
-  slots resolve the request's per-vhost keyspace, where they used to always
-  hit the process-global store. A module relying on node-wide `kv_*` state
-  should move those calls to the matching `kv_*_global` slot; anything
-  per-tenant should stay put and simply becomes isolated. Keys built from
-  the vhost id change name once, at upgrade.
+- **Minor 3 also redefined two existing surfaces** (issues #390 and #376), and
+  the two have *different* blast radii — do not read them as one bullet:
+  - `request_vhost_id` changes on **every** node. It returns the canonical
+    site key, and **NULL** when no vhost matched, where it used to return the
+    raw `Host` and was never NULL. A **single-site node matches no vhost at
+    all**, so on that shape — the most common one — it now returns NULL on
+    *every* request. **C modules must null-check it**: a
+    `strcmp(host->request_vhost_id(req), …)` that was safe against every
+    prior minor segfaults now. Rust modules get a compile error instead,
+    since the safe wrapper returns `Option<&str>`. Use `request_host` if what
+    you actually wanted was the host as sent.
+  - The `kv_*` slots change **only on a multi-tenant node**, where they now
+    resolve the request's per-vhost keyspace instead of always hitting the
+    process-global store. A module relying on node-wide `kv_*` state should
+    move those calls to the matching `kv_*_global` slot; anything per-tenant
+    should stay put and simply becomes isolated. On a single-site node there
+    is one store and this half really is a no-op.
+
+  Keys built from the vhost id change name once, at upgrade — on a single-site
+  node to whatever the module substitutes for "no tenant" (the stock modules
+  use `UNMATCHED_VHOST`).
 - `config_json` is the mount's `config` table serialised to JSON (NULL when
   the mount has no config).
 - The host callback table is passed **by pointer at `init`** and is valid

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -357,6 +357,12 @@ ephpm_kv_get("cache:page:home");
 
 Keys are stored exactly as PHP sends them — no prefixes, no munging. The isolation is physical, not logical. A site's store is a completely separate data structure.
 
+### Native middleware sees the same per-site store
+
+A mounted [native middleware](/guides/native-middleware/)'s `kv_get`/`kv_set`/`kv_incr_ttl` resolve the **serving vhost's** store too — the same `Arc<Store>` that vhost's PHP reaches. So a rate limiter is per-tenant without prefixing anything, and a module can read a key the site's own PHP wrote. Which vhost is decided by the canonical site key the router resolved, never re-derived from the `Host` header, so it always agrees with the database file and the RESP credential.
+
+A request whose `Host` matched no vhost has no tenant identity and falls back to the process-global store rather than minting a keyspace from the header. Middleware that genuinely needs node-wide state — operator-owned config a tenant must not be able to rewrite — uses the explicit `kv_*_global` accessors (ABI minor 3).
+
 ### Per-Site Memory Limits
 
 Each site store has its own memory limit and eviction policy. One site filling its cache doesn't evict another site's data:

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -85,7 +85,7 @@ Knobs that were *removed* but are still honoured for upgrades — `[db.sqlite.sq
 |-----|------|---------|-------------|
 | `enabled` | bool | `false` | Cache PHP-emitted ETags in the KV store; serve 304s without re-running PHP. |
 | `ttl_secs` | i64 | `300` | TTL for cached entries. `<=0` means cache indefinitely. |
-| `key_prefix` | string | `"etag:"` | KV key prefix for cached entries. |
+| `key_prefix` | string | `"etag:"` | KV key prefix for cached entries. Full key is `{prefix}{site}:{method}:{path}?{query}`, where `{site}` is the request's canonical site key (empty for a host matching no vhost — i.e. always empty on a single-site node). |
 
 ### `[server.security]`
 


### PR DESCRIPTION
> ## Read this first — three downstream consequences
>
> This PR is correctness-only in behaviour, but it changes three things people
> outside this repo can feel. Nothing here is accidental; each is argued below.
>
> **1. Middleware ABI minor 2 → 3, and two existing surfaces changed *meaning*.**
> The slots and their signatures are unchanged, so every major-1 module still
> loads — it just gets different semantics, silently. The two redefinitions have
> **different blast radii**:
>
> - **`request_vhost_id` changes on every node, including single-site.** It
>   returns the canonical site key, and **NULL** when no vhost matched, where it
>   used to return the raw `Host` and was never NULL. A single-site node matches
>   no vhost at all (`resolve_site` short-circuits to `key: None` when neither
>   `sites_dir` nor any `[[site]]` is set), so **on that shape it returns NULL on
>   every request**. **C modules must null-check it** — a
>   `strcmp(host->request_vhost_id(req), …)` that was safe against every prior
>   minor segfaults now. Rust modules get a compile error instead (see #2).
> - **The `kv_*` callbacks change only on a multi-tenant node**, where they now
>   resolve the request's per-vhost keyspace instead of the process-global store.
>   A module that deliberately wanted node-wide KV state must move those calls to
>   the new `kv_*_global` slots. On a single-site node there is one store and
>   this half is a genuine no-op.
>
> *(An earlier revision of this PR claimed both were no-ops on a single-site
> node. That was wrong for `request_vhost_id`, caught in review, and corrected
> in `2d49ec6` — the same wrong sentence appeared in the two `abi.rs` migration
> docs and the guide's C ABI section, which is precisely where a C author would
> have read it and skipped the null check.)*
>
> **2. Source-level break for out-of-tree Rust modules:**
> `Request::vhost_id()` returns `Option<&str>` instead of `&str`. One line at
> each call site:
>
> ```rust
> // bucket unmatched hosts together (rate limiters, counters):
> let site = req.vhost_id().unwrap_or(ephpm_middleware::UNMATCHED_VHOST);
> // or fail closed (auth gates — the reason this is an Option at all):
> let Some(site) = req.vhost_id() else { return Response::respond(404, "unknown host") };
> ```
>
> I chose this over returning `""` for an unmatched host deliberately: an empty
> tenant key that a module will happily use as a lookup key is *the exact bug
> class* #390 is about. Making it unrepresentable is the fix. Happy to be
> overruled — the fallback is a two-line change.
>
> **3. `maintenance-mode` KV keys are renamed on upgrade — on every node.** The
> default template `mw:maintenance:<vhost>` now substitutes the canonical site
> key. Multi-tenant: `mw:maintenance:blog.localhost` → `mw:maintenance:blog`
> (one flag per tenant instead of one per spelling). **Single-site: →
> `mw:maintenance:_UNMATCHED`**, since no vhost is ever matched there — this is
> the case an operator is most likely to have deployed and least likely to
> expect. **An operator with a maintenance flag set at upgrade time will find
> the site quietly comes back up** and must re-set the flag under the new name.
> (Same shape, lower stakes, for the PHP ETag cache: entries are renamed,
> orphaned rather than served, and expire on their TTL — except indefinite-TTL
> deployments, which should clear the old `etag:GET:...` keys once.)
>
> **Worth weighing on the other side:** #390 fixes a live rate-limit bypass.
> `ratelimit` keyed its budget on the raw `Host`, so a caller could reset their
> own budget just by varying the header — and under `maintenance-mode` /
> `basic-auth`-style lookups, a `Host` differing only in letter case missed its
> entry entirely.

---

Three multi-tenant correctness bugs, one root cause: a per-tenant value that
was **not** derived from the canonical site key `Router::resolve_site` returns.
CLAUDE.md's "one canonical site key" invariant says the agreement between a
tenant's database file, temp/session root, wire credential, KV keyspace and
OPcache vhost "is a property of one function rather than of four call sites
that happen to agree today." These were the three call sites that didn't.

Closes #366
Closes #390
Closes #376

---

## #366 — PHP ETag cache key had no site component (security-relevant)

**Root cause.** `php_etag_cache_key` built `{prefix}{method}:{path}?{query}`
and stored it in the **process-wide** KV store. On a multi-tenant node
`tenant-a.example/index.php` and `tenant-b.example/index.php` normalize to one
key — and that key decides a `304`, so tenant A's content hash could answer
tenant B's `If-None-Match`.

**Fix.** The key is now `{prefix}{site}:{method}:{path}?{query}`, with `{site}`
taken from the already-resolved `ResolvedSite.key` (in scope at both call
sites — no plumbing needed). Same model as `opcache:version:<vhost>`: global
store, tenant baked into the key.

A host that matched no vhost renders as the **empty** site component
(`etag::GET:/x`). Empty is deliberate rather than a `_default`-style sentinel:
`is_valid_site_key("")` is false, so the unmatched-host bucket is unspellable
and cannot collide with a named site — whereas a real vhost directory *can* be
called `_default`.

**Cache-key surface audit** (the issue asked for the whole surface, not just
the reported one):

| surface | site-scoped? | where |
|---|---|---|
| PHP ETag cache key | **was not — fixed here** | `router.rs` `php_etag_cache_key` |
| OPcache vhost key | already, from the canonical key | `opcache_vhost_key` |
| PHP userland KV | already | `SiteIdentities::kv` |
| `FileCache` (DashMap) | implicitly — keyed by absolute FS path under the site's docroot | `file_cache.rs` |
| static-file ETag *values* | N/A — content/mtime derived, not path derived, and no shared keyspace | `static_files.rs`, `file_cache.rs` |

**Isolation test.** The ETag key joined `Derivations` in
`router::tests::site_key_agreement`, so it is now covered by the existing
every-spelling-agrees and distinct-sites-stay-distinct guards. Plus
`site_key_agreement::etag_cache_key_isolates_two_sites_on_the_same_path`: two
vhosts on the identical method+path never collide, an unmatched host lands in
the unspellable bucket, and every legal spelling of one tenant still shares its
own entry (or the cache would simply never hit).

Also fixed a stale doc claim found on the way: `architecture/http.md` said the
ETag cache is "enabled by default". It is `enabled = false`.

---

## #390 — `request_vhost_id` returned the raw `Host` header

**Root cause.** The accessor returned `Host` with only the port stripped:
un-normalized, client-controlled, and never NULL. Two distinct problems, both
called out in the issue:

1. `Site.Example` and `site.example` read as two tenants. Three separate
   middlewares had each re-normalized it locally, one of them with an auth
   bypass reachable by changing a letter's case.
2. Normalizing isn't sufficient. For a host that matched no vhost the value is
   arbitrary client input, and a module could not tell "tenant `foo`" from
   "someone sent `Host: foo`" — exactly the distinction an authorization
   decision needs.

**Fix.** `request_vhost_id` returns the canonical site key, and **NULL** (not
`""`) when no vhost matched, so a gate can fail closed. `RequestCtx::new`'s
fifth parameter is now the site key (empty = no site), threaded from
`ResolvedSite.key` at all three chain-invoking call sites — the PHP path, the
static request phase, and the response phase. The normalized request host stays
available, unchanged, as `request_host`, now documented as explicitly *not* a
tenant identity.

**Downstream workarounds.** The three modules named in the issue (#387/#388/
#389) are out-of-tree, so there was nothing in-tree to delete. Both in-tree
consumers were fixed to use the canonical key.

**`ratelimit` security fix, included here.** A `Host`-keyed budget could be
reset by varying the header. Unmatched hosts now share one
`ephpm_middleware::UNMATCHED_VHOST` bucket — a sentinel that is uppercase and
therefore unspellable as a site key, since the router lowercases before
matching and `is_valid_site_key` accepts only `[a-z0-9._-]`.

**Isolation tests.** `host::tests::unmatched_host_has_no_vhost_identity`
(matched → `Some(key)`, unmatched → `None`, and the raw C accessor returns a
genuine NULL); `vhost_id_and_http_host_stay_distinct`; and the dlopen
round-trip test now asserts the NULL survives the real C boundary as `<none>`.

`site/content/guides/native-middleware.md` gains a "`vhost_id()` is the tenant
identity; `http_host()` is not" section with the fail-closed pattern.

---

## #376 — middleware KV callbacks were process-global

**Root cause.** `KV_STORE: OnceLock<Arc<Store>>` in
`ephpm-middleware/src/host.rs`, bound once at startup and never rebound per
request, while PHP's `ephpm_kv_*` is rebound to the vhost's store on every
request. Two lanes, scoped differently by construction. As the issue notes this
is **not** a disclosure bug (site stores are physically separate `DashMap`s, so
middleware holding the global store cannot reach a tenant's keys) — it is
capability and surprise: a PHP-driven revocation demo works single-site and
silently does nothing multi-site, and a rate limiter shares one budget across
every tenant.

**Fix.** The `kv_*` slots resolve the serving vhost's store — the same
`Arc<Store>` `MultiTenantStore` hands the PHP bridge — so middleware and PHP
meet on a key by default and tenants are isolated by default.

The KV slots take no `EphpmRequest*` and changing that would break the ABI, so
the store is bound by an **RAII thread-local scope** entered around each
synchronous chain invocation, mirroring `ephpm_php::kv_bridge`'s per-thread
site store. The guard restores the previous value on drop, so a pooled tokio
worker cannot carry one tenant's scope into the next request it picks up. It is
never held across an `.await`.

**One deliberate divergence from `SiteIdentities::kv`.** A request that matched
no vhost gets the process-global store, where PHP's `kv` identity instead falls
back to the normalized `Host`. Reason: the chain runs on *every* request,
static files included, and site stores are created lazily and never evicted —
minting a keyspace per `Host` value there is a cheap way to grow the site map
without bound. Documented at the derivation site.

### Escape hatch — interaction with #384

**#384 is not implemented here, and is not designed out — it is made
implementable.** Its premise is that operator-owned middleware state must live
where no tenant's PHP can rewrite it, which is exactly the process-global
store. So the global store stays reachable, now *explicitly*: five appended
slots (`kv_get_global`, `kv_set_global`, `kv_set_nx_global`, `kv_incr_global`,
`kv_incr_ttl_global`, ABI minor 3) always resolve it, minor-gated in the safe
wrapper so a minor-3 module never reads past a minor-2 host's shorter table.
That keeps a node-wide edge rate limiter expressible and keeps #384's per-site
credential map readable; #384 still needs its RESP/CLI *write* path.

**Isolation tests.**

- `host::tests::two_sites_never_share_a_middleware_kv_key` — two sites, one key
  name, no read/write bleed either way, nothing leaking to global, and each
  site's counter starting from zero (the rate-limiter case).
- `host::tests::the_site_scope_does_not_outlive_its_guard` — the pooled-thread
  hazard.
- `host::tests::nested_scopes_restore_the_outer_store`.
- `host::tests::global_kv_reaches_the_process_store_from_inside_a_site_scope` —
  the #384 escape hatch, including that a tenant writing the same key name
  shadows nothing.
- `host::tests::minor_gate_hides_global_kv_on_an_older_host`.
- `router::tests::middleware_kv_scope::*` — store *selection*: each site gets
  its own store and it is the same `Arc` PHP gets; every spelling of one tenant
  resolves one store; an unmatched host mints nothing (`site_count() == 0`);
  single-site mode never overrides.
- `router::tests::middleware_kv_scope::the_router_enters_the_site_scope_around_the_chain`
  — the one that proves the fix is *wired*, not merely correct in isolation: it
  drives the real builtin `ratelimit` module through `static_request_phase` for
  two vhosts and reads the counters back out of each tenant's own store.

---

## Overlap with in-flight work

`crates/ephpm-server/src/router.rs` is touched by all three fixes; edits were
kept surgical. Known concurrent work and where this brushes against it:

- **#443** (`ephpm-php` WorkerPool/FpmPool + server pool plumbing) — no overlap;
  nothing here touches the pools.
- **#444** (router `/_ephpm/*` internal-route dispatch) — no overlap; the
  changes here are in `handle_inner`'s vhost/ETag path, `handle_php`'s chain
  block, and the two middleware-phase helpers.
- **#435** (router static-file **response-phase** tests) — closest. This PR
  changes the *signatures* of `static_request_phase` and `run_response_phase`
  (both gain a `site_key: Option<&str>` parameter before `server_name`) and adds
  `router::tests::middleware_kv_scope`. Whichever lands second needs a trivial
  rebase on those two signatures.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test --workspace` — clean (stub mode, no `PHP_SDK_PATH`)
