### PR TITLE
docs(guides): PR Previews for Your App — an onboarding hub for the preview system

### DIFF
--- a/site/content/guides/_index.md
+++ b/site/content/guides/_index.md
@@ -10,7 +10,8 @@ Task-oriented walkthroughs for common deployments.
 - **[Laravel](laravel/)** — Laravel with embedded SQLite or MySQL passthrough.
 - **[Virtual Hosts](virtual-hosts/)** — multi-tenant directory-based hosting.
 - **[TLS / ACME](tls-acme/)** — automatic Let's Encrypt certificates, including DNS-01 wildcards across five DNS providers.
-- **[PR Preview Bot](preview-bot/)** — per-PR preview URLs via the `switchboard` daemon + `switchboard-api` webhook receiver, running on ePHPm's multi-tenant runtime.
+- **[PR Previews for Your App](pr-previews/)** — start here if you want your pull requests to get live URLs: what the environment is, what goes in `ephpm.yaml`, and how the database and KV are wired.
+- **[PR Preview Bot](preview-bot/)** — the operator side of the same system: the `switchboard` daemon + `switchboard-api` webhook receiver, wildcard TLS, and the cluster fan-out.
 - **[Clustering Setup](clustering-setup/)** — gossip-based HA with clustered SQLite.
 - **[Database from PHP](db-from-php/)** — the in-process `ephpm_db_*` bridge, and how it relates to the `pdo_mysql` wire path.
 - **[KV from PHP](kv-from-php/)** — the `ephpm_kv_*` SAPI functions.

--- a/site/content/guides/pr-previews.md
+++ b/site/content/guides/pr-previews.md
@@ -1,0 +1,312 @@
++++
+title = "PR Previews for Your App"
+weight = 6
++++
+
+Every pull request gets a live URL, with its own database and its own KV
+keyspace, deployed in seconds and torn down when the PR closes. A bot leaves a
+single sticky comment with the link.
+
+This page is the orientation: what the environment is, what you put in your
+repository, and where the depth lives. It is deliberately short and it does not
+restate the two reference documents — it points at them, because a fact restated
+in two places is a fact that will drift.
+
+- **[Making your PHP app work as a preview](https://github.com/ephpm/switchboard/blob/main/docs/preview-app-guide.md)**
+  — the full app-developer contract: every manifest field, the `$_SERVER`
+  rules, `open_basedir`, disabled functions, recipes for WordPress, Laravel and
+  Symfony. Read it once before your first deploy.
+- **[PR Preview Bot](/guides/preview-bot/)** — the operator side: how the
+  webhook receiver and the deploy daemon fit together, wildcard TLS, and how to
+  stand the whole system up yourself.
+
+## What you get
+
+A preview is a **virtual host inside one shared ePHPm process** — not a
+container, not a VM, not a chroot. Other people's previews run in the same
+process, on the same uid. Everything per-tenant hangs off one
+[canonical site key](/guides/virtual-hosts/): your document root, your database
+file, your KV keyspace, your private temp and session directory.
+
+Concretely, per preview:
+
+| | |
+|---|---|
+| A hostname | `<owner>-<repo>-pr-<N>.<preview-domain>`, behind a wildcard certificate |
+| A database | Its own embedded, SQLite-compatible Turso file. Nothing shared with other previews. There is no MySQL or PostgreSQL server on the host. |
+| A KV store | Its own keyspace in ePHPm's in-process KV. There is no Redis server. |
+| Isolation | `open_basedir` confined to your checkout plus your private temp root, plus a function denylist (no `exec`, no `mail`, no persistent connections) |
+| A sticky PR comment | One comment, updated in place on every push, rewritten on close |
+
+What you do **not** get, and should plan around: no shelling out at request
+time, no `dl()`, no `queue:work` worker, and no authentication in front of the
+preview URL (see [Private repositories](#private-repositories) below).
+
+## The GitHub App
+
+There is **no public marketplace App to install.** The App that comments on
+`ephpm/*` pull requests as `ephpm[bot]` is a *private* GitHub App — visit
+[github.com/apps/ephpm](https://github.com/apps/ephpm) and GitHub says so
+plainly. A private App can only be installed on the account that owns it, so it
+cannot be installed on a repository outside the ePHPm organization.
+
+So there are two real situations:
+
+**Your repo is in the `ephpm` org.** The App is already installed. Add an
+`ephpm.yaml`, open a pull request, and the bot comments. Nothing else to do.
+
+**Your repo is anywhere else.** You run the system yourself, and part of that is
+creating your own GitHub App — one App per preview deployment, pointed at your
+own webhook endpoint. The permissions, the webhook event to subscribe to, and
+the rest of the standing-up work are in
+[PR Preview Bot → Install it on your repo](/guides/preview-bot/#install-it-on-your-repo).
+Do not wait for a hosted service; there is not one today.
+
+## What happens on a pull request
+
+The short version, in the order you will see it happen:
+
+1. GitHub sends a `pull_request` webhook (`opened`, `synchronize`, `reopened`
+   → deploy; `closed` → teardown).
+2. The deploy daemon fetches `refs/pull/<N>/head` at the recorded head SHA from
+   the **base** repository — which resolves fork PRs, and still resolves after
+   the fork is deleted, without ever trusting a third-party clone URL.
+3. It reads your `ephpm.yaml`, runs your `build:` steps, and moves the manifest
+   out of the served tree.
+4. It swaps the built checkout into place atomically and publishes your
+   `docroot:` as ePHPm's per-site document-root override.
+5. It runs your `seed:` steps, polls your `health:` path for a 200, and posts or
+   updates the comment.
+
+Two consequences worth internalising now, because they surprise everyone once:
+
+**`build:` and `seed:` run outside ePHPm.** They are plain `sh -c` children of
+the daemon, not HTTP requests, so they get no `$_SERVER['DB_*']` and cannot
+reach your preview's database. `composer install` is fine; `php artisan migrate`
+and `wp core install` are not. Anything that must touch the database has to
+arrive as an HTTP request to your own preview — that is what the worked example
+does.
+
+**`build:` and `seed:` failures are logged, not fatal.** Your real gate is
+`health:` — make it a path that only returns 200 once the app is genuinely
+usable.
+
+## Your manifest
+
+Put an `ephpm.yaml` at your repository root. Everything except `version` is
+optional, and a repo with no manifest still gets a preview (one is synthesized
+from the detected framework).
+
+```yaml
+version: 1                 # required; only version 1 is understood
+php: "8.5"
+docroot: "public"          # the web root; default "." — see the warning below
+build:
+  - "composer install --no-dev --optimize-autoloader --no-interaction"
+services:
+  database: "turso"        # "turso" (default) or false
+  kv: true                 # default true
+  websocket: true          # default: auto-detect websocket.php at the docroot
+seed:
+  - "curl -fsS \"$PREVIEW_URL/preview-migrate.php?token=$MIGRATE_TOKEN\""
+env:
+  APP_ENV: "staging"
+health: "/"
+```
+
+Field-by-field semantics, defaults, and the framework-detection table are in the
+[app guide](https://github.com/ephpm/switchboard/blob/main/docs/preview-app-guide.md#1-ephpmyaml--the-manifest).
+Three things are worth stating here because they change what you write:
+
+**`services:` records intent; it does not provision anything.** The values are
+type-checked — `database: "banana"` fails the parse with `unknown database
+service "banana" (expected "turso" or false)` — but beyond that the deploy only
+logs them and writes them into a sidecar file, and an unrecognised *key* under
+`services:` is ignored rather than rejected. ePHPm never reads your manifest at
+all. Your per-site database and KV come from the *operator's*
+ePHPm configuration, and they are there whether or not you declare them. Setting
+`kv: true` does not turn anything on; setting `database: false` does not turn
+anything off. Treat the block as documentation of what your app uses.
+
+**`docroot: "."` publishes your entire repository.** It is the default and it is
+genuinely right for WordPress, whose repository root *is* its web root. But
+every non-dot-prefixed file in your checkout becomes public — `composer.json`,
+`README.md`, a stray `*.sql` dump, whatever a build step left behind. The deploy
+warns on every such deploy, and your `ephpm.yaml` is moved to `.switchboard/`
+before the site goes live so it is not served
+([switchboard#16](https://github.com/ephpm/switchboard/issues/16)), but nothing
+can vet the rest of your files. Declare a subdirectory if you have anything at
+the root you would not paste into a public issue.
+
+**`env:` may not reach your app yet.** The values are written to a `.env` at
+your repository root, which is exactly right for Laravel, Symfony, Drupal, and
+anything else built on `vlucas/phpdotenv` or `symfony/dotenv`. For an app that
+does not read a `.env` — WordPress, most bespoke apps — the deploy also writes
+`.ephpm-preview-prepend.php`, but nothing loads it for you yet. ePHPm shipped
+the server half of the fix
+([#463](https://github.com/ephpm/ephpm/issues/463), merged as
+[#472](https://github.com/ephpm/ephpm/pull/472)): a per-site override file can
+now carry an `auto_prepend_file` alongside `document_root`, applied as a
+per-request INI directive. The deploy daemon does not generate that key yet
+([switchboard#4](https://github.com/ephpm/switchboard/issues/4)). Until it does,
+the workaround is one line at the top of your front controller:
+
+```php
+$__preview = __DIR__ . '/.ephpm-preview-prepend.php';
+if (is_file($__preview)) {
+    require_once $__preview;   // no-op off the preview host
+}
+```
+
+## Database
+
+Your preview gets its own Turso file. Two ways to reach it, both landing on the
+same database.
+
+**Stock `pdo_mysql`.** ePHPm runs one MySQL-wire listener and injects a per-site
+credential into each request. Your ORM does not know anything changed. The
+credentials arrive in **`$_SERVER`** — not `$_ENV`, not `getenv()` — because the
+process environment is shared by every tenant in the process:
+
+```php
+$pdo = new PDO(
+    "mysql:host={$_SERVER['DB_HOST']};port={$_SERVER['DB_PORT']};dbname={$_SERVER['DB_NAME']}",
+    $_SERVER['DB_USER'],
+    $_SERVER['DB_PASSWORD'],
+);
+```
+
+Both naming conventions are injected in per-site mode (`DB_DATABASE`/`DB_USERNAME`
+as well as `DB_NAME`/`DB_USER`, plus `DB_CONNECTION` and `DATABASE_URL`), so
+Laravel's default `mysql` connection works unmodified. The password is
+HMAC-derived from a master secret held only in memory, so it **rotates on every
+restart of the host** — read it per request and never bake it into a cached
+config. The username is a claim; the credential is the identity, and
+authentication happens before the backend is resolved. See
+[Multi-tenant `pdo_mysql`](/guides/multi-tenant-pdo-mysql/).
+
+**The native bridge.** `ephpm_db_*` runs SQL in-process: no wire protocol, no
+connection setup, nothing to authenticate. Install the adapter for your stack
+rather than calling the raw functions — [`ephpm/db`](https://github.com/ephpm/db)
+(base), [`ephpm/db-wordpress`](https://github.com/ephpm/db-wordpress),
+[`ephpm/db-laravel`](https://github.com/ephpm/db-laravel),
+[`ephpm/db-doctrine`](https://github.com/ephpm/db-doctrine) (DBAL 4),
+[`ephpm/mysqli-shim`](https://github.com/ephpm/mysqli-shim). These are
+distributed from their GitHub repos as Composer `vcs` repositories, **not
+Packagist**. Details in [Database from PHP](/guides/db-from-php/).
+
+It is SQLite underneath either way. MySQL-only SQL — stored procedures, `ENUM`
+semantics, vendor functions — is the thing most likely to fail first.
+
+## KV
+
+You get an in-process KV store. There is **no Redis server**; there is a
+RESP-compatible listener in front of the store for clients that speak Redis.
+
+The native path is less work on a preview: install
+[`ephpm/cache`](https://github.com/ephpm/cache) (PSR-6/PSR-16),
+[`ephpm/cache-laravel`](https://github.com/ephpm/cache-laravel),
+[`ephpm/cache-symfony`](https://github.com/ephpm/cache-symfony),
+[`ephpm/cache-wordpress`](https://github.com/ephpm/cache-wordpress),
+[`ephpm/predis-connection`](https://github.com/ephpm/predis-connection), or
+[`ephpm/session-handler`](https://github.com/ephpm/session-handler), and forget
+about connections entirely.
+
+If you insist on the RESP path, be ready for one asymmetry that catches
+everybody: the database variables use the conventional names your framework
+already reads, but the KV variables are `EPHPM_`-prefixed —
+`EPHPM_REDIS_HOST`, `EPHPM_REDIS_PORT`, `EPHPM_REDIS_USERNAME`,
+`EPHPM_REDIS_PASSWORD`. Laravel reads `REDIS_HOST`/`REDIS_PORT`/`REDIS_USERNAME`/
+`REDIS_PASSWORD`, and nothing bridges the two for you. The listener also requires
+a two-argument `AUTH <username> <password>` in multi-tenant mode; a
+password-only client will fail to authenticate. The mapping snippet is in the
+[app guide](https://github.com/ephpm/switchboard/blob/main/docs/preview-app-guide.md#10-kv--redis-and-the-naming-asymmetry);
+sessions and the store itself are covered in [KV from PHP](/guides/kv-from-php/).
+
+Note also that persistent connections are disabled on a multi-tenant host, so
+phpredis `pconnect` will not work regardless of which path you choose.
+
+## Private repositories
+
+Be clear-eyed about this one: **preview deployments of private repositories are
+not supported today.** Two independent reasons, both verified in source rather
+than inferred.
+
+**The checkout is unauthenticated.** The daemon mints a GitHub App installation
+token, but it uses it only to post the comment and create the Deployment record.
+The `git fetch` of `refs/pull/<N>/head` runs as an ordinary `git` child process
+against the plain `https://github.com/<owner>/<repo>.git` clone URL, with no
+credential helper, no `http.extraheader`, and no token in the URL. A public repo
+fetches fine; a private one fails. (An operator could in principle give the
+daemon's OS user ambient git credentials — that is outside switchboard's
+contract, is not documented by it, and is not tested.)
+
+**The preview URL has no gate.** Even with the checkout solved, a preview is
+served at a guessable public hostname with no authentication in front of it.
+Middleware to gate previews behind HTTP Basic, signed session cookies, or GitHub
+OAuth was proposed as ePHPm PRs
+[#387](https://github.com/ephpm/ephpm/pull/387),
+[#388](https://github.com/ephpm/ephpm/pull/388) and
+[#389](https://github.com/ephpm/ephpm/pull/389), and all three were **closed
+unmerged**. There is no such builtin. So a private repository's code and seeded
+data would be published to anyone who guesses the URL.
+
+The related, separable fact — and the one that *is* about degrading gracefully —
+is that GitHub **reporting** is optional. Configure both `--app-id` and
+`--app-key` and previews are reported on the PR; configure neither and deploys
+still run, they just say nothing. Configuring exactly one is a startup error, so
+a half-configured App cannot silently never report.
+
+If you need previews of private code today, run the whole system on
+infrastructure you control and put your own authentication in front of the
+preview domain. Treat anything you seed into a preview as public.
+
+## The worked example
+
+[`ephpm/wordpress-sample`](https://github.com/ephpm/wordpress-sample) is the
+reference: real WordPress on a per-site Turso database, with the KV object cache
+and a native WebSocket activity ticker. Read its
+[`ephpm.yaml`](https://github.com/ephpm/wordpress-sample/blob/main/ephpm.yaml)
+and its [`wp-config.php`](https://github.com/ephpm/wordpress-sample/blob/main/wp-config.php)
+together — that pair is the concrete answer to "how do I wire the database and
+KV properly."
+
+The one thing about it that is not obvious from the packages' own READMEs, and
+that will cost you an afternoon if you get it wrong: **the drop-ins and their
+classes must be real files inside the document root.** Multi-tenant mode sets
+`open_basedir` to your site container, so a `wp-content/db.php` symlinked to a
+shared checkout outside it is denied — and WordPress does not fail loudly, it
+silently falls back to stock mysqli and you get "Error establishing a database
+connection." The sample vendors the files and points each drop-in at an
+autoloader living under the docroot:
+
+```php
+// wp-config.php
+define('EPHPM_DB_AUTOLOAD',    __DIR__ . '/ephpm-db/autoload.php');
+define('EPHPM_CACHE_AUTOLOAD', __DIR__ . '/ephpm-cache/autoload.php');
+```
+
+Both drop-ins degrade rather than fatal when the SAPI functions are absent —
+`db.php` hands WordPress back to mysqli, `object-cache.php` falls back to the
+built-in non-persistent cache — which is what keeps the same checkout working on
+ordinary hosting.
+
+The other detail worth copying is the seed strategy. Because `seed:` runs
+outside ePHPm, the sample cannot use `wp core install`; it drives WordPress's own
+web installer and its in-docroot generator scripts **over HTTP**, so every insert
+runs through the drop-in and lands in the per-site database.
+
+A live preview of that repository is usually running at
+`ephpm-wordpress-sample-pr-6.preview.ephpm.dev`. Previews are ephemeral by
+definition — treat any specific URL as a demo that may be gone.
+
+## Where to go deeper
+
+- [Making your PHP app work as a preview](https://github.com/ephpm/switchboard/blob/main/docs/preview-app-guide.md)
+  — the complete app-facing contract. The single most useful next click.
+- [PR Preview Bot](/guides/preview-bot/) — running the system yourself.
+- [Virtual Hosts](/guides/virtual-hosts/) — the multi-tenant runtime underneath.
+- [Database from PHP](/guides/db-from-php/) · [Multi-tenant `pdo_mysql`](/guides/multi-tenant-pdo-mysql/) · [KV from PHP](/guides/kv-from-php/)
+- [Native WebSockets](/guides/websockets/) — opt-in on the server, HTTP/1.1 only.
+- [PHP packages](/reference/php-packages/) — every Composer adapter.
+- [Preview Deployments roadmap](/roadmap/preview/) — what is still design, not shipped.

--- a/site/content/guides/preview-bot.md
+++ b/site/content/guides/preview-bot.md
@@ -1,12 +1,17 @@
 +++
 title = "PR Preview Bot"
-weight = 6
+weight = 7
 +++
 
 Every pull request gets a live preview URL — its own database, its own KV
 keyspace, deployed in seconds and torn down when the PR closes — and a sticky
 comment with the link. This is the same machinery that runs the previews on
 `ephpm/wordpress-sample`.
+
+This page is **operator-facing**: how the pieces fit together and how to stand
+the system up. If you are an application developer who just wants previews on
+your repository, start at
+[PR Previews for Your App](/guides/pr-previews/) instead.
 
 The runtime half is ePHPm itself: multi-tenant [virtual hosts](/guides/virtual-hosts/),
 per-site Turso databases, per-site KV, and the `[server] preview` limits preset.
@@ -166,8 +171,18 @@ below require:
 |------------|--------|-----|
 | Pull requests | Read & write | Post and update the sticky PR comment. |
 | Deployments | Read & write | Create the Deployment and its status. |
-| Contents | Read | `git fetch refs/pull/<N>/head` from the repo. |
+| Contents | Read | Read repository content through the API. Note the deploy's own `git fetch` does **not** use this token — see below. |
 | Metadata | Read | Mandatory for every GitHub App. |
+
+**The App credential is for reporting, not for the checkout.** The daemon mints
+an installation token to post the comment and create the Deployment, and for the
+claim-time PR-state check. The deploy itself runs `git fetch refs/pull/<N>/head`
+as an ordinary `git` child against the plain `https://github.com/<owner>/<repo>.git`
+clone URL, with no credential helper, no `http.extraheader`, and no token in the
+URL. Public repositories fetch fine; **a private repository's fetch will fail**
+unless the daemon's OS user has ambient git credentials, which switchboard
+neither configures nor tests. See
+[PR Previews for Your App → Private repositories](/guides/pr-previews/#private-repositories).
 
 Set the App's **webhook URL** to your switchboard-api endpoint
 (`https://switchboard.<your-domain>/webhook`) and set a **webhook secret** — the


### PR DESCRIPTION
Adds `site/content/guides/pr-previews.md` — **"PR Previews for Your App"** — the page you can link someone and say "this is how it works." Live at `https://ephpm.dev/guides/pr-previews/` once this merges (`docs.yml` fires on push to `main` with a `site/**` paths filter; all three touched files are under `site/`, so the deploy is covered).

**Do not merge yet** — opened for review.

## The problem this solves

The app-facing documentation already exists and is genuinely good: `ephpm/switchboard`'s `docs/preview-app-guide.md`, 896 lines. It lives in a repo nobody browsing ephpm.dev will find. The site's only preview page is `preview-bot.md`, which is operator-facing — create a GitHub App, issue a wildcard cert, run `switchboard-api` and the daemon. An application developer who just wants previews on their PRs had no entry point at all.

So this is a **hub page**, not a third copy. It orients, answers the four questions, and routes to the depth that already exists.

## What I deliberately linked rather than restated

Per-field manifest semantics and defaults; the full `$_SERVER` vs `getenv()` argument; the `open_basedir` measurement; the verbatim `disable_functions` list; extensions; rate limits; the Laravel/Symfony/Drupal/bespoke recipes; the RESP credential-mapping snippet; the operator install procedure and its permission table. All of that is one click away and none of it is duplicated here.

## What I verified, and how

Everything asserted was checked in source or against the live API — nothing carried over on faith from the existing docs.

| Claim | How |
|---|---|
| **No public App exists** | `https://github.com/apps/ephpm` fetched anonymously renders the literal text *"ePHPm is a private GitHub App."* `gh api /apps/ephpm` → 404. The bot commenting on wordpress-sample#6 is `ephpm[bot]`, `"type": "Bot"`. A private App can only be installed on the account that owns it, so there is no install URL to hand anyone outside the org — and I did not invent one. |
| **Private repos: the fetch is unauthenticated** | `switchboard/src/deployer.rs::fetch_checkout` runs `git fetch` against `req.fetch_url`, which `job.rs` sets to `repository.clone_url` — the plain `https://github.com/<owner>/<repo>.git`. `run_git` inherits the environment and sets no git config. Grepped the whole crate for `extraheader`, `askpass`, `credential`, `x-access-token`, `insteadOf`: no hits. The installation token is minted in `main.rs` only for comments, Deployments, and the claim-time PR-state check. |
| **Private repos: no access gate either** | ephpm#387 (basic-auth), #388 (session-cookie), #389 (GitHub OAuth) all `"state": "closed"`, `"merged": false`. |
| **Reporting degrades, fetching does not** | `config.rs::github_reporting_enabled` + the startup INFO in `main.rs`; supplying exactly one of `--app-id`/`--app-key` is a startup error. |
| **Fetch is from the *base* repo at the recorded SHA** | `job.rs::to_preview_request` (`fetch_url` = base `clone_url`), pinned by `preview_request_fetches_from_the_base_repo`, which substitutes an attacker fork URL and asserts the base is still used. |
| **`services: {database, kv, websocket}`** | `manifest.rs::Services` — `database: DatabaseService` (default `Turso`), `kv: bool` (default `true`), `websocket: Option<bool>` (auto-detect `websocket.php`). |
| **…and they provision nothing** | Only three uses in the whole crate: a `tracing::info!` field and the `.switchboard-preview.json` sidecar in `deployer.rs`. Nothing branches on them, and ePHPm never reads the manifest. `Services` has no `deny_unknown_fields`, so an unknown key under `services:` is silently ignored — stated on the page. |
| **Injected `$_SERVER` keys** | `router.rs` — per-site: `DB_CONNECTION/HOST/PORT/DATABASE/NAME/USER/USERNAME/PASSWORD` + `DATABASE_URL`; KV: `EPHPM_REDIS_HOST/PORT/USERNAME/PASSWORD`. |
| **The password rotates per restart** | `site_wire_auth.rs` — `HMAC-SHA256(master_secret, site_key)`, master secret is 32 random bytes generated at startup, never written to disk; pinned by `master_secret_is_per_process`. |
| **Two-argument `AUTH` in multi-tenant mode** | `ephpm-kv/src/server.rs` — `ServerConfig::secret` doc + `extract_auth_args`; `AUTH <hostname> <derived_password>`. |
| **Persistent connections disabled** | `crates/ephpm/src/main.rs` writes `mysqli/pgsql/odbc.allow_persistent=0` under `vhost_hardening`. |
| **`ephpm_db_*` / `ephpm_kv_*` exist** | The `PHP_FE` tables in `ephpm_wrapper.c`. |
| **`auto_prepend_file` half-landed** | `c3cdcff` = PR #472 closing issue #463 — ePHPm side shipped, switchboard#4 still `"state": "open"`. Page says exactly that, with the one-line `require_once` workaround. |
| **`docroot: "."` publishes the repo** | switchboard#16 closed (manifest is now moved to `.switchboard/`), but the rest of the checkout is still public — `site_override.rs` module docs. Stated plainly. |
| **The wordpress-sample wiring** | Read `ephpm.yaml`, `wp-config.php`, `assemble.sh`, and both drop-in headers at `c4573a4`. |
| **Live preview** | One read-only `GET` to `ephpm-wordpress-sample-pr-6.preview.ephpm.dev` → 200, `X-Powered-By: PHP/8.5.7`. Referenced as "usually running", not promised. |
| **Links** | All 8 internal links resolve to built pages under `site/public/`. All external links return 200 anonymously. All 14 linked `ephpm/*` repos are public. |
| **Ordering** | Built with hugo + hextra and read the rendered sidebar: `… db-from-php | kv-from-php | **pr-previews** | multi-tenant-pdo-mysql | preview-bot | …` |

## Things worth a second opinion

**One genuine docs-vs-code mismatch found, and fixed here.** `preview-bot.md`'s permission table said `Contents | Read | git fetch refs/pull/<N>/head from the repo`. The App token is never used for the fetch. That row is corrected and a short note added explaining what the credential is actually for. This is a truthfulness fix under the repo's own rule, not a rewrite of the page.

**`preview-bot.md` weight 6 → 7.** hextra sorts the sidebar by `weight`, and a tie would have fallen back to title, putting "PR Preview **Bot**" ahead of "PR **Previews**" alphabetically — the wrong order for a newcomer. Bumping it to 7 makes the ordering deliberate. Weight 7 already has three other guides, so this is consistent with the existing (loose) scheme. `preview-bot.md` also now says in its first paragraph that it is the operator page and points at the new one, and both `_index.md` entries are reworded so they do not read as duplicates.

**I did not claim the `[server] preview` preset is enabled on the reference cluster.** The live response carried no `X-Ephpm-Preview: 1`. That could mean the preset is off, or that an edge proxy strips it — I could not distinguish the two from outside, so the page tells you to check for the header rather than asserting either way.

**What I left out for lack of confirmation:** minimum ePHPm versions for the PHP packages. Every one of `ephpm/db`, `cache`, `db-wordpress`, `cache-wordpress`, `session-handler` requires only `"php": "^8.2"` in `composer.json` — there is no ePHPm constraint expressible there, and I found no version claim in their READMEs I could point at. CLAUDE.md says `ephpm/db` needs ≥ v0.6.3 and `ephpm_kv_*` has shipped since v0.1.0; I believe that, but I could not verify it from the packages themselves, so the page states no minimums. Easy to add if you want to make the claim from the ePHPm side.

## Recommendation: where should `preview-app-guide.md` live?

**Do not move it, and do not mirror it. Link it now; publish it from switchboard later if the URL matters.**

Roughly 40% of that guide is switchboard-owned fact — every manifest field, `${secret.NAME}`, the `.env` materialization, `build:`/`seed:` semantics, the docroot-override generation. Those are documented right next to `manifest.rs` and `deployer.rs`, in the repo where a PR changing them gets reviewed. Moving the guide into `ephpm/ephpm` separates the two: a switchboard PR could then change the manifest schema and pass its own review with the docs untouched in a repo its author never opens. That is precisely the failure mode the #106/#107 audit found ~25 instances of. Mirroring is worse still — two copies, guaranteed divergence, and the brief rules it out anyway.

The remaining ~60% is ePHPm behaviour that ePHPm's own guides already cover (virtual-hosts, multi-tenant-pdo-mysql, db-from-php, kv-from-php, websockets), and the guide correctly cross-links to them rather than restating.

So, ranked:

1. **Now (this PR): keep it in switchboard, link it prominently.** It is the first bullet on the new page and the first item under "Where to go deeper." Zero drift cost, solves most of the discoverability problem, ships today.
2. **If the URL genuinely matters — publish it, don't copy it.** Add a step to `docs.yml` that fetches `ephpm/switchboard@main:docs/preview-app-guide.md` at build time into `site/content/guides/`, injecting front matter. Single source of truth, appears in the site's flexsearch index, no manual sync. Costs a cross-repo build dependency and breaks if switchboard renames the file — so it wants a build-time failure, not a silent skip. Happy to open an issue and do it as a follow-up if you want it.
3. **Copy it into `site/content/guides/`.** Solves discoverability today, guarantees drift tomorrow. Not recommended.

My read: (1) now, and only reach for (2) if someone actually complains they could not find it. The hub page is the cheaper half of the fix and it is the half that was missing.
