### PR TITLE
feat(middleware): per-site GitHub OAuth preview gate; fix cross-tenant session replay (#396)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ephpm-middleware-github-auth"
+version = "0.1.0"
+dependencies = [
+ "base64ct",
+ "ephpm-middleware",
+ "getrandom 0.3.4",
+ "hmac 0.12.1",
+ "reqwest",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "serde_json",
+ "sha2 0.10.9",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "ephpm-middleware-jwt"
 version = "0.1.0"
 dependencies = [
@@ -1532,6 +1548,14 @@ dependencies = [
 
 [[package]]
 name = "ephpm-middleware-security-headers"
+version = "0.1.0"
+dependencies = [
+ "ephpm-middleware",
+ "ephpm-middleware-builtins",
+]
+
+[[package]]
+name = "ephpm-middleware-session-cookie"
 version = "0.1.0"
 dependencies = [
  "ephpm-middleware",

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -113,9 +113,9 @@ pub struct MiddlewareMount {
     ///    the rest of the value is a path to a `.php` file, relative to the
     ///    request's document root. See [`MiddlewareMount::php_script`].
     /// 2. Otherwise the value is checked against the builtin registry (`jwt`,
-    ///    `cors`, `ratelimit`/`rate-limit`, `security-headers` and their
-    ///    `ephpm-middleware-*` long forms are compiled into every binary — no
-    ///    dlopen).
+    ///    `cors`, `ratelimit`/`rate-limit`, `security-headers`,
+    ///    `session-cookie` and their `ephpm-middleware-*` long forms are
+    ///    compiled into every binary — no dlopen).
     /// 3. Anything else is a shared library: either a bare name (resolved
     ///    through the middleware search path with a platform suffix, e.g.
     ///    `auth-jwt` → `auth-jwt.linux-x86_64.so`) or an explicit path — a

--- a/crates/ephpm-middleware-builtins/src/hs256.rs
+++ b/crates/ephpm-middleware-builtins/src/hs256.rs
@@ -1,0 +1,330 @@
+//! Shared HS256 token verification, used by both token-validating builtins.
+//!
+//! [`jwt`](crate::jwt) (API bearer tokens, `401` on failure) and
+//! [`session_cookie`](crate::session_cookie) (browser session cookies, `302`
+//! to a login service on failure) are deliberately separate modules — two
+//! threat models, two failure behaviours, two config surfaces. What they must
+//! **not** have separately is the verification itself: one implementation,
+//! one set of tests, no chance of one growing a weakness the other fixed.
+//!
+//! The policy is strict by construction:
+//!
+//! * the signature is checked **first**, so no unauthenticated JSON is ever
+//!   parsed;
+//! * comparison is constant-time (`hmac::Mac::verify_slice`);
+//! * `alg` is pinned to `HS256` after verification, so `alg: none` is
+//!   rejected even when the HMAC happens to match;
+//! * `exp` is **required** — a token that cannot expire is a config bug;
+//! * `nbf` is honoured when present, `iss`/`aud` when configured;
+//! * the **per-tenant `site` binding** is enforced when the caller supplies
+//!   the request's canonical site key — see [`Hs256Policy::verify`] and issue
+//!   #396.
+
+use base64ct::{Base64UrlUnpadded, Encoding};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+/// An HS256 validation policy: the shared secret plus the optional
+/// registered-claim constraints. Built once at `init`.
+pub struct Hs256Policy {
+    secret: Vec<u8>,
+    issuer: Option<String>,
+    audience: Option<String>,
+}
+
+impl Hs256Policy {
+    /// Build a policy from an already-validated secret and claim constraints.
+    #[must_use]
+    pub fn new(secret: Vec<u8>, issuer: Option<String>, audience: Option<String>) -> Self {
+        Self { secret, issuer, audience }
+    }
+
+    /// Read `secret`/`issuer`/`audience` out of a mount's `config` table.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message when `secret` is missing, empty or
+    /// not a string, or when `issuer`/`audience` are present but not strings.
+    pub fn from_config(config: &serde_json::Value) -> Result<Self, String> {
+        let secret = config
+            .get("secret")
+            .ok_or("`secret` is required (HS256 shared secret)")?
+            .as_str()
+            .ok_or("`secret` must be a string")?;
+        if secret.is_empty() {
+            return Err("`secret` must not be empty".into());
+        }
+        Ok(Self::new(
+            secret.as_bytes().to_vec(),
+            opt_str(config, "issuer")?,
+            opt_str(config, "audience")?,
+        ))
+    }
+
+    /// Verify `token` against this policy at time `now` (unix seconds).
+    /// Returns the raw claims JSON on success, `None` on any failure.
+    ///
+    /// `expected_site` is the request's **canonical site key** (what
+    /// `Router::resolve_site` produced, surfaced to a module as
+    /// [`ephpm_middleware::Request::vhost_id`]). When it is `Some`, the token's
+    /// `site` claim must be a string equal to it, or verification fails — a
+    /// token with **no** `site` claim, or one bound to a **different** site,
+    /// fails closed. This is the fix for issue #396: the `github-auth` issuer
+    /// binds each session to one preview via the `site` claim, and this is the
+    /// check that honours that binding, so a session minted for preview A does
+    /// not verify on preview B. Pass `None` to skip the check — the `jwt` API
+    /// gate has no tenancy semantics and always does.
+    ///
+    /// Every rejection collapses to `None` on purpose: the caller turns that
+    /// into one indistinguishable outcome, so a client cannot learn *why* a
+    /// token was refused (bad signature vs expired vs wrong site).
+    #[must_use]
+    pub fn verify(&self, token: &str, now: u64, expected_site: Option<&str>) -> Option<String> {
+        let mut parts = token.split('.');
+        let (header_b64, payload_b64, sig_b64) = (parts.next()?, parts.next()?, parts.next()?);
+        if parts.next().is_some() {
+            return None;
+        }
+
+        // Signature first — never parse unauthenticated JSON.
+        let sig = Base64UrlUnpadded::decode_vec(sig_b64).ok()?;
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.secret).ok()?;
+        mac.update(header_b64.as_bytes());
+        mac.update(b".");
+        mac.update(payload_b64.as_bytes());
+        // Constant-time comparison via the hmac crate.
+        mac.verify_slice(&sig).ok()?;
+
+        // The signature is ours, but still pin the algorithm: HS256 only.
+        let header: serde_json::Value =
+            serde_json::from_slice(&Base64UrlUnpadded::decode_vec(header_b64).ok()?).ok()?;
+        if header.get("alg").and_then(serde_json::Value::as_str) != Some("HS256") {
+            return None;
+        }
+
+        let payload = Base64UrlUnpadded::decode_vec(payload_b64).ok()?;
+        let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+
+        // `exp` is required — a token that cannot expire is a config bug.
+        // RFC 7519 NumericDate allows non-integer values, so accept a JSON
+        // float (floored) as well as an integer rather than rejecting a valid
+        // token.
+        let exp = claims.get("exp").and_then(numeric_date)?;
+        if exp <= now {
+            return None;
+        }
+        if let Some(nbf) = claims.get("nbf")
+            && numeric_date(nbf)? > now
+        {
+            return None;
+        }
+        if let Some(expected) = &self.issuer
+            && claims.get("iss").and_then(serde_json::Value::as_str) != Some(expected.as_str())
+        {
+            return None;
+        }
+        if let Some(expected) = &self.audience {
+            let ok = match claims.get("aud") {
+                Some(serde_json::Value::String(aud)) => aud == expected,
+                Some(serde_json::Value::Array(auds)) => {
+                    auds.iter().any(|a| a.as_str() == Some(expected.as_str()))
+                }
+                _ => false,
+            };
+            if !ok {
+                return None;
+            }
+        }
+
+        // Per-tenant binding (issue #396). When the caller keys this request to
+        // a site, the token must be bound to the *same* site. Absent, non-string
+        // or mismatched `site` all collapse to "not this tenant" and fail closed.
+        if let Some(site) = expected_site
+            && claims.get("site").and_then(serde_json::Value::as_str) != Some(site)
+        {
+            return None;
+        }
+
+        String::from_utf8(payload).ok()
+    }
+}
+
+/// Read an optional non-empty string key from a mount's `config` table.
+///
+/// An absent key, JSON `null`, and the empty string all mean "unset" — the
+/// same shape every builtin's optional string knobs use.
+///
+/// # Errors
+///
+/// Returns a message when the key is present but not a string.
+pub fn opt_str(config: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
+    match config.get(key) {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
+        None | Some(serde_json::Value::Null | serde_json::Value::String(_)) => Ok(None),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+/// Read an optional boolean key, falling back to `default` when absent.
+///
+/// # Errors
+///
+/// Returns a message when the key is present but not a boolean. A security
+/// knob is never allowed to be silently mistyped into its permissive state.
+pub fn opt_bool(config: &serde_json::Value, key: &str, default: bool) -> Result<bool, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("`{key}` must be a boolean, got {other}")),
+    }
+}
+
+/// Current unix time in whole seconds (0 if the clock predates the epoch).
+#[must_use]
+pub fn now_unix() -> u64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_secs())
+}
+
+/// Parse an RFC 7519 NumericDate claim (`exp`/`nbf`) as seconds since the
+/// epoch. Accepts a JSON integer or a JSON float (floored to whole seconds,
+/// negatives rejected); returns `None` for any other JSON type. This keeps
+/// enforcement identical while tolerating the non-integer NumericDates the
+/// spec permits.
+fn numeric_date(v: &serde_json::Value) -> Option<u64> {
+    if let Some(u) = v.as_u64() {
+        return Some(u);
+    }
+    let f = v.as_f64()?;
+    // floor() keeps the "not valid until this whole second" semantics; only
+    // finite, non-negative values within u64 range map to a NumericDate.
+    if f.is_finite() && (0.0..18_446_744_073_709_551_616.0).contains(&f) {
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "bounds checked: finite, in [0, u64::MAX), floored"
+        )]
+        Some(f.floor() as u64)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "test-secret-please-rotate";
+
+    /// Forge a token through the same HMAC code path the module verifies
+    /// with (independent of `Hs256Policy::verify`'s parsing).
+    pub(crate) fn sign(secret: &str, header_json: &str, claims_json: &str) -> String {
+        let h = Base64UrlUnpadded::encode_string(header_json.as_bytes());
+        let p = Base64UrlUnpadded::encode_string(claims_json.as_bytes());
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("hmac key");
+        mac.update(format!("{h}.{p}").as_bytes());
+        let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+        format!("{h}.{p}.{sig}")
+    }
+
+    fn policy() -> Hs256Policy {
+        Hs256Policy::from_config(&serde_json::json!({ "secret": SECRET })).expect("init")
+    }
+
+    fn token(claims: &str) -> String {
+        sign(SECRET, r#"{"alg":"HS256","typ":"JWT"}"#, claims)
+    }
+
+    #[test]
+    fn from_config_rejects_a_missing_or_unusable_secret() {
+        assert!(Hs256Policy::from_config(&serde_json::Value::Null).is_err());
+        assert!(Hs256Policy::from_config(&serde_json::json!({ "secret": "" })).is_err());
+        assert!(Hs256Policy::from_config(&serde_json::json!({ "secret": 42 })).is_err());
+    }
+
+    #[test]
+    fn valid_token_returns_its_claims_json() {
+        let claims = r#"{"sub":"u1","exp":2000}"#;
+        assert_eq!(policy().verify(&token(claims), 1000, None).as_deref(), Some(claims));
+    }
+
+    #[test]
+    fn tampering_with_any_segment_is_rejected() {
+        let good = token(r#"{"sub":"u1","exp":2000}"#);
+        let mut parts = good.split('.');
+        let (h, p, s) =
+            (parts.next().expect("h"), parts.next().expect("p"), parts.next().expect("s"));
+        // Swapped payload with a signature that no longer covers it.
+        let forged_payload = Base64UrlUnpadded::encode_string(br#"{"sub":"root","exp":2000}"#);
+        assert!(policy().verify(&format!("{h}.{forged_payload}.{s}"), 1000, None).is_none());
+        // Flipped last signature character.
+        let flipped = if s.ends_with('A') { "B" } else { "A" };
+        let tampered_sig = format!("{}{flipped}", &s[..s.len() - 1]);
+        assert!(policy().verify(&format!("{h}.{p}.{tampered_sig}"), 1000, None).is_none());
+        // Truncated signature.
+        assert!(policy().verify(&format!("{h}.{p}."), 1000, None).is_none());
+    }
+
+    #[test]
+    fn exp_is_mandatory_and_enforced() {
+        assert!(policy().verify(&token(r#"{"sub":"u1"}"#), 1000, None).is_none());
+        assert!(
+            policy().verify(&token(r#"{"exp":1000}"#), 1000, None).is_none(),
+            "exp == now expires"
+        );
+        assert!(policy().verify(&token(r#"{"exp":1001}"#), 1000, None).is_some());
+    }
+
+    #[test]
+    fn alg_none_is_rejected_even_with_a_valid_hmac() {
+        let t = sign(SECRET, r#"{"alg":"none"}"#, r#"{"exp":2000}"#);
+        assert!(policy().verify(&t, 1000, None).is_none());
+    }
+
+    #[test]
+    fn wrong_secret_is_rejected() {
+        let t = sign("other-secret", r#"{"alg":"HS256"}"#, r#"{"exp":2000}"#);
+        assert!(policy().verify(&t, 1000, None).is_none());
+    }
+
+    /// Issue #396, at the crypto core: a session bound to one site must not
+    /// verify on another. The `None` calls reproduce the **pre-fix** verifier
+    /// (which took no site argument and ignored the claim) — and they still
+    /// accept the token, which is exactly the cross-tenant bypass. The site-
+    /// aware calls are the fix: accepted only on its own site, and a token
+    /// with no `site` claim fails closed under enforcement.
+    #[test]
+    fn a_site_bound_token_verifies_only_on_its_own_site() {
+        let claims = r#"{"sub":"u1","site":"alpha","exp":2000}"#;
+        let t = token(claims);
+
+        // Pre-fix behaviour (no site enforcement): accepted regardless. This
+        // is what shipped before #396 and why the bug was invisible.
+        assert!(policy().verify(&t, 1000, None).is_some());
+
+        // The fix: accepted on its own site, rejected on any other.
+        assert_eq!(policy().verify(&t, 1000, Some("alpha")).as_deref(), Some(claims));
+        assert!(
+            policy().verify(&t, 1000, Some("beta")).is_none(),
+            "a session for `alpha` must not verify on `beta`"
+        );
+
+        // A token with NO site claim fails closed once a site is required...
+        let no_site = token(r#"{"sub":"u1","exp":2000}"#);
+        assert!(policy().verify(&no_site, 1000, Some("alpha")).is_none());
+        // ...but is fine when the caller does not require one (the `jwt` lane).
+        assert!(policy().verify(&no_site, 1000, None).is_some());
+
+        // A non-string `site` claim is not a tenant match either.
+        let bad_site = token(r#"{"sub":"u1","site":42,"exp":2000}"#);
+        assert!(policy().verify(&bad_site, 1000, Some("alpha")).is_none());
+    }
+
+    #[test]
+    fn opt_bool_rejects_a_mistyped_security_knob() {
+        assert_eq!(opt_bool(&serde_json::json!({}), "k", true), Ok(true));
+        assert_eq!(opt_bool(&serde_json::json!({ "k": false }), "k", true), Ok(false));
+        // "false" as a STRING must not be read as `true` (nor silently as
+        // false): a mistyped security knob has to fail startup.
+        assert!(opt_bool(&serde_json::json!({ "k": "false" }), "k", true).is_err());
+    }
+}

--- a/crates/ephpm-middleware-builtins/src/jwt.rs
+++ b/crates/ephpm-middleware-builtins/src/jwt.rs
@@ -7,10 +7,12 @@
 //! claims JSON in a request header (`claims_header`) so PHP can read them
 //! without re-verifying.
 //!
-//! Verification: constant-time HMAC check (`hmac::Mac::verify_slice`), the
-//! token's `alg` must be `HS256`, `exp` is **required** and must be in the
-//! future, `nbf` is honoured when present, and `iss`/`aud` are enforced when
-//! configured.
+//! Verification lives in the shared [`crate::hs256`] core (constant-time HMAC,
+//! `alg` pinned to HS256, `exp` mandatory, `nbf`/`iss`/`aud` enforced), so
+//! this API gate and the [`session_cookie`](crate::session_cookie) browser
+//! gate can never diverge in crypto. `jwt` is an API gate with no tenancy, so
+//! it passes `None` as the expected site — the per-tenant `site` binding (issue
+//! #396) is a session-cookie concern.
 //!
 //! Configuration (`[[middleware]] config = { ... }`):
 //!
@@ -22,18 +24,14 @@
 //! | `header` (string) | `"Authorization"` | request header carrying the token; a `Bearer ` prefix is stripped |
 //! | `claims_header` (string) | unset | when set, REWRITE with this request header = the raw claims JSON |
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use base64ct::{Base64UrlUnpadded, Encoding};
 use ephpm_middleware::{Middleware, Request, Response};
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
+
+use crate::hs256::{Hs256Policy, now_unix, opt_str};
 
 /// JWT validation policy, built once at `init`.
 pub struct Jwt {
-    secret: Vec<u8>,
-    issuer: Option<String>,
-    audience: Option<String>,
+    /// Signature + registered-claim policy, shared with `session_cookie`.
+    policy: Hs256Policy,
     header: String,
     claims_header: Option<String>,
 }
@@ -51,120 +49,15 @@ fn strip_bearer(value: &str) -> &str {
     trimmed
 }
 
-impl Jwt {
-    /// Verify `token` against this policy at time `now` (unix seconds).
-    /// Returns the raw claims JSON on success, `None` on any failure.
-    fn verify(&self, token: &str, now: u64) -> Option<String> {
-        let mut parts = token.split('.');
-        let (header_b64, payload_b64, sig_b64) = (parts.next()?, parts.next()?, parts.next()?);
-        if parts.next().is_some() {
-            return None;
-        }
-
-        // Signature first — never parse unauthenticated JSON.
-        let sig = Base64UrlUnpadded::decode_vec(sig_b64).ok()?;
-        let mut mac = Hmac::<Sha256>::new_from_slice(&self.secret).ok()?;
-        mac.update(header_b64.as_bytes());
-        mac.update(b".");
-        mac.update(payload_b64.as_bytes());
-        // Constant-time comparison via the hmac crate.
-        mac.verify_slice(&sig).ok()?;
-
-        // The signature is ours, but still pin the algorithm: HS256 only.
-        let header: serde_json::Value =
-            serde_json::from_slice(&Base64UrlUnpadded::decode_vec(header_b64).ok()?).ok()?;
-        if header.get("alg").and_then(serde_json::Value::as_str) != Some("HS256") {
-            return None;
-        }
-
-        let payload = Base64UrlUnpadded::decode_vec(payload_b64).ok()?;
-        let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
-
-        // `exp` is required — a token that cannot expire is a config bug.
-        // RFC 7519 NumericDate allows non-integer values, so accept a JSON
-        // float (floored) as well as an integer rather than 401-ing a valid
-        // token.
-        let exp = claims.get("exp").and_then(numeric_date)?;
-        if exp <= now {
-            return None;
-        }
-        if let Some(nbf) = claims.get("nbf")
-            && numeric_date(nbf)? > now
-        {
-            return None;
-        }
-        if let Some(expected) = &self.issuer
-            && claims.get("iss").and_then(serde_json::Value::as_str) != Some(expected.as_str())
-        {
-            return None;
-        }
-        if let Some(expected) = &self.audience {
-            let ok = match claims.get("aud") {
-                Some(serde_json::Value::String(aud)) => aud == expected,
-                Some(serde_json::Value::Array(auds)) => {
-                    auds.iter().any(|a| a.as_str() == Some(expected.as_str()))
-                }
-                _ => false,
-            };
-            if !ok {
-                return None;
-            }
-        }
-
-        String::from_utf8(payload).ok()
-    }
-}
-
-/// Parse an RFC 7519 NumericDate claim (`exp`/`nbf`) as seconds since the
-/// epoch. Accepts a JSON integer or a JSON float (floored to whole seconds,
-/// negatives rejected); returns `None` for any other JSON type. This keeps
-/// enforcement identical while tolerating the non-integer NumericDates the
-/// spec permits.
-fn numeric_date(v: &serde_json::Value) -> Option<u64> {
-    if let Some(u) = v.as_u64() {
-        return Some(u);
-    }
-    let f = v.as_f64()?;
-    // floor() keeps the "not valid until this whole second" semantics; only
-    // finite, non-negative values within u64 range map to a NumericDate.
-    if f.is_finite() && (0.0..18_446_744_073_709_551_616.0).contains(&f) {
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "bounds checked: finite, in [0, u64::MAX), floored"
-        )]
-        Some(f.floor() as u64)
-    } else {
-        None
-    }
-}
-
 impl Middleware for Jwt {
     const CONFIG_KEYS: Option<&'static [&'static str]> =
         Some(&["secret", "issuer", "audience", "header", "claims_header"]);
 
     fn init(config: &serde_json::Value) -> Result<Self, String> {
-        let secret = config
-            .get("secret")
-            .ok_or("`secret` is required (HS256 shared secret)")?
-            .as_str()
-            .ok_or("`secret` must be a string")?;
-        if secret.is_empty() {
-            return Err("`secret` must not be empty".into());
-        }
-        let opt_str = |key: &str| -> Result<Option<String>, String> {
-            match config.get(key) {
-                Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(Some(s.clone())),
-                None | Some(serde_json::Value::Null | serde_json::Value::String(_)) => Ok(None),
-                Some(other) => Err(format!("`{key}` must be a string, got {other}")),
-            }
-        };
         Ok(Self {
-            secret: secret.as_bytes().to_vec(),
-            issuer: opt_str("issuer")?,
-            audience: opt_str("audience")?,
-            header: opt_str("header")?.unwrap_or_else(|| "Authorization".to_owned()),
-            claims_header: opt_str("claims_header")?,
+            policy: Hs256Policy::from_config(config)?,
+            header: opt_str(config, "header")?.unwrap_or_else(|| "Authorization".to_owned()),
+            claims_header: opt_str(config, "claims_header")?,
         })
     }
 
@@ -176,8 +69,8 @@ impl Middleware for Jwt {
         if token.is_empty() {
             return Response::respond(401, "missing bearer token");
         }
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
-        match self.verify(token, now) {
+        // An API gate is not tenant-scoped, so no `site` binding is enforced.
+        match self.policy.verify(token, now_unix(), None) {
             Some(claims_json) => match &self.claims_header {
                 Some(name) => Response::rewrite().header(name.as_str(), claims_json),
                 None => Response::cont(),
@@ -191,15 +84,18 @@ impl Middleware for Jwt {
 mod tests {
     #![allow(unsafe_code)] // tests build the FFI Request view by hand.
 
+    use base64ct::{Base64UrlUnpadded, Encoding};
     use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND, ACTION_REWRITE};
     use ephpm_middleware::host::{RequestCtx, host_table};
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
 
     use super::*;
 
     const SECRET: &str = "test-secret-please-rotate";
 
     /// Forge a token through the same HMAC code path the module verifies
-    /// with (independent of `Jwt::verify`'s parsing).
+    /// with (independent of the verifier's parsing).
     fn sign(secret: &str, header_json: &str, claims_json: &str) -> String {
         let h = Base64UrlUnpadded::encode_string(header_json.as_bytes());
         let p = Base64UrlUnpadded::encode_string(claims_json.as_bytes());
@@ -214,7 +110,7 @@ mod tests {
     }
 
     fn future_exp() -> u64 {
-        SystemTime::now().duration_since(UNIX_EPOCH).expect("clock").as_secs() + 3600
+        now_unix() + 3600
     }
 
     fn jwt(config: serde_json::Value) -> Jwt {
@@ -222,7 +118,7 @@ mod tests {
     }
 
     fn invoke(mw: &Jwt, headers: &[(String, String)]) -> Response {
-        let ctx = RequestCtx::new("GET", "/api/x", "", "203.0.113.9", "example.test", headers);
+        let ctx = RequestCtx::new("GET", "/api/x", "", "203.0.113.9", "example", headers);
         // SAFETY: `ctx` outlives the view; host_table() is 'static.
         let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
         mw.invoke(&req)

--- a/crates/ephpm-middleware-builtins/src/lib.rs
+++ b/crates/ephpm-middleware-builtins/src/lib.rs
@@ -1,4 +1,4 @@
-//! The ten in-tree official ePHPm middleware modules as plain Rust library
+//! The in-tree official ePHPm middleware modules as plain Rust library
 //! code.
 //!
 //! Each module here is an ordinary [`ephpm_middleware::Middleware`]
@@ -9,13 +9,20 @@
 //!
 //! The modules, by phase:
 //!
-//! - **Request phase** ([`ephpm_middleware::Middleware`]): [`jwt`], [`cors`],
-//!   [`ratelimit`], [`security_headers`], [`api_key`], [`ip_allowlist`],
-//!   [`maintenance_mode`], [`redirect`].
+//! - **Request phase** ([`ephpm_middleware::Middleware`]): [`jwt`],
+//!   [`session_cookie`], [`cors`], [`ratelimit`], [`security_headers`],
+//!   [`api_key`], [`ip_allowlist`], [`maintenance_mode`], [`redirect`].
 //! - **Request + response phase** (also
 //!   [`ephpm_middleware::ResponseMiddleware`], registered in the server via
 //!   [`ephpm_middleware::builtin::BuiltinModule::init_response`]):
 //!   [`request_id`], [`header_transform`].
+//!
+//! [`hs256`] is not a middleware: it is the token-verification core that
+//! [`jwt`] (API bearer tokens) and [`session_cookie`] (browser sessions) both
+//! call, so the two gates can differ in policy and failure behaviour without
+//! ever differing in crypto. [`session_cookie`] additionally enforces a
+//! per-tenant `site` binding (issue #396) so a session minted for one preview
+//! cannot open another.
 //!
 //! The sibling `ephpm-middleware-<name>` crates in the `ephpm/middleware`
 //! (examples) repository are thin cdylib shells: they re-export these types
@@ -39,6 +46,7 @@
 pub mod api_key;
 pub mod cors;
 pub mod header_transform;
+pub mod hs256;
 pub mod ip_allowlist;
 pub mod jwt;
 pub mod maintenance_mode;
@@ -46,6 +54,7 @@ pub mod ratelimit;
 pub mod redirect;
 pub mod request_id;
 pub mod security_headers;
+pub mod session_cookie;
 
 #[cfg(test)]
 mod config_strictness_tests {
@@ -93,6 +102,10 @@ mod config_strictness_tests {
         strict::<crate::security_headers::SecurityHeaders>(
             &json!({ "hsts": true }),
             "referer_policy",
+        );
+        strict::<crate::session_cookie::SessionCookie>(
+            &json!({ "secret": "s3cret", "login_url": "https://login.example/start" }),
+            "require_sites",
         );
     }
 

--- a/crates/ephpm-middleware-builtins/src/session_cookie.rs
+++ b/crates/ephpm-middleware-builtins/src/session_cookie.rs
@@ -1,0 +1,985 @@
+//! `session-cookie` — ePHPm native middleware gating a whole site on a
+//! signed session cookie minted by an external identity service, redirecting
+//! unauthenticated browsers to that service's login URL.
+//!
+//! The split this exists for: an external service ("the login service") runs
+//! whatever identity dance it likes — OAuth, SSO, SAML, a magic link — and,
+//! once it is satisfied, mints an HS256 token and sets it as a cookie on the
+//! application's domain. ePHPm then does the *only* part that has to happen
+//! on every request: verify the signature, the expiry, and the per-tenant
+//! binding, locally, and send the browser to the login URL when that fails.
+//!
+//! **ePHPm never talks to the identity provider.** Verification is a single
+//! HMAC over bytes already in the request: no network call, no rate limits,
+//! no OAuth client secret on the serving nodes. The nodes hold one shared
+//! HMAC secret, and a compromise of a node yields the ability to mint
+//! sessions for that one deployment — not access to the identity provider.
+//!
+//! Relationship to [`crate::jwt`]: identical verification (both call
+//! [`crate::hs256`]) and deliberately *nothing* else. `jwt` is an API gate —
+//! token in a header, `401` on failure, a machine reads the status code.
+//! This is a browser gate — token in a cookie, redirect on failure, a human
+//! reads the login page.
+//!
+//! ## Per-tenant binding (issue #396)
+//!
+//! On a multi-tenant preview host every preview resolves to its own
+//! **canonical site key** ([`Request::vhost_id`]), and the issuer binds each
+//! session to one site via a `site` claim. By default (`require_site = true`)
+//! this gate requires the token's `site` claim to equal the request's site
+//! key, so a session minted for preview A does **not** open preview B. A token
+//! with no `site` claim, or one bound to another site, fails closed. This is
+//! the fix for #396: without it a session legitimately issued for one preview
+//! was a valid session for every preview on the node. Set `require_site =
+//! false` only on a genuinely single-tenant deployment whose login service
+//! mints site-less tokens — an explicit, documented opt-out, never inferred.
+//!
+//! Configuration (`[[middleware]] config = { ... }`):
+//!
+//! | key | default | meaning |
+//! |-----|---------|---------|
+//! | `secret` (string) | **required** | HS256 shared secret, same key the login service signs with |
+//! | `login_url` (string) | **required** | absolute `https://`/`http://` URL, or a same-origin absolute path, to redirect unauthenticated browsers to |
+//! | `cookie` (string) | `"ephpm_session"` | name of the cookie carrying the token |
+//! | `return_to_param` (string) | unset (no return-to is sent) | query parameter on `login_url` carrying the validated, same-origin return path |
+//! | `site_param` (string) | unset | query parameter carrying this request's canonical site key, so one login service can serve many sites |
+//! | `issuer` (string) | unset | required `iss` claim value |
+//! | `audience` (string) | unset | required `aud` claim value (string or array member) |
+//! | `claims_header` (string) | unset | when set, REWRITE with this request header = the verified claims JSON |
+//! | `require_https` (bool) | `true` | refuse to accept a session cookie on a cleartext request (loopback clients exempt) |
+//! | `require_site` (bool) | `true` | require the token's `site` claim to equal the request's canonical site key (issue #396) |
+
+use std::net::IpAddr;
+
+use ephpm_middleware::{Middleware, Request, Response};
+
+use crate::hs256::{Hs256Policy, now_unix, opt_bool, opt_str};
+
+/// Default cookie name when the mount does not set one.
+const DEFAULT_COOKIE: &str = "ephpm_session";
+
+/// Longest return-to target (path + query) we are willing to hand to the
+/// login service. Anything longer is dropped — the user still reaches the
+/// login page, just without a return-to. Well under the ~8 KB request-line
+/// limit typical proxies enforce, so the redirect can never build a URL the
+/// next hop refuses.
+const MAX_RETURN_TO: usize = 2048;
+
+/// Session-cookie gate policy, built once at `init`.
+pub struct SessionCookie {
+    /// Signature + registered-claim policy, shared with `jwt`.
+    policy: Hs256Policy,
+    cookie: String,
+    login_url: String,
+    return_to_param: Option<String>,
+    site_param: Option<String>,
+    claims_header: Option<String>,
+    require_https: bool,
+    require_site: bool,
+}
+
+impl SessionCookie {
+    /// Build the `Location` for an unauthenticated request.
+    ///
+    /// `return_to` is already sanitized by [`same_origin_return_to`]; both it
+    /// and the site key are percent-encoded into the query, so nothing the
+    /// client controls can add a parameter, a fragment, or a second URL. The
+    /// site key is the router's already-canonical value (or `None` for an
+    /// unmatched host), so no local normalization is needed.
+    fn login_location(&self, return_to: Option<&str>, site: Option<&str>) -> String {
+        let mut url = self.login_url.clone();
+        // A login_url may already carry query parameters of its own.
+        let mut sep = if url.contains('?') { '&' } else { '?' };
+        if let (Some(param), Some(target)) = (self.return_to_param.as_deref(), return_to) {
+            url.push(sep);
+            url.push_str(&percent_encode(param));
+            url.push('=');
+            url.push_str(&percent_encode(target));
+            sep = '&';
+        }
+        if let (Some(param), Some(site)) = (self.site_param.as_deref(), site)
+            && !site.is_empty()
+        {
+            url.push(sep);
+            url.push_str(&percent_encode(param));
+            url.push('=');
+            url.push_str(&percent_encode(site));
+        }
+        url
+    }
+
+    /// The redirect verdict for an unauthenticated request.
+    ///
+    /// `302` for GET/HEAD, `303` for everything else: after an unauthenticated
+    /// POST, `303` is what tells the browser to *GET* the login page rather
+    /// than re-submit the form body to the identity service.
+    ///
+    /// `Cache-Control: no-store` keeps a shared cache from serving one user's
+    /// redirect to another, and `Vary: Cookie` keeps any cache from treating
+    /// the authenticated and unauthenticated responses for a URL as the same
+    /// entry.
+    fn redirect(&self, req: &Request<'_>) -> Response {
+        let status = if matches!(req.method(), "GET" | "HEAD") { 302 } else { 303 };
+        let return_to = same_origin_return_to(req.path(), req.query());
+        Response::respond(status, "redirecting to login")
+            .header("Location", self.login_location(return_to.as_deref(), req.vhost_id()))
+            .header("Cache-Control", "no-store")
+            .header("Vary", "Cookie")
+    }
+}
+
+impl Middleware for SessionCookie {
+    const CONFIG_KEYS: Option<&'static [&'static str]> = Some(&[
+        "secret",
+        "login_url",
+        "cookie",
+        "return_to_param",
+        "site_param",
+        "issuer",
+        "audience",
+        "claims_header",
+        "require_https",
+        "require_site",
+    ]);
+
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let login_url = opt_str(config, "login_url")?
+            .ok_or("`login_url` is required (where to send unauthenticated browsers)")?;
+        // Constrain the redirect target we will emit. A `javascript:` or
+        // `data:` login_url would turn this module into an XSS primitive on
+        // every unauthenticated request, so only real HTTP origins and
+        // same-origin absolute paths are accepted. `//host` is rejected for
+        // the same reason it is rejected in a return-to: it is a
+        // protocol-relative URL, not a path.
+        let absolute = login_url.starts_with("https://") || login_url.starts_with("http://");
+        let same_origin_path = login_url.starts_with('/') && !login_url.starts_with("//");
+        if !absolute && !same_origin_path {
+            return Err(format!(
+                "`login_url` must be an https:// or http:// URL, or a same-origin absolute path \
+                 starting with `/` — got {login_url:?}"
+            ));
+        }
+        Ok(Self {
+            policy: Hs256Policy::from_config(config)?,
+            cookie: opt_str(config, "cookie")?.unwrap_or_else(|| DEFAULT_COOKIE.to_owned()),
+            login_url,
+            return_to_param: opt_str(config, "return_to_param")?,
+            site_param: opt_str(config, "site_param")?,
+            claims_header: opt_str(config, "claims_header")?,
+            require_https: opt_bool(config, "require_https", true)?,
+            require_site: opt_bool(config, "require_site", true)?,
+        })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        // Transport check first: a session cookie presented over cleartext is
+        // one an on-path observer has already read, so it is not evidence of
+        // anything. Loopback is exempt because the web platform itself treats
+        // `http://127.0.0.1` as a secure context — that is what makes local
+        // development possible without an opt-out that then ships to prod.
+        //
+        // This is a hard stop, not a redirect: bouncing to an HTTPS login
+        // service that sets a cookie the browser then returns over HTTP would
+        // loop forever, and a loop is a worse diagnostic than a message.
+        if self.require_https && !req.is_secure() && !is_loopback(req.remote_ip()) {
+            return Response::respond(
+                403,
+                "session cookie authentication requires HTTPS (see `require_https`)",
+            )
+            .header("Cache-Control", "no-store");
+        }
+
+        // Resolve the per-tenant binding this request's cookie must satisfy
+        // (issue #396). When `require_site` is on, a session is only valid for
+        // the canonical site key the router resolved for this request.
+        let expected_site = if self.require_site {
+            let Some(site) = req.vhost_id() else {
+                // `require_site` is on but the request matched no known virtual
+                // host, so there is no tenant to bind a session to. We cannot
+                // prove which preview a cookie was minted for, so we accept
+                // none. A hard 403, not a redirect: on a matched preview this
+                // branch never runs, and looping an unmatched host through the
+                // login service is a worse diagnostic than a clear message.
+                return Response::respond(
+                    403,
+                    "this session gate requires a resolved site (see `require_site`)",
+                )
+                .header("Cache-Control", "no-store");
+            };
+            Some(site)
+        } else {
+            None
+        };
+
+        let Some(raw) = req.header("Cookie") else {
+            return self.redirect(req);
+        };
+
+        // Try EVERY cookie of this name, not just the first. A cookie set on
+        // a parent domain shadows one set on this host, so accepting only the
+        // first match would let anyone who can write a cookie on the parent
+        // domain lock every user out of the site. Each candidate still has to
+        // pass the same HMAC, expiry and site check, so trying them all costs
+        // an HMAC and grants nothing.
+        let now = now_unix();
+        let verified = cookie_values(raw, &self.cookie)
+            .find_map(|token| self.policy.verify(token, now, expected_site));
+
+        match verified {
+            Some(claims_json) => match &self.claims_header {
+                Some(name) => Response::rewrite().header(name.as_str(), claims_json),
+                None => Response::cont(),
+            },
+            None => self.redirect(req),
+        }
+    }
+
+    fn describe() -> &'static str {
+        "session-cookie/1.0"
+    }
+}
+
+/// Iterate the values of every cookie named `name` in a `Cookie` header.
+///
+/// RFC 6265 §4.2.1: the header is `name=value` pairs separated by `;`, with
+/// optional surrounding whitespace. Two details a naive `split('=')` or a
+/// `contains("name=")` check get wrong, and both are exploitable:
+///
+/// * a value may itself contain `=` (base64 padding, for one), so the split
+///   is on the **first** `=` only;
+/// * substring matching would let `evil_ephpm_session=...` satisfy a lookup
+///   for `ephpm_session`, so names are compared **whole and exactly** —
+///   cookie names are case-sensitive.
+///
+/// A matched pair of surrounding double quotes is stripped (RFC 6265's
+/// `cookie-value` production permits them).
+fn cookie_values<'a>(header: &'a str, name: &'a str) -> impl Iterator<Item = &'a str> {
+    header.split(';').filter_map(move |pair| {
+        let (raw_name, raw_value) = pair.split_once('=')?;
+        if raw_name.trim_matches([' ', '\t']) != name {
+            return None;
+        }
+        let value = raw_value.trim_matches([' ', '\t']);
+        Some(match value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) {
+            Some(unquoted) => unquoted,
+            None => value,
+        })
+    })
+}
+
+/// Validate this request's own path+query for use as a return-to target,
+/// returning `None` when it cannot be proven same-origin.
+///
+/// The target is never taken from a client-supplied parameter — it is the
+/// path the browser actually asked for. That removes most of the open-redirect
+/// surface by construction, but not all of it: the request line is still
+/// client-controlled, and a login service that does `Location: <return_to>`
+/// would happily follow a *protocol-relative* URL. `GET //evil.example/ HTTP/1.1`
+/// is a legal request whose path is `//evil.example/`.
+///
+/// So the target must be an absolute path and nothing else:
+///
+/// * it starts with a single `/` — never `//` (protocol-relative) and never
+///   `/\` or `\`, which browsers normalise to `/` and therefore treat exactly
+///   like `//`;
+/// * it contains no ASCII control character, space, or `DEL`, which could
+///   split a header or truncate a URL, and no non-ASCII byte (paths reach us
+///   percent-encoded);
+/// * it fits in [`MAX_RETURN_TO`].
+///
+/// Anything else yields `None` and the user is simply sent to the login page
+/// without a return-to — failing safe, never failing open. Percent-encoded
+/// slashes (`/%2F%2Fevil.example`) survive validation and are harmless: they
+/// stay a single-segment path when resolved, and a browser does not decode
+/// `%2F` before deciding a URL's origin.
+fn same_origin_return_to(path: &str, query: &str) -> Option<String> {
+    if !path.starts_with('/') || path.starts_with("//") || path.starts_with("/\\") {
+        return None;
+    }
+    if path.len() + query.len() + 1 > MAX_RETURN_TO {
+        return None;
+    }
+    let unsafe_byte =
+        |s: &str| s.bytes().any(|b| !(0x21..=0x7E).contains(&b) || b == b'\\' || b == b'#');
+    if unsafe_byte(path) || unsafe_byte(query) {
+        return None;
+    }
+    if query.is_empty() { Some(path.to_owned()) } else { Some(format!("{path}?{query}")) }
+}
+
+/// Percent-encode a string for use as a URL query component.
+///
+/// Everything outside the RFC 3986 unreserved set is encoded, `/` and `&` and
+/// `=` and `#` included. Over-encoding is the point: whatever the login
+/// service's URL parser does, a value produced here cannot introduce a
+/// parameter, a fragment, or a second URL.
+fn percent_encode(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(char::from(byte));
+        } else {
+            out.push('%');
+            out.push(char::from(HEX[usize::from(byte >> 4)]));
+            out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    out
+}
+
+/// Whether a client-IP string is a loopback address.
+///
+/// The host passes the client IP **after** trusted-proxy resolution, so this
+/// is loopback only for a client genuinely on this machine (or one a trusted
+/// proxy reported as such). An unparseable value is treated as not loopback —
+/// the fail-closed direction.
+fn is_loopback(remote_ip: &str) -> bool {
+    remote_ip.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code)] // tests build the FFI Request view by hand.
+
+    use base64ct::{Base64UrlUnpadded, Encoding};
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND, ACTION_REWRITE};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    use super::*;
+
+    const SECRET: &str = "test-secret-please-rotate";
+    const LOGIN: &str = "https://login.example/start";
+    /// The canonical site key the router resolves for the test request — the
+    /// value `req.vhost_id()` returns and that tokens must be bound to.
+    const SITE: &str = "pr-42.preview.example";
+
+    /// Forge a token through the same HMAC code path the module verifies with.
+    fn sign(secret: &str, header_json: &str, claims_json: &str) -> String {
+        let h = Base64UrlUnpadded::encode_string(header_json.as_bytes());
+        let p = Base64UrlUnpadded::encode_string(claims_json.as_bytes());
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("hmac key");
+        mac.update(format!("{h}.{p}").as_bytes());
+        let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+        format!("{h}.{p}.{sig}")
+    }
+
+    fn token(secret: &str, claims_json: &str) -> String {
+        sign(secret, r#"{"alg":"HS256","typ":"JWT"}"#, claims_json)
+    }
+
+    fn future_exp() -> u64 {
+        now_unix() + 3600
+    }
+
+    /// A session token bound to `site` — the production shape (`github-auth`
+    /// always mints a `site` claim).
+    fn site_token(site: &str) -> String {
+        token(SECRET, &format!(r#"{{"sub":"octocat","site":{site:?},"exp":{}}}"#, future_exp()))
+    }
+
+    /// A session token bound to the default test site [`SITE`].
+    fn valid_token() -> String {
+        site_token(SITE)
+    }
+
+    fn gate(mut config: serde_json::Value) -> SessionCookie {
+        // Every test mount shares the secret and login URL unless it set them.
+        let map = config.as_object_mut().expect("object config");
+        map.entry("secret").or_insert_with(|| SECRET.into());
+        map.entry("login_url").or_insert_with(|| LOGIN.into());
+        SessionCookie::init(&config).expect("init")
+    }
+
+    /// Invoke over HTTPS from a non-loopback client for site [`SITE`] — the
+    /// production shape.
+    fn invoke(mw: &SessionCookie, headers: &[(String, String)]) -> Response {
+        invoke_on(mw, "GET", "/index.php", "", headers, true, "203.0.113.9", SITE)
+    }
+
+    /// Invoke over HTTPS for a named site — used by the cross-tenant tests.
+    fn invoke_on_site(mw: &SessionCookie, site: &str, headers: &[(String, String)]) -> Response {
+        invoke_on(mw, "GET", "/index.php", "", headers, true, "203.0.113.9", site)
+    }
+
+    /// Invoke with everything but the site fixed to [`SITE`] — the existing
+    /// tests' shape.
+    fn invoke_full(
+        mw: &SessionCookie,
+        method: &str,
+        path: &str,
+        query: &str,
+        headers: &[(String, String)],
+        https: bool,
+        ip: &str,
+    ) -> Response {
+        invoke_on(mw, method, path, query, headers, https, ip, SITE)
+    }
+
+    #[allow(clippy::too_many_arguments, reason = "test harness; every axis varies across tests")]
+    fn invoke_on(
+        mw: &SessionCookie,
+        method: &str,
+        path: &str,
+        query: &str,
+        headers: &[(String, String)],
+        https: bool,
+        ip: &str,
+        site: &str,
+    ) -> Response {
+        // The 5th argument is the request's canonical site key (empty = the
+        // host matched no vhost, so `vhost_id()` reads as `None`).
+        let ctx = RequestCtx::new(method, path, query, ip, site, headers).with_scheme(https);
+        // SAFETY: `ctx` outlives the view; host_table() is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn cookie(value: &str) -> Vec<(String, String)> {
+        vec![("Cookie".to_owned(), value.to_owned())]
+    }
+
+    fn header_of<'a>(resp: &'a Response, name: &str) -> Option<&'a str> {
+        resp.__headers().iter().find(|(n, _)| n == name).map(|(_, v)| v.as_str())
+    }
+
+    /// Assert the verdict is a redirect to the login service, and return the
+    /// `Location` so the caller can inspect the query it carries.
+    fn assert_redirect(resp: &Response) -> String {
+        assert_eq!(resp.__action(), ACTION_RESPOND, "unauthenticated must short-circuit");
+        assert_eq!(resp.__status(), 302);
+        assert_eq!(header_of(resp, "Cache-Control"), Some("no-store"));
+        assert_eq!(header_of(resp, "Vary"), Some("Cookie"));
+        header_of(resp, "Location").expect("Location header").to_owned()
+    }
+
+    // ── config ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn init_requires_secret_and_login_url() {
+        assert!(SessionCookie::init(&serde_json::json!({ "secret": SECRET })).is_err());
+        assert!(SessionCookie::init(&serde_json::json!({ "login_url": LOGIN })).is_err());
+        assert!(
+            SessionCookie::init(&serde_json::json!({ "secret": "", "login_url": LOGIN })).is_err()
+        );
+    }
+
+    #[test]
+    fn init_rejects_a_dangerous_login_url() {
+        // A `javascript:` login_url would be an XSS primitive fired on every
+        // unauthenticated request; `//host` is protocol-relative, not a path.
+        for bad in
+            ["javascript:alert(1)", "data:text/html,x", "//evil.example/login", "evil.example"]
+        {
+            let cfg = serde_json::json!({ "secret": SECRET, "login_url": bad });
+            assert!(SessionCookie::init(&cfg).is_err(), "{bad} must be rejected");
+        }
+        for good in ["https://login.example/start", "http://login.local/start", "/login.php"] {
+            let cfg = serde_json::json!({ "secret": SECRET, "login_url": good });
+            assert!(SessionCookie::init(&cfg).is_ok(), "{good} must be accepted");
+        }
+    }
+
+    #[test]
+    fn config_absent_keys_take_their_documented_defaults() {
+        // "section absent": only the two required keys are set. The cookie
+        // name defaults, require_https and require_site default ON, and no
+        // return-to or site parameter is emitted unless asked for.
+        let mw = gate(serde_json::json!({}));
+        assert_eq!(mw.cookie, DEFAULT_COOKIE);
+        assert!(mw.require_https, "require_https must default to ON");
+        assert!(mw.require_site, "require_site must default to ON (issue #396)");
+        assert_eq!(
+            mw.login_location(Some("/a"), Some("site")),
+            LOGIN,
+            "no params unless configured"
+        );
+        let resp = invoke(&mw, &cookie(&format!("{DEFAULT_COOKIE}={}", valid_token())));
+        assert_eq!(resp.__action(), ACTION_CONTINUE, "the default cookie name is honoured");
+    }
+
+    #[test]
+    fn config_present_keys_are_all_honoured() {
+        let mw = gate(serde_json::json!({
+            "cookie": "sb_session",
+            "return_to_param": "next",
+            "site_param": "site",
+            "claims_header": "X-Session-Claims",
+            "require_https": false,
+            "require_site": false,
+        }));
+        assert_eq!(mw.cookie, "sb_session");
+        assert!(!mw.require_https);
+        assert!(!mw.require_site);
+        let resp = invoke_full(&mw, "GET", "/a.php", "b=1", &[], true, "203.0.113.9");
+        let location = assert_redirect(&resp);
+        assert_eq!(location, format!("{LOGIN}?next=%2Fa.php%3Fb%3D1&site=pr-42.preview.example"));
+    }
+
+    #[test]
+    fn a_mistyped_bool_knob_fails_startup() {
+        // `require_https = "false"` (a string) must not be quietly read as
+        // "set, therefore truthy" nor as false — it fails the mount. Same for
+        // `require_site`, the #396 gate.
+        for knob in ["require_https", "require_site"] {
+            let cfg = serde_json::json!({ "secret": SECRET, "login_url": LOGIN, knob: "false" });
+            assert!(SessionCookie::init(&cfg).is_err(), "{knob} = \"false\" must fail");
+        }
+    }
+
+    // ── the happy path ───────────────────────────────────────────────────
+
+    #[test]
+    fn valid_cookie_continues_to_php() {
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke(&mw, &cookie(&format!("ephpm_session={}", valid_token())));
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn valid_cookie_forwards_claims_when_configured() {
+        let mw = gate(serde_json::json!({ "claims_header": "X-Session-Claims" }));
+        let claims = format!(r#"{{"sub":"octocat","site":{SITE:?},"exp":{}}}"#, future_exp());
+        let resp = invoke(&mw, &cookie(&format!("ephpm_session={}", token(SECRET, &claims))));
+        assert_eq!(resp.__action(), ACTION_REWRITE);
+        assert_eq!(header_of(&resp, "X-Session-Claims"), Some(claims.as_str()));
+    }
+
+    // ── #396: per-tenant binding ─────────────────────────────────────────
+
+    /// THE test that #396 was missing. A session minted for `alpha` is
+    /// accepted only when serving `alpha`, and REJECTED when serving `beta` —
+    /// two previews on one node, one preview's login is not the other's. This
+    /// is what the pre-fix verifier (which ignored the `site` claim) failed.
+    #[test]
+    fn a_session_for_one_site_is_rejected_on_another() {
+        let mw = gate(serde_json::json!({})); // require_site defaults ON
+        let alpha = site_token("alpha");
+
+        // Accepted on the site it was minted for.
+        assert_eq!(
+            invoke_on_site(&mw, "alpha", &cookie(&format!("ephpm_session={alpha}"))).__action(),
+            ACTION_CONTINUE,
+            "a session must be accepted on its own site"
+        );
+
+        // Rejected on a different site — the whole point of #396.
+        assert_redirect(&invoke_on_site(&mw, "beta", &cookie(&format!("ephpm_session={alpha}"))));
+
+        // And symmetrically: a `beta` session opens `beta`, not `alpha`.
+        let beta = site_token("beta");
+        assert_eq!(
+            invoke_on_site(&mw, "beta", &cookie(&format!("ephpm_session={beta}"))).__action(),
+            ACTION_CONTINUE
+        );
+        assert_redirect(&invoke_on_site(&mw, "alpha", &cookie(&format!("ephpm_session={beta}"))));
+    }
+
+    /// A session with no `site` claim fails closed while `require_site` is on:
+    /// the issuer always sets `site`, so a site-less token is either forged or
+    /// from a mismatched configuration, and either way must not open a preview.
+    #[test]
+    fn a_cookie_without_a_site_claim_is_rejected_when_require_site_is_on() {
+        let mw = gate(serde_json::json!({}));
+        let no_site = token(SECRET, &format!(r#"{{"sub":"octocat","exp":{}}}"#, future_exp()));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={no_site}"))));
+    }
+
+    /// The explicit single-tenant opt-out: with `require_site = false` a
+    /// site-less token is accepted, and the `site` claim is not checked at all.
+    /// This is the documented escape hatch for a single-tenant login service —
+    /// and its cross-site laxity is the trade it makes, stated in a test so it
+    /// cannot be mistaken for the default.
+    #[test]
+    fn require_site_false_accepts_a_site_less_token() {
+        let mw = gate(serde_json::json!({ "require_site": false }));
+        let no_site = token(SECRET, &format!(r#"{{"sub":"octocat","exp":{}}}"#, future_exp()));
+        assert_eq!(
+            invoke(&mw, &cookie(&format!("ephpm_session={no_site}"))).__action(),
+            ACTION_CONTINUE
+        );
+        // A token bound to some *other* site is likewise accepted when the
+        // operator has explicitly opted out of the binding.
+        let other = site_token("some-other-preview");
+        assert_eq!(
+            invoke(&mw, &cookie(&format!("ephpm_session={other}"))).__action(),
+            ACTION_CONTINUE
+        );
+    }
+
+    /// With `require_site` on and no vhost resolved (an unmatched `Host`, or a
+    /// single-site node), the gate cannot bind a session to a tenant, so it
+    /// refuses with a hard 403 rather than serving or looping.
+    #[test]
+    fn require_site_with_no_resolved_site_is_a_hard_403() {
+        let mw = gate(serde_json::json!({}));
+        // Empty site key ⇒ `vhost_id()` is None.
+        let resp = invoke_on(
+            &mw,
+            "GET",
+            "/index.php",
+            "",
+            &cookie(&format!("ephpm_session={}", valid_token())),
+            true,
+            "203.0.113.9",
+            "",
+        );
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 403, "no tenant to bind to must fail closed");
+    }
+
+    // ── the rejection paths ──────────────────────────────────────────────
+
+    #[test]
+    fn missing_cookie_header_redirects() {
+        assert_redirect(&invoke(&gate(serde_json::json!({})), &[]));
+    }
+
+    #[test]
+    fn a_differently_named_cookie_redirects() {
+        let mw = gate(serde_json::json!({}));
+        let t = valid_token();
+        assert_redirect(&invoke(&mw, &cookie(&format!("other={t}"))));
+        // Substring matching would accept this; whole-name matching must not.
+        assert_redirect(&invoke(&mw, &cookie(&format!("evil_ephpm_session={t}"))));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session_x={t}"))));
+    }
+
+    #[test]
+    fn expired_cookie_redirects() {
+        let mw = gate(serde_json::json!({}));
+        let expired = token(SECRET, &format!(r#"{{"sub":"octocat","site":{SITE:?},"exp":1000}}"#));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={expired}"))));
+    }
+
+    #[test]
+    fn a_cookie_without_exp_redirects() {
+        // A session token that cannot expire is a config bug, not a session.
+        let mw = gate(serde_json::json!({}));
+        let no_exp = token(SECRET, &format!(r#"{{"sub":"octocat","site":{SITE:?}}}"#));
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={no_exp}"))));
+    }
+
+    #[test]
+    fn tampered_signature_redirects_and_the_tamper_is_actually_detected() {
+        let mw = gate(serde_json::json!({}));
+        let good = valid_token();
+
+        // Control: the untampered token IS accepted, so a redirect below
+        // proves detection rather than the token never having been valid.
+        assert_eq!(
+            invoke(&mw, &cookie(&format!("ephpm_session={good}"))).__action(),
+            ACTION_CONTINUE
+        );
+
+        let mut parts = good.split('.');
+        let (h, p, s) =
+            (parts.next().expect("h"), parts.next().expect("p"), parts.next().expect("s"));
+
+        // 1. Payload swapped for a privilege-escalating one, signature kept.
+        let forged = Base64UrlUnpadded::encode_string(
+            format!(r#"{{"sub":"root","site":{SITE:?},"exp":{}}}"#, future_exp()).as_bytes(),
+        );
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={h}.{forged}.{s}"))));
+
+        // 2. One flipped character in the signature.
+        let flipped = if s.ends_with('A') { 'B' } else { 'A' };
+        let tampered = format!("{}{flipped}", &s[..s.len() - 1]);
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={h}.{p}.{tampered}"))));
+
+        // 3. Signed with a different key.
+        let other = token(
+            "attacker-key",
+            &format!(r#"{{"sub":"root","site":{SITE:?},"exp":{}}}"#, future_exp()),
+        );
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={other}"))));
+
+        // 4. `alg: none` with a signature that verifies under our key.
+        let alg_none = sign(
+            SECRET,
+            r#"{"alg":"none"}"#,
+            &format!(r#"{{"site":{SITE:?},"exp":{}}}"#, future_exp()),
+        );
+        assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={alg_none}"))));
+
+        // 5. Structurally broken tokens.
+        for junk in ["", "not-a-jwt", "a.b.c.d", "..", "e30.e30."] {
+            assert_redirect(&invoke(&mw, &cookie(&format!("ephpm_session={junk}"))));
+        }
+    }
+
+    #[test]
+    fn a_non_get_request_redirects_with_303() {
+        // 303 makes the browser GET the login page instead of re-POSTing the
+        // form body to the identity service.
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke_full(&mw, "POST", "/submit.php", "", &[], true, "203.0.113.9");
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 303);
+        assert!(header_of(&resp, "Location").is_some());
+    }
+
+    // ── cookie parsing ───────────────────────────────────────────────────
+
+    #[test]
+    fn cookie_parsing_handles_real_browser_headers() {
+        let mw = gate(serde_json::json!({}));
+        let t = valid_token();
+        for header in [
+            // Surrounded by other cookies, with the usual "; " separator.
+            format!("_ga=GA1.1.9; ephpm_session={t}; wordpress_test_cookie=WP"),
+            // No space after the separator.
+            format!("a=1;ephpm_session={t};b=2"),
+            // Leading/trailing whitespace and tabs around the pair.
+            format!("a=1; \t ephpm_session={t} \t ; b=2"),
+            // RFC 6265 permits a quoted cookie-value.
+            format!("ephpm_session=\"{t}\""),
+            // Last cookie in the header, no trailing separator.
+            format!("a=1; ephpm_session={t}"),
+        ] {
+            assert_eq!(
+                invoke(&mw, &cookie(&header)).__action(),
+                ACTION_CONTINUE,
+                "must find the cookie in {header:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cookie_value_containing_equals_survives_parsing() {
+        // Splitting on every `=` instead of the first would truncate this.
+        let padded = format!("{}==", valid_token());
+        assert_eq!(
+            cookie_values(&format!("ephpm_session={padded}"), "ephpm_session").next(),
+            Some(padded.as_str())
+        );
+        // And a value that is only `=` signs still parses as a value.
+        assert_eq!(cookie_values("a==b=c", "a").next(), Some("=b=c"));
+    }
+
+    #[test]
+    fn a_shadowing_cookie_cannot_lock_a_user_out() {
+        // An attacker who can set `ephpm_session` on a PARENT domain gets it
+        // sent first, shadowing the real one. Taking only the first match
+        // would be a trivial denial of service; every candidate is tried.
+        let mw = gate(serde_json::json!({}));
+        let t = valid_token();
+        let shadowed = format!("ephpm_session=garbage-from-parent-domain; ephpm_session={t}");
+        assert_eq!(invoke(&mw, &cookie(&shadowed)).__action(), ACTION_CONTINUE);
+        // ...and a valid token first, junk second, also works.
+        let reversed = format!("ephpm_session={t}; ephpm_session=junk");
+        assert_eq!(invoke(&mw, &cookie(&reversed)).__action(), ACTION_CONTINUE);
+        // Two invalid ones still redirect — trying all candidates must not
+        // become "accept anything".
+        assert_redirect(&invoke(&mw, &cookie("ephpm_session=junk; ephpm_session=more-junk")));
+    }
+
+    #[test]
+    fn malformed_cookie_headers_do_not_panic_or_admit() {
+        let mw = gate(serde_json::json!({}));
+        for header in ["", ";", ";;;", "=", "=value", "ephpm_session", "ephpm_session;", "   "] {
+            assert_redirect(&invoke(&mw, &cookie(header)));
+        }
+    }
+
+    // ── return-to (open redirect) ────────────────────────────────────────
+
+    #[test]
+    fn return_to_carries_the_requested_path_and_query() {
+        let mw = gate(serde_json::json!({ "return_to_param": "next" }));
+        let resp =
+            invoke_full(&mw, "GET", "/wp-admin/edit.php", "post=7&x=a b", &[], true, "203.0.113.9");
+        // Space is not a legal request-target byte; such a query is dropped
+        // rather than encoded, so this one yields no `next` at all.
+        assert_eq!(assert_redirect(&resp), LOGIN);
+
+        let resp =
+            invoke_full(&mw, "GET", "/wp-admin/edit.php", "post=7", &[], true, "203.0.113.9");
+        assert_eq!(
+            assert_redirect(&resp),
+            format!("{LOGIN}?next=%2Fwp-admin%2Fedit.php%3Fpost%3D7")
+        );
+    }
+
+    #[test]
+    fn hostile_return_to_targets_are_rejected() {
+        // Every one of these is a legal request target that a login service
+        // doing `Location: <next>` would follow off-origin, or that could
+        // break out of the query parameter. None may ever appear in `next`.
+        let hostile = [
+            "//evil.example/",              // protocol-relative
+            "///evil.example/",             // three slashes, still off-origin
+            "//evil.example/path?a=b",      //
+            "/\\evil.example/",             // browsers normalise \ to /
+            "/\\/evil.example",             //
+            "\\\\evil.example",             // does not start with / at all
+            "https://evil.example/",        // absolute URL
+            "http:/evil.example",           //
+            "javascript:alert(1)",          // XSS payload
+            "/x\nLocation:%20https://evil", // header injection attempt
+            "/x\r\nSet-Cookie:%20a=b",      //
+            "/x y",                         // raw space truncates a URL
+            "/x#@evil.example",             // fragment/userinfo confusion
+            "/\u{7f}",                      // DEL
+            "/\u{e9}vil",                   // raw non-ASCII
+            "",                             // empty
+            "relative/path",                // not absolute
+        ];
+        let mw = gate(serde_json::json!({ "return_to_param": "next" }));
+        for target in hostile {
+            assert_eq!(
+                same_origin_return_to(target, ""),
+                None,
+                "{target:?} must not be usable as a return-to"
+            );
+            // ...and end to end: the emitted Location carries no `next`.
+            let resp = invoke_full(&mw, "GET", target, "", &[], true, "203.0.113.9");
+            let location = assert_redirect(&resp);
+            assert_eq!(location, LOGIN, "{target:?} leaked into {location}");
+        }
+        // A hostile QUERY is caught too, even with an innocuous path.
+        assert_eq!(same_origin_return_to("/ok.php", "a=b\r\nX: y"), None);
+        assert_eq!(same_origin_return_to("/ok.php", "a=#b"), None);
+
+        // A NUL is rejected here...
+        assert_eq!(same_origin_return_to("/x\u{0}y", ""), None);
+        // ...but never reaches a module as one: the host strips interior NULs
+        // when it builds the request context, so end to end this arrives as
+        // the perfectly ordinary path `/xy` and is returned to as such. Both
+        // layers are checked because either alone would be load-bearing.
+        let resp = invoke_full(&mw, "GET", "/x\u{0}y", "", &[], true, "203.0.113.9");
+        assert_eq!(assert_redirect(&resp), format!("{LOGIN}?next=%2Fxy"));
+    }
+
+    #[test]
+    fn a_percent_encoded_slash_is_safe_to_return_to() {
+        // `/%2F%2Fevil.example` is a single-segment path, not a
+        // protocol-relative URL: a browser does not decode %2F before
+        // deciding origin, so this one is allowed through — and it comes back
+        // double-encoded, so it cannot decode into `//` at the login service.
+        let mw = gate(serde_json::json!({ "return_to_param": "next" }));
+        let resp = invoke_full(&mw, "GET", "/%2F%2Fevil.example", "", &[], true, "203.0.113.9");
+        assert_eq!(assert_redirect(&resp), format!("{LOGIN}?next=%2F%252F%252Fevil.example"));
+    }
+
+    #[test]
+    fn an_overlong_return_to_is_dropped_not_truncated() {
+        let long = format!("/{}", "a".repeat(MAX_RETURN_TO));
+        assert_eq!(same_origin_return_to(&long, ""), None);
+    }
+
+    #[test]
+    fn return_to_appends_to_a_login_url_that_already_has_a_query() {
+        let mw = gate(serde_json::json!({
+            "login_url": "https://login.example/start?tenant=acme",
+            "return_to_param": "next",
+            "site_param": "site",
+        }));
+        let resp = invoke_full(&mw, "GET", "/a.php", "", &[], true, "203.0.113.9");
+        assert_eq!(
+            assert_redirect(&resp),
+            "https://login.example/start?tenant=acme&next=%2Fa.php&site=pr-42.preview.example"
+        );
+    }
+
+    #[test]
+    fn the_site_identity_lets_one_login_service_serve_many_sites() {
+        // `site_param` carries the router's canonical site key straight
+        // through — already normalized, so no local massaging is needed.
+        let mw = gate(serde_json::json!({ "site_param": "site" }));
+        let resp = invoke(&mw, &[]);
+        assert_eq!(assert_redirect(&resp), format!("{LOGIN}?site=pr-42.preview.example"));
+    }
+
+    #[test]
+    fn no_site_param_is_emitted_when_the_host_matched_no_vhost() {
+        // With no resolved site, `login_location` emits no `site` parameter
+        // rather than an empty one. (`require_site` is off here so we reach
+        // the redirect at all.)
+        let mw = gate(serde_json::json!({ "site_param": "site", "require_site": false }));
+        assert_eq!(mw.login_location(None, None), LOGIN);
+        assert_eq!(mw.login_location(None, Some("")), LOGIN);
+        let resp = invoke_on(&mw, "GET", "/i.php", "", &[], true, "203.0.113.9", "");
+        assert_eq!(assert_redirect(&resp), LOGIN);
+    }
+
+    // ── transport ────────────────────────────────────────────────────────
+
+    #[test]
+    fn cleartext_from_a_remote_client_is_refused_by_default() {
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke_full(
+            &mw,
+            "GET",
+            "/index.php",
+            "",
+            &cookie(&format!("ephpm_session={}", valid_token())),
+            false,
+            "203.0.113.9",
+        );
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 403, "a valid cookie over cleartext is still refused");
+    }
+
+    #[test]
+    fn cleartext_from_loopback_is_allowed_so_local_development_works() {
+        let mw = gate(serde_json::json!({}));
+        for ip in ["127.0.0.1", "::1"] {
+            let resp = invoke_full(
+                &mw,
+                "GET",
+                "/index.php",
+                "",
+                &cookie(&format!("ephpm_session={}", valid_token())),
+                false,
+                ip,
+            );
+            assert_eq!(resp.__action(), ACTION_CONTINUE, "loopback {ip} is a secure context");
+        }
+        // And a loopback client with no cookie still gets the redirect, not
+        // the 403 — the transport check must not swallow the normal path.
+        let resp = invoke_full(&mw, "GET", "/index.php", "", &[], false, "127.0.0.1");
+        assert_redirect(&resp);
+    }
+
+    #[test]
+    fn require_https_false_allows_cleartext_from_anywhere() {
+        let mw = gate(serde_json::json!({ "require_https": false }));
+        let resp = invoke_full(
+            &mw,
+            "GET",
+            "/index.php",
+            "",
+            &cookie(&format!("ephpm_session={}", valid_token())),
+            false,
+            "203.0.113.9",
+        );
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+    }
+
+    #[test]
+    fn an_unparseable_client_ip_is_not_treated_as_loopback() {
+        assert!(!is_loopback(""));
+        assert!(!is_loopback("localhost"));
+        assert!(!is_loopback("127.0.0.1, 203.0.113.9"));
+        assert!(is_loopback("127.0.0.1"));
+        assert!(is_loopback("127.99.1.2"));
+        assert!(is_loopback("::1"));
+        assert!(!is_loopback("203.0.113.9"));
+    }
+
+    #[test]
+    fn a_forged_x_forwarded_proto_does_not_satisfy_require_https() {
+        // The header reaches modules exactly as the client sent it; only the
+        // host's own verdict counts.
+        let mw = gate(serde_json::json!({}));
+        let headers = vec![
+            ("X-Forwarded-Proto".to_owned(), "https".to_owned()),
+            ("Cookie".to_owned(), format!("ephpm_session={}", valid_token())),
+        ];
+        let resp = invoke_full(&mw, "GET", "/i.php", "", &headers, false, "203.0.113.9");
+        assert_eq!(resp.__status(), 403, "a client-set X-Forwarded-Proto must not unlock this");
+    }
+}

--- a/crates/ephpm-middleware-github-auth/Cargo.toml
+++ b/crates/ephpm-middleware-github-auth/Cargo.toml
@@ -1,0 +1,82 @@
+[package]
+name = "ephpm-middleware-github-auth"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "ePHPm native middleware: GitHub OAuth login gate (cold path) that issues a stateless signed session for private preview sites"
+
+[lib]
+# Artifact name: libgithub_auth.so / libgithub_auth.dylib / github_auth.dll.
+# That file is what `[[middleware]] library = "..."` points at.
+name = "github_auth"
+# cdylib is the loadable module. The rlib exists only so the unit and
+# integration tests can link the same code; a shipped module needs cdylib
+# alone.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ephpm-middleware.workspace = true
+serde_json.workspace = true
+# Session/state token signing. Same primitives (and the same constant-time
+# `Mac::verify_slice`) as the builtin `jwt` module, so a token minted here and
+# a token verified there agree by construction.
+base64ct.workspace = true
+hmac.workspace = true
+sha2.workspace = true
+# OS entropy for the OAuth `state` nonce. A syscall shim, not a generator.
+getrandom.workspace = true
+
+# NOTE: `tracing` is deliberately NOT a dependency. A dlopen'd module links
+# its own copy of the `tracing` crate with its own global dispatcher, which is
+# never the host's — a `tracing::info!` here would be silently swallowed. The
+# ABI's `log` callback (`ephpm_middleware::Host::log`) is the only thing that
+# reaches ePHPm's log stream, and it is what this module uses.
+
+# ── Outbound HTTPS to GitHub ──────────────────────────────────────────────
+#
+# This is the reason the module ships as a dlopen'd cdylib rather than a
+# builtin: an HTTP client and a TLS stack are real weight, and none of it
+# belongs in the ephpm binary. Nothing below is a dependency of `ephpm`.
+#
+# `rustls-tls-manual-roots-no-provider` is the ONLY correct reqwest TLS
+# feature here. Every other `rustls-tls-*` feature also enables reqwest's
+# `__rustls-ring` and links `ring`, which is the multi-provider bug tracked in
+# ephpm#241. "manual roots" + "no provider" means reqwest supplies neither a
+# crypto provider nor a root store; `github.rs` hands it a fully-built
+# `rustls::ClientConfig` instead. Inherited from the workspace, which pins
+# exactly that feature set for the OTLP exporter.
+reqwest.workspace = true
+# rustls is declared here rather than inherited with `workspace = true`, for
+# one reason: the workspace pin still carries `features = ["ring"]`, and
+# inheriting it would put a SECOND crypto provider in the shipped `.so`.
+#
+# `aws-lc-rs` is the right single provider: it is what ephpm#241/PR#368
+# converges the server on, it is already enabled on rustls 0.23 elsewhere in
+# this workspace (rustls-acme, rcgen, pgwire, hyper-rustls), and it is what
+# `github.rs` names explicitly in `builder_with_provider`. Naming `ring`
+# instead would break the moment #368 drops it from the pin.
+#
+# Verified with `cargo tree -e features,no-dev -p ephpm-middleware-github-auth
+# -i ring` (no match) and `... -p ephpm -i ring` (byte-identical to main).
+# The version tracks the workspace pin below it; Cargo resolves both to the
+# same 0.23.x lock entry, so there is no second rustls. When #368 lands and
+# the workspace pin loses `ring`, this can become `workspace = true`.
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "tls12",
+    "logging",
+    "aws-lc-rs",
+] }
+rustls-native-certs.workspace = true
+webpki-roots.workspace = true
+
+[dev-dependencies]
+# `host` supplies the request context and callback table so tests can build a
+# real `Request` without a running server. A shipped module never enables it.
+ephpm-middleware = { workspace = true, features = ["host"] }
+
+[lints]
+workspace = true

--- a/crates/ephpm-middleware-github-auth/README.md
+++ b/crates/ephpm-middleware-github-auth/README.md
@@ -1,0 +1,62 @@
+# `ephpm-middleware-github-auth`
+
+A GitHub OAuth **login gate** for ePHPm, shipped as a `dlopen`'d native
+middleware module. It answers *"does the person at this browser have access,
+on GitHub, to the repo this preview is for?"* — **once**, at login — and then
+issues a stateless signed session.
+
+Full operator documentation: **[GitHub OAuth Gate
+(native middleware)](../../site/content/guides/github-auth-middleware.md)**.
+
+```bash
+cargo build --release -p ephpm-middleware-github-auth
+# target/release/libgithub_auth.so | .dylib | github_auth.dll
+```
+
+```toml
+[[middleware]]
+library = "/opt/ephpm/modules/libgithub_auth.so"
+order   = 10
+config  = { client_id = "Iv1.…", client_secret = "env:GH_CLIENT_SECRET",
+            session_secret = "env:EPHPM_SESSION_SECRET", repo = "acme/web" }
+```
+
+## Three things to know before reading the code
+
+1. **This is the cold path only.** It issues sessions; it never verifies one.
+   A request carrying the session cookie gets `CONTINUE` and a separate
+   session-verifier module decides. **Mounted alone it is not an
+   authenticator** — it logs that at startup.
+2. **No GitHub call ever happens on a request that has a session.** That is
+   structural: `GithubAuth::route` is a pure function, only its `Callback`
+   variant reaches `github.rs`, and only the exact configured `callback_path`
+   produces it. `tests/oauth_round_trip.rs` asserts the stub GitHub's request
+   counter does not move across 50 authenticated requests.
+3. **It is a `cdylib`, not a builtin, on purpose.** It needs an HTTP client
+   and TLS; none of that is in the `ephpm` binary
+   (`cargo tree -e features,no-dev -p ephpm -i ring` is byte-identical with
+   and without this crate). The module itself links exactly one crypto
+   provider, `aws-lc-rs` — see the comment on the `rustls` dependency in
+   `Cargo.toml`, which is load-bearing.
+
+## Layout
+
+| file | what it holds |
+|---|---|
+| `src/lib.rs` | routing (`Route`), the login/callback/bypass flows, `declare!` |
+| `src/config.rs` | strict, fail-closed config parsing; `env:` secret indirection |
+| `src/github.rs` | the outbound half: TLS, token exchange, the three access checks |
+| `src/token.rs` | HS256 minting, key derivation, constant-time comparison |
+| `src/redirect.rs` | return-to validation (the open-redirect defence) |
+| `src/cookie.rs` | cookie reading and `Set-Cookie` construction |
+| `tests/oauth_round_trip.rs` | the whole flow against a stub GitHub over real sockets |
+
+## Tests
+
+```bash
+cargo test -p ephpm-middleware-github-auth
+```
+
+What is **not** covered, and needs a human: a round trip against the real
+`github.com` with a registered GitHub App. Everything this side of that is
+exercised over real TCP against a stub.

--- a/crates/ephpm-middleware-github-auth/src/config.rs
+++ b/crates/ephpm-middleware-github-auth/src/config.rs
@@ -1,0 +1,829 @@
+//! Configuration parsing for the gate.
+//!
+//! Everything arrives as the `[[middleware]] config` table, serialised to
+//! JSON by ePHPm. Parsing is strict and fail-closed: an unusable value is an
+//! `Err` out of `init`, which aborts server startup with the message rather
+//! than booting a gate that silently lets everyone through.
+//!
+//! # Where the secrets come from
+//!
+//! Three values are secrets: `client_secret`, `session_secret` and the
+//! optional `bypass_token`. Each accepts either a literal or an
+//! **`env:NAME`** indirection that reads the named environment variable at
+//! startup. `env:` is the recommended form — `ephpm.toml` is frequently
+//! templated, checked in, or rendered into a ConfigMap, and a literal in it
+//! is a secret in git.
+//!
+//! Read [`Secret`] and then the crate-level "Operational cost" section: the
+//! OAuth client secret genuinely lives on the node, and that is the price of
+//! doing this in-process instead of in an external identity service.
+
+use std::collections::BTreeMap;
+
+use crate::cookie::{CookieAttrs, SameSite, validate_cookie_name};
+
+/// Default reserved path that receives GitHub's OAuth redirect.
+pub const DEFAULT_CALLBACK_PATH: &str = "/_ephpm/auth/github/callback";
+/// Default reserved path that starts a login.
+pub const DEFAULT_LOGIN_PATH: &str = "/_ephpm/auth/github/login";
+/// Default session cookie name.
+pub const DEFAULT_COOKIE_NAME: &str = "ephpm_session";
+/// Default session lifetime: one working day.
+pub const DEFAULT_SESSION_TTL: u64 = 8 * 60 * 60;
+/// Lifetime of the OAuth `state` cookie — long enough to type a password and
+/// answer an MFA prompt, short enough that a stolen one is worthless.
+pub const STATE_TTL_SECS: u64 = 600;
+/// Default automation-bypass session lifetime.
+pub const DEFAULT_BYPASS_TTL: u64 = 60 * 60;
+/// Default header carrying the automation bypass token.
+pub const DEFAULT_BYPASS_HEADER: &str = "x-ephpm-bypass";
+/// Default `iss` claim.
+pub const DEFAULT_ISSUER: &str = "ephpm-github-auth";
+
+/// A configured secret.
+///
+/// The `Debug` impl redacts, so a secret cannot reach a log through a
+/// derived `Debug` on some struct that happens to contain one. That is not
+/// hypothetical tidiness: `tracing`'s `?value` sigil is one keystroke away
+/// from `%value`.
+#[derive(Clone)]
+pub struct Secret(Vec<u8>);
+
+impl Secret {
+    /// The raw bytes, for signing and comparison only.
+    #[must_use]
+    pub fn expose(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Secret(<redacted>)")
+    }
+}
+
+/// Which GitHub relationship grants access to a preview.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Check {
+    /// The user can read `owner/name`. The default, and the tightest answer
+    /// to "does this person have access to the repo this preview is for?".
+    Repo {
+        /// `owner` segment.
+        owner: String,
+        /// Repository name.
+        name: String,
+    },
+    /// The user is an *active* member of the organisation.
+    Org {
+        /// Organisation login.
+        org: String,
+    },
+    /// The user is an *active* member of a specific team.
+    Team {
+        /// Organisation login.
+        org: String,
+        /// Team slug.
+        team: String,
+    },
+}
+
+impl Check {
+    /// A short, non-secret description for logs and error bodies.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Repo { owner, name } => format!("repo {owner}/{name}"),
+            Self::Org { org } => format!("org {org}"),
+            Self::Team { org, team } => format!("team {org}/{team}"),
+        }
+    }
+}
+
+/// The gate's fully-resolved configuration.
+#[derive(Debug)]
+pub struct Config {
+    /// OAuth client id (not a secret).
+    pub client_id: String,
+    /// OAuth client secret.
+    pub client_secret: Secret,
+    /// HMAC key for the session token. Shared with the hot-path verifier.
+    pub session_secret: Secret,
+    /// Key for the OAuth `state` cookie, derived from `session_secret`.
+    pub state_secret: Secret,
+
+    /// Access check applied when the request's vhost has no `sites` entry.
+    pub default_check: Option<Check>,
+    /// Per-vhost access checks (`request_vhost_id` → check).
+    pub sites: BTreeMap<String, Check>,
+
+    /// Reserved path that starts a login.
+    pub login_path: String,
+    /// Reserved path that receives GitHub's redirect.
+    pub callback_path: String,
+
+    /// Session cookie name. Must match the hot-path verifier's.
+    pub cookie_name: String,
+    /// OAuth `state` cookie name.
+    pub state_cookie_name: String,
+    /// Attributes applied to both cookies.
+    pub cookie_attrs: CookieAttrs,
+    /// Session lifetime, seconds.
+    pub session_ttl_secs: u64,
+
+    /// `iss` claim written into issued tokens.
+    pub issuer: String,
+    /// `aud` claim written into issued tokens, when configured.
+    pub audience: Option<String>,
+
+    /// Pre-shared automation bypass token.
+    pub bypass_token: Option<Secret>,
+    /// Header carrying the bypass token.
+    pub bypass_header: String,
+    /// Query parameter carrying the bypass token; off unless configured.
+    pub bypass_query: Option<String>,
+    /// Lifetime of a bypass-issued session, seconds.
+    pub bypass_ttl_secs: u64,
+
+    /// OAuth authorize/token host (`https://github.com`, or a GHES host).
+    pub github_base: String,
+    /// REST API base (`https://api.github.com`, or `https://ghes/api/v3`).
+    pub github_api_base: String,
+    /// Explicit `redirect_uri`. When unset it is derived per request as
+    /// `https://<vhost><callback_path>`.
+    pub redirect_uri: Option<String>,
+    /// OAuth scopes requested. Empty is correct for a GitHub App.
+    pub scopes: Vec<String>,
+    /// Timeout for each outbound GitHub call, seconds.
+    pub http_timeout_secs: u64,
+}
+
+/// Read a string field.
+fn opt_str(config: &serde_json::Value, key: &str) -> Result<Option<String>, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s)) if s.is_empty() => Ok(None),
+        Some(serde_json::Value::String(s)) => Ok(Some(s.clone())),
+        Some(other) => Err(format!("`{key}` must be a string, got {other}")),
+    }
+}
+
+fn req_str(config: &serde_json::Value, key: &str) -> Result<String, String> {
+    opt_str(config, key)?.ok_or_else(|| format!("`{key}` is required and must be non-empty"))
+}
+
+fn opt_bool(config: &serde_json::Value, key: &str, default: bool) -> Result<bool, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("`{key}` must be a boolean, got {other}")),
+    }
+}
+
+fn opt_u64(config: &serde_json::Value, key: &str, default: u64) -> Result<u64, String> {
+    match config.get(key) {
+        None | Some(serde_json::Value::Null) => Ok(default),
+        Some(v) => v.as_u64().ok_or_else(|| format!("`{key}` must be a positive integer, got {v}")),
+    }
+}
+
+/// How a secret's `env:NAME` indirection is resolved.
+///
+/// Injected rather than calling [`std::env::var`] inline so the tests can
+/// exercise the indirection without `set_var`, which is `unsafe` in the 2024
+/// edition and a genuine data race in a multi-threaded test binary.
+pub type EnvLookup<'a> = &'a dyn Fn(&str) -> Option<String>;
+
+/// Resolve a secret, following an `env:NAME` indirection.
+fn secret(
+    config: &serde_json::Value,
+    key: &str,
+    env: EnvLookup<'_>,
+) -> Result<Option<Secret>, String> {
+    let Some(raw) = opt_str(config, key)? else {
+        return Ok(None);
+    };
+    let value = if let Some(var) = raw.strip_prefix("env:") {
+        if var.is_empty() {
+            return Err(format!("`{key}` is `env:` with no variable name"));
+        }
+        // The variable NAME is safe to name in an error; the value never is.
+        env(var).ok_or_else(|| {
+            format!("`{key}` points at environment variable `{var}`, which is not set")
+        })?
+    } else {
+        raw
+    };
+    if value.is_empty() {
+        return Err(format!("`{key}` resolved to an empty value"));
+    }
+    Ok(Some(Secret(value.into_bytes())))
+}
+
+/// Shortest accepted `session_secret`.
+///
+/// 32 bytes is the HMAC-SHA256 block-security level. Shorter keys are what
+/// make an offline forgery attempt on a self-contained token worth
+/// attempting, and the whole security of the session rests on this one value.
+const MIN_SESSION_SECRET: usize = 32;
+
+/// Parse a `check` selection out of a JSON object (the top-level config or
+/// one `sites` entry). Returns `None` when the object names no target.
+fn parse_check(v: &serde_json::Value, ctx: &str) -> Result<Option<Check>, String> {
+    let kind = opt_str(v, "check")?;
+    let repo = opt_str(v, "repo")?;
+    let org = opt_str(v, "org")?;
+    let team = opt_str(v, "team")?;
+
+    // Infer the kind when it is unambiguous, so the common single-key form
+    // (`{ repo = "acme/web" }`) needs no ceremony.
+    let kind = match kind.as_deref() {
+        Some(k) => k.to_ascii_lowercase(),
+        None if team.is_some() => "team".into(),
+        None if repo.is_some() => "repo".into(),
+        None if org.is_some() => "org".into(),
+        None => return Ok(None),
+    };
+
+    match kind.as_str() {
+        "repo" => {
+            let spec = repo.ok_or_else(|| format!("{ctx}: `check = \"repo\"` needs `repo` set"))?;
+            let (owner, name) = spec
+                .split_once('/')
+                .ok_or_else(|| format!("{ctx}: `repo` must be `owner/name`, got {spec:?}"))?;
+            if owner.is_empty() || name.is_empty() || name.contains('/') {
+                return Err(format!("{ctx}: `repo` must be exactly `owner/name`, got {spec:?}"));
+            }
+            validate_path_segment(owner, &format!("{ctx}: repo owner"))?;
+            validate_path_segment(name, &format!("{ctx}: repo name"))?;
+            Ok(Some(Check::Repo { owner: owner.to_owned(), name: name.to_owned() }))
+        }
+        "org" => {
+            let org = org.ok_or_else(|| format!("{ctx}: `check = \"org\"` needs `org` set"))?;
+            validate_path_segment(&org, &format!("{ctx}: org"))?;
+            Ok(Some(Check::Org { org }))
+        }
+        "team" => {
+            let org = org.ok_or_else(|| format!("{ctx}: `check = \"team\"` needs `org` set"))?;
+            let team = team.ok_or_else(|| format!("{ctx}: `check = \"team\"` needs `team` set"))?;
+            validate_path_segment(&org, &format!("{ctx}: org"))?;
+            validate_path_segment(&team, &format!("{ctx}: team"))?;
+            Ok(Some(Check::Team { org, team }))
+        }
+        other => Err(format!("{ctx}: `check` must be repo, org or team, got {other:?}")),
+    }
+}
+
+/// Reject anything that would not survive being interpolated into a GitHub
+/// API path. This is the one place configured strings become part of an
+/// outbound URL, so it is the one place path traversal or a smuggled query
+/// could be introduced.
+fn validate_path_segment(s: &str, what: &str) -> Result<(), String> {
+    let ok = !s.is_empty()
+        && s.len() <= 100
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        && s != "."
+        && s != "..";
+    if ok { Ok(()) } else { Err(format!("{what}: {s:?} is not a valid GitHub name")) }
+}
+
+/// Validate a reserved path: absolute, no query, no traversal.
+fn validate_reserved_path(p: &str, key: &str) -> Result<(), String> {
+    if !p.starts_with('/') || p.contains(['?', '#', '\\', ' ']) || !p.is_ascii() {
+        return Err(format!("`{key}` must be an absolute ASCII path with no query, got {p:?}"));
+    }
+    Ok(())
+}
+
+/// Validate an `https://…` (or loopback `http://…`) base URL.
+///
+/// Plaintext is permitted **only** to a loopback literal. That single
+/// exception is what lets the integration tests point the module at a stub
+/// OAuth server on `127.0.0.1`; it cannot be turned into "plaintext to
+/// github.com", which would put the client secret and the access token on
+/// the wire in clear.
+fn validate_base_url(url: &str, key: &str) -> Result<(), String> {
+    let rest = if let Some(r) = url.strip_prefix("https://") {
+        r
+    } else if let Some(r) = url.strip_prefix("http://") {
+        let host = r.split(['/', ':']).next().unwrap_or("");
+        if !matches!(host, "127.0.0.1" | "localhost" | "[::1]" | "::1") {
+            return Err(format!(
+                "`{key}` may only use http:// for a loopback host (got {url:?}); \
+                 plaintext to a real GitHub host would expose the client secret \
+                 and the user's access token"
+            ));
+        }
+        r
+    } else {
+        return Err(format!("`{key}` must start with https:// (got {url:?})"));
+    };
+    if rest.is_empty() || url.ends_with('/') {
+        return Err(format!("`{key}` must have a host and no trailing slash (got {url:?})"));
+    }
+    if !url.is_ascii() || url.chars().any(|c| c.is_ascii_control()) {
+        return Err(format!("`{key}` must be printable ASCII (got {url:?})"));
+    }
+    Ok(())
+}
+
+impl Config {
+    /// Parse and validate the mount's config table.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable message for any missing, malformed or unsafe
+    /// value. Every one of these aborts server startup.
+    pub fn parse(config: &serde_json::Value) -> Result<Self, String> {
+        Self::parse_with_env(config, &|var| std::env::var(var).ok())
+    }
+
+    /// [`Config::parse`] with the `env:` resolver injected.
+    ///
+    /// # Errors
+    ///
+    /// As [`Config::parse`].
+    #[allow(clippy::too_many_lines, reason = "one flat, auditable validation pass")]
+    pub fn parse_with_env(config: &serde_json::Value, env: EnvLookup<'_>) -> Result<Self, String> {
+        if !config.is_object() {
+            return Err("config must be a table (`config = { client_id = ... }`)".into());
+        }
+
+        let client_id = req_str(config, "client_id")?;
+        let client_secret =
+            secret(config, "client_secret", env)?.ok_or("`client_secret` is required")?;
+        let session_secret =
+            secret(config, "session_secret", env)?.ok_or("`session_secret` is required")?;
+        if session_secret.expose().len() < MIN_SESSION_SECRET {
+            return Err(format!(
+                "`session_secret` must be at least {MIN_SESSION_SECRET} bytes; the whole \
+                 security of an unrevocable, self-contained session token rests on it"
+            ));
+        }
+        let state_secret = Secret(crate::token::derive_key(
+            session_secret.expose(),
+            crate::token::STATE_KEY_LABEL,
+        ));
+
+        // Access targets. `sites` maps a vhost id to its own check, which is
+        // what lets one mount serve a fleet of per-PR preview hostnames.
+        let mut sites = BTreeMap::new();
+        match config.get("sites") {
+            None | Some(serde_json::Value::Null) => {}
+            Some(serde_json::Value::Object(map)) => {
+                for (host, entry) in map {
+                    let host_key = normalize_vhost(host);
+                    validate_vhost(&host_key)?;
+                    let check = parse_check(entry, &format!("sites.{host}"))?
+                        .ok_or_else(|| format!("sites.{host}: no repo/org/team configured"))?;
+                    sites.insert(host_key, check);
+                }
+            }
+            Some(other) => return Err(format!("`sites` must be a table, got {other}")),
+        }
+        let default_check = parse_check(config, "config")?;
+        if default_check.is_none() && sites.is_empty() {
+            return Err(
+                "no access target configured: set `repo` (or `org`/`team`), or a `sites` table \
+                 mapping each vhost to one. A gate with nothing to check would authenticate \
+                 every GitHub user in the world."
+                    .into(),
+            );
+        }
+
+        let login_path =
+            opt_str(config, "login_path")?.unwrap_or_else(|| DEFAULT_LOGIN_PATH.to_owned());
+        let callback_path =
+            opt_str(config, "callback_path")?.unwrap_or_else(|| DEFAULT_CALLBACK_PATH.to_owned());
+        validate_reserved_path(&login_path, "login_path")?;
+        validate_reserved_path(&callback_path, "callback_path")?;
+        if login_path == callback_path {
+            return Err("`login_path` and `callback_path` must differ".into());
+        }
+
+        let cookie_name =
+            opt_str(config, "cookie_name")?.unwrap_or_else(|| DEFAULT_COOKIE_NAME.to_owned());
+        validate_cookie_name(&cookie_name)?;
+        let state_cookie_name =
+            opt_str(config, "state_cookie_name")?.unwrap_or_else(|| format!("{cookie_name}_oauth"));
+        validate_cookie_name(&state_cookie_name)?;
+        if state_cookie_name == cookie_name {
+            return Err("`state_cookie_name` must differ from `cookie_name`".into());
+        }
+
+        let cookie_path = opt_str(config, "cookie_path")?.unwrap_or_else(|| "/".to_owned());
+        validate_reserved_path(&cookie_path, "cookie_path")?;
+        let same_site =
+            SameSite::parse(opt_str(config, "cookie_samesite")?.as_deref().unwrap_or("Lax"))?;
+        let secure = opt_bool(config, "cookie_secure", true)?;
+        if same_site == SameSite::None && !secure {
+            return Err("`cookie_samesite = \"None\"` requires `cookie_secure = true`".into());
+        }
+
+        let session_ttl_secs = opt_u64(config, "session_ttl_secs", DEFAULT_SESSION_TTL)?;
+        if !(60..=7 * 24 * 60 * 60).contains(&session_ttl_secs) {
+            return Err(
+                "`session_ttl_secs` must be between 60 and 604800: the token cannot be revoked \
+                 before it expires, so its lifetime is the blast radius of a stolen cookie"
+                    .into(),
+            );
+        }
+
+        let bypass_token = secret(config, "bypass_token", env)?;
+        if let Some(t) = &bypass_token
+            && t.expose().len() < MIN_SESSION_SECRET
+        {
+            return Err(format!(
+                "`bypass_token` must be at least {MIN_SESSION_SECRET} bytes — it is a password \
+                 that skips GitHub entirely"
+            ));
+        }
+        let bypass_ttl_secs = opt_u64(config, "bypass_ttl_secs", DEFAULT_BYPASS_TTL)?;
+        if !(60..=7 * 24 * 60 * 60).contains(&bypass_ttl_secs) {
+            return Err("`bypass_ttl_secs` must be between 60 and 604800".into());
+        }
+        let bypass_header = opt_str(config, "bypass_header")?
+            .unwrap_or_else(|| DEFAULT_BYPASS_HEADER.to_owned())
+            .to_ascii_lowercase();
+        let bypass_query = opt_str(config, "bypass_query")?;
+
+        let github_base =
+            opt_str(config, "github_base")?.unwrap_or_else(|| "https://github.com".to_owned());
+        let github_api_base = opt_str(config, "github_api_base")?
+            .unwrap_or_else(|| "https://api.github.com".to_owned());
+        validate_base_url(&github_base, "github_base")?;
+        validate_base_url(&github_api_base, "github_api_base")?;
+
+        let redirect_uri = opt_str(config, "redirect_uri")?;
+        if let Some(uri) = &redirect_uri {
+            let base = uri.split(['?', '#']).next().unwrap_or(uri);
+            validate_base_url(base, "redirect_uri")?;
+            if !base.ends_with(&callback_path) {
+                return Err(format!(
+                    "`redirect_uri` must end with `callback_path` ({callback_path}); GitHub \
+                     redirects there and only that path is handled"
+                ));
+            }
+        }
+
+        let scopes = match config.get("scopes") {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(serde_json::Value::Array(items)) => items
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(str::to_owned)
+                        .ok_or_else(|| format!("`scopes` entries must be strings, got {v}"))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            Some(other) => return Err(format!("`scopes` must be an array, got {other}")),
+        };
+        for s in &scopes {
+            if !s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, ':' | '_' | '-')) {
+                return Err(format!("`scopes` entry {s:?} contains unexpected characters"));
+            }
+        }
+
+        let http_timeout_secs = opt_u64(config, "http_timeout_secs", 10)?;
+        if !(1..=60).contains(&http_timeout_secs) {
+            return Err(
+                "`http_timeout_secs` must be between 1 and 60 — `invoke` is synchronous, so this \
+                 is how long one request thread can be parked on GitHub"
+                    .into(),
+            );
+        }
+
+        Ok(Self {
+            client_id,
+            client_secret,
+            session_secret,
+            state_secret,
+            default_check,
+            sites,
+            login_path,
+            callback_path,
+            cookie_name,
+            state_cookie_name,
+            cookie_attrs: CookieAttrs { path: cookie_path, secure, same_site },
+            session_ttl_secs,
+            issuer: opt_str(config, "issuer")?.unwrap_or_else(|| DEFAULT_ISSUER.to_owned()),
+            audience: opt_str(config, "audience")?,
+            bypass_token,
+            bypass_header,
+            bypass_query,
+            bypass_ttl_secs,
+            github_base,
+            github_api_base,
+            redirect_uri,
+            scopes,
+            http_timeout_secs,
+        })
+    }
+
+    /// The access check that applies to `vhost`.
+    ///
+    /// `vhost` must already have been through [`normalize_vhost`]; the keys
+    /// of `sites` were normalised at parse time, so anything else silently
+    /// misses.
+    ///
+    /// When a `sites` table is configured it is authoritative: a vhost with
+    /// no entry gets **no** check and therefore no access, even if a
+    /// top-level `repo` is also set. Falling back would mean a hostname
+    /// nobody mapped quietly inherits some other tenant's rule.
+    #[must_use]
+    pub fn check_for(&self, vhost: &str) -> Option<&Check> {
+        if self.sites.is_empty() {
+            return self.default_check.as_ref();
+        }
+        self.sites.get(vhost)
+    }
+
+    /// Paths the gate owns, for the return-to loop check.
+    #[must_use]
+    pub fn reserved_paths(&self) -> [&str; 2] {
+        [self.login_path.as_str(), self.callback_path.as_str()]
+    }
+}
+
+/// Canonicalise the middleware ABI's `request_vhost_id` before it is used as
+/// a key or written into a token.
+///
+/// **This is not cosmetic.** `request_vhost_id` is the router's `SERVER_NAME`
+/// — the raw `Host` header with the port split off and *nothing else*. It is
+/// **not** lowercased, the FQDN-root dot is not stripped, and it is not the
+/// canonical site key that `Router::resolve_site` produces. `Host` is
+/// case-insensitive per RFC 9110 and entirely client-controlled, so without
+/// this a `sites` lookup misses on `Host: PR-1.Preview.Test`, and — worse —
+/// two spellings of the same host would mint sessions with two different
+/// `site` claims and two different derived `redirect_uri`s.
+///
+/// The port is deliberately **not** split off here: the server already
+/// removed it, and splitting on `:` would corrupt an IPv6 literal
+/// (`[::1]` → `[`). If a future ABI change reintroduced the port, the key
+/// would simply stop matching, which fails closed.
+///
+/// `ephpm-server`'s own `normalize_host_key` is `pub(crate)`, so a module
+/// cannot call it; the duplication is forced.
+#[must_use]
+pub fn normalize_vhost(raw: &str) -> String {
+    raw.trim().trim_end_matches('.').to_ascii_lowercase()
+}
+
+/// Reject a vhost id that could not appear in a URL authority.
+///
+/// The vhost is interpolated into the derived `redirect_uri`, so it is
+/// attacker-influenced input (it comes from the `Host` header) heading for an
+/// outbound URL.
+///
+/// # Errors
+///
+/// Returns a message when the name is empty, over-long, non-ASCII, or
+/// contains anything outside the host/port character set.
+pub fn validate_vhost(host: &str) -> Result<(), String> {
+    let ok = !host.is_empty()
+        && host.len() <= 253
+        && host.is_ascii()
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | ':' | '[' | ']'));
+    if ok { Ok(()) } else { Err(format!("{host:?} is not a usable virtual-host name")) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> serde_json::Value {
+        serde_json::json!({
+            "client_id": "Iv1.abc",
+            "client_secret": "shhh",
+            "session_secret": "0123456789abcdef0123456789abcdef",
+            "repo": "acme/web",
+        })
+    }
+
+    fn parse(v: serde_json::Value) -> Result<Config, String> {
+        Config::parse(&v)
+    }
+
+    #[test]
+    fn defaults_are_the_documented_ones() {
+        let c = parse(base()).expect("parse");
+        assert_eq!(c.login_path, DEFAULT_LOGIN_PATH);
+        assert_eq!(c.callback_path, DEFAULT_CALLBACK_PATH);
+        assert_eq!(c.cookie_name, DEFAULT_COOKIE_NAME);
+        assert_eq!(c.state_cookie_name, "ephpm_session_oauth");
+        assert_eq!(c.session_ttl_secs, DEFAULT_SESSION_TTL);
+        assert!(c.cookie_attrs.secure);
+        assert_eq!(c.cookie_attrs.same_site, SameSite::Lax);
+        assert_eq!(c.cookie_attrs.path, "/");
+        assert_eq!(c.github_base, "https://github.com");
+        assert_eq!(c.github_api_base, "https://api.github.com");
+        assert_eq!(c.issuer, DEFAULT_ISSUER);
+        assert!(c.scopes.is_empty(), "empty scopes is correct for a GitHub App");
+        assert_eq!(c.http_timeout_secs, 10);
+        assert_eq!(c.default_check, Some(Check::Repo { owner: "acme".into(), name: "web".into() }));
+    }
+
+    #[test]
+    fn required_fields_are_required() {
+        for missing in ["client_id", "client_secret", "session_secret"] {
+            let mut v = base();
+            v.as_object_mut().expect("object").remove(missing);
+            assert!(parse(v).is_err(), "{missing} must be required");
+        }
+        // No target at all.
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        let err = parse(v).expect_err("a gate with no target must not start");
+        assert!(err.contains("every GitHub user in the world"));
+    }
+
+    #[test]
+    fn weak_session_secret_is_refused() {
+        let mut v = base();
+        v["session_secret"] = serde_json::json!("too-short");
+        assert!(parse(v).expect_err("weak secret").contains("at least 32 bytes"));
+    }
+
+    #[test]
+    fn env_indirection_reads_the_variable() {
+        let env = |var: &str| {
+            (var == "GH_SESSION_SECRET").then(|| "0123456789abcdef0123456789abcdef".to_owned())
+        };
+        let mut v = base();
+        v["session_secret"] = serde_json::json!("env:GH_SESSION_SECRET");
+        let c = Config::parse_with_env(&v, &env).expect("parse");
+        assert_eq!(c.session_secret.expose(), b"0123456789abcdef0123456789abcdef");
+
+        let mut v = base();
+        v["session_secret"] = serde_json::json!("env:NOT_SET_ANYWHERE");
+        let err = Config::parse_with_env(&v, &env).expect_err("unset var");
+        assert!(err.contains("is not set"));
+        assert!(err.contains("NOT_SET_ANYWHERE"), "the variable NAME is safe to report");
+
+        // `env:` with no name is a config error, not a lookup of "".
+        let mut v = base();
+        v["client_secret"] = serde_json::json!("env:");
+        assert!(Config::parse_with_env(&v, &env).is_err());
+    }
+
+    #[test]
+    fn secret_debug_is_redacted() {
+        let c = parse(base()).expect("parse");
+        let rendered = format!("{:?}", c.client_secret);
+        assert_eq!(rendered, "Secret(<redacted>)");
+        // And through the whole struct, which derives Debug.
+        let whole = format!("{c:?}");
+        assert!(!whole.contains("shhh"), "a secret must not reach a Debug rendering");
+        assert!(!whole.contains("0123456789abcdef"));
+    }
+
+    #[test]
+    fn plaintext_github_base_is_refused_except_on_loopback() {
+        for bad in ["http://github.com", "http://evil.test", "ftp://x", "github.com", "https://x/"]
+        {
+            let mut v = base();
+            v["github_base"] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{bad:?} must be refused");
+        }
+        for ok in ["http://127.0.0.1:9000", "http://localhost:1", "https://ghe.corp.example"] {
+            let mut v = base();
+            v["github_base"] = serde_json::json!(ok);
+            assert!(parse(v).is_ok(), "{ok:?} must be accepted");
+        }
+    }
+
+    #[test]
+    fn repo_spec_must_be_owner_slash_name() {
+        for bad in ["acme", "acme/web/extra", "/web", "acme/", "../../etc", "acme/we b"] {
+            let mut v = base();
+            v["repo"] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{bad:?} must be refused");
+        }
+    }
+
+    #[test]
+    fn org_and_team_checks_parse() {
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        v["org"] = serde_json::json!("acme");
+        assert_eq!(
+            parse(v.clone()).expect("org").default_check,
+            Some(Check::Org { org: "acme".into() })
+        );
+        v["team"] = serde_json::json!("platform");
+        assert_eq!(
+            parse(v).expect("team").default_check,
+            Some(Check::Team { org: "acme".into(), team: "platform".into() })
+        );
+    }
+
+    #[test]
+    fn sites_table_is_authoritative_when_present() {
+        let mut v = base();
+        v["sites"] = serde_json::json!({
+            "pr-1.preview.example.com": { "repo": "acme/web" },
+            "PR-2.preview.example.com": { "org": "acme" },
+        });
+        let c = parse(v).expect("parse");
+        assert_eq!(
+            c.check_for("pr-1.preview.example.com"),
+            Some(&Check::Repo { owner: "acme".into(), name: "web".into() })
+        );
+        // A `sites` KEY written in mixed case is normalised at parse time.
+        assert_eq!(
+            c.check_for("pr-2.preview.example.com"),
+            Some(&Check::Org { org: "acme".into() })
+        );
+        // An unmapped vhost gets nothing — it does NOT inherit the top-level
+        // `repo`, which is also set in this config.
+        assert_eq!(c.check_for("pr-99.preview.example.com"), None);
+    }
+
+    #[test]
+    fn vhost_normalisation_closes_the_case_bypass() {
+        // `request_vhost_id` is the RAW `Host` header. Without normalisation
+        // a client picks its own key by changing a letter's case, and mints
+        // sessions whose `site` claim disagrees with everyone else's.
+        for raw in [
+            "PR-1.Preview.Example.COM",
+            "pr-1.preview.example.com.",
+            "  pr-1.preview.example.com  ",
+            "PR-1.PREVIEW.EXAMPLE.COM.",
+        ] {
+            assert_eq!(normalize_vhost(raw), "pr-1.preview.example.com", "{raw:?}");
+        }
+        // An IPv6 literal survives: the port is already gone, and splitting
+        // on ':' here would truncate it to "[".
+        assert_eq!(normalize_vhost("[::1]"), "[::1]");
+        assert!(validate_vhost(&normalize_vhost("[::1]")).is_ok());
+
+        let mut v = base();
+        v["sites"] = serde_json::json!({ "PR-1.Preview.Example.COM": { "repo": "acme/web" } });
+        let c = parse(v).expect("parse");
+        assert!(c.check_for(&normalize_vhost("pr-1.PREVIEW.example.com")).is_some());
+        assert!(c.check_for(&normalize_vhost("PR-1.preview.example.com.")).is_some());
+    }
+
+    #[test]
+    fn session_ttl_is_bounded() {
+        for bad in [0u64, 59, 7 * 24 * 60 * 60 + 1] {
+            let mut v = base();
+            v["session_ttl_secs"] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{bad} must be refused");
+        }
+    }
+
+    #[test]
+    fn reserved_paths_must_be_absolute_and_distinct() {
+        for (k, bad) in [
+            ("login_path", "no-slash"),
+            ("callback_path", "/cb?x=1"),
+            ("login_path", "/a b"),
+            ("callback_path", "/a\\b"),
+        ] {
+            let mut v = base();
+            v[k] = serde_json::json!(bad);
+            assert!(parse(v).is_err(), "{k}={bad:?} must be refused");
+        }
+        let mut v = base();
+        v["login_path"] = serde_json::json!("/same");
+        v["callback_path"] = serde_json::json!("/same");
+        assert!(parse(v).is_err());
+    }
+
+    #[test]
+    fn redirect_uri_must_end_at_the_callback_path() {
+        let mut v = base();
+        v["redirect_uri"] = serde_json::json!("https://preview.example.com/somewhere-else");
+        assert!(parse(v.clone()).is_err());
+        v["redirect_uri"] =
+            serde_json::json!(format!("https://preview.example.com{DEFAULT_CALLBACK_PATH}"));
+        assert!(parse(v).is_ok());
+    }
+
+    #[test]
+    fn samesite_none_requires_secure() {
+        let mut v = base();
+        v["cookie_samesite"] = serde_json::json!("None");
+        v["cookie_secure"] = serde_json::json!(false);
+        assert!(parse(v).is_err());
+    }
+
+    #[test]
+    fn weak_bypass_token_is_refused() {
+        let mut v = base();
+        v["bypass_token"] = serde_json::json!("hunter2");
+        assert!(parse(v).expect_err("weak bypass").contains("at least 32 bytes"));
+    }
+
+    #[test]
+    fn vhost_validation() {
+        assert!(validate_vhost("pr-1.preview.example.com").is_ok());
+        assert!(validate_vhost("localhost:8080").is_ok());
+        for bad in ["", "has space", "evil.test/path", "a@b", "caf\u{e9}.test", "x\r\ny"] {
+            assert!(validate_vhost(bad).is_err(), "{bad:?}");
+        }
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/cookie.rs
+++ b/crates/ephpm-middleware-github-auth/src/cookie.rs
@@ -1,0 +1,201 @@
+//! Cookie reading and `Set-Cookie` construction.
+//!
+//! # Why these attributes
+//!
+//! Every cookie this module sets — the session and the short-lived OAuth
+//! `state` — carries the same set, and each one is load-bearing:
+//!
+//! * **`HttpOnly`** — the token *is* the session. A preview site is
+//!   pre-production code, which is precisely where XSS lives; script must not
+//!   be able to read the value that gets a stranger past the gate.
+//! * **`Secure`** (default on) — the token is a bearer credential, so it must
+//!   never ride a plaintext hop. Configurable only because a local
+//!   `http://…localhost` preview cannot set it at all, and silently dropping
+//!   the flag there would be worse than making the operator ask for it.
+//! * **`SameSite=Lax`** — `Strict` breaks the product: a preview link is
+//!   almost always clicked from somewhere else (a PR comment, Slack), and
+//!   `Strict` withholds the cookie on that first cross-site navigation, so an
+//!   already-logged-in user gets bounced back through GitHub every time.
+//!   `Lax` sends it on top-level GET navigations, which is exactly that case
+//!   and also exactly what the OAuth callback needs. `None` would be strictly
+//!   worse — it permits the cookie on cross-site subrequests, which nothing
+//!   here needs.
+//! * **`Path`** (default `/`) — the gate protects the whole site, so the
+//!   cookie has to be sent for the whole site.
+//! * **`Max-Age`** — a real expiry, matching the `exp` inside the signed
+//!   token. The signature is what actually enforces it; `Max-Age` just stops
+//!   the browser from keeping a corpse around.
+//! * **no `Domain`** — deliberately absent, which makes the cookie
+//!   **host-only**. Adding `Domain=.preview.example.com` would send one
+//!   tenant's session to every other tenant on the wildcard, and in this
+//!   product the tenants are different customers' code. Host-only is the
+//!   isolation boundary, and it is not configurable for that reason.
+
+use std::fmt::Write as _;
+
+/// `SameSite` values this module will emit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SameSite {
+    /// Sent on same-site requests and top-level cross-site GET navigations.
+    Lax,
+    /// Never sent on any cross-site request.
+    Strict,
+    /// Sent on all cross-site requests; requires `Secure`.
+    None,
+}
+
+impl SameSite {
+    /// Parse the config spelling (case-insensitive).
+    ///
+    /// # Errors
+    ///
+    /// Returns a message naming the accepted values for anything else.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "lax" => Ok(Self::Lax),
+            "strict" => Ok(Self::Strict),
+            "none" => Ok(Self::None),
+            other => Err(format!("`cookie_samesite` must be Lax, Strict or None, got {other:?}")),
+        }
+    }
+
+    /// The attribute value as it appears in a `Set-Cookie` header.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Lax => "Lax",
+            Self::Strict => "Strict",
+            Self::None => "None",
+        }
+    }
+}
+
+/// Attributes shared by every cookie this module sets.
+#[derive(Clone, Debug)]
+pub struct CookieAttrs {
+    /// `Path` attribute.
+    pub path: String,
+    /// Emit `Secure`.
+    pub secure: bool,
+    /// `SameSite` attribute.
+    pub same_site: SameSite,
+}
+
+/// Build a `Set-Cookie` value.
+///
+/// `max_age` of `0` emits `Max-Age=0` plus an expired `Expires`, i.e. a
+/// deletion — used when a login attempt consumes its `state` cookie.
+#[must_use]
+pub fn set_cookie(name: &str, value: &str, max_age: i64, attrs: &CookieAttrs) -> String {
+    let mut out = String::with_capacity(name.len() + value.len() + 96);
+    // `name` and `value` are validated at init / produced by this crate, so
+    // neither can contain a `;` or a control character.
+    let _ = write!(out, "{name}={value}; Path={}; Max-Age={max_age}", attrs.path);
+    if max_age == 0 {
+        out.push_str("; Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+    }
+    out.push_str("; HttpOnly");
+    if attrs.secure {
+        out.push_str("; Secure");
+    }
+    let _ = write!(out, "; SameSite={}", attrs.same_site.as_str());
+    out
+}
+
+/// Read one cookie out of a raw `Cookie:` request header.
+///
+/// Returns the **first** occurrence, which is what RFC 6265 §5.4 orders most
+/// specific first, and — more to the point — is what stops an attacker who
+/// can set a cookie on a broader path or a parent domain from shadowing the
+/// real session by appending a second one.
+#[must_use]
+pub fn read_cookie<'a>(header: &'a str, name: &str) -> Option<&'a str> {
+    header.split(';').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k.trim() == name).then(|| v.trim())
+    })
+}
+
+/// Reject cookie names that would need quoting or could not round-trip.
+///
+/// RFC 6265 says a cookie name is an RFC 7230 `token`. Validating at `init`
+/// means [`set_cookie`] can concatenate without escaping.
+///
+/// # Errors
+///
+/// Returns a message when the name is empty or contains a separator,
+/// a control character, or a non-ASCII byte.
+pub fn validate_cookie_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("cookie name must not be empty".into());
+    }
+    const SEPARATORS: &[char] = &[
+        '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ',
+    ];
+    if name.chars().any(|c| !c.is_ascii() || c.is_ascii_control() || SEPARATORS.contains(&c)) {
+        return Err(format!("cookie name {name:?} is not a valid RFC 6265 token"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attrs() -> CookieAttrs {
+        CookieAttrs { path: "/".into(), secure: true, same_site: SameSite::Lax }
+    }
+
+    #[test]
+    fn set_cookie_carries_every_required_attribute() {
+        let c = set_cookie("ephpm_session", "abc.def.ghi", 28_800, &attrs());
+        assert_eq!(
+            c,
+            "ephpm_session=abc.def.ghi; Path=/; Max-Age=28800; HttpOnly; Secure; SameSite=Lax"
+        );
+        // The isolation-critical negative: never a Domain attribute.
+        assert!(!c.contains("Domain"), "cookies must stay host-only");
+    }
+
+    #[test]
+    fn secure_can_be_dropped_for_plaintext_local_previews() {
+        let a = CookieAttrs { secure: false, ..attrs() };
+        let c = set_cookie("s", "v", 60, &a);
+        assert!(!c.contains("Secure"));
+        assert!(c.contains("HttpOnly"), "HttpOnly is never optional");
+    }
+
+    #[test]
+    fn zero_max_age_deletes() {
+        let c = set_cookie("s", "", 0, &attrs());
+        assert!(c.contains("Max-Age=0"));
+        assert!(c.contains("Expires=Thu, 01 Jan 1970"));
+    }
+
+    #[test]
+    fn read_cookie_finds_values_and_ignores_neighbours() {
+        let h = "a=1; ephpm_session=tok.en; b=2";
+        assert_eq!(read_cookie(h, "ephpm_session"), Some("tok.en"));
+        assert_eq!(read_cookie(h, "a"), Some("1"));
+        assert_eq!(read_cookie(h, "missing"), None);
+        // A name that is a prefix/suffix of another must not match.
+        assert_eq!(read_cookie("ephpm_session_x=no", "ephpm_session"), None);
+        assert_eq!(read_cookie("x_ephpm_session=no", "ephpm_session"), None);
+    }
+
+    #[test]
+    fn duplicate_cookie_resolves_to_the_first() {
+        // A shadowing cookie set on a parent domain or broader path arrives
+        // after the host-only one; taking the first is what ignores it.
+        assert_eq!(read_cookie("s=real; s=forged", "s"), Some("real"));
+    }
+
+    #[test]
+    fn cookie_name_validation() {
+        assert!(validate_cookie_name("ephpm_session").is_ok());
+        assert!(validate_cookie_name("__Host-sess").is_ok());
+        for bad in ["", "has space", "has;semi", "has=eq", "has,comma", "tab\there", "caf\u{e9}"] {
+            assert!(validate_cookie_name(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/github.rs
+++ b/crates/ephpm-middleware-github-auth/src/github.rs
@@ -1,0 +1,448 @@
+//! The outbound half: exchanging an OAuth `code` for a token and asking
+//! GitHub whether this user may see this preview.
+//!
+//! **Everything in this module runs exactly once per login.** It is the cold
+//! path by construction — nothing here is reachable from a request that
+//! already carries a session cookie, and the crate's request routing is
+//! written so that it cannot become reachable by accident. See the crate
+//! docs, and `lib.rs`'s `route` table.
+//!
+//! # The calls this module makes
+//!
+//! In order, per login, against `github_api_base` unless noted:
+//!
+//! | # | Call | Purpose | Minimum GitHub App permission / OAuth scope |
+//! |---|---|---|---|
+//! | 1 | `POST {github_base}/login/oauth/access_token` | code → user access token | none (this *is* the grant) |
+//! | 2 | `GET /user` | the login name that becomes the token's `sub` | GitHub App: none beyond the grant. OAuth App: `read:user` |
+//! | 3a | `GET /repos/{owner}/{name}` | `check = "repo"` | GitHub App: `metadata: read` on the installation. OAuth App: `repo` (private repos) |
+//! | 3b | `GET /user/memberships/orgs/{org}` | `check = "org"` | `read:org` |
+//! | 3c | `GET /orgs/{org}/teams/{team}/memberships/{login}` | `check = "team"` | `read:org` |
+//!
+//! Three requests, once, at login. A session then lasts `session_ttl_secs`
+//! and costs GitHub nothing.
+//!
+//! # Why a GitHub App is the recommended shape
+//!
+//! With a classic OAuth App, seeing a private repository at all requires the
+//! `repo` scope — which is read **and write** on **every** repository the
+//! user can touch, granted to a preview-hosting service. With a GitHub App,
+//! the user-to-server token is bounded by the app's installation: `GET
+//! /repos/{owner}/{name}` returns 200 only when the user has access *and* the
+//! app is installed there, and no `repo` scope is involved. That is why
+//! `scopes` defaults to empty rather than to something that "just works".
+//!
+//! # Redirects are not followed
+//!
+//! The client is built with [`reqwest::redirect::Policy::none()`]. A 3xx on
+//! the token exchange is an attempt to move a request carrying the client
+//! secret somewhere else; a 3xx on an API call is treated as "no access".
+//! The visible consequence is that a **renamed** repository stops matching
+//! until the config is updated, which is the safe direction.
+
+use std::io::Read as _;
+use std::time::Duration;
+
+use crate::config::{Check, Config};
+
+/// Largest response body read from GitHub. Every response this module parses
+/// is a small JSON object; the cap turns a hostile or broken endpoint into an
+/// error instead of unbounded memory on a request thread.
+const MAX_RESPONSE_BYTES: u64 = 256 * 1024;
+
+/// User agent sent on every call. GitHub requires one.
+const USER_AGENT: &str = concat!("ephpm-middleware-github-auth/", env!("CARGO_PKG_VERSION"));
+
+/// Failures from the GitHub round trip.
+///
+/// `Display` is written to be safe to log and safe to show a user: no
+/// variant carries a code, a token or a secret. That is enforced by
+/// construction — the values simply are not in the type.
+#[derive(Debug)]
+pub enum GhError {
+    /// The client could not be built (TLS or configuration).
+    Client(String),
+    /// The request never completed (DNS, connect, TLS, timeout).
+    Transport {
+        /// Which call failed, e.g. `"token exchange"`.
+        what: &'static str,
+    },
+    /// GitHub answered, but not with something usable.
+    Status {
+        /// Which call.
+        what: &'static str,
+        /// HTTP status returned.
+        status: u16,
+    },
+    /// The body was not the JSON this module expects.
+    Body {
+        /// Which call.
+        what: &'static str,
+    },
+    /// GitHub reported an OAuth-level error (its `error` field). The value is
+    /// one of GitHub's fixed identifiers, never user data.
+    OAuth {
+        /// GitHub's `error` identifier, e.g. `bad_verification_code`.
+        code: String,
+    },
+}
+
+impl std::fmt::Display for GhError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Client(m) => write!(f, "GitHub client could not be built: {m}"),
+            Self::Transport { what } => write!(f, "{what} could not reach GitHub"),
+            Self::Status { what, status } => write!(f, "{what} returned HTTP {status}"),
+            Self::Body { what } => write!(f, "{what} returned an unexpected body"),
+            Self::OAuth { code } => write!(f, "GitHub rejected the authorization: {code}"),
+        }
+    }
+}
+
+impl std::error::Error for GhError {}
+
+/// The identity behind an access token.
+#[derive(Debug, Clone)]
+pub struct User {
+    /// GitHub login (the `sub` claim).
+    pub login: String,
+    /// Numeric account id — stable across renames, which `login` is not.
+    pub id: u64,
+}
+
+/// Blocking GitHub client, built once at `init`.
+pub struct GitHub {
+    http: reqwest::blocking::Client,
+    github_base: String,
+    api_base: String,
+    client_id: String,
+    client_secret: Vec<u8>,
+    trust_anchors: String,
+}
+
+/// Build the TLS configuration for the outbound client.
+///
+/// Two things here are deliberate and neither is stylistic:
+///
+/// 1. **The crypto provider is named.** This workspace compiles both `ring`
+///    and `aws-lc-rs` into the graph, so rustls' `from_crate_features()`
+///    returns `None` and a bare `ClientConfig::builder()` panics at runtime
+///    (ephpm#241, and the long comment on `ephpm-server`'s
+///    `tls::crypto_provider`). `aws_lc_rs` is named rather than `ring`
+///    because it is the provider ePHPm is converging on — this module keeps
+///    working when `ring` leaves the workspace pin.
+/// 2. **Roots are the union of the OS store and the bundled Mozilla set** —
+///    the same choice the OTLP exporter makes. The OS store is what lets a
+///    GitHub Enterprise Server behind a private CA work at all (and it
+///    honours `SSL_CERT_FILE`/`SSL_CERT_DIR`, so no ePHPm-specific trust
+///    knob is needed); the bundled set is what keeps `api.github.com`
+///    reachable from a distroless image that ships no CA bundle.
+///
+/// Returns the config and a non-secret description of the trust store, which
+/// the caller logs through the host once. A GHES certificate problem is
+/// otherwise invisible until the first login fails.
+fn tls_config() -> Result<(rustls::ClientConfig, String), GhError> {
+    let mut roots = rustls::RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    let (native_added, _ignored) = roots.add_parsable_certificates(native.certs);
+    let bundled = webpki_roots::TLS_SERVER_ROOTS.len();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let description = format!("{native_added} OS trust anchors + {bundled} bundled");
+
+    rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| GhError::Client(format!("crypto provider rejected the default TLS versions: {e}")))
+    .map(|b| (b.with_root_certificates(roots).with_no_client_auth(), description))
+}
+
+impl GitHub {
+    /// Build the client.
+    ///
+    /// # Errors
+    ///
+    /// [`GhError::Client`] when TLS or the HTTP client cannot be constructed.
+    pub fn new(config: &Config) -> Result<Self, GhError> {
+        let (tls, trust_anchors) = tls_config()?;
+        let timeout = Duration::from_secs(config.http_timeout_secs);
+
+        // `reqwest::blocking::Client::builder().build()` starts a background
+        // runtime, and reqwest documents that as a panic when it happens
+        // inside one. `init` runs before ePHPm's runtime exists, so this is
+        // already safe; building on a plain thread makes it a local
+        // guarantee rather than an obligation on whoever calls `init` next.
+        // (Per-request *use* is fine from any thread — the blocking client
+        // hands work to that background runtime over a channel.)
+        let http = std::thread::spawn(move || {
+            reqwest::blocking::Client::builder()
+                .timeout(timeout)
+                .connect_timeout(timeout)
+                // See the module docs: a 3xx is never followed.
+                .redirect(reqwest::redirect::Policy::none())
+                .user_agent(USER_AGENT)
+                .use_preconfigured_tls(tls)
+                .build()
+        })
+        .join()
+        .map_err(|_| GhError::Client("client builder thread panicked".into()))?
+        .map_err(|e| GhError::Client(e.to_string()))?;
+
+        Ok(Self {
+            http,
+            github_base: config.github_base.clone(),
+            api_base: config.github_api_base.clone(),
+            client_id: config.client_id.clone(),
+            client_secret: config.client_secret.expose().to_vec(),
+            trust_anchors,
+        })
+    }
+
+    /// Non-secret description of the TLS trust store, for the startup log.
+    #[must_use]
+    pub fn trust_anchors(&self) -> &str {
+        &self.trust_anchors
+    }
+
+    /// Exchange an authorization `code` for a user access token.
+    ///
+    /// The returned token is a live credential: it is used for the access
+    /// check and then dropped. It is never written to a cookie, a log, or
+    /// the issued session — the session carries the *verdict*, not the token.
+    ///
+    /// # Errors
+    ///
+    /// See [`GhError`]. GitHub answers OAuth failures with HTTP 200 and an
+    /// `error` field, which becomes [`GhError::OAuth`].
+    pub fn exchange_code(&self, code: &str, redirect_uri: &str) -> Result<String, GhError> {
+        let what = "token exchange";
+        let secret = String::from_utf8_lossy(&self.client_secret).into_owned();
+        let resp = self
+            .http
+            .post(format!("{}/login/oauth/access_token", self.github_base))
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", secret.as_str()),
+                ("code", code),
+                ("redirect_uri", redirect_uri),
+            ])
+            .send()
+            .map_err(|_| GhError::Transport { what })?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            return Err(GhError::Status { what, status });
+        }
+        let body = read_json(resp, what)?;
+        // GitHub reports `bad_verification_code`, `redirect_uri_mismatch`,
+        // ... with HTTP 200. Checking `error` first is mandatory.
+        if let Some(code) = body.get("error").and_then(serde_json::Value::as_str) {
+            return Err(GhError::OAuth { code: sanitize_identifier(code) });
+        }
+        body.get("access_token")
+            .and_then(serde_json::Value::as_str)
+            .filter(|t| !t.is_empty())
+            .map(str::to_owned)
+            .ok_or(GhError::Body { what })
+    }
+
+    /// `GET /user` — the identity the session will name.
+    ///
+    /// # Errors
+    ///
+    /// See [`GhError`].
+    pub fn current_user(&self, token: &str) -> Result<User, GhError> {
+        let what = "user lookup";
+        let body =
+            self.api_get(token, "/user", what)?.ok_or(GhError::Status { what, status: 404 })?;
+        let login = body
+            .get("login")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .ok_or(GhError::Body { what })?;
+        let id =
+            body.get("id").and_then(serde_json::Value::as_u64).ok_or(GhError::Body { what })?;
+        Ok(User { login: login.to_owned(), id })
+    }
+
+    /// Does `user` satisfy `check`?
+    ///
+    /// Returns `Ok(false)` for a clean "no" (GitHub answered, the answer was
+    /// negative) and `Err` only when the question could not be asked. The
+    /// caller must treat `Err` as a denial too — see `lib.rs` — but the two
+    /// produce different messages, because "you are not on this repo" and
+    /// "GitHub is down" are different problems for the person reading the
+    /// page.
+    ///
+    /// # Errors
+    ///
+    /// See [`GhError`].
+    pub fn check_access(&self, token: &str, check: &Check, user: &User) -> Result<bool, GhError> {
+        match check {
+            Check::Repo { owner, name } => {
+                let what = "repository access check";
+                // A user access token only ever sees repositories the user
+                // can see, so a 200 here *is* the authorization answer. 404
+                // is GitHub's deliberate "exists but not for you" — it does
+                // not distinguish absence from denial, and neither do we.
+                let Some(body) = self.api_get(token, &format!("/repos/{owner}/{name}"), what)?
+                else {
+                    return Ok(false);
+                };
+                // When the field is present, require read. When it is absent
+                // (some token types omit it), the 200 stands on its own.
+                Ok(body
+                    .get("permissions")
+                    .and_then(|p| p.get("pull"))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(true))
+            }
+            Check::Org { org } => {
+                let what = "organisation membership check";
+                let Some(body) =
+                    self.api_get(token, &format!("/user/memberships/orgs/{org}"), what)?
+                else {
+                    return Ok(false);
+                };
+                // `pending` means invited but not joined — not a member.
+                Ok(body.get("state").and_then(serde_json::Value::as_str) == Some("active"))
+            }
+            Check::Team { org, team } => {
+                let what = "team membership check";
+                // The login is URL-safe: it came from GitHub's own `/user`,
+                // and `encode_segment` is applied regardless.
+                let path =
+                    format!("/orgs/{org}/teams/{team}/memberships/{}", encode_segment(&user.login));
+                let Some(body) = self.api_get(token, &path, what)? else {
+                    return Ok(false);
+                };
+                Ok(body.get("state").and_then(serde_json::Value::as_str) == Some("active"))
+            }
+        }
+    }
+
+    /// One authenticated `GET`. `Ok(None)` means 403/404 — a clean "no".
+    fn api_get(
+        &self,
+        token: &str,
+        path: &str,
+        what: &'static str,
+    ) -> Result<Option<serde_json::Value>, GhError> {
+        let resp = self
+            .http
+            .get(format!("{}{path}", self.api_base))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .bearer_auth(token)
+            .send()
+            .map_err(|_| GhError::Transport { what })?;
+
+        match resp.status().as_u16() {
+            200 => Ok(Some(read_json(resp, what)?)),
+            // 403 = forbidden, 404 = GitHub's "not visible to you", 302/301 =
+            // a redirect we refuse to follow. All of them are "no".
+            301 | 302 | 403 | 404 => Ok(None),
+            status => Err(GhError::Status { what, status }),
+        }
+    }
+}
+
+/// Read a bounded JSON body.
+fn read_json(
+    resp: reqwest::blocking::Response,
+    what: &'static str,
+) -> Result<serde_json::Value, GhError> {
+    let mut buf = Vec::new();
+    resp.take(MAX_RESPONSE_BYTES).read_to_end(&mut buf).map_err(|_| GhError::Transport { what })?;
+    serde_json::from_slice(&buf).map_err(|_| GhError::Body { what })
+}
+
+/// Keep only characters GitHub uses in its OAuth error identifiers, so a
+/// hostile endpoint cannot inject markup or newlines into a page or a log
+/// line through the `error` field.
+fn sanitize_identifier(s: &str) -> String {
+    s.chars().filter(|c| c.is_ascii_alphanumeric() || *c == '_').take(64).collect()
+}
+
+/// Percent-encode one path segment.
+#[must_use]
+pub fn encode_segment(s: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+            out.push(char::from(b));
+        } else {
+            let _ = write!(out, "%{b:02X}");
+        }
+    }
+    out
+}
+
+/// Percent-encode a query-string value (`application/x-www-form-urlencoded`
+/// component rules, but with space as `%20` since these go in a URL path
+/// query rather than a form body).
+#[must_use]
+pub fn encode_query(s: &str) -> String {
+    encode_segment(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_never_carries_a_credential() {
+        // The point of the check: no variant of GhError has a field that
+        // could hold a code, a token or a secret, so no Display can leak one.
+        let cases = [
+            GhError::Client("boom".into()),
+            GhError::Transport { what: "token exchange" },
+            GhError::Status { what: "token exchange", status: 500 },
+            GhError::Body { what: "user lookup" },
+            GhError::OAuth { code: "bad_verification_code".into() },
+        ];
+        for e in cases {
+            let rendered = format!("{e} {e:?}");
+            assert!(!rendered.contains("secret"));
+            assert!(!rendered.contains("access_token"));
+        }
+    }
+
+    #[test]
+    fn oauth_error_identifiers_are_sanitized() {
+        assert_eq!(sanitize_identifier("bad_verification_code"), "bad_verification_code");
+        assert_eq!(sanitize_identifier("<script>alert(1)</script>"), "scriptalert1script");
+        assert_eq!(sanitize_identifier("a\r\nSet-Cookie: x"), "aSetCookiex");
+        assert_eq!(sanitize_identifier(&"x".repeat(200)).len(), 64);
+    }
+
+    #[test]
+    fn tls_names_its_provider_and_never_installs_a_process_default() {
+        // A dlopen'd module shares a process with the host. `install_default`
+        // is process-global and single-shot, so a module that called it would
+        // either lose a race with ePHPm's own TLS setup or win one and change
+        // the server's provider out from under it. This module must build a
+        // config from a NAMED provider and leave the process default alone.
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "nothing in this crate may install a process-default provider"
+        );
+        let (_config, description) = tls_config().expect("aws-lc-rs supports the default versions");
+        assert!(description.contains("bundled"), "trust store is described for the log");
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_none(),
+            "building a ClientConfig must not have installed a process default"
+        );
+    }
+
+    #[test]
+    fn segment_encoding_blocks_traversal_and_query_smuggling() {
+        assert_eq!(encode_segment("octocat"), "octocat");
+        assert_eq!(encode_segment("../../admin"), "..%2F..%2Fadmin");
+        assert_eq!(encode_segment("a?b=c"), "a%3Fb%3Dc");
+        assert_eq!(encode_segment("a b"), "a%20b");
+        assert_eq!(encode_segment("a#b"), "a%23b");
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -1,0 +1,1156 @@
+//! `github-auth` — a GitHub OAuth login gate for ePHPm, shipped as a
+//! `dlopen`'d native middleware module.
+//!
+//! It answers one question for a private preview site: *does the person at
+//! this browser have access, on GitHub, to the thing this preview is for?*
+//! It answers it **once**, at login, and then issues a stateless signed
+//! session that every later request is judged by locally.
+//!
+//! # This module is the cold path. It is half of a pair.
+//!
+//! There are two jobs here and they are deliberately in two modules:
+//!
+//! | | Cold path — **this module** | Hot path — the session verifier |
+//! |---|---|---|
+//! | Runs on | login, callback, and the first request of a session | every request |
+//! | Talks to GitHub | yes, ~3 calls | **never** |
+//! | Owns | issuing tokens | the token format and its verification |
+//! | Verdict when unhappy | `RESPOND` 302 → GitHub | `RESPOND` 302 → `login_path` |
+//!
+//! Mount them in that order and they compose into a complete gate. The
+//! verifier this is designed to pair with is the **`session-cookie` builtin**
+//! (ephpm#388), which performs exactly the HS256 verification this module's
+//! tokens are minted for:
+//!
+//! ```toml
+//! [[middleware]]
+//! library = "/opt/ephpm/modules/libgithub_auth.so"
+//! order   = 10                       # cold path: owns the reserved paths
+//! config  = { client_id = "Iv1.…", client_secret = "env:GH_CLIENT_SECRET",
+//!             session_secret = "env:EPHPM_SESSION_SECRET", repo = "acme/web" }
+//!
+//! [[middleware]]
+//! library = "session-cookie"          # hot path: verifies, redirects to login
+//! order   = 20
+//! config  = { secret = "env:EPHPM_SESSION_SECRET", cookie = "ephpm_session",
+//!             login_url = "/_ephpm/auth/github/login",
+//!             return_to_param = "next" }
+//! ```
+//!
+//! Exactly three things have to line up: the HMAC key
+//! (`session_secret` ↔ `secret`), the cookie name (`cookie_name` ↔ `cookie`,
+//! whose defaults already match), and the login path (`login_path` ↔
+//! `login_url`, with `return_to_param = "next"` because this module reads the
+//! return-to from `?next=`).
+//!
+//! **This module performs no signature verification of a session cookie, by
+//! design.** On a request that already carries the session cookie it returns
+//! `CONTINUE` immediately and lets the verifier decide. Which leads to the
+//! one thing an operator must not get wrong:
+//!
+//! > **Mounted alone, this module is not an authenticator.** It stops a
+//! > request that has *no* cookie, but it does not — and must not — judge one
+//! > that has a cookie of any kind. It logs that fact at every startup. Mount
+//! > the verifier.
+//!
+//! Splitting it this way is not ceremony. It is what keeps a network call off
+//! the hot path structurally rather than by discipline: the code that can
+//! reach GitHub is only reachable from two fixed paths and from a request
+//! with no session cookie at all, and [`GithubAuth::route`] is a flat,
+//! testable statement of exactly that.
+//!
+//! # The flow
+//!
+//! | Request | Verdict | Cost |
+//! |---|---|---|
+//! | no session cookie | `RESPOND` 302 → GitHub `authorize`, `Set-Cookie` state | no network |
+//! | `GET {callback_path}?code=…&state=…` | `RESPOND` 302 → return-to, `Set-Cookie` session | 3 GitHub calls |
+//! | `GET {login_path}` | `RESPOND` 302 → GitHub `authorize` | no network |
+//! | valid bypass token, no cookie | `RESPOND` 302 → same path, `Set-Cookie` session | no network |
+//! | session cookie present | `CONTINUE` | **no network, no PHP-side work** |
+//!
+//! PHP does not run on any of the `RESPOND` rows — the middleware chain is
+//! evaluated before PHP dispatch and before the request body is read.
+//!
+//! # Sessions are self-contained
+//!
+//! The session is an HS256 JWT (see [`token`]) carrying its subject, the
+//! vhost it was issued for, how it was obtained, and an expiry. There is no
+//! server-side session record: restarts do not log anyone out, a second node
+//! needs no replication, and the module never touches the middleware KV
+//! surface — which is process-global rather than per-site (ephpm#376) and
+//! therefore the wrong place for anything tenant-scoped.
+//!
+//! The cost of that, stated plainly: **an issued session cannot be revoked
+//! before it expires.** Rotating `session_secret` invalidates every session
+//! at once and is the only revocation available. `session_ttl_secs` is
+//! therefore the blast radius of a stolen cookie, and it defaults to eight
+//! hours.
+//!
+//! # Share links, for free
+//!
+//! Issuance and verification are separate on purpose, and issuance is not
+//! privileged: anything holding `session_secret` can mint an acceptable
+//! token. A hosting control plane that wants to give a designer with no
+//! GitHub account a two-hour link needs **no change to this module** — it
+//! mints the same HS256 JWT with `via: "share"` and a short `exp`, and hands
+//! out `https://<preview>/?…` with the cookie set by its own redirect. The
+//! claim set is documented under [`GithubAuth::session_claims`]; a share
+//! token differs from a login token only in `sub` and `via`.
+//!
+//! # Automation bypass
+//!
+//! Set `bypass_token` and CI can reach a protected preview without a browser.
+//! Presenting it (header `bypass_header`, default `x-ephpm-bypass`) yields
+//! *the same kind of session* — a 302 and a `Set-Cookie` — rather than a
+//! special-cased pass-through, so Playwright and Lighthouse follow one extra
+//! redirect on their first request and behave normally afterwards. Designing
+//! it now rather than retrofitting is the whole point: a bypass bolted on
+//! later tends to become a header that skips the gate entirely on every
+//! request, which is a second, weaker authenticator.
+//!
+//! # Operational cost: the client secret lives on the node
+//!
+//! Doing OAuth in-process means the OAuth **client secret** is on every node
+//! that serves previews, readable by the ePHPm process. That is the real
+//! price of not running a separate identity service, and it should be
+//! supplied as `client_secret = "env:GH_CLIENT_SECRET"` from a secret store,
+//! never as a literal in a templated `ephpm.toml`.
+//!
+//! Blast radius if a node is compromised: the attacker can impersonate the
+//! OAuth app — i.e. complete an authorization flow for any user who can be
+//! induced to click an authorize link — and, holding `session_secret`, can
+//! mint sessions for any user and any site this gate protects. They cannot
+//! read a user's GitHub data without that user authorizing, and no long-lived
+//! GitHub token is stored: the access token is used during the login and
+//! dropped. Rotate `client_secret` and `session_secret` together after any
+//! node compromise.
+//!
+//! # Why a `dlopen`'d module and not a builtin
+//!
+//! The gate needs an HTTP client and a TLS stack. Compiling those into every
+//! ePHPm binary is real weight for a feature most deployments do not use, and
+//! it would put a second TLS surface next to the one ephpm#241/#368 is busy
+//! converging onto a single crypto provider. As a separate `cdylib` none of
+//! it is in the `ephpm` binary — `cargo build -p ephpm` does not compile a
+//! line of this crate.
+//!
+//! The trade-off is explicit: **a fully static (musl) ePHPm cannot `dlopen`,
+//! so it cannot use this module.** The stock Linux release is glibc-dynamic
+//! and can; a custom `-musl` build cannot, and would need this compiled in as
+//! a builtin instead.
+//!
+//! # Requirement: the reserved paths must reach PHP routing
+//!
+//! ePHPm evaluates the middleware chain on the **PHP-bound** path, so
+//! `login_path` and `callback_path` must resolve to a PHP script for this
+//! module to see them. With ePHPm's default
+//! `fallback = ["$uri", "$uri/", "/index.php?$query_string"]` and a front
+//! controller at `index.php` — WordPress, Laravel, Symfony, and every preview
+//! shape this was written for — that is automatic, and PHP still never runs
+//! because the chain short-circuits first. A site with **no** `index.php` and
+//! a `=404` fallback would 404 the callback before the module is consulted.
+//! [`GithubAuth::describe`] repeats this at startup.
+
+pub mod config;
+pub mod cookie;
+pub mod github;
+pub mod redirect;
+pub mod token;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ephpm_middleware::abi::{LOG_ERROR, LOG_INFO, LOG_WARN};
+use ephpm_middleware::{Middleware, Request, Response};
+
+use crate::config::{Check, Config, STATE_TTL_SECS};
+use crate::cookie::{read_cookie, set_cookie};
+use crate::github::{GhError, GitHub, encode_query};
+
+/// What the gate decided to do with a request, before any work is done.
+///
+/// Extracted from [`GithubAuth::invoke`] so the routing rule — *which
+/// requests can reach the network* — is a value a test can assert on rather
+/// than a shape inferred from control flow.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Route {
+    /// Start a login. Never touches the network.
+    StartLogin {
+        /// Where to send the user after a successful login.
+        return_to: String,
+    },
+    /// Handle GitHub's redirect. **The only variant that reaches GitHub.**
+    Callback,
+    /// A valid automation bypass token was presented. No network.
+    Bypass,
+    /// A session cookie is present: hand off to the verifier. No network.
+    HasSession,
+}
+
+/// The gate.
+pub struct GithubAuth {
+    config: Config,
+    github: GitHub,
+    /// Startup banner is emitted on the first request, because `init` has no
+    /// usable host logger of its own.
+    banner_done: AtomicBool,
+}
+
+impl GithubAuth {
+    /// Decide what to do with a request from its path, query and cookies
+    /// alone.
+    ///
+    /// Pure, and pure on purpose: this is the function that makes
+    /// "no network call on the hot path" checkable. Only [`Route::Callback`]
+    /// leads to `github.rs`, and it is reachable only from the exact
+    /// configured `callback_path`.
+    #[must_use]
+    pub fn route(&self, path: &str, query: &str, cookies: &str, bypass: Option<&str>) -> Route {
+        let reserved = self.config.reserved_paths();
+
+        if path == self.config.callback_path {
+            return Route::Callback;
+        }
+        if path == self.config.login_path {
+            // `?next=` lets the verifier hand the original destination over
+            // when it redirects an expired session here.
+            let next = query_param(query, "next").unwrap_or_default();
+            return Route::StartLogin { return_to: redirect::sanitize_return_to(&next, &reserved) };
+        }
+        // A request that already carries a session belongs to the verifier —
+        // checked before the bypass so an automation client mints once and
+        // then behaves like any other client.
+        if read_cookie(cookies, &self.config.cookie_name).is_some_and(|v| !v.is_empty()) {
+            return Route::HasSession;
+        }
+        if let (Some(expected), Some(presented)) = (self.config.bypass_token.as_ref(), bypass)
+            && token::constant_time_eq(
+                self.config.state_secret.expose(),
+                presented.as_bytes(),
+                expected.expose(),
+            )
+        {
+            return Route::Bypass;
+        }
+        Route::StartLogin { return_to: redirect::sanitize_return_to(&here(path, query), &reserved) }
+    }
+
+    /// The claim set of an issued session.
+    ///
+    /// | claim | meaning |
+    /// |---|---|
+    /// | `iss` | `issuer` (default `ephpm-github-auth`) |
+    /// | `sub` | GitHub login, or the bypass subject |
+    /// | `aud` | `audience`, when configured |
+    /// | `exp` / `iat` | expiry / issue time, seconds since the epoch |
+    /// | `site` | the vhost this session is for — a session for one preview must not open another |
+    /// | `via` | `"github"` or `"bypass"`; an external minter uses `"share"` |
+    /// | `gh_id` | numeric GitHub account id (stable across renames), for `via = "github"` |
+    /// | `check` | the rule that was satisfied, e.g. `repo acme/web` — for audit |
+    #[must_use]
+    pub fn session_claims(
+        &self,
+        subject: &str,
+        vhost: &str,
+        via: &str,
+        gh_id: Option<u64>,
+        check: Option<&Check>,
+        now: u64,
+        ttl: u64,
+    ) -> serde_json::Value {
+        let mut claims = serde_json::json!({
+            "iss": self.config.issuer,
+            "sub": subject,
+            "iat": now,
+            "exp": now.saturating_add(ttl),
+            "site": vhost,
+            "via": via,
+        });
+        if let Some(aud) = &self.config.audience {
+            claims["aud"] = serde_json::Value::String(aud.clone());
+        }
+        if let Some(id) = gh_id {
+            claims["gh_id"] = serde_json::Value::from(id);
+        }
+        if let Some(c) = check {
+            claims["check"] = serde_json::Value::String(c.describe());
+        }
+        claims
+    }
+
+    /// Build the `redirect_uri` for this request.
+    fn redirect_uri(&self, vhost: &str) -> String {
+        self.config
+            .redirect_uri
+            .clone()
+            .unwrap_or_else(|| format!("https://{vhost}{}", self.config.callback_path))
+    }
+
+    /// 302 to GitHub's authorize endpoint, with a fresh signed `state`.
+    fn start_login(&self, req: &Request<'_>, vhost: &str, return_to: &str, now: u64) -> Response {
+        let Some(check) = self.config.check_for(vhost) else {
+            log(
+                req,
+                LOG_WARN,
+                &format!(
+                    "github-auth: refusing login for vhost {vhost:?} — it has no `sites` entry and \
+                 no default target, so there is nothing to check access against"
+                ),
+            );
+            return deny(403, "This preview is not configured for GitHub access control.");
+        };
+
+        let nonce = token::random_nonce();
+        let state_claims = serde_json::json!({
+            "n": nonce,
+            "rt": return_to,
+            "v": vhost,
+            "exp": now.saturating_add(STATE_TTL_SECS),
+        });
+        let Some(state_cookie) = token::mint(self.config.state_secret.expose(), &state_claims)
+        else {
+            log(req, LOG_ERROR, "github-auth: could not mint the OAuth state token");
+            return deny(500, "Login could not be started.");
+        };
+
+        let mut url = format!(
+            "{}/login/oauth/authorize?client_id={}&redirect_uri={}&state={}&response_type=code",
+            self.config.github_base,
+            encode_query(&self.config.client_id),
+            encode_query(&self.redirect_uri(vhost)),
+            encode_query(&nonce),
+        );
+        if !self.config.scopes.is_empty() {
+            url.push_str("&scope=");
+            url.push_str(&encode_query(&self.config.scopes.join(" ")));
+        }
+
+        log(
+            req,
+            LOG_INFO,
+            &format!(
+                "github-auth: starting login for vhost {vhost:?} against {}",
+                check.describe()
+            ),
+        );
+        redirect_to(&url).header(
+            "Set-Cookie",
+            set_cookie(
+                &self.config.state_cookie_name,
+                &state_cookie,
+                i64::try_from(STATE_TTL_SECS).unwrap_or(600),
+                &self.config.cookie_attrs,
+            ),
+        )
+    }
+
+    /// Handle GitHub's redirect: verify `state`, exchange the code, check
+    /// access, issue the session.
+    ///
+    /// **Every local rejection happens before the first network call** — the
+    /// `state` cookie, its signature, its expiry, the nonce comparison, the
+    /// vhost binding and the shape of `code` are all checked first. An
+    /// attacker without a valid `state` cookie therefore cannot make this
+    /// module talk to GitHub at all, which is what keeps the callback from
+    /// being an amplification endpoint.
+    #[allow(clippy::too_many_lines, reason = "one linear flow, each step guarded")]
+    fn handle_callback(&self, req: &Request<'_>, vhost: &str, now: u64) -> Response {
+        let query = req.query();
+        let clear_state =
+            set_cookie(&self.config.state_cookie_name, "", 0, &self.config.cookie_attrs);
+
+        // GitHub reports a user-side refusal (`access_denied`) here.
+        if let Some(err) = query_param(query, "error") {
+            let id: String = err.chars().filter(char::is_ascii_alphanumeric).take(64).collect();
+            log(req, LOG_INFO, &format!("github-auth: GitHub declined the authorization ({id})"));
+            return deny(403, "GitHub did not authorize this login.")
+                .header("Set-Cookie", clear_state);
+        }
+
+        // ── CSRF: the state parameter must match the signed state cookie ──
+        //
+        // Both halves are required. The cookie is HttpOnly and was set by a
+        // login this browser started, so an attacker who plants their own
+        // `code`+`state` in a victim's browser cannot also supply the
+        // matching cookie — which is exactly the login-CSRF an unvalidated
+        // callback allows.
+        let Some(cookie_value) =
+            req.header("cookie").and_then(|c| read_cookie(c, &self.config.state_cookie_name))
+        else {
+            log(req, LOG_WARN, "github-auth: callback with no OAuth state cookie — rejected");
+            return deny(400, "This login link is not valid here. Start again.");
+        };
+        let Some(state_claims) =
+            token::verify(self.config.state_secret.expose(), cookie_value, now)
+        else {
+            log(req, LOG_WARN, "github-auth: OAuth state cookie failed verification — rejected");
+            return deny(400, "This login has expired. Start again.")
+                .header("Set-Cookie", clear_state);
+        };
+        let presented_state = query_param(query, "state").unwrap_or_default();
+        let expected_nonce =
+            state_claims.get("n").and_then(serde_json::Value::as_str).unwrap_or_default();
+        if expected_nonce.is_empty()
+            || !token::constant_time_eq(
+                self.config.state_secret.expose(),
+                presented_state.as_bytes(),
+                expected_nonce.as_bytes(),
+            )
+        {
+            log(req, LOG_WARN, "github-auth: OAuth state mismatch — rejected");
+            return deny(400, "This login link is not valid here. Start again.")
+                .header("Set-Cookie", clear_state);
+        }
+        // The state is bound to the vhost it was issued on, so a state minted
+        // for one tenant cannot complete a login on another.
+        if state_claims.get("v").and_then(serde_json::Value::as_str) != Some(vhost) {
+            log(req, LOG_WARN, "github-auth: OAuth state was issued for a different host");
+            return deny(400, "This login link is not valid here. Start again.")
+                .header("Set-Cookie", clear_state);
+        }
+
+        // Re-sanitize even though we signed it: the value was attacker-chosen
+        // before it was signed, and a signature attests origin, not safety.
+        let return_to = redirect::sanitize_return_to(
+            state_claims.get("rt").and_then(serde_json::Value::as_str).unwrap_or("/"),
+            &self.config.reserved_paths(),
+        );
+
+        let Some(check) = self.config.check_for(vhost) else {
+            return deny(403, "This preview is not configured for GitHub access control.")
+                .header("Set-Cookie", clear_state);
+        };
+
+        let Some(code) = query_param(query, "code").filter(|c| is_plausible_code(c)) else {
+            log(req, LOG_WARN, "github-auth: callback with no usable `code`");
+            return deny(400, "This login link is not valid here. Start again.")
+                .header("Set-Cookie", clear_state);
+        };
+
+        // ── The only network calls in the module ─────────────────────────
+        let outcome =
+            self.github.exchange_code(&code, &self.redirect_uri(vhost)).and_then(|access| {
+                let user = self.github.current_user(&access)?;
+                let allowed = self.github.check_access(&access, check, &user)?;
+                Ok((user, allowed))
+            });
+
+        let (user, allowed) = match outcome {
+            Ok(v) => v,
+            Err(e) => {
+                // `GhError`'s Display carries no credential — see github.rs.
+                log(req, LOG_ERROR, &format!("github-auth: login failed: {e}"));
+                let status = if matches!(e, GhError::OAuth { .. }) { 400 } else { 502 };
+                return deny(status, "Could not complete the GitHub login.")
+                    .header("Set-Cookie", clear_state);
+            }
+        };
+
+        if !allowed {
+            log(
+                req,
+                LOG_INFO,
+                &format!(
+                    "github-auth: denied {} on vhost {vhost:?} — no access to {}",
+                    user.login,
+                    check.describe()
+                ),
+            );
+            return deny(403, "Your GitHub account does not have access to this preview.")
+                .header("Set-Cookie", clear_state);
+        }
+
+        self.issue(
+            req,
+            vhost,
+            &user.login,
+            "github",
+            Some(user.id),
+            Some(check),
+            now,
+            self.config.session_ttl_secs,
+            &return_to,
+        )
+        .header("Set-Cookie", clear_state)
+    }
+
+    /// Mint a session and 302 to `return_to` carrying it.
+    #[allow(clippy::too_many_arguments, reason = "one call site each; all values are required")]
+    fn issue(
+        &self,
+        req: &Request<'_>,
+        vhost: &str,
+        subject: &str,
+        via: &str,
+        gh_id: Option<u64>,
+        check: Option<&Check>,
+        now: u64,
+        ttl: u64,
+        return_to: &str,
+    ) -> Response {
+        let claims = self.session_claims(subject, vhost, via, gh_id, check, now, ttl);
+        let Some(session) = token::mint(self.config.session_secret.expose(), &claims) else {
+            log(req, LOG_ERROR, "github-auth: could not mint the session token");
+            return deny(500, "Login could not be completed.");
+        };
+        log(
+            req,
+            LOG_INFO,
+            &format!("github-auth: session issued for {subject} on vhost {vhost:?} (via {via})"),
+        );
+        redirect_to(return_to).header(
+            "Set-Cookie",
+            set_cookie(
+                &self.config.cookie_name,
+                &session,
+                i64::try_from(ttl).unwrap_or(i64::MAX),
+                &self.config.cookie_attrs,
+            ),
+        )
+    }
+
+    /// One-shot startup banner, emitted on the first request because `init`
+    /// has no host logger available to it.
+    fn banner(&self, req: &Request<'_>) {
+        if self.banner_done.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let target = self.config.default_check.as_ref().map_or_else(
+            || format!("{} vhost(s) mapped", self.config.sites.len()),
+            Check::describe,
+        );
+        log(
+            req,
+            LOG_INFO,
+            &format!(
+                "github-auth: active — login {}, callback {}, cookie {} ({}s), target {}, \
+                 bypass {}, TLS {}. This module ISSUES sessions only; a session-verifier \
+                 middleware must be mounted at a higher `order` or a request carrying any \
+                 cookie value will pass through unchecked.",
+                self.config.login_path,
+                self.config.callback_path,
+                self.config.cookie_name,
+                self.config.session_ttl_secs,
+                target,
+                if self.config.bypass_token.is_some() { "enabled" } else { "off" },
+                self.github.trust_anchors(),
+            ),
+        );
+    }
+}
+
+impl Middleware for GithubAuth {
+    fn init(config: &serde_json::Value) -> Result<Self, String> {
+        let config = Config::parse(config)?;
+        let github = GitHub::new(&config).map_err(|e| e.to_string())?;
+        Ok(Self { config, github, banner_done: AtomicBool::new(false) })
+    }
+
+    fn invoke(&self, req: &Request<'_>) -> Response {
+        self.banner(req);
+
+        // The canonical site key the router resolved for this request — the
+        // ONE tenant identity (issue #390). Use only this value below: the
+        // `sites` key, the `site` claim, the state binding and the derived
+        // `redirect_uri`. Since ABI minor 3, `request_vhost_id` IS the canonical
+        // site key (already normalized, suffix-stripped, lowercased) — the exact
+        // value the session verifier checks the `site` claim against, so the
+        // issuer and the verifier agree on tenant identity by construction. That
+        // agreement is what closes issue #396; do not re-derive the vhost from
+        // the raw `Host` here.
+        //
+        // `None` means the request matched no known virtual host — there is no
+        // tenant to gate, so fail closed rather than inventing one from a
+        // client-supplied header.
+        let Some(vhost) = req.vhost_id() else {
+            log(req, LOG_WARN, "github-auth: request matched no known virtual host — rejected");
+            return deny(400, "Bad request.");
+        };
+        // Defense in depth: the router already validated the key, but this
+        // value is interpolated into an outbound `redirect_uri`.
+        if config::validate_vhost(vhost).is_err() {
+            log(req, LOG_WARN, "github-auth: resolved site key is not a usable host name");
+            return deny(400, "Bad request.");
+        }
+
+        let cookies = req.header("cookie").unwrap_or_default();
+        let bypass = self.presented_bypass(req);
+        let now = unix_now();
+
+        match self.route(req.path(), req.query(), cookies, bypass.as_deref()) {
+            Route::HasSession => Response::cont(),
+            Route::StartLogin { return_to } => self.start_login(req, vhost, &return_to, now),
+            Route::Callback => self.handle_callback(req, vhost, now),
+            Route::Bypass => {
+                let return_to = redirect::sanitize_return_to(
+                    &here(req.path(), req.query()),
+                    &self.config.reserved_paths(),
+                );
+                self.issue(
+                    req,
+                    vhost,
+                    "automation",
+                    "bypass",
+                    None,
+                    None,
+                    now,
+                    self.config.bypass_ttl_secs,
+                    &return_to,
+                )
+            }
+        }
+    }
+
+    fn describe() -> &'static str {
+        "github-auth (GitHub OAuth login gate — issues sessions; pair with a session verifier)"
+    }
+}
+
+impl GithubAuth {
+    /// The bypass token presented on this request, if any.
+    ///
+    /// The header form is the default. A query-parameter form exists because
+    /// some tools (and every "just paste a link into a browser" case) cannot
+    /// set headers, but it is **off unless `bypass_query` is configured**:
+    /// a query string lands in access logs, browser history and `Referer`,
+    /// which a header does not.
+    fn presented_bypass(&self, req: &Request<'_>) -> Option<String> {
+        self.config.bypass_token.as_ref()?;
+        if let Some(v) = req.header(&self.config.bypass_header).filter(|v| !v.is_empty()) {
+            return Some(v.to_owned());
+        }
+        let name = self.config.bypass_query.as_deref()?;
+        query_param(req.query(), name)
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+/// Log through the host's `tracing` subscriber.
+///
+/// The module's own `tracing` crate instance has a different global
+/// dispatcher than ePHPm's, so this callback is the only thing that reaches
+/// the server's logs. Nothing passed here may contain a code, a token or a
+/// secret; every call site in this crate is written to that rule.
+fn log(req: &Request<'_>, level: i32, msg: &str) {
+    req.host().log(level, msg);
+}
+
+/// Seconds since the Unix epoch.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_secs())
+}
+
+/// The current request as a return-to (`path` plus `?query`).
+fn here(path: &str, query: &str) -> String {
+    if query.is_empty() { path.to_owned() } else { format!("{path}?{query}") }
+}
+
+/// A 302 with caching disabled.
+///
+/// `no-store` matters: without it a shared cache (or the browser's back/
+/// forward cache) can serve one user the redirect — and the `Set-Cookie` —
+/// minted for another.
+fn redirect_to(location: &str) -> Response {
+    Response::respond(302, Vec::new())
+        .header("Location", location)
+        .header("Cache-Control", "no-store, private")
+}
+
+/// A refusal page. Plain text on purpose: no template, no interpolation of
+/// anything GitHub or the client said, and therefore no way to turn the gate
+/// into a reflected-XSS surface on the preview's own origin.
+fn deny(status: u16, message: &str) -> Response {
+    Response::respond(status, message.as_bytes().to_vec())
+        .header("Content-Type", "text/plain; charset=utf-8")
+        .header("Cache-Control", "no-store, private")
+}
+
+/// An OAuth `code` is an opaque token; anything else is not one.
+fn is_plausible_code(code: &str) -> bool {
+    !code.is_empty()
+        && code.len() <= 512
+        && code.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '~'))
+}
+
+/// Read one parameter out of a raw query string, percent-decoded.
+#[must_use]
+pub fn query_param(query: &str, name: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (percent_decode(k) == name).then(|| percent_decode(v))
+    })
+}
+
+/// `application/x-www-form-urlencoded` decoding. Invalid escapes are left
+/// literal rather than dropped, so a malformed value stays visibly malformed
+/// instead of silently becoming a different valid one.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).ok();
+                if let Some(b) = hex.and_then(|h| u8::from_str_radix(h, 16).ok()) {
+                    out.push(b);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+ephpm_middleware::declare!(GithubAuth);
+
+#[cfg(test)]
+mod tests {
+    #![allow(unsafe_code, reason = "tests build the FFI Request view by hand")]
+
+    use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+    use ephpm_middleware::host::{RequestCtx, host_table};
+
+    use super::*;
+
+    const SESSION_SECRET: &str = "0123456789abcdef0123456789abcdef";
+    const BYPASS: &str = "bypass-token-that-is-long-enough-32";
+
+    fn gate(extra: serde_json::Value) -> GithubAuth {
+        let mut cfg = serde_json::json!({
+            "client_id": "Iv1.test",
+            "client_secret": "client-secret",
+            "session_secret": SESSION_SECRET,
+            "repo": "acme/web",
+            // Loopback so `init` does not need to be pointed at real GitHub.
+            "github_base": "http://127.0.0.1:1",
+            "github_api_base": "http://127.0.0.1:1",
+        });
+        for (k, v) in extra.as_object().cloned().unwrap_or_default() {
+            cfg[k] = v;
+        }
+        GithubAuth::init(&cfg).expect("init")
+    }
+
+    fn invoke(mw: &GithubAuth, path: &str, query: &str, headers: &[(String, String)]) -> Response {
+        let ctx = RequestCtx::new("GET", path, query, "203.0.113.9", "pr-1.preview.test", headers);
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    fn header(resp: &Response, name: &str) -> Option<String> {
+        resp.__headers().iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.clone())
+    }
+
+    fn all_headers(resp: &Response, name: &str) -> Vec<String> {
+        resp.__headers()
+            .iter()
+            .filter(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.clone())
+            .collect()
+    }
+
+    // ── routing: what can reach the network ──────────────────────────────
+
+    #[test]
+    fn only_the_callback_path_can_reach_github() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        let cases = [
+            ("/", "", "", None),
+            ("/index.php", "a=b", "", None),
+            ("/_ephpm/auth/github/login", "", "", None),
+            ("/wp-admin/", "", "ephpm_session=tok", None),
+            ("/", "", "", Some(BYPASS)),
+            // Near misses on the callback path must NOT route to Callback.
+            ("/_ephpm/auth/github/callback/", "code=x", "", None),
+            ("/_ephpm/auth/github/CALLBACK", "code=x", "", None),
+            ("/_ephpm/auth/github/callbackx", "code=x", "", None),
+        ];
+        for (path, query, cookies, bypass) in cases {
+            assert_ne!(
+                mw.route(path, query, cookies, bypass),
+                Route::Callback,
+                "{path} must not reach the GitHub round trip"
+            );
+        }
+        assert_eq!(
+            mw.route("/_ephpm/auth/github/callback", "code=x&state=y", "", None),
+            Route::Callback
+        );
+    }
+
+    #[test]
+    fn a_request_with_a_session_cookie_is_handed_straight_to_the_verifier() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        // Present, valid-looking: CONTINUE.
+        assert_eq!(mw.route("/", "", "ephpm_session=anything", None), Route::HasSession);
+        // Present but garbage: still CONTINUE — judging it is the verifier's
+        // job, and re-deciding it here would be a second, divergent verifier.
+        assert_eq!(mw.route("/", "", "ephpm_session=not.a.token", None), Route::HasSession);
+        // Present alongside a bypass token: the cookie wins, so an automation
+        // client mints once instead of on every request.
+        assert_eq!(mw.route("/", "", "ephpm_session=x", Some(BYPASS)), Route::HasSession);
+        // Empty value is not a session.
+        assert_ne!(mw.route("/", "", "ephpm_session=", None), Route::HasSession);
+    }
+
+    #[test]
+    fn no_cookie_starts_a_login_that_remembers_where_you_were() {
+        let mw = gate(serde_json::json!({}));
+        assert_eq!(
+            mw.route("/wp-admin/edit.php", "post=7", "", None),
+            Route::StartLogin { return_to: "/wp-admin/edit.php?post=7".into() }
+        );
+    }
+
+    #[test]
+    fn login_path_honours_next_but_sanitizes_it() {
+        let mw = gate(serde_json::json!({}));
+        assert_eq!(
+            mw.route("/_ephpm/auth/github/login", "next=%2Fdashboard", "", None),
+            Route::StartLogin { return_to: "/dashboard".into() }
+        );
+        // The verifier hands `next` over verbatim from a client-controlled
+        // URL, so it gets the same treatment as any other return-to.
+        for hostile in ["next=https%3A%2F%2Fevil.test", "next=%2F%2Fevil.test", "next=%2F%5Cevil"] {
+            assert_eq!(
+                mw.route("/_ephpm/auth/github/login", hostile, "", None),
+                Route::StartLogin { return_to: "/".into() },
+                "{hostile} must not survive"
+            );
+        }
+    }
+
+    // ── the 302 to GitHub ───────────────────────────────────────────────
+
+    #[test]
+    fn unauthenticated_request_redirects_to_github_with_a_state() {
+        let mw = gate(serde_json::json!({ "github_base": "http://127.0.0.1:1" }));
+        let resp = invoke(&mw, "/secret.php", "x=1", &[]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 302);
+        assert!(resp.__body().is_empty(), "no body — PHP never ran and neither did a template");
+
+        let location = header(&resp, "Location").expect("Location");
+        assert!(location.starts_with("http://127.0.0.1:1/login/oauth/authorize?"));
+        assert!(location.contains("client_id=Iv1.test"));
+        assert!(location.contains("&state="), "state is mandatory (CSRF)");
+        assert!(
+            location.contains(
+                "redirect_uri=https%3A%2F%2Fpr-1.preview.test%2F_ephpm%2Fauth%2Fgithub%2Fcallback"
+            ),
+            "redirect_uri derives from the request's vhost: {location}"
+        );
+
+        let set = header(&resp, "Set-Cookie").expect("state cookie");
+        assert!(set.starts_with("ephpm_session_oauth="));
+        assert!(set.contains("HttpOnly") && set.contains("Secure") && set.contains("SameSite=Lax"));
+        assert!(set.contains("Max-Age=600"));
+        assert_eq!(header(&resp, "Cache-Control").as_deref(), Some("no-store, private"));
+    }
+
+    #[test]
+    fn scopes_are_omitted_unless_configured() {
+        assert!(
+            !header(&invoke(&gate(serde_json::json!({})), "/", "", &[]), "Location")
+                .expect("Location")
+                .contains("scope="),
+            "an empty scope list is the GitHub App shape and must not send `scope=`"
+        );
+        let mw = gate(serde_json::json!({ "scopes": ["read:user", "repo"] }));
+        assert!(
+            header(&invoke(&mw, "/", "", &[]), "Location")
+                .expect("Location")
+                .contains("scope=read%3Auser%20repo")
+        );
+    }
+
+    #[test]
+    fn an_unmapped_vhost_is_denied_rather_than_defaulted() {
+        let mw = gate(serde_json::json!({
+            "sites": { "pr-2.preview.test": { "repo": "acme/other" } },
+        }));
+        let resp = invoke(&mw, "/", "", &[]);
+        assert_eq!(resp.__status(), 403, "an unmapped host must not inherit another tenant's rule");
+    }
+
+    // ── callback: CSRF ──────────────────────────────────────────────────
+
+    /// Drive a login, then replay its state cookie into a callback.
+    fn login_state_cookie(mw: &GithubAuth) -> (String, String) {
+        let resp = invoke(mw, "/dashboard", "", &[]);
+        let location = header(&resp, "Location").expect("Location");
+        let state = query_param(location.split_once('?').expect("query").1, "state")
+            .expect("state parameter");
+        let cookie = header(&resp, "Set-Cookie").expect("Set-Cookie");
+        let value = cookie.split(';').next().expect("cookie pair").to_owned();
+        (state, value)
+    }
+
+    #[test]
+    fn callback_without_a_state_cookie_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let resp = invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=whatever", &[]);
+        assert_eq!(resp.__status(), 400);
+        assert!(
+            all_headers(&resp, "Set-Cookie").iter().all(|c| !c.starts_with("ephpm_session=")),
+            "a rejected callback must not issue a session"
+        );
+    }
+
+    #[test]
+    fn callback_with_a_forged_state_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let (_state, cookie) = login_state_cookie(&mw);
+        let headers = vec![("Cookie".to_owned(), cookie)];
+        for forged in
+            ["", "state=", "state=guessed", "state=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]
+        {
+            let q = if forged.is_empty() {
+                "code=abc".to_owned()
+            } else {
+                format!("code=abc&{forged}")
+            };
+            let resp = invoke(&mw, "/_ephpm/auth/github/callback", &q, &headers);
+            assert_eq!(resp.__status(), 400, "state {forged:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn callback_with_a_state_cookie_signed_by_someone_else_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        // Mint a state token under a different key — the shape is right, the
+        // signature is not.
+        let other = token::derive_key(b"a-completely-different-secret-key", token::STATE_KEY_LABEL);
+        let forged = token::mint(
+            &other,
+            &serde_json::json!({ "n": "abc", "rt": "/", "v": "pr-1.preview.test", "exp": unix_now() + 300 }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={forged}"))];
+        let resp = invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=abc", &headers);
+        assert_eq!(resp.__status(), 400);
+    }
+
+    #[test]
+    fn callback_state_is_bound_to_the_host_it_was_issued_on() {
+        let mw = gate(serde_json::json!({}));
+        let state_token = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({
+                "n": "nonce-value", "rt": "/", "v": "other.preview.test",
+                "exp": unix_now() + 300,
+            }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state_token}"))];
+        let resp =
+            invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=nonce-value", &headers);
+        assert_eq!(
+            resp.__status(),
+            400,
+            "a state minted for another tenant must not complete here"
+        );
+    }
+
+    #[test]
+    fn expired_state_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let state_token = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({ "n": "n", "rt": "/", "v": "pr-1.preview.test", "exp": 1_000 }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state_token}"))];
+        let resp = invoke(&mw, "/_ephpm/auth/github/callback", "code=abc&state=n", &headers);
+        assert_eq!(resp.__status(), 400);
+    }
+
+    #[test]
+    fn callback_rejects_an_implausible_code_before_any_network_call() {
+        let mw = gate(serde_json::json!({}));
+        let (state, cookie) = login_state_cookie(&mw);
+        let headers = vec![("Cookie".to_owned(), cookie)];
+        // `github_base` points at 127.0.0.1:1 (closed), so a network attempt
+        // would surface as 502. A 400 proves the code was refused first.
+        for bad in ["", "a b", "a/b", "<script>", &"x".repeat(513)] {
+            let q = format!("code={}&state={state}", github::encode_query(bad));
+            let resp = invoke(&mw, "/_ephpm/auth/github/callback", &q, &headers);
+            assert_eq!(resp.__status(), 400, "code {bad:?} must be refused locally");
+        }
+    }
+
+    // ── bypass ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn bypass_token_issues_a_normal_session() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS, "bypass_ttl_secs": 900 }));
+        let headers = vec![("x-ephpm-bypass".to_owned(), BYPASS.to_owned())];
+        let resp = invoke(&mw, "/report", "a=1", &headers);
+        assert_eq!(resp.__status(), 302);
+        assert_eq!(header(&resp, "Location").as_deref(), Some("/report?a=1"));
+        let set = header(&resp, "Set-Cookie").expect("session cookie");
+        assert!(set.starts_with("ephpm_session="));
+        assert!(set.contains("Max-Age=900"));
+    }
+
+    #[test]
+    fn a_wrong_bypass_token_falls_through_to_github_and_never_pretends_otherwise() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        for wrong in
+            ["", "x", "bypass-token-that-is-long-enough-3", "bypass-token-that-is-long-enough-320"]
+        {
+            let headers = vec![("x-ephpm-bypass".to_owned(), wrong.to_owned())];
+            let resp = invoke(&mw, "/", "", &headers);
+            assert_eq!(resp.__status(), 302);
+            assert!(
+                header(&resp, "Location").expect("Location").contains("/login/oauth/authorize"),
+                "a wrong bypass token must behave exactly like no token at all"
+            );
+        }
+    }
+
+    #[test]
+    fn the_bypass_query_parameter_is_off_unless_asked_for() {
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS }));
+        let resp = invoke(&mw, "/", &format!("_bypass={BYPASS}"), &[]);
+        assert!(header(&resp, "Location").expect("Location").contains("/login/oauth/authorize"));
+
+        let mw = gate(serde_json::json!({ "bypass_token": BYPASS, "bypass_query": "_bypass" }));
+        let resp = invoke(&mw, "/", &format!("_bypass={BYPASS}"), &[]);
+        assert!(header(&resp, "Set-Cookie").expect("Set-Cookie").starts_with("ephpm_session="));
+    }
+
+    // ── issued token ────────────────────────────────────────────────────
+
+    #[test]
+    fn issued_sessions_carry_the_documented_claims() {
+        let mw = gate(serde_json::json!({ "audience": "preview", "issuer": "switchboard" }));
+        let claims = mw.session_claims(
+            "octocat",
+            "pr-1.preview.test",
+            "github",
+            Some(583_231),
+            Some(&Check::Repo { owner: "acme".into(), name: "web".into() }),
+            1_000,
+            3_600,
+        );
+        assert_eq!(claims["iss"], "switchboard");
+        assert_eq!(claims["sub"], "octocat");
+        assert_eq!(claims["aud"], "preview");
+        assert_eq!(claims["iat"], 1_000);
+        assert_eq!(claims["exp"], 4_600);
+        assert_eq!(claims["site"], "pr-1.preview.test");
+        assert_eq!(claims["via"], "github");
+        assert_eq!(claims["gh_id"], 583_231);
+        assert_eq!(claims["check"], "repo acme/web");
+    }
+
+    #[test]
+    fn an_externally_minted_share_token_is_the_same_object() {
+        // The share-link claim: a control plane holding `session_secret` can
+        // mint an acceptable session with no help from this module.
+        let mw = gate(serde_json::json!({}));
+        let external = token::mint(
+            mw.config.session_secret.expose(),
+            &serde_json::json!({
+                "iss": "ephpm-github-auth", "sub": "share:designer@example.com",
+                "site": "pr-1.preview.test", "via": "share",
+                "iat": unix_now(), "exp": unix_now() + 7_200,
+            }),
+        )
+        .expect("mint");
+        // Same three-part HS256 shape as one this module issues.
+        assert_eq!(external.split('.').count(), 3);
+        // And it is what the gate treats as a session.
+        assert_eq!(
+            mw.route("/", "", &format!("ephpm_session={external}"), None),
+            Route::HasSession
+        );
+    }
+
+    // ── misc ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_session_cookie_costs_nothing_and_adds_no_headers() {
+        let mw = gate(serde_json::json!({}));
+        let headers = vec![("Cookie".to_owned(), "ephpm_session=abc.def.ghi".to_owned())];
+        let resp = invoke(&mw, "/index.php", "", &headers);
+        assert_eq!(resp.__action(), ACTION_CONTINUE);
+        assert!(resp.__headers().is_empty());
+        assert!(resp.__response_headers().is_empty());
+    }
+
+    #[test]
+    fn the_resolved_site_key_is_used_verbatim_as_the_identity() {
+        // Since ABI minor 3, `request_vhost_id` IS the router's canonical site
+        // key — already normalized, one spelling per host. This module trusts
+        // that and uses it verbatim as the `site` claim, the `sites` key and
+        // the derived `redirect_uri`, so it agrees with the session verifier by
+        // construction (issue #396). The "two Host spellings collapse to one
+        // identity" property now lives in the router's `resolve_site`, not here.
+        let mw = gate(serde_json::json!({}));
+        let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", "pr-1.preview.test", &[]);
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        let resp = mw.invoke(&req);
+        assert_eq!(resp.__status(), 302);
+        let loc = header(&resp, "Location").expect("Location");
+        let redirect_uri = loc
+            .split("redirect_uri=")
+            .nth(1)
+            .and_then(|s| s.split('&').next())
+            .expect("redirect_uri");
+        assert!(redirect_uri.contains("pr-1.preview.test"), "{redirect_uri}");
+    }
+
+    #[test]
+    fn a_request_that_matched_no_vhost_is_rejected() {
+        // Empty site key ⇒ `vhost_id()` reads as `None` ⇒ no tenant to gate ⇒
+        // fail closed rather than inventing a tenant from the `Host` (#390).
+        let mw = gate(serde_json::json!({}));
+        let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", "", &[]);
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert_eq!(mw.invoke(&req).__status(), 400);
+    }
+
+    #[test]
+    fn a_hostile_host_header_is_rejected() {
+        let mw = gate(serde_json::json!({}));
+        let ctx = RequestCtx::new("GET", "/", "", "203.0.113.9", "evil.test/../x", &[]);
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        assert_eq!(mw.invoke(&req).__status(), 400);
+    }
+
+    #[test]
+    fn query_parsing_decodes_and_does_not_confuse_prefixes() {
+        assert_eq!(query_param("a=1&next=%2Fx%20y", "next").as_deref(), Some("/x y"));
+        assert_eq!(query_param("nextish=1&next=2", "next").as_deref(), Some("2"));
+        assert_eq!(query_param("a=1", "b"), None);
+        assert_eq!(query_param("", "a"), None);
+        assert_eq!(query_param("a=b+c", "a").as_deref(), Some("b c"));
+        // A truncated escape stays literal rather than silently changing.
+        assert_eq!(query_param("a=%2", "a").as_deref(), Some("%2"));
+        assert_eq!(query_param("a=%zz", "a").as_deref(), Some("%zz"));
+    }
+
+    #[test]
+    fn describe_names_the_pairing_requirement() {
+        assert!(GithubAuth::describe().contains("session verifier"));
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/redirect.rs
+++ b/crates/ephpm-middleware-github-auth/src/redirect.rs
@@ -1,0 +1,200 @@
+//! Return-to validation — the open-redirect and header-injection defence.
+//!
+//! A login gate has to remember where the user was going, and that value is
+//! attacker-controlled: anyone can hand a victim
+//! `https://preview.example.com/anything` and the gate will faithfully carry
+//! the path through GitHub and back into a `Location:` header. If the check
+//! is sloppy the gate becomes an open redirector wearing the preview site's
+//! hostname — which is exactly the property phishing wants, because the
+//! *first* hop is genuinely the site the victim expects.
+//!
+//! [`sanitize_return_to`] therefore does not try to parse a URL and compare
+//! origins. It applies an allowlist: a return-to is either an unambiguous
+//! **same-origin absolute path** or it is replaced by `/`. There is no
+//! rejection path a caller can forget to handle.
+//!
+//! # What is rejected, and why
+//!
+//! | Input shape | Example | Why |
+//! |---|---|---|
+//! | absolute URL | `https://evil.test/x` | different origin |
+//! | scheme-relative | `//evil.test/x` | browsers resolve this against the current scheme — a different origin |
+//! | backslash forms | `/\evil.test`, `\\evil.test` | WHATWG URL parsing treats `\` as `/`, so these are scheme-relative too |
+//! | any `\` at all | `/a\b` | belt and braces: no legitimate path needs one, and normalisation differs between browsers |
+//! | non-`/` start | `evil.test`, `?a=1`, `javascript:…` | relative or a scheme; only absolute paths are same-origin by construction |
+//! | control characters | a raw CR/LF (a decoded `%0d%0a`) | `Location:` header injection / response splitting |
+//! | `..` segments | `/..//evil.test` | same-origin per RFC 3986 and WHATWG, rejected anyway — no return-to needs one |
+//! | non-ASCII | `/café` | a `Location` value must be ASCII; clients percent-encode, so a raw non-ASCII byte is a sign of something else |
+//! | over-long | 2 KiB+ | bounded work, bounded header |
+//! | the gate's own paths | `/…/auth/github/login` | a redirect loop, not a destination |
+//!
+//! Percent-encoded separators (`/%2f%2fevil.test`, `/%5c%5cevil.test`) are
+//! **kept**. They are not a bypass: browsers do not decode `%2f`/`%5c` before
+//! resolving a URL, so the request stays on this origin as a path whose first
+//! segment happens to be `%2f%2fevil.test`. Rejecting them would break
+//! legitimate paths that contain encoded slashes.
+
+/// Longest return-to accepted. Anything beyond this is replaced by `/`.
+const MAX_RETURN_TO: usize = 2048;
+
+/// Reduce an attacker-supplied return-to to a safe same-origin path.
+///
+/// Returns the input unchanged when it is an unambiguous absolute path on
+/// this origin, and `"/"` in every other case — including the empty string.
+/// `reserved` lists paths the gate owns (login, callback); a return-to that
+/// targets one of them would loop, so it is replaced too.
+///
+/// This is deliberately total: there is no `Err` for a caller to swallow.
+#[must_use]
+pub fn sanitize_return_to(raw: &str, reserved: &[&str]) -> String {
+    if is_safe_return_to(raw, reserved) { raw.to_owned() } else { "/".to_owned() }
+}
+
+/// The predicate behind [`sanitize_return_to`], split out so tests can state
+/// the intent directly.
+#[must_use]
+pub fn is_safe_return_to(raw: &str, reserved: &[&str]) -> bool {
+    if raw.len() > MAX_RETURN_TO {
+        return false;
+    }
+    // Must be an absolute path. This alone rules out `https://evil.test`,
+    // `javascript:…`, `evil.test` and `?a=1`.
+    let Some(rest) = raw.strip_prefix('/') else {
+        return false;
+    };
+    // `//evil.test` is scheme-relative; `/\evil.test` is the same thing after
+    // WHATWG backslash normalisation. Checking the *whole* string for `\`
+    // covers both and costs nothing.
+    if rest.starts_with('/') || raw.contains('\\') {
+        return false;
+    }
+    // ASCII, no controls, no DEL. Blocks CR/LF response splitting into the
+    // `Location:` header, and raw tabs/NULs that different parsers disagree
+    // about.
+    if !raw.is_ascii() || raw.chars().any(|c| c.is_ascii_control()) {
+        return false;
+    }
+    // A space is legal in a path only percent-encoded; a raw one would be
+    // re-parsed by some clients as the end of the header value.
+    if raw.contains(' ') {
+        return false;
+    }
+    // Reject `..` segments. `/..//evil.test` is *technically* still
+    // same-origin — RFC 3986 dot-segment removal leaves the authority alone,
+    // and so does the WHATWG parser — but the value of that guarantee is
+    // "every client agrees with the spec", which is not a bet worth taking on
+    // a redirect target when no legitimate return-to needs a `..`.
+    let path_part = raw.split(['?', '#']).next().unwrap_or(raw);
+    if path_part.split('/').any(|seg| seg == "..") {
+        return false;
+    }
+    // The gate's own endpoints are not destinations.
+    let path_only = raw.split(['?', '#']).next().unwrap_or(raw);
+    !reserved.contains(&path_only)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Paths the gate owns, as `lib.rs` passes them.
+    const RESERVED: &[&str] = &["/_ephpm/auth/github/login", "/_ephpm/auth/github/callback"];
+
+    #[test]
+    fn plain_paths_survive() {
+        for ok in [
+            "/",
+            "/index.php",
+            "/wp-admin/",
+            "/a/b/c?d=e&f=g",
+            "/search?q=%20quoted%20",
+            "/page#anchor",
+            // Encoded separators stay: browsers do not decode them before
+            // resolving, so these remain same-origin paths.
+            "/%2f%2fevil.test",
+            "/%5c%5cevil.test",
+            // A query value that merely *mentions* another origin is fine —
+            // the browser still navigates to this origin.
+            "/redirect?next=https://evil.test",
+        ] {
+            assert!(is_safe_return_to(ok, RESERVED), "{ok} should be accepted");
+            assert_eq!(sanitize_return_to(ok, RESERVED), ok);
+        }
+    }
+
+    #[test]
+    fn hostile_inputs_collapse_to_root() {
+        // Every one of these was tried against the gate; each must come back
+        // as `/` rather than as a redirect off this origin.
+        for bad in [
+            "",
+            // Absolute URLs, every scheme shape.
+            "https://evil.test",
+            "http://evil.test/x",
+            "//evil.test",
+            "///evil.test",
+            "////evil.test",
+            "https:/\\evil.test",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "vbscript:msgbox(1)",
+            // Dot segments: same-origin per spec, rejected anyway (see the
+            // predicate) because it costs nothing and removes a whole class
+            // of "does this client normalise like the spec says" doubt.
+            "/..//evil.test",
+            "/a/../../evil",
+            "/..",
+            "/foo/..",
+            // Backslash normalisation.
+            "/\\evil.test",
+            "\\\\evil.test",
+            "\\/evil.test",
+            "/path\\..\\..\\evil",
+            // Not absolute.
+            "evil.test",
+            "?next=/",
+            "#fragment",
+            "../../etc/passwd",
+            // Userinfo trick — still not a path.
+            "//user@evil.test/",
+            "https://preview.example.com@evil.test/",
+            // Header injection / response splitting.
+            "/ok\r\nSet-Cookie: pwned=1",
+            "/ok\nLocation: https://evil.test",
+            "/ok\rX: y",
+            "/ok\0",
+            "/ok\ttab",
+            "/ok\x0bvtab",
+            // Raw space ends a header value for some parsers.
+            "/ok evil",
+            // Non-ASCII.
+            "/café",
+            "/\u{202e}gnp.exe",
+            // Loops back into the gate.
+            "/_ephpm/auth/github/login",
+            "/_ephpm/auth/github/callback",
+            "/_ephpm/auth/github/callback?code=x&state=y",
+        ] {
+            assert!(!is_safe_return_to(bad, RESERVED), "{bad:?} must be rejected");
+            assert_eq!(sanitize_return_to(bad, RESERVED), "/", "{bad:?} must collapse to /");
+        }
+    }
+
+    #[test]
+    fn over_long_is_rejected() {
+        let long = format!("/{}", "a".repeat(MAX_RETURN_TO));
+        assert!(!is_safe_return_to(&long, RESERVED));
+        // Exactly at the cap is still fine.
+        let at_cap = format!("/{}", "a".repeat(MAX_RETURN_TO - 1));
+        assert_eq!(at_cap.len(), MAX_RETURN_TO);
+        assert!(is_safe_return_to(&at_cap, RESERVED));
+    }
+
+    #[test]
+    fn reserved_match_is_exact_not_prefix() {
+        // A real application page that merely shares a prefix with the gate's
+        // endpoints is a legitimate destination.
+        assert!(is_safe_return_to("/_ephpm/auth/github/login-help", RESERVED));
+        assert!(is_safe_return_to("/_ephpm/auth/github/callbacks", RESERVED));
+    }
+}

--- a/crates/ephpm-middleware-github-auth/src/token.rs
+++ b/crates/ephpm-middleware-github-auth/src/token.rs
@@ -1,0 +1,271 @@
+//! HS256 token minting, plus the two constant-time comparisons this module
+//! needs.
+//!
+//! # Format, and who owns it
+//!
+//! The session this module issues is a **compact HS256 JWT** — the same shape
+//! the in-tree `jwt` builtin (`crates/ephpm-middleware-builtins/src/jwt.rs`)
+//! already verifies, down to `alg` pinning and a mandatory `exp`. That is not
+//! a coincidence and not a new invention: the hot-path verifier is a separate
+//! module, this one only *issues*, and picking the format the workspace
+//! already verifies is what keeps the two from diverging.
+//!
+//! Nothing here verifies a session token. Reading the session cookie is the
+//! verifier's job; see the crate docs for how the two modules compose.
+//!
+//! # Why it is self-contained
+//!
+//! No server-side session record exists, anywhere. The token carries its own
+//! subject, its own expiry and its own audience, and a restart or a second
+//! node changes nothing — there is no store to lose, replicate or evict. It
+//! also keeps the module clear of the process-global (not per-site)
+//! middleware KV surface tracked in ephpm#376.
+//!
+//! The direct consequence, which belongs in the operator's head and not just
+//! in a footnote: **an issued token cannot be revoked before it expires.**
+//! Session lifetime is therefore the blast radius of a stolen cookie, which
+//! is why `session_ttl_secs` defaults to eight hours rather than a week.
+//!
+//! # Key separation
+//!
+//! The OAuth `state` cookie is signed with a key *derived* from the session
+//! secret rather than the secret itself
+//! ([`derive_key`]). A `state` token and a session token can then never be
+//! swapped for one another even though both are HS256 and both are minted
+//! here — forging one from the other would require inverting HMAC.
+
+use base64ct::{Base64UrlUnpadded, Encoding as _};
+use hmac::{Hmac, Mac as _};
+use sha2::Sha256;
+
+/// Fixed JOSE header. `alg` is pinned so a verifier can reject anything else
+/// (the `alg: none` family of attacks).
+const HEADER_JSON: &str = r#"{"alg":"HS256","typ":"JWT"}"#;
+
+/// Domain-separation label for the OAuth `state` signing key.
+pub const STATE_KEY_LABEL: &[u8] = b"ephpm-github-auth/oauth-state/v1";
+
+/// Derive a subkey from the session secret for a specific purpose.
+///
+/// `HMAC-SHA256(secret, label)`. Used so the `state` cookie and the session
+/// cookie are signed under keys that cannot be substituted for each other.
+#[must_use]
+pub fn derive_key(secret: &[u8], label: &[u8]) -> Vec<u8> {
+    let mut mac = new_mac(secret);
+    mac.update(label);
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// `Hmac<Sha256>` over an arbitrary-length key.
+///
+/// `new_from_slice` is documented as infallible for HMAC (any key length is
+/// accepted, being hashed down when over-long), so the `expect` is a type
+/// artefact rather than a reachable path.
+fn new_mac(key: &[u8]) -> Hmac<Sha256> {
+    Hmac::<Sha256>::new_from_slice(key).expect("HMAC accepts keys of any length")
+}
+
+/// Mint a compact HS256 JWT carrying `claims`.
+///
+/// `claims` must be a JSON object; the caller is responsible for including
+/// `exp`. Returns `None` only if `claims` cannot be serialised, which for a
+/// `serde_json::Value` built in-process does not happen.
+#[must_use]
+pub fn mint(secret: &[u8], claims: &serde_json::Value) -> Option<String> {
+    let payload = serde_json::to_vec(claims).ok()?;
+    let header_b64 = Base64UrlUnpadded::encode_string(HEADER_JSON.as_bytes());
+    let payload_b64 = Base64UrlUnpadded::encode_string(&payload);
+
+    let mut mac = new_mac(secret);
+    mac.update(header_b64.as_bytes());
+    mac.update(b".");
+    mac.update(payload_b64.as_bytes());
+    let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+
+    Some(format!("{header_b64}.{payload_b64}.{sig}"))
+}
+
+/// Verify a token minted by [`mint`] and return its claims.
+///
+/// **Only used for this module's own OAuth `state` cookie.** The session
+/// cookie is verified by the separate hot-path module, never here.
+///
+/// The signature is checked *before* the payload is parsed, so no
+/// unauthenticated JSON is ever deserialised, and `exp` is mandatory.
+#[must_use]
+pub fn verify(secret: &[u8], token: &str, now: u64) -> Option<serde_json::Value> {
+    let mut parts = token.split('.');
+    let (header_b64, payload_b64, sig_b64) = (parts.next()?, parts.next()?, parts.next()?);
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let sig = Base64UrlUnpadded::decode_vec(sig_b64).ok()?;
+    let mut mac = new_mac(secret);
+    mac.update(header_b64.as_bytes());
+    mac.update(b".");
+    mac.update(payload_b64.as_bytes());
+    // Constant-time: `verify_slice` compares through `subtle::ConstantTimeEq`.
+    mac.verify_slice(&sig).ok()?;
+
+    // The MAC is ours, but still pin the algorithm.
+    let header: serde_json::Value =
+        serde_json::from_slice(&Base64UrlUnpadded::decode_vec(header_b64).ok()?).ok()?;
+    if header.get("alg").and_then(serde_json::Value::as_str) != Some("HS256") {
+        return None;
+    }
+
+    let claims: serde_json::Value =
+        serde_json::from_slice(&Base64UrlUnpadded::decode_vec(payload_b64).ok()?).ok()?;
+    let exp = claims.get("exp").and_then(serde_json::Value::as_u64)?;
+    if exp <= now {
+        return None;
+    }
+    Some(claims)
+}
+
+/// Constant-time equality for two secrets of arbitrary, possibly differing,
+/// length.
+///
+/// Comparing the HMACs rather than the bytes is what makes the timing
+/// independent of both the contents *and* the length of `presented` — a plain
+/// `==` on `&str` leaks the length of the shared secret and the position of
+/// the first differing byte, which is enough to walk a token out of a server
+/// one character at a time.
+///
+/// `key` only needs to be unpredictable to the attacker; the module passes
+/// the derived state key.
+#[must_use]
+pub fn constant_time_eq(key: &[u8], presented: &[u8], expected: &[u8]) -> bool {
+    let mut a = new_mac(key);
+    a.update(presented);
+    let mut b = new_mac(key);
+    b.update(expected);
+    a.verify_slice(&b.finalize().into_bytes()).is_ok()
+}
+
+/// Fill `out` with cryptographically secure random bytes.
+///
+/// # Panics
+///
+/// Panics if the OS entropy source fails. That is not a recoverable
+/// condition for a module whose whole job is issuing credentials, and
+/// `declare!` converts the panic into a fail-closed `500` rather than a
+/// login with a predictable `state`.
+pub fn random_bytes(out: &mut [u8]) {
+    getrandom::fill(out).expect("OS entropy source unavailable");
+}
+
+/// 32 bytes of entropy, base64url-encoded — the OAuth `state` nonce.
+#[must_use]
+pub fn random_nonce() -> String {
+    let mut buf = [0u8; 32];
+    random_bytes(&mut buf);
+    Base64UrlUnpadded::encode_string(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"a-test-secret-at-least-32-bytes-long!!";
+
+    fn claims(exp: u64) -> serde_json::Value {
+        serde_json::json!({ "sub": "octocat", "exp": exp })
+    }
+
+    #[test]
+    fn round_trip() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        let got = verify(SECRET, &t, 1_000).expect("verify");
+        assert_eq!(got["sub"], "octocat");
+    }
+
+    #[test]
+    fn minted_token_has_the_jwt_shape_the_builtin_verifier_expects() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        let parts: Vec<&str> = t.split('.').collect();
+        assert_eq!(parts.len(), 3, "compact JWS serialisation");
+        let header = Base64UrlUnpadded::decode_vec(parts[0]).expect("header b64url");
+        let header: serde_json::Value = serde_json::from_slice(&header).expect("header json");
+        assert_eq!(header["alg"], "HS256");
+        assert_eq!(header["typ"], "JWT");
+        // Unpadded base64url: no '=' anywhere, and no '+' or '/'.
+        assert!(!t.contains('='), "padding would break cookie and URL use");
+        assert!(!t.contains('+') && !t.contains('/'));
+    }
+
+    #[test]
+    fn wrong_secret_fails() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        assert!(verify(b"different-secret", &t, 1_000).is_none());
+    }
+
+    #[test]
+    fn tampered_payload_fails() {
+        let t = mint(SECRET, &claims(2_000)).expect("mint");
+        let mut parts: Vec<String> = t.split('.').map(str::to_owned).collect();
+        parts[1] = Base64UrlUnpadded::encode_string(br#"{"sub":"admin","exp":2000}"#);
+        assert!(verify(SECRET, &parts.join("."), 1_000).is_none());
+    }
+
+    #[test]
+    fn expired_and_missing_exp_fail() {
+        let t = mint(SECRET, &claims(1_000)).expect("mint");
+        assert!(verify(SECRET, &t, 1_000).is_none(), "exp == now is expired");
+        assert!(verify(SECRET, &t, 5_000).is_none());
+        let no_exp = mint(SECRET, &serde_json::json!({ "sub": "x" })).expect("mint");
+        assert!(verify(SECRET, &no_exp, 1_000).is_none(), "exp is mandatory");
+    }
+
+    #[test]
+    fn alg_none_is_rejected_even_with_a_valid_mac() {
+        // Forge a token through the same MAC path but with `alg: none`.
+        let header_b64 = Base64UrlUnpadded::encode_string(br#"{"alg":"none"}"#);
+        let payload_b64 = Base64UrlUnpadded::encode_string(br#"{"sub":"x","exp":2000}"#);
+        let mut mac = new_mac(SECRET);
+        mac.update(header_b64.as_bytes());
+        mac.update(b".");
+        mac.update(payload_b64.as_bytes());
+        let sig = Base64UrlUnpadded::encode_string(&mac.finalize().into_bytes());
+        let forged = format!("{header_b64}.{payload_b64}.{sig}");
+        assert!(verify(SECRET, &forged, 1_000).is_none());
+    }
+
+    #[test]
+    fn malformed_tokens_fail() {
+        for bad in ["", "a", "a.b", "a.b.c.d", "....", "not-base64!.x.y"] {
+            assert!(verify(SECRET, bad, 1_000).is_none(), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn derived_keys_are_domain_separated() {
+        let state_key = derive_key(SECRET, STATE_KEY_LABEL);
+        assert_ne!(state_key.as_slice(), SECRET, "the state key is not the session key");
+        // A token signed for one domain must not verify under the other.
+        let t = mint(&state_key, &claims(2_000)).expect("mint");
+        assert!(verify(SECRET, &t, 1_000).is_none());
+        let s = mint(SECRET, &claims(2_000)).expect("mint");
+        assert!(verify(&state_key, &s, 1_000).is_none());
+    }
+
+    #[test]
+    fn constant_time_eq_matches_semantics_of_equality() {
+        let k = b"key";
+        assert!(constant_time_eq(k, b"abc", b"abc"));
+        assert!(!constant_time_eq(k, b"abc", b"abd"));
+        assert!(!constant_time_eq(k, b"abc", b"abcd"), "length differences are unequal");
+        assert!(!constant_time_eq(k, b"", b"abc"));
+        assert!(constant_time_eq(k, b"", b""));
+    }
+
+    #[test]
+    fn nonces_are_unique_and_url_safe() {
+        let a = random_nonce();
+        let b = random_nonce();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 43, "32 bytes, unpadded base64url");
+        assert!(a.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+}

--- a/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
+++ b/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
@@ -1,0 +1,484 @@
+//! The OAuth round trip, driven against a stub GitHub over real sockets.
+//!
+//! A real `github.com` round trip cannot be completed unattended — it needs a
+//! human at a browser and a registered GitHub App. Everything *this side* of
+//! that can be exercised for real, and is: a loopback HTTP server stands in
+//! for `github.com` and `api.github.com`, and the module's own
+//! `reqwest`/`rustls` client talks to it over an actual TCP connection with
+//! actual request and response bytes. The token exchange, the `Authorization`
+//! header, the JSON parsing, the access decision, the `Set-Cookie` and the
+//! `Location` are all the shipping code paths.
+//!
+//! What the stub cannot tell you: that GitHub's real responses match these
+//! shapes, and that a real App's redirect URL is registered correctly. Those
+//! need a human with a GitHub App — see the README's verification table.
+//!
+//! The stub also **counts every request it receives**, which is how the most
+//! important assertion in this file is made:
+//! [`a_request_with_a_session_makes_no_network_call`] shows the counter does
+//! not move.
+//!
+//! The crate's `[lib] name` is `github_auth` (that is what the loadable
+//! artefact is called), so it is imported under that name here.
+#![allow(unsafe_code, reason = "the test builds the FFI Request view by hand")]
+
+use std::io::{BufRead as _, BufReader, Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use ephpm_middleware::abi::{ACTION_CONTINUE, ACTION_RESPOND};
+use ephpm_middleware::host::{RequestCtx, host_table};
+use ephpm_middleware::{Middleware as _, Request, Response};
+use github_auth::{GithubAuth, query_param};
+
+const VHOST: &str = "pr-1.preview.test";
+const SESSION_SECRET: &str = "0123456789abcdef0123456789abcdef";
+const CLIENT_SECRET: &str = "stub-client-secret";
+const GOOD_CODE: &str = "goodcode";
+const ACCESS_TOKEN: &str = "gho_stubtoken";
+
+// ── the stub GitHub ───────────────────────────────────────────────────────
+
+/// What the stub saw, so tests can assert on traffic rather than on outcomes
+/// alone.
+#[derive(Default)]
+struct Seen {
+    /// `"METHOD PATH"` for every request served.
+    requests: Vec<String>,
+    /// Bodies of the token-exchange POSTs.
+    token_bodies: Vec<String>,
+    /// `Authorization` header values seen on API calls.
+    authorizations: Vec<String>,
+}
+
+struct Stub {
+    base: String,
+    seen: Arc<Mutex<Seen>>,
+    count: Arc<AtomicUsize>,
+}
+
+impl Stub {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let base = format!("http://{}", listener.local_addr().expect("addr"));
+        let seen = Arc::new(Mutex::new(Seen::default()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let (seen_t, count_t) = (Arc::clone(&seen), Arc::clone(&count));
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                // One request per connection; every response carries
+                // `Connection: close`, so the client opens a fresh one.
+                handle(stream, &seen_t, &count_t);
+            }
+        });
+        Self { base, seen, count }
+    }
+
+    fn requests(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+
+    fn seen(&self) -> std::sync::MutexGuard<'_, Seen> {
+        self.seen.lock().expect("stub state")
+    }
+}
+
+fn handle(mut stream: TcpStream, seen: &Arc<Mutex<Seen>>, count: &Arc<AtomicUsize>) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+    let mut line = String::new();
+    if reader.read_line(&mut line).is_err() || line.is_empty() {
+        return;
+    }
+    let mut parts = line.split_whitespace();
+    let (method, path) =
+        (parts.next().unwrap_or("").to_owned(), parts.next().unwrap_or("").to_owned());
+
+    let mut content_length = 0usize;
+    let mut authorization = String::new();
+    loop {
+        let mut h = String::new();
+        if reader.read_line(&mut h).is_err() || h.trim().is_empty() {
+            break;
+        }
+        let lower = h.to_ascii_lowercase();
+        if let Some(v) = lower.strip_prefix("content-length:") {
+            content_length = v.trim().parse().unwrap_or(0);
+        } else if lower.starts_with("authorization:") {
+            // Split the ORIGINAL line — the token is case-sensitive.
+            authorization.clear();
+            authorization.push_str(h.split_once(':').map_or("", |(_, v)| v.trim()));
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 && reader.read_exact(&mut body).is_err() {
+        return;
+    }
+    let body = String::from_utf8_lossy(&body).into_owned();
+
+    count.fetch_add(1, Ordering::SeqCst);
+    {
+        let mut s = seen.lock().expect("stub state");
+        s.requests.push(format!("{method} {path}"));
+        if path.starts_with("/login/oauth/access_token") {
+            s.token_bodies.push(body.clone());
+        } else if !authorization.is_empty() {
+            s.authorizations.push(authorization.clone());
+        }
+    }
+
+    let (status, json) = respond(&method, &path, &body, &authorization);
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{json}",
+        json.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// The stub's GitHub. Deliberately literal about the two behaviours that
+/// catch real bugs: GitHub reports OAuth failures with **HTTP 200** and an
+/// `error` field, and it answers "exists but not for you" with **404**.
+fn respond(method: &str, path: &str, body: &str, authorization: &str) -> (&'static str, String) {
+    match (method, path) {
+        ("POST", "/login/oauth/access_token") => {
+            if !body.contains(&format!("code={GOOD_CODE}")) {
+                return ("200 OK", r#"{"error":"bad_verification_code"}"#.to_owned());
+            }
+            if !body.contains("client_secret=stub-client-secret") {
+                return ("200 OK", r#"{"error":"incorrect_client_credentials"}"#.to_owned());
+            }
+            ("200 OK", format!(r#"{{"access_token":"{ACCESS_TOKEN}","token_type":"bearer"}}"#))
+        }
+        // Everything below requires the token the exchange handed out.
+        _ if authorization != format!("Bearer {ACCESS_TOKEN}") => {
+            ("401 Unauthorized", r#"{"message":"Bad credentials"}"#.to_owned())
+        }
+        ("GET", "/user") => ("200 OK", r#"{"login":"octocat","id":583231}"#.to_owned()),
+        ("GET", "/repos/acme/web") => (
+            "200 OK",
+            r#"{"full_name":"acme/web","permissions":{"pull":true,"push":false}}"#.to_owned(),
+        ),
+        // Visible, but read is explicitly denied.
+        ("GET", "/repos/acme/noread") => ("200 OK", r#"{"permissions":{"pull":false}}"#.to_owned()),
+        ("GET", "/user/memberships/orgs/acme") => ("200 OK", r#"{"state":"active"}"#.to_owned()),
+        ("GET", "/user/memberships/orgs/other") => ("200 OK", r#"{"state":"pending"}"#.to_owned()),
+        ("GET", "/orgs/acme/teams/platform/memberships/octocat") => {
+            ("200 OK", r#"{"state":"active"}"#.to_owned())
+        }
+        // Everything else — including `/repos/acme/secret` and
+        // `/orgs/acme/teams/secret-team/memberships/octocat` — is GitHub's
+        // deliberate "exists but not for you": a 404, not a 403.
+        _ => ("404 Not Found", r#"{"message":"Not Found"}"#.to_owned()),
+    }
+}
+
+// ── driving the module ────────────────────────────────────────────────────
+
+fn gate(stub: &Stub, extra: serde_json::Value) -> GithubAuth {
+    let mut cfg = serde_json::json!({
+        "client_id": "Iv1.stub",
+        "client_secret": CLIENT_SECRET,
+        "session_secret": SESSION_SECRET,
+        "repo": "acme/web",
+        "github_base": stub.base,
+        "github_api_base": stub.base,
+        // The derived redirect_uri would be https://<vhost>/…; pin it so the
+        // exchange body is deterministic.
+        "redirect_uri": format!("https://{VHOST}/_ephpm/auth/github/callback"),
+    });
+    for (k, v) in extra.as_object().cloned().unwrap_or_default() {
+        cfg[k] = v;
+    }
+    GithubAuth::init(&cfg).expect("init")
+}
+
+fn call(mw: &GithubAuth, path: &str, query: &str, headers: &[(String, String)]) -> Response {
+    let ctx = RequestCtx::new("GET", path, query, "203.0.113.9", VHOST, headers);
+    // SAFETY: `ctx` outlives the borrow and `host_table()` is 'static — the
+    // exact contract `Request::from_raw` documents.
+    let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+    mw.invoke(&req)
+}
+
+fn header(resp: &Response, name: &str) -> Option<String> {
+    resp.__headers().iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.clone())
+}
+
+fn set_cookies(resp: &Response) -> Vec<String> {
+    resp.__headers()
+        .iter()
+        .filter(|(n, _)| n.eq_ignore_ascii_case("set-cookie"))
+        .map(|(_, v)| v.clone())
+        .collect()
+}
+
+/// Run the login half and return `(state parameter, state cookie pair)`.
+fn begin_login(mw: &GithubAuth, from: &str) -> (String, String) {
+    let resp = call(mw, from, "", &[]);
+    assert_eq!(resp.__status(), 302);
+    let location = header(&resp, "Location").expect("Location");
+    let state = query_param(location.split_once('?').expect("query").1, "state").expect("state");
+    let cookie = set_cookies(&resp)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session_oauth="))
+        .expect("state cookie");
+    (state, cookie.split(';').next().expect("pair").to_owned())
+}
+
+/// Complete a callback with the given code.
+fn finish_login(mw: &GithubAuth, state: &str, cookie: &str, code: &str) -> Response {
+    call(
+        mw,
+        "/_ephpm/auth/github/callback",
+        &format!("code={code}&state={state}"),
+        &[("Cookie".to_owned(), cookie.to_owned())],
+    )
+}
+
+/// The session cookie value out of a successful callback.
+fn session_value(resp: &Response) -> String {
+    set_cookies(resp)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session="))
+        .expect("session cookie")
+        .split(';')
+        .next()
+        .expect("pair")
+        .to_owned()
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn happy_path_exchanges_the_code_checks_access_and_issues_a_session() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+
+    let (state, cookie) = begin_login(&mw, "/wp-admin/index.php");
+    assert_eq!(stub.requests(), 0, "starting a login must not touch GitHub");
+
+    let resp = finish_login(&mw, &state, &cookie, GOOD_CODE);
+    assert_eq!(resp.__action(), ACTION_RESPOND);
+    assert_eq!(resp.__status(), 302);
+    assert_eq!(
+        header(&resp, "Location").as_deref(),
+        Some("/wp-admin/index.php"),
+        "the user lands where they were going"
+    );
+
+    // Exactly the three documented calls, in order.
+    let seen = stub.seen();
+    assert_eq!(
+        seen.requests,
+        vec![
+            "POST /login/oauth/access_token".to_owned(),
+            "GET /user".to_owned(),
+            "GET /repos/acme/web".to_owned(),
+        ]
+    );
+    // The exchange carried the client credentials and the redirect_uri.
+    let body = seen.token_bodies.first().expect("token body");
+    assert!(body.contains("client_id=Iv1.stub"));
+    assert!(body.contains("client_secret=stub-client-secret"));
+    assert!(body.contains(&format!("code={GOOD_CODE}")));
+    assert!(body.contains("redirect_uri="));
+    // Both API calls were bearer-authenticated with the exchanged token.
+    assert_eq!(seen.authorizations.len(), 2);
+    assert!(seen.authorizations.iter().all(|a| a == &format!("Bearer {ACCESS_TOKEN}")));
+    drop(seen);
+
+    // The session cookie is a three-part HS256 JWT with the right attributes.
+    let session = session_value(&resp);
+    let value = session.strip_prefix("ephpm_session=").expect("prefix");
+    assert_eq!(value.split('.').count(), 3);
+    let raw = set_cookies(&resp).into_iter().find(|c| c.starts_with("ephpm_session=")).expect("c");
+    assert!(raw.contains("HttpOnly") && raw.contains("Secure") && raw.contains("SameSite=Lax"));
+    assert!(raw.contains("Max-Age=28800"));
+    assert!(!raw.contains("Domain="), "host-only, so one tenant's session cannot reach another");
+
+    // The state cookie is cleared on the way out.
+    assert!(
+        set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session_oauth=;")
+            || c.starts_with("ephpm_session_oauth=; ")
+            || (c.starts_with("ephpm_session_oauth=") && c.contains("Max-Age=0"))),
+        "the one-shot state cookie must be deleted: {:?}",
+        set_cookies(&resp)
+    );
+
+    // And the payload says what it should.
+    let payload = value.split('.').nth(1).expect("payload");
+    let json: serde_json::Value =
+        serde_json::from_slice(&base64_url_decode(payload).expect("payload is base64url"))
+            .expect("payload is JSON");
+    assert_eq!(json["sub"], "octocat");
+    assert_eq!(json["gh_id"], 583_231);
+    assert_eq!(json["site"], VHOST);
+    assert_eq!(json["via"], "github");
+    assert_eq!(json["check"], "repo acme/web");
+}
+
+#[test]
+fn a_request_with_a_session_makes_no_network_call() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+
+    let (state, cookie) = begin_login(&mw, "/");
+    let session = session_value(&finish_login(&mw, &state, &cookie, GOOD_CODE));
+    let after_login = stub.requests();
+    assert_eq!(after_login, 3);
+
+    // Fifty ordinary requests carrying the session. This is the constraint
+    // the whole design exists to satisfy: the counter must not move.
+    let headers = vec![("Cookie".to_owned(), session)];
+    for i in 0..50 {
+        let resp = call(&mw, "/index.php", &format!("i={i}"), &headers);
+        assert_eq!(resp.__action(), ACTION_CONTINUE, "request {i} must reach PHP");
+    }
+    assert_eq!(
+        stub.requests(),
+        after_login,
+        "a request with a session cookie must never reach GitHub"
+    );
+}
+
+#[test]
+fn a_bad_code_is_rejected_and_issues_nothing() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+    let (state, cookie) = begin_login(&mw, "/");
+
+    let resp = finish_login(&mw, &state, &cookie, "wrongcode");
+    // GitHub answers HTTP 200 with an `error` field; treating that as success
+    // is the classic OAuth implementation bug.
+    assert_eq!(resp.__status(), 400);
+    assert!(
+        !set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")),
+        "a failed exchange must not issue a session"
+    );
+    assert_eq!(
+        stub.seen().requests,
+        vec!["POST /login/oauth/access_token".to_owned()],
+        "the flow stops at the exchange — no identity or access call is made"
+    );
+}
+
+#[test]
+fn a_user_without_repo_access_is_denied() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({ "repo": "acme/secret" }));
+    let (state, cookie) = begin_login(&mw, "/");
+
+    let resp = finish_login(&mw, &state, &cookie, GOOD_CODE);
+    assert_eq!(resp.__status(), 403);
+    assert!(!set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")));
+    // The 404 GitHub returns for "exists but not yours" is a denial, not an
+    // error — the flow completed and answered no.
+    assert_eq!(stub.seen().requests.len(), 3);
+}
+
+#[test]
+fn a_repo_with_read_explicitly_denied_is_denied() {
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({ "repo": "acme/noread" }));
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 403);
+}
+
+#[test]
+fn org_membership_must_be_active_not_pending() {
+    let stub = Stub::start();
+
+    let mw = gate(&stub, serde_json::json!({ "check": "org", "org": "acme", "repo": null }));
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 302);
+
+    // `pending` is an unaccepted invitation — not a member.
+    let mw = gate(&stub, serde_json::json!({ "check": "org", "org": "other", "repo": null }));
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 403);
+}
+
+#[test]
+fn team_membership_is_checked_against_the_logged_in_user() {
+    let stub = Stub::start();
+
+    let mw = gate(
+        &stub,
+        serde_json::json!({ "check": "team", "org": "acme", "team": "platform", "repo": null }),
+    );
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 302);
+    // The path is built from `/user`'s login, not from anything the client said.
+    assert!(
+        stub.seen()
+            .requests
+            .iter()
+            .any(|r| r == "GET /orgs/acme/teams/platform/memberships/octocat")
+    );
+
+    let mw = gate(
+        &stub,
+        serde_json::json!({ "check": "team", "org": "acme", "team": "secret-team", "repo": null }),
+    );
+    let (state, cookie) = begin_login(&mw, "/");
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 403);
+}
+
+#[test]
+fn state_is_a_signed_value_not_a_one_time_server_side_record() {
+    // Replaying a completed login's state with a fresh code still requires the
+    // state to verify — it does, because it is stateless and not yet expired.
+    // What it CANNOT do is complete without the cookie, which is the property
+    // that matters and which `callback_without_a_state_cookie_is_rejected`
+    // pins. This test records the honest limitation rather than implying a
+    // stronger one: a stateless state token is replayable within its 10-minute
+    // window by whoever holds the cookie, i.e. by the user themselves.
+    let stub = Stub::start();
+    let mw = gate(&stub, serde_json::json!({}));
+    let (state, cookie) = begin_login(&mw, "/");
+
+    assert_eq!(finish_login(&mw, &state, &cookie, GOOD_CODE).__status(), 302);
+    // Second use: the state still verifies (it is a signed value with a TTL),
+    // and GitHub is what refuses a reused authorization code.
+    assert_eq!(finish_login(&mw, &state, &cookie, "wrongcode").__status(), 400);
+}
+
+#[test]
+fn github_being_unreachable_is_a_502_not_a_pass() {
+    // Point the gate at a closed port: the exchange cannot complete.
+    let stub = Stub::start();
+    let mw = gate(
+        &stub,
+        serde_json::json!({
+            "github_base": "http://127.0.0.1:1",
+            "github_api_base": "http://127.0.0.1:1",
+            "http_timeout_secs": 2,
+        }),
+    );
+    let (state, cookie) = begin_login(&mw, "/");
+    let resp = finish_login(&mw, &state, &cookie, GOOD_CODE);
+    assert_eq!(resp.__status(), 502, "an unreachable identity provider must fail closed");
+    assert!(!set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")));
+}
+
+/// Minimal unpadded base64url decoder for asserting on the issued payload.
+fn base64_url_decode(s: &str) -> Option<Vec<u8>> {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut acc: u32 = 0;
+    let mut bits = 0u32;
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    for c in s.bytes() {
+        let v = u32::try_from(TABLE.iter().position(|t| *t == c)?).ok()?;
+        acc = (acc << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(u8::try_from((acc >> bits) & 0xFF).ok()?);
+        }
+    }
+    Some(out)
+}

--- a/crates/ephpm-middleware-session-cookie/Cargo.toml
+++ b/crates/ephpm-middleware-session-cookie/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ephpm-middleware-session-cookie"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "ePHPm native middleware: signed session-cookie validation with redirect-to-login (loadable cdylib shell; implementation in ephpm-middleware-builtins)"
+
+[lib]
+# cdylib = the loadable module for the dlopen lane. The implementation (and
+# the rlib ephpm-server links) is ephpm-middleware-builtins — this shell only
+# adds the C ABI exports, which must never be linked into the host binary
+# (several modules exporting the same `ephpm_middleware_*` symbols collide).
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ephpm-middleware.workspace = true
+ephpm-middleware-builtins.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ephpm-middleware-session-cookie/src/lib.rs
+++ b/crates/ephpm-middleware-session-cookie/src/lib.rs
@@ -1,0 +1,14 @@
+//! `session-cookie` — loadable cdylib shell around the shared implementation
+//! in [`ephpm_middleware_builtins::session_cookie`].
+//!
+//! The middleware itself (signed session-cookie validation with
+//! redirect-to-login and the per-tenant `site` binding of issue #396, docs and
+//! tests included) lives in `ephpm-middleware-builtins`, where it is also
+//! compiled into every ePHPm binary as the builtin `session-cookie` registry
+//! entry — no cdylib needed there. This crate only adds the C ABI exports
+//! (`declare!`) so the same module can be dlopened by dynamically linked
+//! builds.
+
+pub use ephpm_middleware_builtins::session_cookie::SessionCookie;
+
+ephpm_middleware::declare!(SessionCookie);

--- a/crates/ephpm-server/src/middleware.rs
+++ b/crates/ephpm-server/src/middleware.rs
@@ -148,6 +148,11 @@ pub type BuiltinBuilder = fn(&serde_json::Value) -> Result<BuiltinModule, String
 /// per module: the short name and the crate name, with `-` and `_`
 /// interchangeable — e.g. `"jwt"`, `"ephpm-middleware-jwt"`,
 /// `"ephpm_middleware_jwt"`. (`"ratelimit"` also answers to `"rate-limit"`.)
+///
+/// Adding an entry here also means checking [`crate::router`]'s ingest-strip
+/// list: any module that forwards data to PHP in a request header (`jwt` and
+/// `session-cookie`'s `claims_header`) must have that header name stripped at
+/// ingest, or a client can forge it on a path the module's `match` glob skips.
 #[must_use]
 pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
     let canonical = name.replace('_', "-");
@@ -163,6 +168,9 @@ pub fn builtin(name: &str) -> Option<BuiltinBuilder> {
         }
         "security-headers" | "ephpm-middleware-security-headers" => {
             BuiltinModule::init::<ephpm_middleware_builtins::security_headers::SecurityHeaders>
+        }
+        "session-cookie" | "ephpm-middleware-session-cookie" => {
+            BuiltinModule::init::<ephpm_middleware_builtins::session_cookie::SessionCookie>
         }
         "api-key" | "ephpm-middleware-api-key" => {
             BuiltinModule::init::<ephpm_middleware_builtins::api_key::ApiKey>
@@ -981,6 +989,7 @@ mod tests {
     /// config strictness is fails the test below.
     const BUILTIN_NAMES: &[&str] = &[
         "jwt",
+        "session-cookie",
         "cors",
         "ratelimit",
         "security-headers",
@@ -1137,6 +1146,10 @@ mod tests {
             "ephpm_middleware_ratelimit",
             "ephpm-middleware-security-headers",
             "ephpm_middleware_security_headers",
+            "session-cookie",
+            "session_cookie",
+            "ephpm-middleware-session-cookie",
+            "ephpm_middleware_session_cookie",
             "api-key",
             "api_key",
             "ephpm-middleware-api-key",
@@ -1162,6 +1175,61 @@ mod tests {
         for name in ["", "jwtx", "my-auth", "jwt.so", "./jwt", "middleware/jwt", "JWT"] {
             assert!(builtin(name).is_none(), "\"{name}\" should NOT resolve as builtin");
         }
+    }
+
+    /// `session-cookie` mounted from the static registry: an unauthenticated
+    /// browser request short-circuits the chain with a redirect to the login
+    /// service, and PHP never runs. The mount is `match`-scoped so the test
+    /// also covers a skipped path continuing normally.
+    #[test]
+    fn builtin_session_cookie_redirects_an_unauthenticated_request() {
+        let mounts = vec![builtin_mount(
+            "session-cookie",
+            Some("/app/*"),
+            10,
+            serde_json::json!({
+                "secret": "shared-with-the-login-service",
+                "login_url": "https://login.example/start",
+                "return_to_param": "next",
+                "site_param": "site",
+            }),
+        )];
+        let chain = MiddlewareChain::load(&mounts).expect("load builtin session-cookie");
+
+        // No cookie on a matching path → 302 to the login service, carrying a
+        // same-origin return-to and the canonical site key. The 5th arg to
+        // RequestCtx::new is the resolved site key (issue #390/#396).
+        let ctx = RequestCtx::new(
+            "GET",
+            "/app/dashboard.php",
+            "tab=1",
+            "203.0.113.7",
+            "pr-42.preview.example",
+            &[],
+        )
+        .with_scheme(true);
+        match chain.evaluate(&ctx, "/app/dashboard.php") {
+            ChainVerdict::Respond { status, headers, .. } => {
+                assert_eq!(status, 302);
+                assert_eq!(
+                    find_header(&headers, "Location"),
+                    Some(
+                        "https://login.example/start?next=%2Fapp%2Fdashboard.php%3Ftab%3D1\
+                         &site=pr-42.preview.example"
+                    )
+                );
+                assert_eq!(find_header(&headers, "Cache-Control"), Some("no-store"));
+            }
+            ChainVerdict::Continue { .. } => {
+                panic!("an unauthenticated request must not reach PHP")
+            }
+        }
+
+        // A path outside the `match` glob is not gated at all.
+        let open =
+            RequestCtx::new("GET", "/health.php", "", "203.0.113.7", "pr-42.preview.example", &[])
+                .with_scheme(true);
+        assert!(matches!(chain.evaluate(&open, "/health.php"), ChainVerdict::Continue { .. }));
     }
 
     /// The full four-module chain, loaded purely from the static registry —

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -771,21 +771,24 @@ const ALWAYS_STRIPPED_INGEST_HEADERS: &[&str] = &["proxy"];
 /// Build the lowercased list of inbound headers to strip at ingest.
 ///
 /// Combines [`ALWAYS_STRIPPED_INGEST_HEADERS`] with the `claims_header` of
-/// every configured `jwt` middleware mount. Because the claims header is only
-/// sanitized by the jwt module when that module actually runs (and in fpm
-/// mode it only runs on `match`-glob paths), stripping it up-front guarantees
-/// a client can never forge it on a path the module skips. Names are
-/// deduplicated and lowercased for the case-insensitive compare in
+/// every configured `jwt` and `session-cookie` middleware mount. Because the
+/// claims header is only sanitized by those modules when they actually run
+/// (and in fpm mode they only run on `match`-glob paths), stripping it
+/// up-front guarantees a client can never forge it on a path the module skips.
+/// Names are deduplicated and lowercased for the case-insensitive compare in
 /// [`extract_headers`].
 fn build_ingest_strip_headers(mounts: &[MiddlewareMount]) -> Vec<String> {
     let mut names: Vec<String> =
         ALWAYS_STRIPPED_INGEST_HEADERS.iter().map(|s| (*s).to_owned()).collect();
     for mount in mounts {
-        // Only the builtin `jwt` module (and its long-form spellings) forwards
-        // a claims header; match the same canonicalization the middleware
-        // registry uses.
+        // Only the builtin `jwt` and `session-cookie` modules (and their
+        // long-form spellings) forward a claims header; match the same
+        // canonicalization the middleware registry uses.
         let canonical = mount.library.replace('_', "-");
-        if !matches!(canonical.as_str(), "jwt" | "ephpm-middleware-jwt") {
+        if !matches!(
+            canonical.as_str(),
+            "jwt" | "ephpm-middleware-jwt" | "session-cookie" | "ephpm-middleware-session-cookie"
+        ) {
             continue;
         }
         if let Some(name) = mount
@@ -6875,9 +6878,29 @@ mod tests {
     }
 
     #[test]
-    fn ingest_strip_list_ignores_non_jwt_mounts() {
+    fn ingest_strip_list_includes_configured_session_cookie_claims_header() {
+        // `session-cookie` forwards verified claims exactly like `jwt` does,
+        // so its claims header needs the same ingest strip — otherwise a
+        // client can forge it on a path the mount's `match` glob skips.
+        let mount = MiddlewareMount {
+            library: "session_cookie".to_string(),
+            match_pattern: Some("/app/*".to_owned()),
+            order: 10,
+            config: Some(serde_json::json!({
+                "secret": "s",
+                "login_url": "https://login.example/start",
+                "claims_header": "X-Session-Claims",
+            })),
+        };
+        let strip = build_ingest_strip_headers(&[mount]);
+        assert!(strip.iter().any(|h| h == "x-session-claims"), "{strip:?}");
+    }
+
+    #[test]
+    fn ingest_strip_list_ignores_non_claims_forwarding_mounts() {
         // A cors mount carrying an incidental `claims_header` key must not
-        // contribute — only the jwt module forwards claims.
+        // contribute — only the claims-forwarding modules (jwt, session-cookie)
+        // do.
         let cors = MiddlewareMount {
             library: "cors".to_string(),
             match_pattern: None,

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -1,0 +1,358 @@
++++
+title = "GitHub OAuth Gate (native middleware)"
+weight = 11
++++
+
+> **Status.** The module is implemented and tested. The complete login has
+> been driven over real HTTP through a running ePHPm against a **stub** GitHub;
+> **a round trip against the real `github.com` with a registered GitHub App has
+> not been performed** and needs a human. See
+> [Verification status](#verification-status) — nothing on this page is claimed
+> beyond what was actually observed.
+
+`github-auth` gates a private preview site on **GitHub identity**: *does the
+person at this browser have access, on GitHub, to the repository (or org, or
+team) this preview belongs to?*
+
+It is a [dynamic (`dlopen`) middleware module](/guides/native-middleware/),
+not a builtin — it needs an HTTP client and a TLS stack, and none of that
+belongs in the `ephpm` binary.
+
+## It is half of a pair
+
+Two jobs, deliberately in two modules:
+
+| | **`github-auth`** (this module) | a session-verifier module |
+|---|---|---|
+| Runs on | login, the OAuth callback, and the first request of a session | every request |
+| Talks to GitHub | yes, 3 calls | **never** |
+| Owns | issuing sessions | the token format and its verification |
+| When unhappy | `RESPOND` 302 → GitHub | `RESPOND` 302 → `login_path` |
+
+**Mounted alone, `github-auth` is not an authenticator.** It stops a request
+that carries *no* session cookie, but it deliberately does **not** verify one
+that does — that is the verifier's job, and doing it in two places would give
+you two subtly different verifiers. The module logs this at startup on its
+first request.
+
+The verifier this is designed to pair with is the **`session-cookie` builtin**
+(ephpm#388) — same HS256 verification as the `jwt` builtin, but reading a
+cookie and redirecting instead of answering `401`:
+
+```toml
+[[middleware]]
+library = "/opt/ephpm/modules/libgithub_auth.so"
+order   = 10                     # cold path — owns the reserved paths
+config  = { client_id = "Iv1.0123456789abcdef",
+            client_secret  = "env:GH_CLIENT_SECRET",
+            session_secret = "env:EPHPM_SESSION_SECRET",
+            repo = "acme/web" }
+
+[[middleware]]
+library = "session-cookie"       # hot path — verifies, redirects to login
+order   = 20
+config  = { secret = "env:EPHPM_SESSION_SECRET",
+            cookie = "ephpm_session",
+            login_url = "/_ephpm/auth/github/login",
+            return_to_param = "next" }
+```
+
+Three things must line up, and only three:
+
+| this module | `session-cookie` | note |
+|---|---|---|
+| `session_secret` | `secret` | the same HMAC key — that is what makes the token verify |
+| `cookie_name` (`ephpm_session`) | `cookie` (`ephpm_session`) | defaults already match |
+| `login_path` | `login_url` + `return_to_param = "next"` | this module reads the return-to from `?next=` and sanitizes it |
+
+`issuer` / `audience` are optional on both sides; set them on both or neither.
+
+### The per-tenant `site` binding is automatic (issue #396)
+
+On a multi-tenant preview host you do **not** configure the tenant scope on
+either side — it is derived. This module stamps every session it mints with a
+`site` claim equal to the request's **canonical site key** (`req.vhost_id()` —
+the one tenant identity the router resolves), and the `session-cookie` verifier
+requires that claim to equal the site key of the request it is gating
+(`require_site = true`, its default). Because both read the *same* router-derived
+key, they agree by construction: a session minted for one preview cannot open
+another. Do not set `require_site = false` on a preview host — that turns the
+binding off and reintroduces the cross-tenant replay #396 fixed. The only place
+it belongs is a genuinely single-tenant deployment whose issuer mints site-less
+sessions.
+
+## What happens per request
+
+| Request | Verdict | Cost |
+|---|---|---|
+| no session cookie | 302 → GitHub `authorize`, `Set-Cookie` state | no network |
+| `GET {callback_path}?code=…&state=…` | 302 → where you were, `Set-Cookie` session | 3 GitHub calls |
+| `GET {login_path}` | 302 → GitHub `authorize` | no network |
+| valid bypass token, no cookie | 302 → same URL, `Set-Cookie` session | no network |
+| session cookie present | `CONTINUE` — the verifier decides | **no network** |
+
+PHP does not run on any redirect row: the middleware chain is evaluated before
+PHP dispatch and before the request body is read.
+
+**A GitHub API call is never made on a request that already has a session.**
+That is structural, not a discipline: only the exact configured
+`callback_path` can reach the network, and the routing decision is a pure
+function with its own tests.
+
+## Requirements
+
+**Use a GitHub App, not a classic OAuth App.** With an OAuth App, seeing a
+private repository at all requires the `repo` scope — read *and write* on
+every repository the user can touch, handed to a preview host. A GitHub App's
+user-to-server token is bounded by the app's installation instead, and needs
+no scope for the repository check. That is why `scopes` defaults to empty.
+
+**The reserved paths must reach PHP routing.** ePHPm evaluates middleware on
+the PHP-bound path, so `login_path` and `callback_path` must resolve to a PHP
+script for the module to see them. With the default
+`fallback = ["$uri", "$uri/", "/index.php?$query_string"]` and a front
+controller at `index.php` — WordPress, Laravel, Symfony — that is automatic,
+and PHP still never runs because the chain short-circuits first. A site with
+no `index.php` and a `=404` fallback would 404 the callback before the module
+is consulted.
+
+**`dlopen` must work.** The stock Linux release is glibc-dynamic and can load
+this. A custom fully static (musl) ePHPm **cannot `dlopen` at all** and
+therefore cannot use this module; such a build would need it compiled in as a
+builtin instead.
+
+## Build and mount
+
+```bash
+cargo build --release -p ephpm-middleware-github-auth
+# target/release/libgithub_auth.so    (Linux)
+# target/release/libgithub_auth.dylib (macOS)
+# target/release/github_auth.dll      (Windows)
+```
+
+`library` must be a **path** (something containing a separator or an
+extension). A bare name is resolved against the compiled-in builtin registry
+first, so it would not load this module.
+
+## Configuration
+
+Secrets accept an **`env:NAME`** indirection, read once at startup. Prefer it:
+`ephpm.toml` is often templated or rendered into a ConfigMap, and a literal in
+it is a secret in git.
+
+| key | default | meaning |
+|---|---|---|
+| `client_id` | **required** | OAuth client id of the GitHub App / OAuth App |
+| `client_secret` | **required** | its client secret; `env:NAME` supported |
+| `session_secret` | **required**, ≥ 32 bytes | HMAC key for issued sessions. Must match the verifier's |
+| `check` | `"repo"` | `"repo"`, `"org"` or `"team"`. Inferred when unambiguous |
+| `repo` | — | `owner/name`, for `check = "repo"` |
+| `org` | — | organisation login, for `check = "org"` / `"team"` |
+| `team` | — | team slug, for `check = "team"` |
+| `sites` | unset | table mapping each vhost to its own `{ repo \| org \| team }` |
+| `login_path` | `/_ephpm/auth/github/login` | reserved: starts a login |
+| `callback_path` | `/_ephpm/auth/github/callback` | reserved: receives GitHub's redirect |
+| `redirect_uri` | derived | full callback URL sent to GitHub. Defaults to `https://<vhost><callback_path>` |
+| `cookie_name` | `ephpm_session` | session cookie. Must match the verifier's |
+| `state_cookie_name` | `<cookie_name>_oauth` | short-lived OAuth `state` cookie |
+| `cookie_path` | `/` | `Path` attribute on both cookies |
+| `cookie_secure` | `true` | emit `Secure`. Turn off only for a plaintext local preview |
+| `cookie_samesite` | `"Lax"` | `Lax`, `Strict` or `None` (`None` requires `cookie_secure`) |
+| `session_ttl_secs` | `28800` (8 h) | 60 – 604800 |
+| `issuer` | `ephpm-github-auth` | `iss` claim |
+| `audience` | unset | `aud` claim |
+| `scopes` | `[]` | OAuth scopes. Empty is correct for a GitHub App |
+| `bypass_token` | unset | pre-shared automation token, ≥ 32 bytes |
+| `bypass_header` | `x-ephpm-bypass` | header carrying it |
+| `bypass_query` | unset | query parameter carrying it — **off unless set** |
+| `bypass_ttl_secs` | `3600` | lifetime of a bypass-issued session |
+| `github_base` | `https://github.com` | authorize/token host (a GHES host works) |
+| `github_api_base` | `https://api.github.com` | REST base (`https://ghes/api/v3`) |
+| `http_timeout_secs` | `10` | 1 – 60, per outbound call |
+
+`github_base` / `github_api_base` must be `https://`, with one exception:
+`http://` is accepted for a **loopback** host, which is what lets the test
+suite point the module at a stub server. Plaintext to a real GitHub host is
+refused outright — it would put the client secret and the user's access token
+on the wire in clear.
+
+If `sites` is present it is **authoritative**: a vhost with no entry gets no
+access at all, even when a top-level `repo` is also configured. A hostname
+nobody mapped must not quietly inherit another tenant's rule.
+
+## Which GitHub calls are made
+
+Per login, once:
+
+| # | Call | Purpose | Minimum permission |
+|---|---|---|---|
+| 1 | `POST {github_base}/login/oauth/access_token` | code → user access token | none — this *is* the grant |
+| 2 | `GET /user` | the login that becomes `sub` | GitHub App: none. OAuth App: `read:user` |
+| 3a | `GET /repos/{owner}/{name}` | `check = "repo"` | GitHub App: `metadata: read`. OAuth App: `repo` |
+| 3b | `GET /user/memberships/orgs/{org}` | `check = "org"` — must be `active` | `read:org` |
+| 3c | `GET /orgs/{org}/teams/{team}/memberships/{login}` | `check = "team"` — must be `active` | `read:org` |
+
+Redirects are never followed. A visible consequence: a **renamed** repository
+stops matching until the config is updated, which is the safe direction.
+
+The access token is used for those calls and then dropped. It is never stored,
+never written to a cookie, and never logged.
+
+## The session
+
+An HS256 JWT — the same shape the builtin `jwt` module already verifies, down
+to `alg` pinning and a mandatory `exp`.
+
+| claim | meaning |
+|---|---|
+| `iss` | `issuer` |
+| `sub` | GitHub login, or `automation` for a bypass session |
+| `aud` | `audience`, when configured |
+| `iat` / `exp` | issue / expiry, seconds since the epoch |
+| `site` | the vhost this session is for |
+| `via` | `github`, `bypass` — or `share` for an externally minted token |
+| `gh_id` | numeric GitHub account id (stable across renames) |
+| `check` | the rule that was satisfied, e.g. `repo acme/web` |
+
+There is **no server-side session record**. Restarts do not log anyone out, a
+second node needs no replication, and the module never touches the middleware
+KV surface (which is process-global rather than per-site — issue #376).
+
+The cost, plainly: **an issued session cannot be revoked before it expires.**
+Rotating `session_secret` invalidates every session at once and is the only
+revocation available. `session_ttl_secs` is therefore the blast radius of a
+stolen cookie.
+
+### Cookie attributes, and why
+
+`HttpOnly` (the token *is* the session, and a preview site is pre-production
+code — exactly where XSS lives), `Secure` (a bearer credential must not ride a
+plaintext hop), `SameSite=Lax` (`Strict` would bounce a user through GitHub
+every time they clicked a preview link from a PR comment or Slack; `Lax` sends
+the cookie on top-level GET navigations, which is that case *and* the OAuth
+callback), `Path` (the gate covers the whole site), a real `Max-Age` matching
+the token's `exp` — and **no `Domain`**, which makes the cookie host-only.
+`Domain=.preview.example.com` would send one tenant's session to every other
+tenant on the wildcard. That one is not configurable.
+
+## Automation bypass
+
+Playwright, Lighthouse and smoke tests need in. Set `bypass_token` (≥ 32
+bytes) and present it:
+
+```bash
+curl -sL -c jar.txt -H "x-ephpm-bypass: $EPHPM_BYPASS" https://pr-123.preview.example.com/
+lighthouse https://pr-123.preview.example.com/ \
+  --extra-headers "{\"x-ephpm-bypass\":\"$EPHPM_BYPASS\"}"
+```
+
+Presenting it yields *the same kind of session* — a 302 and a `Set-Cookie` —
+not a per-request pass-through. The client follows one extra redirect on its
+first request and behaves normally afterwards. The comparison is constant-time
+and independent of length; a wrong token behaves exactly like no token at all
+(302 to GitHub), so the header is not an oracle.
+
+`bypass_query` exists for tools that cannot set headers, and is **off unless
+configured**: a query string lands in access logs, browser history and
+`Referer` headers, which a header does not.
+
+## Share links
+
+Because issuance and verification are separate, and issuance is not
+privileged, **a hosting control plane can mint its own sessions with no change
+to this module.** Anything holding `session_secret` can produce an acceptable
+token: same HS256 JWT, `via = "share"`, whatever `sub` and `exp` you want.
+
+```php
+$claims = ['iss' => 'ephpm-github-auth', 'sub' => 'share:designer@example.com',
+           'site' => 'pr-123.preview.example.com', 'via' => 'share',
+           'iat' => time(), 'exp' => time() + 7200];
+$b64 = fn($v) => rtrim(strtr(base64_encode($v), '+/', '-_'), '=');
+$signing = $b64('{"alg":"HS256","typ":"JWT"}') . '.' . $b64(json_encode($claims));
+$token = $signing . '.' . $b64(hash_hmac('sha256', $signing, $secret, true));
+// then: Set-Cookie: ephpm_session=$token; Path=/; Max-Age=7200; HttpOnly; Secure; SameSite=Lax
+```
+
+This is a real capability and a real risk: `session_secret` is a minting key.
+Treat it like one.
+
+## Security properties
+
+**CSRF on the callback is enforced.** A login mints a 32-byte random nonce,
+puts it in the `state` parameter *and* in an `HttpOnly` signed cookie bound to
+the vhost and expiring in 10 minutes. The callback requires both, compares
+them in constant time, and refuses when the cookie is missing, unsigned,
+expired, or issued for another host. An attacker who plants their own
+`code`+`state` in a victim's browser cannot supply the matching cookie.
+
+**Return-to is constrained to a same-origin path.** Absolute URLs,
+scheme-relative `//evil.test`, backslash forms, `javascript:`/`data:`, raw
+control characters, non-ASCII, `..` segments and over-long values all collapse
+to `/`. Values are re-validated after being read back out of the signed state
+cookie — a signature attests origin, not safety.
+
+**Constant-time comparison** is used for every secret and signature (HMAC
+verification for tokens; an HMAC-of-both comparison for the bypass token, so
+the timing leaks neither the contents nor the length).
+
+**Nothing secret is logged.** No code, token, secret or minted session appears
+in any log line; the error type physically cannot carry one. GitHub's OAuth
+error identifiers are filtered to `[A-Za-z0-9_]` before being logged. Refusal
+pages are plain text with no interpolation, so the gate cannot become a
+reflected-XSS surface on the preview's own origin.
+
+**Fail-closed everywhere.** GitHub unreachable → 502. A vhost with no
+configured target → 403. A panic anywhere in the module → 500 (the `declare!`
+macro's containment). None of these fall through to PHP.
+
+### The client secret lives on the node
+
+This is the real cost of doing OAuth in-process instead of in a separate
+identity service. The OAuth **client secret** is present on every node serving
+previews, readable by the ePHPm process.
+
+If a node is compromised the attacker can impersonate the OAuth app — complete
+an authorization flow for any user who can be induced to click an authorize
+link — and, holding `session_secret`, mint sessions for any user and any site
+this gate protects. They cannot read a user's GitHub data without that user
+authorizing, and no long-lived GitHub token is stored: the access token is
+used during the login and dropped. **Rotate `client_secret` and
+`session_secret` together after any node compromise.**
+
+## Limitations
+
+- **One callback host per app.** GitHub does not support wildcard callback
+  URLs. A fleet of per-PR hostnames needs a single auth origin and a
+  cross-host hand-off; that is **not implemented here**. Today, `redirect_uri`
+  is derived per request from the vhost, which works when each preview host is
+  registered (or when one host is used).
+- **No revocation before expiry.** See [The session](#the-session).
+- **The `state` cookie is replayable within its 10-minute window** by whoever
+  holds it — i.e. by the user themselves. Reuse of an authorization *code* is
+  refused by GitHub, not here.
+- **The callback is not rate-limited by this module.** Every check that can
+  reject a callback locally — the `state` cookie, its signature, its expiry,
+  the nonce comparison, the vhost binding, and the shape of `code` — runs
+  *before* any network call, so an attacker with no valid `state` cookie
+  cannot make this module talk to GitHub at all. A user who has started a
+  real login can replay their own callback within its 10-minute window,
+  though, and each replay costs one exchange attempt. Mount the `ratelimit`
+  builtin on `match = "/_ephpm/auth/*"` if that matters to you.
+- **No `dlopen`, no module** — see [Requirements](#requirements).
+
+## Verification status
+
+| Behaviour | How it was verified |
+|---|---|
+| **The whole login, cold: no cookie → 302 → callback → 3 GitHub calls → session → the app** | **real HTTP through a running ePHPm with the module `dlopen`ed**, against a stub GitHub in its own process, driven with `curl` and a cookie jar |
+| The callback emits **both** `Set-Cookie` headers (session issued, `state` cleared) | same run — two `set-cookie` lines on the wire |
+| No cookie → 302 to GitHub carrying a `state`, PHP never runs | same run: `content-length: 0`, no PHP output; the same URL *with* a cookie reaches PHP |
+| Session cookie → `CONTINUE`, PHP dispatched, gate adds no headers | same run |
+| A request with a session makes **zero** outbound calls | 21 live requests after login left the stub GitHub's log unchanged; the integration test asserts the same across 50 |
+| Callback with missing / forged / empty / wrong-host / expired `state` → 400 | real HTTP + unit tests |
+| Hostile return-to values (27 shapes) collapse to `/` | real HTTP, decoding the signed state cookie |
+| Bypass token accepted; a wrong one is indistinguishable from none | real HTTP |
+| Code exchange, `/user`, and all three access checks | integration test against a stub GitHub over real sockets, using the module's own reqwest/rustls client |
+| Denials: no repo access, `pull: false`, `pending` org membership, missing team | integration test |
+| GitHub unreachable → 502, no session issued | integration test |
+| **A round trip against real `github.com` with a real GitHub App** | **not done — needs a human.** Register an App, set `client_id`/`client_secret`, log in with a browser, confirm the `Set-Cookie` and the landing page |

--- a/site/content/guides/native-middleware.md
+++ b/site/content/guides/native-middleware.md
@@ -19,17 +19,22 @@ There are **two ways a compiled module runs** — plus an experimental
 which trades the "before PHP, before the body" position for not needing a
 compiler at all:
 
-- **Built-in (static registry).** Ten official modules — `jwt`, `cors`,
-  `ratelimit`, `security-headers`, `api-key`, `ip-allowlist`,
-  `maintenance-mode`, `redirect`, `request-id`, and `header-transform` — are
-  compiled into **every** ePHPm binary. `library = "jwt"` just works: no
-  shared library on disk, no `dlopen`, no special build. Two of them
-  (`request-id`, `header-transform`) also run in the **response phase**.
+- **Built-in (static registry).** Eleven official modules — `jwt`,
+  `session-cookie`, `cors`, `ratelimit`, `security-headers`, `api-key`,
+  `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, and
+  `header-transform` — are compiled into **every** ePHPm binary. `library =
+  "jwt"` just works: no shared library on disk, no `dlopen`, no special build.
+  Two of them (`request-id`, `header-transform`) also run in the **response
+  phase**.
 - **Dynamic (shared library).** Custom out-of-tree modules are `.so` /
   `.dylib` / `.dll` files speaking a small, versioned C ABI, loaded once at
   startup via `dlopen` (`LoadLibrary` on Windows). This works out of the
   box with the stock release binaries on every platform — see
-  [the dynamic lane](#the-dynamic-lane).
+  [the dynamic lane](#the-dynamic-lane). A worked, shipped example lives in
+  the workspace: [the GitHub OAuth gate](/guides/github-auth-middleware/)
+  (`crates/ephpm-middleware-github-auth`), which authenticates a browser user
+  against GitHub and issues the stateless signed session that `session-cookie`
+  verifies.
 
 ## Quick start
 
@@ -161,9 +166,9 @@ Two things are deliberately *not* checked:
 
 The `library` value is checked against the **builtin registry first**.
 Each built-in answers to its short name and its crate name, with `-` and
-`_` interchangeable: `jwt`, `cors`, `ratelimit` (also `rate-limit`),
-`security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`,
-`redirect`, `request-id`, `header-transform`, and the
+`_` interchangeable: `jwt`, `session-cookie`, `cors`, `ratelimit` (also
+`rate-limit`), `security-headers`, `api-key`, `ip-allowlist`,
+`maintenance-mode`, `redirect`, `request-id`, `header-transform`, and the
 `ephpm-middleware-*` / `ephpm_middleware_*` long forms. Builtin mounts
 never touch the filesystem.
 
@@ -307,7 +312,7 @@ files too — ships as
 
 ## The built-in modules
 
-All ten are compiled into every ePHPm binary and run in-process — mount
+All eleven are compiled into every ePHPm binary and run in-process — mount
 them by short name (`library = "jwt"`) with no shared library on disk.
 `request-id` and `header-transform` additionally run in the response phase.
 Loadable cdylib builds of the same implementations (for the dlopen lane, or
@@ -371,6 +376,92 @@ therefore trust `HTTP_X_JWT_CLAIMS` regardless of request path.
 > defense), so it never surfaces as `$_SERVER['HTTP_PROXY']`.
 
 v1 is HS256 only — RS256/JWKS is not implemented.
+
+### `session-cookie`
+
+Gates a whole site in a **browser** on a signed session cookie minted by an
+external identity service, and redirects unauthenticated visitors to that
+service. Same crypto core as `jwt`, different threat model: a token in a
+cookie instead of a header, and a redirect instead of a `401`, because a
+browser can do nothing useful with a `401`. They are separate modules on
+purpose — no key in the `jwt` config can turn its `401`s into redirects, and
+no key here can silently stop redirecting.
+
+**ePHPm never calls the identity provider.** Verification is one HMAC over
+bytes already in the request: no network call on the request path, no
+provider rate limits, no OAuth client secret on the serving nodes.
+
+| key | default | meaning |
+|-----|---------|---------|
+| `secret` (string) | **required** | HS256 shared secret — the same key the login service signs with |
+| `login_url` (string) | **required** | where to send unauthenticated browsers. Must be an `https://`/`http://` URL or a same-origin absolute path; `javascript:`/`//host` fail startup |
+| `cookie` (string) | `"ephpm_session"` | name of the cookie carrying the token |
+| `return_to_param` (string) | unset — no return-to is sent | query parameter on `login_url` carrying the validated, same-origin return path |
+| `site_param` (string) | unset | query parameter carrying this request's canonical site key, so one login service can serve many sites |
+| `issuer` (string) | unset | required `iss` claim value |
+| `audience` (string) | unset | required `aud` claim value (string or array member) |
+| `claims_header` (string) | unset | forward the verified claims JSON to PHP in this request header |
+| `require_https` (bool) | `true` | refuse to accept a session cookie on a cleartext request (loopback exempt) |
+| `require_site` (bool) | `true` | require the token's `site` claim to equal the request's canonical site key — the per-tenant binding (issue #396) |
+
+```toml
+[[middleware]]
+library = "session-cookie"
+order   = 10
+config  = {
+  secret          = "shared-with-the-login-service",
+  login_url       = "https://previews.example/auth/start",
+  return_to_param = "next",
+  site_param      = "site",
+  claims_header   = "X-Session-Claims",
+}
+```
+
+Verification is exactly `jwt`'s (signature first, constant-time HMAC, `alg`
+pinned to HS256, `exp` required, `nbf`/`iss`/`aud` enforced when configured),
+**plus** the per-tenant `site` binding below. Every rejection produces the
+same redirect, so a client cannot learn *why* it was refused.
+
+#### Per-tenant binding (`require_site`, issue #396)
+
+On a multi-tenant preview host every preview resolves to its own **canonical
+site key** — the one tenant identity the router derives (the same value that
+selects the per-site database and KV keyspace), exposed to a module as
+`req.vhost_id()`. The issuer (see the [GitHub OAuth
+gate](/guides/github-auth-middleware/)) binds each session to one preview by
+putting that key in a `site` claim.
+
+With the default `require_site = true`, this gate requires the cookie's `site`
+claim to **equal the request's canonical site key**. A session minted for
+preview A therefore does **not** open preview B; a token with no `site` claim,
+or one bound to another site, fails closed. Without this check a session
+legitimately issued for one preview was a valid session for *every* preview on
+the node — that was the cross-tenant replay of #396.
+
+If `require_site` is on and the request matched **no** known virtual host
+(an unrecognised `Host`, or a single-site node where there is no vhost to
+resolve), the gate cannot bind the session to a tenant and refuses with a hard
+`403`. Set `require_site = false` **only** on a genuinely single-tenant
+deployment whose login service mints site-less tokens — an explicit,
+documented opt-out that turns the `site` check off entirely, never something
+to reach for to "make it work" on a preview host.
+
+#### Return-to, HTTPS, and the login service's half
+
+The redirect is `302` for `GET`/`HEAD`, `303` otherwise (so an unauthenticated
+`POST` becomes a `GET` of the login page, not a re-submit), and carries
+`Cache-Control: no-store` and `Vary: Cookie`. `return_to` is taken from **the
+path the browser requested**, never a client `?next=`; it must be a single
+absolute path (no `//`, `\`, control bytes, `#`, or non-ASCII) under 2048
+bytes, is percent-encoded aggressively, and is otherwise dropped — the login
+service must still validate whatever it receives. `require_https` refuses a
+session cookie on cleartext (loopback exempt) using the host's
+trusted-proxy-aware verdict, not a client `X-Forwarded-Proto`. The login
+service authenticates the visitor once, mints an HS256 JWT with the same
+`secret`, a future `exp`, and a `site` claim equal to the site key it was told
+via `site_param`, and sets it as a `Secure; HttpOnly` cookie on the site's
+domain. There is no revocation: `exp` (kept short) is the only thing that ends
+a session early; rotating `secret` invalidates all sessions at once.
 
 ### `ratelimit`
 

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -817,10 +817,11 @@ and the membership check is per-host and trusts the TCP source address.
 ## `[[middleware]]`
 
 Native middleware mounts — repeatable array-of-tables. Each mount resolves
-against the **builtin registry first**: the ten official modules (`jwt`,
-`cors`, `ratelimit`, `security-headers`, `api-key`, `ip-allowlist`,
-`maintenance-mode`, `redirect`, `request-id`, `header-transform`) are
-compiled into every binary and run in-process — no shared library on disk,
+against the **builtin registry first**: the eleven official modules (`jwt`,
+`session-cookie`, `cors`, `ratelimit`, `security-headers`, `api-key`,
+`ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`,
+`header-transform`) are compiled into every binary and run in-process — no
+shared library on disk,
 no `dlopen`. `request-id` and `header-transform` also run in the response
 phase. Any other name
 loads a shared library (`.so`/`.dylib`/`.dll`) at startup. Loading is
@@ -841,7 +842,7 @@ at startup) — see the guide's
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `library` | string | **required** | A `php:`-prefixed script path (**experimental PHP lane** — see below), a builtin name (`jwt`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, `header-transform`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
+| `library` | string | **required** | A `php:`-prefixed script path (**experimental PHP lane** — see below), a builtin name (`jwt`, `session-cookie`, `cors`, `ratelimit`/`rate-limit`, `security-headers`, `api-key`, `ip-allowlist`, `maintenance-mode`, `redirect`, `request-id`, `header-transform`, or their `ephpm-middleware-*` long forms; `-`/`_` interchangeable), a bare module name resolved through the middleware search path (`<name>.<os>-<arch>.<ext>`, `lib<name>.<ext>`, `<name>.<ext>` in the working directory, `$EPHPM_MIDDLEWARE_DIR`, then `/usr/local/lib/ephpm/middleware`), or an explicit path (any value containing a path separator or file extension). Must not be empty. |
 | `match` | string | (none) | Glob the request path must match for the mount to run. `*` matches any character sequence, including `/`. Unset = every PHP-bound request. |
 | `order` | u32 | **required** | Chain position; lower runs first. Equal orders keep declaration order. Orders sort **within a lane**, not across the two lanes — see the PHP lane below. |
 | `config` | inline table | (none) | Arbitrary module configuration, serialised to JSON and passed to the module's `init` (native lanes) or returned by `ephpm_middleware_config()` (PHP lane). |

--- a/site/content/roadmap/preview-access-gate.md
+++ b/site/content/roadmap/preview-access-gate.md
@@ -1,0 +1,206 @@
+# Preview Access Gate
+
+> **Status: PARTIALLY SHIPPED.** The GitHub-identity login gate and its
+> per-tenant session verifier have shipped, with the cross-tenant session-replay
+> bug (issue #396) fixed. Two further grant paths — a per-site request-phase
+> credential (issue #487) and time-limited shareable URLs — are **designed here,
+> not yet implemented**. Anything below marked *Planned* is design only.
+
+A deployed preview at `<label>.preview.ephpm.dev` resolves for anyone who knows
+the hostname. Fetching **private** code for a preview (switchboard#26) is
+pointless if the resulting site is world-readable, so a preview needs an access
+gate. This page collects the three grant paths into one enforcement story.
+
+## What ships now: the GitHub OAuth login gate (issues #388/#389, #396 fixed)
+
+Two composed native-middleware modules, documented in full at
+[GitHub OAuth gate](/guides/github-auth-middleware/) and
+[`session-cookie`](/guides/native-middleware/#session-cookie):
+
+- **`github-auth`** (dlopen cdylib, cold path) runs the OAuth round trip against
+  GitHub *once* at login — "does this browser's GitHub account have read access
+  to the repo this preview is for?" — and mints a stateless HS256 session bound
+  to the preview via a `site` claim.
+- **`session-cookie`** (builtin, hot path) verifies that session on every
+  request with a single local HMAC — no network call — and redirects
+  unauthenticated browsers to the login path.
+
+### The #396 fix — per-tenant binding
+
+The issuer always bound each session to one preview (`"site": <vhost>` claim),
+but the verifier originally **ignored** that claim: a session minted for preview
+A verified on every preview on the node — a cross-tenant auth bypass on the one
+deployment shape the feature exists for.
+
+The fix makes the verifier honour the binding, and makes issuer and verifier
+agree on identity **by construction**:
+
+- Both derive the tenant identity from the router's one canonical site key
+  (`Request::vhost_id()`, ABI minor 3 / issue #390) — never from the raw `Host`.
+- `Hs256Policy::verify(token, now, expected_site: Option<&str>)` gained the
+  `expected_site` parameter. When `Some`, the token's `site` claim must be a
+  string equal to it; absent, non-string, or mismatched fails closed. The `jwt`
+  API gate passes `None` (it has no tenancy).
+- `session-cookie` gained `require_site` (**default `true`**). It passes the
+  request's canonical site key as `expected_site`. If the request matched no
+  vhost (unrecognised `Host`, or a single-site node), it cannot bind a session
+  to a tenant and refuses with a hard `403`. `require_site = false` is an
+  explicit single-tenant opt-out, never a preview-host setting.
+
+The regression guard is a test that mints a session for `site:"alpha"` and
+asserts it is **rejected** when serving `beta` and accepted only on `alpha`
+(`ephpm-middleware-builtins`, `session_cookie::tests`), plus the crypto-core
+proof that the pre-fix call shape (`verify(.., None)`) still accepts the token
+while the site-aware call rejects it off its site.
+
+### Static assets are already covered
+
+Because the middleware **request phase** runs on both the PHP path and
+`Router::static_request_phase` (issue #395) — with the same canonical site key
+and connection scheme on both — mounting `session-cookie` gates a preview's
+**static files too**, per-site and fail-closed, with no extra work. An
+unauthenticated `GET /wp-content/uploads/secret.png` redirects to login exactly
+as `GET /index.php` does. This is the property a switchboard
+`auto_prepend_file` gate could never have: that runs only on the PHP path.
+
+## Planned: per-site request-phase credential (issue #487)
+
+*Design only — not implemented.* The OAuth gate answers "does this GitHub
+account have repo access?". Sometimes the operator wants a lighter gate — a
+per-preview shared credential — without standing up an OAuth login service, and
+switchboard needs a channel to set that credential per preview. The switchboard
+side wrote the full design in `ephpm/switchboard:docs/preview-access-gate.md`
+(PR #30); this is the ePHPm contract.
+
+### Mechanism
+
+Reuse the same request-phase enforcement point (`static_request_phase` +
+`handle_php`), so it covers static and PHP alike and fails closed. Add a **typed
+per-site override key** carrying an HTTP Basic-auth **verifier** (never the
+plaintext) to the operator-owned per-site override file switchboard already
+writes:
+
+```toml
+# <site_overrides_dir>/<site-key>.toml   (written by switchboard, not the tenant)
+document_root      = "public"
+require_basic_auth = "<user>:<bcrypt-or-hmac-of-password>"   # NEW, planned
+```
+
+- Add `require_basic_auth` as a typed field on `RawOverride` + `KNOWN_KEYS` in
+  `ephpm-server/src/site_overrides.rs`. The loader already validates and
+  **fail-closes per site** (a broken override serves nothing for that one site,
+  never the wider default — the narrowing-config rule from #463).
+- Enforcement: when the resolved site has `require_basic_auth`, a request whose
+  `Authorization: Basic` header does not verify (constant-time compare) gets
+  `401 WWW-Authenticate: Basic`, ahead of both the static and PHP serving
+  paths. The credential is checked against the **operator-owned** override, not
+  anything the tenant's PHP can write.
+- **Forward-compat:** an ePHPm predating the key treats it as an unknown
+  override key and ignores it (the existing per-site-override leniency contract;
+  distinct from the strict config-section rule). switchboard only writes the key
+  once an enforcing ePHPm is deployed — the same rollout-ordering discipline the
+  `document_root` override followed.
+
+### The contract switchboard must satisfy
+
+1. Generate a per-preview credential, hash it, write `require_basic_auth` to
+   `<site_overrides_dir>/<site-key>.toml` using the **canonical site key** (the
+   `Router::resolve_site` derivation switchboard already ports in
+   `src/site_key.rs`), published atomically *before* the site is served.
+2. Post the plaintext in the PR comment (the intended audience already has repo
+   read access, so seeing it is not a new disclosure — see threat model).
+3. Rotate the credential per deploy; remove the override file on teardown.
+4. Do **not** put the credential anywhere the tenant's own repo controls — it
+   travels the operator-owned override channel only, exactly as `document_root`
+   does.
+
+*Alternative considered (option 2 in the switchboard design): expose the site
+key to a `RequestCtx` and add a builtin `preview_auth` module reading a per-site
+source. More surface than preview-privacy warrants; the override-key path is
+smaller and reuses machinery that already fail-closes per site.*
+
+## Planned: temporary shareable URLs
+
+*Design only — not implemented.* A second grant path into the **same**
+enforcement point, for people who lack GitHub repo access — stakeholders,
+designers, a client — so they can see a preview without a login and without
+being added to the repo.
+
+### Shape
+
+A time-limited, signed **capability token**, minted with the same HS256 secret
+the `session-cookie` gate already holds, carrying:
+
+- `site` = the preview's canonical site key (so it is **per-preview**, checked
+  by the exact `require_site` binding above — a share link for preview A never
+  opens B);
+- `via = "share"` (distinguishes it from an OAuth session in logs/audit);
+- a short `exp` (default **≤ 1 hour**, hard-capped well below a session TTL);
+- optionally `jti` (see revocation).
+
+The gate accepts it as an **alternative** to the OAuth session at the same
+verification point: presented either as the session cookie (a share link that
+lands and sets the cookie) or as a `?ephpm_share=<token>` query parameter that
+the gate exchanges for the cookie on first use and strips from the redirect.
+Because it verifies through the same `Hs256Policy` with the same `expected_site`,
+**no new verification code and no second verifier** — the property #396's
+one-verifier design exists to protect.
+
+### Minting
+
+Two options, both keeping the OAuth flow the only thing that talks to GitHub:
+
+1. **By switchboard** (operator control plane), on request from an authenticated
+   repo member — switchboard already holds the secret to write per-site config,
+   so it can mint. Simplest; no new ePHPm endpoint.
+2. **By an authenticated repo-member hitting an ePHPm endpoint** — a reserved
+   path on `github-auth` (e.g. `/_ephpm/auth/github/share`) that, *only* for a
+   request already carrying a valid OAuth session for this preview, mints a
+   `via:"share"` token with a bounded TTL and returns the link. This keeps
+   minting gated on real repo access and needs no switchboard round trip.
+
+Issuance is deliberately unprivileged in the sense that *anything holding the
+secret* can mint — that is inherent to a self-contained HS256 token and is why
+the blast radius is bounded below, not by an issuance ACL.
+
+### Expiry and revocation
+
+- **Expiry** is the primary control: a short `exp` means a leaked link stops
+  working on its own. This is the same "TTL is the blast radius" property as the
+  OAuth session, tightened.
+- **Revocation before expiry** needs state, since the token is self-contained.
+  The design uses the embedded KV store the gate can already reach: a
+  **deny-list** keyed by `jti` (`share:revoked:<jti>` with a TTL == the token's
+  remaining life), replicated across the cluster by gossip, checked on the hot
+  path only for `via:"share"` tokens (so a normal session pays nothing). Teardown
+  of a preview revokes all its outstanding share tokens by writing the site's
+  epoch marker (`share:epoch:<site>`) — a token minted before the current epoch
+  is refused, so closing a PR invalidates every share link for it at once
+  without enumerating `jti`s.
+
+### Threat model — say it plainly
+
+A share URL is a **bearer capability**: anyone who has the link is in, until it
+expires or is revoked. That is the point (sharing with people who cannot
+authenticate), and it is a *weaker* property than the OAuth gate — state it in
+every place a link is minted. Blast radius is bounded by design:
+
+- **Per-preview** (`site` claim + `require_site`): a link opens exactly one
+  preview, never the fleet.
+- **Short-lived** (`exp` ≤ 1 hour default): a leaked link self-heals.
+- **Revocable** (KV deny-list + per-site epoch): a link can be killed before
+  expiry, and teardown kills all of them.
+- **HTTPS-only and same transport rules** as the session it stands in for.
+
+What it explicitly does **not** defend: someone the link was shared with
+forwarding it within its TTL, or a compromised holder. Those are accepted for a
+preview-privacy feature and out of scope; a preview is not a secrets vault.
+
+## Relationship to multi-tenant isolation
+
+This gate defends **preview privacy** — stopping an internet visitor who guessed
+a hostname from reading a preview. It is **not** the multi-tenant isolation
+boundary (per-site databases, KV keyspaces, `open_basedir`), which is a separate,
+existing property. The one place the two meet is the canonical site key: the gate
+binds to the exact identity the isolation layer uses, so "authorized for preview
+A" and "served preview A's data" are the same tenant by construction.


### PR DESCRIPTION
Revives the two closed preview-auth PRs (**#389** issuer, **#388** verifier) onto current `main` as one coherent change and **fixes the CRITICAL cross-tenant session-replay bug #396** that blocked shipping them together. **Do not merge — for review.**

## Deliverable 1 (implemented + tested): the OAuth gate with #396 fixed

Two composed native-middleware modules:
- **`github-auth`** (dlopen cdylib, cold path) — OAuth round trip vs GitHub *once* at login, mints a stateless HS256 session bound to the preview (`site` claim).
- **`session-cookie`** (builtin, hot path) — verifies that session on every request with one local HMAC, redirects unauthenticated browsers to login.

### The #396 fix

The issuer always bound each session to one preview (`"site": <vhost>`), but the verifier **ignored** the claim — a session for preview A verified on every preview on the node. The fix makes issuer and verifier agree on tenant identity **by construction** and the verifier honour the binding:

- `Hs256Policy::verify(token, now, expected_site: Option<&str>)` — new `expected_site`. When `Some`, the token's `site` claim must be a string equal to it; **absent, non-string, or mismatched fails closed**. `jwt` (API gate, no tenancy) passes `None`, so its behaviour is unchanged.
- `session-cookie` gains **`require_site` (default `true`)** and passes the request's **canonical site key** (`Request::vhost_id()`, ABI minor 3 / #390) as `expected_site`. No resolved vhost + `require_site` → hard `403`. `require_site = false` is an explicit single-tenant opt-out.
- `github-auth` derives the vhost from `vhost_id()` (the canonical site key) instead of re-normalizing the raw `Host` — the exact value the verifier checks, so the two key on one identity.

### The test that was missing (#396) and proof it fails pre-fix

- `session_cookie::tests::a_session_for_one_site_is_rejected_on_another` — a session minted for `site:"alpha"` is **rejected** on `beta` and accepted only on `alpha` (both directions).
- `hs256::tests::a_site_bound_token_verifies_only_on_its_own_site` — the **pre-fix call shape** `verify(t, now, None)` (which ignored `site`) still **accepts** the token, while the site-aware `verify(t, now, Some("beta"))` **rejects** it. That contrast is the regression guard: the old, site-blind verifier accepted it; the fix does not.
- Also covered: expired / wrong-secret / no-`site`-claim rejected; happy path accepted on the correct site; two previews on one node don't share a session; the `require_site = false` opt-out and its stated cross-site laxity.

### Rebased onto current `main` (not cherry-picked)

The ABI moved to minor 3 and the builtin set to ten since #388/#389 were written, so the logic was rebased onto the current structures:
- `session-cookie` registered as the **11th builtin** + a cdylib shell crate; `hs256` extracted as the shared core; `jwt` refactored onto it (`verify(.., None)`).
- Host plumbing #388 originally added (`request_is_secure`, repeated-header joining) is **already in main** via later minors — reused, not re-added. `vhost_id()`/`is_secure()`/`with_scheme()` adapted to the current API.
- `session-cookie`'s `claims_header` added to the ingest-strip list; `CONFIG_KEYS` declared for the #473 strictness check (both registry and dlopen lanes); registry + strictness tests extended. `github-auth` stays a dlopen-only cold-path crate.

**Static assets are already covered:** the request phase runs on both `handle_php` and `static_request_phase` (#395) with the same canonical site key and scheme, so mounting `session-cookie` gates a preview's static files per-site, fail-closed — no extra work.

Tests: `ephpm-middleware-builtins` 145 pass; `github-auth` 64 lib + 9 integration pass; `ephpm-server` middleware/router/registry/strictness tests pass. Clippy pedantic `-D warnings` and nightly fmt clean on every touched crate.

## Deliverable 2 (design, written): the two remaining pieces

`site/content/roadmap/preview-access-gate.md` (design only, labelled not-implemented):
- **Request-phase enforcement (#487):** a per-site HTTP Basic-auth **verifier** carried on switchboard's operator-owned per-site override file (`require_basic_auth`, a hash never the plaintext), enforced at the same request phase so it covers **static + PHP**, fail-closed. Includes the exact contract switchboard must satisfy (canonical-key filename, secret plumbing, rollout ordering, teardown).
- **Temporary shareable URLs:** a time-limited signed **capability token** into the *same* enforcement point (same `Hs256Policy`, same `require_site` binding, no second verifier) for people without repo access. Minting (switchboard or an authenticated repo-member endpoint), expiry, KV deny-list + per-site epoch revocation, and an explicit bearer-capability threat model with a bounded blast radius.

## Docs

`session-cookie` and the `require_site`/#396 binding documented in `native-middleware.md` and `reference/config.md`; the `github-auth` guide notes the automatic per-tenant binding; the roadmap doc labels the unbuilt pieces as design only.
