### PR TITLE
feat(server): emit structured JSON access log on [server.logging] access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5647,6 +5647,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5656,12 +5666,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ figment = { version = "0.10", features = ["toml", "env"] }
 # untrusted input, and TOML has no anchor/alias expansion to defend against.
 toml = "0.8"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # OTLP trace export — only compiled behind the `otlp` cargo feature on
 # ephpm-server (forwarded by the ephpm binary's `otlp` feature). The
 # opentelemetry / tracing-opentelemetry pair must be bumped in lockstep:

--- a/crates/ephpm-config/src/lib.rs
+++ b/crates/ephpm-config/src/lib.rs
@@ -1448,6 +1448,18 @@ impl ServerConfig {
 pub struct LoggingConfig {
     /// Path to the access log file. Empty string disables access logging.
     ///
+    /// When set, the server writes one structured-JSON record per served
+    /// request to this file, with fields: `method`, `path` (request path
+    /// only — never the query string), `status`, `duration_ms`, `bytes`
+    /// (omitted for streaming responses of unknown size), `client_ip` (the
+    /// effective client after trusted-proxy resolution), and `version`.
+    ///
+    /// For safety the log deliberately carries **no** request headers
+    /// (`Authorization`/`Cookie`), no query string, and no `$_SERVER` value
+    /// (`DB_PASSWORD`, `DATABASE_URL`, `PHP_AUTH_PW`), so it cannot leak a
+    /// credential. Records are written only to this file, not echoed to
+    /// stdout or the service log.
+    ///
     /// Default: `""` (disabled).
     #[serde(default)]
     pub access: String,

--- a/crates/ephpm-server/src/lib.rs
+++ b/crates/ephpm-server/src/lib.rs
@@ -846,7 +846,10 @@ async fn bind_listeners(
         .with_db_health(db_health)
         .with_primary_view(primary_view)
         .with_websocket(websocket)
-        .with_request_log(request_log);
+        .with_request_log(request_log)
+        // Access logging is on whenever `[server.logging] access` names a
+        // file; the file layer that consumes the records is built in `main`.
+        .with_access_log(!config.server.logging.access.is_empty());
 
         let router = match per_site_db_wire {
             Some((auth, listen)) => router.with_per_site_db_wire(auth, listen),

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -762,6 +762,12 @@ pub struct Router {
     /// Enabled by default in dev mode, opt-in via
     /// `[server.diagnostics] request_log` in serve mode.
     request_log: Option<Arc<crate::timeline::RequestLog>>,
+    /// Emit one access-log record per served request on the dedicated
+    /// `access_log` tracing target. `false` (the default) skips the capture
+    /// entirely — the shared serve-mode hot path allocates nothing. Enabled
+    /// when `[server.logging] access` names a file; the file layer that
+    /// consumes the target is wired up in the `ephpm` binary's `main`.
+    access_log_enabled: bool,
     /// Whether this node is currently the writable SQLite target, exposed at
     /// `/_ephpm/primary` so an external load balancer can route
     /// active-passive to the elected cluster primary.
@@ -1319,6 +1325,7 @@ impl Router {
             ingest_strip_headers: build_ingest_strip_headers(&config.middleware),
             db_health: None,
             request_log: None,
+            access_log_enabled: false,
             // Default: this node is a writable SQLite target (standalone /
             // non-clustered). Clustered-SQLite mode replaces this with the
             // election's shared view via `with_primary_view`.
@@ -1586,6 +1593,15 @@ impl Router {
         request_log: Option<Arc<crate::timeline::RequestLog>>,
     ) -> Self {
         self.request_log = request_log;
+        self
+    }
+
+    /// Enable per-request access logging when `[server.logging] access` names
+    /// a file. Kept out of `new()`'s signature so existing call sites stay
+    /// unchanged; `false` (the default) leaves the capture off.
+    #[must_use]
+    pub(crate) fn with_access_log(mut self, enabled: bool) -> Self {
+        self.access_log_enabled = enabled;
         self
     }
 
@@ -2428,6 +2444,33 @@ impl Router {
             }
         });
 
+        // Access-log capture (`[server.logging] access`). The record is
+        // emitted once the response status is known, but the request fields
+        // have to be taken before `req` is consumed below. `None` — and zero
+        // allocation on the shared serve-mode hot path — when access logging
+        // is disabled.
+        //
+        // Deliberately NOT captured: request headers (`Authorization`,
+        // `Cookie`), the query string (`uri().path()` excludes it by
+        // construction, and it routinely carries tokens), and every `$_SERVER`
+        // value (`DB_PASSWORD`, `DATABASE_URL`, `PHP_AUTH_PW`). The access
+        // logger reads only this struct, so — unlike a logger that reaches
+        // into `PhpRequest`/`$_SERVER` — it cannot dump a credential. That is
+        // the same posture the `/_ephpm/requests` timeline holds (it logs no
+        // headers) and that #482's redacting `Debug` impls enforce for the
+        // request types.
+        let access_capture = if self.access_log_enabled {
+            let (client, _) = self.resolve_proxy_info(&req, remote_addr, is_tls);
+            Some(AccessLogCapture {
+                method: req.method().as_str().to_owned(),
+                path: req.uri().path().to_owned(),
+                version: http_version_label(req.version()),
+                client_ip: client.ip(),
+            })
+        } else {
+            None
+        };
+
         // Request span for OTLP export. DEBUG level under a dedicated target
         // (`crate::OTEL_TRACE_TARGET`) so the default info-level stack leaves
         // the callsite disabled — the span only materializes when a layer
@@ -2540,6 +2583,13 @@ impl Router {
                     php_ms: timings.and_then(|t| t.execute).map(|d| d.as_secs_f64() * 1000.0),
                     response_bytes,
                 });
+            }
+
+            // Access log (`[server.logging] access`): reuse `elapsed` and the
+            // response's own body-size hint — nothing is re-measured.
+            if let Some(cap) = access_capture {
+                let response_bytes = hyper::body::Body::size_hint(resp.body()).exact();
+                emit_access_log(&cap, resp.status().as_u16(), elapsed * 1000.0, response_bytes);
             }
         }
 
@@ -5414,6 +5464,70 @@ fn server_span_status_is_error(status: StatusCode) -> bool {
     status.is_server_error()
 }
 
+/// The tracing target the access log travels on. A file-only fmt layer in the
+/// `ephpm` binary's `main` subscribes to exactly this target, and the main
+/// (stdout / service-log) layer silences it, so an enabled access log is
+/// written only to `[server.logging] access` — never echoed to the console.
+const ACCESS_LOG_TARGET: &str = "access_log";
+
+/// Safe, owned request envelope captured before dispatch for the access log.
+///
+/// Carries only fields that cannot leak a credential: no request headers
+/// (`Authorization`/`Cookie`), no query string, no `$_SERVER` value. See the
+/// capture site in [`Router::handle`] for the full rationale.
+struct AccessLogCapture {
+    method: String,
+    /// Request path only — never the query string (it can carry tokens).
+    path: String,
+    version: &'static str,
+    client_ip: IpAddr,
+}
+
+/// Map an HTTP version to a stable `&'static str` for the access log.
+fn http_version_label(version: http::Version) -> &'static str {
+    match version {
+        http::Version::HTTP_09 => "HTTP/0.9",
+        http::Version::HTTP_10 => "HTTP/1.0",
+        http::Version::HTTP_11 => "HTTP/1.1",
+        http::Version::HTTP_2 => "HTTP/2",
+        http::Version::HTTP_3 => "HTTP/3",
+        _ => "HTTP/?",
+    }
+}
+
+/// Emit one access-log record on the [`ACCESS_LOG_TARGET`] tracing target.
+///
+/// Only the safe request/response envelope in [`AccessLogCapture`] plus the
+/// response status, duration, and body size are logged — never a header,
+/// query string, or `$_SERVER` credential. `bytes` is `None` for a streaming
+/// response whose size is unknown at header time, in which case the field is
+/// simply omitted rather than logged as a misleading zero.
+fn emit_access_log(cap: &AccessLogCapture, status: u16, duration_ms: f64, bytes: Option<u64>) {
+    match bytes {
+        Some(bytes) => tracing::info!(
+            target: ACCESS_LOG_TARGET,
+            method = %cap.method,
+            path = %cap.path,
+            version = cap.version,
+            status,
+            duration_ms,
+            bytes,
+            client_ip = %cap.client_ip,
+            "access"
+        ),
+        None => tracing::info!(
+            target: ACCESS_LOG_TARGET,
+            method = %cap.method,
+            path = %cap.path,
+            version = cap.version,
+            status,
+            duration_ms,
+            client_ip = %cap.client_ip,
+            "access"
+        ),
+    }
+}
+
 /// Map an HTTP status code to a `&'static str` metrics label.
 ///
 /// The `metrics` macros require label values to be `'static`; returning a
@@ -7336,6 +7450,182 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(attrs.clone());
         let guard = tracing::subscriber::set_default(subscriber);
         (attrs, guard)
+    }
+
+    /// Test layer capturing the router's `access_log`-target **events** — the
+    /// per-request record the access logger emits. It sees exactly the fields
+    /// that reach the file layer in `main`, so the no-leak assertions below
+    /// are checking the real record, not a proxy for it.
+    #[derive(Clone, Default)]
+    struct AccessLogCollector(Arc<std::sync::Mutex<Vec<SpanAttrs>>>);
+
+    impl AccessLogCollector {
+        fn snapshot(&self) -> Vec<SpanAttrs> {
+            self.0.lock().unwrap().clone()
+        }
+
+        /// The single captured record, when a test drove exactly one request.
+        fn only(&self) -> SpanAttrs {
+            let events = self.snapshot();
+            assert_eq!(events.len(), 1, "expected exactly one access_log event: {events:?}");
+            events.into_iter().next().unwrap()
+        }
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for AccessLogCollector
+    where
+        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            if event.metadata().target() != ACCESS_LOG_TARGET {
+                return;
+            }
+            let mut fields = SpanAttrs::new();
+            event.record(&mut AttrVisitor(&mut fields));
+            self.0.lock().unwrap().push(fields);
+        }
+    }
+
+    /// Install an `AccessLogCollector` for the duration of a test.
+    fn collect_access_log() -> (AccessLogCollector, tracing::subscriber::DefaultGuard) {
+        enable_span_callsites();
+        let collector = AccessLogCollector::default();
+        let subscriber = tracing_subscriber::registry().with(collector.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        (collector, guard)
+    }
+
+    /// A served request emits exactly one access record with the safe
+    /// request/response envelope — method, request path, status, duration,
+    /// body size, client IP, and HTTP version.
+    #[tokio::test]
+    async fn access_log_records_a_served_request() {
+        let (log, _guard) = collect_access_log();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("page.html"), b"<h1>hi</h1>").unwrap();
+        let router = test_router(dir.path()).with_access_log(true);
+        let addr: SocketAddr = "203.0.113.7:52100".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/page.html").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rec = log.only();
+        assert_eq!(rec.get("method").map(String::as_str), Some("GET"), "{rec:?}");
+        assert_eq!(rec.get("path").map(String::as_str), Some("/page.html"), "{rec:?}");
+        assert_eq!(rec.get("status").map(String::as_str), Some("200"), "{rec:?}");
+        assert_eq!(rec.get("client_ip").map(String::as_str), Some("203.0.113.7"), "{rec:?}");
+        assert_eq!(rec.get("version").map(String::as_str), Some("HTTP/1.1"), "{rec:?}");
+        // A known-size static body records `bytes`; the value is the served
+        // length, not asserted exactly here (compression/headers may vary).
+        assert!(rec.contains_key("bytes"), "a fixed-size response records bytes: {rec:?}");
+        assert!(rec.contains_key("duration_ms"), "{rec:?}");
+    }
+
+    /// With access logging off (the default), a served request emits **no**
+    /// access record — the capture and the emit are both gated.
+    #[tokio::test]
+    async fn access_log_off_emits_nothing() {
+        let (log, _guard) = collect_access_log();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("page.html"), b"<h1>hi</h1>").unwrap();
+        let router = test_router(dir.path()); // no with_access_log
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        let req =
+            Request::builder().method("GET").uri("/page.html").body(Empty::<Bytes>::new()).unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert!(log.snapshot().is_empty(), "access logging is off: {:?}", log.snapshot());
+    }
+
+    /// The property the whole feature turns on: an access log must never leak
+    /// a credential. A request carrying a bearer token, a session cookie, and
+    /// secrets in the query string is served, and no field of the emitted
+    /// record contains any of them — the logger reads only the safe envelope
+    /// (method / path-without-query / status / timing / bytes / client IP),
+    /// never a header, the query string, or a `$_SERVER` value.
+    #[tokio::test]
+    async fn access_log_never_leaks_credentials() {
+        let (log, _guard) = collect_access_log();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("page.html"), b"<h1>hi</h1>").unwrap();
+        let router = test_router(dir.path()).with_access_log(true);
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+
+        // Secrets in three places an access logger is tempted to reach for:
+        // the query string (tokens), the `Authorization` header, and a cookie.
+        // `DB_PASSWORD=` in the query stands in for the `$_SERVER` credential
+        // family (#482) — a bulk field dump would surface it.
+        let req = Request::builder()
+            .method("GET")
+            .uri("/page.html?token=SUPERSECRETTOKEN&DB_PASSWORD=leakedpw")
+            .header("authorization", "Bearer AUTHSECRETVALUE")
+            .header("cookie", "session=COOKIESECRETVALUE")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rec = log.only();
+        // The path is logged without its query string.
+        assert_eq!(rec.get("path").map(String::as_str), Some("/page.html"), "{rec:?}");
+
+        // No header/query fields are recorded at all.
+        for banned in ["authorization", "cookie", "query", "url.query", "headers"] {
+            assert!(!rec.contains_key(banned), "field `{banned}` must not be logged: {rec:?}");
+        }
+
+        // And no secret value appears in ANY field, however named.
+        for secret in
+            ["SUPERSECRETTOKEN", "leakedpw", "DB_PASSWORD", "AUTHSECRETVALUE", "COOKIESECRETVALUE"]
+        {
+            for (name, value) in &rec {
+                assert!(
+                    !value.contains(secret),
+                    "secret `{secret}` leaked into access field `{name}` = `{value}`: {rec:?}"
+                );
+            }
+        }
+    }
+
+    /// A spoofed `X-Forwarded-For` from an untrusted peer is ignored: with no
+    /// `[server] trusted_proxies`, the access record logs the real socket peer,
+    /// not the attacker-supplied header — so `client_ip` cannot be forged into
+    /// the log.
+    #[tokio::test]
+    async fn access_log_client_ip_ignores_untrusted_xff() {
+        let (log, _guard) = collect_access_log();
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("page.html"), b"<h1>hi</h1>").unwrap();
+        let router = test_router(dir.path()).with_access_log(true);
+        let addr: SocketAddr = "198.51.100.9:4444".parse().unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/page.html")
+            .header("x-forwarded-for", "1.2.3.4")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = router.handle(req, addr, false).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rec = log.only();
+        assert_eq!(
+            rec.get("client_ip").map(String::as_str),
+            Some("198.51.100.9"),
+            "untrusted XFF must not override the real peer: {rec:?}"
+        );
     }
 
     /// The OTel HTTP semconv span-status rule for a **server** span, pinned as

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -1126,10 +1126,24 @@ fn run_with_config(
     // (Scoping also keeps a global info-level filter from disabling the
     // DEBUG-level request spans the OTLP layer needs; that layer carries
     // its own target filter.)
+    // Access records travel on their own tracing target (`access_log`, see
+    // `ephpm_server::router`) to the dedicated file layer below. Silence that
+    // target on the main fmt layer so an enabled access log is written only to
+    // its file and never *also* echoed to stdout / the service log. Harmless
+    // when access logging is off — the router emits nothing on that target.
+    let env_filter = env_filter
+        .add_directive("access_log=off".parse().expect("static access_log directive parses"));
+
     let mut layers: Vec<Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync>> = Vec::new();
     layers.push(fmt_layer.with_filter(env_filter).boxed());
 
-    // Set up access log file writer if configured.
+    // Set up access log file writer if configured. One structured-JSON record
+    // per served request is emitted by the router on the `access_log` target;
+    // this layer is the only subscriber to it and writes to the configured
+    // file. JSON (rather than a combined/common text line) is deliberate: the
+    // record carries attacker-influenced fields (request path, client IP via
+    // X-Forwarded-For), and serde's escaping makes log-injection impossible,
+    // matching ePHPm's other structured diagnostics (`/_ephpm/requests`).
     let _access_guard = if config.server.logging.access.is_empty() {
         None
     } else {
@@ -1142,8 +1156,11 @@ fn run_with_config(
             tracing_appender::rolling::never(access_dir, access_file),
         );
         let access_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
             .with_writer(access_writer)
-            .with_target(true)
             .with_filter(EnvFilter::new("access_log=info"));
         layers.push(access_layer.boxed());
         Some(guard)

--- a/ephpm.toml
+++ b/ephpm.toml
@@ -48,7 +48,8 @@ index_files = ["index.php", "index.html"]
 # allowed_php_paths = []   # PHP execution allowlist, e.g. ["/index.php", "/wp-admin/*.php"]
 
 # [server.logging]
-# access = ""              # access log file path (empty = disabled)
+# access = ""              # access log file (empty = disabled); one JSON record
+#                          # per request — no headers, query string, or secrets
 # level = "info"           # trace, debug, info, warn, error
 
 [php]

--- a/site/content/reference/config.md
+++ b/site/content/reference/config.md
@@ -145,8 +145,29 @@ Per-vhost kernel network policy via eBPF. **Linux-only, multi-tenant-only, exper
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `access` | string | `""` | Path to access log file. Empty = disabled. |
+| `access` | string | `""` | Path to the access log file. Empty = disabled. When set, one structured-JSON record is written per served request (see below). |
 | `level` | string | `"info"` | Log level: `trace`, `debug`, `info`, `warn`, `error`. Overridden by `RUST_LOG`. |
+
+When `access` names a file, the server writes one JSON object per served
+request to it — for example:
+
+```json
+{"timestamp":"2026-09-08T12:00:00.123456Z","level":"INFO","method":"GET","path":"/wp-login.php","status":200,"duration_ms":12.4,"bytes":5321,"client_ip":"203.0.113.7","version":"HTTP/1.1","target":"access_log","message":"access"}
+```
+
+Fields: `method`, `path` (the request path only — **never** the query
+string), `status`, `duration_ms`, `bytes` (omitted for streaming responses of
+unknown size), `client_ip` (the effective client after trusted-proxy
+resolution — a spoofed `X-Forwarded-For` from an untrusted peer is ignored),
+and `version`.
+
+The access log deliberately carries **no** request headers
+(`Authorization`/`Cookie`), no query string, and no `$_SERVER` value
+(`DB_PASSWORD`, `DATABASE_URL`, `PHP_AUTH_PW`), so it cannot leak a
+credential. Records go only to this file — they are not echoed to stdout or
+the service log. JSON (rather than a combined/common text line) is chosen so
+that attacker-influenced fields (the request path, the forwarded client IP)
+are escaped and cannot inject forged log lines.
 
 ### `[server.metrics]`
 


### PR DESCRIPTION
Closes #483.

## The problem

`[server.logging] access` set up an access-log file writer in `crates/ephpm/src/main.rs`, but **no code ever wrote a record to it** — an operator who enabled access logging got a configured, silent sink. Same silent-no-op class as #429/#463/#473.

## Decision: implement (Option A)

Access logging is a reasonable thing for an app server to have, and the file layer was already half-built, so this implements the knob rather than declaring it not-yet-implemented.

## How it works

- The router emits **one record per served request** on a dedicated `access_log` tracing target, at the same point in `Router::handle` where the `/_ephpm/requests` timeline is recorded — reusing the `elapsed` timing and the response body-size hint already measured (nothing is re-measured).
- A JSON, file-only `tracing_subscriber` layer in `main` is the sole subscriber to that target; the main (stdout / service-log) fmt layer is given an `access_log=off` directive so records go **only** to the configured file, never also to the console.
- Capture and emit are gated by a `Router` flag set from `!config.server.logging.access.is_empty()`, so the shared serve-mode hot path allocates nothing when access logging is off.

## Format — structured JSON

Chosen over combined/common text deliberately: the record carries attacker-influenced fields (the request path, the forwarded client IP), and serde's escaping makes log-injection impossible. It also matches ePHPm's other structured diagnostics (`/_ephpm/requests` is JSON). Enabling this required adding the `json` feature to the workspace `tracing-subscriber` dep (one new transitive crate, `tracing-serde`, MIT; `cargo deny` clean).

Example line:

```json
{"timestamp":"...","level":"INFO","method":"GET","path":"/wp-login.php","status":200,"duration_ms":12.4,"bytes":5321,"client_ip":"203.0.113.7","version":"HTTP/1.1","target":"access_log","message":"access"}
```

## Fields logged / redacted

**Logged:** `method`, `path` (request path only — **never** the query string), `status`, `duration_ms`, `bytes` (omitted for streaming responses of unknown size), `client_ip` (the effective client *after* trusted-proxy resolution — a spoofed `X-Forwarded-For` from an untrusted peer is ignored), `version`.

**Never logged:** request headers (`Authorization`/`Cookie`), the query string, and every `$_SERVER` value (`DB_PASSWORD`, `DATABASE_URL`, `PHP_AUTH_PW`).

### How #482's redaction is reused

The access logger reads **only** the safe request envelope off the `hyper::Request`/`Response` in the outer `handle()` — it never touches `PhpRequest`/`WorkerRequestOwned` or `$_SERVER`, so the credential surface #482 added redacting `Debug` impls for is out of reach by construction. This is the strongest form of "build against the redaction": there is no bulk field dump to redact, because the logger never reaches for the fields that carry secrets. It matches the `/_ephpm/requests` timeline's bar (logs no headers).

## Tests (in `router.rs`)

- `access_log_records_a_served_request` — a served request emits exactly one record with the expected fields.
- `access_log_off_emits_nothing` — the default (disabled) emits no record.
- **`access_log_never_leaks_credentials`** (the important one) — a request carrying a bearer token, a session cookie, and secrets in the query string (`?token=…&DB_PASSWORD=…`) is served, and **no field** of the emitted record contains any of them; the path is logged without its query string.
- `access_log_client_ip_ignores_untrusted_xff` — an untrusted `X-Forwarded-For` cannot forge `client_ip`.

## Checks

`cargo clippy -p ephpm-server -p ephpm --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check`, the four new tests, `cargo test -p ephpm-config` (241 pass), and `cargo deny check licenses bans` all pass.

Docs updated: `reference/config.md` (format + redaction), the `ephpm.toml` example comment. The roadmap parity table already claimed "Access logging … structured JSON — Yes", which is now actually true.