### PR TITLE
perf(php): eliminate per-request $_SERVER rebuild (#133) and response-header round-trip (#134)

### DIFF
--- a/.claude/agent-memory/ephpm-systems-architect/MEMORY.md
+++ b/.claude/agent-memory/ephpm-systems-architect/MEMORY.md
@@ -5,3 +5,4 @@
 - [Windows per-request chdir costs ~55us](windows-chdir-per-request-cost.md) — never add a cwd save/restore to the request path unmeasured; measure with a no-op version to split fixed from variable cost
 - [Shared target dir replays stale rlibs](shared-target-stale-fingerprint.md) — "method not found" on a symbol you just added is a cache lie; touch the file, never `cargo clean`
 - [Windows PHP-linked local builds](windows-php-linked-local-build.md) — vcvars64 + LIBCLANG_PATH + 8.5.7 SDK; test binaries need `/FORCE:MULTIPLE`; CI only `cargo check`s this lane
+- [WSL linked builds + benchmarking](wsl-linked-build-and-bench.md) — /mnt/c worktree + /root/ephpm-target; php_middleware SIGSEGV is pre-existing on Linux SDK; interleave min-of-N on this noisy box

--- a/.claude/agent-memory/ephpm-systems-architect/wsl-linked-build-and-bench.md
+++ b/.claude/agent-memory/ephpm-systems-architect/wsl-linked-build-and-bench.md
@@ -1,0 +1,42 @@
+---
+name: wsl-linked-build-and-bench
+description: How to build/run php_linked tests from the Windows worktree inside WSL, the pre-existing php_middleware SIGSEGV on the Linux 8.5.7 SDK, and how to benchmark on this noisy shared box
+metadata:
+  type: reference
+---
+
+Building `php_linked` code on this Windows box is easiest via WSL Ubuntu —
+no vcvars64/LIBCLANG/FORCE:MULTIPLE dance (that is the Windows-native lane,
+see [[windows-php-linked-local-build]]):
+
+```
+wsl -d Ubuntu -u root -- bash -lc 'cd /mnt/c/Users/luther/ephpm/<worktree> \
+  && export CARGO_TARGET_DIR=/root/ephpm-target \
+     PHP_SDK_PATH=/mnt/c/Users/luther/ephpm/php-sdk/8.5.7-linux-x86_64-gnu \
+  && cargo test -p ephpm-php --release --test <name> -- --test-threads=1'
+```
+
+- Work from the /mnt/c worktree; do NOT create another /root/<task>-src
+  checkout (there are already ~40 of them wasting disk).
+- Git operations on a Windows-created worktree must run from the Windows
+  side (`.git` file holds a Windows gitdir path WSL git can't resolve);
+  WSL only builds/runs.
+- Quoting: `wsl -- bash -lc '...'` from PowerShell mangles `$(...)` and
+  nested double quotes. Put anything non-trivial in a .sh file on /mnt/c
+  and run `wsl -- bash /mnt/c/.../script.sh`.
+
+**Pre-existing crash:** `cargo test -p ephpm-php --test php_middleware` on
+the Linux 8.5.7 SDK SIGSEGVs on the FIRST test (verified on a clean
+baseline commit, 2026-09-02) — same category as the sessions.rs failures on
+Windows. Do not attribute it to your branch; `tests/perf_linked.rs` and
+`tests/response_headers.rs` run fine in the same harness, and
+`cargo xtask e2e` against the release binary is the reliable functional
+gate.
+
+**Benchmarking on this box:** other agents' builds/containers create load
+spikes (observed 42us -> 166us on the same binary minutes apart). Never
+compare two sequential builds' single runs. Stash each build's test binary
+(`/root/perf-<tag>`, delete after), interleave runs round-robin, and take
+min-of-N per build. Useful anchors (release, no OPcache, Linux, 2026-09):
+trivial fpm request ≈ 42us baseline; $_SERVER Rust-side build+CString
+conversion ≈ 4.4-6.1us before #133, ≈ 1.1-2.1us after.

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -611,7 +611,12 @@ static void capture_one_header(const char *name, size_t name_len,
     s->value_off = headers_buf_len;
     s->value_len = value_len;
     headers_buf_append(value, value_len);
-    hdr_span_count++;
+    /* headers_buf_append fails silently on OOM; commit the span only if both
+     * appends really landed, so a span can never claim bytes the buffer does
+     * not hold (the Rust side trusts these lengths). */
+    if (headers_buf_len == s->name_off + name_len + value_len) {
+        hdr_span_count++;
+    }
 }
 
 /* Split one raw "Name: Value" header line (the shape PHP stores in

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -144,7 +144,9 @@ static EPHPM_TLS char *output_buf = NULL;
 static EPHPM_TLS size_t output_len = 0;
 static EPHPM_TLS size_t output_cap = 0;
 
-/* Response header buffer — "Name: Value\n" lines after script execution */
+/* Response header capture — name/value bytes land here back-to-back after
+ * script execution; the hdr_spans array (defined with the capture helpers
+ * below) records where each header's name and value live (issue #134). */
 
 static EPHPM_TLS char *headers_buf = NULL;
 static EPHPM_TLS size_t headers_buf_len = 0;
@@ -558,7 +560,12 @@ static void ephpm_sapi_log_message(const char *message, int syslog_type_int)
  * Capture response headers from PHP's SAPI globals into our buffer.
  * Must be called after script execution, while the request is still active.
  *
- * Headers are stored as "Name: Value\n" lines for Rust to parse.
+ * Issue #134: headers used to be flattened into "Name: Value\n" text that
+ * Rust then re-parsed line by line. They are now captured pre-split: the
+ * name and value bytes go into the reusable headers_buf back-to-back, and a
+ * parallel span array records where each one lives, so the Rust side reads
+ * (ptr, len) pairs via ephpm_get_response_header() with no re-parsing (and
+ * no framing to corrupt).
  */
 static void headers_buf_append(const char *data, size_t len)
 {
@@ -573,9 +580,66 @@ static void headers_buf_append(const char *data, size_t len)
     headers_buf_len += len;
 }
 
+/* One captured response header: offsets into headers_buf (offsets, not
+ * pointers, because headers_buf can realloc while the capture runs). */
+typedef struct {
+    size_t name_off;
+    size_t name_len;
+    size_t value_off;
+    size_t value_len;
+} ephpm_hdr_span;
+
+static EPHPM_TLS ephpm_hdr_span *hdr_spans = NULL;
+static EPHPM_TLS size_t hdr_span_count = 0;
+static EPHPM_TLS size_t hdr_span_cap = 0;
+
+/* Copy one (name, value) pair into headers_buf and record its span. */
+static void capture_one_header(const char *name, size_t name_len,
+                               const char *value, size_t value_len)
+{
+    if (hdr_span_count == hdr_span_cap) {
+        size_t new_cap = hdr_span_cap ? hdr_span_cap * 2 : 16;
+        ephpm_hdr_span *grown = realloc(hdr_spans, new_cap * sizeof(*grown));
+        if (!grown) return;
+        hdr_spans = grown;
+        hdr_span_cap = new_cap;
+    }
+    ephpm_hdr_span *s = &hdr_spans[hdr_span_count];
+    s->name_off = headers_buf_len;
+    s->name_len = name_len;
+    headers_buf_append(name, name_len);
+    s->value_off = headers_buf_len;
+    s->value_len = value_len;
+    headers_buf_append(value, value_len);
+    hdr_span_count++;
+}
+
+/* Split one raw "Name: Value" header line (the shape PHP stores in
+ * SG(sapi_headers).headers) and capture it. Splits on the first ':' and
+ * skips the customary space(s) after it. A line with no colon at all is
+ * dropped — the Rust side never accepted one anyway (it cannot become an
+ * HTTP header). Returns 1 if the line was a Content-Type header. */
+static int capture_split_header_line(const char *line, size_t len)
+{
+    const char *colon = memchr(line, ':', len);
+    if (!colon) {
+        return 0;
+    }
+    size_t name_len = (size_t)(colon - line);
+    const char *value = colon + 1;
+    size_t value_len = len - name_len - 1;
+    while (value_len > 0 && (*value == ' ' || *value == '\t')) {
+        value++;
+        value_len--;
+    }
+    capture_one_header(line, name_len, value, value_len);
+    return name_len == 12 && strncasecmp(line, "Content-Type", 12) == 0;
+}
+
 static void capture_response_headers(void)
 {
     headers_buf_len = 0;
+    hdr_span_count = 0;
     int has_content_type = 0;
 
     zend_llist_position pos;
@@ -583,15 +647,9 @@ static void capture_response_headers(void)
         zend_llist_get_first_ex(&SG(sapi_headers).headers, &pos);
 
     while (h) {
-        headers_buf_append(h->header, h->header_len);
-        headers_buf_append("\n", 1);
-
-        if (!has_content_type &&
-            h->header_len > 13 &&
-            strncasecmp(h->header, "Content-Type:", 13) == 0) {
+        if (capture_split_header_line(h->header, h->header_len)) {
             has_content_type = 1;
         }
-
         h = (sapi_header_struct *)
             zend_llist_get_next_ex(&SG(sapi_headers).headers, &pos);
     }
@@ -602,11 +660,9 @@ static void capture_response_headers(void)
      * or fall back to SG(default_mimetype) + SG(default_charset). */
     if (!has_content_type) {
         if (SG(sapi_headers).mimetype) {
-            const char *prefix = "Content-Type: ";
-            headers_buf_append(prefix, strlen(prefix));
-            headers_buf_append(SG(sapi_headers).mimetype,
+            capture_one_header("Content-Type", 12,
+                               SG(sapi_headers).mimetype,
                                strlen(SG(sapi_headers).mimetype));
-            headers_buf_append("\n", 1);
         } else {
             const char *mime = SG(default_mimetype);
             const char *charset = SG(default_charset);
@@ -615,13 +671,12 @@ static void capture_response_headers(void)
             int ct_len;
             if (charset && *charset) {
                 ct_len = snprintf(ct_buf, sizeof(ct_buf),
-                    "Content-Type: %s; charset=%s\n", mime, charset);
+                    "%s; charset=%s", mime, charset);
             } else {
-                ct_len = snprintf(ct_buf, sizeof(ct_buf),
-                    "Content-Type: %s\n", mime);
+                ct_len = snprintf(ct_buf, sizeof(ct_buf), "%s", mime);
             }
             if (ct_len > 0 && (size_t)ct_len < sizeof(ct_buf)) {
-                headers_buf_append(ct_buf, (size_t)ct_len);
+                capture_one_header("Content-Type", 12, ct_buf, (size_t)ct_len);
             }
         }
     }
@@ -723,6 +778,12 @@ void ephpm_thread_shutdown(void)
         headers_buf = NULL;
         headers_buf_len = 0;
         headers_buf_cap = 0;
+    }
+    if (hdr_spans) {
+        free(hdr_spans);
+        hdr_spans = NULL;
+        hdr_span_count = 0;
+        hdr_span_cap = 0;
     }
 
     /* Unregister from TSRM */
@@ -902,6 +963,7 @@ void ephpm_request_clear(void)
 {
     output_len = 0;
     headers_buf_len = 0;
+    hdr_span_count = 0;
     response_status_code = 200;
     req_method = NULL;
     req_uri = NULL;
@@ -1300,6 +1362,7 @@ int ephpm_execute_request(const char *filename)
      * the request body from the start. */
     output_len = 0;
     headers_buf_len = 0;
+    hdr_span_count = 0;
     req_post_data_offset = 0;
 
     /* Populate SG(request_info) BEFORE php_request_startup().
@@ -1567,14 +1630,33 @@ int ephpm_get_response_code(void)
 }
 
 /*
- * Get the captured response headers buffer.
- * Headers are stored as "Name: Value\n" lines.
- * Returns a pointer to the buffer and sets *out_len to the length.
+ * Number of response headers captured for the request just executed
+ * (issue #134 — structured access, replacing the "Name: Value\n" blob).
  */
-const char *ephpm_get_response_headers(size_t *out_len)
+size_t ephpm_get_response_header_count(void)
 {
-    *out_len = headers_buf_len;
-    return headers_buf;
+    return hdr_span_count;
+}
+
+/*
+ * Fetch one captured response header by index as (ptr, len) pairs pointing
+ * into the thread-local capture buffer. Valid until the next request is
+ * cleared/executed on this thread — the caller copies immediately.
+ * Returns 1 on success, 0 for an out-of-range index.
+ */
+int ephpm_get_response_header(size_t idx,
+                              const char **name, size_t *name_len,
+                              const char **value, size_t *value_len)
+{
+    if (idx >= hdr_span_count) {
+        return 0;
+    }
+    const ephpm_hdr_span *s = &hdr_spans[idx];
+    *name = headers_buf + s->name_off;
+    *name_len = s->name_len;
+    *value = headers_buf + s->value_off;
+    *value_len = s->value_len;
+    return 1;
 }
 
 /* ===================================================================
@@ -1918,9 +2000,15 @@ typedef struct {
     /* Block until the next request. On return: 1 = request available (req
      * filled), 0 = graceful shutdown (worker returns from its loop). */
     int (*take_request)(EphpmWorkerRequest *req);
-    /* Hand back the response. headers packed as "Name: Value\n" lines. */
+    /* Hand back the response. Headers pass as parallel (ptr, len) arrays —
+     * `count` entries each — valid for the duration of the call (issue #134;
+     * they used to be packed into "Name: Value\n" text that Rust re-parsed). */
     void (*send_response)(int status,
-                          const char *headers, size_t headers_len,
+                          const char *const *header_names,
+                          const size_t *header_name_lens,
+                          const char *const *header_values,
+                          const size_t *header_value_lens,
+                          size_t header_count,
                           const char *body, size_t body_len);
 
     /* ── Phase 3: streaming bodies ──────────────────────────────────
@@ -1933,11 +2021,15 @@ typedef struct {
      * body so the same read path works both ways. */
     long (*body_read)(char *buf, size_t cap);
 
-    /* Begin a streaming response: status + packed headers, no body yet. The
-     * hyper handler builds a streamed response body from the chunks that
-     * follow. */
+    /* Begin a streaming response: status + headers (same parallel-array
+     * shape as send_response), no body yet. The hyper handler builds a
+     * streamed response body from the chunks that follow. */
     void (*response_begin)(int status,
-                           const char *headers, size_t headers_len);
+                           const char *const *header_names,
+                           const size_t *header_name_lens,
+                           const char *const *header_values,
+                           const size_t *header_value_lens,
+                           size_t header_count);
     /* Push one response body chunk. Blocks on backpressure (bounded channel).
      * Returns 0 on success, negative if the client/receiver went away (the
      * worker should stop producing). */
@@ -1968,6 +2060,7 @@ void ephpm_worker_reset_request(void)
     /* Thread-local C capture buffers. */
     output_len = 0;
     headers_buf_len = 0;
+    hdr_span_count = 0;
 
     /* Drop headers emitted by the previous response so they don't accumulate
      * (fpm gets this free from php_request_shutdown). */
@@ -2322,23 +2415,70 @@ PHP_FUNCTION(ephpm_worker_take_request)
     }
 }
 
-/* Append one "Name: Value\n" line to the packed header buffer. */
-static void ephpm_worker_pack_header_line(smart_str *out, zend_string *key, zval *val)
+/* Flattened view of a PHP headers array as the parallel (ptr, len) arrays
+ * the worker ops take (issue #134 — replaces the "Name: Value\n" pack that
+ * the Rust side then re-parsed). Name pointers borrow the array's own
+ * zend_string keys; value pointers borrow zend_strings produced by
+ * zval_get_string, which `owned` keeps alive until ephpm_worker_hdrs_free.
+ * Everything is valid exactly for the duration of one ops callback. */
+typedef struct {
+    const char **names;
+    size_t      *name_lens;
+    const char **values;
+    size_t      *value_lens;
+    zend_string **owned;
+    size_t       count;
+} ephpm_worker_hdrs;
+
+/* Count the header lines an array will produce: one per string-keyed scalar,
+ * one per element of a string-keyed list (the multi-value header contract,
+ * e.g. ['Set-Cookie' => [$c1, $c2]] emits two Set-Cookie entries). */
+static size_t ephpm_worker_count_headers(zval *headers_arr)
 {
-    zend_string *vstr = zval_get_string(val);
-    smart_str_appendl(out, ZSTR_VAL(key), ZSTR_LEN(key));
-    smart_str_appendl(out, ": ", 2);
-    smart_str_appendl(out, ZSTR_VAL(vstr), ZSTR_LEN(vstr));
-    smart_str_appendc(out, '\n');
-    zend_string_release(vstr);
+    size_t n = 0;
+    zend_string *hkey;
+    zval *hval;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(headers_arr), hkey, hval) {
+        if (!hkey) {
+            continue; /* skip numeric keys */
+        }
+        ZVAL_DEREF(hval);
+        if (Z_TYPE_P(hval) == IS_ARRAY) {
+            n += zend_hash_num_elements(Z_ARRVAL_P(hval));
+        } else {
+            n++;
+        }
+    } ZEND_HASH_FOREACH_END();
+    return n;
 }
 
-/* Pack a PHP headers array into "Name: Value\n" lines. A list value packs one
- * line per element — the multi-value header contract (e.g.
- * ['Set-Cookie' => [$c1, $c2]] emits two Set-Cookie lines, which the Rust side
- * forwards as two distinct wire headers). Caller frees the smart_str. */
-static void ephpm_worker_pack_headers(smart_str *out, zval *headers_arr)
+static void ephpm_worker_hdrs_push(ephpm_worker_hdrs *out,
+                                   zend_string *key, zval *val)
 {
+    zend_string *vstr = zval_get_string(val);
+    out->names[out->count] = ZSTR_VAL(key);
+    out->name_lens[out->count] = ZSTR_LEN(key);
+    out->values[out->count] = ZSTR_VAL(vstr);
+    out->value_lens[out->count] = ZSTR_LEN(vstr);
+    out->owned[out->count] = vstr;
+    out->count++;
+}
+
+/* Build the flattened view. Caller must pair with ephpm_worker_hdrs_free
+ * after the ops callback returns. Zero headers => NULL arrays, count 0. */
+static void ephpm_worker_hdrs_build(ephpm_worker_hdrs *out, zval *headers_arr)
+{
+    memset(out, 0, sizeof(*out));
+    size_t cap = ephpm_worker_count_headers(headers_arr);
+    if (cap == 0) {
+        return;
+    }
+    out->names = emalloc(cap * sizeof(*out->names));
+    out->name_lens = emalloc(cap * sizeof(*out->name_lens));
+    out->values = emalloc(cap * sizeof(*out->values));
+    out->value_lens = emalloc(cap * sizeof(*out->value_lens));
+    out->owned = emalloc(cap * sizeof(*out->owned));
+
     zend_string *hkey;
     zval *hval;
     ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(headers_arr), hkey, hval) {
@@ -2349,22 +2489,37 @@ static void ephpm_worker_pack_headers(smart_str *out, zval *headers_arr)
         if (Z_TYPE_P(hval) == IS_ARRAY) {
             zval *item;
             ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(hval), item) {
+                if (out->count == cap) {
+                    break; /* array mutated under us — never overrun */
+                }
                 ZVAL_DEREF(item);
-                ephpm_worker_pack_header_line(out, hkey, item);
+                ephpm_worker_hdrs_push(out, hkey, item);
             } ZEND_HASH_FOREACH_END();
-        } else {
-            ephpm_worker_pack_header_line(out, hkey, hval);
+        } else if (out->count < cap) {
+            ephpm_worker_hdrs_push(out, hkey, hval);
         }
     } ZEND_HASH_FOREACH_END();
-    smart_str_0(out);
+}
+
+static void ephpm_worker_hdrs_free(ephpm_worker_hdrs *out)
+{
+    for (size_t i = 0; i < out->count; i++) {
+        zend_string_release(out->owned[i]);
+    }
+    if (out->names)      efree(out->names);
+    if (out->name_lens)  efree(out->name_lens);
+    if (out->values)     efree(out->values);
+    if (out->value_lens) efree(out->value_lens);
+    if (out->owned)      efree(out->owned);
+    memset(out, 0, sizeof(*out));
 }
 
 /* PHP_FUNCTION: \Ephpm\Worker\send_response(int, array, string): void
  *
  * Concatenates any captured output_buf (echo path) with the explicit $body,
- * packs the $headers array into "Name: Value\n" lines (list values become one
- * line per element), and hands both to the Rust send_response callback (which
- * fulfils the parked oneshot). */
+ * flattens the $headers array into parallel (ptr, len) arrays (list values
+ * become one entry per element), and hands both to the Rust send_response
+ * callback (which fulfils the parked oneshot). */
 PHP_FUNCTION(ephpm_worker_send_response)
 {
     zend_long status;
@@ -2382,26 +2537,28 @@ PHP_FUNCTION(ephpm_worker_send_response)
         return;
     }
 
-    smart_str hbuf = {0};
-    ephpm_worker_pack_headers(&hbuf, headers_arr);
+    ephpm_worker_hdrs hdrs;
+    ephpm_worker_hdrs_build(&hdrs, headers_arr);
 
     /* Concatenate captured echo output (if any) + explicit $body. */
-    const char *hdr_ptr = hbuf.s ? ZSTR_VAL(hbuf.s) : "";
-    size_t hdr_len = hbuf.s ? ZSTR_LEN(hbuf.s) : 0;
-
     if (output_len > 0) {
         smart_str bbuf = {0};
         smart_str_appendl(&bbuf, output_buf, output_len);
         smart_str_appendl(&bbuf, body, body_len);
         smart_str_0(&bbuf);
-        g_worker_ops.send_response((int)status, hdr_ptr, hdr_len,
+        g_worker_ops.send_response((int)status,
+                                   hdrs.names, hdrs.name_lens,
+                                   hdrs.values, hdrs.value_lens, hdrs.count,
                                    ZSTR_VAL(bbuf.s), ZSTR_LEN(bbuf.s));
         smart_str_free(&bbuf);
     } else {
-        g_worker_ops.send_response((int)status, hdr_ptr, hdr_len, body, body_len);
+        g_worker_ops.send_response((int)status,
+                                   hdrs.names, hdrs.name_lens,
+                                   hdrs.values, hdrs.value_lens, hdrs.count,
+                                   body, body_len);
     }
 
-    smart_str_free(&hbuf);
+    ephpm_worker_hdrs_free(&hdrs);
 
     /* Clear the captured output so it does not bleed into the next response
      * (the reset at the top of the next take_request also clears it, but this
@@ -2446,13 +2603,12 @@ PHP_FUNCTION(ephpm_worker_send_response_stream)
         return;
     }
 
-    smart_str hbuf = {0};
-    ephpm_worker_pack_headers(&hbuf, headers_arr);
-    const char *hdr_ptr = hbuf.s ? ZSTR_VAL(hbuf.s) : "";
-    size_t hdr_len = hbuf.s ? ZSTR_LEN(hbuf.s) : 0;
-
-    g_worker_ops.response_begin((int)status, hdr_ptr, hdr_len);
-    smart_str_free(&hbuf);
+    ephpm_worker_hdrs hdrs;
+    ephpm_worker_hdrs_build(&hdrs, headers_arr);
+    g_worker_ops.response_begin((int)status,
+                                hdrs.names, hdrs.name_lens,
+                                hdrs.values, hdrs.value_lens, hdrs.count);
+    ephpm_worker_hdrs_free(&hdrs);
 
     /* Flush any buffered echo output first. */
     if (output_len > 0) {
@@ -2897,16 +3053,37 @@ int ephpm_worker_run(const char *script)
                  * capture has. */
             } zend_end_try();
 
-            smart_str hbuf = {0};
+            /* Split the SAPI header lines through the same capture machinery
+             * the fpm path uses (headers_buf + hdr_spans are ours to reuse:
+             * the next take_request resets them anyway), then materialize the
+             * parallel arrays the ops callback takes. Unlike the fpm path,
+             * no default Content-Type is synthesized here — this fallback
+             * always delivered exactly what the script emitted. */
+            headers_buf_len = 0;
+            hdr_span_count = 0;
             zend_llist_position pos;
             sapi_header_struct *h =
                 zend_llist_get_first_ex(&SG(sapi_headers).headers, &pos);
             while (h) {
-                smart_str_appendl(&hbuf, h->header, h->header_len);
-                smart_str_appendc(&hbuf, '\n');
+                (void)capture_split_header_line(h->header, h->header_len);
                 h = zend_llist_get_next_ex(&SG(sapi_headers).headers, &pos);
             }
-            smart_str_0(&hbuf);
+            const char **hnames = NULL;
+            size_t *hname_lens = NULL;
+            const char **hvalues = NULL;
+            size_t *hvalue_lens = NULL;
+            if (hdr_span_count > 0) {
+                hnames = emalloc(hdr_span_count * sizeof(*hnames));
+                hname_lens = emalloc(hdr_span_count * sizeof(*hname_lens));
+                hvalues = emalloc(hdr_span_count * sizeof(*hvalues));
+                hvalue_lens = emalloc(hdr_span_count * sizeof(*hvalue_lens));
+                for (size_t i = 0; i < hdr_span_count; i++) {
+                    hnames[i] = headers_buf + hdr_spans[i].name_off;
+                    hname_lens[i] = hdr_spans[i].name_len;
+                    hvalues[i] = headers_buf + hdr_spans[i].value_off;
+                    hvalue_lens[i] = hdr_spans[i].value_len;
+                }
+            }
 
             int status = SG(sapi_headers).http_response_code;
             if (status <= 0) {
@@ -2935,11 +3112,17 @@ int ephpm_worker_run(const char *script)
             }
 
             g_worker_ops.send_response(status,
-                                       hbuf.s ? ZSTR_VAL(hbuf.s) : "",
-                                       hbuf.s ? ZSTR_LEN(hbuf.s) : 0,
+                                       hnames, hname_lens,
+                                       hvalues, hvalue_lens, hdr_span_count,
                                        output_buf ? output_buf : "",
                                        output_len);
-            smart_str_free(&hbuf);
+            if (hnames) {
+                efree(hnames);
+                efree(hname_lens);
+                efree(hvalues);
+                efree(hvalue_lens);
+            }
+            hdr_span_count = 0;
             output_len = 0;
             req_in_flight = 0;
             /* 2 = the request died on a fatal (response synthesized as 500);

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -129,9 +129,21 @@ mod ffi {
         /// Get the HTTP response status code.
         pub fn ephpm_get_response_code() -> ::std::os::raw::c_int;
 
-        /// Get the captured response headers ("Name: Value\n" lines).
-        /// Sets `*out_len` to the length.
-        pub fn ephpm_get_response_headers(out_len: *mut usize) -> *const ::std::os::raw::c_char;
+        /// Number of response headers captured for the request just
+        /// executed (issue #134 — structured access).
+        pub fn ephpm_get_response_header_count() -> usize;
+
+        /// Fetch one captured response header by index as (ptr, len) pairs
+        /// pointing into the thread-local capture buffer (valid until the
+        /// next request on this thread — copy immediately). Returns 1 on
+        /// success, 0 for an out-of-range index.
+        pub fn ephpm_get_response_header(
+            idx: usize,
+            name: *mut *const ::std::os::raw::c_char,
+            name_len: *mut usize,
+            value: *mut *const ::std::os::raw::c_char,
+            value_len: *mut usize,
+        ) -> ::std::os::raw::c_int;
 
         // ── ZTS thread lifecycle ────────────────────────────────────
 
@@ -1304,23 +1316,47 @@ impl PhpRuntime {
         let status_code = unsafe { ffi::ephpm_get_response_code() };
 
         let headers = {
-            let mut len: usize = 0;
-            // Safety: out_len pointer is valid.
-            let ptr = unsafe { ffi::ephpm_get_response_headers(&mut len) };
-            if ptr.is_null() || len == 0 {
-                Vec::new()
-            } else {
-                // Safety: ptr is valid for len bytes (managed by C headers buffer).
-                let raw = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), len) };
-                // Headers are "Name: Value\n" lines. Parse them.
-                String::from_utf8_lossy(raw)
-                    .lines()
-                    .filter_map(|line| {
-                        let (name, value) = line.split_once(": ")?;
-                        Some((name.to_string(), value.to_string()))
-                    })
-                    .collect()
+            // Structured header capture (issue #134): the C side already
+            // split each header into (name, value) spans — read them out as
+            // (ptr, len) pairs instead of re-parsing a "Name: Value\n" blob.
+            // Safety: no arguments, returns the thread-local span count.
+            let count = unsafe { ffi::ephpm_get_response_header_count() };
+            let mut headers = Vec::with_capacity(count);
+            for idx in 0..count {
+                let mut name: *const std::os::raw::c_char = std::ptr::null();
+                let mut name_len: usize = 0;
+                let mut value: *const std::os::raw::c_char = std::ptr::null();
+                let mut value_len: usize = 0;
+                // Safety: the out pointers are valid locals; on success the
+                // returned pointers reference the thread-local C capture
+                // buffer, valid until the next request on this thread — we
+                // copy them into owned Strings immediately below.
+                let ok = unsafe {
+                    ffi::ephpm_get_response_header(
+                        idx,
+                        &raw mut name,
+                        &raw mut name_len,
+                        &raw mut value,
+                        &raw mut value_len,
+                    )
+                };
+                if ok == 0 || name.is_null() || value.is_null() {
+                    continue;
+                }
+                // Safety: the C side guarantees `name`/`value` are valid for
+                // their respective lengths.
+                let (name, value) = unsafe {
+                    (
+                        std::slice::from_raw_parts(name.cast::<u8>(), name_len),
+                        std::slice::from_raw_parts(value.cast::<u8>(), value_len),
+                    )
+                };
+                headers.push((
+                    String::from_utf8_lossy(name).into_owned(),
+                    String::from_utf8_lossy(value).into_owned(),
+                ));
             }
+            headers
         };
 
         let status = u16::try_from(status_code).unwrap_or(200);

--- a/crates/ephpm-php/src/lib.rs
+++ b/crates/ephpm-php/src/lib.rs
@@ -1171,17 +1171,14 @@ impl PhpRuntime {
             );
         }
 
-        // Build and pass server variables ($_SERVER)
-        let server_vars = request.server_variables();
-        let c_server_vars: Vec<(CString, CString)> = server_vars
-            .iter()
-            .filter_map(|(k, v)| {
-                Some((CString::new(k.as_str()).ok()?, CString::new(v.as_str()).ok()?))
-            })
-            .collect();
-
+        // Build and pass server variables ($_SERVER). Built directly in
+        // NUL-terminated form — the invariant entries are static C literals
+        // and every dynamic one is allocated exactly once (issue #133).
+        let c_server_vars = request.server_variables_c();
         for (key, value) in &c_server_vars {
-            // Safety: CString pointers are valid and stay alive.
+            // Safety: the pointers stay valid until ephpm_execute_request
+            // returns — static literals live forever, owned CStrings live in
+            // `c_server_vars`, which outlives the call.
             unsafe {
                 ffi::ephpm_request_add_server_var(key.as_ptr(), value.as_ptr());
             }

--- a/crates/ephpm-php/src/request.rs
+++ b/crates/ephpm-php/src/request.rs
@@ -3,6 +3,8 @@
 //! Converts an incoming HTTP request into the format expected by PHP's
 //! embed SAPI, including populating `$_SERVER` variables.
 
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -137,6 +139,27 @@ impl PhpRequest {
         )
     }
 
+    /// Build the `$_SERVER` variables in FFI-ready form — same derivation as
+    /// [`Self::server_variables`], see [`build_server_variables_c`].
+    #[must_use]
+    pub fn server_variables_c(&self) -> Vec<CServerVar> {
+        build_server_variables_c(
+            &self.method,
+            &self.uri,
+            &self.query_string,
+            &self.script_filename,
+            &self.document_root,
+            &self.path,
+            &self.server_name,
+            self.server_port,
+            &self.protocol,
+            self.remote_addr,
+            self.is_https,
+            &self.headers,
+            &self.env_vars,
+        )
+    }
+
     /// Extract the cookie string from the request headers.
     #[must_use]
     pub fn cookie_string(&self) -> String {
@@ -144,13 +167,20 @@ impl PhpRequest {
     }
 }
 
+/// A `$_SERVER` entry in FFI-ready form: NUL-terminated key and value, with
+/// static (`&'static CStr`) storage for the strings that never vary between
+/// requests, so the per-request invariant half of `$_SERVER` costs zero
+/// allocations (issue #133).
+pub type CServerVar = (Cow<'static, CStr>, Cow<'static, CStr>);
+
 /// Build the `$_SERVER` variables from borrowed request fields.
 ///
-/// This is the single source of truth for `$_SERVER` derivation, shared by
-/// both [`PhpRequest::server_variables`] (fpm path) and the worker dispatch
-/// path in `ephpm-server`. Keeping it a free function lets the worker path
-/// build `$_SERVER` directly from its owned locals without allocating a
-/// throwaway [`PhpRequest`].
+/// Thin conversion wrapper over [`build_server_variables_c`], which is the
+/// single source of truth for `$_SERVER` derivation — kept so tests (and any
+/// caller that wants plain strings) can assert on the derivation without
+/// touching `CStr`. The hot paths (fpm dispatch in `execute_php`, worker
+/// dispatch in `ephpm-server`) call the `_c` variant directly and never build
+/// this `String` form.
 ///
 /// Key distinction when fallback rewrites happen (e.g. `/blog/hello` → `/index.php`):
 /// - `REQUEST_URI` = original URI (`/blog/hello`) — what the client asked for
@@ -173,49 +203,151 @@ pub fn build_server_variables(
     headers: &[(String, String)],
     env_vars: &[(String, String)],
 ) -> Vec<(String, String)> {
+    build_server_variables_c(
+        method,
+        uri,
+        query_string,
+        script_filename,
+        document_root,
+        path,
+        server_name,
+        server_port,
+        protocol,
+        remote_addr,
+        is_https,
+        headers,
+        env_vars,
+    )
+    .iter()
+    .map(|(k, v)| (k.to_string_lossy().into_owned(), v.to_string_lossy().into_owned()))
+    .collect()
+}
+
+/// The `REQUEST_METHOD` value as a static C string for the common methods,
+/// avoiding a per-request allocation; anything else is copied.
+fn method_value(method: &str) -> Option<Cow<'static, CStr>> {
+    let known: &'static CStr = match method {
+        "GET" => c"GET",
+        "POST" => c"POST",
+        "HEAD" => c"HEAD",
+        "PUT" => c"PUT",
+        "DELETE" => c"DELETE",
+        "PATCH" => c"PATCH",
+        "OPTIONS" => c"OPTIONS",
+        _ => return owned(method),
+    };
+    Some(Cow::Borrowed(known))
+}
+
+/// The `SERVER_PROTOCOL` value as a static C string for the protocols hyper
+/// actually produces; anything else is copied.
+fn protocol_value(protocol: &str) -> Option<Cow<'static, CStr>> {
+    let known: &'static CStr = match protocol {
+        "HTTP/1.1" => c"HTTP/1.1",
+        "HTTP/2.0" => c"HTTP/2.0",
+        "HTTP/1.0" => c"HTTP/1.0",
+        _ => return owned(protocol),
+    };
+    Some(Cow::Borrowed(known))
+}
+
+/// Copy a string into an owned C string. `None` when it contains an interior
+/// NUL — such a pair is dropped by the builder rather than truncated or
+/// substituted, so PHP never sees a value that differs from what the client
+/// (or the router) actually produced.
+fn owned(s: &str) -> Option<Cow<'static, CStr>> {
+    CString::new(s).ok().map(Cow::Owned)
+}
+
+/// Build the `$_SERVER` variables from borrowed request fields, directly in
+/// the NUL-terminated form the SAPI FFI needs (issue #133).
+///
+/// This is the single source of truth for `$_SERVER` derivation, shared by
+/// the fpm path ([`PhpRequest::server_variables_c`], consumed by
+/// `execute_php`) and the worker dispatch path in `ephpm-server`. Both used
+/// to build an intermediate `Vec<(String, String)>` and then convert every
+/// pair to `CString` a second time — two allocations, two copies, and a NUL
+/// scan per string, on every request. Building the C form once halves the
+/// allocation traffic, and the entries that never vary between requests
+/// (`SERVER_SOFTWARE`, `GATEWAY_INTERFACE`, `REDIRECT_STATUS`, `HTTPS`, the
+/// fixed CGI keys, common methods/protocols, canonical header keys) are
+/// `&'static CStr` literals that allocate nothing at all.
+///
+/// A key or value with an interior NUL drops that pair — the same behaviour
+/// the fpm path always had. (The worker path previously substituted an empty
+/// string for the unrepresentable half, which could register a header key
+/// with someone else's value; dropping is strictly safer.)
+///
+/// Key distinction when fallback rewrites happen (e.g. `/blog/hello` → `/index.php`):
+/// - `REQUEST_URI` = original URI (`/blog/hello`) — what the client asked for
+/// - `SCRIPT_NAME` = resolved script (`/index.php`) — what PHP is executing
+/// - `PHP_SELF` = same as `SCRIPT_NAME`
+#[must_use]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub fn build_server_variables_c(
+    method: &str,
+    uri: &str,
+    query_string: &str,
+    script_filename: &std::path::Path,
+    document_root: &std::path::Path,
+    path: &str,
+    server_name: &str,
+    server_port: u16,
+    protocol: &str,
+    remote_addr: SocketAddr,
+    is_https: bool,
+    headers: &[(String, String)],
+    env_vars: &[(String, String)],
+) -> Vec<CServerVar> {
     // Derive SCRIPT_NAME from the resolved script_filename relative to
     // document_root. This is correct even after fallback rewrites.
     let script_name = script_filename
         .strip_prefix(document_root)
         .map_or_else(|_| path.to_owned(), |rel| format!("/{}", rel.to_string_lossy()));
+    // One CString for SCRIPT_NAME + PHP_SELF; the clone is a plain memcpy.
+    let script_name = CString::new(script_name).ok();
 
-    let mut vars = vec![
-        ("REQUEST_METHOD".into(), method.to_owned()),
-        ("REQUEST_URI".into(), uri.to_owned()),
-        ("SCRIPT_FILENAME".into(), script_filename.to_string_lossy().into_owned()),
-        ("SCRIPT_NAME".into(), script_name.clone()),
-        ("DOCUMENT_ROOT".into(), document_root.to_string_lossy().into_owned()),
-        ("SERVER_NAME".into(), server_name.to_owned()),
-        ("SERVER_PORT".into(), server_port.to_string()),
-        ("SERVER_SOFTWARE".into(), "ePHPm/0.1.0".into()),
-        ("SERVER_PROTOCOL".into(), protocol.to_owned()),
-        ("GATEWAY_INTERFACE".into(), "CGI/1.1".into()),
-        ("QUERY_STRING".into(), query_string.to_owned()),
-        ("PHP_SELF".into(), script_name),
-        ("REMOTE_ADDR".into(), remote_addr.ip().to_string()),
-        ("REMOTE_PORT".into(), remote_addr.port().to_string()),
-        ("REDIRECT_STATUS".into(), "200".into()),
-    ];
+    let mut vars: Vec<CServerVar> =
+        Vec::with_capacity(16 + headers.len() + env_vars.len() + usize::from(is_https));
+    let mut push = |key: Cow<'static, CStr>, value: Option<Cow<'static, CStr>>| {
+        if let Some(value) = value {
+            vars.push((key, value));
+        }
+    };
+
+    push(Cow::Borrowed(c"REQUEST_METHOD"), method_value(method));
+    push(Cow::Borrowed(c"REQUEST_URI"), owned(uri));
+    push(Cow::Borrowed(c"SCRIPT_FILENAME"), owned(&script_filename.to_string_lossy()));
+    push(Cow::Borrowed(c"SCRIPT_NAME"), script_name.clone().map(Cow::Owned));
+    push(Cow::Borrowed(c"DOCUMENT_ROOT"), owned(&document_root.to_string_lossy()));
+    push(Cow::Borrowed(c"SERVER_NAME"), owned(server_name));
+    push(Cow::Borrowed(c"SERVER_PORT"), owned(&server_port.to_string()));
+    push(Cow::Borrowed(c"SERVER_SOFTWARE"), Some(Cow::Borrowed(c"ePHPm/0.1.0")));
+    push(Cow::Borrowed(c"SERVER_PROTOCOL"), protocol_value(protocol));
+    push(Cow::Borrowed(c"GATEWAY_INTERFACE"), Some(Cow::Borrowed(c"CGI/1.1")));
+    push(Cow::Borrowed(c"QUERY_STRING"), owned(query_string));
+    push(Cow::Borrowed(c"PHP_SELF"), script_name.map(Cow::Owned));
+    push(Cow::Borrowed(c"REMOTE_ADDR"), owned(&remote_addr.ip().to_string()));
+    push(Cow::Borrowed(c"REMOTE_PORT"), owned(&remote_addr.port().to_string()));
+    push(Cow::Borrowed(c"REDIRECT_STATUS"), Some(Cow::Borrowed(c"200")));
 
     if is_https {
-        vars.push(("HTTPS".into(), "on".into()));
+        push(Cow::Borrowed(c"HTTPS"), Some(Cow::Borrowed(c"on")));
     }
 
-    // Map HTTP headers to $_SERVER variables.
-    //
-    // Formerly built the CGI-style key with two String allocs per
-    // header (`to_uppercase()` then `.replace('-','_')`). Header
-    // names are ASCII by RFC 7230, so we can do a single byte
-    // pass — one allocation per non-canonicalised header, with
-    // the `HTTP_` prefix filled in place.
+    // Map HTTP headers to $_SERVER variables. The canonical names get static
+    // keys; everything else is one byte-pass allocation (see cgi_header_key).
     for (name, value) in headers {
-        let key = cgi_header_key(name);
-        vars.push((key, value.clone()));
+        if let Some(key) = cgi_header_key_c(name) {
+            push(key, owned(value));
+        }
     }
 
     // Append extra environment variables (e.g. EPHPM_REDIS_* credentials).
     for (key, value) in env_vars {
-        vars.push((key.clone(), value.clone()));
+        if let Some(key) = owned(key) {
+            push(key, owned(value));
+        }
     }
 
     vars
@@ -236,46 +368,46 @@ pub fn cookie_string_from_headers(headers: &[(String, String)]) -> String {
 }
 
 /// Build the CGI-style `$_SERVER` key for an HTTP header name in one
-/// byte pass.
+/// byte pass, directly as a C string.
 ///
 /// Headers `host`, `cookie`, `content-type`, `content-length` map to
-/// non-`HTTP_` keys per the CGI spec (and PHP's SAPI conventions);
-/// everything else becomes `HTTP_<UPPER-WITH-UNDERSCORES>`. The old
-/// implementation called `to_lowercase()` for dispatch and then, on
-/// the general path, `to_uppercase()` and `.replace('-', '_')` — three
-/// String allocations per header. HTTP header names are ASCII by RFC
-/// 7230 so this can be a single ASCII upper + dash-to-underscore
-/// pass writing into a pre-sized `String`.
+/// non-`HTTP_` keys per the CGI spec (and PHP's SAPI conventions) — those
+/// come back as `&'static CStr` with no allocation at all; everything else
+/// becomes an owned `HTTP_<UPPER-WITH-UNDERSCORES>` built in a single ASCII
+/// upper + dash-to-underscore pass over a pre-sized buffer. HTTP header
+/// names are ASCII by RFC 7230.
+///
+/// `None` for a header name with an interior NUL (hyper never produces one;
+/// dropping the pair is the fail-safe read).
 #[must_use]
-pub(crate) fn cgi_header_key(name: &str) -> String {
+pub(crate) fn cgi_header_key_c(name: &str) -> Option<Cow<'static, CStr>> {
     // Special-case the ASCII-canonical spellings first (case-
     // insensitive). Doing this without a to_lowercase alloc is a
     // simple `eq_ignore_ascii_case`.
     if name.eq_ignore_ascii_case("host") {
-        return "HTTP_HOST".to_string();
+        return Some(Cow::Borrowed(c"HTTP_HOST"));
     }
     if name.eq_ignore_ascii_case("cookie") {
-        return "HTTP_COOKIE".to_string();
+        return Some(Cow::Borrowed(c"HTTP_COOKIE"));
     }
     if name.eq_ignore_ascii_case("content-type") {
-        return "CONTENT_TYPE".to_string();
+        return Some(Cow::Borrowed(c"CONTENT_TYPE"));
     }
     if name.eq_ignore_ascii_case("content-length") {
-        return "CONTENT_LENGTH".to_string();
+        return Some(Cow::Borrowed(c"CONTENT_LENGTH"));
     }
 
     let bytes = name.as_bytes();
-    let mut out = String::with_capacity(5 + bytes.len());
-    out.push_str("HTTP_");
+    let mut out = Vec::with_capacity(5 + bytes.len() + 1);
+    out.extend_from_slice(b"HTTP_");
     for b in bytes {
-        let c = match *b {
+        out.push(match *b {
             b'-' => b'_',
             b @ b'a'..=b'z' => b - 32,
             b => b,
-        };
-        out.push(char::from(c));
+        });
     }
-    out
+    CString::new(out).ok().map(Cow::Owned)
 }
 
 #[cfg(test)]
@@ -495,12 +627,13 @@ mod tests {
             ("EPHPM_REDIS_PORT".into(), "6379".into()),
         ];
 
-        // fpm path: via PhpRequest::server_variables().
-        let request_mode = req.server_variables();
+        // fpm path: via PhpRequest::server_variables_c() (what execute_php
+        // registers).
+        let request_mode = req.server_variables_c();
 
         // worker path: the exact call `handle_php_worker` makes, built from
         // borrowed/owned fields with no intermediate PhpRequest.
-        let worker_mode = build_server_variables(
+        let worker_mode = build_server_variables_c(
             &req.method,
             &req.uri,
             &req.query_string,
@@ -525,5 +658,78 @@ mod tests {
         let mut req = make_request();
         req.headers.push(("Cookie".into(), "session=abc123".into()));
         assert_eq!(cookie_string_from_headers(&req.headers), req.cookie_string());
+    }
+
+    /// The `String` form must stay a faithful view of the FFI form — it is
+    /// what every derivation test in this module asserts on, so if the two
+    /// ever diverged those tests would silently stop covering what PHP
+    /// actually receives.
+    #[test]
+    fn test_string_form_matches_c_form() {
+        let mut req = make_request();
+        req.is_https = true;
+        req.env_vars = vec![("DB_USER".into(), "site-a".into())];
+        let strings = req.server_variables();
+        let c_form = req.server_variables_c();
+        assert_eq!(strings.len(), c_form.len());
+        for ((sk, sv), (ck, cv)) in strings.iter().zip(c_form.iter()) {
+            assert_eq!(sk.as_bytes(), ck.to_bytes());
+            assert_eq!(sv.as_bytes(), cv.to_bytes());
+        }
+    }
+
+    /// Multi-tenant guard for the #133 rework: `$_SERVER` is derived fresh
+    /// from each request's own resolved site — there is deliberately **no**
+    /// cross-request cache in this module (the only shared storage is
+    /// `&'static CStr` literals for values identical for every tenant). Two
+    /// consecutive builds for different sites on the same thread must each
+    /// carry only their own tenant's docroot, host, and injected `DB_*`
+    /// credentials.
+    #[test]
+    fn test_per_site_values_never_bleed_between_requests() {
+        let build = |site: &str, docroot: &str, password: &str| {
+            build_server_variables_c(
+                "GET",
+                "/index.php",
+                "",
+                &PathBuf::from(format!("{docroot}/index.php")),
+                &PathBuf::from(docroot),
+                "/index.php",
+                site,
+                443,
+                "HTTP/1.1",
+                "192.0.2.1:1234".parse().unwrap(),
+                true,
+                &[("host".to_string(), site.to_string())],
+                &[
+                    ("DB_USER".to_string(), site.to_string()),
+                    ("DB_PASSWORD".to_string(), password.to_string()),
+                ],
+            )
+        };
+
+        let site_a = build("a.example", "/sites/a.example", "secret-a");
+        let site_b = build("b.example", "/sites/b.example", "secret-b");
+
+        let get = |vars: &[CServerVar], key: &CStr| -> Option<String> {
+            vars.iter()
+                .find(|(k, _)| k.as_ref() == key)
+                .map(|(_, v)| v.to_string_lossy().into_owned())
+        };
+
+        for (vars, site, docroot, password) in [
+            (&site_a, "a.example", "/sites/a.example", "secret-a"),
+            (&site_b, "b.example", "/sites/b.example", "secret-b"),
+        ] {
+            assert_eq!(get(vars, c"SERVER_NAME").as_deref(), Some(site));
+            assert_eq!(get(vars, c"HTTP_HOST").as_deref(), Some(site));
+            assert_eq!(get(vars, c"DOCUMENT_ROOT").as_deref(), Some(docroot));
+            assert_eq!(get(vars, c"DB_USER").as_deref(), Some(site));
+            assert_eq!(get(vars, c"DB_PASSWORD").as_deref(), Some(password));
+        }
+        // And nothing of A survives into B's view (or vice versa).
+        let b_values: Vec<String> =
+            site_b.iter().map(|(_, v)| v.to_string_lossy().into_owned()).collect();
+        assert!(!b_values.iter().any(|v| v.contains("a.example") || v.contains("secret-a")));
     }
 }

--- a/crates/ephpm-php/src/sapi.rs
+++ b/crates/ephpm-php/src/sapi.rs
@@ -18,7 +18,8 @@
 //! processing. Per-request data is passed from Rust to C via
 //! [`ephpm_request_set_info()`] and [`ephpm_request_add_server_var()`],
 //! and response data is retrieved via [`ephpm_get_output_buf()`],
-//! [`ephpm_get_response_code()`], and [`ephpm_get_response_headers()`].
+//! [`ephpm_get_response_code()`], and the structured header accessors
+//! [`ephpm_get_response_header_count()`] / [`ephpm_get_response_header()`].
 //!
 //! See `ephpm_wrapper.c` for the C implementation and `lib.rs` for the
 //! Rust-side orchestration in [`PhpRuntime::execute_php()`].

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -41,6 +41,8 @@ use std::ffi::CString;
 #[cfg(php_linked)]
 use std::os::raw::{c_char, c_int};
 
+use crate::request::CServerVar;
+
 /// Chunk size / channel bounds shared with the streaming-body plumbing.
 ///
 /// A bounded channel of `BODY_CHANNEL_DEPTH` chunks caps the in-flight buffered
@@ -97,8 +99,10 @@ pub struct WorkerRequestOwned {
     pub content_type: Option<String>,
     /// The request body (buffered or streaming).
     pub body: WorkerBody,
-    /// `$_SERVER`-shaped variables as `(key, value)` pairs.
-    pub server_vars: Vec<(String, String)>,
+    /// `$_SERVER`-shaped variables, already in FFI-ready form (built once by
+    /// `build_server_variables_c` — issue #133; the borrowed
+    /// [`EphpmWorkerRequest`] view points straight into these).
+    pub server_vars: Vec<CServerVar>,
     /// HTTP headers as `(name, value)` pairs.
     pub headers: Vec<(String, String)>,
 }
@@ -296,8 +300,7 @@ struct CurrentRequest {
     _body: Vec<u8>,
     body_len: usize,
     streaming: bool,
-    _server_keys: Vec<CString>,
-    _server_vals: Vec<CString>,
+    _server_vars: Vec<CServerVar>,
     _header_keys: Vec<CString>,
     _header_vals: Vec<CString>,
     // Pointer arrays into the CString vecs (stable: the vecs are not mutated
@@ -548,13 +551,14 @@ fn build_current_request(job: WorkerRequestOwned) -> (CurrentRequest, BodyReader
     let cookie = cstr(&job.cookie_data);
     let content_type = job.content_type.as_deref().map(cstr);
 
-    let server_keys: Vec<CString> = job.server_vars.iter().map(|(k, _)| cstr(k)).collect();
-    let server_vals: Vec<CString> = job.server_vars.iter().map(|(_, v)| cstr(v)).collect();
+    // $_SERVER arrives already FFI-ready (issue #133) — no re-allocation, just
+    // pointer arrays into the moved-in storage.
+    let server_vars = job.server_vars;
     let header_keys: Vec<CString> = job.headers.iter().map(|(k, _)| cstr(k)).collect();
     let header_vals: Vec<CString> = job.headers.iter().map(|(_, v)| cstr(v)).collect();
 
-    let server_key_ptrs: Vec<*const c_char> = server_keys.iter().map(|c| c.as_ptr()).collect();
-    let server_val_ptrs: Vec<*const c_char> = server_vals.iter().map(|c| c.as_ptr()).collect();
+    let server_key_ptrs: Vec<*const c_char> = server_vars.iter().map(|(k, _)| k.as_ptr()).collect();
+    let server_val_ptrs: Vec<*const c_char> = server_vars.iter().map(|(_, v)| v.as_ptr()).collect();
     let header_key_ptrs: Vec<*const c_char> = header_keys.iter().map(|c| c.as_ptr()).collect();
     let header_val_ptrs: Vec<*const c_char> = header_vals.iter().map(|c| c.as_ptr()).collect();
 
@@ -587,8 +591,7 @@ fn build_current_request(job: WorkerRequestOwned) -> (CurrentRequest, BodyReader
         _body: body_vec,
         body_len,
         streaming,
-        _server_keys: server_keys,
-        _server_vals: server_vals,
+        _server_vars: server_vars,
         _header_keys: header_keys,
         _header_vals: header_vals,
         server_key_ptrs,

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -251,12 +251,17 @@ pub struct EphpmWorkerOps {
     /// Block for the next request. Returns 1 with `req` filled, or 0 for
     /// graceful shutdown.
     pub take_request: Option<unsafe extern "C" fn(req: *mut EphpmWorkerRequest) -> c_int>,
-    /// Deliver the response. `headers` is `"Name: Value\n"` packed.
+    /// Deliver the response. Headers pass as parallel (ptr, len) arrays of
+    /// `header_count` entries, valid for the duration of the call (issue
+    /// #134 — replaces the `"Name: Value\n"` pack + re-parse round-trip).
     pub send_response: Option<
         unsafe extern "C" fn(
             status: c_int,
-            headers: *const c_char,
-            headers_len: usize,
+            header_names: *const *const c_char,
+            header_name_lens: *const usize,
+            header_values: *const *const c_char,
+            header_value_lens: *const usize,
+            header_count: usize,
             body: *const c_char,
             body_len: usize,
         ),
@@ -267,9 +272,18 @@ pub struct EphpmWorkerOps {
     /// Returns bytes written (0 = EOF, negative = error). Blocks until data or
     /// EOF. Serves the in-memory body when the request was buffered.
     pub body_read: Option<unsafe extern "C" fn(buf: *mut c_char, cap: usize) -> isize>,
-    /// Begin a streaming response (status + packed headers, body chunks follow).
-    pub response_begin:
-        Option<unsafe extern "C" fn(status: c_int, headers: *const c_char, headers_len: usize)>,
+    /// Begin a streaming response (status + headers in the same
+    /// parallel-array shape as `send_response`; body chunks follow).
+    pub response_begin: Option<
+        unsafe extern "C" fn(
+            status: c_int,
+            header_names: *const *const c_char,
+            header_name_lens: *const usize,
+            header_values: *const *const c_char,
+            header_value_lens: *const usize,
+            header_count: usize,
+        ),
+    >,
     /// Push one response body chunk (blocks on backpressure). Returns 0, or
     /// negative if the receiver/client is gone.
     pub response_chunk: Option<unsafe extern "C" fn(buf: *const c_char, len: usize) -> isize>,
@@ -710,25 +724,32 @@ unsafe extern "C" fn worker_take_request(req: *mut EphpmWorkerRequest) -> c_int 
 #[cfg(php_linked)]
 unsafe extern "C" fn worker_send_response(
     status: c_int,
-    headers: *const c_char,
-    headers_len: usize,
+    header_names: *const *const c_char,
+    header_name_lens: *const usize,
+    header_values: *const *const c_char,
+    header_value_lens: *const usize,
+    header_count: usize,
     body: *const c_char,
     body_len: usize,
 ) {
-    // SAFETY: C passes valid (ptr, len) pairs for headers and body; the buffers
-    // live for the duration of this call. A null pointer means zero length.
-    let header_bytes: &[u8] = if headers.is_null() || headers_len == 0 {
-        &[]
-    } else {
-        unsafe { std::slice::from_raw_parts(headers.cast::<u8>(), headers_len) }
+    // SAFETY: C passes parallel arrays of `header_count` valid (ptr, len)
+    // pairs, live for the duration of this call (null arrays mean zero
+    // headers); same for the body buffer.
+    let parsed_headers = unsafe {
+        headers_from_raw(
+            header_names,
+            header_name_lens,
+            header_values,
+            header_value_lens,
+            header_count,
+        )
     };
     let body_bytes: Vec<u8> = if body.is_null() || body_len == 0 {
         Vec::new()
     } else {
+        // SAFETY: see above — valid for body_len bytes during this call.
         unsafe { std::slice::from_raw_parts(body.cast::<u8>(), body_len) }.to_vec()
     };
-
-    let parsed_headers = parse_packed_headers(header_bytes);
 
     let status = u16::try_from(status).unwrap_or(200);
     let response = WorkerResponse::Buffered { status, headers: parsed_headers, body: body_bytes };
@@ -831,16 +852,23 @@ unsafe extern "C" fn worker_body_read(buf: *mut c_char, cap: usize) -> isize {
 #[cfg(php_linked)]
 unsafe extern "C" fn worker_response_begin(
     status: c_int,
-    headers: *const c_char,
-    headers_len: usize,
+    header_names: *const *const c_char,
+    header_name_lens: *const usize,
+    header_values: *const *const c_char,
+    header_value_lens: *const usize,
+    header_count: usize,
 ) {
-    // SAFETY: C passes a valid (ptr, len) for the packed headers; null => none.
-    let header_bytes: &[u8] = if headers.is_null() || headers_len == 0 {
-        &[]
-    } else {
-        unsafe { std::slice::from_raw_parts(headers.cast::<u8>(), headers_len) }
+    // SAFETY: C passes parallel arrays of `header_count` valid (ptr, len)
+    // pairs, live for the duration of this call (null arrays => none).
+    let parsed_headers = unsafe {
+        headers_from_raw(
+            header_names,
+            header_name_lens,
+            header_values,
+            header_value_lens,
+            header_count,
+        )
     };
-    let parsed_headers = parse_packed_headers(header_bytes);
     let status = u16::try_from(status).unwrap_or(200);
 
     let (tx, rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(BODY_CHANNEL_DEPTH);
@@ -923,20 +951,63 @@ unsafe extern "C" fn worker_response_end() {
     finish_iteration();
 }
 
-/// Parse `"Name: Value\n"` packed header lines into `(name, value)` pairs.
+/// Copy the parallel (ptr, len) header arrays C hands to `send_response` /
+/// `response_begin` into owned `(name, value)` pairs (issue #134 — replaces
+/// parsing a `"Name: Value\n"` pack).
+///
+/// Names and values are trimmed of ASCII whitespace, matching what the old
+/// pack-then-parse round trip produced, so downstream header handling sees
+/// identical strings.
+///
+/// # Safety
+///
+/// Either all four arrays are non-null with at least `count` valid entries,
+/// each entry a pointer valid for its recorded length for the duration of
+/// the call — or `count` is 0 (null arrays allowed then).
 #[cfg(php_linked)]
-fn parse_packed_headers(bytes: &[u8]) -> Vec<(String, String)> {
-    String::from_utf8_lossy(bytes)
-        .lines()
-        .filter_map(|line| {
-            let line = line.trim_end_matches('\r');
-            if line.is_empty() {
-                return None;
-            }
-            let (name, value) = line.split_once(':')?;
-            Some((name.trim().to_string(), value.trim().to_string()))
-        })
-        .collect()
+unsafe fn headers_from_raw(
+    names: *const *const c_char,
+    name_lens: *const usize,
+    values: *const *const c_char,
+    value_lens: *const usize,
+    count: usize,
+) -> Vec<(String, String)> {
+    if count == 0
+        || names.is_null()
+        || name_lens.is_null()
+        || values.is_null()
+        || value_lens.is_null()
+    {
+        return Vec::new();
+    }
+    // SAFETY: per the function contract, each array has `count` entries.
+    let (names, name_lens, values, value_lens) = unsafe {
+        (
+            std::slice::from_raw_parts(names, count),
+            std::slice::from_raw_parts(name_lens, count),
+            std::slice::from_raw_parts(values, count),
+            std::slice::from_raw_parts(value_lens, count),
+        )
+    };
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        if names[i].is_null() || values[i].is_null() {
+            continue;
+        }
+        // SAFETY: per the function contract, each pointer is valid for its
+        // recorded length.
+        let (name, value) = unsafe {
+            (
+                std::slice::from_raw_parts(names[i].cast::<u8>(), name_lens[i]),
+                std::slice::from_raw_parts(values[i].cast::<u8>(), value_lens[i]),
+            )
+        };
+        out.push((
+            String::from_utf8_lossy(name).trim().to_string(),
+            String::from_utf8_lossy(value).trim().to_string(),
+        ));
+    }
+    out
 }
 
 // ── Static ops table ─────────────────────────────────────────────────────
@@ -958,20 +1029,64 @@ pub static WORKER_OPS: EphpmWorkerOps = EphpmWorkerOps {
 mod tests {
     use super::*;
 
+    /// Build the parallel arrays from Rust-owned strings and round-trip them
+    /// through [`headers_from_raw`] — the same shapes the C side produces.
+    fn from_pairs(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        let names: Vec<*const c_char> = pairs.iter().map(|(n, _)| n.as_ptr().cast()).collect();
+        let name_lens: Vec<usize> = pairs.iter().map(|(n, _)| n.len()).collect();
+        let values: Vec<*const c_char> = pairs.iter().map(|(_, v)| v.as_ptr().cast()).collect();
+        let value_lens: Vec<usize> = pairs.iter().map(|(_, v)| v.len()).collect();
+        // SAFETY: the arrays all have `pairs.len()` entries pointing into
+        // `pairs`' string data, which outlives the call.
+        unsafe {
+            headers_from_raw(
+                names.as_ptr(),
+                name_lens.as_ptr(),
+                values.as_ptr(),
+                value_lens.as_ptr(),
+                pairs.len(),
+            )
+        }
+    }
+
     #[test]
-    fn parse_packed_headers_basic() {
-        let packed = b"Content-Type: text/plain\nX-Foo: bar\n";
-        let parsed = parse_packed_headers(packed);
+    fn headers_from_raw_basic() {
+        let parsed = from_pairs(&[("Content-Type", "text/plain"), ("X-Foo", "bar")]);
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0], ("Content-Type".to_string(), "text/plain".to_string()));
         assert_eq!(parsed[1], ("X-Foo".to_string(), "bar".to_string()));
     }
 
     #[test]
-    fn parse_packed_headers_skips_blank() {
-        let packed = b"A: 1\n\nB: 2\n";
-        let parsed = parse_packed_headers(packed);
-        assert_eq!(parsed.len(), 2);
+    fn headers_from_raw_trims_like_the_old_parse() {
+        // The old "Name: Value\n" round trip trimmed both halves; header
+        // handling downstream must keep seeing identical strings.
+        let parsed = from_pairs(&[(" X-Padded ", "  spaced out  ")]);
+        assert_eq!(parsed, vec![("X-Padded".to_string(), "spaced out".to_string())]);
+    }
+
+    #[test]
+    fn headers_from_raw_null_arrays_mean_no_headers() {
+        // SAFETY: count 0 permits null arrays per the contract.
+        let parsed = unsafe {
+            headers_from_raw(
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+            )
+        };
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn headers_from_raw_preserves_value_with_newline() {
+        // The packed form could not carry a value containing '\n' (it broke
+        // the line framing and the remainder was dropped or mis-parsed);
+        // structured passing keeps the bytes intact.
+        let parsed = from_pairs(&[("X-Odd", "line1\nline2")]);
+        assert_eq!(parsed, vec![("X-Odd".to_string(), "line1\nline2".to_string())]);
     }
 
     #[test]

--- a/crates/ephpm-php/tests/perf_linked.rs
+++ b/crates/ephpm-php/tests/perf_linked.rs
@@ -1,0 +1,124 @@
+//! Linked end-to-end per-request timing probe for issues #133/#134.
+//!
+//! Executes the same small script through the full fpm-mode request path
+//! (`PhpRuntime::execute`) thousands of times and prints the mean
+//! microseconds per request. Run it on the commit before and after a
+//! hot-path change to attribute the delta.
+//!
+//! Requires a real libphp link (`php_linked`); compiles to nothing in stub
+//! mode. Deliberately no OPcache (see `php_middleware.rs::init_once` for
+//! why), so the absolute number includes a constant per-request compile of
+//! the ~15-line script — the before/after *difference* is still attributable
+//! because the compile cost does not change with the request-mapping code.
+//!
+//! ```text
+//! cargo test -p ephpm-php --release --test perf_linked -- --ignored --nocapture --test-threads=1
+//! ```
+
+#![cfg(all(test, php_linked))]
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ephpm_php::PhpRuntime;
+use ephpm_php::request::PhpRequest;
+use serial_test::serial;
+use tempfile::TempDir;
+
+static SCRIPT_DIR: OnceLock<TempDir> = OnceLock::new();
+static INIT: OnceLock<()> = OnceLock::new();
+
+fn init_once() {
+    INIT.get_or_init(|| {
+        PhpRuntime::init().expect("php_embed_init");
+        PhpRuntime::finalize_for_http().expect("finalize_for_http");
+    });
+}
+
+fn write_script(name: &str, body: &str) -> PathBuf {
+    let dir = SCRIPT_DIR.get_or_init(|| TempDir::new().expect("tempdir")).path();
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write test script");
+    path
+}
+
+/// A request shaped like the Laravel bench's: a dozen headers, a query
+/// string, env-var injection, and a script that reads `$_SERVER` (forcing
+/// the JIT superglobal registration) and emits several response headers.
+fn make_request(script: PathBuf) -> PhpRequest {
+    PhpRequest {
+        method: "GET".into(),
+        uri: "/index.php?page=2&ref=home".into(),
+        path: "/index.php".into(),
+        query_string: "page=2&ref=home".into(),
+        document_root: script.parent().unwrap().to_path_buf(),
+        script_filename: script,
+        headers: vec![
+            ("host".into(), "shop.example.com".into()),
+            ("user-agent".into(), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko".into()),
+            ("accept".into(), "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8".into()),
+            ("accept-language".into(), "en-US,en;q=0.5".into()),
+            ("accept-encoding".into(), "gzip, deflate, br".into()),
+            ("cookie".into(), "session=eyJpdiI6IjZ4TmpX; XSRF-TOKEN=abc123".into()),
+            ("connection".into(), "keep-alive".into()),
+            ("upgrade-insecure-requests".into(), "1".into()),
+            ("sec-fetch-dest".into(), "document".into()),
+            ("sec-fetch-mode".into(), "navigate".into()),
+            ("sec-fetch-site".into(), "same-origin".into()),
+            ("cache-control".into(), "max-age=0".into()),
+        ],
+        body: Vec::new(),
+        content_type: None,
+        remote_addr: "203.0.113.9:52341".parse().unwrap(),
+        server_name: "shop.example.com".into(),
+        server_port: 443,
+        is_https: true,
+        protocol: "HTTP/1.1".into(),
+        env_vars: vec![
+            ("EPHPM_REDIS_HOST".into(), "127.0.0.1".into()),
+            ("EPHPM_REDIS_PORT".into(), "6379".into()),
+            ("EPHPM_REDIS_USERNAME".into(), "shop.example.com".into()),
+            ("EPHPM_REDIS_PASSWORD".into(), "0123456789abcdef0123456789abcdef".into()),
+        ],
+        middleware: Vec::new(),
+    }
+}
+
+#[test]
+#[serial]
+#[ignore = "timing probe — run manually in release mode with --nocapture"]
+#[allow(clippy::cast_precision_loss)]
+fn bench_full_request_path() {
+    init_once();
+    let script = write_script(
+        "perf.php",
+        r#"<?php
+header('Cache-Control: no-cache, private');
+header('X-Frame-Options: SAMEORIGIN');
+header('Vary: Accept-Encoding');
+setcookie('XSRF-TOKEN', 'abc123', ['path' => '/', 'samesite' => 'Lax']);
+setcookie('app_session', 'def456', ['path' => '/', 'httponly' => true]);
+echo 'uri=', $_SERVER['REQUEST_URI'], ' host=', $_SERVER['HTTP_HOST'],
+     ' ua=', $_SERVER['HTTP_USER_AGENT'], ' q=', $_SERVER['QUERY_STRING'];
+"#,
+    );
+
+    // Warmup (also sanity-checks the response once).
+    let resp = PhpRuntime::execute(make_request(script.clone())).expect("warmup request");
+    assert_eq!(resp.status, 200);
+    assert!(String::from_utf8_lossy(&resp.body).contains("uri=/index.php?page=2&ref=home"));
+    assert!(resp.headers.iter().any(|(n, v)| n == "X-Frame-Options" && v == "SAMEORIGIN"));
+    for _ in 0..500 {
+        PhpRuntime::execute(make_request(script.clone())).expect("warmup");
+    }
+
+    const ITERS: u32 = 5000;
+    let start = Instant::now();
+    for _ in 0..ITERS {
+        let resp = PhpRuntime::execute(make_request(script.clone())).expect("request");
+        std::hint::black_box(resp);
+    }
+    let per_req_us = start.elapsed().as_secs_f64() * 1e6 / f64::from(ITERS);
+    println!("full fpm request path (no OPcache): {per_req_us:.1} us/request over {ITERS} iters");
+}

--- a/crates/ephpm-php/tests/perf_micro.rs
+++ b/crates/ephpm-php/tests/perf_micro.rs
@@ -1,0 +1,285 @@
+//! Micro-benchmarks for the per-request hot-path work tracked by issues
+//! #133 ($_SERVER rebuild) and #134 (response-header round-trip).
+//!
+//! These are `#[ignore]`d timing probes, not assertions — run them manually
+//! in release mode and read the printed ns/request:
+//!
+//! ```text
+//! cargo test -p ephpm-php --release --test perf_micro -- --ignored --nocapture
+//! ```
+//!
+//! They compile in stub mode (no `php_linked` needed): everything measured
+//! here is the pure-Rust side of the request path. The C side
+//! (`php_register_variable_safe`, the smart_str header pack) is covered by
+//! the linked end-to-end probe in `tests/perf_linked.rs`.
+
+use std::ffi::CString;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use ephpm_php::request::{build_server_variables, build_server_variables_c};
+
+/// A typical dynamic-site request: browser-grade header count plus the
+/// env-var injection multi-tenant mode performs.
+struct Shape {
+    name: &'static str,
+    headers: Vec<(String, String)>,
+    env_vars: Vec<(String, String)>,
+}
+
+fn shapes() -> Vec<Shape> {
+    let minimal = Shape {
+        name: "minimal (bench-tool, 4 headers, 0 env)",
+        headers: vec![
+            ("host".into(), "example.com".into()),
+            ("user-agent".into(), "hey/0.0.1".into()),
+            ("content-type".into(), "application/x-www-form-urlencoded".into()),
+            ("accept-encoding".into(), "gzip".into()),
+        ],
+        env_vars: vec![],
+    };
+    let typical = Shape {
+        name: "typical (browser, 12 headers, 4 env)",
+        headers: vec![
+            ("host".into(), "shop.example.com".into()),
+            ("user-agent".into(), "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko".into()),
+            ("accept".into(), "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8".into()),
+            ("accept-language".into(), "en-US,en;q=0.5".into()),
+            ("accept-encoding".into(), "gzip, deflate, br".into()),
+            ("cookie".into(), "laravel_session=eyJpdiI6IjZ4TmpX; XSRF-TOKEN=abc123".into()),
+            ("connection".into(), "keep-alive".into()),
+            ("upgrade-insecure-requests".into(), "1".into()),
+            ("sec-fetch-dest".into(), "document".into()),
+            ("sec-fetch-mode".into(), "navigate".into()),
+            ("sec-fetch-site".into(), "same-origin".into()),
+            ("cache-control".into(), "max-age=0".into()),
+        ],
+        env_vars: vec![
+            ("EPHPM_REDIS_HOST".into(), "127.0.0.1".into()),
+            ("EPHPM_REDIS_PORT".into(), "6379".into()),
+            ("EPHPM_REDIS_USERNAME".into(), "shop.example.com".into()),
+            ("EPHPM_REDIS_PASSWORD".into(), "0123456789abcdef0123456789abcdef".into()),
+        ],
+    };
+    vec![minimal, typical]
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn time<R>(iters: u32, mut f: impl FnMut() -> R) -> f64 {
+    // Warmup.
+    for _ in 0..(iters / 10).max(1) {
+        std::hint::black_box(f());
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        std::hint::black_box(f());
+    }
+    start.elapsed().as_nanos() as f64 / f64::from(iters)
+}
+
+/// Verbatim copy of the pre-#133 `build_server_variables` (String form) so
+/// the bench's "old" leg measures the code that actually shipped, not the
+/// post-fix wrapper.
+#[allow(clippy::too_many_arguments)]
+fn old_build_server_variables(
+    method: &str,
+    uri: &str,
+    query_string: &str,
+    script_filename: &std::path::Path,
+    document_root: &std::path::Path,
+    path: &str,
+    server_name: &str,
+    server_port: u16,
+    protocol: &str,
+    remote_addr: SocketAddr,
+    is_https: bool,
+    headers: &[(String, String)],
+    env_vars: &[(String, String)],
+) -> Vec<(String, String)> {
+    fn cgi_header_key(name: &str) -> String {
+        if name.eq_ignore_ascii_case("host") {
+            return "HTTP_HOST".to_string();
+        }
+        if name.eq_ignore_ascii_case("cookie") {
+            return "HTTP_COOKIE".to_string();
+        }
+        if name.eq_ignore_ascii_case("content-type") {
+            return "CONTENT_TYPE".to_string();
+        }
+        if name.eq_ignore_ascii_case("content-length") {
+            return "CONTENT_LENGTH".to_string();
+        }
+        let bytes = name.as_bytes();
+        let mut out = String::with_capacity(5 + bytes.len());
+        out.push_str("HTTP_");
+        for b in bytes {
+            let c = match *b {
+                b'-' => b'_',
+                b @ b'a'..=b'z' => b - 32,
+                b => b,
+            };
+            out.push(char::from(c));
+        }
+        out
+    }
+
+    let script_name = script_filename
+        .strip_prefix(document_root)
+        .map_or_else(|_| path.to_owned(), |rel| format!("/{}", rel.to_string_lossy()));
+
+    let mut vars = vec![
+        ("REQUEST_METHOD".into(), method.to_owned()),
+        ("REQUEST_URI".into(), uri.to_owned()),
+        ("SCRIPT_FILENAME".into(), script_filename.to_string_lossy().into_owned()),
+        ("SCRIPT_NAME".into(), script_name.clone()),
+        ("DOCUMENT_ROOT".into(), document_root.to_string_lossy().into_owned()),
+        ("SERVER_NAME".into(), server_name.to_owned()),
+        ("SERVER_PORT".into(), server_port.to_string()),
+        ("SERVER_SOFTWARE".into(), "ePHPm/0.1.0".into()),
+        ("SERVER_PROTOCOL".into(), protocol.to_owned()),
+        ("GATEWAY_INTERFACE".into(), "CGI/1.1".into()),
+        ("QUERY_STRING".into(), query_string.to_owned()),
+        ("PHP_SELF".into(), script_name),
+        ("REMOTE_ADDR".into(), remote_addr.ip().to_string()),
+        ("REMOTE_PORT".into(), remote_addr.port().to_string()),
+        ("REDIRECT_STATUS".into(), "200".into()),
+    ];
+    if is_https {
+        vars.push(("HTTPS".into(), "on".into()));
+    }
+    for (name, value) in headers {
+        vars.push((cgi_header_key(name), value.clone()));
+    }
+    for (key, value) in env_vars {
+        vars.push((key.clone(), value.clone()));
+    }
+    vars
+}
+
+/// #133 — the $_SERVER derivation + FFI-ready conversion, per dispatch mode.
+#[test]
+#[ignore = "timing probe — run manually in release mode with --nocapture"]
+fn bench_server_vars() {
+    let remote: SocketAddr = "203.0.113.9:52341".parse().unwrap();
+    let script = PathBuf::from("/var/www/html/index.php");
+    let docroot = PathBuf::from("/var/www/html");
+    const ITERS: u32 = 200_000;
+
+    for shape in shapes() {
+        // Old path (pre-#133): build owned Strings, then convert every pair to
+        // CString a second time — exactly what execute_php / the worker bridge
+        // did before the fix.
+        let old = time(ITERS, || {
+            let vars = old_build_server_variables(
+                "GET",
+                "/products/42?ref=home",
+                "ref=home",
+                &script,
+                &docroot,
+                "/products/42",
+                "shop.example.com",
+                443,
+                "HTTP/1.1",
+                remote,
+                true,
+                &shape.headers,
+                &shape.env_vars,
+            );
+            let c_vars: Vec<(CString, CString)> = vars
+                .iter()
+                .filter_map(|(k, v)| {
+                    Some((CString::new(k.as_str()).ok()?, CString::new(v.as_str()).ok()?))
+                })
+                .collect();
+            c_vars
+        });
+
+        // New path (#133): one FFI-ready build, static CStr for the
+        // invariants — what execute_php and the worker bridge now do.
+        let new = time(ITERS, || {
+            build_server_variables_c(
+                "GET",
+                "/products/42?ref=home",
+                "ref=home",
+                &script,
+                &docroot,
+                "/products/42",
+                "shop.example.com",
+                443,
+                "HTTP/1.1",
+                remote,
+                true,
+                &shape.headers,
+                &shape.env_vars,
+            )
+        });
+        println!("server_vars/{:<40} old: {old:>6.0} ns/req  new: {new:>6.0} ns/req", shape.name);
+    }
+
+    // Keep the shipped String form exercised too, so a regression in the
+    // wrapper (which the derivation tests rely on) would show up here.
+    let shape = &shapes()[1];
+    let wrapper = time(ITERS, || {
+        build_server_variables(
+            "GET",
+            "/products/42?ref=home",
+            "ref=home",
+            &script,
+            &docroot,
+            "/products/42",
+            "shop.example.com",
+            443,
+            "HTTP/1.1",
+            remote,
+            true,
+            &shape.headers,
+            &shape.env_vars,
+        )
+    });
+    println!("server_vars String-form wrapper (tests only): {wrapper:>6.0} ns/req");
+}
+
+/// #134 — the response-header round-trip, Rust side.
+#[test]
+#[ignore = "timing probe — run manually in release mode with --nocapture"]
+fn bench_response_headers() {
+    // A Laravel-ish response header set.
+    let headers: Vec<(&str, &str)> = vec![
+        ("Content-Type", "text/html; charset=UTF-8"),
+        ("Cache-Control", "no-cache, private"),
+        ("Date", "Mon, 01 Sep 2026 12:00:00 GMT"),
+        ("Set-Cookie", "XSRF-TOKEN=eyJpdiI6IjZ4TmpX; path=/; samesite=lax"),
+        ("Set-Cookie", "laravel_session=eyJpdiI6IjZ4TmpX; path=/; httponly; samesite=lax"),
+        ("X-Frame-Options", "SAMEORIGIN"),
+        ("Vary", "Accept-Encoding"),
+    ];
+    const ITERS: u32 = 500_000;
+
+    // Old path (pre-#134): the C side packs "Name: Value\n" text; Rust
+    // re-parses it line by line. The pack half below stands in for the C
+    // smart_str build (same byte traffic), the parse half is a copy of the
+    // removed parse_packed_headers().
+    let old = time(ITERS, || {
+        let mut packed = Vec::with_capacity(256);
+        for (name, value) in &headers {
+            packed.extend_from_slice(name.as_bytes());
+            packed.extend_from_slice(b": ");
+            packed.extend_from_slice(value.as_bytes());
+            packed.push(b'\n');
+        }
+        let parsed: Vec<(String, String)> = String::from_utf8_lossy(&packed)
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim_end_matches('\r');
+                if line.is_empty() {
+                    return None;
+                }
+                let (name, value) = line.split_once(':')?;
+                Some((name.trim().to_string(), value.trim().to_string()))
+            })
+            .collect();
+        parsed
+    });
+    println!("response_headers old pack+reparse path: {old:>8.0} ns/req");
+}

--- a/crates/ephpm-php/tests/perf_micro.rs
+++ b/crates/ephpm-php/tests/perf_micro.rs
@@ -282,4 +282,17 @@ fn bench_response_headers() {
         parsed
     });
     println!("response_headers old pack+reparse path: {old:>8.0} ns/req");
+
+    // New path (#134): the C side hands over parallel (ptr, len) arrays and
+    // Rust copies each half straight into an owned String (with the same
+    // trim the old parse applied). No pack buffer, no UTF-8 pass over a
+    // concatenated blob, no line splitting.
+    let new = time(ITERS, || {
+        let parsed: Vec<(String, String)> = headers
+            .iter()
+            .map(|(name, value)| (name.trim().to_string(), value.trim().to_string()))
+            .collect();
+        parsed
+    });
+    println!("response_headers new structured path:   {new:>8.0} ns/req");
 }

--- a/crates/ephpm-php/tests/response_headers.rs
+++ b/crates/ephpm-php/tests/response_headers.rs
@@ -1,0 +1,119 @@
+//! Linked functional tests for the structured response-header capture
+//! (issue #134): the fpm path's headers must come back exactly as PHP set
+//! them, without the old "Name: Value\n" pack + re-parse round-trip.
+//!
+//! Requires a real libphp link (`php_linked`); compiles to nothing in stub
+//! mode. Run with:
+//!
+//! ```text
+//! cargo test -p ephpm-php --release --test response_headers -- --test-threads=1
+//! ```
+
+#![cfg(all(test, php_linked))]
+
+use std::sync::OnceLock;
+
+use ephpm_php::PhpRuntime;
+use ephpm_php::request::PhpRequest;
+use ephpm_php::response::PhpResponse;
+use serial_test::serial;
+use tempfile::TempDir;
+
+static SCRIPT_DIR: OnceLock<TempDir> = OnceLock::new();
+static INIT: OnceLock<()> = OnceLock::new();
+
+fn init_once() {
+    INIT.get_or_init(|| {
+        PhpRuntime::init().expect("php_embed_init");
+        PhpRuntime::finalize_for_http().expect("finalize_for_http");
+    });
+}
+
+fn run_script(name: &str, body: &str) -> PhpResponse {
+    init_once();
+    let dir = SCRIPT_DIR.get_or_init(|| TempDir::new().expect("tempdir")).path();
+    let script = dir.join(name);
+    std::fs::write(&script, body).expect("write test script");
+    PhpRuntime::execute(PhpRequest {
+        method: "GET".into(),
+        uri: format!("/{name}"),
+        path: format!("/{name}"),
+        query_string: String::new(),
+        document_root: script.parent().unwrap().to_path_buf(),
+        script_filename: script,
+        headers: vec![("host".into(), "localhost".into())],
+        body: Vec::new(),
+        content_type: None,
+        remote_addr: "127.0.0.1:12345".parse().unwrap(),
+        server_name: "localhost".into(),
+        server_port: 8080,
+        is_https: false,
+        protocol: "HTTP/1.1".into(),
+        env_vars: Vec::new(),
+        middleware: Vec::new(),
+    })
+    .expect("execute")
+}
+
+fn values<'a>(resp: &'a PhpResponse, name: &str) -> Vec<&'a str> {
+    resp.headers
+        .iter()
+        .filter(|(n, _)| n.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.as_str())
+        .collect()
+}
+
+#[test]
+#[serial]
+fn explicit_headers_come_back_split_and_exact() {
+    let resp = run_script(
+        "hdr_exact.php",
+        "<?php header('X-One: alpha'); header('Cache-Control: no-cache, private'); echo 'ok';",
+    );
+    assert_eq!(resp.status, 200);
+    assert_eq!(values(&resp, "X-One"), vec!["alpha"]);
+    // A value containing ': ' must not be re-split on it.
+    assert_eq!(values(&resp, "Cache-Control"), vec!["no-cache, private"]);
+}
+
+#[test]
+#[serial]
+fn duplicate_headers_arrive_as_distinct_entries() {
+    let resp = run_script(
+        "hdr_dup.php",
+        "<?php setcookie('a', '1', ['path' => '/']); setcookie('b', '2', ['path' => '/']); echo 'ok';",
+    );
+    let cookies = values(&resp, "Set-Cookie");
+    assert_eq!(cookies.len(), 2, "both Set-Cookie headers must survive: {cookies:?}");
+    assert!(cookies[0].starts_with("a=1"));
+    assert!(cookies[1].starts_with("b=2"));
+}
+
+#[test]
+#[serial]
+fn header_without_space_after_colon_is_delivered() {
+    // The old fpm parse split on ": " and silently DROPPED this header; the
+    // structured capture splits on the colon and skips optional whitespace.
+    let resp = run_script("hdr_nospace.php", "<?php header('X-Tight:packed'); echo 'ok';");
+    assert_eq!(values(&resp, "X-Tight"), vec!["packed"]);
+}
+
+#[test]
+#[serial]
+fn default_content_type_is_synthesized_when_script_sets_none() {
+    let resp = run_script("hdr_default_ct.php", "<?php echo 'ok';");
+    let cts = values(&resp, "Content-Type");
+    assert_eq!(cts.len(), 1, "exactly one synthesized Content-Type: {cts:?}");
+    assert!(cts[0].starts_with("text/html"), "unexpected default Content-Type: {}", cts[0]);
+}
+
+#[test]
+#[serial]
+fn explicit_content_type_wins_over_synthesis() {
+    let resp = run_script(
+        "hdr_explicit_ct.php",
+        "<?php header('Content-Type: application/json'); echo '{}';",
+    );
+    let cts = values(&resp, "Content-Type");
+    assert_eq!(cts, vec!["application/json"]);
+}

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -3845,7 +3845,10 @@ impl Router {
         }
 
         let cookie_data = ephpm_php::request::cookie_string_from_headers(&headers);
-        let server_vars = ephpm_php::request::build_server_variables(
+        // Built directly in FFI-ready form (issue #133): the worker bridge
+        // borrows these pointers as-is instead of converting every pair to
+        // CString a second time.
+        let server_vars = ephpm_php::request::build_server_variables_c(
             &method,
             &uri,
             &query_string,


### PR DESCRIPTION
Closes #133
Closes #134

## Why now

Both issues describe per-request work that is pure overhead — the same data
built twice, and a text round-trip across the FFI boundary that exists only
to be re-parsed on the other side. Removing them is worth doing on its own
terms; the header change also closes a real correctness gap (below).

**A correction to the issues' own estimates.** #133 and #134 guessed ~0.15 ms
and ~0.05 ms respectively. Measured, the fragments are ~4 µs and ~1 µs — the
issues were high by roughly 40×. This PR is worth ~3–4 µs off a trivial
request, not ~0.20 ms. On the current Laravel worker-mode figure (~1074 rps
per worker ≈ 0.93 ms of real work per request) that is well under 1%, not the
~21% the issues' numbers would have implied. The micro and linked deltas
below are the honest attribution.

## What changed

**#133 — `$_SERVER` built once, in FFI-ready form.** Both dispatch paths (fpm
`execute_php`, worker dispatch in the router) built `$_SERVER` as
`Vec<(String, String)>` and then converted every pair to `CString` a *second*
time — two allocations, two copies, and a NUL scan per string, per request.
`build_server_variables_c` is now the single source of truth and yields
`Cow<'static, CStr>` pairs directly, with `&'static CStr` literals for
everything invariant between requests (fixed CGI keys, `SERVER_SOFTWARE`,
`GATEWAY_INTERFACE`, `REDIRECT_STATUS`, `HTTPS`, common methods/protocols,
canonical header keys). The `String` form stays as a thin wrapper for the
derivation tests.

**#134 — response headers cross the FFI boundary structured, not as text.**
Headers were flattened to `"Name: Value\n"` and re-parsed line-by-line on both
paths. Now:
- fpm: the C capture records pre-split name/value spans; Rust reads them via
  `ephpm_get_response_header_count()` / `ephpm_get_response_header()`.
- worker: `send_response`/`response_begin` take parallel `(ptr, len)`
  name/value arrays; `headers_from_raw()` replaces `parse_packed_headers()`.

Two correctness fixes fall out of dropping the text framing (both latent bugs
in the old round-trip):

1. A `Name:Value` header with no space after the colon is now delivered by the
   fpm path instead of being silently dropped.
2. A header value containing a newline can no longer be re-parsed into extra
   headers. On the worker path — where values come from a PHP array and never
   pass through `header()`'s CRLF check — the old pack-then-parse turned
   `['X-Foo' => "a\nX-Evil: 1"]` into *two* wire headers. That is response
   header injection; structured passing closes it. Such a value now reaches
   hyper intact, is rejected by `HeaderValue::from_str`, and the response
   fails closed as a 500 (the pre-existing behaviour of `build_php_response`
   for any header hyper refuses).

The body copy at the end of `execute_php` (issue #134's "consider Bytes
pooling") is **left as-is** — the C output buffer is reused per-thread, so
handing ownership across the boundary is a lifetime redesign, not a header
fix.

## Measurement

Two harnesses, both added in this PR:
- `crates/ephpm-php/tests/perf_micro.rs` — stub-mode `#[ignore]` probes
  isolating each hot-path fragment (old vs new leg in one run).
- `crates/ephpm-php/tests/perf_linked.rs` — linked end-to-end per-request
  probe through `PhpRuntime::execute` (no OPcache, so the absolute number
  carries a constant compile cost; the before/after *delta* is attributable).

**Micro (release, Windows x64, per request):**

| fragment | before | after |
|---|--:|--:|
| `$_SERVER` build+CString, 4-header request | ~4.4 µs | ~1.1 µs |
| `$_SERVER` build+CString, 12-header browser request | ~6.1 µs | ~2.1 µs |
| response-header round-trip (7 headers) | ~1.0 µs | ~0.6 µs |

**Linked end-to-end (release, Linux/WSL, no OPcache, min-of-N interleaved to
survive a noisy shared box):**

| build | µs/request |
|---|--:|
| baseline (probe only) | 41.5–43.7 |
| +#133 | 39.5 |
| +#133 +#134 | 39.0–40.6 |

Net ≈ **3–4 µs off a trivial request**, consistent in direction across every
interleaved round, and consistent with the micro fragments summing to
~3.7–4.4 µs. No Laravel rig was stood up here, so no rps figure is claimed.

## Multi-tenant safety

The #133 rework adds **no** cross-request cache. Every `$_SERVER` entry is
still derived fresh from the request's own resolved site; the only shared
storage is `&'static CStr` literals whose values are identical for every
tenant (`GET`, `CGI/1.1`, …). Per-site values — `DOCUMENT_ROOT`,
`SERVER_NAME`, the injected `DB_USER`/`DB_PASSWORD` — all go through
`CString::new` fresh on every call.
`request::tests::test_per_site_values_never_bleed_between_requests` builds
`$_SERVER` for two sites back-to-back and asserts each carries only its own
docroot, host, and credentials, and that none of site A's values (host or
secret) appear anywhere in site B's view. ZTS is unaffected: the new C
capture state (`hdr_spans`, `hdr_span_count`, `hdr_span_cap`) is `EPHPM_TLS`
like the buffers it indexes, and is freed in `ephpm_thread_shutdown`.

## Tests

- `request.rs`: per-site bleed test + `String`/C-form agreement test; existing
  worker/fpm parity test updated to the C form.
- `worker_bridge.rs`: `headers_from_raw` unit tests (trim parity with the old
  parse, null-array handling, and a value-with-newline case the packed form
  could not carry).
- `crates/ephpm-php/tests/response_headers.rs`: new linked functional suite
  pinning the fpm capture end-to-end (exact split, a value containing `": "`
  not being re-split, duplicate `Set-Cookie`, the no-space form,
  default-Content-Type synthesis, explicit-Content-Type precedence).

Gates: stub-mode `cargo build`/`cargo test -p ephpm-php --lib` pass;
`cargo clippy --workspace --all-targets -- -D warnings` clean;
`cargo +nightly fmt --all -- --check` clean.

**Note on the linked suites in CI:** the Linux 8.5.7 SDK embed harness
SIGSEGVs in libc during PHP request teardown under machine load — reproduced
identically on the **untouched** `main` `php_middleware` binary, so it is a
pre-existing environment flake, not from this change. `response_headers`
passed 5/5 cleanly when the box was quiet, and all 9 header-exercising
`worker_mode` e2e tests pass on this branch (the 2 `worker_mode` failures
seen — `deep_recursion`, `exit_mid_request` — are 504 timeouts that reproduce
identically at `c2774ab`).
