### PR TITLE
docs(middleware): the guide's fail-closed vhost snippet denied every single-site request (#453)

### DIFF
--- a/examples/rust-middleware/README.md
+++ b/examples/rust-middleware/README.md
@@ -23,6 +23,7 @@ Everything below was verified end to end — see
 | Request | Verdict | Result |
 |---|---|---|
 | `GET /health.php` | `ACTION_CONTINUE` | PHP runs untouched; `X-Api-Gate: bypass` appended |
+| `GET /api/v1/users` (no vhost matched, `require_vhost = true`) | `ACTION_RESPOND` | `404` JSON, PHP never runs — **off by default**, see [`require_vhost`](#require_vhost-and-why-the-default-is-false) |
 | `GET /api/v1/users` (no key) | `ACTION_RESPOND` | `401` JSON, PHP never runs |
 | `GET /api/v1/users` (revoked key) | `ACTION_RESPOND` | `403` JSON, PHP never runs |
 | `GET /api/v1/users` (over budget) | `ACTION_RESPOND` | `429` + `Retry-After`, PHP never runs |
@@ -176,6 +177,26 @@ than silently not running — which is the only safe default for an auth module.
 | `prefix` (string) | `"/api/"` | only paths with this prefix are gated |
 | `strip_prefix` (string) | unset | removed from the front of the path on `REWRITE` |
 | `requests_per_window` (integer) | `100` | budget per tenant per 10-second window |
+| `require_vhost` (bool) | `false` | deny requests that matched no virtual host — see below |
+
+### `require_vhost`, and why the default is `false`
+
+`req.vhost_id()` is `None` for **two** situations the ABI cannot tell apart
+(issue [#453](https://github.com/ephpm/ephpm/issues/453)): a node with no
+tenancy configured (no `sites_dir`, no `[[site]]` — nothing to match, so *every*
+request is `None`), and a multi-site node that matched nothing. A module that
+denies on `None` unconditionally therefore denies all traffic on the first
+shape, which is the majority of deployments.
+
+So this module treats "no tenant" as one untenanted bucket
+(`ephpm_middleware::UNMATCHED_VHOST`) by default — the same choice the stock
+`ratelimit` and `maintenance-mode` modules make — and denial is an operator
+opt-in via `require_vhost = true`, set only by someone who knows the node is
+multi-tenant. The three-way block that implements this is the one the
+[native-middleware guide](https://ephpm.dev/guides/native-middleware/) quotes;
+`tests/guide_snippet.rs` fails the build if the guide and `src/lib.rs` drift
+apart, and `a_single_site_node_is_served_not_denied` in `src/lib.rs` asserts
+the untenanted request is actually served.
 
 ---
 
@@ -342,8 +363,10 @@ The refusals are asserted **before** the accepted call on purpose: `declare!`
 stashes the host table and instance in `OnceLock`s, so a successful `init`
 first would make the refusal unfalsifiable.
 
-Plus `cargo test -p ephpm-middleware-example` — 8 unit tests covering config
-validation, all three verdicts, per-tenant budget isolation and revocation.
+Plus `cargo test -p ephpm-middleware-example` — 11 unit tests covering config
+validation, all three verdicts, per-tenant budget isolation, revocation and the
+untenanted (single-site) scope, and 2 integration tests keeping the guide's
+quoted snippet in lockstep with this crate's source.
 
 ### Not verified here
 

--- a/examples/rust-middleware/src/lib.rs
+++ b/examples/rust-middleware/src/lib.rs
@@ -24,6 +24,7 @@
 //! | Situation | Verdict | Result |
 //! |---|---|---|
 //! | Path outside `prefix` | `CONTINUE` | PHP runs unchanged; `X-Api-Gate: bypass` appended to the response |
+//! | No vhost matched, `require_vhost = true` | `RESPOND` | `404` JSON, PHP never runs (off by default — see *Tenancy* below) |
 //! | Missing / unknown `X-Api-Key` | `RESPOND` | `401` JSON, PHP never runs |
 //! | Key revoked at runtime (KV) | `RESPOND` | `403` JSON, PHP never runs |
 //! | Over the request budget | `RESPOND` | `429` JSON + `Retry-After`, PHP never runs |
@@ -79,6 +80,28 @@
 //! | `prefix` (string) | `"/api/"` | only paths with this prefix are gated |
 //! | `strip_prefix` (string) | unset | removed from the front of the path on `REWRITE` |
 //! | `requests_per_window` (integer) | `100` | budget per tenant per 10-second window |
+//! | `require_vhost` (bool) | `false` | deny requests that matched no virtual host — see the tenancy note |
+//!
+//! # Tenancy: what `vhost_id() == None` means
+//!
+//! [`Request::vhost_id`] is the router's canonical site key, and `None` is
+//! **two** different situations that the ABI (minor 3) cannot tell apart:
+//!
+//! 1. **This node has no tenancy configured** — no `sites_dir`, no
+//!    `[[site]]`, so there is nothing to match and *every* request is `None`.
+//!    That is the majority deployment shape.
+//! 2. **A multi-site node matched nothing** — the `Host` is unrecognised and
+//!    the request is being served from the default document root.
+//!
+//! A module that denies on `None` unconditionally therefore denies 100% of
+//! traffic on shape 1 (issue #453). Denial has to be an operator opt-in, which
+//! is what `require_vhost` is: it defaults to **false**, and the default
+//! behaviour is to treat "no tenant" as one untenanted bucket
+//! ([`ephpm_middleware::UNMATCHED_VHOST`]) — the same choice the stock
+//! `ratelimit` and `maintenance-mode` modules make. The three-way handling in
+//! [`ApiGate::invoke`] is the block the native-middleware guide quotes; a
+//! lockstep test (`tests/guide_snippet.rs`) fails the build if the guide and
+//! this source diverge.
 //!
 //! # Failure posture
 //!
@@ -88,6 +111,9 @@
 //! unavailable, the request is allowed with a warning. Dropping all traffic
 //! because the counter tier hiccuped turns a soft protection into a hard
 //! outage — the same trade-off the builtin `ratelimit` module makes.
+//! Tenancy is **fail-open by default and fail-closed on request**, for the
+//! reason above: the safe default cannot be one that black-holes the most
+//! common node shape.
 
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -120,6 +146,13 @@ pub struct ApiGate {
     keys: HashMap<String, String>,
     /// Requests allowed per tenant per [`WINDOW_SECS`] window.
     budget: i64,
+    /// Deny a request whose `Host` matched no virtual host. **Off by
+    /// default**, and that default is load-bearing: on a node with no
+    /// `sites_dir` and no `[[site]]` there is nothing to match, so
+    /// `vhost_id()` is `None` on every request and denying would drop all
+    /// traffic (issue #453). Only an operator who knows the node is
+    /// multi-tenant can turn this on.
+    require_vhost: bool,
 }
 
 impl ApiGate {
@@ -193,8 +226,14 @@ impl Middleware for ApiGate {
         if budget <= 0 {
             return Err("`requests_per_window` must be > 0".into());
         }
+        // Absent means false: a module cannot detect for itself whether the
+        // node has virtual hosting, so denying "no tenant" is opt-in.
+        let require_vhost = match config.get("require_vhost") {
+            None | Some(serde_json::Value::Null) => false,
+            Some(v) => v.as_bool().ok_or("`require_vhost` must be a boolean")?,
+        };
 
-        Ok(Self { prefix, strip_prefix, keys, budget })
+        Ok(Self { prefix, strip_prefix, keys, budget, require_vhost })
     }
 
     fn invoke(&self, req: &Request<'_>) -> Response {
@@ -206,6 +245,33 @@ impl Middleware for ApiGate {
         }
 
         let host = req.host();
+
+        // ── The request's tenant scope ────────────────────────────────────
+        // GUIDE-SNIPPET-BEGIN: tenant-scope
+        // Three-way, and only the middle branch is a policy decision.
+        //
+        // `vhost_id()` is the router's canonical site key. `None` does *not*
+        // mean "hostile": it is every request on a single-site node (no
+        // `sites_dir`, no `[[site]]`, so nothing to match) and an unmatched
+        // `Host` on a multi-site one — and the ABI cannot tell those two
+        // apart (issue #453). A bare `let Some(site) = … else { deny }`
+        // therefore denies 100% of traffic on the most common node shape.
+        let vhost = match req.vhost_id() {
+            // A router-resolved tenant. Scope per-site state to this key —
+            // never to `http_host()`, which the client chose.
+            Some(site) => site,
+            // No tenant, and the operator has declared this node multi-tenant
+            // (`require_vhost = true`), so an unmatched `Host` really is
+            // unknown: deny. Opt-in only, for the reason above.
+            None if self.require_vhost => return Self::reject(404, "unknown host"),
+            // No tenant and tenancy is not in use: serve the request as the
+            // single untenanted bucket. `UNMATCHED_VHOST` is unspellable as a
+            // site key, so it cannot collide with a real tenant, and every
+            // unmatched request shares one budget instead of minting a fresh
+            // one per `Host` value (issue #390).
+            None => ephpm_middleware::UNMATCHED_VHOST,
+        };
+        // GUIDE-SNIPPET-END: tenant-scope
 
         // ── RESPOND: authentication (fail-closed) ─────────────────────────
         let Some(tenant) = req.header("X-Api-Key").and_then(|key| self.keys.get(key)) else {
@@ -224,10 +290,6 @@ impl Middleware for ApiGate {
         // ── RESPOND: fixed-window rate limit (fail-open) ──────────────────
         let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
         let window = now / WINDOW_SECS;
-        // `vhost_id()` is the canonical site key, `None` when the request
-        // matched no vhost. Bucket those together rather than trusting the
-        // header — otherwise varying `Host` mints a fresh budget.
-        let vhost = req.vhost_id().unwrap_or(ephpm_middleware::UNMATCHED_VHOST);
         let key = Self::window_key(vhost, tenant, window);
 
         // One atomic call: increment, and stamp the TTL only if this call
@@ -312,6 +374,11 @@ mod tests {
     /// one store, and a shared tenant would let one test's revocation marker
     /// or window counter decide another test's verdict.
     fn gate_for(tenant: &str) -> ApiGate {
+        gate_with(tenant, false)
+    }
+
+    /// [`gate_for`] with an explicit `require_vhost` setting.
+    fn gate_with(tenant: &str, require_vhost: bool) -> ApiGate {
         let mut keys = serde_json::Map::new();
         keys.insert(format!("k-{tenant}"), serde_json::Value::String(tenant.to_owned()));
         ApiGate::init(&serde_json::json!({
@@ -319,6 +386,7 @@ mod tests {
             "prefix": "/api/",
             "strip_prefix": "/api/v1",
             "requests_per_window": 3,
+            "require_vhost": require_vhost,
         }))
         .expect("init")
     }
@@ -461,5 +529,67 @@ mod tests {
         }
         // Tenant b is unaffected on its first request.
         assert_ne!(invoke(&mw, "vh-split", "/api/x", &b).__status(), 429);
+    }
+
+    /// Issue #453 — the regression this module's tenant-scope block exists to
+    /// prevent, and the one the guide's old snippet would have caused.
+    ///
+    /// A single-site node (no `sites_dir`, no `[[site]]`) matches no virtual
+    /// host, so `Router::resolve_site` returns no key and `vhost_id()` is
+    /// `None` on **every** request — the empty site key below is exactly what
+    /// the router passes in that shape. An authenticated request there must
+    /// still be served. A module written as
+    /// `let Some(site) = req.vhost_id() else { return deny };` fails this
+    /// test with a 404, which is what it would do to 100% of production
+    /// traffic on the majority deployment shape.
+    #[test]
+    fn a_single_site_node_is_served_not_denied() {
+        setup_kv();
+        let resp = invoke(&gate_for("solo"), "", "/api/v1/users", &key_header("solo"));
+        assert_eq!(
+            resp.__action(),
+            ACTION_REWRITE,
+            "an untenanted node must be served, not treated as an unknown host"
+        );
+        assert_eq!(resp.__status(), 0, "no short-circuit response");
+        assert_eq!(find(resp.__headers(), "X-Api-Tenant"), Some("solo"));
+    }
+
+    /// The untenanted bucket is a real, collision-proof scope rather than a
+    /// hole: two requests with no vhost share one budget instead of minting a
+    /// fresh one, and the key they share is the sentinel no site key can spell.
+    #[test]
+    fn untenanted_requests_share_one_budget() {
+        setup_kv();
+        let mw = gate_for("bucket");
+        let mut limited = false;
+        for _ in 0..12 {
+            if invoke(&mw, "", "/api/v1/x", &key_header("bucket")).__status() == 429 {
+                limited = true;
+                break;
+            }
+        }
+        assert!(limited, "untenanted requests must count into one shared budget");
+        assert!(
+            ApiGate::window_key(ephpm_middleware::UNMATCHED_VHOST, "bucket", 0)
+                .contains("_UNMATCHED"),
+            "the shared bucket is keyed by the sentinel, not by a client-supplied host"
+        );
+    }
+
+    /// Denying "no tenant" is legitimate — for an operator who knows the node
+    /// is multi-tenant. It has to be that operator's explicit choice, which is
+    /// what `require_vhost` is; the same request that is served above is
+    /// refused here, and only because the config said so.
+    #[test]
+    fn require_vhost_denies_only_when_the_operator_opted_in() {
+        setup_kv();
+        let resp = invoke(&gate_with("strict", true), "", "/api/v1/users", &key_header("strict"));
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 404);
+        // A resolved tenant is unaffected by the knob.
+        let ok =
+            invoke(&gate_with("strict2", true), "vh-known", "/api/v1/x", &key_header("strict2"));
+        assert_eq!(ok.__action(), ACTION_REWRITE);
     }
 }

--- a/examples/rust-middleware/tests/guide_snippet.rs
+++ b/examples/rust-middleware/tests/guide_snippet.rs
@@ -1,0 +1,133 @@
+//! Docs-vs-code lockstep for the tenant-scope pattern in
+//! `site/content/guides/native-middleware.md`.
+//!
+//! # Why this test exists
+//!
+//! The guide used to carry a hand-typed snippet that was *type-correct and
+//! semantically wrong* (issue #453): it denied every request whose
+//! `vhost_id()` was `None`, which on a single-site node is every request. It
+//! compiled; it would have passed a doctest; it contradicted the prose eight
+//! lines above it and shipped that way from birth. Nothing in the tree tied
+//! the words to the code.
+//!
+//! So the guide no longer owns that snippet. It quotes the block between the
+//! `GUIDE-SNIPPET-BEGIN/END: tenant-scope` markers in this crate's
+//! `src/lib.rs` — real, compiled, clippy-linted code whose behaviour is
+//! asserted by `a_single_site_node_is_served_not_denied` and its siblings —
+//! and this test fails the build when the two drift apart.
+//!
+//! Both files are pulled in with `include_str!`, so moving or renaming either
+//! is a compile error rather than a silently skipped check.
+//!
+//! # What it does not catch
+//!
+//! It pins *one* marked block in *one* guide. A wrong pattern written
+//! somewhere else in the docs is out of scope, except for the specific shape
+//! of #453, which [`no_unconditional_vhost_denial_in_the_guide`] greps for
+//! across the whole file. And CI skips docs-only changes
+//! (`ci.yml`'s `paths-ignore`), so a PR that edits only markdown will not run
+//! this — the mismatch surfaces on the next PR that touches code.
+
+/// The module the guide quotes.
+const SOURCE: &str = include_str!("../src/lib.rs");
+
+/// The guide that quotes it.
+const GUIDE: &str = include_str!("../../../site/content/guides/native-middleware.md");
+
+/// Marks the quoted region in [`SOURCE`].
+const SOURCE_BEGIN: &str = "GUIDE-SNIPPET-BEGIN: tenant-scope";
+/// Ends the quoted region in [`SOURCE`].
+const SOURCE_END: &str = "GUIDE-SNIPPET-END: tenant-scope";
+/// Marks the quoting fenced block in [`GUIDE`]; the ```` ```rust ```` fence
+/// on the next line opens the block this test compares.
+const GUIDE_MARKER: &str = "<!-- guide-snippet: tenant-scope -->";
+
+/// Strip the common leading indentation and normalise line endings, so the
+/// guide can present the block unindented while the source keeps it nested
+/// inside `invoke`.
+fn dedent(lines: &[&str]) -> String {
+    let indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+    lines
+        .iter()
+        .map(|l| if l.len() >= indent { &l[indent..] } else { l.trim_start() })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The marked region of `src/lib.rs`, marker lines excluded.
+fn snippet_from_source() -> String {
+    let lines: Vec<&str> = SOURCE.lines().collect();
+    let begin = lines
+        .iter()
+        .position(|l| l.contains(SOURCE_BEGIN))
+        .expect("src/lib.rs must carry the GUIDE-SNIPPET-BEGIN marker");
+    let end = lines
+        .iter()
+        .position(|l| l.contains(SOURCE_END))
+        .expect("src/lib.rs must carry the GUIDE-SNIPPET-END marker");
+    assert!(end > begin + 1, "the marked region must not be empty");
+    dedent(&lines[begin + 1..end])
+}
+
+/// The fenced Rust block the guide introduces with [`GUIDE_MARKER`].
+fn snippet_from_guide() -> String {
+    let lines: Vec<&str> = GUIDE.lines().collect();
+    let marker = lines
+        .iter()
+        .position(|l| l.trim() == GUIDE_MARKER)
+        .expect("the guide must introduce the quoted block with the HTML marker");
+    let open = marker + 1;
+    assert_eq!(
+        lines.get(open).map(|l| l.trim()),
+        Some("```rust"),
+        "the marker must be immediately followed by a ```rust fence"
+    );
+    let close = lines[open + 1..]
+        .iter()
+        .position(|l| l.trim() == "```")
+        .expect("the quoted block must be closed")
+        + open
+        + 1;
+    dedent(&lines[open + 1..close])
+}
+
+/// The guide's tenant-scope block must be the compiled module's, verbatim.
+///
+/// Editing one without the other fails here. Fix it by copying the source
+/// block into the guide — the source is the original, because it is the copy
+/// that runs.
+#[test]
+fn guide_quotes_the_compiled_tenant_scope_block() {
+    let source = snippet_from_source();
+    let guide = snippet_from_guide();
+    assert_eq!(
+        guide, source,
+        "site/content/guides/native-middleware.md has drifted from \
+         examples/rust-middleware/src/lib.rs.\n\n--- guide ---\n{guide}\n\n--- source ---\n{source}"
+    );
+}
+
+/// Issue #453's exact shape, anywhere in the guide.
+///
+/// `let Some(x) = req.vhost_id() else { ... }` has no correct unconditional
+/// form: the `else` arm runs on every request of a single-site node, so a
+/// snippet written that way either denies all traffic or teaches a reader to.
+/// A module that genuinely wants to deny gates it on operator config (see the
+/// `require_vhost` branch of the block above) rather than on `None` alone.
+#[test]
+fn no_unconditional_vhost_denial_in_the_guide() {
+    for (n, line) in GUIDE.lines().enumerate() {
+        let compact: String = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            !compact.contains("= req.vhost_id() else"),
+            "native-middleware.md:{} reintroduces the #453 let-else denial: {}",
+            n + 1,
+            line.trim()
+        );
+    }
+}

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -647,10 +647,10 @@ and a configured `sites_domain_suffix` is already stripped.
 
 `None` means the request matched **no** known virtual host. That is a decision,
 not a missing value: ePHPm serves unrecognised hosts from the default document
-root, so `http_host()` there is arbitrary client input. Use `None` to fail
-closed, or bucket it under `ephpm_middleware::UNMATCHED_VHOST` — never
-substitute the header, or a caller gets a fresh keyspace (and a fresh rate-limit
-budget) per `Host` value they invent.
+root, so `http_host()` there is arbitrary client input. Bucket `None` under
+`ephpm_middleware::UNMATCHED_VHOST` — never substitute the header, or a caller
+gets a fresh keyspace (and a fresh rate-limit budget) per `Host` value they
+invent.
 
 **`None` is the normal case on a single-site node**, not an edge case. With
 neither `sites_dir` nor any `[[site]]` configured there are no vhosts to match,
@@ -660,13 +660,54 @@ single-site `maintenance-mode` flag lives at `mw:maintenance:_UNMATCHED`. (C
 modules get a raw NULL here and **must** null-check; Rust's `Option` makes it a
 compile error.)
 
+**`None` is two situations the ABI cannot tell apart** (issue
+[#453](https://github.com/ephpm/ephpm/issues/453)): "this node has no tenancy
+configured" and "this multi-site node matched nothing". Minor 3 exposes no
+`multi_tenant` flag, so a module cannot distinguish them. That makes *denying*
+on `None` an operator decision, not a module default: a module that denies
+unconditionally — a bare `let Some(site) = … else { return deny };` over
+`vhost_id()` — denies **100% of traffic** on the single-site shape, which is
+the majority of deployments. Expose it as a config knob (below, `require_vhost`, default
+`false`) and let the operator who knows the node is multi-tenant switch it on.
+
+The three-way handling, quoted verbatim from
+[`examples/rust-middleware`](https://github.com/ephpm/ephpm/blob/main/examples/rust-middleware/src/lib.rs)
+— it is compiled, linted and unit-tested in-tree, and a lockstep test fails the
+build if this block and that source ever diverge:
+
+<!-- guide-snippet: tenant-scope -->
 ```rust
-// Fail closed: no tenant, no policy.
-let Some(site) = req.vhost_id() else {
-    return Response::respond(404, "unknown host");
+// Three-way, and only the middle branch is a policy decision.
+//
+// `vhost_id()` is the router's canonical site key. `None` does *not*
+// mean "hostile": it is every request on a single-site node (no
+// `sites_dir`, no `[[site]]`, so nothing to match) and an unmatched
+// `Host` on a multi-site one — and the ABI cannot tell those two
+// apart (issue #453). A bare `let Some(site) = … else { deny }`
+// therefore denies 100% of traffic on the most common node shape.
+let vhost = match req.vhost_id() {
+    // A router-resolved tenant. Scope per-site state to this key —
+    // never to `http_host()`, which the client chose.
+    Some(site) => site,
+    // No tenant, and the operator has declared this node multi-tenant
+    // (`require_vhost = true`), so an unmatched `Host` really is
+    // unknown: deny. Opt-in only, for the reason above.
+    None if self.require_vhost => return Self::reject(404, "unknown host"),
+    // No tenant and tenancy is not in use: serve the request as the
+    // single untenanted bucket. `UNMATCHED_VHOST` is unspellable as a
+    // site key, so it cannot collide with a real tenant, and every
+    // unmatched request shares one budget instead of minting a fresh
+    // one per `Host` value (issue #390).
+    None => ephpm_middleware::UNMATCHED_VHOST,
 };
-let creds = host.kv_get_global(&format!("basicauth:{site}"));
 ```
+
+`Self::reject` is that module's own JSON-error helper and `require_vhost` is a
+key in its `config` table, defaulting to `false`. The stock `ratelimit` and
+`maintenance-mode` modules take the third branch unconditionally — plain
+`req.vhost_id().unwrap_or(UNMATCHED_VHOST)`, no knob — because a shared bucket
+is the right answer for them either way. Reserve the deny branch for an
+operator gate (an `api-key`-shaped module), and keep it behind config.
 
 Reach for `http_host()` only when you genuinely want the host as sent — a
 canonical-host redirect, a log line — never as a lookup key for per-tenant


### PR DESCRIPTION
Closes the docs half of #453. The ABI half is split out into a separate issue (linked below) on purpose — an ABI minor bump does not belong in a docs fix.

## What was wrong

`site/content/guides/native-middleware.md` contradicted itself eight lines apart. The prose (correct):

> **`None` is the normal case on a single-site node**, not an edge case. […] Handle it as "one tenant", not as an error.

The code block immediately below (wrong):

```rust
// Fail closed: no tenant, no policy.
let Some(site) = req.vhost_id() else {
    return Response::respond(404, "unknown host");
};
```

`Router::resolve_site` (`crates/ephpm-server/src/router.rs`) returns the default site with **no** key when `sites_dir.is_none() && sites.is_empty()`, so `vhost_id()` is `None` on *every* request on a single-site node. A module copying that snippet 404s 100% of its traffic on the majority deployment shape. Prose and snippet landed in the same commit (`691e6fe`, #448) — it was self-contradictory from birth, not drift.

Nothing else in `site/content/`, `docs/`, `examples/` or `README.md` carried a copy; the guide was the only hit.

## The correct pattern

Three-way, and only the middle branch is a policy decision:

1. `Some(site)` — a router-resolved tenant; scope per-site state to that key.
2. `None` **and the operator has said this node is multi-tenant** — deny. Opt-in config, never a module default.
3. `None` otherwise — serve it as the single `UNMATCHED_VHOST` bucket, which is what the in-tree `ratelimit` and `maintenance_mode` builtins do unconditionally (`req.vhost_id().unwrap_or(UNMATCHED_VHOST)`), and why a single-site `maintenance-mode` flag lives at `mw:maintenance:_UNMATCHED`.

Branch 2 has to be operator config because **a module cannot detect tenancy itself**: "single-site node, tenancy not in use" and "multi-site node, `Host` matched nothing" are both `None` and the ABI exposes nothing else. `examples/rust-middleware` grows a `require_vhost` key (default `false`) as the worked form of that opt-in — read and enforced in this PR, not a placeholder.

## Coverage added, and what it does and does not catch

Compile-testing the snippet would not have caught this: it was type-correct and built fine. It was semantically wrong, so a doctest is the wrong instrument.

**The guide no longer owns the snippet.** It quotes a marked block in `examples/rust-middleware/src/lib.rs` — real code that is compiled, clippy-pedantic-linted, rustfmt'd and unit-tested, in the workspace member that exists precisely so `cargo clippy --workspace` catches ABI drift. Three tests back it:

| Test | Catches |
|---|---|
| `a_single_site_node_is_served_not_denied` (unit) | Executes the documented pattern with the empty site key the router passes on a single-site node and asserts the request is **served**, not 404'd. |
| `untenanted_requests_share_one_budget` (unit) | The untenanted bucket is a real shared scope keyed by the sentinel, not a per-`Host` hole. |
| `guide_quotes_the_compiled_tenant_scope_block` (integration) | The markdown block and the compiled source have drifted. |
| `no_unconditional_vhost_denial_in_the_guide` (integration) | The `let Some(..) = req.vhost_id() else` shape anywhere in the guide — it has no correct unconditional form. |

**Verified to fail on the pre-fix code, not assumed:**

* Reimplementing the module the pre-fix way ⇒ `a_single_site_node_is_served_not_denied` fails (`left: 1` RESPOND vs `right: 2` REWRITE) and `untenanted_requests_share_one_budget` fails.
* Restoring the pre-fix snippet into the guide ⇒ both integration tests fail, one naming the line number.

**What it does not catch, stated plainly:**

* It pins **one** marked block in **one** guide. A wrong pattern written elsewhere in the docs is out of scope, except for #453's exact `let-else` shape, which is grepped across the whole guide file.
* **CI skips docs-only changes** (`ci.yml` `paths-ignore: site/**, docs/**, **.md`). A PR that edits *only* the markdown will not run these tests; the mismatch then surfaces on the next PR that touches code, not on the offending one. #448 itself touched Rust, so this coverage *would* have red-flagged it as submitted. Narrowing `paths-ignore` to let this one guide through is a one-line change if maintainers want the hole closed — deliberately not done here, since it makes every edit to that file pay for the full matrix on a small fleet.
* It is a **lockstep check, not an include**. Hugo's `readFile` is confined to `site/`, so it cannot pull `examples/rust-middleware/src/lib.rs` in at build time; asserting equality is the closest structurally-enforced equivalent.

### Approaches weighed and rejected

* **A doctest on the snippet** — the snippet compiles. It would have passed.
* **An e2e case** (`crates/ephpm-e2e/`) mounting a fail-closed-shaped module on a single-site config — the decisive argument against it: **the server is not buggy**. It resolves and passes the site key correctly; only the *documented* code was wrong. An e2e would exercise ePHPm, not the guide. It would also need a PHP-linked release build plus a purpose-built deny-shaped cdylib fixture, and `cargo xtask e2e` is not part of the per-PR gate — 100× the cost to catch strictly less.
* **A second `declare!`-ing example crate** for the tenancy pattern — a new cdylib and another build target to teach one branch. Folding it into the existing gate keeps the code on a live path rather than in a demo that nothing calls.

## Not in this PR

The ABI gap — a module cannot distinguish an untenanted node from an unmatched host, so "deny unknown tenants" is not merely easy to get wrong, it is *unimplementable*. Proposal for an additive minor 4 is in **#469**. Until it lands, module authors are where this PR leaves them: bucket by default, and expose an operator knob (`require_vhost`-shaped) for the deny case. That is a workaround — it pushes knowledge of the node's shape into every module's config — but it is correct today and it never denies traffic nobody asked it to deny.

## Verification

```
cargo test -p ephpm-middleware-example          # 11 unit + 2 integration, all pass
cargo clippy -p ephpm-middleware-example --all-targets -- -D warnings   # clean
cargo +nightly fmt --all -- --check             # clean
```
