### PR TITLE
fix(opcache): unspellable sentinel vhosts (#450); test: pin the remaining middleware KV scope sites (#451)

### DIFF
--- a/crates/ephpm-e2e/tests/opcache_invalidation.rs
+++ b/crates/ephpm-e2e/tests/opcache_invalidation.rs
@@ -3,9 +3,10 @@
 //! Validates the watcher end-to-end:
 //!   1. PRE — warm the OPcache by hitting `opcache_status.php` (warming
 //!      probe) and confirming the target file is cached.
-//!   2. Trigger — write `opcache:version:_default` (single-node) or
-//!      `opcache:version:_all` (cluster) via the RESP listener so the watcher
-//!      fires on the next request.
+//!   2. Trigger — write `opcache:version:_DEFAULT` (single-node) or
+//!      `opcache:version:_ALL` (cluster) via the RESP listener so the watcher
+//!      fires on the next request. Both sentinels are uppercase so no vhost
+//!      directory can claim them (issue #450).
 //!   3. POST — hit `opcache_status.php?warm=0` (cold probe). The request
 //!      trips the watcher BEFORE the probe script runs, so the probe must
 //!      see the target genuinely dropped (`opcache_is_script_cached` =
@@ -39,9 +40,9 @@ use tokio::net::TcpStream;
 /// KV key prefix — must match `ephpm-server::opcache::KV_VERSION_PREFIX`.
 const OPCACHE_VERSION_PREFIX: &str = "opcache:version:";
 /// Broadcast vhost — must match `ephpm-server::opcache::BROADCAST_VHOST`.
-const OPCACHE_BROADCAST_VHOST: &str = "_all";
+const OPCACHE_BROADCAST_VHOST: &str = "_ALL";
 /// Default vhost — must match `ephpm-server::opcache::DEFAULT_VHOST`.
-const OPCACHE_DEFAULT_VHOST: &str = "_default";
+const OPCACHE_DEFAULT_VHOST: &str = "_DEFAULT";
 
 fn cluster_env(name: &str) -> Option<String> {
     std::env::var(name).ok()
@@ -367,8 +368,10 @@ mod helper_tests {
     // workspace and needs to compile without the server's dep tree).
     #[test]
     fn constants_documented() {
-        assert_eq!(OPCACHE_DEFAULT_VHOST, "_default");
-        assert_eq!(OPCACHE_BROADCAST_VHOST, "_all");
+        // Uppercase is load-bearing, not cosmetic: it is what makes these two
+        // buckets unspellable as `sites_dir` directory names (issue #450).
+        assert_eq!(OPCACHE_DEFAULT_VHOST, "_DEFAULT");
+        assert_eq!(OPCACHE_BROADCAST_VHOST, "_ALL");
         assert_eq!(OPCACHE_VERSION_PREFIX, "opcache:version:");
         assert!(required_env_documented());
     }

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -269,6 +269,37 @@ impl MiddlewareChain {
         Ok(Self { modules, php })
     }
 
+    /// Test-only: mount one in-process module directly, bypassing the
+    /// `library`-name registry in [`builtin`].
+    ///
+    /// [`MiddlewareChain::load`] can only reach the ten shipped modules, and
+    /// none of them touches the KV store in its **response** phase — so there
+    /// is otherwise no way to write a test that observes whether the router
+    /// entered the per-vhost KV scope around `run_response_phase` (issue
+    /// #451). This is the same construction `middleware.rs`'s own response
+    /// tests do inline; exposing it `pub(crate)` lets `router.rs` drive the
+    /// whole request through [`Router::handle`](crate::router::Router::handle)
+    /// with a probe mounted, rather than asserting on internals.
+    ///
+    /// `#[cfg(test)]` on purpose: a runtime registration hook would be a way
+    /// for a mount to name a module the registry deliberately does not ship.
+    #[cfg(test)]
+    pub(crate) fn with_test_response_module<T: ephpm_middleware::ResponseMiddleware>(
+        name: &str,
+        config: &serde_json::Value,
+    ) -> Self {
+        Self {
+            modules: vec![Loaded {
+                name: name.to_owned(),
+                match_pattern: None,
+                backend: Backend::Builtin(
+                    BuiltinModule::init_response::<T>(config).expect("test module init"),
+                ),
+            }],
+            php: Vec::new(),
+        }
+    }
+
     /// The `php:` mounts whose `match` glob accepts `path`, in chain order.
     ///
     /// Empty for every request when no `php:` mount is configured, which is the

--- a/crates/ephpm-server/src/opcache.rs
+++ b/crates/ephpm-server/src/opcache.rs
@@ -9,6 +9,30 @@
 //!
 //! Design: `site/content/roadmap/opcache-clustering.md` (Phase 1).
 //!
+//! # Sentinel names
+//!
+//! Two vhost names in this key space are not vhosts: [`DEFAULT_VHOST`] (the
+//! default document root, and every `Host` that matched no site) and
+//! [`BROADCAST_VHOST`] (`ephpm deploy --all`). Both are **uppercase**, which
+//! makes them unspellable as a site key — the router lowercases every `Host`
+//! before matching, `ephpm deploy --site` lowercases its argument, and
+//! `router::is_valid_site_key` accepts only `[a-z0-9._-]`. So no `sites_dir`
+//! directory, and no operator flag, can name either bucket.
+//!
+//! That is the fix for issue #450. The old spellings (`_default`, `_all`) were
+//! both legal vhost directory names, and the `_default` collision was a
+//! correctness bug rather than cosmetics: a tenant site called `_default` and
+//! the default document root shared one `SiteOpcacheState`, so whichever of
+//! the two saw a new version first advanced the shared counter and the other
+//! never invalidated at all — a deploy silently dropped, stale bytecode served.
+//! (`_all` only ever over-invalidated: it shares the broadcast KV key but not
+//! a state entry. Closed with the same rule so "a sentinel is unspellable" is
+//! one invariant rather than a per-name judgement.)
+//!
+//! The `router::is_valid_site_key` side of the invariant is asserted in this
+//! module's tests, so weakening either half fails a test rather than silently
+//! reopening the collision.
+//!
 //! # Concurrency
 //!
 //! - Fast path is one atomic load + one `DashMap::get` — sub-microsecond, no
@@ -38,8 +62,13 @@ use ephpm_kv::store::Store;
 pub const KV_VERSION_PREFIX: &str = "opcache:version:";
 
 /// The fallback vhost name for `[server] document_root` when no `sites_dir` is
-/// configured, or when the CLI runs `ephpm cache reset` without `--site`.
-pub const DEFAULT_VHOST: &str = "_default";
+/// configured, for a `Host` that matched no known vhost, or when the CLI runs
+/// `ephpm cache reset` without `--site`.
+///
+/// **Uppercase on purpose** — see the module's "Sentinel names" note. This was
+/// `_default` until issue #450, which is a name a `sites_dir` directory can
+/// legally have.
+pub const DEFAULT_VHOST: &str = "_DEFAULT";
 
 /// Broadcast key written by `ephpm deploy --all`. When present, the watcher
 /// treats it as a "cluster-wide invalidate every vhost" event and folds its
@@ -47,7 +76,10 @@ pub const DEFAULT_VHOST: &str = "_default";
 /// single-write cover every site without requiring the CLI to enumerate
 /// them — a brand-new site whose per-vhost key has never been written still
 /// picks up the broadcast on its first request.
-pub const BROADCAST_VHOST: &str = "_all";
+///
+/// **Uppercase on purpose** — see the module's "Sentinel names" note. This was
+/// `_all` until issue #450.
+pub const BROADCAST_VHOST: &str = "_ALL";
 
 /// What triggered an invalidation. Used as a Prometheus label.
 ///
@@ -114,9 +146,14 @@ pub enum Decision {
 /// dispatch.
 #[derive(Clone, Debug)]
 pub struct OpcacheWatcher {
-    /// Per-vhost state keyed by the lowercased vhost name. `DashMap` for
+    /// Per-vhost state keyed by the canonical site key (already lowercase),
+    /// or by [`DEFAULT_VHOST`] for a request with no site. `DashMap` for
     /// lock-free reads on the hot path; new entries are inserted lazily on
     /// first sight of a vhost.
+    ///
+    /// Two names sharing an entry means they share `last_invalidated_version`,
+    /// and one of them will miss a deploy — which is why the sentinel must not
+    /// be spellable as a site key (issue #450).
     sites: Arc<DashMap<String, Arc<SiteOpcacheState>>>,
     /// Whether cluster invalidation is enabled. When `false`,
     /// [`OpcacheWatcher::check`] short-circuits to [`Decision::NoOp`] before
@@ -396,9 +433,72 @@ mod tests {
         }
     }
 
+    /// Issue #450. Neither sentinel may be a name a `sites_dir` directory can
+    /// have, or a tenant shares an invalidation keyspace with a bucket that is
+    /// not a tenant.
+    ///
+    /// For `DEFAULT_VHOST` that sharing is a *correctness* bug, not just
+    /// noise: the entry in `sites` carries `last_invalidated_version`, so the
+    /// site and the default docroot would take turns swallowing each other's
+    /// deploys (`missing_the_deploy_when_a_sentinel_is_spellable` below shows
+    /// the exact mechanism).
+    ///
+    /// This asserts the invariant, not the spelling — an author is free to
+    /// pick a different unspellable sentinel, and free to change
+    /// `is_valid_site_key`, as long as the two keep disagreeing.
+    #[test]
+    fn sentinel_vhosts_are_unspellable_as_site_keys() {
+        for sentinel in [DEFAULT_VHOST, BROADCAST_VHOST] {
+            assert!(
+                !crate::router::is_valid_site_key(sentinel),
+                "`{sentinel}` is a legal sites_dir directory name — a tenant could claim this \
+                 OPcache bucket (issue #450)"
+            );
+        }
+        assert_ne!(DEFAULT_VHOST, BROADCAST_VHOST);
+        // The old spellings are exactly what a vhost directory may be called;
+        // this is the property the fix turned around.
+        for old in ["_default", "_all"] {
+            assert!(crate::router::is_valid_site_key(old));
+        }
+    }
+
+    /// The mechanism #450 closes, demonstrated on the watcher itself: two
+    /// names that collapse to one key take turns swallowing each other's
+    /// deploys, because they share one `last_invalidated_version`.
+    ///
+    /// Written against a deliberately-collided pair rather than against
+    /// `DEFAULT_VHOST`, so it keeps documenting *why* the sentinel must stay
+    /// unspellable even after the sentinel itself is safe.
+    #[test]
+    fn a_shared_vhost_key_swallows_the_second_deploy() {
+        let store = store();
+        let watcher = OpcacheWatcher::new(true);
+        write_version(&store, "collide", 100);
+
+        // The default docroot's request sees the deploy and invalidates.
+        let Decision::Invalidate { version } = watcher.check(&store, "collide") else {
+            panic!("expected Invalidate");
+        };
+        watcher.mark_invalidated(
+            "collide",
+            &PathBuf::from("/srv/default"),
+            version,
+            InvalidationTrigger::Kv,
+            |_| Some(1),
+        );
+
+        // The tenant that happens to share the key now gets NOTHING for the
+        // very same deploy — its docroot keeps serving stale bytecode.
+        assert!(
+            matches!(watcher.check(&store, "collide"), Decision::NoOp),
+            "a shared vhost key means the second docroot never invalidates — issue #450"
+        );
+    }
+
     #[test]
     fn broadcast_key_triggers_all_vhosts() {
-        // ephpm deploy --all writes opcache:version:_all. Every vhost that
+        // ephpm deploy --all writes the broadcast key. Every vhost that
         // has never had a per-vhost key still picks up the broadcast on its
         // first check.
         let store = store();

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -10468,6 +10468,218 @@ echo "post response";
             assert_eq!(count_in(&global, "shop"), None);
             assert_eq!(count_in(&global, "blog"), None);
         }
+
+        // ── the other two chain call sites, and the argument (#451) ────────
+        //
+        // `the_router_enters_the_site_scope_around_the_chain` above pins ONE
+        // of the three places the router enters the scope, and pins it by
+        // calling `static_request_phase` with a site key the test supplies.
+        // Deleting `enter_site_kv` at the `handle_php` call site or the
+        // response-phase call site failed no test, and nothing checked that
+        // `handle_inner` passes `resolved.key` rather than `server_name` — a
+        // swap that would restore #390 with every other test green. The tests
+        // below close both holes, and each fails on a single-line revert.
+
+        /// A probe that stamps the KV store in **both** middleware phases,
+        /// keyed by the tenant identity the chain was handed and the request
+        /// path: `mw:probe:<phase>:<vhost>:<path>`.
+        ///
+        /// One key makes two separate things observable. **Which store** the
+        /// router scoped the chain to — the key lands there and nowhere else —
+        /// and **which value** the router passed as the site key, since the
+        /// key is named after it. No shipped module writes KV in the response
+        /// phase, so a probe is also the only way to reach that call site at
+        /// all; hence `MiddlewareChain::with_test_response_module`.
+        struct KvScopeProbe;
+
+        fn stamp(req: &ephpm_middleware::Request<'_>, phase: &str) {
+            let vhost = req.vhost_id().unwrap_or(ephpm_middleware::UNMATCHED_VHOST);
+            // Deliberately not asserted here: a panic inside a module is
+            // caught by the chain and turned into a 500, so it would never
+            // surface as a test failure. The absent key is what the caller
+            // asserts on.
+            let _ = req.host().kv_set(&format!("mw:probe:{phase}:{vhost}:{}", req.path()), b"1", 0);
+        }
+
+        impl ephpm_middleware::Middleware for KvScopeProbe {
+            fn init(_config: &serde_json::Value) -> Result<Self, String> {
+                Ok(Self)
+            }
+
+            fn invoke(&self, req: &ephpm_middleware::Request<'_>) -> ephpm_middleware::Response {
+                stamp(req, "req");
+                ephpm_middleware::Response::cont()
+            }
+        }
+
+        impl ephpm_middleware::ResponseMiddleware for KvScopeProbe {
+            fn invoke_response(
+                &self,
+                req: &ephpm_middleware::Request<'_>,
+                _resp: &mut ephpm_middleware::ResponseView<'_>,
+            ) {
+                stamp(req, "resp");
+            }
+        }
+
+        /// A multi-tenant router with [`KvScopeProbe`] mounted.
+        ///
+        /// The fixture's `sites_domain_suffix = ".local"` is what lets these
+        /// tests tell `resolved.key` from `server_name` at all: `Host:
+        /// shop.local` has key `shop` and server name `shop.local`, so a swap
+        /// renames the probe's key instead of being invisible.
+        fn probe_router(
+            dir: &Path,
+            sites: &Path,
+        ) -> (Router, Arc<Store>, ephpm_kv::multi_tenant::MultiTenantStore) {
+            let (router, global, mt) = multi_tenant_router(dir, sites);
+            let chain = crate::middleware::MiddlewareChain::with_test_response_module::<KvScopeProbe>(
+                "kv-scope-probe",
+                &serde_json::Value::Null,
+            );
+            (router.with_middleware_chain(Some(Arc::new(chain))), global, mt)
+        }
+
+        /// Two tenants, each with a PHP entrypoint and a static asset.
+        fn probe_sites(dir: &Path) -> PathBuf {
+            let sites = dir.join("sites");
+            for name in ["shop", "blog"] {
+                fs::create_dir_all(sites.join(name)).unwrap();
+                fs::write(sites.join(name).join("index.php"), b"<?php echo 1;").unwrap();
+                fs::write(sites.join(name).join("a.css"), b"body{}").unwrap();
+            }
+            sites
+        }
+
+        fn probe_addr() -> SocketAddr {
+            "198.51.100.30:5000".parse().unwrap()
+        }
+
+        /// Issue #451(1): the chain that runs on the **PHP** path — the common
+        /// one — must run inside this vhost's KV scope.
+        ///
+        /// Driven through `handle` rather than `handle_php` so `handle_inner`'s
+        /// choice of argument is on the hook too: the key is named `shop`,
+        /// which is `resolved.key`, not `shop.local`, which is `server_name`.
+        /// (Stub mode answers the PHP request with a 500 or a stub 200 — the
+        /// chain has already run either way, which is the point.)
+        #[tokio::test]
+        async fn the_php_path_enters_the_site_scope_around_the_chain() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = probe_sites(dir.path());
+            let (router, global, mt) = probe_router(dir.path(), &sites);
+
+            let _ = router
+                .handle(get_with_host("/index.php", "shop.local"), probe_addr(), false)
+                .await
+                .unwrap();
+
+            let shop = mt.get_site_store("shop");
+            assert!(
+                shop.get("mw:probe:req:shop:/index.php").is_some(),
+                "the PHP path's chain must run inside this vhost's KV scope, keyed by the \
+                 canonical site key — issue #451"
+            );
+            assert!(
+                shop.get("mw:probe:resp:shop:/index.php").is_some(),
+                "the response phase must run inside this vhost's KV scope too — issue #451"
+            );
+            // Nothing else — in particular nothing named after the request
+            // host, which is what a `server_name` argument would produce.
+            let mut got = shop.keys("mw:probe:*");
+            got.sort();
+            assert_eq!(
+                got,
+                vec![
+                    "mw:probe:req:shop:/index.php".to_string(),
+                    "mw:probe:resp:shop:/index.php".to_string(),
+                ]
+            );
+            assert!(
+                global.keys("mw:probe:*").is_empty(),
+                "a tenant's middleware state must not land in the process-global store"
+            );
+        }
+
+        /// Issue #451(1), response phase on the **static** path: the same
+        /// guarantee for the one call site no shipped module can reach.
+        ///
+        /// The sibling test above pins `static_request_phase` when called
+        /// directly with a supplied site key; this drives it the way
+        /// `handle_inner` does, and adds the response phase behind it.
+        #[tokio::test]
+        async fn the_static_path_enters_the_site_scope_in_both_phases() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = probe_sites(dir.path());
+            let (router, global, mt) = probe_router(dir.path(), &sites);
+
+            let resp = router
+                .handle(get_with_host("/a.css", "shop.local"), probe_addr(), false)
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "the probe must not have blocked the file");
+
+            let shop = mt.get_site_store("shop");
+            assert!(
+                shop.get("mw:probe:req:shop:/a.css").is_some(),
+                "the static request phase must run inside this vhost's KV scope — issue #451"
+            );
+            assert!(
+                shop.get("mw:probe:resp:shop:/a.css").is_some(),
+                "the response phase must run inside this vhost's KV scope — issue #451"
+            );
+            assert!(
+                global.keys("mw:probe:*").is_empty(),
+                "a tenant's middleware state must not land in the process-global store"
+            );
+        }
+
+        /// Issue #451(2), stated on its own: **every** chain call site is told
+        /// the canonical site key, never the request host.
+        ///
+        /// Swapping `resolved.key` back to `server_name` at any one of the
+        /// three call sites leaves the rest of this module passing, because
+        /// nothing else inspects a value where the two differ. Here they do:
+        /// `Host: shop.local` resolves to key `shop`, so a swap both renames
+        /// every probe key and — since the same value picks the store — moves
+        /// it into a keyspace minted from the header. That is #390 restored.
+        #[tokio::test]
+        async fn every_chain_call_site_is_told_the_canonical_key_not_the_host() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = probe_sites(dir.path());
+            let (router, _global, mt) = probe_router(dir.path(), &sites);
+
+            for (host, key) in [("shop.local", "shop"), ("blog.local", "blog")] {
+                for path in ["/a.css", "/index.php"] {
+                    let _ = router
+                        .handle(get_with_host(path, host), probe_addr(), false)
+                        .await
+                        .unwrap();
+                }
+                let store = mt.get_site_store(key);
+                let mut got = store.keys("mw:probe:*");
+                got.sort();
+                assert_eq!(
+                    got,
+                    vec![
+                        format!("mw:probe:req:{key}:/a.css"),
+                        format!("mw:probe:req:{key}:/index.php"),
+                        format!("mw:probe:resp:{key}:/a.css"),
+                        format!("mw:probe:resp:{key}:/index.php"),
+                    ],
+                    "`Host: {host}` must reach the chain as tenant `{key}` — at every call site, \
+                     and in {key}'s own store — issues #390/#451"
+                );
+            }
+
+            // ...and the host spelling never became a tenant of its own.
+            for spelling in ["shop.local", "blog.local"] {
+                assert!(
+                    mt.get_site_store(spelling).keys("mw:probe:*").is_empty(),
+                    "`{spelling}` must not have minted its own middleware keyspace"
+                );
+            }
+        }
     }
 
     // ── streaming compression (worker send_response_stream) ────────

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -4871,10 +4871,18 @@ pub(crate) fn normalize_host_key(host: &str) -> String {
 /// that vhost's names (`blog`, `blog.localhost`, `BLOG.`) the client used.
 ///
 /// A host that names no known site has no deployable identity, so it maps to
-/// [`crate::opcache::DEFAULT_VHOST`] (`_default`, the default document root)
-/// rather than to a key invented from the header. That also keeps the
-/// invalidation key space bounded by the site fleet instead of by what a client
-/// can type.
+/// [`crate::opcache::DEFAULT_VHOST`] (the default document root) rather than to
+/// a key invented from the header. That also keeps the invalidation key space
+/// bounded by the site fleet instead of by what a client can type.
+///
+/// That sentinel is **uppercase**, which is what stops it from colliding with a
+/// real tenant (issue #450) — the same "unspellable bucket" property the PHP
+/// ETag cache key gets from its empty site component, in the form this key
+/// needs. Empty would work for a key the operator never sees; this one is a
+/// Prometheus label, a log field, and the value `ephpm deploy` writes with no
+/// `--site`, so it has to stay readable. [`is_valid_site_key`] rejects
+/// uppercase and the router lowercases every `Host`, so no `sites_dir`
+/// directory can produce it.
 fn opcache_vhost_key(site_key: Option<&str>) -> String {
     site_key.map_or_else(|| crate::opcache::DEFAULT_VHOST.to_string(), str::to_owned)
 }
@@ -10173,6 +10181,85 @@ echo "post response";
                     shop,
                     "`{spelling}` is the same tenant and must share its ETag cache entry"
                 );
+            }
+        }
+
+        /// Issue #450, stated directly: the OPcache vhost a tenant gets is
+        /// never the bucket an unmatched host gets, **even for a tenant that
+        /// picked the sentinel's old name**.
+        ///
+        /// `_default` was a legal `sites_dir` directory name, so a site called
+        /// `_default` and the default document root landed on one key. They
+        /// then shared the watcher's `last_invalidated_version`, and whichever
+        /// of the two absorbed a deploy first left the other serving stale
+        /// bytecode — not merely a shared namespace, a dropped invalidation.
+        ///
+        /// Same shape as `etag_cache_key_isolates_two_sites_on_the_same_path`:
+        /// distinct tenants never collide, every spelling of one tenant always
+        /// does.
+        #[tokio::test]
+        async fn opcache_vhost_key_isolates_tenants_from_the_default_bucket() {
+            let dir = tempfile::tempdir().unwrap();
+            let sites = dir.path().join("sites");
+            let dbdir = dir.path().join("dbs");
+            // `_default` and `_all` are ordinary vhost names — that is the
+            // whole problem, so the fixture creates them as real tenants.
+            for name in ["shop", "blog", "_default", "_all"] {
+                fs::create_dir_all(sites.join(name)).unwrap();
+            }
+
+            let backends =
+                SiteBackends::new(dbdir.clone(), 8, stats(), tokio::runtime::Handle::current())
+                    .expect("registry");
+            let auth = SiteWireAuth::new(backends.clone()).expect("secret");
+            let router = router_with(dir.path(), &sites, &dbdir, Some(".local"), &auth);
+
+            let shop = derive(&router, &backends, "shop.local").opcache;
+            let blog = derive(&router, &backends, "blog.local").opcache;
+            let named_default = derive(&router, &backends, "_default.local").opcache;
+            let named_all = derive(&router, &backends, "_all.local").opcache;
+            let unmatched = derive(&router, &backends, "nobody.example.com").opcache;
+
+            assert_eq!(shop, "shop");
+            assert_eq!(blog, "blog");
+            // A tenant literally named `_default` keeps its own key...
+            assert_eq!(named_default, "_default");
+            assert_eq!(named_all, "_all");
+            // ...because the sentinel is not that name.
+            assert_eq!(unmatched, crate::opcache::DEFAULT_VHOST);
+            assert_ne!(
+                named_default, unmatched,
+                "a site named `_default` must not share the default docroot's OPcache \
+                 invalidation counter — issue #450"
+            );
+            assert_ne!(
+                named_all,
+                crate::opcache::BROADCAST_VHOST,
+                "a site named `_all` must not sit on the broadcast key — issue #450"
+            );
+            for (a, b) in [
+                (&shop, &blog),
+                (&shop, &unmatched),
+                (&blog, &named_default),
+                (&named_default, &named_all),
+            ] {
+                assert_ne!(a, b, "OPcache vhost keys must be pairwise distinct — #450");
+            }
+
+            // ...while every legal spelling of ONE tenant still shares its own
+            // key, or `ephpm deploy --site shop` would miss requests that
+            // arrived under a different spelling of the same vhost.
+            for spelling in ["shop", "shop.local", "SHOP.LOCAL", "shop.local:8080", "shop."] {
+                assert_eq!(
+                    derive(&router, &backends, spelling).opcache,
+                    shop,
+                    "`{spelling}` is the same tenant and must share its OPcache vhost"
+                );
+            }
+            // And every spelling of the unmatched bucket collapses to the one
+            // sentinel rather than minting a key per header value.
+            for host in ["nobody.example.com", "127.0.0.1:8080", "not-a-site"] {
+                assert_eq!(derive(&router, &backends, host).opcache, unmatched);
             }
         }
 

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -178,7 +178,7 @@ enum Commands {
 
     /// Deploy: invalidate the cluster-wide OPcache for one vhost, or every
     /// vhost via the broadcast key. Writes `opcache:version:<vhost>` (or
-    /// `opcache:version:_all`) via the running server's RESP listener; gossip
+    /// `opcache:version:_ALL`) via the running server's RESP listener; gossip
     /// replicates the write to every peer within seconds.
     ///
     /// Requires the running server to have `[kv.redis_compat] enabled = true`
@@ -188,7 +188,7 @@ enum Commands {
         #[arg(long, group = "target")]
         site: Option<String>,
 
-        /// Invalidate every vhost via the broadcast key (`opcache:version:_all`).
+        /// Invalidate every vhost via the broadcast key (`opcache:version:_ALL`).
         #[arg(long, group = "target")]
         all: bool,
 
@@ -1884,13 +1884,21 @@ async fn kv_ttl(host: &str, port: u16, auth: &KvAuth, key: &str) -> anyhow::Resu
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Vhost name used when neither `--site` nor `--all` is supplied. Mirrors the
-/// server-side `crate::opcache::DEFAULT_VHOST`; kept in-lockstep manually since
-/// the CLI does not depend on `ephpm-server`.
-const OPCACHE_DEFAULT_VHOST: &str = "_default";
+/// server-side `ephpm_server::opcache::DEFAULT_VHOST`; kept in-lockstep
+/// manually since the CLI does not depend on `ephpm-server`.
+///
+/// **Uppercase on purpose (issue #450).** [`resolve_target`] lowercases
+/// `--site`, and the server lowercases every `Host`, so neither an operator
+/// flag nor a `sites_dir` directory can reach this bucket — it is only ever
+/// written by *omitting* `--site`. Before the fix it was `_default`, which a
+/// tenant site could be named, and the two then shared one invalidation
+/// counter on the server.
+const OPCACHE_DEFAULT_VHOST: &str = "_DEFAULT";
 
 /// Broadcast vhost name written by `--all`. Kept in-lockstep with the
-/// server-side `crate::opcache::BROADCAST_VHOST`.
-const OPCACHE_BROADCAST_VHOST: &str = "_all";
+/// server-side `ephpm_server::opcache::BROADCAST_VHOST`. Uppercase for the
+/// same reason as [`OPCACHE_DEFAULT_VHOST`] (was `_all`).
+const OPCACHE_BROADCAST_VHOST: &str = "_ALL";
 
 /// KV key prefix for the per-vhost version counter.
 const OPCACHE_VERSION_PREFIX: &str = "opcache:version:";
@@ -2434,6 +2442,30 @@ mod cli_tests {
     #[test]
     fn resolve_target_rejects_empty_site() {
         assert!(resolve_target(Some("   "), false).is_err());
+    }
+
+    /// Issue #450, CLI half: `--site` lowercases, so no value an operator can
+    /// type reaches a sentinel bucket. That is what makes the uppercase
+    /// sentinels unreachable from *both* directions — the server refuses to
+    /// derive them from a `Host`, and the CLI refuses to spell them.
+    ///
+    /// Also pins that a site genuinely *named* `_default` or `_all` now
+    /// targets itself, which is the behaviour the collision used to steal.
+    #[test]
+    fn no_site_flag_can_name_a_sentinel_bucket() {
+        for spelling in ["_DEFAULT", "_default", "_ALL", "_all", "_Default"] {
+            let target = resolve_target(Some(spelling), false).unwrap();
+            assert_ne!(
+                target, OPCACHE_DEFAULT_VHOST,
+                "`--site {spelling}` must not reach the default bucket — issue #450"
+            );
+            assert_ne!(
+                target, OPCACHE_BROADCAST_VHOST,
+                "`--site {spelling}` must not reach the broadcast bucket — issue #450"
+            );
+        }
+        assert_eq!(resolve_target(Some("_default"), false).unwrap(), "_default");
+        assert_eq!(resolve_target(Some("_all"), false).unwrap(), "_all");
     }
 
     #[test]

--- a/site/content/reference/cli/deploy.md
+++ b/site/content/reference/cli/deploy.md
@@ -4,7 +4,7 @@ weight = 4
 +++
 
 Trigger a cluster-wide OPcache invalidation. The command writes
-`opcache:version:<vhost>` (or the broadcast key `opcache:version:_all`)
+`opcache:version:<vhost>` (or the broadcast key `opcache:version:_ALL`)
 to the running server's RESP listener; gossip replicates the write to
 every peer within seconds, and each node's watcher invalidates its
 OPcache under the vhost's docroot on the next PHP request.
@@ -29,8 +29,18 @@ ephpm deploy                 [--rev SHA] [--host HOST] [--port PORT] [--password
 | `--port` | `6379` | RESP server port |
 | `--password` | `$EPHPM_KV_PASSWORD` | Password sent as RESP `AUTH` before the write. Required when the server sets `[kv.redis_compat] password`. See [`ephpm kv`](/reference/cli/kv/#authentication) for the two auth modes and the per-site HMAC limitation. |
 
-Neither `--site` nor `--all` means "the default vhost" (`_default`),
-which is what a single-node deployment with no `sites_dir` uses.
+Neither `--site` nor `--all` means "the default vhost" (`_DEFAULT`),
+which is what a single-node deployment with no `sites_dir` uses — and
+what any `Host` that matches no configured vhost falls back to.
+
+The two sentinel names, `_DEFAULT` and `_ALL`, are **uppercase on
+purpose**. `--site` lowercases its argument and the server lowercases
+every `Host`, so neither a flag nor a `sites_dir` directory can name
+either bucket. A site literally called `_default` therefore gets its
+own invalidation counter, as any other site does. (Through v0.8.8 these
+were spelled `_default`/`_all`; a script that writes those keys with a
+raw RESP client must be updated. `ephpm deploy` and `ephpm cache reset`
+need no change.)
 
 The running server must have `[kv.redis_compat] enabled = true`; the
 CLI is a separate process from the server, so it cannot poke the

--- a/site/content/roadmap/opcache-clustering.md
+++ b/site/content/roadmap/opcache-clustering.md
@@ -101,8 +101,19 @@ When the value changes (any nondecreasing comparison; absolute value
 doesn't matter), every node treats it as a deploy event for that
 vhost.
 
-For the default `document_root` (no vhost), the key is
-`opcache:version:_default`.
+For the default `document_root` (and for any `Host` that matched no
+configured vhost), the key is `opcache:version:_DEFAULT`.
+
+Both sentinel names — `_DEFAULT` here and `_ALL` for the broadcast key
+below — are uppercase on purpose, and that is load-bearing rather than
+stylistic. A vhost directory name is lowercase by construction (the
+router lowercases every `Host`, and `is_valid_site_key` accepts only
+`[a-z0-9._-]`), so an uppercase sentinel is a name no tenant can claim.
+With the earlier lowercase spelling a site literally called `_default`
+shared the default docroot's entry — including its
+`last_invalidated_version` — so whichever of the two saw a deploy first
+advanced the shared counter and the other never invalidated at all.
+Issue #450.
 
 #### Why a version key rather than tombstones
 
@@ -173,7 +184,7 @@ ephpm deploy --site blog
 # for observability; doesn't affect invalidation logic)
 ephpm deploy --site blog --rev a8f13d2
 
-# Invalidate every vhost via the broadcast key opcache:version:_all
+# Invalidate every vhost via the broadcast key opcache:version:_ALL
 ephpm deploy --all
 
 # Same reset, named for a non-deploy context. Wire-identical to `deploy`

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -85,9 +85,9 @@ const ISOLATED_DB_SUITES: &[&str] = &[
 ///
 /// `opcache_invalidation` needs `[opcache] cluster_invalidation = true` (off by
 /// default in single-node mode) AND a config where the default document_root
-/// request resolves to the `_default` OPcache vhost -- which means NOT setting
+/// request resolves to the `_DEFAULT` OPcache vhost -- which means NOT setting
 /// `sites_dir` (with a sites_dir configured, the vhost key becomes the request
-/// host `127.0.0.1`, not `_default`, and the test's `opcache:version:_default`
+/// host `127.0.0.1`, not `_DEFAULT`, and the test's `opcache:version:_DEFAULT`
 /// write would never match). See `SingleNodeOptions`.
 /// `rate_limit` is the one suite that *wants* to be throttled: it fires a burst
 /// and asserts a 429. Sharing a token bucket with every other suite made both
@@ -1064,8 +1064,8 @@ struct SingleNodeOptions {
     ///    can run on a `sites_dir` node.
     ///
     /// It also moves the OPcache vhost key for a `127.0.0.1` request from
-    /// `_default` to the request host, which is why `opcache_invalidation`
-    /// (which writes `opcache:version:_default`) must not have it.
+    /// `_DEFAULT` to the request host, which is why `opcache_invalidation`
+    /// (which writes `opcache:version:_DEFAULT`) must not have it.
     with_sites_dir: bool,
     /// Emit `[opcache] cluster_invalidation = true`. Off by default in
     /// single-node mode, so the opcache_invalidation suite needs it turned on
@@ -1181,7 +1181,7 @@ impl SingleNodeOptions {
         let slug = format!("single-{name}");
         match name {
             // opcache_invalidation: enable the watcher, drop sites_dir so the
-            // default docroot resolves to the `_default` OPcache vhost.
+            // default docroot resolves to the `_DEFAULT` OPcache vhost.
             "opcache_invalidation" => Self {
                 slug,
                 with_sites_dir: false,


### PR DESCRIPTION
Two follow-ups from #448's review, both about the same theme: a per-tenant
value that a tenant could reach when it shouldn't, and tests that would not
have noticed.

Closes #450
Closes #451

---

## #450 — the OPcache sentinel vhosts were spellable site keys

`opcache_vhost_key` mapped a `Host` that matched no vhost to `_default`, and
`ephpm deploy --all` writes `_all`. Both are legal `sites_dir` directory
names, so a tenant could be named either one.

**Approach chosen: (a) — a component that cannot collide with any valid site
key, in the uppercase form #448 itself introduced.**

The issue offered (a) an unspellable component, preferably the empty one, or
(b) rejecting `_default` as a site directory name at startup. (a) is right —
it needs no operator action — but the *empty* component does not fit this
particular key. The ETag cache key can be empty because nothing reads it; the
OPcache vhost is a Prometheus label (`ephpm_opcache_invalidations_total{vhost=…}`),
a `tracing` field, and the value `ephpm deploy` writes when `--site` is
omitted. `vhost=""` is legal Prometheus and unreadable in a dashboard.

So this uses #448's *other* unspellable-bucket form — the one that PR added
in `ephpm_middleware::UNMATCHED_VHOST` for exactly the case where a readable
non-empty value is wanted: **uppercase**. `_DEFAULT` and `_ALL` are
unreachable from both directions. The router lowercases every `Host` and
`is_valid_site_key` accepts only `[a-z0-9._-]`, so no vhost directory can
produce them; `resolve_target` lowercases `--site`, so no operator flag can
either. Only the two constants write them. A site genuinely called `_default`
now gets its own counter, which is what the collision used to steal.

**Why `_default` was a correctness bug and not a namespace nit.** The
watcher's per-vhost `DashMap` entry carries `last_invalidated_version`, so a
tenant named `_default` and the default document root shared one counter:
whichever absorbed a deploy first advanced it, and the other never
invalidated at all — a deploy silently dropped, stale bytecode served, every
health check green. `a_shared_vhost_key_swallows_the_second_deploy` pins that
mechanism directly so it keeps documenting *why* the rule exists.

**`_all` is included, and it is a smaller problem — say so if you'd rather it
weren't.** It shares the broadcast KV key but *not* a state entry, so its
only effect is over-invalidation: `ephpm deploy --site _all` would flush every
tenant's OPcache. Closed with the same rule so "a sentinel is unspellable" is
one testable invariant rather than a per-name judgement. Dropping it is a
one-line change if you disagree.

**Operator-visible.** A script poking `opcache:version:_default` or
`opcache:version:_all` through a raw RESP client must switch to the uppercase
keys — the roadmap page documented those raw keys, so it is a real break.
`ephpm deploy` and `ephpm cache reset` need no change. Docs updated in
`reference/cli/deploy.md` and `roadmap/opcache-clustering.md`.

`Derivations` in `router::tests::site_key_agreement` already carried the
opcache key (#448 added the ETag one beside it), so this adds the two-site
isolation test in the same shape as
`etag_cache_key_isolates_two_sites_on_the_same_path` — with real `_default`
and `_all` tenants in the fixture.

## #451 — the two unpinned KV-scope call sites, and the argument

#448 wired the per-vhost KV scope at three places and pinned one.
`the_router_enters_the_site_scope_around_the_chain` drove
`static_request_phase` directly with a site key the test supplied. Deleting
`enter_site_kv` at the `handle_php` call site or the response-phase call site
failed no test, and nothing asserted that `handle_inner` passes
`resolved.key` rather than `server_name`.

Three tests, all driven through `Router::handle` so `handle_inner`'s choice
of argument is exercised rather than supplied:

| test | pins |
|---|---|
| `the_php_path_enters_the_site_scope_around_the_chain` | `handle_php`'s chain call + the response phase behind it |
| `the_static_path_enters_the_site_scope_in_both_phases` | `static_request_phase` as `handle_inner` calls it + the response phase |
| `every_chain_call_site_is_told_the_canonical_key_not_the_host` | the argument, at all three sites, for two tenants |

They read the effect out of the KV store through a probe module that stamps
`mw:probe:<phase>:<vhost>:<path>` in both phases. One key carries both facts:
**which store** the chain was scoped to (the key lands there and nowhere
else) and **which value** was passed as the site key (the key is named after
it). The fixture sets `sites_domain_suffix = ".local"`, so `Host: shop.local`
has key `shop` and server name `shop.local` — the existing two-site tests
survive a swap precisely because nothing they assert on distinguishes those.

No shipped module writes KV in the response phase, so that call site was
unreachable from a `library`-name mount at all.
`MiddlewareChain::with_test_response_module` (`#[cfg(test)]`, `pub(crate)`)
mounts an in-process module directly — the same construction `middleware.rs`'s
own response-phase tests already do inline. Deliberately *not* a runtime
registration hook: that would be a way for a real mount to name a module the
registry does not ship.

### Revert verification

Every test here was verified by actually making the revert, watching it fail,
then restoring — the diff is purely additive, confirmed by `git diff --stat`.

| # | revert | tests that failed |
|---|---|---|
| 1 | drop `enter_site_kv` at `handle_php` | php, argument |
| 2 | drop `enter_site_kv` in `static_request_phase` | static, argument, **and #448's** |
| 3 | drop `enter_site_kv` in `run_response_phase` | php, static, argument |
| 4 | `handle_inner` → `static_request_phase` given `&host` | static, argument |
| 5 | `handle_inner` → `run_response_phase` given `&host` | php, static, argument |
| 6 | `handle_php`'s `RequestCtx::new` given `&server_name` | php, argument |

Revert 6 is the sharpest: the probe key comes back reading
`mw:probe:req:shop.local:/index.php` — literally #390's shape.

For #450, the same treatment: flipping `DEFAULT_VHOST` back to `_default`
fails `sentinel_vhosts_are_unspellable_as_site_keys` and
`opcache_vhost_key_isolates_tenants_from_the_default_bucket`; flipping
`BROADCAST_VHOST` back to `_all` fails the same two; flipping the CLI's
`OPCACHE_DEFAULT_VHOST` fails `no_site_flag_can_name_a_sentinel_bucket`.

## Checks

`cargo test --workspace` green (exit 0, incl. the dlopen suites after
`cargo build --workspace --lib --examples`), `cargo clippy --workspace
--all-targets -- -D warnings` clean, `cargo +nightly fmt --all -- --check`
clean. Stub mode throughout (no `PHP_SDK_PATH`).

## Overlap

Rebased on `main` at 691e6fe (#448). Both commits touch `router.rs`; the #450
hunk is `opcache_vhost_key`'s doc comment plus a test in `site_key_agreement`,
and the #451 hunk is entirely new tests in `middleware_kv_scope` — so #446's
internal-route namespace work and any #435 test-infra churn should merge
around them, but shout if you'd rather I rebase again on top of those.
