### PR TITLE
docs: rewrite the front page; move credits to their own page

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -7,41 +7,50 @@ type = "docs"
   type = "docs"
 +++
 
-**Embedded PHP application server, written in Rust.**
+**A PHP application server that embeds the runtime and its dependencies in a single binary.**
 
-Run PHP applications without the infrastructure. No PHP-FPM, no MySQL server, no Redis, no reverse proxy, no certbot. One binary, one config file. Drop in WordPress or Laravel and go.
+ePHPm is an application server for PHP, written in Rust. The Zend engine is compiled in as a static library and executed via FFI on the server's own worker threads — there is no PHP-FPM pool and no FastCGI socket between the web server and the interpreter. HTTP is served by hyper on tokio; the PHP context lives on the same threads that accept the connection.
 
-When you need more, it's already built in: MySQL connection pooling, read/write splitting, a Redis-compatible KV store, clustered SQLite with automatic failover, TLS, and Prometheus metrics.
+The services a PHP application normally reaches over a network are compiled in beside it. The database is **Turso**, the pure-Rust rewrite of SQLite, with MVCC and concurrent writers. The cache is a **DashMap**. Both live in the server process, and there are two ways to reach them.
+
+Existing code keeps its drivers. **litewire** puts Turso behind the MySQL, PostgreSQL, Hrana and TDS wire protocols, so a `pdo_mysql` connection to `127.0.0.1:3306` works untouched, and the cache answers RESP2, so any Redis client library connects and talks the protocol it expects. Nothing has to change to run.
+
+Or skip the protocol entirely. `ephpm_db_query()`, `ephpm_kv_get()` and `ephpm_ws_broadcast()` are native functions in the SAPI — thirty-plus of them — that call straight into the engine on the calling thread. No socket, no wire format to encode, no connection to pool. This is the fast path, and it is what the [WordPress and Laravel integrations](/guides/) use.
+
+## Get started
+
+```bash
+docker run -p 8080:8080 ephpm/ephpm:latest
+```
+
+Or download an archive from [Releases](https://github.com/ephpm/ephpm/releases) and let the binary install itself:
+
+```bash
+sudo ./ephpm install
+```
+
+`install` places the binary, writes a default config, registers a systemd unit or launchd plist, and starts the service. There is no install script and no package repository to add.
+
+## What's inside
+
+| | |
+|---|---|
+| **PHP** | Zend engine, statically linked, thread-safe on every platform including Windows |
+| **Turso** | SQLite-compatible storage engine, MVCC, no external process |
+| **litewire** | MySQL / PostgreSQL / Hrana / TDS wire protocols translated to SQL against Turso |
+| **DashMap** | in-process key-value store over RESP2 — PSR-16/PSR-6 cache, sessions, object cache |
+| **SAPI bridge** | `ephpm_db_*`, `ephpm_kv_*`, `ephpm_ws_*` — native functions that bypass the wire protocols entirely |
+| **rustls** | TLS with ACME issuance, including DNS-01 wildcards across five providers |
+| **chitchat** | SWIM gossip for membership, failure detection and replication |
+| **hyper / tokio** | HTTP/1.1 and HTTP/2, async I/O, per-vhost routing |
+
+Multi-tenant hosting gives every virtual host its own Turso database, cache keyspace and session state. Native WebSockets are held by the server and dispatched to PHP per event. Two execution modes: a worker mode that boots your framework once, and a per-request mode that behaves like PHP-FPM.
+
+## Runs
+
+WordPress · Laravel · Symfony · any PSR-15 application
 
 [Get Started →](/getting-started/)
 [Architecture →](/architecture/)
+[Credits →](/credits/)
 [GitHub](https://github.com/ephpm/ephpm)
-
----
-
-## Built with
-
-ePHPm stands on the shoulders of some excellent open-source projects.
-
-### ePHPm ecosystem
-
-- [litewire](https://github.com/ephpm/litewire) — MySQL/PostgreSQL wire protocol proxy that translates queries to SQLite. This is what lets PHP applications talk `pdo_mysql` to an embedded SQLite database with zero config changes.
-- [ephemerd](https://github.com/luthermonson/ephemerd) — self-hosted GitHub Actions runner manager. ePHPm borrows its self-installing binary pattern (`ephpm install` / `ephpm uninstall`).
-
-### Rust crates
-
-- [tokio](https://github.com/tokio-rs/tokio) — async runtime powering the HTTP server, KV store, cluster protocol, and every background task
-- [hyper](https://github.com/hyperium/hyper) — low-level HTTP/1.1 and HTTP/2 implementation behind the request router
-- [rustls](https://github.com/rustls/rustls) — TLS library for manual cert loading and automatic ACME (Let's Encrypt)
-- [Turso Database](https://github.com/tursodatabase/turso) — the pure-Rust SQLite rewrite used by litewire as the embedded database engine (single-node and clustered)
-- [chitchat](https://github.com/quickwit-oss/chitchat) — SWIM gossip protocol library for cluster membership, failure detection, and KV replication
-- [dashmap](https://github.com/xacrimon/dashmap) — concurrent hashmap backing the in-process KV store
-- [figment](https://github.com/SergioBenitez/Figment) — layered configuration (TOML files + `EPHPM_` environment variable overrides)
-- [clap](https://github.com/clap-rs/clap) — CLI argument parsing
-- [tracing](https://github.com/tokio-rs/tracing) — structured logging and diagnostics
-- [metrics](https://github.com/metrics-rs/metrics) + [metrics-exporter-prometheus](https://github.com/metrics-rs/metrics) — Prometheus-compatible metrics export
-
-### Embedded at build time
-
-- [PHP](https://www.php.net/) — embedded via FFI as a statically linked library (ZTS on every platform, Windows included)
-- [static-php-cli](https://github.com/crazywhalecc/static-php-cli) — builds PHP and its extensions as a single static archive that gets linked into the ephpm binary

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -11,6 +11,8 @@ type = "docs"
 
 ePHPm is an application server for PHP, written in Rust. The Zend engine is compiled in as a static library and executed via FFI on the server's own worker threads — there is no PHP-FPM pool and no FastCGI socket between the web server and the interpreter. HTTP is served by hyper on tokio; the PHP context lives on the same threads that accept the connection.
 
+It is a drop-in replacement for that stack. Point it at a document root and your application runs unmodified — the same code, the same drivers, the same framework configuration. There is nothing to port and no ePHPm-specific API you have to adopt.
+
 The services a PHP application normally reaches over a network are compiled in beside it. The database is **Turso**, the pure-Rust rewrite of SQLite, with MVCC and concurrent writers. The cache is a **DashMap**. Both live in the server process, and there are two ways to reach them.
 
 Existing code keeps its drivers. **litewire** puts Turso behind the MySQL, PostgreSQL, Hrana and TDS wire protocols, so a `pdo_mysql` connection to `127.0.0.1:3306` works untouched, and the cache answers RESP2, so any Redis client library connects and talks the protocol it expects. Nothing has to change to run.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -48,6 +48,14 @@ sudo ./ephpm install
 
 Multi-tenant hosting gives every virtual host its own Turso database, cache keyspace and session state. Native WebSockets are held by the server and dispatched to PHP per event. Two execution modes: a worker mode that boots your framework once, and a per-request mode that behaves like PHP-FPM.
 
+## Preview environments
+
+Open a pull request and it deploys as a running site at its own hostname, with its own database, cache keyspace and session state — the same isolation every virtual host gets. Merge or close the PR and the site is removed, database included.
+
+Two pieces do it: a daemon that fetches the branch, builds it and installs it as a vhost, and a small PHP application that receives the GitHub webhooks — itself running on ePHPm. You run both on your own cluster; there is no hosted service.
+
+[PR previews for your app →](/guides/pr-previews/) · [Running the preview bot →](/guides/preview-bot/)
+
 ## Runs
 
 WordPress · Laravel · Symfony · any PSR-15 application

--- a/site/content/credits.md
+++ b/site/content/credits.md
@@ -1,0 +1,30 @@
++++
+title = "Credits"
+type = "docs"
+weight = 11
++++
+
+ePHPm stands on the shoulders of some excellent open-source projects. Everything below is either linked into the binary or part of the toolchain that builds it.
+
+## ePHPm ecosystem
+
+- [litewire](https://github.com/ephpm/litewire) — MySQL/PostgreSQL/Hrana/TDS wire protocol proxy that translates queries to SQLite. This is what lets PHP applications talk `pdo_mysql` to an embedded database with zero config changes.
+- [ephemerd](https://github.com/luthermonson/ephemerd) — self-hosted GitHub Actions runner manager. ePHPm borrows its self-installing binary pattern (`ephpm install` / `ephpm uninstall`).
+
+## Rust crates
+
+- [tokio](https://github.com/tokio-rs/tokio) — async runtime powering the HTTP server, KV store, cluster protocol, and every background task
+- [hyper](https://github.com/hyperium/hyper) — low-level HTTP/1.1 and HTTP/2 implementation behind the request router
+- [rustls](https://github.com/rustls/rustls) — TLS library for manual cert loading and automatic ACME (Let's Encrypt)
+- [Turso Database](https://github.com/tursodatabase/turso) — the pure-Rust SQLite rewrite used by litewire as the embedded database engine (single-node and clustered)
+- [chitchat](https://github.com/quickwit-oss/chitchat) — SWIM gossip protocol library for cluster membership, failure detection, and KV replication
+- [dashmap](https://github.com/xacrimon/dashmap) — concurrent hashmap backing the in-process KV store
+- [figment](https://github.com/SergioBenitez/Figment) — layered configuration (TOML files + `EPHPM_` environment variable overrides)
+- [clap](https://github.com/clap-rs/clap) — CLI argument parsing
+- [tracing](https://github.com/tokio-rs/tracing) — structured logging and diagnostics
+- [metrics](https://github.com/metrics-rs/metrics) + [metrics-exporter-prometheus](https://github.com/metrics-rs/metrics) — Prometheus-compatible metrics export
+
+## Embedded at build time
+
+- [PHP](https://www.php.net/) — embedded via FFI as a statically linked library (ZTS on every platform, Windows included)
+- [static-php-cli](https://github.com/crazywhalecc/static-php-cli) — builds PHP and its extensions as a single static archive that gets linked into the ephpm binary


### PR DESCRIPTION
The front page spent **thirty of its forty-seven lines** listing dependencies. That is an acknowledgements page, and it pushed everything about the product below the fold.

### What changed

**Structure.** Rewritten in the shape the projects in this space actually use — checked against FrankenPHP, RoadRunner, k3s and Cilium. All four lead with a flat categorical definition, name the enabling technology in one paragraph, then show an install command, then a short feature list. None of them open with prose.

**Named engines instead of generic nouns.** "SQLite-compatible database engine" becomes **Turso**; "key-value store" becomes **DashMap**; the wire translation is credited to **litewire**. FrankenPHP names Caddy and Cilium names eBPF for the same reason — the substrate *is* the interesting part to this audience.

**Both access paths, not just the compatible one.** The old page described only the drop-in story. It now covers the wire protocols for unmodified code *and* the `ephpm_db_*` / `ephpm_kv_*` / `ephpm_ws_*` SAPI functions for the fast path. The native bridge — the thing the WordPress drop-in and Laravel driver actually use — was absent from the front page entirely.

**A truthfulness fix.** An earlier draft of this rewrite used a `curl … | sh` install block copied from the pattern the other projects use. There is no such script: `https://ephpm.dev/install.sh` returns **404**, and `getting-started/install.md` states plainly that "there's no install script — the binary registers and controls its own system service." The block now shows the Docker image and `ephpm install` from a release archive, which are the paths that exist.

### Verification

- Function names and counts taken from the `PHP_FE` table in `crates/ephpm-php/ephpm_wrapper.c`: 8 `ephpm_db_*`, 13 `ephpm_kv_*`, 9 `ephpm_ws_*`, plus `ephpm_middleware_config`. The page says "thirty-plus" rather than a figure that goes stale on the next addition.
- Install commands taken from `site/content/getting-started/install.md`, not invented.
- `credits.md` carries the ecosystem, Rust-crate and build-time lists **verbatim** — no claims added or removed, only relocated.
- `weight = 11` places Credits last, after `roadmap`/`benchmarking` at 10.

### Deliberately not included

Benchmark numbers. Worker mode measures 16–19% ahead of FrankenPHP and 13–25% ahead of nginx+PHP-FPM on our harness, but those are one host and one operator, and a performance claim on a landing page invites scrutiny a footnote cannot carry. They belong on a benchmarks page with the methodology, the run spread, and the endpoint where FrankenPHP wins the tail.
