### PR TITLE
fix(server): close eBPF loopback classifier cross-tenant bypass

### DIFF
--- a/crates/ephpm-server/bpf/vhostnet.bpf.c
+++ b/crates/ephpm-server/bpf/vhostnet.bpf.c
@@ -43,7 +43,48 @@
 
 char LICENSE[] SEC("license") = "GPL";
 
-#define LOOPBACK4_BE bpf_htonl(0x7f000001) // 127.0.0.1, network byte order
+// ---- loopback classification (shared by bind + connect, v4 + v6) -----------
+//
+// Linux treats the ENTIRE 127.0.0.0/8 range as loopback (RFC 1122 §3.2.1.3),
+// not just 127.0.0.1, and an IPv4-mapped IPv6 address `::ffff:a.b.c.d` reaches
+// the same IPv4 stack as `a.b.c.d`. Classifying only the exact literals
+// 127.0.0.1 / ::1 as loopback let a tagged tenant reach a neighbour's loopback
+// sidecar by aliasing the destination (127.0.0.2, ::ffff:127.0.0.1, ...):
+// do_connect() saw `is_loopback == 0`, skipped the port-ownership check, and
+// allowed the connect. These helpers are the single source of truth for both
+// hooks so the two sides can never drift apart again.
+//
+// Everything is compared in NETWORK byte order (the on-wire order of the UAPI
+// user_ip4 / user_ip6 context fields), so masks/literals are wrapped in
+// bpf_htonl(). All loads are of the aligned 32-bit context words, so the
+// verifier is happy and there are no unaligned reads.
+
+// 127.0.0.0/8 in network byte order.
+static __always_inline int is_loopback4_be(__u32 ip_be)
+{
+    return (ip_be & bpf_htonl(0xff000000)) == bpf_htonl(0x7f000000);
+}
+
+// Classify a 128-bit IPv6 address (four network-order 32-bit words) as loopback:
+//   * ::1                         -> loopback
+//   * ::ffff:a.b.c.d (v4-mapped)  -> loopback IFF a.b.c.d is in 127.0.0.0/8
+// An IPv4-mapped address that embeds a NON-loopback v4 (e.g. ::ffff:1.1.1.1)
+// is deliberately NOT loopback — it belongs to the egress allowlist layer, same
+// as the bare IPv4 would. IPv4-COMPATIBLE addresses (::a.b.c.d, RFC 4291
+// §2.5.5.1 deprecated) are intentionally not folded in: Linux does not route
+// them onto the v4 loopback, so there is no reachable bypass, and treating the
+// ::/96 prefix as "classify by embedded v4" would misclassify ::1 itself
+// (embedded 0.0.0.1, outside 127/8) as non-loopback.
+static __always_inline int is_loopback6(const __u32 ip6[4])
+{
+    // ::1 (network order: high 96 bits zero, low word == 1).
+    if (ip6[0] == 0 && ip6[1] == 0 && ip6[2] == 0 && ip6[3] == bpf_htonl(1))
+        return 1;
+    // ::ffff:0:0/96 — IPv4-mapped: first 80 bits zero, next 16 bits 0xffff.
+    if (ip6[0] == 0 && ip6[1] == 0 && ip6[2] == bpf_htonl(0x0000ffff))
+        return is_loopback4_be(ip6[3]);
+    return 0;
+}
 
 // Compile-time ceiling for the real-port pool/ownership maps. ePHPm fills only
 // the configured sidecar_port_range (default 20000-32767 ~= 12768) at load; this
@@ -159,7 +200,18 @@ static __always_inline __u32 quota_max(void)
 }
 
 // ---- bind: pool allocation + quota + transparent rewrite -------------------
-
+//
+// NOTE ON LOOPBACK CLASSIFICATION: unlike do_connect(), do_bind() does NOT gate
+// on the destination address — it rewrites the port of EVERY bind by a tagged
+// task (loopback, wildcard 0.0.0.0/::, or a specific address) to a private real
+// port the vhost owns. So there is no exact-127.0.0.1/::1 classification here to
+// keep in sync with the connect side; the is_loopback4_be/is_loopback6 helpers
+// are a connect-side concern only. This is safe because the security boundary is
+// the connect-side ownership check (port_owner keyed on the real port): whatever
+// address a sidecar binds, a peer tenant reaching its real port is denied there.
+// A tagged bind to a wildcard address is still rewritten and owned, so a peer
+// aliasing it via 127.x now hits that same ownership deny once connect classifies
+// the whole 127.0.0.0/8 + mapped range as loopback.
 static __always_inline int do_bind(struct bpf_sock_addr *ctx)
 {
     __u32 *vhostp = current_vhost();
@@ -245,13 +297,13 @@ static __always_inline int do_connect(struct bpf_sock_addr *ctx, int is_loopback
 SEC("cgroup/connect4")
 int vhost_connect4(struct bpf_sock_addr *ctx)
 {
-    return do_connect(ctx, ctx->user_ip4 == LOOPBACK4_BE);
+    // Whole 127.0.0.0/8, not just 127.0.0.1 — see is_loopback4_be().
+    return do_connect(ctx, is_loopback4_be(ctx->user_ip4));
 }
 
 SEC("cgroup/connect6")
 int vhost_connect6(struct bpf_sock_addr *ctx)
 {
-    int lo = ctx->user_ip6[0] == 0 && ctx->user_ip6[1] == 0 &&
-             ctx->user_ip6[2] == 0 && ctx->user_ip6[3] == bpf_htonl(1); // ::1
-    return do_connect(ctx, lo);
+    // ::1 and IPv4-mapped loopback (::ffff:127.x) — see is_loopback6().
+    return do_connect(ctx, is_loopback6(ctx->user_ip6));
 }

--- a/crates/ephpm-server/tests/tenant_ebpf_loopback.rs
+++ b/crates/ephpm-server/tests/tenant_ebpf_loopback.rs
@@ -1,0 +1,230 @@
+//! Live regression test for the eBPF per-vhost loopback-classifier bypass.
+//!
+//! The `vhostnet` connect classifier once recognised only the exact literals
+//! `127.0.0.1` / `::1` as loopback, so a tagged tenant could reach a neighbour
+//! tenant's loopback sidecar by aliasing the destination — `127.0.0.2`,
+//! `::ffff:127.0.0.1`, `::ffff:127.0.0.2` — which the classifier called
+//! *non*-loopback, causing `do_connect` to skip the port-ownership check.
+//!
+//! This test stands up two tagged tenants (Alice, Bob) in one process/cgroup,
+//! has Alice bind an unauthenticated loopback sidecar (its bind is rewritten to
+//! a private real port Alice owns), and then has Bob try to reach that real port
+//! through each aliased address. After the fix every alias is denied at the
+//! `connect` hook (`EPERM`) and Alice's secret marker never crosses; before the
+//! fix Bob's connect succeeds and reads the marker, so this test fails.
+//!
+//! It also checks the invariants the fix must NOT break: ePHPm's own infra port
+//! (`3306`) stays reachable, a non-loopback egress is not denied by the loopback
+//! floor, and Alice can still reach her own sidecar.
+//!
+//! ## Running
+//!
+//! Ignored by default — it needs `CAP_BPF`/`CAP_NET_ADMIN` (i.e. root) and a
+//! writable cgroup v2 hierarchy, which a normal `cargo test` run does not have.
+//! Run it as root on a Linux ≥ 5.10 host:
+//!
+//! ```text
+//! cargo test -p ephpm-server --test tenant_ebpf_loopback --no-run
+//! sudo ./target/debug/deps/tenant_ebpf_loopback-<hash> --ignored --nocapture
+//! ```
+//!
+//! (On this project's WSL box: build as the unprivileged user, run the test
+//! binary via `wsl -u root`.)
+
+#![cfg(target_os = "linux")]
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use ephpm_server::tenant_ebpf::TenantEbpf;
+
+/// EPERM — the errno a `cgroup/connect` BPF program returns to deny a connect.
+const EPERM: i32 = 1;
+
+/// Create a dedicated cgroup v2 leaf and move this whole process into it, so the
+/// cgroup-attached BPF programs observe our bind/connect syscalls. Returns the
+/// leaf path, or `None` when the environment can't support the test (not root,
+/// no cgroup v2) — in which case the caller skips.
+fn enter_test_cgroup() -> Option<PathBuf> {
+    let root = std::path::Path::new("/sys/fs/cgroup");
+    if !root.join("cgroup.controllers").exists() {
+        eprintln!("SKIP: no cgroup v2 unified hierarchy at /sys/fs/cgroup");
+        return None;
+    }
+    let leaf = root.join(format!("ephpm-ebpf-loopback-test-{}", std::process::id()));
+    if std::fs::create_dir_all(&leaf).is_err() {
+        eprintln!("SKIP: cannot create {} (need root)", leaf.display());
+        return None;
+    }
+    if std::fs::write(leaf.join("cgroup.procs"), std::process::id().to_string()).is_err() {
+        eprintln!("SKIP: cannot move process into {} (need root)", leaf.display());
+        let _ = std::fs::remove_dir(&leaf);
+        return None;
+    }
+    Some(leaf)
+}
+
+/// Move back to the root cgroup and remove the leaf. Best-effort teardown.
+fn leave_test_cgroup(leaf: &std::path::Path) {
+    let _ = std::fs::write("/sys/fs/cgroup/cgroup.procs", std::process::id().to_string());
+    let _ = std::fs::remove_dir(leaf);
+}
+
+/// Attempt a connect and report the outcome distinctly: the marker string if the
+/// connection succeeded and data was read, `Err(errno)` for a syscall error
+/// (EPERM = BPF deny, ECONNREFUSED = BPF allowed but nothing listening at dest).
+fn probe(addr: SocketAddr) -> Result<Option<String>, i32> {
+    match TcpStream::connect_timeout(&addr, Duration::from_millis(500)) {
+        Ok(mut s) => {
+            s.set_read_timeout(Some(Duration::from_millis(500))).ok();
+            let mut buf = [0u8; 128];
+            let n = s.read(&mut buf).unwrap_or(0);
+            Ok((n > 0).then(|| String::from_utf8_lossy(&buf[..n]).into_owned()))
+        }
+        Err(e) => Err(e.raw_os_error().unwrap_or(0)),
+    }
+}
+
+/// True when a connect result is a hard BPF denial (`EPERM`) with no data.
+fn is_denied(r: &Result<Option<String>, i32>) -> bool {
+    matches!(r, Err(e) if *e == EPERM)
+}
+
+#[test]
+#[ignore = "needs root (CAP_BPF/CAP_NET_ADMIN) + writable cgroup v2; run manually"]
+fn aliased_and_mapped_loopback_is_ownership_checked() {
+    let Some(leaf) = enter_test_cgroup() else {
+        return; // environment can't support the test; skip.
+    };
+    let leaf_path = leaf.clone();
+    // Ensure teardown even on assertion panic.
+    let _guard = scopeguard(move || leave_test_cgroup(&leaf_path));
+
+    let cgroup = leaf.to_str().unwrap();
+    let ebpf = TenantEbpf::load_and_attach(Some(cgroup), &[3306, 6379])
+        .expect("load+attach vhostnet BPF (need CAP_BPF and a real, non-placeholder object)");
+    ebpf.fill_pool((20000, 20100), 8).expect("fill port pool");
+
+    // --- infra listener on 3306 (untagged bind => not rewritten) ---
+    let infra = TcpListener::bind("127.0.0.1:3306").expect("bind infra 3306");
+    std::thread::spawn(move || {
+        for s in infra.incoming().flatten() {
+            let mut s = s;
+            let _ = s.write_all(b"INFRA-3306-OK");
+        }
+    });
+
+    // --- Alice (tenant 1): sidecar bound SPECIFICALLY to 127.0.0.1 ---
+    let (tx, rx) = mpsc::channel::<u16>();
+    let alice_ebpf = ebpf.clone();
+    std::thread::spawn(move || {
+        let _tag = alice_ebpf.tag_current_thread("alice");
+        let l = TcpListener::bind("127.0.0.1:8080").expect("alice bind (rewritten)");
+        let real = l.local_addr().unwrap().port();
+        tx.send(real).unwrap();
+        for s in l.incoming().flatten() {
+            let mut s = s;
+            let _ = s.write_all(format!("ALICE-SECRET-{real}").as_bytes());
+        }
+    });
+    let alice_port = rx.recv_timeout(Duration::from_secs(5)).expect("alice real port");
+
+    // --- Alice sidecar #2 bound to 0.0.0.0 (reachable at any 127.x alias) ---
+    let (tx2, rx2) = mpsc::channel::<u16>();
+    let alice_ebpf2 = ebpf.clone();
+    std::thread::spawn(move || {
+        let _tag = alice_ebpf2.tag_current_thread("alice");
+        let l = TcpListener::bind("0.0.0.0:8081").expect("alice wildcard bind");
+        let real = l.local_addr().unwrap().port();
+        tx2.send(real).unwrap();
+        for s in l.incoming().flatten() {
+            let mut s = s;
+            let _ = s.write_all(format!("ALICE-WILDCARD-{real}").as_bytes());
+        }
+    });
+    let alice_wild = rx2.recv_timeout(Duration::from_secs(5)).expect("alice wildcard port");
+
+    std::thread::sleep(Duration::from_millis(200));
+
+    // --- Bob (tenant 2): attempt to reach Alice ---
+    let _bob = ebpf.tag_current_thread("bob");
+
+    let v4 = |ip: Ipv4Addr, p: u16| SocketAddr::new(IpAddr::V4(ip), p);
+    let v6 = |ip: Ipv6Addr, p: u16| SocketAddr::new(IpAddr::V6(ip), p);
+
+    // Baseline: exact 127.0.0.1 to Alice's real port is denied (always was).
+    let exact = probe(v4(Ipv4Addr::LOCALHOST, alice_port));
+    assert!(is_denied(&exact), "127.0.0.1 must be ownership-denied, got {exact:?}");
+
+    // THE BUG: mapped loopback ::ffff:127.0.0.1 to Alice's 127.0.0.1 sidecar.
+    // Pre-fix: connects and reads "ALICE-SECRET-*". Post-fix: EPERM, no marker.
+    let mapped = probe(v6("::ffff:127.0.0.1".parse().unwrap(), alice_port));
+    assert!(
+        is_denied(&mapped),
+        "BYPASS: ::ffff:127.0.0.1 reached Alice's 127.0.0.1 sidecar: {mapped:?}"
+    );
+
+    // THE BUG: aliased loopback 127.0.0.2 to Alice's 0.0.0.0 sidecar.
+    // Pre-fix: connects and reads "ALICE-WILDCARD-*". Post-fix: EPERM.
+    let aliased = probe(v4(Ipv4Addr::new(127, 0, 0, 2), alice_wild));
+    assert!(is_denied(&aliased), "BYPASS: 127.0.0.2 reached Alice's 0.0.0.0 sidecar: {aliased:?}");
+
+    // THE BUG: mapped aliased ::ffff:127.0.0.2 to Alice's 0.0.0.0 sidecar.
+    let mapped_alias = probe(v6("::ffff:127.0.0.2".parse().unwrap(), alice_wild));
+    assert!(
+        is_denied(&mapped_alias),
+        "BYPASS: ::ffff:127.0.0.2 reached Alice's 0.0.0.0 sidecar: {mapped_alias:?}"
+    );
+
+    // Also confirm the 127.0.0.2 vector against the 127.0.0.1-only sidecar is
+    // denied at the BPF layer (pre-fix it was ALLOWED — ECONNREFUSED because the
+    // socket is 127.0.0.1-specific — which is still a policy bypass).
+    let aliased_specific = probe(v4(Ipv4Addr::new(127, 0, 0, 2), alice_port));
+    assert!(
+        is_denied(&aliased_specific),
+        "127.0.0.2 must be ownership-denied by the loopback floor, got {aliased_specific:?}"
+    );
+
+    // --- Invariants the fix must NOT break ---
+
+    // Infra port stays reachable and serves its marker.
+    let infra_probe = probe(v4(Ipv4Addr::LOCALHOST, 3306));
+    assert_eq!(
+        infra_probe.as_ref().ok().and_then(Clone::clone).as_deref(),
+        Some("INFRA-3306-OK"),
+        "infra port 3306 must stay reachable, got {infra_probe:?}"
+    );
+
+    // A non-loopback egress must NOT be EPERM'd by the loopback floor (it belongs
+    // to the egress allowlist layer). 192.0.2.1 (TEST-NET-1) is unroutable here,
+    // so we expect a timeout/unreachable, never EPERM.
+    let egress = probe(v4(Ipv4Addr::new(192, 0, 2, 1), 9));
+    assert!(
+        !matches!(&egress, Err(e) if *e == EPERM),
+        "public egress must not be denied by the loopback floor, got {egress:?}"
+    );
+
+    // Alice can still reach her OWN sidecar (ownership allow).
+    let _alice_again = ebpf.tag_current_thread("alice");
+    let own = probe(v4(Ipv4Addr::LOCALHOST, alice_port));
+    assert_eq!(
+        own.as_ref().ok().and_then(Clone::clone).as_deref(),
+        Some(&format!("ALICE-SECRET-{alice_port}")[..]),
+        "Alice must still reach her own sidecar, got {own:?}"
+    );
+}
+
+/// Minimal drop-guard so cgroup teardown runs even if an assertion panics
+/// (avoids a `scopeguard` crate dependency in dev-deps).
+fn scopeguard<F: FnMut()>(f: F) -> impl Drop {
+    struct G<F: FnMut()>(F);
+    impl<F: FnMut()> Drop for G<F> {
+        fn drop(&mut self) {
+            (self.0)();
+        }
+    }
+    G(f)
+}


### PR DESCRIPTION
## Summary

The per-vhost eBPF network policy (`crates/ephpm-server/bpf/vhostnet.bpf.c`) had a **cross-tenant isolation bypass**. The `cgroup/connect` classifier recognised only the exact addresses `127.0.0.1` and `::1` as loopback. Linux treats the entire `127.0.0.0/8` as loopback, and an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) reaches the same IPv4 stack as `a.b.c.d`. A connection to a mapped/aliased loopback address was classed **non-loopback**, so `do_connect()` hit `if (!is_loopback) return 1;` and **skipped the per-vhost port-ownership check** — letting a tagged tenant reach a neighbour tenant's localhost sidecar.

Confirmed live (Linux 6.18, same aya 0.13 loader ePHPm uses): a tenant *Bob* reached tenant *Alice*'s unauthenticated sidecar and read an Alice-only marker via `::ffff:127.0.0.1` (Alice bound to `127.0.0.1` specifically), and via `127.0.0.2` / `::ffff:127.0.0.2` against a wildcard-bound sidecar.

## Fix

A single shared `__always_inline` classifier, used by both `connect4` and `connect6` so the two sides can't drift again:

- **connect4:** whole `127.0.0.0/8` — `(ip & htonl(0xff000000)) == htonl(0x7f000000)`.
- **connect6:** keep `::1`; add IPv4-mapped loopback (`::ffff:0:0/96`) classified by its embedded IPv4. A mapped **non**-loopback (`::ffff:1.1.1.1`) stays non-loopback → egress layer. IPv4-**compatible** (`::a.b.c.d`, deprecated) is deliberately **not** folded in: Linux does not route it onto v4 loopback (no reachable bypass), and treating the `::/96` prefix as "classify by embedded v4" would misclassify `::1` itself.

**Bind side:** `do_bind` does not classify loopback at all — it rewrites *every* tagged bind — so it had no analogous exact-address gap. A comment records this and why the connect-side ownership check (keyed on the real port) is the actual boundary. Infra-port allowlist (`:3306` wire-auth, KV RESP) is unaffected.

## Before / after (live, two tenants, one cgroup)

| Vector (Bob → Alice) | pre-fix | post-fix |
|---|---|---|
| `127.0.0.1:rport` (exact) | EPERM (denied) | EPERM |
| `::ffff:127.0.0.1:rport` (Alice on 127.0.0.1) | **CONNECT OK, read `ALICE-SECRET`** | **EPERM** |
| `127.0.0.2:rport` (Alice on 0.0.0.0) | **CONNECT OK, read `ALICE-WILDCARD`** | **EPERM** |
| `::ffff:127.0.0.2:rport` (Alice on 0.0.0.0) | **CONNECT OK, read `ALICE-WILDCARD`** | **EPERM** |
| `127.0.0.2:rport` (Alice on 127.0.0.1) | ECONNREFUSED (BPF **allowed**) | EPERM |
| `127.0.0.1:3306` (infra) | OK | OK |
| `192.0.2.1:9` / `::ffff:1.1.1.1:9` (public egress) | ETIMEDOUT (not denied) | ETIMEDOUT (not denied) |
| Alice → her own `rport` | OK | OK |

## Test

`crates/ephpm-server/tests/tenant_ebpf_loopback.rs` — a root-only, `#[ignore]`d Linux integration test that runs the two-tenant attack through the real `TenantEbpf` and asserts the mapped/aliased vectors are ownership-denied and never cross the marker, while infra/egress/own-sidecar still work. It **fails against the pre-fix classifier** (`BYPASS: ::ffff:127.0.0.1 reached Alice's 127.0.0.1 sidecar: Ok(Some("ALICE-SECRET-20000"))`) and **passes after the fix**. Both states verified live; the BPF verifier accepts the new classifier, and teardown leaves 0 progs / 0 maps.

`clang -Werror` (via `build.rs`), clippy pedantic `-D warnings`, and nightly `fmt --check` all clean.

## Companion finding — the nft floor (report only, not changed here)

The static nft egress floor documented in `site/content/guides/ebpf-per-vhost-network.md` drops `ip daddr 127.0.0.0/8` (all v4 aliases) **and** `ip6 daddr ::1/128`. Unlike the eBPF hook, nft filters the **post-translation packet**: a `::ffff:127.x` connect egresses as an *IPv4* packet and is caught by the `ip daddr 127.0.0.0/8` rule, and IPv6 has only the single loopback `::1`. So the nft floor as written should **not** share this gap, and the currently-active preview-node exposure is likely limited to nodes where the eBPF layer is enabled. This reasoning was **not** verifiable on the test box (no `nft`/`iptables`); it should be confirmed with rule counters on a node that has nftables. Tracking separately.

**Do not merge on my behalf — for review.**
