### PR TITLE
fix(kv): surface OOM refusals on the wire (#477) and stop readers reaping refreshed values (#478)

### DIFF
--- a/crates/ephpm-kv/src/command.rs
+++ b/crates/ephpm-kv/src/command.rs
@@ -8,7 +8,12 @@ use std::time::Duration;
 use tracing::debug;
 
 use crate::resp::Frame;
-use crate::store::Store;
+use crate::store::{OOM_ERROR, SetNxOutcome, Store};
+
+/// Error frame for a write refused by the memory budget (Redis `-OOM`).
+fn oom() -> Frame {
+    Frame::error(OOM_ERROR)
+}
 
 /// Early-return an error frame if `argv` has fewer than `n` elements.
 macro_rules! check_args {
@@ -112,8 +117,7 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
                 _ => return Frame::error("ERR invalid expire time in 'setex' command"),
             };
             let val = argv[2].to_vec();
-            store.set(key, val, Some(Duration::from_secs(secs)));
-            Frame::ok()
+            if store.set(key, val, Some(Duration::from_secs(secs))) { Frame::ok() } else { oom() }
         }
         "MGET" => {
             if argv.is_empty() {
@@ -135,9 +139,15 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
             if argv.len() < 2 || !argv.len().is_multiple_of(2) {
                 return Frame::error("ERR wrong number of arguments for 'mset' command");
             }
+            // Best-effort under memory pressure: a refused pair returns `-OOM`
+            // and stops, so earlier pairs may already be stored. Redis rejects
+            // the whole MSET up front; we do not pre-check total size, and this
+            // only bites under `noeviction` at the limit.
             for pair in argv.chunks(2) {
                 let key = str_from(pair[0]);
-                store.set(key, pair[1].to_vec(), None);
+                if !store.set(key, pair[1].to_vec(), None) {
+                    return oom();
+                }
             }
             Frame::ok()
         }
@@ -146,11 +156,12 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
             let key = str_from(argv[0]);
             // Atomic check-and-set under the per-key shard lock — the
             // exists/set pair this used to do was racy under concurrent
-            // callers.
-            if store.set_nx(key, argv[1].to_vec(), None) {
-                Frame::integer(1)
-            } else {
-                Frame::integer(0)
+            // callers. The outcome distinguishes "key exists" (`:0`) from a
+            // memory refusal (`-OOM`) — the plain boolean conflated them (#477).
+            match store.set_nx_outcome(key, argv[1].to_vec(), None) {
+                SetNxOutcome::Inserted => Frame::integer(1),
+                SetNxOutcome::Exists => Frame::integer(0),
+                SetNxOutcome::OutOfMemory => oom(),
             }
         }
         "INCR" => {
@@ -196,8 +207,10 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
         "APPEND" => {
             check_args!(cmd, argv, 2);
             let key = str_from(argv[0]);
-            let new_len = store.append(&key, argv[1]);
-            Frame::integer(i64::try_from(new_len).unwrap_or(i64::MAX))
+            match store.append(&key, argv[1]) {
+                Some(new_len) => Frame::integer(i64::try_from(new_len).unwrap_or(i64::MAX)),
+                None => oom(),
+            }
         }
         "STRLEN" => {
             check_args!(cmd, argv, 1);
@@ -211,7 +224,9 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
             check_args!(cmd, argv, 2);
             let key = str_from(argv[0]);
             let old = store.get(&key);
-            store.set(key, argv[1].to_vec(), None);
+            if !store.set(key, argv[1].to_vec(), None) {
+                return oom();
+            }
             match old {
                 Some(v) => Frame::bulk(v),
                 None => Frame::Null,
@@ -313,7 +328,11 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
                     // Convert Bytes → Vec<u8> at the write boundary
                     // (Store::set still takes an owned Vec). RENAME is
                     // cold enough that this extra copy is fine.
-                    store.set(new_key, val.to_vec(), ttl);
+                    if !store.set(new_key, val.to_vec(), ttl) {
+                        // The old key is still intact — the set that would
+                        // replace it was refused, so leave RENAME a no-op.
+                        return oom();
+                    }
                     store.remove(&old_key);
                     Frame::ok()
                 }
@@ -490,20 +509,28 @@ fn cmd_set(store: &Arc<Store>, argv: &[&[u8]]) -> Frame {
     // is rarely used and the value fetched here is still consistent
     // with what's stored after the call.
     if nx {
-        let inserted = store.set_nx(key.clone(), val, ttl);
-        return if get {
-            if inserted {
-                Frame::Null
-            } else {
-                match store.get(&key) {
-                    Some(v) => Frame::bulk(v),
-                    None => Frame::Null,
+        return match store.set_nx_outcome(key.clone(), val, ttl) {
+            // A memory refusal is `-OOM`, distinct from the `nil` that means
+            // "the key already existed" (#477).
+            SetNxOutcome::OutOfMemory => oom(),
+            SetNxOutcome::Inserted => {
+                if get {
+                    // NX+GET on a successful insert: no prior value.
+                    Frame::Null
+                } else {
+                    Frame::ok()
                 }
             }
-        } else if inserted {
-            Frame::ok()
-        } else {
-            Frame::Null
+            SetNxOutcome::Exists => {
+                if get {
+                    match store.get(&key) {
+                        Some(v) => Frame::bulk(v),
+                        None => Frame::Null,
+                    }
+                } else {
+                    Frame::Null
+                }
+            }
         };
     }
 
@@ -514,7 +541,9 @@ fn cmd_set(store: &Arc<Store>, argv: &[&[u8]]) -> Frame {
         return Frame::Null;
     }
 
-    store.set(key, val, ttl);
+    if !store.set(key, val, ttl) {
+        return oom();
+    }
 
     if get {
         match old {
@@ -1057,5 +1086,110 @@ mod tests {
         assert_eq!(cmd(&s, &["set", "k", "v"]), Frame::ok());
         assert_eq!(bulk_str(&cmd(&s, &["get", "k"])), Some("v"));
         assert_eq!(cmd(&s, &["Set", "k2", "v2"]), Frame::ok());
+    }
+
+    // ── Out-of-memory refusal is surfaced on the wire (#477) ──────────────
+
+    /// A store with a tiny budget and `NoEviction`, so a large value cannot be
+    /// stored and small ones can. `memory_limit: 200` fits a `k=v`-sized entry
+    /// but not a kilobyte (same sizing the store's `noeviction_rejects_writes`
+    /// test relies on).
+    fn tiny_store() -> Arc<Store> {
+        Store::new(StoreConfig {
+            memory_limit: 200,
+            eviction_policy: crate::store::EvictionPolicy::NoEviction,
+            compression: crate::store::CompressionConfig::default(),
+        })
+    }
+
+    /// A value guaranteed not to fit `tiny_store`'s budget.
+    fn too_big() -> String {
+        "x".repeat(1024)
+    }
+
+    fn is_oom(f: &Frame) -> bool {
+        matches!(f, Frame::Error(m) if m.starts_with("OOM"))
+    }
+
+    #[test]
+    fn set_within_budget_still_succeeds() {
+        let s = tiny_store();
+        assert_eq!(cmd(&s, &["SET", "k", "v"]), Frame::ok());
+        assert_eq!(bulk_str(&cmd(&s, &["GET", "k"])), Some("v"));
+    }
+
+    #[test]
+    fn set_over_budget_returns_oom_not_ok() {
+        let s = tiny_store();
+        let big = too_big();
+        let f = cmd(&s, &["SET", "big", &big]);
+        assert!(is_oom(&f), "expected -OOM, got {f:?}");
+        // The refused write must not have been stored.
+        assert_eq!(cmd(&s, &["GET", "big"]), Frame::Null);
+    }
+
+    #[test]
+    fn set_nx_option_over_budget_returns_oom() {
+        let s = tiny_store();
+        let big = too_big();
+        assert!(is_oom(&cmd(&s, &["SET", "big", &big, "NX"])));
+    }
+
+    #[test]
+    fn setex_over_budget_returns_oom() {
+        let s = tiny_store();
+        let big = too_big();
+        assert!(is_oom(&cmd(&s, &["SETEX", "big", "60", &big])));
+    }
+
+    #[test]
+    fn setnx_over_budget_returns_oom_not_zero() {
+        let s = tiny_store();
+        let big = too_big();
+        // A fresh key that does not fit is `-OOM`, distinct from the `:0` that
+        // means "key already exists".
+        assert!(is_oom(&cmd(&s, &["SETNX", "big", &big])));
+    }
+
+    #[test]
+    fn setnx_existing_key_is_zero_not_oom() {
+        let s = tiny_store();
+        assert_eq!(cmd(&s, &["SETNX", "k", "v"]), Frame::integer(1));
+        assert_eq!(cmd(&s, &["SETNX", "k", "v2"]), Frame::integer(0));
+    }
+
+    #[test]
+    fn append_create_over_budget_returns_oom() {
+        let s = tiny_store();
+        let big = too_big();
+        assert!(is_oom(&cmd(&s, &["APPEND", "big", &big])));
+    }
+
+    #[test]
+    fn getset_over_budget_returns_oom() {
+        let s = tiny_store();
+        let big = too_big();
+        assert!(is_oom(&cmd(&s, &["GETSET", "big", &big])));
+    }
+
+    #[test]
+    fn mset_over_budget_returns_oom() {
+        let s = tiny_store();
+        let big = too_big();
+        assert!(is_oom(&cmd(&s, &["MSET", "big", &big])));
+    }
+
+    #[test]
+    fn incr_create_over_budget_returns_oom() {
+        // A budget too small for any entry: the INCR create path reserves
+        // memory and must be refused with `-OOM` rather than creating a
+        // counter that does not fit.
+        let s = Store::new(StoreConfig {
+            memory_limit: 8,
+            eviction_policy: crate::store::EvictionPolicy::NoEviction,
+            compression: crate::store::CompressionConfig::default(),
+        });
+        let f = cmd(&s, &["INCR", "counter"]);
+        assert!(is_oom(&f), "expected -OOM, got {f:?}");
     }
 }

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -52,6 +52,37 @@ impl EvictionPolicy {
     }
 }
 
+/// Redis-compatible out-of-memory error message, surfaced on the wire as
+/// `-OOM …`.
+///
+/// Returned when a write is refused under the [`EvictionPolicy::NoEviction`]
+/// policy with the store already over its `memory_limit`. Matching Redis'
+/// wording verbatim means client libraries that special-case `-OOM` (Predis,
+/// phpredis, and the PSR cache wrappers built on them) behave against ePHPm's
+/// KV exactly as they do against Redis — the write is reported as failed
+/// rather than silently answered `+OK` (#477).
+pub const OOM_ERROR: &str = "OOM command not allowed when used memory > 'maxmemory'";
+
+/// Outcome of a memory-guarded conditional write (`SET … NX` / `SETNX`).
+///
+/// The plain write path ([`Store::set`]) needs no such type: it returns
+/// `false` for exactly one reason — an out-of-memory refusal — so a caller can
+/// map `false` straight to [`OOM_ERROR`]. A conditional write has *two*
+/// distinct not-stored outcomes, and the RESP layer must tell them apart: a
+/// failed `NX` precondition is a normal `nil`/`:0` reply, whereas an
+/// out-of-memory refusal is `-OOM`. Collapsing them into one `bool` is what let
+/// a memory-refused `SETNX` answer as if the key merely already existed (#477).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SetNxOutcome {
+    /// The value was inserted (the key was absent or held an expired entry).
+    Inserted,
+    /// A live entry already exists at this key; nothing was written.
+    Exists,
+    /// Refused: the `NoEviction` policy is active and the store is over its
+    /// `memory_limit`. Surfaced on the wire as [`OOM_ERROR`].
+    OutOfMemory,
+}
+
 /// Compression algorithm for stored values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CompressionAlgo {
@@ -453,10 +484,19 @@ impl Store {
     pub fn get(&self, key: &str) -> Option<Bytes> {
         let entry = self.data.get(key)?;
         if entry.is_expired() {
+            let observed = entry.expires_at;
             drop(entry);
             // Lazy-expiry cleanup: local only. Replicas expire the key on
             // their own timelines; no need to broadcast the reap.
-            self.remove_local(key);
+            //
+            // Compare-and-remove, not an unconditional reap: only drop the
+            // entry we actually observed expire. A `set` that landed in the
+            // gap after we dropped the read guard carries a different
+            // `expires_at` and must survive — otherwise the reader destroys a
+            // fresh value the writer just stored (#478).
+            if let Some(exp) = observed {
+                self.reap_if_expired(key, exp);
+            }
             return None;
         }
         entry.touch(self.now_nanos());
@@ -474,9 +514,14 @@ impl Store {
         // Check string keys.
         if let Some(entry) = self.data.get(key) {
             if entry.is_expired() {
+                let observed = entry.expires_at;
                 drop(entry);
-                // Lazy-expiry cleanup: local only.
-                self.remove_local(key);
+                // Lazy-expiry cleanup: local only, compare-and-remove so a
+                // value written after we observed the expiry is not reaped by
+                // this reader (#478).
+                if let Some(exp) = observed {
+                    self.reap_if_expired(key, exp);
+                }
             } else {
                 return true;
             }
@@ -492,9 +537,13 @@ impl Store {
     pub fn pttl(&self, key: &str) -> Option<i64> {
         let entry = self.data.get(key)?;
         if entry.is_expired() {
+            let observed = entry.expires_at;
             drop(entry);
-            // Lazy-expiry cleanup: local only.
-            self.remove_local(key);
+            // Lazy-expiry cleanup: local only, compare-and-remove so a value
+            // written after we observed the expiry is not reaped here (#478).
+            if let Some(exp) = observed {
+                self.reap_if_expired(key, exp);
+            }
             return Some(-2);
         }
         match entry.expires_at {
@@ -832,11 +881,12 @@ impl Store {
     /// Report a write refused by the memory budget: `warn!` for the first one
     /// in the process, `debug!` for every one after.
     ///
-    /// It has to be loud at least once, because nothing else says so. The
-    /// RESP `SET` handler discards [`Store::set`]'s boolean and answers `+OK`
-    /// regardless, so a client is never told its write was refused; under
-    /// `noeviction` this line is the only signal that the store is parked at
-    /// its limit and silently dropping writes.
+    /// The RESP layer now surfaces a refusal to the client as Redis `-OOM`
+    /// (#477), so a network client is no longer left in the dark. This line
+    /// stays because not every caller reads the return value — the in-process
+    /// `ephpm_kv_*` bridge hands PHP a `0`/`false` a caller may ignore, and an
+    /// operator watching the log still wants one clear signal that the store is
+    /// parked at its limit under `noeviction`.
     ///
     /// It also has to go quiet, for the same reason
     /// [`Store::warn_hash_not_replicated`] does: a store sitting at the limit
@@ -877,7 +927,31 @@ impl Store {
     ///
     /// Returns `false` if the `NoEviction` policy refuses the write
     /// because of memory pressure (same as `set()`).
+    ///
+    /// This is a thin wrapper over [`set_nx_outcome`](Self::set_nx_outcome),
+    /// which distinguishes the "key already exists" refusal from an
+    /// out-of-memory refusal — a distinction the RESP layer needs but this
+    /// boolean cannot carry. Callers that only need "did it store?" (the
+    /// distributed-lock / idempotency-key use cases) keep this signature.
     pub fn set_nx(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) -> bool {
+        matches!(self.set_nx_outcome(key, value, ttl), SetNxOutcome::Inserted)
+    }
+
+    /// Atomically set a key only if it doesn't already exist, reporting *why*
+    /// the write was or was not stored.
+    ///
+    /// Same atomicity and memory semantics as [`set_nx`](Self::set_nx) — the
+    /// existence check and the insert happen under the same per-key write lock
+    /// — but returns a [`SetNxOutcome`] so the RESP layer can answer a normal
+    /// `nil`/`:0` when the key already exists and Redis' `-OOM` when the write
+    /// was refused for memory. The two used to be indistinguishable, so a
+    /// memory-refused `SETNX` looked identical to "key already present" (#477).
+    pub fn set_nx_outcome(
+        &self,
+        key: String,
+        value: Vec<u8>,
+        ttl: Option<Duration>,
+    ) -> SetNxOutcome {
         // Fast path: peek without taking the per-key write lock. If the
         // key is already present and live we can bail before triggering
         // any eviction work. The TOCTOU window between this peek and the
@@ -887,7 +961,7 @@ impl Store {
         if let Some(existing) = self.data.get(&key)
             && !existing.is_expired()
         {
-            return false;
+            return SetNxOutcome::Exists;
         }
 
         // Keep the *logical* bytes for the publish below, before compression
@@ -922,21 +996,21 @@ impl Store {
         // including this one) and would deadlock if called under the
         // entry guard. The `set()` method makes the same trade-off.
         if !self.ensure_memory(new_size) {
-            return false;
+            return SetNxOutcome::OutOfMemory;
         }
 
         let published_expiry = new_entry.expires_at;
         let has_ttl = new_entry.expires_at.is_some();
         // Atomic check-and-insert. The shard write lock held by `entry()`
         // serialises concurrent set_nx calls for this key.
-        let (inserted, key_ref) = match self.data.entry(key) {
+        let key_ref = match self.data.entry(key) {
             dashmap::Entry::Occupied(mut occ) => {
                 if !occ.get().is_expired() {
                     // Lost the race; another writer landed first. We
                     // already ran `ensure_memory` which may have evicted
                     // unrelated keys — that's wasted work but not a
                     // correctness bug.
-                    return false;
+                    return SetNxOutcome::Exists;
                 }
                 // The existing entry has expired; reclaim its bytes and
                 // replace it.
@@ -944,32 +1018,30 @@ impl Store {
                 self.mem_add(new_size);
                 let k = occ.key().clone();
                 occ.insert(new_entry);
-                (true, k)
+                k
             }
             dashmap::Entry::Vacant(vac) => {
                 self.mem_add(new_size);
                 let k = vac.key().clone();
                 vac.insert(new_entry);
-                (true, k)
+                k
             }
         };
-        if inserted {
-            if has_ttl {
-                self.ttl_keys.insert(key_ref.clone());
-            } else {
-                self.ttl_keys.remove(&key_ref);
-            }
-            // Wake any waiters — the insert is visible at this point.
-            self.notify_write(&key_ref);
-            // Broadcast the winning value. This path already *has* the exact
-            // bytes and TTL it inserted (they are the caller's arguments), so
-            // there is nothing to re-read. Per-node atomic, cluster-wide
-            // last-arrival-wins — see `replicate_published_value`.
-            if let Some(value) = published_value {
-                self.replicate_published_value(&key_ref, value, published_expiry);
-            }
+        if has_ttl {
+            self.ttl_keys.insert(key_ref.clone());
+        } else {
+            self.ttl_keys.remove(&key_ref);
         }
-        inserted
+        // Wake any waiters — the insert is visible at this point.
+        self.notify_write(&key_ref);
+        // Broadcast the winning value. This path already *has* the exact
+        // bytes and TTL it inserted (they are the caller's arguments), so
+        // there is nothing to re-read. Per-node atomic, cluster-wide
+        // last-arrival-wins — see `replicate_published_value`.
+        if let Some(value) = published_value {
+            self.replicate_published_value(&key_ref, value, published_expiry);
+        }
+        SetNxOutcome::Inserted
     }
 
     /// Remove a key, returning `true` if it existed. Removes from both
@@ -1007,6 +1079,51 @@ impl Store {
             self.notify_write(key);
         }
         removed
+    }
+
+    /// Compare-and-remove an entry that a read path just observed expired.
+    ///
+    /// The lazy-expiry reap on `get`/`exists`/`pttl` used to call
+    /// [`remove_local`](Self::remove_local) unconditionally after dropping the
+    /// read guard. A `set` that landed in the gap between the observation and
+    /// the removal was then destroyed by the *reader* — the writer's success
+    /// silently undone. That is the stampede-refresh pattern exactly (write a
+    /// fresh value as the old one expires), so the window is aimed at, not
+    /// incidental (#478).
+    ///
+    /// The removal is now conditional on the entry still carrying the exact
+    /// `expires_at` the caller observed. Every TTL'd write builds a *fresh*
+    /// [`Instant`] (`Instant::now() + ttl`), and a TTL-less write stores
+    /// `None`, so a value written after the observation never compares equal —
+    /// it is preserved. A wholly new entry likewise does not match. The
+    /// observed instant is therefore a stable identity for "the entry I saw
+    /// expire", and equality alone suffices: it was already in the past when
+    /// observed, so a matching entry is still expired.
+    ///
+    /// Returns `true` if this call removed the entry.
+    ///
+    /// # Locking
+    ///
+    /// [`DashMap::remove_if`] evaluates the predicate under the shard write
+    /// lock and hands back the displaced entry with the lock already released.
+    /// The predicate touches no other lock, and the reconciliation
+    /// (`mem_sub` / `ttl_keys` / `notify_write`) runs after the guard is
+    /// dropped. So — unlike the eviction path — this never holds a shard guard
+    /// across [`ensure_memory`](Self::ensure_memory); the #476 deadlock
+    /// constraint does not apply here and is not reintroduced.
+    fn reap_if_expired(&self, key: &str, observed: Instant) -> bool {
+        let removed = self.data.remove_if(key, |_, entry| entry.expires_at == Some(observed));
+        if let Some((_, old)) = removed {
+            self.mem_sub(old.mem_size);
+            // Keep the TTL hint set consistent, same as remove_local.
+            self.ttl_keys.remove(key);
+            // A reap is a state change (the key becomes absent) — wake waiters,
+            // matching remove_local's contract.
+            self.notify_write(key);
+            true
+        } else {
+            false
+        }
     }
 
     /// Set an expiry on an existing key. Returns `false` if the key doesn't exist.
@@ -1136,7 +1253,9 @@ impl Store {
                 Entry::new(Bytes::from(delta.to_string().into_bytes()), key.len(), false, 0)
                     .mem_size;
             if !self.ensure_memory(create_size) {
-                return Err("ERR out of memory".to_string());
+                // Redis-compatible `-OOM` so INCR fails the same way SET does
+                // when the store is parked at its limit (#477).
+                return Err(OOM_ERROR.to_string());
             }
         }
 
@@ -1250,8 +1369,14 @@ impl Store {
     }
 
     /// Append `value` to the existing value at `key`, or create it.
-    /// Returns the new length of the value.
-    pub fn append(&self, key: &str, value: &[u8]) -> usize {
+    ///
+    /// Returns `Some(new_length)` on success. Returns `None` only when the key
+    /// was **absent** and the create was refused by the memory budget
+    /// (`NoEviction` over `memory_limit`) — the RESP layer maps that to Redis
+    /// `-OOM` instead of falsely answering with a length (#477). Growing an
+    /// *existing* value is done in place and is not memory-guarded, so it never
+    /// returns `None`.
+    pub fn append(&self, key: &str, value: &[u8]) -> Option<usize> {
         if let Some(mut entry) = self.data.get_mut(key) {
             if entry.is_expired() {
                 drop(entry);
@@ -1312,13 +1437,18 @@ impl Store {
                 if let Some(value) = published_value {
                     self.replicate_published_value(key, value, published_expiry);
                 }
-                return final_len;
+                return Some(final_len);
             }
         }
 
         let len = value.len();
-        self.set(key.to_string(), value.to_vec(), None);
-        len
+        if self.set(key.to_string(), value.to_vec(), None) {
+            Some(len)
+        } else {
+            // Create refused for memory — report it rather than claiming a
+            // length for a value that was never stored.
+            None
+        }
     }
 
     // ── Hash operations ──────────────────────────────────────────
@@ -2203,7 +2333,7 @@ mod tests {
     #[test]
     fn append_new_key() {
         let s = test_store();
-        assert_eq!(s.append("k", b"hello"), 5);
+        assert_eq!(s.append("k", b"hello"), Some(5));
         assert_eq!(s.get("k").as_deref(), Some(&b"hello"[..]));
     }
 
@@ -2211,7 +2341,7 @@ mod tests {
     fn append_existing() {
         let s = test_store();
         s.set("k".into(), b"hello".to_vec(), None);
-        assert_eq!(s.append("k", b" world"), 11);
+        assert_eq!(s.append("k", b" world"), Some(11));
         assert_eq!(s.get("k").as_deref(), Some(&b"hello world"[..]));
     }
 
@@ -2277,6 +2407,76 @@ mod tests {
         assert!(s.set("k".into(), b"v".to_vec(), None));
         // Fill up memory with a large value.
         assert!(!s.set("big".into(), vec![0u8; 1024], None));
+    }
+
+    #[test]
+    fn set_nx_outcome_distinguishes_exists_from_oom() {
+        // #477: the boolean `set_nx` conflated "already exists" with an
+        // out-of-memory refusal. The outcome variant must tell them apart.
+        let s = Store::new(StoreConfig {
+            memory_limit: 200,
+            eviction_policy: EvictionPolicy::NoEviction,
+            compression: CompressionConfig::default(),
+        });
+        assert_eq!(s.set_nx_outcome("k".into(), b"v".to_vec(), None), SetNxOutcome::Inserted);
+        // Live key present → Exists, NOT OutOfMemory.
+        assert_eq!(s.set_nx_outcome("k".into(), b"v2".to_vec(), None), SetNxOutcome::Exists);
+        // A fresh key too large for the budget → OutOfMemory, NOT Exists.
+        assert_eq!(
+            s.set_nx_outcome("big".into(), vec![0u8; 1024], None),
+            SetNxOutcome::OutOfMemory
+        );
+
+        // The boolean wrapper still means exactly "was it inserted?".
+        let s2 = test_store();
+        assert!(s2.set_nx("fresh".into(), b"x".to_vec(), None));
+        assert!(!s2.set_nx("fresh".into(), b"y".to_vec(), None));
+    }
+
+    #[test]
+    fn expired_key_is_still_lazily_reaped_on_get() {
+        // The compare-and-remove must still reap in the ordinary case: an
+        // expired key with no concurrent writer is removed on read.
+        let s = test_store();
+        let past = Instant::now() - Duration::from_secs(60);
+        s.data.insert("k".into(), Entry::with_expiry(Bytes::from_static(b"v"), 1, false, past, 0));
+        s.ttl_keys.insert("k".into());
+
+        assert_eq!(s.get("k"), None);
+        assert!(!s.data.contains_key("k"), "expired entry should be reaped");
+        assert!(!s.ttl_keys.contains("k"), "TTL hint should be cleared");
+    }
+
+    #[test]
+    fn refresh_at_expiry_survives_concurrent_reader_reap() {
+        // #478: a reader observes a key expired and, before it reaps, a writer
+        // stores a fresh value. The reader's compare-and-remove must not
+        // delete that fresh write.
+        let s = test_store();
+
+        // Plant an already-expired entry directly so we know the exact
+        // `expires_at` a reader would observe — fully deterministic, no sleep.
+        let observed = Instant::now() - Duration::from_secs(60);
+        s.data.insert(
+            "k".into(),
+            Entry::with_expiry(Bytes::from_static(b"old"), 1, false, observed, 0),
+        );
+
+        // The writer lands in the gap after the reader observed expiry,
+        // replacing the entry with a fresh, non-expiring value.
+        assert!(s.set("k".into(), b"new".to_vec(), None));
+
+        // The stale reader now runs its reap with the expiry it observed. The
+        // live entry carries a different `expires_at` (None), so the reap is a
+        // no-op and the fresh value survives.
+        assert!(!s.reap_if_expired("k", observed), "reap must not remove the refreshed value");
+        assert_eq!(s.get("k").as_deref(), Some(&b"new"[..]));
+
+        // Documents the pre-fix hazard on the same setup: the old
+        // unconditional reap (`remove_local`) destroys the fresh write.
+        assert!(s.set("k".into(), b"new2".to_vec(), None));
+        s.remove_local("k"); // what get()/exists()/pttl() used to call
+        assert_eq!(s.get("k"), None, "unconditional reap loses the refresh — the #478 bug");
     }
 
     #[test]
@@ -2365,8 +2565,8 @@ mod tests {
             eviction_policy: EvictionPolicy::AllKeysLru,
             compression: CompressionConfig { algo: CompressionAlgo::Zstd, level: 6, min_size: 1 },
         });
-        assert_eq!(s.append("key", b"hello"), 5);
-        assert_eq!(s.append("key", b" world"), 11);
+        assert_eq!(s.append("key", b"hello"), Some(5));
+        assert_eq!(s.append("key", b" world"), Some(11));
         let retrieved = s.get("key");
         assert_eq!(retrieved.as_deref(), Some(&b"hello world"[..]));
     }


### PR DESCRIPTION
Two lost-write follow-ups flagged during #452 / PR #476, both in `ephpm-kv`. Bundled as one PR — same crate, adjacent code, no overlap.

## #477 — a write refused for memory answered `+OK`
`cmd_set` (and every other refuse-capable command) discarded the boolean `Store::set` returns and replied `+OK` even when the store was at its `memory_limit` under `noeviction` and the value was dropped. A cache/session client could not tell "stored" from "silently dropped".

**Fix — the RESP layer now returns Redis' `-OOM command not allowed when used memory > 'maxmemory'` on a refused write.** Commands audited and changed:

| Command | Primitive | How refusal is now surfaced |
|---|---|---|
| `SET` / `SET … XX` | `Store::set` (bool) | `false` ⇒ `-OOM` |
| `SETEX`, `MSET`, `GETSET`, `RENAME` | `Store::set` (bool) | `false` ⇒ `-OOM` |
| `SETNX`, `SET … NX` | new `Store::set_nx_outcome` → `{Inserted, Exists, OutOfMemory}` | `OutOfMemory` ⇒ `-OOM`, distinct from the `:0`/`nil` that means "key exists" |
| `APPEND` | `Store::append` now `Option<usize>` | `None` (create refused) ⇒ `-OOM` |
| `INCR`/`DECR`/`INCRBY`/`DECRBY` | `Store::incr_by` (already `Result`) | create-path OOM message normalised to the same `-OOM` string |

`set_nx`'s old `bool` conflated "already exists" with an OOM refusal; `set_nx_outcome` splits them and `set_nx` stays a thin `bool` wrapper for the lock/idempotency callers. **`HSET`/`HDEL` are not memory-guarded at all** (tracked, never refused), so there is nothing to surface there — noted, not changed.

**Consumer compatibility:** `ephpm/cache`, `ephpm/cache-wordpress`, `ephpm/session-handler`, and `ephpm/predis-connection` all reach the KV through the **in-process `ephpm_kv_*` SAPI functions**, not the RESP wire (predis-connection's README: "zero socket round-trips, zero RESP parsing"). Those bridge return values are **unchanged** (`kv_set`/`kv_set_nx` still `0/1`; there is no `kv_append`; `SapiKvOps::set` already maps `0` → `false`). The `-OOM` reply therefore reaches only genuine RESP clients on the KV listener (redis-cli, phpredis/predis over TCP, monitoring), where it is the standard, expected failure signal. **No in-tree consumer changes behavior.**

## #478 — lazy expiry deleted a value written after the reader observed expiry
`get`/`exists`/`pttl` observed an expired entry, dropped the read guard, then called `remove_local` **unconditionally**. A `set` landing in that gap was reaped by the *reader* — the writer's success destroyed. That is exactly the stampede-refresh pattern (write a fresh value as the old one expires).

**Fix — the reap is now a compare-and-remove** (`reap_if_expired`, via `DashMap::remove_if`) keyed on the exact `expires_at` the reader observed. Every TTL'd write builds a fresh `Instant` (and a TTL-less write stores `None`), so a value written in the gap never matches and survives. The predicate holds no lock across `ensure_memory`, so the #476 eviction/removal deadlock constraint is **not** reintroduced.

## Tests (all fail on pre-fix code)
- **#477**: per-command wire tests on a `NoEviction` + tiny-budget store — a `SET`/`SETEX`/`SETNX`/`SET NX`/`APPEND`/`GETSET`/`MSET`/`INCR` over budget returns `-OOM` (not `+OK`/`:0`/a length); a `SET` that fits still succeeds; `SETNX` on an existing key is still `:0` (not `-OOM`). Store-level `set_nx_outcome_distinguishes_exists_from_oom`.
- **#478**: `refresh_at_expiry_survives_concurrent_reader_reap` — deterministic: plant an expired entry, refresh it, run the reader's compare-and-remove with the stale observed instant; it is a no-op and the fresh value survives. The test also runs the real pre-fix primitive (`remove_local`) on the same setup to demonstrate the data loss. `expired_key_is_still_lazily_reaped_on_get` guards the ordinary reap. A single-threaded, get()-level deterministic repro isn't possible (the window is inside one call); a purely probabilistic thread race did not reliably fault pre-fix on an unloaded host, so it was omitted in favour of the mechanism-level guard.

`cargo test -p ephpm-kv` (247 lib + 57 integration + doctests), `cargo clippy -p ephpm-kv --all-targets -- -D warnings`, and nightly `fmt` all clean; dependent crates (`ephpm-middleware`/`-cluster`/`-server`/`-php`) still compile.

Closes #477
Closes #478