### PR TITLE
test(e2e): drive [db.mysql] proxy from real PHP pdo_mysql (#433)

### DIFF
--- a/.github/workflows/pdo-mysql-e2e.yml
+++ b/.github/workflows/pdo-mysql-e2e.yml
@@ -1,0 +1,249 @@
+# pdo_mysql through the [db.mysql] proxy, end to end (issue #433).
+#
+# Why this workflow exists
+# ------------------------
+# `e2e.yml` runs the PHP-linked binary but only ever against the embedded Turso
+# engine (`[db.sqlite]`). `db-integration.yml` runs the `[db.mysql]` proxy
+# against a real MySQL but drives it with `mysql_async`, not PHP's `pdo_mysql`.
+# Nothing put the two together, so a regression visible only to `pdo_mysql`'s
+# connection/protocol behaviour toward the proxy — the exact class #425 was
+# about — had no CI guard. This job boots a real MySQL, builds the PHP-linked
+# ephpm, and drives a `pdo_mysql` write/read round-trip through a `[db.mysql]`
+# proxy in front of it.
+#
+# Why a separate workflow
+# -----------------------
+# It is the union of the two expensive things neither sibling pays for: it boots
+# a database (which `e2e.yml` does not) AND it does a full `lto=fat`,
+# `codegen-units=1` release build with PHP statically linked (which
+# `db-integration.yml` does not — it only builds the `ephpm-db` test binaries).
+# Paying both on every PR would be a real cost to everyone's queue time, so this
+# is path-filtered on the code that can break it, with an unconditional daily
+# run of `main` as the belt-and-suspenders (same reasoning as
+# `db-integration.yml`; a path filter that misses a transitive break still gets
+# caught within a day).
+#
+# The MySQL provisioning below is lifted from `db-integration.yml` and the
+# ephemerd-fleet quirks it documents apply verbatim: publishing is a userspace
+# proxy on a containerd shim, so host ports must be explicit (an empty host port
+# is silently dropped), a successful TCP connect proves nothing about mysqld
+# (readiness is the handshake packet, which also must NOT authenticate — a
+# single root auth warms the caching_sha2 cache and hides the full-auth branch
+# the proxy has to handle), containers run with `-t` so `docker logs` does not
+# choke on the un-multiplexed stream, and the endpoint is probed both on the
+# published port and directly on the container IP.
+
+name: pdo_mysql proxy E2E
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/ephpm-db/**"
+      - "crates/ephpm-php/**"
+      - "crates/ephpm-server/**"
+      - "crates/ephpm-config/**"
+      - "crates/ephpm-e2e/**"
+      - "xtask/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/pdo-mysql-e2e.yml"
+  pull_request:
+    branches: [main, "feat/**"]
+    paths:
+      - "crates/ephpm-db/**"
+      - "crates/ephpm-php/**"
+      - "crates/ephpm-server/**"
+      - "crates/ephpm-config/**"
+      - "crates/ephpm-e2e/**"
+      - "xtask/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/pdo-mysql-e2e.yml"
+  # Unconditional daily coverage of main, so a break arriving through a path not
+  # listed above still surfaces within a day.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# One PHP-linked release build is ~2.3 GB peak RSS; group by ref so a burst of
+# merges to main queues instead of piling onto the small self-hosted fleet.
+# PRs cancel superseded runs (only the head commit needs to be green); pushes to
+# main do not, so every commit keeps its own bisectable result. Mirrors
+# `e2e.yml`.
+concurrency:
+  group: pdo-mysql-e2e-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  # Credentials for a throwaway loopback container that lives for one job. Not a
+  # secret.
+  MYSQL_PW: ephpm-test
+  # PHP minor to build the linked binary against. One leg is enough for a
+  # protocol/connection round-trip — this is not a per-version matrix.
+  PHP_VERSION: "8.4"
+
+jobs:
+  pdo-mysql-e2e:
+    name: pdo_mysql through the [db.mysql] proxy
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build prerequisites
+        # Same resolver as ci.yml/e2e.yml: some fleet runners come up as root
+        # without `sudo`, so a bare `sudo apt-get` exits 127 and reds the job in
+        # seconds for reasons unrelated to the change under test.
+        run: |
+          set -eu
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "apt-get unavailable; assuming the image already provides build prerequisites"
+            exit 0
+          fi
+          if [ "$(id -u)" -eq 0 ]; then
+            SUDO=""
+          elif command -v sudo >/dev/null 2>&1; then
+            SUDO="sudo"
+          else
+            echo "::error::not running as root and sudo is unavailable"
+            exit 1
+          fi
+          $SUDO apt-get update
+          $SUDO apt-get install -y --no-install-recommends build-essential libclang-dev pkg-config
+
+      - name: Resolve container runtime
+        run: |
+          set -eu
+          if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+            RUNTIME=docker
+          elif command -v podman >/dev/null 2>&1; then
+            RUNTIME=podman
+          else
+            echo "::error::neither docker nor podman is usable on this runner; cannot start a test database"
+            exit 1
+          fi
+          echo "RUNTIME=$RUNTIME" >> "$GITHUB_ENV"
+          echo "using $RUNTIME"
+          $RUNTIME --version
+
+      - name: Start MySQL
+        run: |
+          set -eu
+          SUFFIX="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "DB_SUFFIX=$SUFFIX" >> "$GITHUB_ENV"
+
+          # Explicit host port derived from the run id so two concurrent runs on
+          # the same runner do not collide. NOT `-p 127.0.0.1::3306`: the
+          # ephemerd fleet's Docker API is a containerd shim whose port-forward
+          # installer silently drops any binding with an empty host port.
+          MYSQL_HOST_PORT=$(( 24000 + (GITHUB_RUN_ID % 20000) ))
+          echo "MYSQL_HOST_PORT=$MYSQL_HOST_PORT" >> "$GITHUB_ENV"
+
+          # MySQL 8 with DEFAULT authentication (caching_sha2_password) — the
+          # plugin the proxy must handle. Do NOT downgrade to
+          # mysql_native_password: that is precisely the workaround that hid
+          # #234.
+          $RUNTIME run -d -t --name "ephpm-mysql-$SUFFIX" \
+            -e MYSQL_ROOT_PASSWORD="$MYSQL_PW" \
+            -e MYSQL_DATABASE=test \
+            -p "127.0.0.1:$MYSQL_HOST_PORT:3306" \
+            docker.io/library/mysql:8.0
+
+      # Toolchain setup overlaps MySQL's ~20-30s initdb.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Resolve database endpoint
+        # On a normal dockerd 127.0.0.1:<published> is right; on the ephemerd
+        # fleet the runner shares the container's CNI bridge and can reach
+        # <container IP>:3306 directly. Probe both, use whichever answers.
+        run: |
+          set -eu
+
+          probe() { timeout 2 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null; }
+
+          c="ephpm-mysql-$DB_SUFFIX"
+          ip="$($RUNTIME inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$c" 2>/dev/null | head -1)"
+          ep=""
+          for _ in $(seq 1 120); do
+            if probe 127.0.0.1 "$MYSQL_HOST_PORT"; then ep="127.0.0.1:$MYSQL_HOST_PORT"; break; fi
+            if [ -n "$ip" ] && probe "$ip" 3306; then ep="$ip:3306"; break; fi
+            sleep 2
+          done
+          if [ -z "$ep" ]; then
+            echo "::error::no reachable endpoint for $c (tried 127.0.0.1:$MYSQL_HOST_PORT and $ip:3306)"
+            $RUNTIME logs "$c" 2>&1 | tail -50 || true
+            exit 1
+          fi
+          echo "MYSQL_EP=$ep" >> "$GITHUB_ENV"
+          echo "resolved: mysql=$ep"
+
+      - name: Wait for MySQL to accept queries
+        # Readiness is "the server sent its handshake packet". It must NOT
+        # authenticate (a single root auth warms the caching_sha2 cache and
+        # hides the full-auth branch), and it cannot be a bare TCP connect (the
+        # publishing proxy accepts before dialling the container). The handshake
+        # is sent unprompted on connect and only the real server sends one —
+        # initdb's temporary server runs with networking disabled.
+        run: |
+          set -eu
+          host="${MYSQL_EP%%:*}" port="${MYSQL_EP##*:}"
+          for _ in $(seq 1 150); do
+            n=$(timeout 5 bash -c "exec 3<>/dev/tcp/$host/$port; head -c 16 <&3" 2>/dev/null | wc -c)
+            if [ "${n:-0}" -gt 0 ]; then
+              echo "MySQL ready (handshake received; nothing authenticated)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::MySQL ($MYSQL_EP) never sent a handshake"
+          exit 1
+
+      - name: Build the PHP-linked ephpm binary
+        # The whole point of this job: a real PHP that can drive pdo_mysql.
+        run: cargo xtask release --php-version "$PHP_VERSION"
+
+      - name: Run the pdo_mysql proxy E2E suite
+        env:
+          # Flip a missing prerequisite from a skip into a panic — the guard
+          # that stops this job going green against no database (issue #238's
+          # failure mode, applied to #433). The suite reads
+          # EPHPM_MYSQL_PROXY_TEST_URL for the backend; `cargo xtask e2e` hands
+          # it EPHPM_BINARY for the freshly built release binary.
+          EPHPM_REQUIRE_DB_TESTS: "1"
+        run: |
+          set -eu
+          export EPHPM_MYSQL_PROXY_TEST_URL="mysql://root:${MYSQL_PW}@${MYSQL_EP}/test"
+          cargo xtask e2e --php-version "$PHP_VERSION" --tests pdo_mysql_proxy
+
+      - name: Verify the guard fails rather than skips
+        # The fail-not-skip guard is itself a thing that can silently stop
+        # working. Assert the negative permanently: with EPHPM_REQUIRE_DB_TESTS=1
+        # and NO backend URL, the suite must FAIL (panic), not self-skip green.
+        if: always()
+        env:
+          EPHPM_REQUIRE_DB_TESTS: "1"
+        run: |
+          set -eu
+          # Deliberately export no EPHPM_MYSQL_PROXY_TEST_URL.
+          if cargo xtask e2e --php-version "$PHP_VERSION" --tests pdo_mysql_proxy > /tmp/guard.log 2>&1; then
+            echo "::error::pdo_mysql_proxy PASSED with no backend URL under EPHPM_REQUIRE_DB_TESTS=1 — the fail-not-skip guard is broken (a missing database could report green, issue #433/#238)."
+            tail -50 /tmp/guard.log
+            exit 1
+          fi
+          if ! grep -qF "EPHPM_MYSQL_PROXY_TEST_URL must be set" /tmp/guard.log; then
+            echo "::error::pdo_mysql_proxy failed, but not for the expected reason (wanted the require-guard panic)."
+            tail -50 /tmp/guard.log
+            exit 1
+          fi
+          echo "ok: the require-guard fails rather than skips"
+
+      - name: MySQL logs
+        if: failure()
+        run: $RUNTIME logs "ephpm-mysql-$DB_SUFFIX" 2>&1 | tail -100 || true
+
+      - name: Tear down MySQL
+        if: always()
+        run: $RUNTIME rm -f "ephpm-mysql-$DB_SUFFIX" >/dev/null 2>&1 || true

--- a/crates/ephpm-e2e/src/lib.rs
+++ b/crates/ephpm-e2e/src/lib.rs
@@ -125,6 +125,111 @@ impl Drop for SingleNodeFixture {
     }
 }
 
+/// A single ephpm process whose database is a **`[db.mysql]` proxy** pointed at
+/// a real MySQL/MariaDB backend.
+///
+/// This is deliberately distinct from [`SingleNodeFixture`], whose node runs
+/// the embedded Turso engine behind litewire (`[db.sqlite]`). The MySQL proxy
+/// (`crates/ephpm-db`) is a different code path entirely: it speaks the MySQL
+/// wire protocol on both sides and forwards to an external server through a
+/// connection pool. Nothing in the bare-process E2E rig provisions a real MySQL,
+/// so before this fixture existed the only PHP-through-`pdo_mysql` coverage ran
+/// against the *embedded* engine — the proxy's own connection/protocol
+/// behaviour toward `pdo_mysql` had no end-to-end guard (issue #433).
+///
+/// Requires a reachable backend URL (`mysql://user:pass@host:port/db`); the
+/// caller supplies it (the e2e suite reads `EPHPM_MYSQL_PROXY_TEST_URL`, set by
+/// the CI job that boots the database). Dropping the fixture SIGTERMs (then
+/// SIGKILLs) the child.
+pub struct MysqlProxyFixture {
+    child: Option<Child>,
+    base_url: String,
+    _tempdir: TempDir,
+}
+
+impl MysqlProxyFixture {
+    /// Spawn an ephpm on a free loopback port with a `[db.mysql]` proxy in
+    /// front of `backend_url`, serving `docroot`, and wait for its health
+    /// endpoint.
+    ///
+    /// The proxy's own listener gets a second reserved loopback port (not the
+    /// default 3306), so this fixture can coexist with any other node on the
+    /// host. `inject_env = true`, so the served PHP sees `DB_HOST`/`DB_PORT`
+    /// pointing at that listener.
+    ///
+    /// # Errors
+    ///
+    /// Fails if ports cannot be reserved, the config/scratch files cannot be
+    /// written, the child cannot be spawned, or it never reports healthy.
+    pub async fn start(ephpm_binary: &Path, docroot: &Path, backend_url: &str) -> Result<Self> {
+        let mut reserver = PortReserver::new();
+        let lease = reserver.lease(&[PortKind::Tcp, PortKind::Tcp])?;
+        let (http_port, proxy_port) = (lease.port(0), lease.port(1));
+
+        let tmp = tempfile::Builder::new()
+            .prefix("ephpm-e2e-mysqlproxy-")
+            .tempdir()
+            .context("create tempdir")?;
+
+        let config = MYSQL_PROXY_TEMPLATE
+            .replace("{HTTP_PORT}", &http_port.to_string())
+            .replace("{PROXY_PORT}", &proxy_port.to_string())
+            .replace("{DOCROOT}", &escape_toml(docroot))
+            // The backend URL carries operator-supplied credentials that may
+            // contain characters TOML treats specially (a backslash, a quote);
+            // escape it exactly like a path.
+            .replace("{BACKEND_URL}", &escape_toml_str(backend_url));
+
+        let config_path = tmp.path().join("ephpm.toml");
+        fs::write(&config_path, config).context("write config")?;
+
+        let stdout = fs::File::create(tmp.path().join("stdout.log")).context("open stdout log")?;
+        let stderr = fs::File::create(tmp.path().join("stderr.log")).context("open stderr log")?;
+
+        // Hand the ports off: release the probes and spawn in the same breath.
+        lease.release();
+        let mut child = Command::new(ephpm_binary)
+            .args(["serve", "--config"])
+            .arg(&config_path)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .with_context(|| format!("spawn ephpm ({})", ephpm_binary.display()))?;
+
+        // The MySQL proxy connects to its backend lazily (deferred), so the
+        // node reports healthy well before the pool warms; 30s is ample for a
+        // cold ~120 MB binary to page in and PHP to init.
+        wait_for_health(&mut child, http_port, Duration::from_secs(30)).await.with_context(
+            || {
+                format!(
+                    "ephpm on 127.0.0.1:{http_port} never healthy — check {}",
+                    tmp.path().join("stderr.log").display()
+                )
+            },
+        )?;
+
+        Ok(Self {
+            child: Some(child),
+            base_url: format!("http://127.0.0.1:{http_port}"),
+            _tempdir: tmp,
+        })
+    }
+
+    /// Base URL (`http://127.0.0.1:<port>`) for HTTP clients.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for MysqlProxyFixture {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            terminate(child);
+        }
+    }
+}
+
 /// How long each cluster node gets to answer `/_ephpm/health`.
 ///
 /// Sized against measured cold-start, not guessed: two ephpm processes
@@ -667,6 +772,35 @@ path = "{DATA_DIR}/ephpm-fixture.db"
 
 [db.sqlite.proxy]
 mysql_listen = "127.0.0.1:{MYSQL_PORT}"
+"#;
+
+/// Config for [`MysqlProxyFixture`]. Placeholders: `{HTTP_PORT}`,
+/// `{PROXY_PORT}` (the `[db.mysql]` listener PHP's `pdo_mysql` connects to),
+/// `{DOCROOT}`, `{BACKEND_URL}` (the real MySQL/MariaDB the proxy forwards to).
+///
+/// This is `[db.mysql]`, NOT `[db.sqlite]`: it exercises the wire-protocol
+/// forwarding proxy in `crates/ephpm-db`, not the embedded engine. `inject_env`
+/// is left at its default (`true`) so the served PHP finds the proxy listener
+/// via `DB_HOST`/`DB_PORT` — the same auto-detection production PHP relies on.
+const MYSQL_PROXY_TEMPLATE: &str = r#"# Auto-generated by ephpm-e2e MysqlProxyFixture — do not edit.
+[server]
+listen = "127.0.0.1:{HTTP_PORT}"
+document_root = "{DOCROOT}"
+index_files = ["index.php", "index.html"]
+
+[server.request]
+trusted_hosts = ["localhost", "127.0.0.1", "127.0.0.1:{HTTP_PORT}"]
+
+[server.metrics]
+enabled = true
+
+[php]
+max_execution_time = 30
+memory_limit = "128M"
+
+[db.mysql]
+url = "{BACKEND_URL}"
+listen = "127.0.0.1:{PROXY_PORT}"
 "#;
 
 const CLUSTER_NODE_TEMPLATE: &str = r#"# Auto-generated by ephpm-e2e ClusterFixture — do not edit.

--- a/crates/ephpm-e2e/tests/pdo_mysql_proxy.rs
+++ b/crates/ephpm-e2e/tests/pdo_mysql_proxy.rs
@@ -1,0 +1,211 @@
+//! `pdo_mysql`-through-the-`[db.mysql]`-proxy end-to-end coverage (issue #433).
+//!
+//! Every other DB-path e2e suite (`rw_split`, `sqlite`, `db_bridge`, ...) drives
+//! `pdo_mysql` against the *embedded* Turso engine behind litewire
+//! (`[db.sqlite]`). The `[db.mysql]` **proxy** — the `crates/ephpm-db` wire
+//! forwarder that sits between PHP and a real MySQL/MariaDB — was covered only
+//! by `crates/ephpm-db/tests/proxy_integration.rs`, which drives it with
+//! `mysql_async`, not PHP's `pdo_mysql`. So a regression visible only to
+//! `pdo_mysql`'s connection/protocol behaviour toward the proxy (exactly the
+//! class of bug #425 was about) had no CI guard.
+//!
+//! This suite closes that gap: it stands up a **PHP-linked** ephpm with a
+//! `[db.mysql]` proxy in front of a real backend, then drives a `CREATE` +
+//! `INSERT` + `SELECT` round-trip from real PHP over HTTP and asserts the row
+//! comes back.
+//!
+//! ## How it is wired
+//!
+//! Self-managed suite: the harness (`cargo xtask e2e`) starts no node for it,
+//! it just receives `EPHPM_BINARY` (see `SELF_MANAGED_SUITES` in
+//! `xtask/src/e2e_bare.rs`) and spawns its own [`MysqlProxyFixture`]. The real
+//! backend comes from `EPHPM_MYSQL_PROXY_TEST_URL`
+//! (`mysql://user:pass@host:port/db`), set by the CI job that boots the
+//! database (`.github/workflows/pdo-mysql-e2e.yml`).
+//!
+//! ## Skip vs. fail
+//!
+//! Both env vars unset ⇒ the suite **self-skips** (prints why, returns `ok`) so
+//! `cargo xtask e2e` on a host with no MySQL — the normal bare-process lane —
+//! does not fail. In the CI job that *does* provision a database,
+//! `EPHPM_REQUIRE_DB_TESTS=1` flips a missing prerequisite from a skip into a
+//! panic, so the whole point of the job cannot silently evaporate into a green
+//! check (the failure mode `.github/workflows/db-integration.yml` documents for
+//! issue #238).
+
+use std::path::PathBuf;
+
+use ephpm_e2e::{MysqlProxyFixture, ephpm_binary_env};
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// The one PHP script this suite serves. Connects through the proxy with the
+/// injected `DB_*` env (the proxy discards client credentials, but production
+/// PHP sends them, so send them here too), then exercises a full write→read
+/// round-trip and reports the result as JSON.
+const PDO_SCRIPT: &str = r#"<?php
+header('Content-Type: application/json');
+
+$host = getenv('DB_HOST') ?: '127.0.0.1';
+$port = getenv('DB_PORT') ?: '3306';
+$name = getenv('DB_NAME') ?: 'test';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASSWORD') ?: '';
+$action = $_GET['action'] ?? 'roundtrip';
+
+try {
+    $pdo = new PDO(
+        "mysql:host={$host};port={$port};dbname={$name}",
+        $user,
+        $pass,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+
+    switch ($action) {
+        case 'roundtrip':
+            // Idempotent: a fresh backend each CI run, but tolerate a re-run.
+            $pdo->exec('DROP TABLE IF EXISTS ephpm_e2e_pdo');
+            $pdo->exec(
+                'CREATE TABLE ephpm_e2e_pdo ('
+                . 'id INT AUTO_INCREMENT PRIMARY KEY, '
+                . 'label VARCHAR(64) NOT NULL)'
+            );
+
+            // Write via a prepared statement (COM_STMT_PREPARE/EXECUTE — the
+            // protocol path a plain query does not exercise).
+            $ins = $pdo->prepare('INSERT INTO ephpm_e2e_pdo (label) VALUES (?)');
+            $ins->execute(['hello-from-pdo']);
+            $id = (int) $pdo->lastInsertId();
+
+            // Read it back.
+            $sel = $pdo->prepare('SELECT id, label FROM ephpm_e2e_pdo WHERE id = ?');
+            $sel->execute([$id]);
+            $row = $sel->fetch(PDO::FETCH_ASSOC);
+
+            $ver = $pdo->query('SELECT VERSION() AS v')->fetch(PDO::FETCH_ASSOC)['v'] ?? '';
+
+            echo json_encode([
+                'status' => 'ok',
+                'inserted_id' => $id,
+                'row' => $row,
+                'server_version' => $ver,
+            ]);
+            break;
+
+        case 'cleanup':
+            $pdo->exec('DROP TABLE IF EXISTS ephpm_e2e_pdo');
+            echo json_encode(['status' => 'ok']);
+            break;
+
+        default:
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'error' => 'unknown action']);
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'error' => $e->getMessage()]);
+}
+"#;
+
+/// Backend MySQL/MariaDB URL, or `None` when the suite should skip.
+fn backend_url() -> Option<String> {
+    std::env::var("EPHPM_MYSQL_PROXY_TEST_URL").ok().filter(|s| !s.is_empty())
+}
+
+/// Whether a missing prerequisite must fail rather than skip. Set by the CI job
+/// that provisions the database; unset everywhere else. Mirrors
+/// `EPHPM_REQUIRE_DB_TESTS` in `crates/ephpm-db/tests/common/mod.rs`.
+fn require_db_tests() -> bool {
+    std::env::var_os("EPHPM_REQUIRE_DB_TESTS").is_some()
+}
+
+/// Resolve `(binary, backend_url)` or return `None` to skip — panicking instead
+/// when [`require_db_tests`] says a skip is not allowed.
+fn prerequisites() -> Option<(PathBuf, String)> {
+    let require = require_db_tests();
+
+    let binary = match ephpm_binary_env() {
+        Some(b) => b,
+        None if require => panic!(
+            "EPHPM_BINARY must be set when EPHPM_REQUIRE_DB_TESTS=1 — the CI job \
+             that provisions MySQL is supposed to build the PHP-linked binary and \
+             run this suite through `cargo xtask e2e`"
+        ),
+        None => {
+            eprintln!("skipping pdo_mysql_proxy: EPHPM_BINARY unset (no built ephpm binary)");
+            return None;
+        }
+    };
+
+    let url = match backend_url() {
+        Some(u) => u,
+        None if require => panic!(
+            "EPHPM_MYSQL_PROXY_TEST_URL must be set when EPHPM_REQUIRE_DB_TESTS=1 — \
+             a real MySQL/MariaDB backend was not provisioned"
+        ),
+        None => {
+            eprintln!("skipping pdo_mysql_proxy: EPHPM_MYSQL_PROXY_TEST_URL unset (no backend)");
+            return None;
+        }
+    };
+
+    Some((binary, url))
+}
+
+/// Write the single PHP script into a throwaway docroot the caller owns.
+///
+/// The suite builds its own docroot rather than serving the shared
+/// `tests/docroot` so it stays fully self-contained (like `turso_cdc`): nothing
+/// about it can perturb — or be perturbed by — another suite's fixtures.
+fn make_docroot() -> TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("ephpm-e2e-pdo-docroot-")
+        .tempdir()
+        .expect("create docroot tempdir");
+    std::fs::write(dir.path().join("pdo_mysql_test.php"), PDO_SCRIPT)
+        .expect("write pdo_mysql_test.php");
+    dir
+}
+
+/// A `CREATE` + prepared `INSERT` + prepared `SELECT` round-trip driven from
+/// real PHP `pdo_mysql`, through the `[db.mysql]` proxy, to a real backend.
+#[tokio::test]
+async fn pdo_mysql_proxy_write_read_roundtrip() {
+    let Some((binary, url)) = prerequisites() else {
+        return;
+    };
+
+    let docroot = make_docroot();
+    let fixture = MysqlProxyFixture::start(&binary, docroot.path(), &url)
+        .await
+        .expect("start ephpm with a [db.mysql] proxy");
+
+    let resp = reqwest::get(format!("{}/pdo_mysql_test.php?action=roundtrip", fixture.base_url()))
+        .await
+        .expect("GET roundtrip");
+    let status = resp.status();
+    let body = resp.text().await.expect("read body");
+
+    assert_eq!(status, 200, "roundtrip should return 200, got {status}: {body}");
+
+    let json: Value = serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("response was not JSON ({e}): {body}"));
+    assert_eq!(json["status"], "ok", "PHP reported an error: {body}");
+
+    // The inserted row must come back through the proxy with both columns
+    // intact — the actual proof that pdo_mysql wrote and read via the proxy.
+    let id = json["inserted_id"].as_i64().unwrap_or(0);
+    assert!(id > 0, "expected a positive AUTO_INCREMENT id, got: {body}");
+    assert_eq!(json["row"]["id"].as_i64(), Some(id), "read-back id mismatch: {body}");
+    assert_eq!(json["row"]["label"], "hello-from-pdo", "read-back label mismatch: {body}");
+
+    // A real MySQL/MariaDB answered VERSION(); an embedded-engine stand-in would
+    // not (this suite must exercise the proxy, not `[db.sqlite]`).
+    assert!(
+        json["server_version"].as_str().is_some_and(|v| !v.is_empty()),
+        "expected a non-empty backend VERSION(): {body}"
+    );
+
+    // Best-effort cleanup; the backend is torn down with the CI job regardless.
+    let _ = reqwest::get(format!("{}/pdo_mysql_test.php?action=cleanup", fixture.base_url())).await;
+}

--- a/crates/ephpm-e2e/tests/pdo_mysql_proxy.rs
+++ b/crates/ephpm-e2e/tests/pdo_mysql_proxy.rs
@@ -46,11 +46,24 @@ use tempfile::TempDir;
 const PDO_SCRIPT: &str = r#"<?php
 header('Content-Type: application/json');
 
-$host = getenv('DB_HOST') ?: '127.0.0.1';
-$port = getenv('DB_PORT') ?: '3306';
-$name = getenv('DB_NAME') ?: 'test';
-$user = getenv('DB_USER') ?: 'root';
-$pass = getenv('DB_PASSWORD') ?: '';
+// ePHPm injects DB_HOST/DB_PORT/... as $_SERVER entries (the SAPI registers
+// them as server variables), NOT into the process environment — so `getenv()`
+// does NOT see them and would fall back to 3306, where nothing listens (the
+// proxy binds a random loopback port). Read $_SERVER first; getenv/defaults
+// are only a fallback for running this script off ePHPm.
+function db_var($key, $default) {
+    if (isset($_SERVER[$key]) && $_SERVER[$key] !== '') {
+        return $_SERVER[$key];
+    }
+    $v = getenv($key);
+    return ($v !== false && $v !== '') ? $v : $default;
+}
+
+$host = db_var('DB_HOST', '127.0.0.1');
+$port = db_var('DB_PORT', '3306');
+$name = db_var('DB_NAME', 'test');
+$user = db_var('DB_USER', 'root');
+$pass = db_var('DB_PASSWORD', '');
 $action = $_GET['action'] ?? 'roundtrip';
 
 try {
@@ -180,11 +193,23 @@ async fn pdo_mysql_proxy_write_read_roundtrip() {
         .await
         .expect("start ephpm with a [db.mysql] proxy");
 
-    let resp = reqwest::get(format!("{}/pdo_mysql_test.php?action=roundtrip", fixture.base_url()))
-        .await
-        .expect("GET roundtrip");
-    let status = resp.status();
-    let body = resp.text().await.expect("read body");
+    // The proxy's listener binds immediately, but it *drains* (accepts then
+    // closes) connections until its backend pool has seeded — a brief window
+    // after the HTTP health endpoint already reports 200. A request that lands
+    // in it fails with a connection error, so poll the (idempotent — it
+    // DROP/CREATEs its own table) round-trip until the proxy is fully up.
+    let roundtrip_url = format!("{}/pdo_mysql_test.php?action=roundtrip", fixture.base_url());
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let (status, body) = loop {
+        let resp = reqwest::get(&roundtrip_url).await.expect("GET roundtrip");
+        let status = resp.status();
+        let body = resp.text().await.expect("read body");
+        if status == 200 || std::time::Instant::now() >= deadline {
+            break (status, body);
+        }
+        eprintln!("roundtrip not ready yet (HTTP {status}); retrying: {body}");
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    };
 
     assert_eq!(status, 200, "roundtrip should return 200, got {status}: {body}");
 

--- a/xtask/src/e2e_bare.rs
+++ b/xtask/src/e2e_bare.rs
@@ -269,11 +269,21 @@ const NO_NODE_SUITES: &[&str] = &["cli"];
 /// `ok`) *and* broken (it derived its docroot from `CARGO_MANIFEST_DIR`, which
 /// is xtask's under this harness). `EPHPM_DOCROOT` below fixes the second half.
 ///
+/// `pdo_mysql_proxy` is here because it needs a `[db.mysql]` node in front of a
+/// **real MySQL/MariaDB** — a backend nothing in the bare-process rig
+/// provisions — so it spawns its own `MysqlProxyFixture` and reads the backend
+/// URL from `EPHPM_MYSQL_PROXY_TEST_URL`. On the ordinary bare-process lane that
+/// variable is unset and the suite self-skips; it does real work only in the
+/// CI job that boots a database (`.github/workflows/pdo-mysql-e2e.yml`), which
+/// also sets `EPHPM_REQUIRE_DB_TESTS=1` so a missing backend fails rather than
+/// skips there (issue #433). Its config is `[db.mysql]`, which must NOT live on
+/// any shared or `[db.sqlite]` node (#288/#295), hence self-managed.
+///
 /// NOTE: `EPHPM_BINARY` goes to exactly these suites and the `middleware`
 /// node — see the note in [`SingleNodeSpawn::env`]. It stays scoped rather
 /// than global because it is an opt-in switch for `ephpm-e2e`'s self-managed
 /// fixtures, and a suite that gets it starts spawning real processes.
-const SELF_MANAGED_SUITES: &[&str] = &["turso_cdc", "bare_process_smoke"];
+const SELF_MANAGED_SUITES: &[&str] = &["turso_cdc", "bare_process_smoke", "pdo_mysql_proxy"];
 
 /// Test suites that must be excluded from bare-process runs entirely.
 ///


### PR DESCRIPTION
Closes #433.

## Problem
No CI coverage drove the `[db.mysql]` proxy from real PHP via `pdo_mysql`: DB-path e2e suites point `pdo_mysql` at the embedded Turso engine, the bare-process rig provisions no MySQL, and `ephpm-db`'s proxy_integration.rs drives the proxy with `mysql_async`, not PHP's driver.

## What this adds
- `pdo_mysql_proxy` e2e suite: PHP-linked ephpm + `[db.mysql]` proxy in front of a real MySQL/MariaDB; CREATE + prepared INSERT + prepared SELECT round-trip over HTTP, asserts the row and a non-empty backend `VERSION()` (so it can't silently pass against the embedded engine).
- `MysqlProxyFixture` — a `[db.mysql]` node distinct from the `[db.sqlite]` `SingleNodeFixture`, on reserved loopback ports. **Shared/[db.sqlite] templates untouched (#288/#295).**
- Wired as a SELF_MANAGED suite in `xtask/src/e2e_bare.rs` (additive). Self-skips with no backend; `EPHPM_REQUIRE_DB_TESTS=1` flips skip→panic (#238 guard).
- `pdo-mysql-e2e.yml`: boots caching_sha2 MySQL 8 (reusing db-integration.yml's provisioning), builds the PHP-linked binary, runs the suite, asserts the require-guard fails rather than skips. Path-filtered + daily cron.

## Validation
Compiles; clippy clean (incl. `xtask -D warnings`); new code fmt-clean; skip and require-guard paths verified by running the built binary. The real-MySQL happy path runs in the new CI job.