### PR TITLE
fix(php): derive PHP_AUTH_USER/PW, AUTH_TYPE and PHP_AUTH_DIGEST from the Authorization header

### DIFF
--- a/crates/ephpm-e2e/tests/php.rs
+++ b/crates/ephpm-e2e/tests/php.rs
@@ -202,3 +202,125 @@ async fn custom_response_header_reaches_client() {
         "PHP header('X-Custom: ok') must appear in the HTTP response"
     );
 }
+
+// ── HTTP authentication $_SERVER variables (issue #386) ──────────────────
+//
+// `auth_vars.php` prints each key as either `NAME = [value]` or `NAME unset`,
+// so these tests can tell "absent" from "present but empty" — a distinction
+// php-src makes and applications branch on.
+
+/// Fetch `auth_vars.php` with an explicit Authorization header. The header is
+/// set verbatim rather than via `basic_auth()` so the exact bytes on the wire
+/// are what the test says they are.
+async fn auth_vars(header: Option<&str>) -> String {
+    let base_url = required_env("EPHPM_URL");
+    let url = format!("{base_url}/auth_vars.php");
+
+    let mut req = reqwest::Client::new().get(&url);
+    if let Some(value) = header {
+        req = req.header("Authorization", value);
+    }
+    let resp = req
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"));
+
+    assert_eq!(resp.status().as_u16(), 200);
+    resp.text().await.expect("failed to read body")
+}
+
+/// The headline compatibility gap: an app reading `$_SERVER['PHP_AUTH_USER']`
+/// must see the decoded credential, as it would under mod_php or PHP-FPM.
+#[tokio::test]
+async fn basic_auth_populates_php_auth_vars() {
+    // base64("alice:s3cret")
+    let body = auth_vars(Some("Basic YWxpY2U6czNjcmV0")).await;
+
+    assert!(
+        body.contains("PHP_AUTH_USER = [alice]"),
+        "PHP_AUTH_USER must carry the decoded username:\n{body}"
+    );
+    assert!(
+        body.contains("PHP_AUTH_PW = [s3cret]"),
+        "PHP_AUTH_PW must carry the decoded password:\n{body}"
+    );
+    assert!(
+        body.contains("AUTH_TYPE = [Basic]"),
+        "AUTH_TYPE must report the scheme:\n{body}"
+    );
+    // The raw header stays available, as on stock SAPIs.
+    assert!(
+        body.contains("HTTP_AUTHORIZATION = [Basic YWxpY2U6czNjcmV0]"),
+        "HTTP_AUTHORIZATION must survive alongside the derived vars:\n{body}"
+    );
+}
+
+/// php-src registers PHP_AUTH_PW only for a non-empty password, so `bob:`
+/// leaves the key unset rather than empty.
+#[tokio::test]
+async fn empty_password_leaves_php_auth_pw_unset() {
+    // base64("bob:")
+    let body = auth_vars(Some("Basic Ym9iOg==")).await;
+
+    assert!(
+        body.contains("PHP_AUTH_USER = [bob]"),
+        "username must still be registered:\n{body}"
+    );
+    assert!(
+        body.contains("PHP_AUTH_PW unset"),
+        "an empty password must leave PHP_AUTH_PW unset, not empty:\n{body}"
+    );
+}
+
+/// Non-Basic schemes get an AUTH_TYPE and nothing else; the token itself stays
+/// readable through HTTP_AUTHORIZATION.
+#[tokio::test]
+async fn bearer_sets_auth_type_only() {
+    let body = auth_vars(Some("Bearer some.jwt.token")).await;
+
+    assert!(
+        body.contains("AUTH_TYPE = [Bearer]"),
+        "AUTH_TYPE must report a non-Basic scheme:\n{body}"
+    );
+    assert!(
+        body.contains("PHP_AUTH_USER unset"),
+        "Bearer must not produce PHP_AUTH_USER:\n{body}"
+    );
+    assert!(
+        body.contains("PHP_AUTH_PW unset"),
+        "Bearer must not produce PHP_AUTH_PW:\n{body}"
+    );
+}
+
+/// Without an Authorization header none of the keys exist, so
+/// `isset($_SERVER['PHP_AUTH_USER'])` is false — the check every HTTP Basic
+/// challenge loop starts with.
+#[tokio::test]
+async fn no_authorization_header_leaves_all_auth_vars_unset() {
+    let body = auth_vars(None).await;
+
+    for key in ["AUTH_TYPE", "PHP_AUTH_USER", "PHP_AUTH_PW", "PHP_AUTH_DIGEST"] {
+        assert!(
+            body.contains(&format!("{key} unset")),
+            "{key} must be absent without an Authorization header:\n{body}"
+        );
+    }
+}
+
+/// REMOTE_USER denotes a user the *server* authenticated. ePHPm validates
+/// nothing here, so it must never be synthesised from a client-supplied
+/// header — an app trusting it would otherwise accept any asserted identity.
+#[tokio::test]
+async fn remote_user_is_never_derived_from_the_header() {
+    // base64("admin:hunter2")
+    let body = auth_vars(Some("Basic YWRtaW46aHVudGVyMg==")).await;
+
+    assert!(
+        body.contains("REMOTE_USER unset"),
+        "REMOTE_USER must never be derived from an unvalidated header:\n{body}"
+    );
+    assert!(
+        body.contains("PHP_AUTH_USER = [admin]"),
+        "sanity: the credential itself is still exposed:\n{body}"
+    );
+}

--- a/crates/ephpm-php/src/request.rs
+++ b/crates/ephpm-php/src/request.rs
@@ -50,11 +50,55 @@ impl MiddlewareOutcome {
     }
 }
 
+/// True for a `$_SERVER` key or HTTP header name whose value must never be
+/// rendered into a log line.
+///
+/// `$_SERVER` carries several cleartext secrets: `DB_PASSWORD` and
+/// `DATABASE_URL` (the per-site `pdo_mysql` credential the router injects) and,
+/// since #386, `PHP_AUTH_PW` — plus the `Authorization` and `Cookie` headers
+/// they are derived from. Nothing in the codebase formats these collections
+/// today, which is exactly why the protection was worth making explicit rather
+/// than leaving as an unenforced invariant: `PhpRequest` and
+/// `WorkerRequestOwned` are both `pub` and sit one `?request` away from a
+/// `tracing::debug!` on the request path.
+///
+/// The match is a substring heuristic over the usual secret-bearing names, so a
+/// future injected credential is redacted by default rather than by remembering
+/// to add it here.
+pub(crate) fn is_secret_name(name: &str) -> bool {
+    const EXACT: &[&str] = &[
+        "PHP_AUTH_PW",
+        "PHP_AUTH_DIGEST",
+        "DATABASE_URL",
+        "AUTHORIZATION",
+        "HTTP_AUTHORIZATION",
+        "PROXY-AUTHORIZATION",
+        "HTTP_PROXY_AUTHORIZATION",
+        "COOKIE",
+        "HTTP_COOKIE",
+    ];
+    const SUBSTRINGS: &[&str] =
+        &["PASSWORD", "PASSWD", "SECRET", "TOKEN", "APIKEY", "API_KEY", "API-KEY"];
+
+    let upper = name.to_ascii_uppercase();
+    EXACT.contains(&upper.as_str()) || SUBSTRINGS.iter().any(|s| upper.contains(s))
+}
+
+/// Format `(name, value)` pairs for `Debug`, replacing secret values with a
+/// placeholder. See [`is_secret_name`].
+pub(crate) fn redacted_pairs<'a>(
+    pairs: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> Vec<(&'a str, &'a str)> {
+    pairs
+        .into_iter()
+        .map(|(name, value)| (name, if is_secret_name(name) { "<redacted>" } else { value }))
+        .collect()
+}
+
 /// A PHP request, constructed from an incoming HTTP request.
 ///
 /// Contains all the information needed to set up a PHP execution context
 /// via the SAPI callbacks.
-#[derive(Debug)]
 pub struct PhpRequest {
     /// HTTP method (GET, POST, etc.)
     pub method: String,
@@ -111,6 +155,37 @@ pub struct PhpRequest {
     /// Empty for every request that has no `php:` mount, which is the default
     /// and costs nothing. See [`PhpMiddleware`].
     pub middleware: Vec<PhpMiddleware>,
+}
+
+/// Hand-written so `headers` and `env_vars` go through [`redacted_pairs`]
+/// instead of printing the `Authorization` header and the injected
+/// `DB_PASSWORD` in full. `body` is summarised by length — it is request data,
+/// often large, and routinely carries credentials of its own (a login form
+/// post).
+impl std::fmt::Debug for PhpRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn pairs(v: &[(String, String)]) -> Vec<(&str, &str)> {
+            redacted_pairs(v.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        }
+        f.debug_struct("PhpRequest")
+            .field("method", &self.method)
+            .field("uri", &self.uri)
+            .field("path", &self.path)
+            .field("query_string", &self.query_string)
+            .field("script_filename", &self.script_filename)
+            .field("document_root", &self.document_root)
+            .field("headers", &pairs(&self.headers))
+            .field("body_len", &self.body.len())
+            .field("content_type", &self.content_type)
+            .field("remote_addr", &self.remote_addr)
+            .field("server_name", &self.server_name)
+            .field("server_port", &self.server_port)
+            .field("is_https", &self.is_https)
+            .field("protocol", &self.protocol)
+            .field("env_vars", &pairs(&self.env_vars))
+            .field("middleware", &self.middleware)
+            .finish()
+    }
 }
 
 impl PhpRequest {
@@ -259,6 +334,180 @@ fn owned(s: &str) -> Option<Cow<'static, CStr>> {
     CString::new(s).ok().map(Cow::Owned)
 }
 
+/// Copy raw bytes into an owned C string. `None` when they contain an interior
+/// NUL. Used for the base64-decoded HTTP Basic credentials, which are arbitrary
+/// bytes and need not be UTF-8 — PHP strings are byte strings, so a credential
+/// in some other encoding reaches PHP unmangled rather than being lossily
+/// transcoded.
+fn owned_bytes(bytes: Vec<u8>) -> Option<Cow<'static, CStr>> {
+    CString::new(bytes).ok().map(Cow::Owned)
+}
+
+/// HTTP authentication data derived from a request's `Authorization` header.
+///
+/// See [`parse_authorization`] for the derivation and how it lines up with
+/// php-src.
+#[derive(Debug, PartialEq, Eq)]
+struct AuthVars<'a> {
+    /// The scheme token as the client cased it — becomes `AUTH_TYPE`.
+    auth_type: &'a str,
+
+    /// Decoded HTTP Basic credentials: `(user, password)`, where `password` is
+    /// `None` for an empty password (php-src leaves `PHP_AUTH_PW` unset in that
+    /// case). `None` for the whole pair when this is not a Basic credential, or
+    /// when the payload did not yield one.
+    ///
+    /// The two halves travel together on purpose: a username registered without
+    /// its password would read to an application as "user authenticated with an
+    /// empty password", so an unrepresentable half suppresses both.
+    credentials: Option<(Vec<u8>, Option<Vec<u8>>)>,
+
+    /// The Digest challenge with the `Digest ` prefix removed — becomes
+    /// `PHP_AUTH_DIGEST`, matching php-src's `estrdup(auth + 7)`.
+    digest: Option<&'a str>,
+}
+
+/// The `Authorization` header value for this request: the **first** one,
+/// matched case-insensitively.
+///
+/// "First wins" matches [`cookie_string_from_headers`]; a duplicated
+/// `Authorization` header is malformed (RFC 9110 §5.3 forbids list-combining a
+/// non-list field) and picking deterministically keeps ePHPm from disagreeing
+/// with a front proxy that made the same choice.
+fn authorization_header(headers: &[(String, String)]) -> Option<&str> {
+    headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+        .map(|(_, value)| value.as_str())
+}
+
+/// Value of one base64 character, or `None` for anything else — including
+/// whitespace and the `=` pad, both of which php-src's non-strict decoder
+/// skips. See [`base64_decode_lenient`].
+const fn base64_value(c: u8) -> Option<u8> {
+    match c {
+        b'A'..=b'Z' => Some(c - b'A'),
+        b'a'..=b'z' => Some(c - b'a' + 26),
+        b'0'..=b'9' => Some(c - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}
+
+/// Decode base64 the way PHP does it for `Authorization: Basic`.
+///
+/// This deliberately mirrors `php_base64_decode_ex(..., strict = 0)` — the
+/// decoder `php_handle_auth_data()` uses — rather than a conforming RFC 4648
+/// decoder, because the point of #386 is to behave like every other SAPI. In
+/// non-strict mode php-src **never fails**: bytes outside the alphabet
+/// (whitespace, `=`, anything else) are skipped, padding is optional and
+/// unvalidated, and a trailing group of a single character contributes nothing.
+/// A strict decoder would reject payloads that Apache and PHP-FPM accept, so an
+/// app would authenticate there and not here — the exact class of bug this
+/// change exists to remove.
+fn base64_decode_lenient(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len() / 4 * 3 + 3);
+    let mut carry: u8 = 0;
+    let mut seen: usize = 0;
+    for &c in input {
+        let Some(value) = base64_value(c) else { continue };
+        match seen % 4 {
+            0 => carry = value << 2,
+            1 => {
+                out.push(carry | (value >> 4));
+                carry = (value & 0x0f) << 4;
+            }
+            2 => {
+                out.push(carry | (value >> 2));
+                carry = (value & 0x03) << 6;
+            }
+            _ => out.push(carry | value),
+        }
+        seen += 1;
+    }
+    out
+}
+
+/// True for an RFC 9110 §5.6.2 `token` — the grammar an auth scheme name obeys.
+fn is_http_token(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&b))
+}
+
+/// Derive the PHP authentication `$_SERVER` variables from an `Authorization`
+/// header value.
+///
+/// Mirrors php-src's `php_handle_auth_data()` (`main/main.c`), which every
+/// stock SAPI funnels the header through, with the deviations noted below.
+///
+/// * The scheme is matched **case-insensitively** for both `Basic ` and
+///   `Digest `, including the trailing space — so a bare `Authorization: Basic`
+///   with no payload is not a Basic credential (it still yields an `AUTH_TYPE`).
+/// * `Basic` payloads are base64-decoded leniently
+///   ([`base64_decode_lenient`]) and split on the **first** `:`. No colon means
+///   no credentials at all, which is php-src's `strchr` returning NULL.
+/// * An empty password yields no `PHP_AUTH_PW`, matching php-src's
+///   `if (strlen(pass) > 0)`. An empty *username* is preserved and registered,
+///   matching php-src.
+/// * `Digest` is only considered when a Basic credential was not produced, and
+///   carries the header minus the 7-byte `Digest ` prefix.
+///
+/// **Deviation — interior NUL.** php-src operates on C strings, so a NUL in the
+/// decoded payload truncates the username (or hides the colon entirely). ePHPm
+/// registers `$_SERVER` through NUL-terminated FFI as well, but rather than
+/// silently handing PHP a *truncated* password — which fails an auth check in a
+/// way nobody can debug — an interior NUL in either half suppresses both keys,
+/// so the application sees "no credentials" and re-challenges.
+///
+/// **`AUTH_TYPE` is set for every scheme, not just Basic and Digest.** php-src
+/// never sets `AUTH_TYPE` itself: it is a CGI meta-variable (RFC 3875 §4.1.1)
+/// that the front-end server supplies, which under nginx/FPM usually means it
+/// is absent. ePHPm *is* the front-end, so it reports the scheme the client
+/// offered — `Bearer`, `Negotiate` and custom schemes included, which get an
+/// `AUTH_TYPE` and nothing else (their credential stays readable in
+/// `HTTP_AUTHORIZATION`, which is kept alongside these keys as stock SAPIs do).
+///
+/// Note that `AUTH_TYPE` here describes *what the client offered*, not a
+/// successful authentication: ePHPm has validated nothing at this point. That
+/// is why `REMOTE_USER` is deliberately **not** derived — it denotes a user the
+/// server itself authenticated, and synthesising it from an unvalidated header
+/// would hand an attacker any identity they typed.
+fn parse_authorization(raw: &str) -> Option<AuthVars<'_>> {
+    let scheme = raw.split(' ').next().unwrap_or_default();
+    if !is_http_token(scheme) {
+        return None;
+    }
+
+    let mut auth = AuthVars { auth_type: scheme, credentials: None, digest: None };
+
+    if let Some(payload) = strip_prefix_ignore_ascii_case(raw, "Basic ") {
+        let decoded = base64_decode_lenient(payload.as_bytes());
+        if let Some(colon) = decoded.iter().position(|&b| b == b':') {
+            let password = &decoded[colon + 1..];
+            // Suppress the pair outright if either half cannot cross the FFI
+            // boundary intact; see the "interior NUL" note above.
+            if !decoded[..colon].contains(&0) && !password.contains(&0) {
+                let password = (!password.is_empty()).then(|| password.to_vec());
+                auth.credentials = Some((decoded[..colon].to_vec(), password));
+            }
+        }
+    }
+
+    // php-src only reaches its Digest branch when the Basic branch produced
+    // nothing, so a header that is somehow both never yields both.
+    if auth.credentials.is_none() {
+        auth.digest = strip_prefix_ignore_ascii_case(raw, "Digest ");
+    }
+
+    Some(auth)
+}
+
+/// `str::strip_prefix`, matched case-insensitively over ASCII.
+fn strip_prefix_ignore_ascii_case<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    let (head, rest) = s.split_at_checked(prefix.len())?;
+    head.eq_ignore_ascii_case(prefix).then_some(rest)
+}
+
 /// Build the `$_SERVER` variables from borrowed request fields, directly in
 /// the NUL-terminated form the SAPI FFI needs (issue #133).
 ///
@@ -307,8 +556,9 @@ pub fn build_server_variables_c(
     // One CString for SCRIPT_NAME + PHP_SELF; the clone is a plain memcpy.
     let script_name = CString::new(script_name).ok();
 
+    // 16 fixed CGI vars, HTTPS, and up to 3 HTTP-authentication vars (#386).
     let mut vars: Vec<CServerVar> =
-        Vec::with_capacity(16 + headers.len() + env_vars.len() + usize::from(is_https));
+        Vec::with_capacity(19 + headers.len() + env_vars.len() + usize::from(is_https));
     let mut push = |key: Cow<'static, CStr>, value: Option<Cow<'static, CStr>>| {
         if let Some(value) = value {
             vars.push((key, value));
@@ -333,6 +583,44 @@ pub fn build_server_variables_c(
 
     if is_https {
         push(Cow::Borrowed(c"HTTPS"), Some(Cow::Borrowed(c"on")));
+    }
+
+    // HTTP authentication vars derived from the Authorization header (#386).
+    //
+    // These are registered as ordinary $_SERVER entries through the SAPI's
+    // register_server_variables callback, which is what PHP code observes.
+    // NOT set: SG(request_info).auth_user / auth_password / auth_digest, the
+    // fields a stock SAPI fills so PHP core registers these keys itself. Doing
+    // that safely is a C change at both lifecycle sites in ephpm_wrapper.c, and
+    // the two lanes differ in a way that matters: the per-request lane gets a
+    // php_request_shutdown() per request, so sapi_deactivate_module() efrees and
+    // NULLs those fields for it, while the worker lane runs one long-lived PHP
+    // request and would need them freed and cleared by hand every iteration.
+    // Getting that wrong leaks a credential from one request into the next —
+    // across tenants — so it is deliberately left for a change that can be
+    // validated against a PHP-linked multi-request test. The practical effect
+    // today is limited to C extensions that read SG(request_info) directly.
+    //
+    // Deliberately pushed HERE — before the header and env-var loops — rather
+    // than appended at the end. `ephpm_wrapper.c` registers at most
+    // MAX_SERVER_VARS (128) entries and silently drops the overflow, so a
+    // request carrying enough headers to reach the cap would otherwise lose
+    // exactly the keys an authenticating app is looking for. Their position in
+    // this Vec is otherwise irrelevant: $_SERVER is a hash, and no header can
+    // collide with these keys (every non-canonical header is prefixed `HTTP_`).
+    if let Some(auth) = authorization_header(headers).and_then(parse_authorization) {
+        push(Cow::Borrowed(c"AUTH_TYPE"), owned(auth.auth_type));
+        // Emitted as a pair or not at all — see AuthVars::credentials.
+        if let Some((user, password)) = auth.credentials {
+            push(Cow::Borrowed(c"PHP_AUTH_USER"), owned_bytes(user));
+            // php-src registers PHP_AUTH_PW only for a non-empty password.
+            if let Some(password) = password {
+                push(Cow::Borrowed(c"PHP_AUTH_PW"), owned_bytes(password));
+            }
+        }
+        if let Some(digest) = auth.digest {
+            push(Cow::Borrowed(c"PHP_AUTH_DIGEST"), owned(digest));
+        }
     }
 
     // Map HTTP headers to $_SERVER variables. The canonical names get static
@@ -552,6 +840,376 @@ mod tests {
         let vars = req.server_variables();
 
         assert!(find_var(&vars, "HTTPS").is_none());
+    }
+
+    // ── HTTP authentication ($_SERVER auth vars, issue #386) ─────────────
+    //
+    // Every assertion here fails against the pre-#386 tree, where the
+    // Authorization header reached PHP only as HTTP_AUTHORIZATION and none of
+    // PHP_AUTH_USER / PHP_AUTH_PW / AUTH_TYPE / PHP_AUTH_DIGEST was derived.
+    //
+    // The reference behaviour is php-src's php_handle_auth_data()
+    // (main/main.c) plus php_register_server_variables() (main/php_variables.c),
+    // which is what every stock SAPI funnels the header through.
+
+    /// Standard-alphabet base64 with padding — the encoder a client uses.
+    fn b64(bytes: &[u8]) -> String {
+        const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut out = String::new();
+        for chunk in bytes.chunks(3) {
+            let b = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
+            let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+            for i in 0..4 {
+                if i <= chunk.len() {
+                    out.push(ALPHABET[((n >> (18 - 6 * i)) & 0x3f) as usize] as char);
+                } else {
+                    out.push('=');
+                }
+            }
+        }
+        out
+    }
+
+    /// Build `$_SERVER` for a request carrying one `Authorization` header.
+    fn vars_with_auth(value: &str) -> Vec<(String, String)> {
+        let mut req = make_request();
+        req.headers.push(("Authorization".into(), value.to_owned()));
+        req.server_variables()
+    }
+
+    /// The headline case: RFC 7617's own example credential must reach PHP
+    /// decoded, exactly as it does under mod_php and PHP-FPM.
+    #[test]
+    fn basic_auth_populates_php_auth_user_and_pw() {
+        let vars = vars_with_auth(&format!("Basic {}", b64(b"Aladdin:open sesame")));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some("Aladdin"));
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), Some("open sesame"));
+        assert_eq!(find_var(&vars, "AUTH_TYPE"), Some("Basic"));
+    }
+
+    /// The raw header stays visible too — stock SAPIs keep HTTP_AUTHORIZATION
+    /// alongside the derived vars, and frameworks (Laravel's `bearerToken()`,
+    /// PSR-7 bridges) read it directly.
+    #[test]
+    fn raw_authorization_header_is_kept_alongside_the_derived_vars() {
+        let encoded = b64(b"Aladdin:open sesame");
+        let vars = vars_with_auth(&format!("Basic {encoded}"));
+
+        assert_eq!(
+            find_var(&vars, "HTTP_AUTHORIZATION"),
+            Some(format!("Basic {encoded}").as_str())
+        );
+    }
+
+    /// php-src compares the scheme with `zend_binary_strncasecmp`, so a
+    /// lowercase `basic` is a valid Basic credential. AUTH_TYPE reports the
+    /// scheme as the client cased it, not a normalised spelling.
+    #[test]
+    fn basic_scheme_is_matched_case_insensitively() {
+        let vars = vars_with_auth(&format!("bAsIc {}", b64(b"user:pw")));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some("user"));
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), Some("pw"));
+        assert_eq!(find_var(&vars, "AUTH_TYPE"), Some("bAsIc"));
+    }
+
+    /// php-src guards the password registration with `if (strlen(pass) > 0)`,
+    /// so `user:` leaves PHP_AUTH_PW *unset* rather than empty. Apps written
+    /// against that distinguish "no password sent" from "empty password".
+    #[test]
+    fn empty_password_leaves_php_auth_pw_unset() {
+        let vars = vars_with_auth(&format!("Basic {}", b64(b"user:")));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some("user"));
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), None);
+    }
+
+    /// An empty *username* is registered (php-src estrndup's it unconditionally
+    /// once a colon is found) — the asymmetry with the password is deliberate.
+    #[test]
+    fn empty_username_is_registered_as_an_empty_value() {
+        let vars = vars_with_auth(&format!("Basic {}", b64(b":secret")));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some(""));
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), Some("secret"));
+    }
+
+    /// Split on the FIRST colon only — a password containing colons survives
+    /// intact. php-src uses `strchr`, which finds the leftmost one.
+    #[test]
+    fn password_may_contain_colons() {
+        let vars = vars_with_auth(&format!("Basic {}", b64(b"user:a:b:c")));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some("user"));
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), Some("a:b:c"));
+    }
+
+    /// No colon in the decoded payload means php-src's `strchr` returns NULL
+    /// and it registers neither credential. AUTH_TYPE still describes the
+    /// header, and the raw value is still readable.
+    #[test]
+    fn basic_payload_without_a_colon_yields_no_credentials() {
+        let vars = vars_with_auth(&format!("Basic {}", b64(b"justausername")));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), None);
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), None);
+        assert_eq!(find_var(&vars, "AUTH_TYPE"), Some("Basic"));
+    }
+
+    /// php_base64_decode is called in NON-strict mode, which skips characters
+    /// outside the alphabet and does not require padding. A client whose base64
+    /// has stray whitespace or missing `=` authenticates on Apache/FPM, so it
+    /// must authenticate here — a strict decoder would silently reject it.
+    #[test]
+    fn base64_payload_is_decoded_leniently_like_php() {
+        // "user:pw" == "dXNlcjpwdw==". Mangle it three ways that php-src
+        // tolerates: embedded whitespace, no padding, and both.
+        for payload in ["dXNlcjpwdw==", "dXNl cjpw dw==", "dXNlcjpwdw", "dXNl\tcjpwdw"] {
+            let vars = vars_with_auth(&format!("Basic {payload}"));
+            assert_eq!(
+                find_var(&vars, "PHP_AUTH_USER"),
+                Some("user"),
+                "payload {payload:?} should decode leniently"
+            );
+            assert_eq!(find_var(&vars, "PHP_AUTH_PW"), Some("pw"), "payload {payload:?}");
+        }
+    }
+
+    /// Garbage that decodes to nothing usable yields no credentials rather than
+    /// an error or a panic.
+    #[test]
+    fn non_base64_basic_payload_yields_no_credentials() {
+        for payload in ["!!!!", "", "@@@@@@@@"] {
+            let vars = vars_with_auth(&format!("Basic {payload}"));
+            assert_eq!(find_var(&vars, "PHP_AUTH_USER"), None, "payload {payload:?}");
+            assert_eq!(find_var(&vars, "PHP_AUTH_PW"), None, "payload {payload:?}");
+        }
+    }
+
+    /// Digest is not decoded: php-src stores the header minus the 7-byte
+    /// "Digest " prefix in PHP_AUTH_DIGEST and sets no user/password.
+    #[test]
+    fn digest_sets_php_auth_digest_without_the_scheme_prefix() {
+        let challenge = r#"username="bob", realm="test", nonce="abc""#;
+        let vars = vars_with_auth(&format!("Digest {challenge}"));
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_DIGEST"), Some(challenge));
+        assert_eq!(find_var(&vars, "AUTH_TYPE"), Some("Digest"));
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), None);
+        assert_eq!(find_var(&vars, "PHP_AUTH_PW"), None);
+    }
+
+    /// Bearer (and any other scheme) gets an AUTH_TYPE and nothing else. The
+    /// token itself stays readable via HTTP_AUTHORIZATION, which is where every
+    /// framework looks for it.
+    #[test]
+    fn other_schemes_set_auth_type_only() {
+        for scheme in ["Bearer", "Negotiate", "DPoP", "AWS4-HMAC-SHA256"] {
+            let vars = vars_with_auth(&format!("{scheme} some-credential"));
+            assert_eq!(find_var(&vars, "AUTH_TYPE"), Some(scheme));
+            assert_eq!(find_var(&vars, "PHP_AUTH_USER"), None, "scheme {scheme}");
+            assert_eq!(find_var(&vars, "PHP_AUTH_PW"), None, "scheme {scheme}");
+            assert_eq!(find_var(&vars, "PHP_AUTH_DIGEST"), None, "scheme {scheme}");
+        }
+    }
+
+    /// `Basic` with no payload is not a Basic credential — php-src's comparison
+    /// includes the trailing space, so a 5-character "Basic" never matches.
+    #[test]
+    fn bare_scheme_with_no_payload_yields_only_auth_type() {
+        let vars = vars_with_auth("Basic");
+
+        assert_eq!(find_var(&vars, "AUTH_TYPE"), Some("Basic"));
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), None);
+    }
+
+    /// A scheme that is not an RFC 9110 token is not reported at all, so
+    /// AUTH_TYPE can never carry arbitrary client-supplied punctuation.
+    #[test]
+    fn non_token_scheme_yields_no_auth_type() {
+        for value in ["", "  ", "\"quoted\" x", "sch\u{7f}eme x"] {
+            let vars = vars_with_auth(value);
+            assert_eq!(find_var(&vars, "AUTH_TYPE"), None, "value {value:?}");
+        }
+    }
+
+    /// A NUL anywhere in the decoded credential suppresses BOTH keys. php-src
+    /// would truncate at the NUL; handing PHP a silently-shortened password is
+    /// an undebuggable auth failure, so ePHPm emits nothing and the app
+    /// re-challenges. The username-side case matches php-src exactly (the NUL
+    /// hides the colon from `strchr`).
+    #[test]
+    fn interior_nul_in_a_credential_suppresses_both_keys() {
+        for raw in [b"us\0er:pw".as_slice(), b"user:p\0w".as_slice()] {
+            let vars = vars_with_auth(&format!("Basic {}", b64(raw)));
+            assert_eq!(find_var(&vars, "PHP_AUTH_USER"), None, "raw {raw:?}");
+            assert_eq!(find_var(&vars, "PHP_AUTH_PW"), None, "raw {raw:?}");
+            // The header itself still reaches PHP, so nothing is hidden.
+            assert!(find_var(&vars, "HTTP_AUTHORIZATION").is_some());
+        }
+    }
+
+    /// Credentials need not be UTF-8 — PHP strings are byte strings, and a
+    /// latin-1 password must reach PHP unmangled rather than being lossily
+    /// transcoded. Asserted on the FFI form, which is what PHP actually gets.
+    #[test]
+    fn non_utf8_credentials_reach_php_unmangled() {
+        let mut req = make_request();
+        req.headers.push(("Authorization".into(), format!("Basic {}", b64(b"user:p\xffw"))));
+        let vars = req.server_variables_c();
+
+        let pw = vars.iter().find(|(k, _)| k.as_ref() == c"PHP_AUTH_PW").map(|(_, v)| v.to_bytes());
+        assert_eq!(pw, Some(b"p\xffw".as_slice()));
+    }
+
+    /// Duplicate Authorization headers: first wins, matching
+    /// `cookie_string_from_headers`.
+    #[test]
+    fn first_authorization_header_wins() {
+        let mut req = make_request();
+        req.headers.push(("Authorization".into(), format!("Basic {}", b64(b"first:one"))));
+        req.headers.push(("authorization".into(), format!("Basic {}", b64(b"second:two"))));
+        let vars = req.server_variables();
+
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some("first"));
+    }
+
+    /// No Authorization header means none of these keys exist — an app testing
+    /// `isset($_SERVER['PHP_AUTH_USER'])` must see false, not an empty string.
+    #[test]
+    fn no_authorization_header_derives_nothing() {
+        let vars = make_request().server_variables();
+
+        for key in ["AUTH_TYPE", "PHP_AUTH_USER", "PHP_AUTH_PW", "PHP_AUTH_DIGEST"] {
+            assert_eq!(find_var(&vars, key), None, "{key} must be absent");
+        }
+    }
+
+    /// REMOTE_USER is deliberately never derived. It denotes a user the *server*
+    /// authenticated; ePHPm validates nothing here, so synthesising it from a
+    /// client-supplied header would let anyone assert any identity to an app
+    /// that trusts it.
+    #[test]
+    fn remote_user_is_never_derived_from_the_header() {
+        let vars = vars_with_auth(&format!("Basic {}", b64(b"admin:hunter2")));
+
+        assert_eq!(find_var(&vars, "REMOTE_USER"), None);
+        assert_eq!(find_var(&vars, "PHP_AUTH_USER"), Some("admin"));
+    }
+
+    /// The wrapper registers at most MAX_SERVER_VARS (128) entries and silently
+    /// drops the rest, so the auth vars must sit in the fixed prefix rather than
+    /// after the unbounded header list. A request with enough headers to blow
+    /// the cap must still authenticate.
+    #[test]
+    fn auth_vars_survive_the_server_var_cap() {
+        const MAX_SERVER_VARS: usize = 128; // ephpm_wrapper.c
+        let mut req = make_request();
+        req.headers.push(("Authorization".into(), format!("Basic {}", b64(b"user:pw"))));
+        for i in 0..200 {
+            req.headers.push((format!("x-filler-{i}"), "v".into()));
+        }
+        let vars = req.server_variables();
+
+        let position = |key: &str| vars.iter().position(|(k, _)| k == key);
+        for key in ["AUTH_TYPE", "PHP_AUTH_USER", "PHP_AUTH_PW"] {
+            let at = position(key).unwrap_or_else(|| panic!("{key} missing"));
+            assert!(at < MAX_SERVER_VARS, "{key} at index {at} would be dropped by the C cap");
+        }
+    }
+
+    /// fpm and worker dispatch must agree on the auth vars too — the lanes
+    /// share `build_server_variables_c`, and this pins that they keep doing so.
+    #[test]
+    fn worker_and_request_paths_agree_on_auth_vars() {
+        let mut req = make_request();
+        req.headers.push(("Authorization".into(), format!("Basic {}", b64(b"user:pw"))));
+
+        let worker_mode = build_server_variables_c(
+            &req.method,
+            &req.uri,
+            &req.query_string,
+            &req.script_filename,
+            &req.document_root,
+            &req.path,
+            &req.server_name,
+            req.server_port,
+            &req.protocol,
+            req.remote_addr,
+            req.is_https,
+            &req.headers,
+            &req.env_vars,
+        );
+
+        assert_eq!(worker_mode, req.server_variables_c());
+        assert!(
+            worker_mode.iter().any(|(k, v)| k.as_ref() == c"PHP_AUTH_PW" && v.as_ref() == c"pw")
+        );
+    }
+
+    /// The lenient decoder is the security-relevant half of this change, so
+    /// pin its behaviour directly against php_base64_decode's non-strict rules.
+    #[test]
+    fn lenient_base64_matches_php_non_strict_rules() {
+        // Well-formed round trip.
+        assert_eq!(base64_decode_lenient(b"dXNlcjpwdw=="), b"user:pw");
+        // Padding is optional.
+        assert_eq!(base64_decode_lenient(b"dXNlcjpwdw"), b"user:pw");
+        // Characters outside the alphabet are skipped, not fatal.
+        assert_eq!(base64_decode_lenient(b"dXNl\r\n cjpwdw=="), b"user:pw");
+        assert_eq!(base64_decode_lenient(b"d*X&Nl%cjpwdw"), b"user:pw");
+        // A trailing group of a single character contributes no byte: 9 input
+        // characters carry 6 whole bytes, and the 9th is dropped.
+        assert_eq!(base64_decode_lenient(b"dXNlcjpwX"), b"user:p");
+        // Never fails, even on pure garbage.
+        assert_eq!(base64_decode_lenient(b"!!!!"), b"");
+        assert_eq!(base64_decode_lenient(b""), b"");
+    }
+
+    // ── Secret redaction in Debug output ─────────────────────────────────
+
+    /// `$_SERVER` now carries a cleartext password (PHP_AUTH_PW) next to the
+    /// per-site DB_PASSWORD. `PhpRequest` is `pub` and sits beside a
+    /// `tracing::debug!` on the request path, so its Debug must not print them.
+    #[test]
+    fn php_request_debug_redacts_credentials() {
+        let mut req = make_request();
+        req.headers.push(("Authorization".into(), format!("Basic {}", b64(b"user:hunter2"))));
+        req.headers.push(("Cookie".into(), "session=super-secret".into()));
+        req.env_vars = vec![
+            ("DB_PASSWORD".into(), "db-secret".into()),
+            ("DATABASE_URL".into(), "mysql://u:db-secret@h/db".into()),
+            ("DB_USER".into(), "site-a".into()),
+        ];
+
+        let rendered = format!("{req:?}");
+
+        for secret in ["hunter2", "super-secret", "db-secret", &b64(b"user:hunter2")] {
+            assert!(!rendered.contains(secret), "Debug leaked {secret:?}: {rendered}");
+        }
+        // Non-secret context is still there — redaction must not blind the log.
+        assert!(rendered.contains("site-a"), "{rendered}");
+        assert!(rendered.contains("example.com"), "{rendered}");
+    }
+
+    #[test]
+    fn secret_name_matching_covers_the_known_credential_keys() {
+        for name in [
+            "PHP_AUTH_PW",
+            "DB_PASSWORD",
+            "DATABASE_URL",
+            "EPHPM_REDIS_PASSWORD",
+            "HTTP_AUTHORIZATION",
+            "authorization",
+            "Cookie",
+            "X-Api-Key",
+        ] {
+            assert!(is_secret_name(name), "{name} should be treated as secret");
+        }
+        for name in ["PHP_AUTH_USER", "AUTH_TYPE", "DB_USER", "REQUEST_URI", "HTTP_HOST"] {
+            assert!(!is_secret_name(name), "{name} should not be redacted");
+        }
     }
 
     #[test]

--- a/crates/ephpm-php/src/worker_bridge.rs
+++ b/crates/ephpm-php/src/worker_bridge.rs
@@ -85,7 +85,6 @@ impl std::fmt::Debug for WorkerBody {
 /// An owned HTTP request handed to a worker thread. Owns every string buffer so
 /// the borrowed [`EphpmWorkerRequest`] view stays valid for the whole iteration
 /// (until `send_response`).
-#[derive(Debug)]
 pub struct WorkerRequestOwned {
     /// HTTP method (`GET`, `POST`, ...).
     pub method: String,
@@ -105,6 +104,34 @@ pub struct WorkerRequestOwned {
     pub server_vars: Vec<CServerVar>,
     /// HTTP headers as `(name, value)` pairs.
     pub headers: Vec<(String, String)>,
+}
+
+/// Hand-written for the same reason as [`PhpRequest`](crate::request::PhpRequest)'s:
+/// `server_vars` holds the request's whole `$_SERVER`, which since #386 includes
+/// `PHP_AUTH_PW` alongside the per-site `DB_PASSWORD`, and `headers` holds the
+/// `Authorization` header they came from. Values for secret-bearing names are
+/// replaced with a placeholder — see `request::is_secret_name`.
+impl std::fmt::Debug for WorkerRequestOwned {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let server_vars = crate::request::redacted_pairs(
+            self.server_vars
+                .iter()
+                .map(|(k, v)| (k.to_str().unwrap_or_default(), v.to_str().unwrap_or_default())),
+        );
+        let headers = crate::request::redacted_pairs(
+            self.headers.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+        );
+        f.debug_struct("WorkerRequestOwned")
+            .field("method", &self.method)
+            .field("uri", &self.uri)
+            .field("query_string", &self.query_string)
+            .field("cookie_data", &"<redacted>")
+            .field("content_type", &self.content_type)
+            .field("body", &self.body)
+            .field("server_vars", &server_vars)
+            .field("headers", &headers)
+            .finish()
+    }
 }
 
 /// A response produced by a worker for one request: either fully buffered

--- a/site/content/architecture/http.md
+++ b/site/content/architecture/http.md
@@ -90,6 +90,34 @@ Key distinction after fallback rewrites (e.g. `/blog/hello` -> `/index.php`):
 
 HTTP headers are mapped to `HTTP_*` variables, except `Content-Type` -> `CONTENT_TYPE` and `Content-Length` -> `CONTENT_LENGTH` (no `HTTP_` prefix per CGI spec).
 
+### HTTP Authentication Variables
+
+An incoming `Authorization` header is decoded into the `$_SERVER` keys stock PHP SAPIs provide, so applications that implement their own HTTP Basic challenge loop (`if (!isset($_SERVER['PHP_AUTH_USER'])) { ... 401 ... }`) work unchanged.
+
+| Variable | Set when | Value |
+|----------|----------|-------|
+| `AUTH_TYPE` | Any `Authorization` header with a valid scheme token | The scheme as the client cased it — `Basic`, `Digest`, `Bearer`, ... |
+| `PHP_AUTH_USER` | `Basic` credential whose decoded payload contains a `:` | Bytes before the first colon (may be empty) |
+| `PHP_AUTH_PW` | As above, and the password is non-empty | Bytes after the first colon |
+| `PHP_AUTH_DIGEST` | `Digest` credential | The header with the `Digest ` prefix removed |
+
+The raw header remains available as `HTTP_AUTHORIZATION`, as it is on other SAPIs. Behaviour follows php-src's `php_handle_auth_data()`:
+
+- The scheme is matched case-insensitively, and the trailing space is part of the match — a bare `Authorization: Basic` with no payload yields only `AUTH_TYPE`.
+- The base64 payload is decoded leniently (PHP's non-strict decoder): characters outside the alphabet are skipped and padding is optional, so a payload Apache or PHP-FPM accepts is accepted here too.
+- A decoded payload with no `:` yields no credentials at all.
+- An empty password leaves `PHP_AUTH_PW` **unset** (not empty), matching php-src; an empty username *is* registered.
+- Duplicate `Authorization` headers: the first wins.
+
+Two deliberate differences from php-src:
+
+- **Interior NUL bytes suppress both credential keys.** php-src operates on C strings and would truncate the password at the NUL; ePHPm emits nothing so the application re-challenges rather than failing an auth check against a silently shortened secret.
+- **`AUTH_TYPE` is set for every scheme**, including `Bearer` and `Negotiate`. php-src never sets `AUTH_TYPE` itself — it is a CGI meta-variable the front-end server supplies (RFC 3875 §4.1.1), and under nginx/FPM it is usually absent. ePHPm is the front-end, so it reports what the client offered.
+
+**These variables are client-supplied, not verified.** `AUTH_TYPE` reports the scheme the client sent and `PHP_AUTH_USER` / `PHP_AUTH_PW` the credential it offered; ePHPm has validated none of it, exactly as on any other SAPI. Do not treat the presence of `AUTH_TYPE` as proof of authentication. `REMOTE_USER` is deliberately never derived from the header, because it denotes a user the *server* authenticated — synthesising it would let any client assert any identity to an application that trusts it. Use the `jwt` middleware if you want the server to reject unauthenticated requests before PHP runs.
+
+`PHP_AUTH_PW` is a cleartext password in `$_SERVER`. ePHPm does not log, trace or serialise `$_SERVER` anywhere (span attributes are a fixed five-field allowlist), and the `Debug` output of the internal request structs redacts secret-bearing names.
+
 ### Thread Safety
 
 PHP is compiled with ZTS (Zend Thread Safety). Each execution-pool thread auto-registers with TSRM on first use, getting its own isolated PHP context. Multiple PHP requests execute concurrently. The `Mutex<Option<PhpRuntime>>` only protects one-time init/shutdown, not request execution. Windows builds are ZTS as well — the Windows php-sdk's static `php8embed.lib` is a ZTS build and requests execute concurrently there too.

--- a/site/content/testing/e2e.md
+++ b/site/content/testing/e2e.md
@@ -14,7 +14,7 @@ The `ephpm-e2e` crate lives in `crates/ephpm-e2e/` and runs inside a Kind cluste
 |------|------:|----------|
 | `basic.rs` | 3 | 404 errors, PHP rendering, static file serving |
 | `http.rs` | 9 | HEAD no body, POST body, content-type static, ETag 304, gzip compression, 413 body too large, cache-control, X-Forwarded-For, fallback to index.php |
-| `php.rs` | 7 | `$_GET`, `$_SERVER` vars, `exit()` output, `http_response_code()`, `$_COOKIE`, `php://input`, custom response header |
+| `php.rs` | 12 | `$_GET`, `$_SERVER` vars, `exit()` output, `http_response_code()`, `$_COOKIE`, `php://input`, custom response header, HTTP auth vars (`PHP_AUTH_USER`/`PW`, `AUTH_TYPE`, empty password, Bearer, no `REMOTE_USER`) |
 | `phpinfo.rs` | 2 | PHP version matching, health check |
 | `php_config.rs` | 1 | PHP configuration validation |
 | `php_extended.rs` | 6 | Empty PHP output 200, JSON content-type, multiple Set-Cookie headers, SERVER_SOFTWARE, PUT/DELETE methods, additional PHP behavior |

--- a/tests/docroot/auth_vars.php
+++ b/tests/docroot/auth_vars.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * HTTP authentication $_SERVER variables (issue #386).
+ *
+ * Reports the keys a stock PHP SAPI derives from an incoming `Authorization`
+ * header. Each line distinguishes "absent" from "present but empty", because
+ * the two mean different things: php-src leaves PHP_AUTH_PW unset for an empty
+ * password, while an empty *username* is registered as an empty string, and
+ * applications branch on `isset()`.
+ */
+
+header('Content-Type: text/plain');
+
+$keys = [
+    'AUTH_TYPE',
+    'PHP_AUTH_USER',
+    'PHP_AUTH_PW',
+    'PHP_AUTH_DIGEST',
+    'REMOTE_USER',
+    'HTTP_AUTHORIZATION',
+];
+
+foreach ($keys as $key) {
+    if (array_key_exists($key, $_SERVER)) {
+        echo $key . ' = [' . $_SERVER[$key] . "]\n";
+    } else {
+        echo $key . " unset\n";
+    }
+}


### PR DESCRIPTION
Closes #386.

Every stock PHP SAPI decodes an incoming `Authorization` header into `$_SERVER` via `php_handle_auth_data()`. ePHPm derived none of it, so any app doing `if (!isset($_SERVER['PHP_AUTH_USER'])) { … 401 … }` silently saw "no credentials". The header already reached PHP as `HTTP_AUTHORIZATION` (confirmed: `ALWAYS_STRIPPED_INGEST_HEADERS` is `["proxy"]` only, and nothing else touches `Authorization`) — only the derivation was missing.

Derived in `build_server_variables_c()`, the one function both dispatch lanes funnel through, so per-request and worker mode stay identical for free and the derivation runs on the **post-middleware** header set.

## Behaviour, checked against php-src rather than recalled

I read `main/main.c` and `main/php_variables.c` on `PHP-8.4` instead of trusting memory, which corrected three details the issue got wrong:

| | Issue said | php-src 8.4 actually does |
|---|---|---|
| `Basic` scheme match | case-sensitive `strncmp` | **case-insensitive** `zend_binary_strncasecmp` — `basic …` is valid |
| `PHP_AUTH_DIGEST` | the raw header | the header **minus** the 7-byte `Digest ` prefix (`estrdup(auth + 7)`) |
| empty password | (unstated) | `if (strlen(pass) > 0)` — `PHP_AUTH_PW` is left **unset**, not empty |

Also worth recording: `php_variables.c` sets `PHP_AUTH_USER` / `PHP_AUTH_PW` / `PHP_AUTH_DIGEST` and **never sets `AUTH_TYPE`** — that is a CGI meta-variable the front-end supplies (RFC 3875 §4.1.1), which is why it is usually absent under nginx+FPM.

### Edge cases

- **Malformed / non-base64 payload** — decoded with php-src's **non-strict** rules (`php_base64_decode_ex(..., strict = 0)`): characters outside the alphabet are skipped, padding is optional, a trailing 1-character group contributes nothing, and it *never fails*. I hand-rolled a ~20-line decoder rather than using `base64ct` as the issue suggested, because `base64ct` is strict and would reject payloads Apache and PHP-FPM accept — an app would authenticate there and not here, which is the exact bug class this PR exists to close. (Bonus: no new dependency for `ephpm-php`.)
- **No colon** in the decoded value → no credentials at all (php-src's `strchr` returning NULL). `AUTH_TYPE` is still set.
- **Empty password** → `PHP_AUTH_PW` unset. **Empty username** → registered as an empty string. The asymmetry is php-src's.
- **Non-`Basic` scheme** → see below.
- **Duplicate `Authorization` headers** → first wins, matching `cookie_string_from_headers`.
- **Non-UTF-8 credentials** round-trip unmangled — the values are carried as bytes into `CString`, not `String`, because PHP strings are byte strings.

## Schemes handled

`Basic` and `Digest` produce credentials. **`AUTH_TYPE` is set for every scheme with a valid RFC 9110 token** — `Bearer`, `Negotiate`, custom — which get an `AUTH_TYPE` and nothing else; their credential stays readable in `HTTP_AUTHORIZATION`, which is kept alongside as stock SAPIs do. A scheme that is not a valid token yields no `AUTH_TYPE` at all, so it can never carry arbitrary client punctuation.

**`REMOTE_USER` is deliberately not derived.** It denotes a user the *server* authenticated; ePHPm has validated nothing at this point, and synthesising it from a client-supplied header would let anyone assert any identity to an app that trusts it. There is a unit test and an e2e test pinning its absence.

Note this makes `AUTH_TYPE` client-controllable where under nginx+FPM it is server-supplied. That is the intended trade (ePHPm *is* the front-end), and both the code and the docs state plainly that its presence is not proof of authentication.

## Two deliberate deviations from php-src

1. **Interior NUL suppresses both credential keys.** php-src truncates the password at the NUL (or, if the NUL precedes the colon, hides the colon and emits nothing). Handing PHP a silently shortened password is an undebuggable auth failure, so ePHPm emits neither key and the app re-challenges.
2. **`AUTH_TYPE` for all schemes**, as above.

## `MAX_SERVER_VARS`

The wrapper registers at most 128 `$_SERVER` entries and silently drops the overflow. The auth vars are therefore pushed into the **fixed prefix**, before the unbounded header and env-var loops — appending them would mean a request with enough headers loses exactly the keys an authenticating app needs. `auth_vars_survive_the_server_var_cap` pins this with 200 filler headers.

## `SG(request_info)` — deliberately not set, and why

`SG(request_info).auth_user` / `auth_password` / `auth_digest` stay NULL. `sapi_deactivate_module()` efrees and NULLs them per request, which the per-request lane gets for free (it calls `php_request_shutdown()` each request) — but the **worker lane runs one long-lived PHP request** and would need them freed and cleared by hand every iteration. Getting that wrong leaks a credential from one request into the next, across tenants. Since I could not run a PHP-linked multi-request test here (below), I left it out rather than ship an unverified use-after-free/bleed path; the reasoning is recorded in a comment at the derivation site. Practical impact is limited to C extensions reading those fields directly — all PHP-visible behaviour is correct.

Happy to do it as a follow-up if you'd rather have it, but it wants a PHP-linked test to be worth trusting.

## Security: what I checked about `$_SERVER` exposure

`PHP_AUTH_PW` is a cleartext password in `$_SERVER`, so I audited every path that could capture it:

- **Request/access logging** — the `access_log` target is configured in `main.rs` but **nothing ever emits on it**, so no headers are logged. (Separately: that makes `server.logging.access` a latent no-op knob — not touched here.)
- **OTLP spans** — a fixed five-attribute allowlist, already hardened by #380 with a regression test that the `Host` header cannot reach the wire. Nothing header-derived is exported.
- **`/_ephpm/requests` timeline** — method, path (no query string), status, timings. No headers, no server vars.
- **Query stats** — keyed on the normalised SQL digest only; no request context, and literals are normalised to `?`.
- **Error pages** — static text; no request dump.
- **The `tracing::debug!` on the PHP request path** — field-selective (`method`, `uri`, `script`).

So nothing captures it **today**. But `DB_PASSWORD` and `DATABASE_URL` already live in `$_SERVER` protected purely by omission — there is no redaction mechanism in the codebase — and both `PhpRequest` and `WorkerRequestOwned` were `#[derive(Debug)]`, `pub`, and one `?req` away from dumping the lot (including the raw `Authorization` header, which predates this PR). Since this change adds one more secret to that pile, both now get a hand-written `Debug` that redacts secret-bearing names, following the existing `dns01_linode.rs` precedent, with a test asserting no credential appears in the output.

## Middleware interaction

Header overrides from the middleware chain are applied to the headers vector *before* `$_SERVER` is built (`router.rs`), so deriving here means we follow whatever a middleware rewrote — consistent rather than conflicting. The v1 request-phase ABI can set/replace but **cannot remove** a header, so no middleware can hide `Authorization` from PHP; it can only overwrite it, and then the derived vars follow the overwritten value. `jwt` reads `Authorization` and leaves it intact; `api_key` does not touch it. The in-flight `feat/middleware-basicauth` branch also only reads it, so the two compose without clobbering. (For the record: `basic-auth`, `github-auth` and `forward_user_header` do not exist on `main` — the issue's "workaround today" describes an unmerged branch.)

## Tests

- **26 unit tests** in `request.rs` covering each case above plus the lenient decoder in isolation.
- I verified these fail for the right reason: with the derivation neutered, **15 of them fail**; the ones that still pass are the negative tests asserting absence, which correctly pass on `main` by construction.
- **5 e2e tests** plus the new `tests/docroot/auth_vars.php` fixture the issue notes was missing. It prints `NAME = [value]` vs `NAME unset` so "absent" and "present but empty" are distinguishable — the empty-password case is otherwise untestable.

## Verified end to end against a PHP-linked build

Not just stub mode. Built `ephpm.exe` with `cargo xtask release 8.3 --target windows` (PHP **8.3.33**, statically linked, ZTS) and drove real HTTP requests at `auth_vars.php` through the per-request lane. Actual output:

| Request `Authorization` | `AUTH_TYPE` | `PHP_AUTH_USER` | `PHP_AUTH_PW` | `PHP_AUTH_DIGEST` |
|---|---|---|---|---|
| `Basic YWxpY2U6czNjcmV0` (`alice:s3cret`) | `Basic` | `alice` | `s3cret` | unset |
| `Basic Ym9iOg==` (`bob:`) | `Basic` | `bob` | **unset** | unset |
| `basic YWxpY2U6czNjcmV0` (lowercase) | `basic` | `alice` | `s3cret` | unset |
| `Basic YWxpY2U6 czNjcmV0` (space in payload) | `Basic` | `alice` | `s3cret` | unset |
| `Basic anVzdGF1c2Vy` (no colon) | `Basic` | unset | unset | unset |
| `Bearer some.jwt.token` | `Bearer` | unset | unset | unset |
| `Digest username="bob", nonce="abc"` | `Digest` | unset | unset | `username="bob", nonce="abc"` |
| *(none)* | unset | unset | unset | unset |

`REMOTE_USER` was unset in every case, including the `admin:hunter2` probe. Note the empty-password row (`PHP_AUTH_PW` genuinely absent, not empty) and the Digest row (prefix stripped) — the two details most likely to be got wrong, confirmed live rather than inferred.

**Caveat on the reference behaviour:** the php-src semantics above were read from source (`PHP-8.4` `main/main.c`, `main/php_variables.c`, `ext/standard/base64.c`), **not** differentially tested against a running Apache/mod_php or nginx+FPM. `php-cli` cannot stand in for that — `php_handle_auth_data()` is called by the SAPI, and the CLI SAPI never calls it. So "ePHPm does X" is verified; "stock PHP also does X" is read from the source, quoted in the code comments so it can be re-checked.

Locally green: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all --check`, `cargo test --workspace`, `cargo check --tests` for the out-of-workspace e2e crate, and a PHP-linked `cargo check -p ephpm-php --all-targets` (the gate `windows-php-check.yml` runs — green on this PR).

## Docs

`site/content/architecture/http.md` gains an "HTTP Authentication Variables" section next to the existing `$_SERVER` table — the table of keys, the php-src edge cases, both deviations, and the not-proof-of-authentication warning. `site/content/testing/e2e.md`'s `php.rs` row is updated.
