### PR TITLE
docs(roadmap): design spike — `ephpm exec --site` sandboxed vhost commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1374,7 @@ dependencies = [
  "ephpm-kv",
  "ephpm-php",
  "ephpm-server",
+ "landlock",
  "libc",
  "mimalloc",
  "reqwest",
@@ -2324,7 +2345,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2729,6 +2750,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy-regex"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,9 +2803,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -3974,7 +4006,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4012,7 +4044,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]

--- a/crates/ephpm-server/src/privdrop.rs
+++ b/crates/ephpm-server/src/privdrop.rs
@@ -99,14 +99,46 @@ pub fn drop_privileges(config: &Config) -> anyhow::Result<()> {
     // directory that exists is surfaced.
     chown_runtime_dirs(config, uid, gid)?;
 
+    drop_to_user(uid, gid)?;
+
+    tracing::info!(
+        uid,
+        gid,
+        "dropped privileges: process now runs unprivileged (single non-root uid — \
+         NOT per-tenant; cross-tenant isolation still rests on open_basedir + \
+         disable_functions)"
+    );
+    Ok(())
+}
+
+/// The irreversible credential drop itself: `setgroups` → `setgid` → `setuid`,
+/// then a fail-closed verification that the drop took and cannot be undone.
+///
+/// Factored out of [`drop_privileges`] so the one-shot sandboxed exec path
+/// (`ephpm exec`) and the long-running server share a single audited
+/// implementation of the sequence. This function performs **only** the
+/// credential syscalls — it does not `chown` anything, resolve names, or log a
+/// summary; the caller owns that context. The process must be `euid == 0` when
+/// this is called (checked by [`drop_privileges`]; the exec path checks it too).
+///
+/// # Errors
+///
+/// Returns an error if any `set*id` syscall fails, if the post-drop identity is
+/// not exactly `(uid, gid)`, or if root can still be regained afterwards
+/// (`seteuid(0)` succeeds) — a reversible or partial drop must never be mistaken
+/// for a real one.
+#[cfg(unix)]
+// The real/effective uid/gid names are intentionally parallel here.
+#[allow(clippy::similar_names)]
+pub fn drop_to_user(uid: u32, gid: u32) -> anyhow::Result<()> {
     // Order is load-bearing: drop supplementary groups and the gid while still
     // uid 0, then the uid last. Doing setuid first would forfeit the privilege
     // needed for setgroups/setgid.
     //
     // SAFETY: setgroups/setgid/setuid are the documented POSIX credential
-    // syscalls. We are single-purpose here (startup), pass a valid pointer/len
-    // for the one-element group list, and check every return value below. glibc
-    // applies these process-wide across all threads.
+    // syscalls. We pass a valid pointer/len for the one-element group list and
+    // check every return value below. glibc applies these process-wide across
+    // all threads.
     let groups = [gid as libc::gid_t];
     let rc = unsafe { libc::setgroups(groups.len() as _, groups.as_ptr()) };
     if rc != 0 {
@@ -144,14 +176,6 @@ pub fn drop_privileges(config: &Config) -> anyhow::Result<()> {
     if unsafe { libc::seteuid(0) } == 0 {
         anyhow::bail!("privilege drop is reversible (seteuid(0) succeeded) — refusing to serve");
     }
-
-    tracing::info!(
-        uid,
-        gid,
-        "dropped privileges: process now runs unprivileged (single non-root uid — \
-         NOT per-tenant; cross-tenant isolation still rests on open_basedir + \
-         disable_functions)"
-    );
     Ok(())
 }
 
@@ -260,8 +284,17 @@ fn set_mode(path: &std::path::Path, mode: u32) {
 
 /// Resolve a user spec (numeric uid or name) to `(uid, primary_gid)`.
 /// `primary_gid` is `Some` only for a named user resolved via `getpwnam`.
+///
+/// Public so the `ephpm exec` sandbox can resolve its target tenant user
+/// through the same audited lookup the server drop uses (e.g. `ephpm-web` →
+/// `(997, Some(989))`).
+///
+/// # Errors
+///
+/// Returns an error if `spec` is a name containing an interior NUL byte or if
+/// no such user exists (`getpwnam` returned NULL).
 #[cfg(unix)]
-fn resolve_user(spec: &str) -> anyhow::Result<(u32, Option<u32>)> {
+pub fn resolve_user(spec: &str) -> anyhow::Result<(u32, Option<u32>)> {
     if let Ok(uid) = spec.parse::<u32>() {
         return Ok((uid, None));
     }
@@ -281,8 +314,16 @@ fn resolve_user(spec: &str) -> anyhow::Result<(u32, Option<u32>)> {
 }
 
 /// Resolve a group spec (numeric gid or name) to a gid.
+///
+/// Public for the same reason as [`resolve_user`] — the `ephpm exec` sandbox
+/// resolves an explicit tenant group through it.
+///
+/// # Errors
+///
+/// Returns an error if `spec` is a name containing an interior NUL byte or if
+/// no such group exists (`getgrnam` returned NULL).
 #[cfg(unix)]
-fn resolve_group(spec: &str) -> anyhow::Result<u32> {
+pub fn resolve_group(spec: &str) -> anyhow::Result<u32> {
     if let Ok(gid) = spec.parse::<u32>() {
         return Ok(gid);
     }

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -5905,6 +5905,97 @@ fn vhost_open_basedir_value(document_root: &Path, state_root: &Path) -> String {
     format!("{}{separator}{}", document_root.display(), state_root.display())
 }
 
+/// A virtual host's filesystem sandbox profile, resolved for an out-of-request
+/// caller such as `ephpm exec --site <key>`.
+///
+/// This is the **same** derivation a request goes through
+/// ([`Router::resolve_site`] → [`Router::site_roots`] →
+/// [`vhost_state_root`]), exposed as a one-shot so a CLI can reconstruct a
+/// tenant's on-disk boundary without standing up a full [`Router`] or, worse,
+/// re-deriving it from a `Host` header (the exact divergence issues #290/#291
+/// exist to prevent). The `key` passed in is treated as an already-canonical
+/// site key (the vhost directory name), normalized and allowlist-checked here
+/// the same way `resolve_site` treats a stripped host.
+pub struct SandboxSite {
+    /// The canonical, normalized, allowlist-clean site key.
+    pub key: String,
+    /// The site **container** — the vhost directory. This is the
+    /// `open_basedir` boundary and the input to [`vhost_state_root`], exactly
+    /// as on the request path (never the `public/` web root).
+    pub container: PathBuf,
+    /// The web root — the container, or its override-declared `public/`-style
+    /// subdirectory. Where an exec'd command should `chdir` and what
+    /// `DOCUMENT_ROOT` would be. Equal to `container` when no override applies.
+    pub document_root: PathBuf,
+    /// This tenant's private temp/session root under `ephpm-vhosts/`.
+    pub state_root: PathBuf,
+    /// The `open_basedir`-shaped path list (`container:state_root`) — the two
+    /// filesystem locations a sandbox should grant read/write, and the string
+    /// a `--no-sandbox` PHP path would still set as the PHP directive.
+    pub open_basedir: String,
+}
+
+/// Resolve `--site <key>` to its filesystem sandbox profile against a loaded
+/// [`Config`], reusing the request-path derivation verbatim.
+///
+/// Fails closed the same way a request does: an invalid key, a config without
+/// `[server] sites_dir` (single-site mode has no tenant to name), or a key with
+/// no matching directory under `sites_dir` all error rather than falling back
+/// to a wider default document root.
+///
+/// # Errors
+///
+/// Returns an error if `key` is not a valid site key, if `[server] sites_dir`
+/// is unset, or if `sites_dir/<key>` is not an existing directory.
+pub fn resolve_sandbox_site(config: &Config, key: &str) -> anyhow::Result<SandboxSite> {
+    let clean = normalize_host_key(key);
+    if !is_valid_site_key(&clean) {
+        anyhow::bail!("invalid site key {key:?} (must be a bare vhost name, no slashes or dots)");
+    }
+
+    let sites_dir = config.server.sites_dir.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[server] sites_dir is not configured — `ephpm exec --site` requires \
+             multi-tenant (vhost) mode; there is no per-site sandbox to enter in \
+             single-site mode"
+        )
+    })?;
+
+    let container = sites_dir.join(&clean);
+    if !container.is_dir() {
+        anyhow::bail!("no virtual host {clean:?}: {} is not a directory", container.display());
+    }
+
+    // Reuse the override-aware web-root resolution the router uses. Without a
+    // configured overrides dir the roots are flat (document_root == container).
+    let roots = match config.server.effective_site_overrides_dir() {
+        Some(overrides_dir) => {
+            let prepend = if config.php.is_worker_mode() {
+                crate::site_overrides::PrependSupport::NoWorkerMode
+            } else {
+                crate::site_overrides::PrependSupport::Yes
+            };
+            resolve_site_roots(container.clone(), overrides_dir, &clean, prepend)
+        }
+        None => SiteRoots::flat(container.clone()),
+    };
+
+    // The state root and open_basedir key on the CONTAINER, not the web root —
+    // matching `Router::handle` (which passes `site_container` to
+    // `ensure_vhost_private_dirs` and `vhost_open_basedir_value`) so a site that
+    // gains or loses a `public/` never re-homes its sessions/temp.
+    let state_root = vhost_state_root(&roots.container);
+    let open_basedir = vhost_open_basedir_value(&roots.container, &state_root);
+
+    Ok(SandboxSite {
+        key: clean,
+        container: roots.container,
+        document_root: roots.document_root,
+        state_root,
+        open_basedir,
+    })
+}
+
 /// Per-vhost private state root — the parent directory that holds this
 /// tenant's `tmp/` and `sessions/` subdirectories.
 ///
@@ -6550,6 +6641,54 @@ mod tests {
             .header("host", host)
             .body(Empty::<Bytes>::new())
             .unwrap()
+    }
+
+    /// `resolve_sandbox_site` (the `ephpm exec` site derivation) must agree with
+    /// the request path — state root and `open_basedir` key on the CONTAINER —
+    /// and fail closed for an unknown site, an invalid key, and single-site mode.
+    #[test]
+    fn resolve_sandbox_site_matches_request_derivation_and_fails_closed() {
+        let root = tempfile::tempdir().unwrap();
+        let sites_dir = root.path().join("sites");
+        fs::create_dir_all(sites_dir.join("shop")).unwrap();
+
+        let config = Config {
+            server: ServerConfig {
+                document_root: root.path().join("docroot"),
+                sites_dir: Some(sites_dir.clone()),
+                ..ServerConfig::default()
+            },
+            php: test_php_config(),
+            db: DbConfig::default(),
+            kv: KvConfig::default(),
+            cluster: ClusterConfig::default(),
+            middleware: Vec::new(),
+            opcache: ephpm_config::OpcacheConfig::default(),
+        };
+
+        let site = super::resolve_sandbox_site(&config, "shop").unwrap();
+        assert_eq!(site.key, "shop");
+        assert_eq!(site.container, sites_dir.join("shop"));
+        // No overrides dir configured, so the web root is the container itself.
+        assert_eq!(site.document_root, sites_dir.join("shop"));
+        // The state root and open_basedir are derived from the CONTAINER,
+        // byte-identical to what `Router::handle` builds per request.
+        assert_eq!(site.state_root, super::vhost_state_root(&site.container));
+        assert_eq!(
+            site.open_basedir,
+            super::vhost_open_basedir_value(&site.container, &site.state_root)
+        );
+
+        // A host key normalizes the same way a request host does.
+        assert_eq!(super::resolve_sandbox_site(&config, "SHOP").unwrap().key, "shop");
+
+        // Fail closed: unknown site, traversal-shaped key, and single-site mode.
+        assert!(super::resolve_sandbox_site(&config, "does-not-exist").is_err());
+        assert!(super::resolve_sandbox_site(&config, "../etc").is_err());
+
+        let mut single = config;
+        single.server.sites_dir = None;
+        assert!(super::resolve_sandbox_site(&single, "shop").is_err());
     }
 
     /// `[server] preview = true` stamps `X-Ephpm-Preview: 1` on every

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -60,6 +60,13 @@ tracing-subscriber.workspace = true
 libc = "0.2"
 mimalloc = { version = "0.1", default-features = false }
 
+# Landlock filesystem sandbox for `ephpm exec` (see src/exec_sandbox.rs). Pure
+# Rust, ABI 1–4, no CAP_SYS_ADMIN, MSRV-compatible. Linux-only: the crate only
+# builds meaningfully on Linux and the sandboxed exec path is `cfg(target_os =
+# "linux")`. Other Unixes (macOS) refuse the subcommand at runtime.
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4"
+
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7"
 windows-sys = { version = "0.59", features = [

--- a/crates/ephpm/src/exec_sandbox.rs
+++ b/crates/ephpm/src/exec_sandbox.rs
@@ -176,44 +176,250 @@ pub fn run(
 /// Create and chown the tenant's private state root (`state_root`, `tmp`,
 /// `sessions`) so the dropped command can write session/temp files there.
 ///
-/// Best-effort ownership: the directories are created while still root, tightened
-/// to `0700`, and `chown`ed to the tenant. Mirrors the router's
-/// `ensure_vhost_private_dirs` so an exec'd tenant CLI shares the same private
-/// temp/session tree its HTTP requests use.
+/// This runs **as root, before the privilege drop**, on a tree whose base
+/// (`$TMPDIR/ephpm-vhosts`) is owned by the untrusted tenant uid this feature
+/// exists to contain. Every path component below the trusted temp anchor is
+/// therefore attacker-controlled, so the function never trusts a path *string*
+/// below the anchor: it walks the tree one component at a time with
+/// `openat(O_NOFOLLOW | O_DIRECTORY)`, refusing (`bail!`) any component that is a
+/// symlink, and then tightens (`fchmod`) and hands over (`fchown`) each directory
+/// **through the open file descriptor** — never a path — so a name swapped
+/// mid-operation (TOCTOU) can never redirect the chmod/chown onto a target
+/// outside the tree.
+///
+/// This closes the symlink-follow privilege escalation that a naïve
+/// `chown`/`set_permissions`/`create_dir_all` on `state_root/tmp` (planted by the
+/// tenant as e.g. `state_root/tmp -> /root`) would otherwise turn into local
+/// root. It mirrors the intent of the sibling `privdrop::chown_tree`, which
+/// already uses `lchown` for the same reason, but goes further with `openat`
+/// traversal so even an active mid-operation swap is defeated rather than merely
+/// the static-symlink case.
+///
+/// # Residual TOCTOU
+///
+/// The tenant uid we hand ownership to is the **same** principal that owns the
+/// enclosing `ephpm-vhosts` base, so the only thing an attacker can substitute
+/// for one of our freshly-`mkdir`ed components is (a) a symlink — refused by
+/// `O_NOFOLLOW` — or (b) another directory *they already own*, which `fchown`ing
+/// to that same uid grants them nothing they did not already have. There is no
+/// cross-principal target reachable, which is exactly the escalation the HIGH
+/// finding described.
 #[cfg(target_os = "linux")]
 fn prepare_state_root(
     site: &ephpm_server::router::SandboxSite,
     uid: u32,
     gid: u32,
 ) -> anyhow::Result<()> {
-    use std::os::unix::fs::PermissionsExt as _;
+    use std::os::unix::ffi::OsStrExt as _;
+    use std::path::Component;
 
     use anyhow::Context as _;
 
-    let tmp = site.state_root.join("tmp");
-    let sessions = site.state_root.join("sessions");
-    for dir in [&site.state_root, &tmp, &sessions] {
-        std::fs::create_dir_all(dir)
-            .with_context(|| format!("failed to create {}", dir.display()))?;
+    // The trusted anchor: the system temp dir (root-owned, sticky on a stock
+    // host). We allow the anchor itself to resolve through a symlink (it is
+    // system config, not tenant-writable), but everything below it is opened
+    // O_NOFOLLOW.
+    let anchor = std::env::temp_dir();
+    let rel = site.state_root.strip_prefix(&anchor).with_context(|| {
+        format!(
+            "tenant state root {} is not under the trusted temp anchor {} — refusing \
+             to prepare it",
+            site.state_root.display(),
+            anchor.display()
+        )
+    })?;
+
+    let anchor_fd = open_anchor_dir(&anchor)
+        .with_context(|| format!("failed to open temp anchor {}", anchor.display()))?;
+
+    // Walk each component below the anchor, creating missing ones, refusing any
+    // symlink. `current` ends pointing at the state root itself.
+    let mut current = anchor_fd;
+    for comp in rel.components() {
+        let Component::Normal(name) = comp else {
+            anyhow::bail!(
+                "refusing tenant state root {}: unexpected path component {comp:?} \
+                 (only plain names are allowed below the temp anchor)",
+                site.state_root.display()
+            );
+        };
+        current =
+            open_or_create_dir_nofollow(&current, name.as_bytes(), 0o700).with_context(|| {
+                format!(
+                    "failed to safely open/create state-root component {:?}",
+                    name.to_string_lossy()
+                )
+            })?;
     }
+
+    // Create the two children under the (now fd-pinned) state root.
+    let tmp_fd = open_or_create_dir_nofollow(&current, b"tmp", 0o700)
+        .context("failed to safely open/create the tenant tmp directory")?;
+    let sessions_fd = open_or_create_dir_nofollow(&current, b"sessions", 0o700)
+        .context("failed to safely open/create the tenant sessions directory")?;
+
+    // Hand ownership over via the open fds — never a path — so no symlink or
+    // renamed target can be substituted. Children first, then the root.
+    fchown_dir(&tmp_fd, uid, gid).context("failed to chown the tenant tmp directory")?;
+    fchown_dir(&sessions_fd, uid, gid).context("failed to chown the tenant sessions directory")?;
     // 0700 on the root so only the tenant uid may traverse it.
-    let _ = std::fs::set_permissions(&site.state_root, std::fs::Permissions::from_mode(0o700));
-    for dir in [&site.state_root, &tmp, &sessions] {
-        chown(dir, uid, gid).with_context(|| format!("failed to chown {}", dir.display()))?;
+    fchmod_dir(&current, 0o700).context("failed to tighten the tenant state root to 0700")?;
+    fchown_dir(&current, uid, gid).context("failed to chown the tenant state root")?;
+    Ok(())
+}
+
+/// Open the trusted temp anchor as a directory fd.
+///
+/// The anchor (e.g. `/tmp`) is system configuration rather than tenant-writable,
+/// so this deliberately *follows* a symlinked anchor (some distributions symlink
+/// `/tmp`) but requires the final target to be a directory (`O_DIRECTORY`).
+/// Everything traversed *below* this fd is opened `O_NOFOLLOW`.
+#[cfg(target_os = "linux")]
+fn open_anchor_dir(path: &std::path::Path) -> std::io::Result<std::os::fd::OwnedFd> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+        .open(path)?;
+    Ok(file.into())
+}
+
+/// Open `name` beneath `parent` as a directory fd, creating it if absent, and
+/// **refusing any symlink** (`O_NOFOLLOW`).
+///
+/// Returns an [`OwnedFd`](std::os::fd::OwnedFd) pinned to the opened inode, so
+/// callers can `fchown`/`fchmod` it without a path and hence without a
+/// symlink/rename race. Because the parent directory can be tenant-writable, a
+/// bounded retry tolerates a concurrent `mkdir`/`rmdir` race but caps the loop so
+/// an active attacker forces a loud failure rather than a spin.
+#[cfg(target_os = "linux")]
+fn open_or_create_dir_nofollow(
+    parent: &std::os::fd::OwnedFd,
+    name: &[u8],
+    mode: libc::mode_t,
+) -> anyhow::Result<std::os::fd::OwnedFd> {
+    use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+
+    use anyhow::Context as _;
+
+    let cname = std::ffi::CString::new(name)
+        .map_err(|_| anyhow::anyhow!("path component contains an interior NUL byte"))?;
+    let flags = libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let shown = String::from_utf8_lossy(name).into_owned();
+
+    for _ in 0..16 {
+        // SAFETY: `parent` is a live directory fd for the whole call, `cname` is a
+        // valid NUL-terminated string that outlives it, and `flags` includes
+        // O_NOFOLLOW so the final component is never dereferenced as a symlink.
+        // A non-negative return is a freshly-owned descriptor wrapped in OwnedFd
+        // immediately (closed on drop); the error path reads errno right away.
+        let fd = unsafe { libc::openat(parent.as_raw_fd(), cname.as_ptr(), flags, 0) };
+        if fd >= 0 {
+            // SAFETY: `fd` is a fresh, exclusively-owned descriptor (>= 0)
+            // returned by openat; wrapping it transfers ownership so it is closed
+            // exactly once on drop.
+            return Ok(unsafe { OwnedFd::from_raw_fd(fd) });
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::ENOENT) => {
+                // SAFETY: same argument validity as the openat above; mkdirat
+                // takes a checked path pointer and a scalar mode, return checked.
+                let rc = unsafe { libc::mkdirat(parent.as_raw_fd(), cname.as_ptr(), mode) };
+                if rc != 0 {
+                    let mkerr = std::io::Error::last_os_error();
+                    if mkerr.raw_os_error() != Some(libc::EEXIST) {
+                        return Err(mkerr).with_context(|| {
+                            format!("mkdirat failed while preparing state-root component {shown:?}")
+                        });
+                    }
+                    // EEXIST: lost the create race; loop to open it (still
+                    // O_NOFOLLOW, so a symlink planted in the gap is refused).
+                }
+                // Loop to open the (now-existing) directory O_NOFOLLOW.
+            }
+            // O_NOFOLLOW on a symlink surfaces as ELOOP; O_DIRECTORY on a
+            // symlink-to-directory surfaces as ENOTDIR on Linux. Either way the
+            // link was NOT followed and no fd was opened, so the target is never
+            // touched — we just probe (lstat) to report the precise reason.
+            Some(libc::ELOOP) => anyhow::bail!(
+                "refusing to operate on state-root component {shown:?}: it is a \
+                 symlink (symlink attack on the tenant-owned state-root tree)"
+            ),
+            Some(libc::ENOTDIR) => {
+                if symlink_present_at(parent, &cname) {
+                    anyhow::bail!(
+                        "refusing to operate on state-root component {shown:?}: it \
+                         is a symlink (symlink attack on the tenant-owned \
+                         state-root tree)"
+                    );
+                }
+                anyhow::bail!(
+                    "refusing to operate on state-root component {shown:?}: it \
+                     exists but is not a directory"
+                );
+            }
+            _ => {
+                return Err(err)
+                    .with_context(|| format!("openat failed for state-root component {shown:?}"));
+            }
+        }
+    }
+    anyhow::bail!(
+        "gave up opening/creating state-root component {shown:?} after repeated \
+         races — refusing (possible active symlink attack on the tenant-owned \
+         state-root tree)"
+    )
+}
+
+/// Return `true` if `name` beneath `parent` currently exists and is a symlink.
+///
+/// Used only to word the refusal precisely on the `openat` error path — the
+/// actual security enforcement is `O_NOFOLLOW`, which already declined to follow
+/// the link. `fstatat` with `AT_SYMLINK_NOFOLLOW` never dereferences it.
+#[cfg(target_os = "linux")]
+fn symlink_present_at(parent: &std::os::fd::OwnedFd, name: &std::ffi::CStr) -> bool {
+    use std::os::fd::AsRawFd as _;
+
+    let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `parent` is a live directory fd for the call, `name` is a valid
+    // NUL-terminated C string, `st` is a correctly-sized, writable `stat` buffer,
+    // and AT_SYMLINK_NOFOLLOW means the link itself (not its target) is stat'd.
+    let rc = unsafe {
+        libc::fstatat(parent.as_raw_fd(), name.as_ptr(), st.as_mut_ptr(), libc::AT_SYMLINK_NOFOLLOW)
+    };
+    if rc != 0 {
+        return false;
+    }
+    // SAFETY: fstatat returned 0, so `st` is fully initialized.
+    let st = unsafe { st.assume_init() };
+    (st.st_mode & libc::S_IFMT) == libc::S_IFLNK
+}
+
+/// `fchown(2)` a directory through its open fd (never a path).
+#[cfg(target_os = "linux")]
+fn fchown_dir(fd: &std::os::fd::OwnedFd, uid: u32, gid: u32) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+
+    // SAFETY: `fd` is a live directory descriptor for the duration of the call;
+    // fchown operates on the already-opened inode (no path, no symlink race) and
+    // the return value is checked.
+    if unsafe { libc::fchown(fd.as_raw_fd(), uid as libc::uid_t, gid as libc::gid_t) } != 0 {
+        return Err(std::io::Error::last_os_error());
     }
     Ok(())
 }
 
-/// `chown(2)` a path to `uid`/`gid`.
+/// `fchmod(2)` a directory through its open fd (never a path).
 #[cfg(target_os = "linux")]
-fn chown(path: &std::path::Path, uid: u32, gid: u32) -> std::io::Result<()> {
-    use std::os::unix::ffi::OsStrExt as _;
+fn fchmod_dir(fd: &std::os::fd::OwnedFd, mode: libc::mode_t) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd as _;
 
-    let c = std::ffi::CString::new(path.as_os_str().as_bytes())
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL"))?;
-    // SAFETY: `c` is a valid NUL-terminated C string that outlives the call; the
-    // return value is checked immediately.
-    if unsafe { libc::chown(c.as_ptr(), uid as libc::uid_t, gid as libc::gid_t) } != 0 {
+    // SAFETY: `fd` is a live directory descriptor for the duration of the call;
+    // fchmod operates on the already-opened inode (no path, no symlink race) and
+    // the return value is checked.
+    if unsafe { libc::fchmod(fd.as_raw_fd(), mode) } != 0 {
         return Err(std::io::Error::last_os_error());
     }
     Ok(())
@@ -283,9 +489,16 @@ fn apply_landlock(site: &ephpm_server::router::SandboxSite) -> anyhow::Result<()
     ]);
 
     // Read-only: the minimum non-secret /etc a program needs (name resolution,
-    // the loader cache, timezone) plus entropy and /proc for self-inspection.
+    // the loader cache, timezone) plus entropy and /proc/self for self-inspection.
     // Deliberately NOT /etc wholesale — that would expose /etc/ephpm and
     // /etc/shadow. Each is an individual path, so only these leaves are granted.
+    //
+    // Deliberately `/proc/self`, NOT `/proc` wholesale: the exec'd command shares
+    // the `ephpm-web` uid with the *running server*, so a broad `/proc` grant
+    // would let it read the server's `/proc/<server-pid>/environ` and `maps`
+    // (same-uid `0400`) and exfiltrate the server's environment (any `EPHPM_*`
+    // secrets) and address layout. An interpreter/shell needs only its own
+    // `/proc/self/*`; per-pid entries for *other* pids stay unreachable.
     let ro: Vec<PathBuf> = existing(&[
         Path::new("/etc/passwd"),
         Path::new("/etc/group"),
@@ -297,7 +510,7 @@ fn apply_landlock(site: &ephpm_server::router::SandboxSite) -> anyhow::Result<()
         Path::new("/etc/hosts"),
         Path::new("/dev/urandom"),
         Path::new("/dev/random"),
-        Path::new("/proc"),
+        Path::new("/proc/self"),
     ]);
 
     let status = Ruleset::default()
@@ -404,4 +617,106 @@ pub fn run(
          this platform. (The --no-sandbox DB-bind-only path is not implemented in \
          this build.)"
     )
+}
+
+/// Regression tests for the HIGH symlink-follow privilege escalation in
+/// `prepare_state_root` (the root-privileged setup phase).
+///
+/// These reproduce the reviewed escape — a tenant-planted symlink where a
+/// `state_root` component or `state_root/tmp` should be — and assert the fixed
+/// code **refuses** it and never touches the link's target. They run rootless
+/// (the refusal happens at `openat(O_NOFOLLOW)`, before any `fchown`), and the
+/// `chmod` tell deterministically fails against the pre-fix `create_dir_all` +
+/// `set_permissions` + `chown` implementation, which follows the symlink and
+/// operates on the target.
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::path::PathBuf;
+
+    use ephpm_server::router::SandboxSite;
+
+    /// A unique scratch base directly under the trusted temp anchor, so it is a
+    /// valid `state_root` prefix for [`super::prepare_state_root`].
+    fn unique_base(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let base =
+            std::env::temp_dir().join(format!("ephpm-exec-{tag}-{}-{nanos}", std::process::id()));
+        std::fs::create_dir_all(&base).expect("create scratch base");
+        base
+    }
+
+    fn site_at(state_root: PathBuf) -> SandboxSite {
+        SandboxSite {
+            key: "symtest".to_string(),
+            container: state_root.clone(),
+            document_root: state_root.clone(),
+            state_root,
+            open_basedir: String::new(),
+        }
+    }
+
+    fn current_ids() -> (u32, u32) {
+        // SAFETY: getuid/getgid take no arguments and cannot fail.
+        let uid = unsafe { libc::getuid() };
+        // SAFETY: getuid/getgid take no arguments and cannot fail.
+        let gid = unsafe { libc::getgid() };
+        (uid, gid)
+    }
+
+    #[test]
+    fn refuses_symlinked_state_root_component_and_leaves_target_untouched() {
+        let base = unique_base("symcomp");
+        let target = base.join("target");
+        std::fs::create_dir_all(&target).expect("create target");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod target 0755");
+        let state_root = base.join("site");
+        std::os::unix::fs::symlink(&target, &state_root).expect("plant symlink");
+        let (uid, gid) = current_ids();
+        let result = super::prepare_state_root(&site_at(state_root), uid, gid);
+        assert!(result.is_err(), "prepare_state_root must refuse a symlinked component");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(msg.contains("symlink"), "error must name the symlink refusal, got: {msg}");
+        let mode = std::fs::metadata(&target).expect("stat target").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "symlink target's mode must be untouched");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn refuses_symlinked_tmp_child_and_leaves_target_untouched() {
+        let base = unique_base("symtmp");
+        let target = base.join("escalate-here");
+        std::fs::create_dir_all(&target).expect("create target");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod target 0755");
+        let state_root = base.join("site");
+        std::fs::create_dir_all(&state_root).expect("create real state_root");
+        std::os::unix::fs::symlink(&target, state_root.join("tmp")).expect("plant tmp symlink");
+        let (uid, gid) = current_ids();
+        let result = super::prepare_state_root(&site_at(state_root), uid, gid);
+        assert!(result.is_err(), "prepare_state_root must refuse a symlinked tmp child");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(msg.contains("symlink"), "error must name the symlink refusal, got: {msg}");
+        let mode = std::fs::metadata(&target).expect("stat target").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "symlink target's mode must be untouched");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn creates_clean_state_root_tree() {
+        let base = unique_base("clean");
+        let state_root = base.join("site");
+        let (uid, gid) = current_ids();
+        super::prepare_state_root(&site_at(state_root.clone()), uid, gid)
+            .expect("clean prepare_state_root should succeed");
+        assert!(state_root.is_dir(), "state root created");
+        assert!(state_root.join("tmp").is_dir(), "tmp created");
+        assert!(state_root.join("sessions").is_dir(), "sessions created");
+        let mode = std::fs::metadata(&state_root).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "state root tightened to 0700");
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/crates/ephpm/src/exec_sandbox.rs
+++ b/crates/ephpm/src/exec_sandbox.rs
@@ -1,0 +1,407 @@
+//! `ephpm exec` — run a command inside a virtual host's tenant sandbox.
+//!
+//! This is the sandboxed execution primitive described in
+//! `site/content/roadmap/ephpm-exec-sandboxed-vhost.md`. It reconstructs a
+//! tenant's on-disk boundary (the same derivation a request goes through, via
+//! [`ephpm_server::router::resolve_sandbox_site`]), then, in order:
+//!
+//! 1. resolves `--site <key>` → the vhost's container + private state root;
+//! 2. sets `PR_SET_NO_NEW_PRIVS` so a setuid binary in the command cannot
+//!    re-escalate;
+//! 3. applies a **Landlock** ruleset scoping filesystem access to the
+//!    container + state root (+ the minimum read/exec set a program needs to
+//!    run) and *nothing else* — `/etc/ephpm`, `/root`, `/etc/shadow` are
+//!    unreachable;
+//! 4. irreversibly drops to the tenant uid/gid (reusing the server's audited
+//!    [`ephpm_server::privdrop::drop_to_user`] sequence), which is what arms
+//!    the host's uid-keyed `ephpm_egress` firewall; then
+//! 5. `execvp`s the command.
+//!
+//! Everything from step 2 on is `cfg(target_os = "linux")`; on any other
+//! platform the subcommand refuses (the sandbox mechanisms are Linux-only). The
+//! module carries **no PHP linkage**, so it compiles and is testable in stub
+//! mode with no PHP SDK.
+//!
+//! # TODO — deliberately out of scope for this proof-of-concept
+//!
+//! - `TODO(#471)`: the per-site DB session bind (`db_bridge::set_resolver` +
+//!   `set_current_site`) so `ephpm exec --site … -- wp …` can reach the
+//!   tenant's Turso database. The containment property this PoC proves does not
+//!   depend on it.
+//! - `TODO`: per-site-clustered owner-refusal (`hrw_owner`) — an exec on a
+//!   non-owner must refuse rather than write to a replica whose writes never
+//!   replicate. Not needed to prove uid/Landlock containment.
+//! - `TODO`: `setrlimit` (`RLIMIT_AS`/`RLIMIT_CPU`) resource caps and a
+//!   transient cgroup. The wall-clock `--timeout` is implemented via `alarm(2)`;
+//!   memory/CPU ceilings are follow-up.
+//! - `TODO`: the `--no-sandbox` DB-bind-only path for Windows/dev. On Linux
+//!   `--no-sandbox` currently just runs the command uncontained (loudly warned);
+//!   on non-Linux the whole subcommand refuses.
+//!
+//! # Intended switchboard call site (follow-up, not wired here)
+//!
+//! Switchboard's deployer runs manifest `build:` / `seed:` steps as root today.
+//! The one-line change is to run each step as, instead of `bash -c "$step"`:
+//!
+//! ```text
+//! ephpm exec --config /etc/ephpm/ephpm.toml --site <key> -- bash -c "$step"
+//! ```
+//!
+//! which inherits the uid drop, Landlock scope, and egress lock. Rewriting
+//! switchboard's deployer is a separate change in that repo.
+
+// The sandbox is a sequence of libc credential/prctl/exec syscalls and Landlock
+// FFI; every unsafe block below carries a SAFETY note explaining the invariant
+// it upholds.
+#![allow(unsafe_code)]
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+/// The tenant user `ephpm exec` drops to when `[server] run_as_user` is unset.
+///
+/// On the preview nodes this resolves to uid 997, which is exactly the uid the
+/// host `inet ephpm_egress` nftables table filters (`meta skuid 997`), so the
+/// drop arms the existing egress jail with no extra configuration.
+#[cfg(target_os = "linux")]
+const DEFAULT_TENANT_USER: &str = "ephpm-web";
+
+/// Entry point for `ephpm exec`. See the module docs for the layer sequence.
+///
+/// # Errors
+///
+/// Returns an error if the config cannot be loaded, the site cannot be
+/// resolved, the sandbox cannot be applied, the privilege drop fails, or the
+/// command cannot be `exec`ed. On success on Linux this never returns — the
+/// process image is replaced by the command.
+#[cfg(target_os = "linux")]
+pub fn run(
+    config_path: &PathBuf,
+    site_key: &str,
+    command: &[String],
+    timeout: u64,
+    no_sandbox: bool,
+) -> anyhow::Result<ExitCode> {
+    use anyhow::Context as _;
+    use ephpm_server::{privdrop, router};
+
+    let program = command.first().context("no command given after `--`")?;
+
+    let config = ephpm_config::Config::load(config_path).context("failed to load configuration")?;
+
+    let site = router::resolve_sandbox_site(&config, site_key)
+        .context("failed to resolve --site to a tenant sandbox")?;
+
+    // Resolve the tenant uid/gid the same way the server drop does: an explicit
+    // [server] run_as_user / run_as_group wins, else the ephpm-web default.
+    let user_spec = config.server.run_as_user.as_deref().unwrap_or(DEFAULT_TENANT_USER);
+    let (uid, primary_gid) = privdrop::resolve_user(user_spec)
+        .with_context(|| format!("failed to resolve tenant user {user_spec:?}"))?;
+    let gid = match config.server.run_as_group.as_deref() {
+        Some(group_spec) => privdrop::resolve_group(group_spec)
+            .with_context(|| format!("failed to resolve tenant group {group_spec:?}"))?,
+        None => primary_gid.unwrap_or(uid),
+    };
+
+    // SAFETY: geteuid never fails and takes no arguments.
+    let euid = unsafe { libc::geteuid() };
+
+    tracing::info!(
+        site = %site.key,
+        uid,
+        gid,
+        timeout,
+        no_sandbox,
+        container = %site.container.display(),
+        document_root = %site.document_root.display(),
+        command = ?command,
+        "ephpm exec: entering tenant sandbox"
+    );
+
+    if no_sandbox {
+        tracing::warn!(
+            "ephpm exec --no-sandbox: NO Landlock scope and NO uid drop — the \
+             command runs with the caller's full privileges. This defeats every \
+             containment layer; never use it for untrusted commands."
+        );
+    } else {
+        if euid != 0 {
+            anyhow::bail!(
+                "ephpm exec must start as root to enter a tenant sandbox (it needs \
+                 to setuid to {uid} and prepare the private state root); current \
+                 euid={euid}. Re-run under sudo, or pass --no-sandbox to run \
+                 uncontained."
+            );
+        }
+        // Create + chown the tenant's private temp/session root while still root,
+        // so the dropped command can write there. Mirrors the router's
+        // `ensure_vhost_private_dirs`.
+        prepare_state_root(&site, uid, gid)?;
+        // Block execve-based privilege regain (setuid binaries, file caps) in the
+        // command we are about to run. Must precede Landlock and the uid drop.
+        set_no_new_privs()?;
+        // Kernel filesystem boundary — the only fs scope for a non-PHP command.
+        apply_landlock(&site).context("failed to apply the Landlock sandbox")?;
+    }
+
+    // Wall-clock deadline. alarm(2) survives execve and the default SIGALRM
+    // disposition terminates the process, so this fires even inside the command.
+    if timeout > 0 {
+        let secs = u32::try_from(timeout).unwrap_or(u32::MAX);
+        // SAFETY: alarm takes a scalar, has no failure mode, and only schedules
+        // a signal; it cancels any previous alarm (there is none here).
+        unsafe {
+            libc::alarm(secs);
+        }
+    }
+
+    // Irreversible drop to the tenant identity, reusing the server's audited
+    // sequence (setgroups → setgid → setuid + fail-closed verification).
+    if !no_sandbox {
+        privdrop::drop_to_user(uid, gid).context("failed to drop to the tenant uid/gid")?;
+    }
+
+    // Run inside the web root so relative paths resolve within the sandbox.
+    if let Err(e) = std::env::set_current_dir(&site.document_root) {
+        tracing::warn!(
+            path = %site.document_root.display(),
+            error = %e,
+            "could not chdir into the document root; continuing from the current directory"
+        );
+    }
+
+    exec(program, command)
+}
+
+/// Create and chown the tenant's private state root (`state_root`, `tmp`,
+/// `sessions`) so the dropped command can write session/temp files there.
+///
+/// Best-effort ownership: the directories are created while still root, tightened
+/// to `0700`, and `chown`ed to the tenant. Mirrors the router's
+/// `ensure_vhost_private_dirs` so an exec'd tenant CLI shares the same private
+/// temp/session tree its HTTP requests use.
+#[cfg(target_os = "linux")]
+fn prepare_state_root(
+    site: &ephpm_server::router::SandboxSite,
+    uid: u32,
+    gid: u32,
+) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use anyhow::Context as _;
+
+    let tmp = site.state_root.join("tmp");
+    let sessions = site.state_root.join("sessions");
+    for dir in [&site.state_root, &tmp, &sessions] {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create {}", dir.display()))?;
+    }
+    // 0700 on the root so only the tenant uid may traverse it.
+    let _ = std::fs::set_permissions(&site.state_root, std::fs::Permissions::from_mode(0o700));
+    for dir in [&site.state_root, &tmp, &sessions] {
+        chown(dir, uid, gid).with_context(|| format!("failed to chown {}", dir.display()))?;
+    }
+    Ok(())
+}
+
+/// `chown(2)` a path to `uid`/`gid`.
+#[cfg(target_os = "linux")]
+fn chown(path: &std::path::Path, uid: u32, gid: u32) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let c = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL"))?;
+    // SAFETY: `c` is a valid NUL-terminated C string that outlives the call; the
+    // return value is checked immediately.
+    if unsafe { libc::chown(c.as_ptr(), uid as libc::uid_t, gid as libc::gid_t) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Set `PR_SET_NO_NEW_PRIVS` so no descendant `execve` can gain privileges via
+/// a setuid/setgid bit or file capabilities. Required for a defence-in-depth
+/// sandbox and a precondition for Landlock without `CAP_SYS_ADMIN`.
+#[cfg(target_os = "linux")]
+fn set_no_new_privs() -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    // SAFETY: prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) is the documented form with
+    // scalar arguments and no pointer operands; the return value is checked.
+    let rc = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error()).context("prctl(PR_SET_NO_NEW_PRIVS) failed");
+    }
+    Ok(())
+}
+
+/// Apply the Landlock filesystem ruleset for this tenant.
+///
+/// Grants read/write beneath the site container and its private state root,
+/// read+execute beneath the standard system directories a program needs to run,
+/// and read on a minimal, non-secret slice of `/etc` (name resolution + the
+/// dynamic loader cache) plus entropy sources. Everything else — crucially
+/// `/etc/ephpm` (the cluster secret), `/root`, and `/etc/shadow` — is denied by
+/// Landlock's default-deny once `restrict_self` runs.
+///
+/// Uses ABI v1 (the widest kernel support) in best-effort mode, and refuses to
+/// run if the kernel does not enforce Landlock at all — a fail-closed posture,
+/// overridable only with the loudly-warned `--no-sandbox`.
+#[cfg(target_os = "linux")]
+fn apply_landlock(site: &ephpm_server::router::SandboxSite) -> anyhow::Result<()> {
+    use std::path::{Path, PathBuf};
+
+    use anyhow::Context as _;
+    use landlock::{
+        ABI, Access, AccessFs, CompatLevel, Compatible, Ruleset, RulesetAttr, RulesetCreatedAttr,
+        RulesetStatus, path_beneath_rules,
+    };
+
+    let abi = ABI::V1;
+    let read_exec = AccessFs::Execute | AccessFs::ReadFile | AccessFs::ReadDir;
+    let read_only = AccessFs::from_read(abi);
+    let read_write = AccessFs::from_all(abi);
+
+    // Read/write: the tenant's own code container and its private temp/session
+    // root. These are the two entries the request-path `open_basedir` grants.
+    let rw: Vec<PathBuf> = existing(&[
+        site.container.as_path(),
+        site.state_root.as_path(),
+        Path::new("/dev/null"),
+        Path::new("/dev/zero"),
+        Path::new("/dev/full"),
+    ]);
+
+    // Read/execute: where interpreters, the loader, and shared libraries live.
+    let rx: Vec<PathBuf> = existing(&[
+        Path::new("/usr"),
+        Path::new("/lib"),
+        Path::new("/lib64"),
+        Path::new("/bin"),
+        Path::new("/sbin"),
+        Path::new("/opt"),
+    ]);
+
+    // Read-only: the minimum non-secret /etc a program needs (name resolution,
+    // the loader cache, timezone) plus entropy and /proc for self-inspection.
+    // Deliberately NOT /etc wholesale — that would expose /etc/ephpm and
+    // /etc/shadow. Each is an individual path, so only these leaves are granted.
+    let ro: Vec<PathBuf> = existing(&[
+        Path::new("/etc/passwd"),
+        Path::new("/etc/group"),
+        Path::new("/etc/nsswitch.conf"),
+        Path::new("/etc/ld.so.cache"),
+        Path::new("/etc/ld.so.preload"),
+        Path::new("/etc/localtime"),
+        Path::new("/etc/resolv.conf"),
+        Path::new("/etc/hosts"),
+        Path::new("/dev/urandom"),
+        Path::new("/dev/random"),
+        Path::new("/proc"),
+    ]);
+
+    let status = Ruleset::default()
+        .set_compatibility(CompatLevel::BestEffort)
+        .handle_access(AccessFs::from_all(abi))
+        .context("landlock: handle_access")?
+        .create()
+        .context("landlock: create ruleset")?
+        .add_rules(path_beneath_rules(&rw, read_write))
+        .context("landlock: add read/write rules")?
+        .add_rules(path_beneath_rules(&rx, read_exec))
+        .context("landlock: add read/exec rules")?
+        .add_rules(path_beneath_rules(&ro, read_only))
+        .context("landlock: add read-only rules")?
+        .restrict_self()
+        .context("landlock: restrict_self")?;
+
+    match status.ruleset {
+        RulesetStatus::FullyEnforced => {
+            tracing::info!(
+                container = %site.container.display(),
+                state_root = %site.state_root.display(),
+                "Landlock: fully enforced (filesystem scoped to the tenant sandbox)"
+            );
+        }
+        RulesetStatus::PartiallyEnforced => {
+            tracing::warn!(
+                "Landlock: partially enforced — this kernel supports only a subset \
+                 of the requested access rights. The sandbox is active but weaker \
+                 than intended."
+            );
+        }
+        RulesetStatus::NotEnforced => {
+            anyhow::bail!(
+                "Landlock is not enforced by this kernel — refusing to run without a \
+                 filesystem sandbox. Pass --no-sandbox to override (removes all \
+                 containment)."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Filter a list of candidate paths down to those that currently exist, as
+/// owned `PathBuf`s. Landlock rule creation opens each path, so a non-existent
+/// entry (e.g. `/etc/ld.so.preload` on a system without one) would otherwise
+/// error; skipping it keeps the ruleset fail-closed on the paths that matter.
+#[cfg(target_os = "linux")]
+fn existing(paths: &[&std::path::Path]) -> Vec<std::path::PathBuf> {
+    paths.iter().filter(|p| p.exists()).map(|p| p.to_path_buf()).collect()
+}
+
+/// `execvp` the command, replacing this process image. Returns only on failure.
+#[cfg(target_os = "linux")]
+fn exec(program: &str, command: &[String]) -> anyhow::Result<ExitCode> {
+    use std::ffi::CString;
+
+    use anyhow::Context as _;
+
+    let prog_c =
+        CString::new(program.as_bytes()).context("command name contains an interior NUL byte")?;
+    let mut argv_owned: Vec<CString> = Vec::with_capacity(command.len());
+    for arg in command {
+        argv_owned.push(
+            CString::new(arg.as_bytes())
+                .context("command argument contains an interior NUL byte")?,
+        );
+    }
+    let mut argv: Vec<*const libc::c_char> = argv_owned.iter().map(|c| c.as_ptr()).collect();
+    argv.push(std::ptr::null());
+
+    // SAFETY: `prog_c` and every `CString` in `argv_owned` outlive the call, and
+    // `argv` is NULL-terminated. On success execvp replaces the process image
+    // and never returns; on failure it returns -1 and we read errno immediately.
+    unsafe {
+        libc::execvp(prog_c.as_ptr(), argv.as_ptr());
+    }
+    let err = std::io::Error::last_os_error();
+    Err(err).with_context(|| format!("failed to exec {program:?}"))
+}
+
+/// Non-Linux stub: sandboxed exec is unavailable, so the subcommand refuses.
+///
+/// The sandbox layers (Landlock, `setuid`, the host egress firewall) are all
+/// Linux mechanisms; pretending to isolate when we cannot would be worse than
+/// refusing. The `--no-sandbox` DB-bind-only path a design doc sketches for
+/// Windows/dev is not implemented in this proof-of-concept.
+///
+/// # Errors
+///
+/// Always returns an error on non-Linux platforms.
+#[cfg(not(target_os = "linux"))]
+pub fn run(
+    config_path: &PathBuf,
+    site_key: &str,
+    command: &[String],
+    timeout: u64,
+    no_sandbox: bool,
+) -> anyhow::Result<ExitCode> {
+    let _ = (config_path, site_key, command, timeout, no_sandbox);
+    anyhow::bail!(
+        "`ephpm exec` sandboxed execution is Linux-only — it relies on Landlock, \
+         setuid, and the host uid-keyed egress firewall, none of which exist on \
+         this platform. (The --no-sandbox DB-bind-only path is not implemented in \
+         this build.)"
+    )
+}

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -30,6 +30,7 @@ use tracing_subscriber::{EnvFilter, Layer};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod exec_sandbox;
 mod fatal_signal;
 mod service;
 
@@ -97,6 +98,48 @@ enum Commands {
         /// Arguments to pass to the PHP interpreter
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
+    },
+
+    /// Run a command inside a virtual host's tenant sandbox (Linux only).
+    ///
+    /// Resolves `--site <key>` to the vhost's filesystem boundary, scopes the
+    /// command to that boundary with Landlock (denying `/etc/ephpm`, `/root`,
+    /// `/etc/shadow`, and everything else), then irreversibly drops to the
+    /// tenant uid/gid before exec — so the process runs as the unprivileged
+    /// `ephpm-web` user the host `ephpm_egress` firewall already jails.
+    ///
+    /// This is the sandboxed execution primitive a control plane (switchboard)
+    /// should call for build/seed steps instead of running them as root. See
+    /// `site/content/roadmap/ephpm-exec-sandboxed-vhost.md`.
+    #[command(disable_help_flag = true)]
+    Exec {
+        /// Path to the configuration file (holds `[server] sites_dir` and the
+        /// per-site derivation). Whoever can read this can already impersonate
+        /// any tenant, so config-file permissions are the authorization gate.
+        #[arg(short, long, default_value = "/etc/ephpm/ephpm.toml")]
+        config: PathBuf,
+
+        /// The virtual host key (the vhost directory name under `sites_dir`).
+        #[arg(short, long)]
+        site: String,
+
+        /// Wall-clock timeout in seconds. `0` (default) means no timeout. The
+        /// deadline is armed with `alarm(2)` and survives `execve`, so it fires
+        /// even inside the exec'd command (default `SIGALRM` disposition
+        /// terminates the process).
+        #[arg(short, long, default_value_t = 0u64)]
+        timeout: u64,
+
+        /// Skip the Landlock scope and uid drop, running the command with the
+        /// caller's privileges. Loudly labelled and never the default — only
+        /// for platforms/paths where the sandbox is unavailable. On Linux this
+        /// removes all containment; prefer omitting it.
+        #[arg(long)]
+        no_sandbox: bool,
+
+        /// The command and its arguments, after `--`.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+        command: Vec<String>,
     },
 
     /// Inspect or manipulate the KV store on a running server
@@ -329,6 +372,10 @@ fn run() -> anyhow::Result<ExitCode> {
 
     match cli.command {
         Some(Commands::Php { args }) => run_php(&php_cli_args(&args)),
+        Some(Commands::Exec { config, site, timeout, no_sandbox, command }) => {
+            ensure_cli_tracing();
+            exec_sandbox::run(&config, &site, &command, timeout, no_sandbox)
+        }
         Some(Commands::Kv { host, port, password, user, subcommand }) => {
             let auth = KvAuth::resolve(user, password)?;
             let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;

--- a/site/content/roadmap/_index.md
+++ b/site/content/roadmap/_index.md
@@ -18,6 +18,7 @@ These pages describe targets, not currently-shipped behavior. For what works tod
 - **[The Deploy Story](deploy-warmup/)** — post-invalidation warmup, `ephpm doctor <framework>`, `cache status`, thin deploy hooks.
 - **[Preview Deployments](preview/)** — instant per-PR preview URLs via a GitHub bot. **Shipped end to end** — the runtime half plus the [`ephpm/switchboard`](https://github.com/ephpm/switchboard) daemon, the [`ephpm/switchboard-api`](https://github.com/ephpm/switchboard-api) webhook receiver, and in-process wildcard certs via DNS-01. See the [PR Preview Bot guide](/guides/preview-bot/) to install it; this roadmap page now holds only the remaining design items (multi-PHP routing, GC/quotas, sandboxed builds, scale-out).
 - **[OPcache Clustering & Per-Vhost Preload](opcache-clustering/)** — Phase 1 (cluster-wide invalidation) shipped in 0.4.0; per-vhost preload and worker-mode invalidation remain.
+- **[`ephpm exec` — Sandboxed Vhost Commands](ephpm-exec-sandboxed-vhost/)** — run an arbitrary command inside a virtual host's tenant sandbox (uid-drop + Landlock + per-site DB bind). Unifies switchboard's build sandbox, issue #471 (CLI DB access), and operator cron/migrations.
 - **[Symfony Runtime Adapter](symfony-runtime-driver/)** — native `ephpm` adapter under `symfony/runtime`, on top of the shipped worker-mode engine.
 - **[Kubernetes Operator](kubernetes/)** — first-class K8s deployment.
 - **[Edge Deployments](edge/)** — running ePHPm at the edge.

--- a/site/content/roadmap/ephpm-exec-sandboxed-vhost.md
+++ b/site/content/roadmap/ephpm-exec-sandboxed-vhost.md
@@ -1,13 +1,15 @@
 # `ephpm exec` — Run a Command Inside a Virtual Host's Tenant Sandbox
 
-> **Status: design spike — not implemented.** Nothing on this page ships. It is
-> a written proposal for a new `ephpm exec --site <key> -- <command...>`
-> subcommand, backed by the current code it would reuse (every file reference
-> below was read while writing this). Anything described in the future tense is
-> *planned*, not present. There is no `exec` subcommand in
-> `crates/ephpm/src/main.rs` today — the CLI surface is `serve` / `dev` / `php`
-> / `kv` / `cache` / service management. Treat the sandboxed form as
-> **Linux-only** for the reasons in [Windows](#windows-the-honest-story).
+> **Status: design spike + working proof-of-concept.** The containment core —
+> uid drop + Landlock filesystem scope + the uid-keyed egress firewall — is
+> **implemented and confirmed on a live preview node** (see
+> [PoC status](#poc-status--implemented-and-confirmed-on-a-preview-node-linux)).
+> A `Commands::Exec` subcommand now exists in `crates/ephpm/src/main.rs`
+> (`crates/ephpm/src/exec_sandbox.rs`). Parts still described in the future tense
+> — the per-site DB bind (#471), per-site-clustered owner-refusal, `setrlimit`
+> caps, and the switchboard integration — are **planned, not present**, and are
+> called out where they appear. Treat the sandboxed form as **Linux-only** for
+> the reasons in [Windows](#windows-the-honest-story).
 
 ## Why this exists — three things it unifies
 
@@ -344,51 +346,109 @@ The line: switchboard stays the privileged control plane (fetch, configure,
 sequence, talk to the daemon); `ephpm exec` becomes the sandboxed execution
 primitive it delegates the actual tenant-scoped work to.
 
-## PoC status — deliberately not written (judgment call)
+## PoC status — implemented and confirmed on a preview node (Linux)
 
-The brief allows an optional PoC proving *uid drop + Landlock filesystem scope +
-running a command* (no DB bind required). **This spike ships design only, no
-PoC**, for one honest reason: the entire sandbox path is `cfg(target_os =
-"linux")`, and this spike was produced on a Windows host where that code cannot
-be compiled, `clippy`-checked under the Linux `cfg`, or run. A PoC I cannot
-build or exercise here would be untested `cfg(linux)` unsafe FFI + a new
-`landlock` crate dependency added blind — that *removes* risk from the design on
-paper while *adding* the risk of shipping broken platform-gated code that CI's
-stub-mode legs (which don't set the Linux sandbox cfg meaningfully) wouldn't
-catch. That trade is backwards for a spike whose job is to de-risk.
+**A working proof-of-concept ships alongside this doc** and was confirmed on a
+live preview node (Debian 13, kernel 6.12, glibc 2.41). It proves the security
+property this design exists for — *uid drop + Landlock filesystem scope + the
+egress firewall*, no DB bind — and closes the exact root-RCE hole the switchboard
+build step exposes.
 
-What the PoC *would* look like, kept cheap for whoever picks it up on Linux:
+What shipped, all of it stub-mode-clean (no PHP SDK needed) and
+`clippy`-pedantic + `-D warnings` clean:
 
-- New `Commands::Exec { site, config, timeout, no_sandbox, command: Vec<String> }`
-  in `crates/ephpm/src/main.rs`, `--` capturing the trailing command (clap
-  `trailing_var_arg` + `allow_hyphen_values`, mirroring how `Php { args }`
-  already slurps PHP flags).
-- A `crates/ephpm/src/exec_sandbox.rs` (or a small `ephpm-sandbox` crate) with a
-  `#[cfg(target_os = "linux")]` impl and a `#[cfg(not)]` refuse-stub, matching
-  the `privdrop` shape exactly.
-- Reuse `privdrop`'s `resolve_user` + the `setgroups`/`setgid`/`setuid` sequence
-  verbatim (factor it out of `ephpm-server::privdrop` into a shared spot so both
-  the server drop and exec drop share one audited implementation).
-- Add `landlock = "0.4"` (pure Rust, ABI 1–4, MSRV-compatible) for the
-  filesystem ruleset; `libc` (already a dep) for `setrlimit`.
-- Prove it with a Linux integration test: `ephpm exec --site t -- cat
-  /etc/ephpm/ephpm.toml` is denied (Landlock), `id -u` prints `997` (drop), and
-  a command under the docroot succeeds — no PHP SDK needed for any of it.
+- `Commands::Exec { config, site, timeout, no_sandbox, command }` in
+  `crates/ephpm/src/main.rs` — `--` captures the trailing command (clap
+  `trailing_var_arg` + `allow_hyphen_values`), mirroring `Php { args }`.
+- `crates/ephpm/src/exec_sandbox.rs` — a `#[cfg(target_os = "linux")]` impl and a
+  `#[cfg(not)]` refuse-stub, matching the `privdrop` shape. Layer order:
+  resolve site → `PR_SET_NO_NEW_PRIVS` → Landlock (ABI v1, best-effort, refuse if
+  `NotEnforced`) → irreversible uid drop → `chdir` → `execvp`. `--timeout` arms
+  `alarm(2)` (survives `execve`; default `SIGALRM` terminates).
+- `ephpm_server::router::resolve_sandbox_site(config, key)` — the site derivation
+  reused verbatim from the request path (`resolve_site` → container +
+  `vhost_state_root`), so the exec sandbox is not a *second*, divergent
+  derivation of tenant identity (issues #290/#291). Pinned by
+  `router::tests::resolve_sandbox_site_matches_request_derivation_and_fails_closed`.
+- `privdrop::drop_to_user(uid, gid)` — the `setgroups`/`setgid`/`setuid` +
+  fail-closed verification, **factored out** of `drop_privileges` so the server
+  drop and the exec drop share one audited implementation; `resolve_user` /
+  `resolve_group` are now `pub` for the same reuse.
+- `landlock = "0.4"` added Linux-only (`libc` was already a dep).
 
-Estimated at more than "a couple hours" once clippy-pedantic + nightly-fmt +
-stub-mode-still-builds + a Linux CI leg to actually exercise it are included,
-and none of it is meaningfully verifiable from this host — so per the brief's
-own guidance ("if a PoC would be more than a couple hours … don't"), it is left
-as the first implementation step, not part of the spike.
+### The confirmed before/after (identical benign probe, run twice)
+
+The site config used was a throwaway (`sites_dir` under `/tmp`), but the probe
+read the node's **real** `/etc/ephpm/ephpm.toml` — the file that holds the
+cluster gossip secret, owned `640 ephpm-web:ephpm-web` (uid 997).
+
+| Probe check | Baseline: run as **root** | Via `ephpm exec --site` | Closed by |
+|---|---|---|---|
+| `id` | `uid=0(root)` | `uid=997(ephpm-web) gid=989` | **uid drop** (`setuid`, irreversible) |
+| `whoami` | `root` | `ephpm-web` | uid drop |
+| write `/root/.sb-poc` | YES | **NO** | Landlock (path not granted) + DAC |
+| read `/etc/shadow` (`open`) | YES | **NO** | DAC (997 ∉ `shadow`) + Landlock |
+| read `/etc/ephpm/ephpm.toml` (`open`) | YES | **NO** | **Landlock only** — see below |
+| `test -r /etc/ephpm/ephpm.toml` (`access(2)`) | YES | **YES** | *nothing* — the tell |
+
+**The sharpest evidence is the last two rows.** `/etc/ephpm/ephpm.toml` is owned
+by uid 997, so after the drop DAC *still permits* the read — `test -r`
+(`access(2)`, which Landlock does not intercept) returns **YES** exactly as it
+did for root. But the actual `open()` returns **NO**. The only layer that can
+account for that gap is **Landlock**: the uid drop alone does not close the
+secret read, Landlock does. That is the whole design's leverage made visible in
+one probe. Landlock reported `FullyEnforced` at ABI v1 on the 6.12 kernel — no
+partial negotiation.
+
+### Firewall layer confirmed too
+
+The uid-997 drop arms the host's `inet ephpm_egress` nftables table with zero
+extra ePHPm code (it keys on `skuid`, `meta skuid != 997 accept`). Demonstrated
+on the node: **root** connects to `127.0.0.1:22` (bypasses the table); the
+**tenant (997)** hangs on the same loopback connect and is `alarm`-killed by
+`--timeout` (`127.0.0.0/8 drop` for 997) — while the tenant's connect to the
+*allowed* public DNS `1.1.1.1:53` **succeeds**. So it is specifically the
+uid-keyed egress policy, not a blanket network cut, and it arms automatically.
+
+### Honest limits / caveats
+
+- **Landlock ABI floor.** The impl pins ABI **v1** best-effort and refuses if the
+  kernel reports `NotEnforced` (fail-closed). It has not been exercised below
+  ABI v1 (a mount-namespace fallback is a follow-up, not built).
+- **`access(2)` is Landlock-blind.** As the table shows, a tenant can still learn
+  a path is DAC-readable via `test -r`; it just cannot `open` it. Code that keys
+  a decision on `access(2)` rather than a real open would be misled — an
+  in-kernel property of Landlock, worth stating.
+- **`--no-sandbox` on Linux removes all containment** (loudly warned) and exists
+  only for the future Windows DB-bind path; on non-Linux the subcommand refuses.
+- **`setrlimit` / cgroup caps not built** — only the `alarm(2)` wall-clock
+  timeout is. Memory/CPU/pids ceilings are follow-up.
+- The DB bind (`TODO(#471)`) and per-site-clustered owner-refusal are **not**
+  wired — out of scope for proving containment, marked `TODO` in the module.
+
+### Intended switchboard call site (follow-up, not in this PR)
+
+Switchboard runs manifest `build:` / `seed:` steps as **root** today — the RCE
+surface. The one-line change is to run each step as, instead of `bash -c "$step"`:
+
+```text
+ephpm exec --config /etc/ephpm/ephpm.toml --site <key> -- bash -c "$step"
+```
+
+which inherits the uid drop, Landlock scope, and egress lock. Rewriting
+switchboard's deployer is a separate change in that repo, deliberately not made
+here.
 
 ## Open questions for review
 
-- **Factor `privdrop` credential-drop into a shared module?** Both the server
-  drop and exec drop want the identical audited `setgroups`/`setgid`/`setuid` +
-  fail-closed verification. One copy, two callers.
-- **Landlock ABI floor.** Preview nodes are 6.12 (ABI 4+ available). What is the
-  minimum supported kernel — refuse below Landlock ABI 3, or fall back to a
-  mount namespace? Refusing is simpler and fail-closed.
+- ~~**Factor `privdrop` credential-drop into a shared module?**~~ **Done in the
+  PoC** — `privdrop::drop_to_user(uid, gid)` is the one audited
+  `setgroups`/`setgid`/`setuid` + fail-closed copy, called by both the server
+  drop and `ephpm exec`.
+- **Landlock ABI floor.** Preview nodes are 6.12; the PoC pins ABI **v1**
+  best-effort and refuses on `NotEnforced` (fail-closed, confirmed
+  `FullyEnforced` on the node). Open: raise the pinned ABI for finer rights, or
+  add a mount-namespace fallback below v1? Refusing is simplest.
 - **cgroup placement.** Is a transient per-exec cgroup (memory/pids cap) worth
   it for a first cut, or are `setrlimit` + wall-clock timeout sufficient? This
   spike says rlimits are sufficient to start.

--- a/site/content/roadmap/ephpm-exec-sandboxed-vhost.md
+++ b/site/content/roadmap/ephpm-exec-sandboxed-vhost.md
@@ -1,0 +1,397 @@
+# `ephpm exec` — Run a Command Inside a Virtual Host's Tenant Sandbox
+
+> **Status: design spike — not implemented.** Nothing on this page ships. It is
+> a written proposal for a new `ephpm exec --site <key> -- <command...>`
+> subcommand, backed by the current code it would reuse (every file reference
+> below was read while writing this). Anything described in the future tense is
+> *planned*, not present. There is no `exec` subcommand in
+> `crates/ephpm/src/main.rs` today — the CLI surface is `serve` / `dev` / `php`
+> / `kv` / `cache` / service management. Treat the sandboxed form as
+> **Linux-only** for the reasons in [Windows](#windows-the-honest-story).
+
+## Why this exists — three things it unifies
+
+1. **A build/deploy sandbox for `ephpm/switchboard`.** Switchboard runs manifest
+   `build:` / `seed:` steps as **root, unsandboxed** today — a confirmed root
+   RCE surface on the live cluster. If those steps ran as
+   `ephpm exec --site <key> -- bash build.sh`, they would inherit ePHPm's
+   existing per-vhost isolation instead of switchboard reimplementing (or
+   omitting) it.
+2. **Issue #471.** `ephpm php` — and therefore wp-cli, `artisan migrate`,
+   Doctrine console, any framework CLI — cannot reach a per-site database,
+   because a per-site DB handle only exists inside an HTTP request where
+   `Router::resolve_site` bound the site. `ephpm exec --site` is the general
+   form of the #471 fix: bind the site, open its DB session, then run the
+   command. See [The #471 relationship](#the-471-relationship).
+3. **Operator cron / queue workers / migrations.** Anyone running an app on
+   ePHPm wants to run periodic tasks in the tenant's sandbox without standing up
+   a second, differently-configured PHP.
+
+The through-line: ePHPm *already computes* a tenant's full isolation profile
+once per request. `ephpm exec` is the question "can that profile be
+reconstructed for a one-shot command outside a request?" — and, mostly, the
+answer is yes, by reusing code that already exists.
+
+## What the per-request sandbox is made of (verified)
+
+Everything below is what a request already gets. The design reuses each piece;
+the file references are the current implementations.
+
+| Layer | Where it lives today | Keyed on |
+|-------|----------------------|----------|
+| Per-vhost `open_basedir` | `router.rs::vhost_open_basedir_value` (docroot + private state root); applied as a per-request INI directive | filesystem paths |
+| Private temp/session root | `router.rs::vhost_state_root` / `ensure_vhost_private_dirs` (`<tmpdir>/ephpm-vhosts/<label>-<digest>`, `0700`) | derived from docroot |
+| `disable_functions` hardening | `main.rs::compose_disable_functions` + `HARDENING_*` constants | process-global php.ini |
+| Per-site DB session | `db_bridge.rs::{set_resolver, set_current_site}` + `SiteBackendResolver` | site key (per-thread) |
+| Per-site KV keyspace | `Router::site_identities` → `ephpm_kv` site store | site key |
+| Single non-root uid | `privdrop.rs::drop_privileges` (`setgroups`+`setgid`+`setuid`, irreversible) | process-wide |
+| Egress firewall | host nftables `inet ephpm_egress`, **not ePHPm code** | `skuid` (uid 997) |
+| Per-vhost eBPF net policy | `tenant_ebpf.rs` + `bpf/vhostnet.bpf.c` | **TID** (per-thread) |
+| Resource limits | `[php] max_execution_time` (Linux per-thread timer); `[server.timeouts] request` | per-request |
+
+The canonical tenant identity is derived **once**, by `Router::resolve_site`
+returning `ResolvedSite { key, document_root, .. }`, and everything per-tenant
+is derived from that `key` via `Router::site_identities` — never re-derived from
+the `Host` header (issues #290/#291, pinned by `router::tests::site_key_agreement`).
+`ephpm exec` must derive the same `key` the same way and feed the same
+`site_identities`, or it becomes a *second*, divergent derivation of tenant
+identity — exactly the class of bug that invariant exists to prevent.
+
+## The key finding: uid-drop makes the existing firewall do the containment
+
+The live preview nodes (verified read-only on `198.58.124.223`, 2026-09-07)
+carry an nftables table whose `output` chain is uid-keyed:
+
+```
+table inet ephpm_egress {
+    chain output {
+        type filter hook output priority filter; policy accept;
+        meta skuid != 997 accept          # everything NOT ephpm-web is unfiltered
+        ct state established,related accept
+        ip daddr { 1.1.1.1, 8.8.8.8 } udp/tcp dport 53 accept   # public DNS only
+        ip daddr 192.168.128.0/17 accept  # cluster range
+        ip daddr 127.0.0.0/8 drop         # loopback denied
+        ip6 daddr ::1 drop
+        ip daddr { 10/8, 169.254/16, 172.16/12, 192.168/16 } drop   # LAN denied
+        ...
+        meta l4proto tcp accept           # public internet TCP allowed
+        counter ... drop
+    }
+}
+```
+
+`getent passwd 997` → `ephpm-web:x:997:989:…:/usr/sbin/nologin`. So the rule
+filters **exactly uid 997 = `ephpm-web`** and nothing else. The consequence is
+the whole design's leverage:
+
+- A command that runs **as uid 997** is automatically egress-locked — no
+  loopback, no LAN, public internet + cluster range + public DNS only — **with
+  zero extra ePHPm code**. The firewall already exists and already keys on
+  `skuid`.
+- Switchboard's current build step runs as **root**, which hits
+  `meta skuid != 997 accept` on the first rule and bypasses the entire table.
+  That is the RCE blast radius in one line.
+
+So `ephpm exec` should **drop to the tenant uid (997)** and let the host
+firewall contain it. The drop primitive already exists —
+`privdrop.rs::drop_privileges` does `setgroups` → `setgid` → `setuid`, verifies
+the drop took, and proves root can't be regained (`seteuid(0)` must fail). The
+one semantic difference: the server drops the *whole long-running process* once
+at startup; `ephpm exec` drops a *one-shot* process (or its forked child)
+before `execve`, which is if anything simpler.
+
+### The loopback-drop tension (important, and not hand-waved)
+
+The same rule that contains a hostile build script — `127.0.0.0/8 drop` for uid
+997 — **also blocks a legitimate one from reaching the local MySQL wire
+listener on `127.0.0.1:3306`.** This is the sharp edge of the design:
+
+- **PHP commands (wp-cli, `artisan migrate`) sidestep it entirely.** The #471
+  DB path is the *in-process* `ephpm_db_*` bridge — a Rust function call
+  (`db_bridge.rs`), not a socket. It never touches loopback, so the firewall is
+  irrelevant to it. This is the case that matters most, and it works.
+- **Arbitrary child commands that expect a TCP database do not.** A `bash
+  build.sh` that runs `mysql -h 127.0.0.1` as uid 997 will have its connection
+  dropped by the firewall. That is *correct* containment, but it means "run any
+  build script unchanged" is not a promise `ephpm exec` can make for scripts
+  that reach a DB over loopback TCP. Such scripts must route DB work through a
+  child `ephpm php` / wp-cli invocation (in-process bridge) rather than a raw
+  socket.
+
+Stating this plainly is the point: `ephpm exec` gives PHP tenant CLIs a working
+database (#471) and gives arbitrary commands a correctly-jailed egress — but the
+intersection ("an arbitrary non-PHP command that also needs the tenant DB over
+TCP") is deliberately closed, because opening loopback for uid 997 would reopen
+the containment the firewall is there to provide.
+
+## Sandbox layers `ephpm exec` would apply
+
+Applied to the command (or its forked child), in this order:
+
+1. **Resolve the site → `ResolvedSite`/`SiteIdentities`.** Reuse
+   `Router::resolve_site` semantics against the loaded config so the key,
+   document root, and identities are byte-identical to the HTTP path. Refuse if
+   the key resolves to `None` (no such site) — same fail-closed as a request
+   that matched no vhost.
+2. **Filesystem scope.** Two options, both Linux-only:
+   - **Landlock ruleset** (kernel ≥ 5.13; preview nodes are 6.12 with
+     `landlock` present in `/sys/kernel/security/lsm`). Grant read/write/exec
+     only under the site's `document_root` and its `vhost_state_root`, plus the
+     minimal read set a program needs (the interpreter, shared libs). Crucially
+     **do not** grant `/etc/ephpm` — where `ephpm.toml` holds the cluster master
+     secret (mode 640, `ephpm-web`-*readable*). Landlock is the tighter fit
+     because it needs no mounts and no `CAP_SYS_ADMIN`, and it composes with the
+     uid drop.
+   - **Mount namespace** (`unshare(CLONE_NEWNS)` + bind mounts) as the fallback
+     on kernels without Landlock ABI 3+, at the cost of needing more privilege
+     to set up. Landlock is the recommended primary.
+
+   Note the relationship to `open_basedir`: for **PHP** commands, `open_basedir`
+   is still set (via the generated php.ini, exactly as a request does) and is
+   the in-interpreter boundary; Landlock is the *kernel* backstop that also
+   covers non-PHP children and anything PHP shells out to. For **non-PHP**
+   commands, Landlock is the only filesystem boundary — there is no
+   `open_basedir` for `bash`.
+3. **uid/gid drop to the tenant uid (997 / `ephpm-web`).** Reuse
+   `privdrop`-style `setgroups`+`setgid`+`setuid` with the same fail-closed
+   verification. This is what arms the `ephpm_egress` firewall
+   (§ [key finding](#the-key-finding-uid-drop-makes-the-existing-firewall-do-the-containment)).
+4. **Resource limits.** `setrlimit` before `execve`: `RLIMIT_AS` /
+   `RLIMIT_DATA` from a memory ceiling (mirror `[php] memory_limit`),
+   `RLIMIT_CPU` and/or a wall-clock `--timeout` enforced by the parent (a
+   `SIGKILL` after N seconds — the same "enforce timeout above the interpreter"
+   posture ePHPm already takes on Windows where per-thread timers are absent).
+   Optionally place the child in a transient cgroup for a memory/pids cap; a
+   cgroup is *not required* for the core design.
+5. **Per-site DB + KV bind (PHP path only).** Register the same
+   `SiteBackendResolver` the server builds, `set_current_site(key)`, and set the
+   KV site store — see [The #471 relationship](#the-471-relationship).
+
+Layers 2–4 are pure Rust + libc/Landlock syscalls with **no PHP linkage**, so
+they are testable independently of the embedded runtime.
+
+### eBPF per-vhost policy: out of scope for `exec` (verified why)
+
+The shipped `[server.tenant_network] ebpf_policy` attaches `cgroup/bind4+6` and
+`cgroup/connect4+6` programs to ePHPm's **own cgroup**, and they act only on
+threads whose **TID** is present in the `tag` BPF hash map
+(`vhostnet.bpf.c`: `tag SEC(".maps")` is `BPF_MAP_TYPE_HASH` keyed on the
+namespace-resolved TID; `lookup_tag` returns null for untagged threads, which
+pass through). ePHPm writes a thread's tag on the per-request dispatch path
+(`TagGuard`), for threads it owns.
+
+An `ephpm exec` child is a **separate process** that `execve`s arbitrary code
+and spawns threads ePHPm never sees, so ePHPm cannot tag its TIDs — and even if
+the child inherits ePHPm's cgroup, untagged threads are un-governed by these
+programs. Making the eBPF policy cover an exec child would require a different
+mechanism (a cgroup-scoped default-deny keyed on cgroup membership, not TID),
+which is a redesign of `tenant_ebpf`, not a reuse of it. **The uid-keyed
+`ephpm_egress` nftables table already provides equivalent egress containment
+for the child, keyed on `skuid` rather than TID** — which is exactly why it,
+not eBPF, is the right tool here. So: eBPF per-vhost policy is **out of scope**
+for the exec child; the nftables uid rule is the containment.
+
+## The authorization model
+
+`ephpm exec --site X` is a **privileged operation by construction**: being able
+to name any site and receive its database, its filesystem, and its KV keyspace
+is precisely the boundary multi-tenancy protects. The design must not make it an
+*easier* cross-tenant path than the wire-auth + site-key invariant already
+guard. The proposal:
+
+- **Authorization is filesystem access to the ePHPm config, not a new auth
+  surface.** `ephpm exec` requires `--config <path>` (or the default
+  `/etc/ephpm/ephpm.toml`) and reads it. Deriving a site's DB path, its
+  `pdo_mysql`/KV credential (`HMAC-SHA256(master_secret, site_key)`), and its
+  document root all require the config and the per-process master secret in it.
+  Whoever can read that file can already impersonate any tenant to the running
+  server; `ephpm exec` grants nothing they didn't already have. So the gate is
+  the config file's own permissions (`640 root:ephpm-web` on the preview
+  nodes), and in practice the caller must be **root / an operator with sudo**.
+- **The launching process needs privilege; the command must not keep it.**
+  `ephpm exec` starts privileged (to bind the site, open the DB dir, set up
+  Landlock, and `setuid`), then drops to 997 and Landlock-scopes **away from
+  `/etc/ephpm`** before `execve`. So even though `ephpm-web` can *read* the
+  config in the normal filesystem, the exec'd command cannot — Landlock removes
+  the path from its view. This is what lets switchboard hand an untrusted
+  `build.sh` to `ephpm exec` without handing it the cluster secret.
+- **No network-reachable exec.** This is deliberately *not* an admin-API verb in
+  this design (see the server-running question). It is a local CLI gated by
+  local privilege. An admin API that exposes exec remotely would need its own
+  authn/authz story and is out of scope.
+
+The honest risk to name: `ephpm exec` is a legitimate cross-tenant tool for
+whoever holds config access. That is the same trust level as "can edit
+`ephpm.toml` and restart the server," so it does not lower the bar — but it does
+make cross-tenant access a *single command* rather than a config edit + restart,
+so it should log every invocation (site key, command, uid) at INFO, the way
+`privdrop` logs the drop.
+
+## Server running or not?
+
+A running `ephpm serve` is a **separate process**; a CLI `ephpm exec` cannot
+reach the daemon's in-memory backend registry, KV store, or cluster membership
+by sharing memory. So there are only two real shapes, and they differ by mode:
+
+- **Single-node per-site (`is_per_site_sqlite`) → open the DB file directly, in
+  the exec process.** `ephpm exec` builds its own `SiteBackends`-style resolver
+  against `[db.sqlite].dir/<key>.db` and binds the bridge. Honest caveat: if the
+  server is *also* running and serving that site, two processes now hold the
+  same Turso file. Turso/SQLite use file locking, and WAL permits concurrent
+  readers, but two concurrent **writers** across processes is the danger zone —
+  so the recommendation is: run schema-changing `exec` commands (migrations,
+  `wp core install`) against an idle site, or accept single-writer discipline.
+  This is the same concurrency story `ephpm php` already has; `exec` does not
+  make it worse, it just finally makes the DB reachable (#471).
+- **Per-site clustered (`is_per_site_clustered`) → refuse on a non-owner, or
+  require routing through the cluster.** Writes are owner-served over
+  `sql/<site>` (`sql_forward.rs`), and a write committed to a non-owner replica
+  is never captured into CDC — it diverges silently (the exact bug the wire
+  route was fixed for). An `ephpm exec` process that opened the site DB locally
+  on a non-owner would reintroduce that bug. The safe options are: (a) **refuse
+  unless this node is the site's HRW owner** (`sqlite_election.rs::hrw_owner`
+  over live membership), with a clear message telling the operator which node
+  owns it; or (b) forward statements to the owner over the cluster channel —
+  which requires a live cluster membership the CLI would have to *join*, a heavy
+  and racy thing for a one-shot process. **Recommendation for a first cut:
+  option (a), refuse on non-owner.** It is correct, cheap, and never writes
+  where writes don't replicate. Note `/_ephpm/primary` returns 200 on every
+  node in this mode, so "which node" must be answered by HRW ownership, not the
+  primary endpoint.
+
+So the chosen answer: **`ephpm exec` is a standalone process that opens
+resources directly (like `ephpm php` does), not an IPC call into the daemon.**
+It does not *require* the server to be running. In single-node mode it accepts
+the operator owns write concurrency; in per-site-clustered mode it refuses
+unless invoked on the site's current HRW owner.
+
+## Windows: the honest story
+
+Landlock, seccomp, nftables, `setuid`, and cgroups are all Linux mechanisms.
+ePHPm already documents Windows as lacking `crash_guard.c` and per-thread
+execution timers, and `privdrop::drop_privileges` is already a warn-only stub on
+non-Unix. Consistent with that: **the sandboxed form of `ephpm exec` is
+Linux-only.** On Windows, `ephpm exec` should either:
+
+- **refuse** with a clear "sandboxed exec is Linux-only" error (the safe
+  default — it never pretends to isolate when it can't), or
+- offer an explicit, loudly-labelled `--no-sandbox` mode that only performs the
+  site DB bind (the #471 mechanism, which *is* cross-platform — `db_bridge` and
+  the Turso engine both work on Windows) and runs the command with **no** uid
+  drop, no Landlock, no egress lock.
+
+The `--no-sandbox` DB-bind-only path is genuinely useful on Windows for local
+development (run `artisan migrate` against a per-site Turso file) and is honest
+as long as it never claims isolation it doesn't provide. The default on Windows
+should be refuse; `--no-sandbox` is opt-in.
+
+## The #471 relationship
+
+`ephpm exec --site` is the general form of the #471 fix. #471 is specifically
+"`ephpm php` can't reach a per-site database"; `exec` solves it by supplying the
+missing **site session** the CLI lacks:
+
+- The bridge is already compiled in and callable from `ephpm php` (issue #471
+  confirms `function_exists("ephpm_db_query")` is `true`), but a query returns
+  *"no embedded database is active"* because no request ever ran
+  `set_resolver` + `set_current_site`.
+- `ephpm exec` performs that bind before running the command: build the same
+  per-site resolver the server builds (`db_bridge::set_resolver` with a
+  `SiteBackendResolver` over `[db.sqlite].dir`), then `set_current_site(key)`.
+- **The `block_on` invariant holds for a CLI.** `db_bridge` drives async
+  `Session::query` via a pinned `tokio::runtime::Handle` and `block_on`, which
+  is legal *only* because the caller is a PHP execution OS thread, never an
+  async task (module docs, `Async boundary`). An `ephpm exec` process running
+  the embedded PHP on a normal (non-async-task) thread with a multi-thread
+  runtime handle satisfies exactly that invariant — the same reason `ephpm
+  serve`'s per-request pool threads may block. So the bind works outside the
+  HTTP request path with no new unsafe assumptions.
+- **Tenant screening is preserved.** `ATTACH`/`DETACH`/`VACUUM`/path-`PRAGMA`
+  are rejected on the tenant path in all modes (`db_bridge::screen_sql` and
+  litewire's session screen). `exec` must route through the *same* screened
+  session, not a raw backend, so a CLI can't become the way around the rejection
+  #471 explicitly warns about.
+
+A narrower fix for #471 alone would be `ephpm php --config <path> --site <key>`
+(no sandbox layers) — and that is a reasonable staged first deliverable. `exec`
+is the superset that adds the uid drop + filesystem scope + arbitrary (non-PHP)
+commands.
+
+## What still lives in switchboard
+
+If `ephpm exec --site` existed, switchboard would **stop** owning:
+
+- the ad-hoc, root, unsandboxed execution of `build:` / `seed:` steps — replaced
+  by `ephpm exec --site <key> -- bash build.sh`, which inherits the uid drop,
+  Landlock scope, egress lock, and (for PHP steps) the site DB bind.
+
+Switchboard would **still** own:
+
+- **Fetching the repo / manifest** and materialising it into the site's document
+  root before any build runs. `ephpm exec` runs a command in an *existing*
+  site's sandbox; it does not clone code.
+- **Writing the per-site override file** (`auto_prepend_file`, etc.) — a
+  privileged config action outside any single tenant's sandbox.
+- **Reaching `loopback:8080`** (the running server's admin/health surface) — the
+  switchboard daemon must run as a **non-997** uid precisely because the
+  `ephpm_egress` rule drops loopback for 997. Switchboard's own control-plane
+  traffic is exactly the "not ephpm-web, so unfiltered" case the firewall's
+  first rule allows.
+- **Orchestration**: deciding *when* to build, sequencing steps, reporting
+  status, retries. `ephpm exec` is one primitive it calls, not the orchestrator.
+
+The line: switchboard stays the privileged control plane (fetch, configure,
+sequence, talk to the daemon); `ephpm exec` becomes the sandboxed execution
+primitive it delegates the actual tenant-scoped work to.
+
+## PoC status — deliberately not written (judgment call)
+
+The brief allows an optional PoC proving *uid drop + Landlock filesystem scope +
+running a command* (no DB bind required). **This spike ships design only, no
+PoC**, for one honest reason: the entire sandbox path is `cfg(target_os =
+"linux")`, and this spike was produced on a Windows host where that code cannot
+be compiled, `clippy`-checked under the Linux `cfg`, or run. A PoC I cannot
+build or exercise here would be untested `cfg(linux)` unsafe FFI + a new
+`landlock` crate dependency added blind — that *removes* risk from the design on
+paper while *adding* the risk of shipping broken platform-gated code that CI's
+stub-mode legs (which don't set the Linux sandbox cfg meaningfully) wouldn't
+catch. That trade is backwards for a spike whose job is to de-risk.
+
+What the PoC *would* look like, kept cheap for whoever picks it up on Linux:
+
+- New `Commands::Exec { site, config, timeout, no_sandbox, command: Vec<String> }`
+  in `crates/ephpm/src/main.rs`, `--` capturing the trailing command (clap
+  `trailing_var_arg` + `allow_hyphen_values`, mirroring how `Php { args }`
+  already slurps PHP flags).
+- A `crates/ephpm/src/exec_sandbox.rs` (or a small `ephpm-sandbox` crate) with a
+  `#[cfg(target_os = "linux")]` impl and a `#[cfg(not)]` refuse-stub, matching
+  the `privdrop` shape exactly.
+- Reuse `privdrop`'s `resolve_user` + the `setgroups`/`setgid`/`setuid` sequence
+  verbatim (factor it out of `ephpm-server::privdrop` into a shared spot so both
+  the server drop and exec drop share one audited implementation).
+- Add `landlock = "0.4"` (pure Rust, ABI 1–4, MSRV-compatible) for the
+  filesystem ruleset; `libc` (already a dep) for `setrlimit`.
+- Prove it with a Linux integration test: `ephpm exec --site t -- cat
+  /etc/ephpm/ephpm.toml` is denied (Landlock), `id -u` prints `997` (drop), and
+  a command under the docroot succeeds — no PHP SDK needed for any of it.
+
+Estimated at more than "a couple hours" once clippy-pedantic + nightly-fmt +
+stub-mode-still-builds + a Linux CI leg to actually exercise it are included,
+and none of it is meaningfully verifiable from this host — so per the brief's
+own guidance ("if a PoC would be more than a couple hours … don't"), it is left
+as the first implementation step, not part of the spike.
+
+## Open questions for review
+
+- **Factor `privdrop` credential-drop into a shared module?** Both the server
+  drop and exec drop want the identical audited `setgroups`/`setgid`/`setuid` +
+  fail-closed verification. One copy, two callers.
+- **Landlock ABI floor.** Preview nodes are 6.12 (ABI 4+ available). What is the
+  minimum supported kernel — refuse below Landlock ABI 3, or fall back to a
+  mount namespace? Refusing is simpler and fail-closed.
+- **cgroup placement.** Is a transient per-exec cgroup (memory/pids cap) worth
+  it for a first cut, or are `setrlimit` + wall-clock timeout sufficient? This
+  spike says rlimits are sufficient to start.
+- **Staged delivery.** Ship `ephpm php --site`/DB-bind (solves #471, cross-
+  platform) first, then the Linux sandbox layers as `ephpm exec`? The #471 pain
+  is immediate and the DB bind is the cross-platform half.

--- a/site/content/roadmap/preview.md
+++ b/site/content/roadmap/preview.md
@@ -20,7 +20,10 @@
 >   [DNS-01 ACME lane](/guides/tls-acme/#dns-01-challenge-wildcards) issues the
 >   `*.preview.<domain>` wildcard in-process — no out-of-band certbot/lego step.
 > - **What is still design:** multi-PHP-version routing, stale-preview GC and
->   per-preview disk quotas, sandboxed (containerized) build steps, and
+>   per-preview disk quotas, sandboxed build steps
+>   ([`ephpm exec`](/roadmap/ephpm-exec-sandboxed-vhost/) — reuse ePHPm's
+>   per-vhost isolation instead of a container, since switchboard currently runs
+>   `build:`/`seed:` as root, unsandboxed), and
 >   scale-out past one VM. Cluster mode exists but is not live-validated.
 >
 > **How it works and how to install it now live in the


### PR DESCRIPTION
## What

A **design spike** (roadmap doc, no implementation) for a proposed
`ephpm exec --site <key> -- <command...>` subcommand: run an arbitrary command
inside a virtual host's full tenant sandbox.

Doc: `site/content/roadmap/ephpm-exec-sandboxed-vhost.md` (linked from the
roadmap index and cross-referenced from `preview.md`, where "sandboxed build
steps" was already listed as a remaining design item).

## Why

It unifies three needs that today each reinvent (or skip) tenant isolation:

1. **Switchboard's build sandbox** — `build:`/`seed:` steps run as **root,
   unsandboxed** (root RCE surface). `ephpm exec --site X -- bash build.sh`
   would inherit ePHPm's per-vhost isolation instead.
2. **Issue #471** — `ephpm php` / wp-cli / `artisan migrate` cannot reach a
   per-site database (no request → no site bind → no DB). `exec` is the general
   form of the fix.
3. **Operator cron / migrations / queue workers** in a tenant's sandbox.

## Verified findings (read-only against live nodes + source)

- The live `inet ephpm_egress` nftables chain keys on **`skuid`** (uid 997 =
  `ephpm-web`): dropping to that uid arms the existing egress firewall with
  **no new code**; root bypasses the whole table (that's the RCE blast radius).
- The uid-drop primitive already exists — `ephpm-server/src/privdrop.rs`
  (`setgroups`/`setgid`/`setuid`, fail-closed).
- The #471 DB bind works outside a request: `db_bridge`'s `block_on` invariant
  holds for a CLI PHP-execution thread; tenant screening
  (`ATTACH`/`VACUUM`/path-`PRAGMA`) is preserved via the same screened session.
- eBPF per-vhost policy (`tenant_ebpf.rs`, `bpf/vhostnet.bpf.c`) is **TID-keyed**
  and cannot cover an exec child → out of scope; the uid-keyed nftables rule is
  the containment.
- Loopback is dropped for uid 997, so non-PHP children can't reach the local
  wire DB over TCP — PHP CLIs sidestep this via the in-process bridge (stated
  as a deliberate, sharp edge, not hidden).

## Design decisions the doc settles

- **Authorization** = filesystem access to `ephpm.toml` (config + master
  secret) — no new auth surface; Landlock scopes the command *away from*
  `/etc/ephpm`, so an untrusted `build.sh` never sees the cluster secret.
- **Server running?** Standalone, direct-open in single-node per-site; **refuse
  on a non-owner** in per-site-clustered mode (never write where CDC won't
  capture).
- **Windows** = Linux-only for the sandboxed form (refuse), with an opt-in
  `--no-sandbox` DB-bind-only path for local dev.

## PoC

**None — deliberate.** The sandbox path is `cfg(target_os = "linux")` and this
spike was produced on a Windows host where it can't be compiled, clippy-checked
under the Linux cfg, or run. The doc includes a precise, cheap implementation
sketch (clap shape, reuse `privdrop`'s drop sequence, `landlock` crate, a Linux
integration test) so the PoC is the first implementation step, not lost.

Not for merge as-is if the team wants changes — it's a spike for review.
