### PR TITLE
feat(preview-auth): per-preview GitHub-repo authorization for previews

### DIFF
--- a/crates/ephpm-middleware-github-auth/src/config.rs
+++ b/crates/ephpm-middleware-github-auth/src/config.rs
@@ -100,6 +100,47 @@ impl Check {
     }
 }
 
+/// Parse an `owner/name` repository spec into a [`Check::Repo`].
+///
+/// The one validation path for a repository string, whether it comes from the
+/// mount `config` (`repo = "owner/name"`), a `sites` entry, or — as of the
+/// per-preview gate — the trusted router `request_gate_repo` channel decoded
+/// back out of a signed OAuth `state`. Sharing it means the state-carried repo
+/// is held to exactly the same shape as a configured one: it becomes part of an
+/// outbound GitHub API path, so a smuggled `..`/`/`/query is refused here.
+///
+/// # Errors
+///
+/// Returns a message when `spec` is not exactly `owner/name` with both segments
+/// valid GitHub names.
+pub fn repo_from_spec(spec: &str, ctx: &str) -> Result<Check, String> {
+    let (owner, name) = spec
+        .split_once('/')
+        .ok_or_else(|| format!("{ctx}: `repo` must be `owner/name`, got {spec:?}"))?;
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        return Err(format!("{ctx}: `repo` must be exactly `owner/name`, got {spec:?}"));
+    }
+    validate_path_segment(owner, &format!("{ctx}: repo owner"))?;
+    validate_path_segment(name, &format!("{ctx}: repo name"))?;
+    Ok(Check::Repo { owner: owner.to_owned(), name: name.to_owned() })
+}
+
+/// How the gate decides *what* to authorize each preview against.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Access {
+    /// The configured `default_check`/`sites` are authoritative — today's
+    /// behaviour, and the default. A per-request `request_gate_repo` is ignored.
+    #[default]
+    Fixed,
+    /// Each preview authorizes against the repository the router sealed into the
+    /// OAuth `state` at login (`request_gate_repo`, from the operator-owned
+    /// per-site override). `default_check`/`sites` become optional; a login or
+    /// callback with no repository fails **closed**. This is the mode a dynamic
+    /// multi-repo preview fleet uses, where the enforceable target is per-PR
+    /// base-repo read access rather than one coarse org/repo check.
+    PerPreview,
+}
+
 /// The gate's fully-resolved configuration.
 #[derive(Debug)]
 pub struct Config {
@@ -112,6 +153,9 @@ pub struct Config {
     /// Key for the OAuth `state` cookie, derived from `session_secret`.
     pub state_secret: Secret,
 
+    /// How each preview's authorization target is chosen — a fixed configured
+    /// check, or the per-preview repository the router sealed into the state.
+    pub access: Access,
     /// Access check applied when the request's vhost has no `sites` entry.
     pub default_check: Option<Check>,
     /// Per-vhost access checks (`request_vhost_id` → check).
@@ -248,15 +292,7 @@ fn parse_check(v: &serde_json::Value, ctx: &str) -> Result<Option<Check>, String
     match kind.as_str() {
         "repo" => {
             let spec = repo.ok_or_else(|| format!("{ctx}: `check = \"repo\"` needs `repo` set"))?;
-            let (owner, name) = spec
-                .split_once('/')
-                .ok_or_else(|| format!("{ctx}: `repo` must be `owner/name`, got {spec:?}"))?;
-            if owner.is_empty() || name.is_empty() || name.contains('/') {
-                return Err(format!("{ctx}: `repo` must be exactly `owner/name`, got {spec:?}"));
-            }
-            validate_path_segment(owner, &format!("{ctx}: repo owner"))?;
-            validate_path_segment(name, &format!("{ctx}: repo name"))?;
-            Ok(Some(Check::Repo { owner: owner.to_owned(), name: name.to_owned() }))
+            repo_from_spec(&spec, ctx).map(Some)
         }
         "org" => {
             let org = org.ok_or_else(|| format!("{ctx}: `check = \"org\"` needs `org` set"))?;
@@ -381,12 +417,30 @@ impl Config {
             }
             Some(other) => return Err(format!("`sites` must be a table, got {other}")),
         }
+        let access = match opt_str(config, "access")?.as_deref() {
+            None | Some("fixed") => Access::Fixed,
+            Some("per-preview") => Access::PerPreview,
+            Some(other) => {
+                return Err(format!(
+                    "`access` must be \"fixed\" or \"per-preview\", got {other:?}"
+                ));
+            }
+        };
+
         let default_check = parse_check(config, "config")?;
-        if default_check.is_none() && sites.is_empty() {
+        // In `fixed` mode a target is mandatory — a gate with nothing to check
+        // authenticates every GitHub user in the world. In `per-preview` mode
+        // the target arrives per request on the trusted `request_gate_repo`
+        // channel (sealed into the OAuth state at login), so `default_check` /
+        // `sites` are optional; a request that carries no repository fails
+        // closed at login/callback instead (see `GithubAuth::start_login` /
+        // `handle_callback`).
+        if access == Access::Fixed && default_check.is_none() && sites.is_empty() {
             return Err(
-                "no access target configured: set `repo` (or `org`/`team`), or a `sites` table \
-                 mapping each vhost to one. A gate with nothing to check would authenticate \
-                 every GitHub user in the world."
+                "no access target configured: set `repo` (or `org`/`team`), a `sites` table \
+                 mapping each vhost to one, or `access = \"per-preview\"` to authorize each \
+                 preview against the repository the router seals into the OAuth state. A gate \
+                 with nothing to check would authenticate every GitHub user in the world."
                     .into(),
             );
         }
@@ -507,6 +561,7 @@ impl Config {
             client_secret,
             session_secret,
             state_secret,
+            access,
             default_check,
             sites,
             login_path,
@@ -838,6 +893,54 @@ mod tests {
         assert!(validate_vhost("localhost:8080").is_ok());
         for bad in ["", "has space", "evil.test/path", "a@b", "caf\u{e9}.test", "x\r\ny"] {
             assert!(validate_vhost(bad).is_err(), "{bad:?}");
+        }
+    }
+
+    // ── access mode (issue #487, per-preview repo gate) ──────────────────
+
+    #[test]
+    fn access_defaults_to_fixed() {
+        assert_eq!(parse(base()).expect("parse").access, Access::Fixed);
+    }
+
+    /// `per-preview` mode makes a configured target OPTIONAL — the repo arrives
+    /// per request. A gate with no `repo`/`sites` must still start.
+    #[test]
+    fn per_preview_access_makes_the_target_optional() {
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        v["access"] = serde_json::json!("per-preview");
+        let c = parse(v).expect("per-preview needs no configured target");
+        assert_eq!(c.access, Access::PerPreview);
+        assert!(c.default_check.is_none());
+        assert!(c.sites.is_empty());
+    }
+
+    /// `fixed` mode (the default) still requires a target — the "authenticate
+    /// every GitHub user in the world" guard is unchanged.
+    #[test]
+    fn fixed_access_still_requires_a_target() {
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        let err = parse(v).expect_err("fixed mode with no target must not start");
+        assert!(err.contains("every GitHub user in the world"));
+    }
+
+    #[test]
+    fn an_unknown_access_value_is_refused() {
+        let mut v = base();
+        v["access"] = serde_json::json!("open");
+        assert!(parse(v).expect_err("bad access").contains("per-preview"));
+    }
+
+    #[test]
+    fn repo_from_spec_validates_owner_slash_name() {
+        assert_eq!(
+            repo_from_spec("acme/web", "x").expect("valid"),
+            Check::Repo { owner: "acme".into(), name: "web".into() }
+        );
+        for bad in ["acme", "acme/", "/web", "acme/web/x", "../../etc", "acme/we b", ".", ".."] {
+            assert!(repo_from_spec(bad, "x").is_err(), "{bad:?} must be refused");
         }
     }
 }

--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -163,7 +163,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use ephpm_middleware::abi::{LOG_ERROR, LOG_INFO, LOG_WARN};
 use ephpm_middleware::{Middleware, Request, Response};
 
-use crate::config::{Check, Config, STATE_TTL_SECS};
+use crate::config::{Access, Check, Config, STATE_TTL_SECS};
 use crate::cookie::{read_cookie, set_cookie};
 use crate::github::{GhError, GitHub, encode_query};
 
@@ -326,27 +326,88 @@ impl GithubAuth {
         }
     }
 
+    /// The per-preview repository this request carries on the trusted router
+    /// channel (`request_gate_repo`), validated into a [`Check::Repo`].
+    ///
+    /// `None` when the channel is empty or the value fails re-validation. It is
+    /// only consulted in [`Access::PerPreview`] mode; the caller decides what an
+    /// absent repository means (a per-preview login/callback with none fails
+    /// closed). The value never comes from a client header — see the accessor.
+    fn gate_repo_check(&self, req: &Request<'_>) -> Option<Check> {
+        let spec = req.gate_repo()?;
+        match config::repo_from_spec(spec, "request_gate_repo") {
+            Ok(check) => Some(check),
+            Err(msg) => {
+                // The spec is operator-owned (not a secret), so naming it is safe
+                // and is the actionable part of a misconfigured override.
+                log(
+                    req,
+                    LOG_WARN,
+                    &format!("github-auth: ignoring invalid gate repository — {msg}"),
+                );
+                None
+            }
+        }
+    }
+
     /// 302 to GitHub's authorize endpoint, with a fresh signed `state`.
     fn start_login(&self, req: &Request<'_>, vhost: &str, return_to: &str, now: u64) -> Response {
-        let Some(check) = self.config.check_for(vhost) else {
-            log(
-                req,
-                LOG_WARN,
-                &format!(
-                    "github-auth: refusing login for vhost {vhost:?} — it has no `sites` entry and \
-                 no default target, so there is nothing to check access against"
-                ),
-            );
-            return deny(403, "This preview is not configured for GitHub access control.");
+        // What to authorize against — and, in per-preview mode, what to seal
+        // into the state so the apex callback (which cannot resolve the repo)
+        // can rebuild the exact `Check`. Each mode fails closed at *this* point
+        // when it has nothing, rather than starting a login the callback would
+        // later refuse.
+        let (check, per_preview_repo) = match self.config.access {
+            // Per-preview: the repository MUST arrive on the trusted router
+            // channel. No fallback to a configured target — that would seal no
+            // `repo` and the callback would deny late instead of here.
+            Access::PerPreview => {
+                let Some(repo) = self.gate_repo_check(req) else {
+                    log(
+                        req,
+                        LOG_WARN,
+                        &format!(
+                            "github-auth: refusing login for vhost {vhost:?} — access is \
+                             \"per-preview\" but no valid repository arrived on the trusted \
+                             channel (the site's `[preview_auth] repo`)"
+                        ),
+                    );
+                    return deny(403, "This preview is not configured for GitHub access control.");
+                };
+                (repo.clone(), Some(repo))
+            }
+            // Fixed: the configured target is authoritative and the channel is
+            // ignored — behaviour unchanged from before this feature.
+            Access::Fixed => {
+                let Some(check) = self.config.check_for(vhost).cloned() else {
+                    log(
+                        req,
+                        LOG_WARN,
+                        &format!(
+                            "github-auth: refusing login for vhost {vhost:?} — it has no `sites` \
+                             entry and no default target, so there is nothing to check access \
+                             against"
+                        ),
+                    );
+                    return deny(403, "This preview is not configured for GitHub access control.");
+                };
+                (check, None)
+            }
         };
 
         let nonce = token::random_nonce();
-        let state_claims = serde_json::json!({
+        let mut state_claims = serde_json::json!({
             "n": nonce,
             "rt": return_to,
             "v": vhost,
             "exp": now.saturating_add(STATE_TTL_SECS),
         });
+        // Seal the per-preview repository into the state so the apex callback can
+        // rebuild the exact `Check`. Only in per-preview mode; fixed mode never
+        // carries it, so its state is byte-for-byte what it was before.
+        if let Some(Check::Repo { owner, name }) = &per_preview_repo {
+            state_claims["repo"] = serde_json::Value::String(format!("{owner}/{name}"));
+        }
         let Some(state_cookie) = token::mint(self.config.state_secret.expose(), &state_claims)
         else {
             log(req, LOG_ERROR, "github-auth: could not mint the OAuth state token");
@@ -476,9 +537,44 @@ impl GithubAuth {
             &self.config.reserved_paths(),
         );
 
-        let Some(check) = self.config.check_for(target) else {
-            return deny(403, "This preview is not configured for GitHub access control.")
-                .header("Set-Cookie", clear_state);
+        // The access check to enforce. In per-preview mode the login sealed the
+        // repository into the state; the callback runs on the apex host where
+        // the router cannot resolve the target's repo, so the *signed* state is
+        // the only trustworthy source. Rebuild the `Check` from it, re-validated
+        // (the value became attacker-chosen input at the router before it was
+        // signed, and a signature attests origin, not shape). A per-preview
+        // state with no valid repository fails closed. Fixed mode keeps using
+        // the configured check exactly as before.
+        let check: Check = match self.config.access {
+            Access::PerPreview => {
+                let repo_claim = state_claims
+                    .get("repo")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                match config::repo_from_spec(repo_claim, "state repo") {
+                    Ok(c) => c,
+                    Err(_) => {
+                        log(
+                            req,
+                            LOG_WARN,
+                            "github-auth: per-preview callback state carries no valid repository \
+                             — rejected",
+                        );
+                        return deny(
+                            403,
+                            "This preview is not configured for GitHub access control.",
+                        )
+                        .header("Set-Cookie", clear_state);
+                    }
+                }
+            }
+            Access::Fixed => {
+                let Some(c) = self.config.check_for(target) else {
+                    return deny(403, "This preview is not configured for GitHub access control.")
+                        .header("Set-Cookie", clear_state);
+                };
+                c.clone()
+            }
         };
 
         let Some(code) = query_param(query, "code").filter(|c| is_plausible_code(c)) else {
@@ -494,7 +590,7 @@ impl GithubAuth {
         let outcome =
             self.github.exchange_code(&code, &self.redirect_uri(target)).and_then(|access| {
                 let user = self.github.current_user(&access)?;
-                let allowed = self.github.check_access(&access, check, &user)?;
+                let allowed = self.github.check_access(&access, &check, &user)?;
                 Ok((user, allowed))
             });
 
@@ -534,7 +630,7 @@ impl GithubAuth {
             &user.login,
             "github",
             Some(user.id),
-            Some(check),
+            Some(&check),
             now,
             self.config.session_ttl_secs,
             &final_return,
@@ -583,10 +679,15 @@ impl GithubAuth {
         if self.banner_done.swap(true, Ordering::Relaxed) {
             return;
         }
-        let target = self.config.default_check.as_ref().map_or_else(
-            || format!("{} vhost(s) mapped", self.config.sites.len()),
-            Check::describe,
-        );
+        let target = match self.config.access {
+            // The repository is per-preview and arrives at login on the trusted
+            // router channel, so there is no single configured target to name.
+            Access::PerPreview => "per-preview repository (from the OAuth state)".to_owned(),
+            Access::Fixed => self.config.default_check.as_ref().map_or_else(
+                || format!("{} vhost(s) mapped", self.config.sites.len()),
+                Check::describe,
+            ),
+        };
         log(
             req,
             LOG_INFO,
@@ -1318,5 +1419,205 @@ mod tests {
         let resp = mw.invoke(&req);
         let set = header(&resp, "Set-Cookie").expect("state cookie");
         assert!(set.contains("Domain=.preview.test"), "state cookie must be domain-scoped: {set}");
+    }
+
+    // ── per-preview repo gate (issue #487) ───────────────────────────────
+
+    /// A per-preview gate with NO configured target — the repo arrives per
+    /// request on the trusted `request_gate_repo` channel.
+    fn per_preview_gate() -> GithubAuth {
+        let cfg = serde_json::json!({
+            "client_id": "Iv1.test",
+            "client_secret": "client-secret",
+            "session_secret": SESSION_SECRET,
+            "access": "per-preview",
+            "github_base": "http://127.0.0.1:1",
+            "github_api_base": "http://127.0.0.1:1",
+        });
+        GithubAuth::init(&cfg).expect("per-preview init needs no default target")
+    }
+
+    /// Invoke with the trusted router repo channel set (or not).
+    fn invoke_repo(
+        mw: &GithubAuth,
+        path: &str,
+        query: &str,
+        headers: &[(String, String)],
+        site: &str,
+        repo: Option<&str>,
+    ) -> Response {
+        let mut ctx = RequestCtx::new("GET", path, query, "203.0.113.9", site, headers);
+        if let Some(r) = repo {
+            ctx = ctx.with_gate_repo(r);
+        }
+        // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+        mw.invoke(&req)
+    }
+
+    /// Decode the `Set-Cookie` OAuth state a login emitted, into its claims.
+    fn state_claims_of(mw: &GithubAuth, resp: &Response) -> serde_json::Value {
+        let set = header(resp, "Set-Cookie").expect("state cookie");
+        let value = set.split(';').next().and_then(|p| p.split_once('=')).expect("cookie pair").1;
+        token::verify(mw.config.state_secret.expose(), value, unix_now()).expect("state verifies")
+    }
+
+    /// The crux (design §4): per-preview login seals the trusted-channel repo
+    /// into the signed state, keyed to the target host, so the apex callback can
+    /// rebuild the exact `Check`.
+    #[test]
+    fn per_preview_login_seals_the_repo_into_the_state() {
+        let mw = per_preview_gate();
+        let resp = invoke_repo(&mw, "/secret.php", "", &[], "pr-1.preview.test", Some("acme/web"));
+        assert_eq!(resp.__status(), 302);
+        let claims = state_claims_of(&mw, &resp);
+        assert_eq!(claims["repo"], "acme/web");
+        assert_eq!(claims["v"], "pr-1.preview.test");
+    }
+
+    /// Fail-closed (design §11): per-preview login with an EMPTY channel is
+    /// denied — and no request header can supply the repo (design §10: the
+    /// channel is not client-controllable).
+    #[test]
+    fn per_preview_login_without_a_repo_is_denied_and_headers_cannot_supply_it() {
+        let mw = per_preview_gate();
+        let spoof = vec![
+            ("x-gate-repo".to_owned(), "attacker/owns".to_owned()),
+            ("x-ephpm-gate-repo".to_owned(), "attacker/owns".to_owned()),
+            ("x-forwarded-repo".to_owned(), "attacker/owns".to_owned()),
+        ];
+        let resp = invoke_repo(&mw, "/", "", &spoof, "pr-1.preview.test", None);
+        assert_eq!(
+            resp.__status(),
+            403,
+            "no repo on the trusted channel ⇒ fail closed, and headers must not supply one"
+        );
+    }
+
+    /// A malformed repo on the channel is refused (fail closed), never gated
+    /// against a bad target.
+    #[test]
+    fn per_preview_login_with_a_malformed_repo_is_denied() {
+        let mw = per_preview_gate();
+        for bad in ["acme", "acme/", "/web", "acme/web/x", "../../etc", "acme/we b"] {
+            let resp = invoke_repo(&mw, "/", "", &[], "pr-1.preview.test", Some(bad));
+            assert_eq!(resp.__status(), 403, "repo {bad:?} must fail closed");
+        }
+    }
+
+    /// No silent behaviour change (design §7): `fixed` mode ignores the channel
+    /// entirely — its state is byte-for-byte what it was before this feature.
+    #[test]
+    fn fixed_mode_ignores_the_gate_repo_channel() {
+        let mw = gate(serde_json::json!({})); // fixed, default_check = repo acme/web
+        let resp = invoke_repo(&mw, "/", "", &[], "pr-1.preview.test", Some("evil/other"));
+        assert_eq!(resp.__status(), 302);
+        let claims = state_claims_of(&mw, &resp);
+        assert!(claims.get("repo").is_none(), "fixed mode must not seal a per-request repo");
+    }
+
+    /// The callback re-reads the sealed repo and builds `Check::Repo` from it:
+    /// a valid repo claim passes the local checks and reaches the exchange
+    /// (proving the repo was honoured) — the closed loopback port surfaces as
+    /// 502, not a 403 refusal.
+    #[test]
+    fn per_preview_callback_with_a_repo_claim_proceeds_to_the_exchange() {
+        let mw = per_preview_gate();
+        let state = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({
+                "n": "nonce-value", "rt": "/", "v": "pr-1.preview.test",
+                "repo": "acme/web", "exp": unix_now() + 300,
+            }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state}"))];
+        let resp = invoke_repo(
+            &mw,
+            "/_ephpm/auth/github/callback",
+            "code=validcode123&state=nonce-value",
+            &headers,
+            "pr-1.preview.test",
+            Some("acme/web"),
+        );
+        assert_eq!(resp.__status(), 502, "a valid repo claim is honoured and reaches the exchange");
+    }
+
+    /// Fail-closed (design §11): a per-preview callback whose state carries NO
+    /// repo (e.g. a state minted by a fixed-mode login, replayed) is refused
+    /// BEFORE any network call — the closed port would be a 502, a 403 proves
+    /// the local refusal.
+    #[test]
+    fn per_preview_callback_without_a_repo_claim_is_denied_before_any_network() {
+        let mw = per_preview_gate();
+        let state = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({
+                "n": "nonce-value", "rt": "/", "v": "pr-1.preview.test", "exp": unix_now() + 300,
+            }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state}"))];
+        let resp = invoke_repo(
+            &mw,
+            "/_ephpm/auth/github/callback",
+            "code=validcode123&state=nonce-value",
+            &headers,
+            "pr-1.preview.test",
+            None,
+        );
+        assert_eq!(resp.__status(), 403, "a per-preview state with no repo must fail closed");
+    }
+
+    /// Design §10: the session binds to the SITE (#396), and the repo is NOT in
+    /// it — so a session minted for preview A cannot be relabelled for another
+    /// repo, and cross-preview replay is a `site`-claim mismatch the verifier
+    /// rejects, independent of any repo.
+    #[test]
+    fn the_session_binds_to_the_site_and_never_carries_the_repo() {
+        let mw = per_preview_gate();
+        let claims = mw.session_claims(
+            "octocat",
+            "pr-1.preview.test",
+            "github",
+            Some(1),
+            Some(&Check::Repo { owner: "acme".into(), name: "web".into() }),
+            1_000,
+            3_600,
+        );
+        assert_eq!(claims["site"], "pr-1.preview.test");
+        assert!(
+            claims.get("repo").is_none(),
+            "the session binds to the site, never the repo (#396)"
+        );
+        // The repo shows only in the audit `check` string, not as an authz key.
+        assert_eq!(claims["check"], "repo acme/web");
+    }
+
+    /// Design §10: a state minted for preview A must not complete a login on
+    /// preview B — the per-vhost `target_is_allowed` binding refuses it before
+    /// any network call, regardless of the repo it carries.
+    #[test]
+    fn a_per_preview_state_for_another_host_is_refused() {
+        let mw = per_preview_gate();
+        let state = token::mint(
+            mw.config.state_secret.expose(),
+            &serde_json::json!({
+                "n": "nonce-value", "rt": "/", "v": "pr-A.preview.test",
+                "repo": "acme/web", "exp": unix_now() + 300,
+            }),
+        )
+        .expect("mint");
+        let headers = vec![("Cookie".to_owned(), format!("ephpm_session_oauth={state}"))];
+        // The callback lands on preview B.
+        let resp = invoke_repo(
+            &mw,
+            "/_ephpm/auth/github/callback",
+            "code=validcode123&state=nonce-value",
+            &headers,
+            "pr-b.preview.test",
+            Some("acme/web"),
+        );
+        assert_eq!(resp.__status(), 400, "a state minted for host A must not complete on host B");
     }
 }

--- a/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
+++ b/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
@@ -585,6 +585,132 @@ fn apex_flow_one_app_serves_the_whole_wildcard_fleet() {
     );
 }
 
+// ── per-preview repo gate (issue #487) ─────────────────────────────────────
+
+/// A per-preview gate with **no** configured target — the repo arrives per
+/// request on the trusted router channel.
+fn per_preview_gate(stub: &Stub) -> GithubAuth {
+    let cfg = serde_json::json!({
+        "client_id": "Iv1.stub",
+        "client_secret": CLIENT_SECRET,
+        "session_secret": SESSION_SECRET,
+        "access": "per-preview",
+        "github_base": stub.base,
+        "github_api_base": stub.base,
+        "redirect_uri": format!("https://{VHOST}/_ephpm/auth/github/callback"),
+    });
+    GithubAuth::init(&cfg).expect("per-preview init needs no configured target")
+}
+
+/// Like [`call_on`] but with the trusted `request_gate_repo` channel set.
+fn call_repo(
+    mw: &GithubAuth,
+    vhost: &str,
+    path: &str,
+    query: &str,
+    headers: &[(String, String)],
+    repo: Option<&str>,
+) -> Response {
+    let mut ctx = RequestCtx::new("GET", path, query, "203.0.113.9", vhost, headers);
+    if let Some(r) = repo {
+        ctx = ctx.with_gate_repo(r);
+    }
+    // SAFETY: `ctx` outlives the borrow; `host_table()` is 'static.
+    let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+    mw.invoke(&req)
+}
+
+/// End to end (design §4/§10): per-preview login seals the trusted-channel repo
+/// into the state; the callback authorizes against the STATE's repo, not the
+/// channel it lands with — the apex callback host's channel could name a
+/// different repo, and the *signed* one must win. Proven by putting a hostile
+/// repo on the callback channel and asserting GitHub was queried for the
+/// state's repo only.
+#[test]
+fn per_preview_gates_on_the_signed_state_repo_not_the_callback_channel() {
+    let stub = Stub::start();
+    let mw = per_preview_gate(&stub);
+
+    let login = call_repo(&mw, VHOST, "/wp-admin/", "", &[], Some("acme/web"));
+    assert_eq!(login.__status(), 302);
+    assert_eq!(stub.requests(), 0, "starting a login must not touch GitHub");
+    let loc = header(&login, "Location").expect("Location");
+    let state = query_param(loc.split_once('?').expect("query").1, "state").expect("state");
+    let cookie = set_cookies(&login)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session_oauth="))
+        .expect("state cookie")
+        .split(';')
+        .next()
+        .expect("pair")
+        .to_owned();
+
+    // The callback channel deliberately names a DIFFERENT repo. The state wins.
+    let resp = call_repo(
+        &mw,
+        VHOST,
+        "/_ephpm/auth/github/callback",
+        &format!("code={GOOD_CODE}&state={state}"),
+        &[("Cookie".to_owned(), cookie)],
+        Some("attacker/owns"),
+    );
+    assert_eq!(resp.__status(), 302, "a readable state repo issues a session");
+
+    let seen = stub.seen();
+    assert!(
+        seen.requests.iter().any(|r| r == "GET /repos/acme/web"),
+        "must authorize against the repo sealed into the state"
+    );
+    assert!(
+        !seen.requests.iter().any(|r| r == "GET /repos/attacker/owns"),
+        "the callback channel's repo must NOT be consulted — the signed state is authoritative"
+    );
+    drop(seen);
+
+    // The session binds to the site and never carries the repo (#396).
+    let session = session_value(&resp);
+    let payload =
+        session.strip_prefix("ephpm_session=").expect("prefix").split('.').nth(1).expect("payload");
+    let json: serde_json::Value =
+        serde_json::from_slice(&base64_url_decode(payload).expect("base64url")).expect("json");
+    assert_eq!(json["site"], VHOST);
+    assert!(json.get("repo").is_none(), "the session binds to the site, not the repo");
+    assert_eq!(json["check"], "repo acme/web");
+}
+
+/// Fail-closed matrix (design §11): in per-preview mode a user without read on
+/// the state's repo is denied — GitHub's "exists but not yours" 404 is a denial,
+/// and the flow completed (3 calls) rather than erroring.
+#[test]
+fn per_preview_denies_a_user_without_access_to_the_state_repo() {
+    let stub = Stub::start();
+    let mw = per_preview_gate(&stub);
+
+    let login = call_repo(&mw, VHOST, "/", "", &[], Some("acme/secret"));
+    let loc = header(&login, "Location").expect("Location");
+    let state = query_param(loc.split_once('?').expect("query").1, "state").expect("state");
+    let cookie = set_cookies(&login)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session_oauth="))
+        .expect("state cookie")
+        .split(';')
+        .next()
+        .expect("pair")
+        .to_owned();
+
+    let resp = call_repo(
+        &mw,
+        VHOST,
+        "/_ephpm/auth/github/callback",
+        &format!("code={GOOD_CODE}&state={state}"),
+        &[("Cookie".to_owned(), cookie)],
+        Some("acme/secret"),
+    );
+    assert_eq!(resp.__status(), 403, "no read on the state's repo ⇒ deny");
+    assert!(!set_cookies(&resp).iter().any(|c| c.starts_with("ephpm_session=")));
+    assert_eq!(stub.seen().requests.len(), 3, "the flow completed and answered no");
+}
+
 /// Minimal unpadded base64url decoder for asserting on the issued payload.
 fn base64_url_decode(s: &str) -> Option<Vec<u8>> {
     const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";

--- a/crates/ephpm-middleware/src/abi.rs
+++ b/crates/ephpm-middleware/src/abi.rs
@@ -44,7 +44,7 @@ use std::os::raw::{c_char, c_int};
 /// Current ABI version (`0xMMmmmmmm`: major byte gates compatibility, the
 /// lower three bytes are an additive minor level).
 ///
-/// `0x0100_0003` = major **1**, minor **3**.
+/// `0x0100_0004` = major **1**, minor **4**.
 ///
 /// - Minor 1 added the optional response phase (the [`SYM_INVOKE_RESPONSE`]
 ///   symbol and the three appended `response_*` accessors on [`EphpmHostV1`]).
@@ -66,6 +66,11 @@ use std::os::raw::{c_char, c_int};
 ///   vhost, so it returns NULL on *every* request there, where it used to
 ///   return the `Host`. C modules must null-check it. See
 ///   [`ABI_MINOR_GLOBAL_KV`] for the migration note.
+/// - Minor 4 appends one request accessor, [`request_gate_repo`] — the
+///   preview access gate's `owner/name` repository, populated only from the
+///   operator-owned per-site override and NULL when unset. Purely additive,
+///   exactly like the minor-2 request accessors: an older module never reads
+///   the slot and a newer module minor-gates it on [`ABI_MINOR_GATE_REPO`].
 ///
 /// The major byte is unchanged across every minor, so **every** module built
 /// against major 1 still loads: growth is additive.
@@ -75,7 +80,8 @@ use std::os::raw::{c_char, c_int};
 /// [`request_host`]: EphpmHostV1::request_host
 /// [`request_body`]: EphpmHostV1::request_body
 /// [`request_vhost_id`]: EphpmHostV1::request_vhost_id
-pub const ABI_V1: u32 = 0x0100_0003;
+/// [`request_gate_repo`]: EphpmHostV1::request_gate_repo
+pub const ABI_V1: u32 = 0x0100_0004;
 
 /// Major version — the compatibility gate. A module refuses to init when the
 /// host's major (`host.abi_version >> 24`) is newer than its own.
@@ -88,7 +94,7 @@ pub const ABI_MAJOR: u32 = 1;
 /// those trailing fields, and reading past a shorter table is undefined
 /// behaviour. See [`ABI_MINOR_RESPONSE_PHASE`] and
 /// [`ABI_MINOR_REQUEST_ACCESSORS`].
-pub const ABI_MINOR: u32 = 3;
+pub const ABI_MINOR: u32 = 4;
 
 /// The minor version that introduced the response phase — the three
 /// `response_*` accessors on [`EphpmHostV1`] and the [`SYM_INVOKE_RESPONSE`]
@@ -150,6 +156,13 @@ pub const ABI_MINOR_REQUEST_ACCESSORS: u32 = 2;
 /// This half genuinely *is* a no-op on a single-site node: there is one store,
 /// and both the scoped and global slots reach it.
 pub const ABI_MINOR_GLOBAL_KV: u32 = 3;
+
+/// The minor version that introduced the appended request accessor
+/// [`EphpmHostV1::request_gate_repo`]. A module needs
+/// `host.abi_version & 0x00FF_FFFF >=` this before calling it: on an older
+/// host the trailing table slot is absent and reading it is undefined
+/// behaviour. Purely additive — nothing pre-existing changed in minor 4.
+pub const ABI_MINOR_GATE_REPO: u32 = 4;
 
 /// Middleware verdicts for one request.
 pub const ACTION_CONTINUE: c_int = 0;
@@ -486,6 +499,31 @@ pub struct EphpmHostV1 {
         ttl_secs: i64,
         out: *mut i64,
     ) -> c_int,
+
+    // ── Preview access gate (minor 4) ─────────────────────────────────────
+    //
+    // Appended after `kv_incr_ttl_global`. A module that reads this must first
+    // confirm `abi_version & 0x00FF_FFFF >= ABI_MINOR_GATE_REPO`.
+    /// The preview access gate's target repository for this request, as an
+    /// `owner/name` string, or NULL when this vhost has no gate repository
+    /// configured.
+    ///
+    /// This is a **trusted, router-populated** channel, exactly like
+    /// [`request_vhost_id`](Self::request_vhost_id): its value comes only from
+    /// the operator-owned per-site override file (`[preview_auth] repo`), never
+    /// from anything a client can send. It exists so the OAuth issuer can seal
+    /// the repository a preview is *for* into the signed OAuth `state` at login
+    /// — login always runs on the target preview host, where the router knows
+    /// the site and its repo, whereas the callback lands on the apex host where
+    /// it does not. A module must not read a repository from any request header;
+    /// that would be client-controllable and defeats the gate.
+    ///
+    /// **NULL means "no gate repository", and a module must fail closed on it**
+    /// when it is operating in a per-preview mode that requires one — inventing
+    /// one would authorize against an attacker-chosen target. Rust modules get
+    /// `Option<&str>` from [`Request::gate_repo`](crate::Request::gate_repo),
+    /// which already null-checks and empty-checks.
+    pub request_gate_repo: unsafe extern "C" fn(*const EphpmRequest) -> *const c_char,
 }
 
 /// Symbol names the loader looks up.

--- a/crates/ephpm-middleware/src/host.rs
+++ b/crates/ephpm-middleware/src/host.rs
@@ -27,6 +27,12 @@ pub struct RequestCtx {
     /// Normalized request host (port/trailing-dot stripped, lowercased) — the
     /// `request_host` accessor. Empty when the request had no usable `Host`.
     host: CString,
+    /// The preview access gate's `owner/name` repository for this request — the
+    /// `request_gate_repo` accessor (ABI minor 4). Router-populated from the
+    /// operator-owned per-site override only, never a client header. Empty when
+    /// this vhost has no gate repository configured, which the accessor turns
+    /// into a NULL return so a module can fail closed on it.
+    gate_repo: CString,
     /// Whether the connection was secure (HTTPS/TLS) — drives `request_scheme`
     /// and `request_is_secure`. Authoritative from the connection.
     is_secure: bool,
@@ -76,6 +82,7 @@ impl RequestCtx {
             remote_ip: cstr(remote_ip),
             site_key: cstr(site_key),
             host: CString::default(),
+            gate_repo: CString::default(),
             is_secure: false,
             body: Vec::new(),
             headers: headers
@@ -98,6 +105,20 @@ impl RequestCtx {
     #[must_use]
     pub fn with_host(mut self, host: &str) -> Self {
         self.host = cstr(host);
+        self
+    }
+
+    /// Set the preview access gate's `owner/name` repository
+    /// (`request_gate_repo`, ABI minor 4). Pass the value the router resolved
+    /// from the operator-owned per-site override; the empty string (the
+    /// default) means "no gate repository" and the accessor returns NULL.
+    ///
+    /// Never pass anything a client can influence here — a module reads this as
+    /// a trusted authorization target (the same contract as
+    /// [`site_key`](Self::new)'s tenant identity).
+    #[must_use]
+    pub fn with_gate_repo(mut self, repo: &str) -> Self {
+        self.gate_repo = cstr(repo);
         self
     }
 
@@ -196,6 +217,16 @@ unsafe extern "C" fn request_is_secure(req: *const EphpmRequest) -> c_int {
 unsafe extern "C" fn request_host(req: *const EphpmRequest) -> *const c_char {
     // SAFETY: ABI contract.
     unsafe { ctx(req) }.map_or(std::ptr::null(), |c| c.host.as_ptr())
+}
+unsafe extern "C" fn request_gate_repo(req: *const EphpmRequest) -> *const c_char {
+    // NULL — not `""` — when no gate repository is configured, mirroring
+    // `request_vhost_id`: an empty C string is a repo-shaped answer a module
+    // would use as an authorization target, whereas NULL cannot be, so a
+    // per-preview gate can fail closed on it.
+    // SAFETY: ABI contract.
+    unsafe { ctx(req) }.map_or(std::ptr::null(), |c| {
+        if c.gate_repo.is_empty() { std::ptr::null() } else { c.gate_repo.as_ptr() }
+    })
 }
 
 // ── Response context (response phase) ─────────────────────────────────────
@@ -790,6 +821,7 @@ static HOST_TABLE: EphpmHostV1 = EphpmHostV1 {
     kv_set_nx_global,
     kv_incr_global,
     kv_incr_ttl_global,
+    request_gate_repo,
 };
 
 /// Wire the process-global KV store into the host table. Call once at startup,
@@ -880,6 +912,38 @@ mod tests {
         let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
         assert_eq!(req.vhost_id(), Some("blog"));
         assert_eq!(req.http_host(), "blog.localhost");
+    }
+
+    /// The gate repo is a trusted authorization target (ABI minor 4), so —
+    /// exactly like `vhost_id` — "not configured" must be `None` (NULL over the
+    /// ABI), never `Some("")` which a per-preview gate would use as a repo.
+    #[test]
+    fn gate_repo_absent_reads_as_none_and_null() {
+        let unset = ctx();
+        // SAFETY: ctx and the real host table outlive the view.
+        let req = unsafe { Request::from_raw(unset.as_abi(), host_table()) };
+        assert_eq!(req.gate_repo(), None, "no gate repo must read as None, never Some(\"\")");
+        // SAFETY: the raw accessor is the C-ABI surface modules see; NULL is the
+        // contract for an unset repo.
+        assert!(unsafe { (host_table().request_gate_repo)(unset.as_abi()) }.is_null());
+
+        let set = ctx().with_gate_repo("acme/web");
+        // SAFETY: as above.
+        let req = unsafe { Request::from_raw(set.as_abi(), host_table()) };
+        assert_eq!(req.gate_repo(), Some("acme/web"));
+    }
+
+    /// A module built against minor 4 talking to an older host must NOT read the
+    /// appended `request_gate_repo` slot — it is past the end of that table. The
+    /// safe wrapper degrades to `None` instead.
+    #[test]
+    fn minor_gate_hides_gate_repo_on_an_older_host() {
+        let old = EphpmHostV1 { abi_version: 0x0100_0003, ..*host_table() };
+        assert!((old.abi_version & 0x00FF_FFFF) < abi::ABI_MINOR_GATE_REPO);
+        let ctx = ctx().with_gate_repo("acme/web");
+        // SAFETY: ctx and `old` outlive the view.
+        let req = unsafe { Request::from_raw(ctx.as_abi(), &old) };
+        assert_eq!(req.gate_repo(), None, "an older host has no gate-repo slot to read");
     }
 
     #[test]

--- a/crates/ephpm-middleware/src/lib.rs
+++ b/crates/ephpm-middleware/src/lib.rs
@@ -353,6 +353,31 @@ impl Request<'_> {
         self.str_of(unsafe { (self.host.request_host)(self.raw) })
     }
 
+    /// The preview access gate's `owner/name` repository for this request — the
+    /// repository the served preview is *for* — or `None` when this vhost has
+    /// no gate repository configured (ABI minor 4).
+    ///
+    /// This is a **trusted, router-populated** value drawn only from the
+    /// operator-owned per-site override, never from a request header, so an
+    /// authorization gate may treat it as authoritative — the same contract as
+    /// [`vhost_id`](Self::vhost_id). The OAuth issuer reads it at *login* (which
+    /// always runs on the target preview host) to seal the repository into the
+    /// signed OAuth `state`, because the callback lands on a different (apex)
+    /// host where the router can no longer resolve it.
+    ///
+    /// `None` on a host older than [`abi::ABI_MINOR_GATE_REPO`] (the accessor is
+    /// absent there), and a per-preview gate must fail closed on `None` rather
+    /// than invent a target.
+    #[must_use]
+    pub fn gate_repo(&self) -> Option<&str> {
+        if self.host_minor() < abi::ABI_MINOR_GATE_REPO {
+            return None;
+        }
+        // SAFETY: contract of `from_raw`; the minor gate above guarantees the
+        // `request_gate_repo` field is present on this host's table.
+        self.opt_str_of(unsafe { (self.host.request_gate_repo)(self.raw) })
+    }
+
     /// Bounded, read-only view of the buffered request body (borrowed; valid
     /// only inside `invoke`).
     ///

--- a/crates/ephpm-server/src/router.rs
+++ b/crates/ephpm-server/src/router.rs
@@ -234,6 +234,18 @@ pub(crate) struct SiteRoots {
     /// per-request clone of this struct is a refcount bump, not a rebuild.
     /// `None` for the overwhelming majority of sites (no gate).
     pub(crate) preview_gate: Option<std::sync::Arc<ephpm_middleware::builtin::BuiltinModule>>,
+    /// This vhost's preview access-gate **repository** (`[preview_auth] repo`,
+    /// `owner/name`), when its override declared one (issue #487, per-preview
+    /// gate). Carried onto the request via `RequestCtx::with_gate_repo` so the
+    /// OAuth *issuer* (a global `[[middleware]]`) can seal it into the signed
+    /// OAuth state at login — the callback lands on the apex host, where the
+    /// router can no longer resolve it.
+    ///
+    /// Deliberately **separate** from [`preview_gate`](Self::preview_gate): the
+    /// per-site verifier that field builds must never see the repo. `None` for
+    /// the overwhelming majority of sites; travels on the trusted router channel
+    /// only, never a request header.
+    pub(crate) preview_gate_repo: Option<String>,
     /// Keys in this site's override file that ePHPm did not understand, sorted.
     ///
     /// **Diagnostic only** — nothing routes on it. It rides the resolution so
@@ -256,6 +268,7 @@ impl SiteRoots {
             auto_prepend_file: None,
             unusable: None,
             preview_gate: None,
+            preview_gate_repo: None,
             unknown_keys: Vec::new(),
         }
     }
@@ -994,6 +1007,7 @@ fn resolve_site_roots(
         auto_prepend_file: over.auto_prepend_file,
         unusable: over.unusable.or(gate_unusable),
         preview_gate,
+        preview_gate_repo: over.preview_gate_repo,
         unknown_keys: over.unknown_keys,
     }
 }
@@ -2892,6 +2906,7 @@ impl Router {
                 site_key.as_deref(),
                 &host,
                 is_https,
+                site_roots.preview_gate_repo.as_deref(),
             ));
         }
 
@@ -2932,7 +2947,10 @@ impl Router {
                     mw_req_headers.as_deref().unwrap_or(&[]),
                 )
                 .with_scheme(is_https)
-                .with_host(&normalize_host_key(&host));
+                .with_host(&normalize_host_key(&host))
+                // Harmless here (the WS gate is the per-site verifier, which does
+                // not read the repo), set for consistency with the other phases.
+                .with_gate_repo(site_roots.preview_gate_repo.as_deref().unwrap_or(""));
                 let verdict = {
                     let _kv_scope = ephpm_middleware::host::enter_site_kv(
                         self.middleware_kv_store(site_key.as_deref()),
@@ -3076,6 +3094,7 @@ impl Router {
                         &host,
                         is_https,
                         site_roots.preview_gate.as_ref(),
+                        site_roots.preview_gate_repo.as_deref(),
                     ) {
                         StaticGate::Respond(resp) => (resp, "middleware"),
                         StaticGate::Continue(extra_headers) => {
@@ -3160,6 +3179,7 @@ impl Router {
                     site_key.as_deref(),
                     &host,
                     is_https,
+                    site_roots.preview_gate_repo.as_deref(),
                 )
                 .await;
         }
@@ -3494,6 +3514,7 @@ impl Router {
             container: site_container,
             auto_prepend_file,
             preview_gate,
+            preview_gate_repo,
             // Both diagnostic; `unusable` was already turned into a 503 at the
             // single gate in `handle`, so a request that reaches PHP has an
             // override that was fully honoured.
@@ -3619,7 +3640,10 @@ impl Router {
                 &headers,
             )
             .with_scheme(is_https)
-            .with_host(&normalize_host_key(&server_name));
+            .with_host(&normalize_host_key(&server_name))
+            // Harmless here (this is the per-site verifier, not the issuer), set
+            // for consistency with the global-chain ctx below.
+            .with_gate_repo(preview_gate_repo.as_deref().unwrap_or(""));
             let verdict = {
                 let _kv_scope = ephpm_middleware::host::enter_site_kv(
                     self.middleware_kv_store(site_key.as_deref()),
@@ -3652,6 +3676,10 @@ impl Router {
             )
             .with_scheme(is_https)
             .with_host(&normalize_host_key(&server_name))
+            // Load-bearing: the OAuth issuer (github-auth) runs on this global
+            // chain, and its `start_login` seals this preview's repo into the
+            // signed OAuth state. Router-populated only — never a request header.
+            .with_gate_repo(preview_gate_repo.as_deref().unwrap_or(""))
             .with_body(body_view);
             // Scope the chain's KV callbacks to this request's vhost keyspace
             // (issue #376) — the same store PHP gets below. The guard is held
@@ -4891,6 +4919,7 @@ impl Router {
         site_key: Option<&str>,
         server_name: &str,
         is_https: bool,
+        gate_repo: Option<&str>,
     ) -> (Response<ServerBody>, &'static str) {
         let Some(chain) = self.middleware_chain.as_ref() else {
             // No middleware at all → nothing can serve auth → 404 (reserved).
@@ -4905,7 +4934,11 @@ impl Router {
             req_headers.unwrap_or(&[]),
         )
         .with_scheme(is_https)
-        .with_host(&normalize_host_key(server_name));
+        .with_host(&normalize_host_key(server_name))
+        // Load-bearing on the apex-less flow: the login path
+        // (`/_ephpm/auth/github/login`) is dispatched here, and the issuer's
+        // `start_login` reads this to seal the preview's repo into the state.
+        .with_gate_repo(gate_repo.unwrap_or(""));
         // Per-vhost KV scope, exactly as the static/PHP request phases use — an
         // auth module may read this tenant's keyspace. Synchronous, so the guard
         // never spans an await.
@@ -4935,6 +4968,7 @@ impl Router {
         server_name: &str,
         is_https: bool,
         preview_gate: Option<&std::sync::Arc<ephpm_middleware::builtin::BuiltinModule>>,
+        gate_repo: Option<&str>,
     ) -> StaticGate {
         // Nothing to run: no global chain AND no per-site gate. (The gate is
         // per-site, so a node with no `[[middleware]]` can still gate a preview.)
@@ -4954,7 +4988,10 @@ impl Router {
             req_headers.unwrap_or(&[]),
         )
         .with_scheme(is_https)
-        .with_host(&normalize_host_key(server_name));
+        .with_host(&normalize_host_key(server_name))
+        // Set for consistency and for the global chain, which runs here too and
+        // could start a login from a static path (issue #487, per-preview gate).
+        .with_gate_repo(gate_repo.unwrap_or(""));
         // Per-vhost KV scope, exactly as on the PHP path (issue #376). This
         // method is synchronous throughout, so the guard never spans an await —
         // and it wraps BOTH the gate (whose share-token revocation reads this
@@ -5009,6 +5046,7 @@ impl Router {
         site_key: Option<&str>,
         server_name: &str,
         is_https: bool,
+        gate_repo: Option<&str>,
     ) -> Response<ServerBody> {
         use hyper::body::Body as _;
 
@@ -5065,7 +5103,10 @@ impl Router {
             req_headers.unwrap_or(&[]),
         )
         .with_scheme(is_https)
-        .with_host(&normalize_host_key(server_name));
+        .with_host(&normalize_host_key(server_name))
+        // Harmless in the response phase (no issuer runs here), set for
+        // consistency with the request phases.
+        .with_gate_repo(gate_repo.unwrap_or(""));
         // Per-vhost KV scope for the response phase too (issue #376). Scoped
         // to the synchronous call: the body `.collect().await` above is
         // already done, and nothing awaits between here and the drop.
@@ -12675,7 +12716,7 @@ echo "post response";
             let addr: SocketAddr = "198.51.100.20:5000".parse().unwrap();
             let gate = |site: Option<&str>| {
                 router.static_request_phase(
-                    None, "GET", "/a.css", "", addr, site, "ignored", false, None,
+                    None, "GET", "/a.css", "", addr, site, "ignored", false, None, None,
                 )
             };
             assert!(matches!(gate(Some("shop")), StaticGate::Continue(_)));

--- a/crates/ephpm-server/src/site_overrides.rs
+++ b/crates/ephpm-server/src/site_overrides.rs
@@ -172,6 +172,20 @@ pub(crate) struct SiteOverride {
     /// must fail **closed** (503) rather than serve the preview ungated — the
     /// same narrowing-instruction rule `document_root` follows.
     pub(crate) preview_gate: Option<serde_json::Value>,
+    /// The preview access gate's target repository (`[preview_auth] repo`),
+    /// validated as `owner/name`. Present only when the operator declared it.
+    ///
+    /// Kept **separate** from [`preview_gate`](Self::preview_gate) on purpose:
+    /// the per-site verifier (the `preview-gate` builtin) must never see it — it
+    /// verifies the session, and repo authorization is the OAuth *issuer*'s job,
+    /// done once at login. The router carries this on the trusted
+    /// `request_gate_repo` ABI channel so the issuer can seal it into the signed
+    /// OAuth state; it never travels a request header.
+    ///
+    /// A present-but-invalid `repo` does **not** land here: it sets
+    /// [`unusable`](Self::unusable), failing the one site closed (503) rather
+    /// than gating it against a malformed target.
+    pub(crate) preview_gate_repo: Option<String>,
     /// Set when the override file **exists but cannot be honoured**: it is
     /// unreadable, it is not valid TOML, or a key this binary implements
     /// carries a value it had to reject. The value is a short, stable reason
@@ -236,12 +250,21 @@ struct RawPreviewAuth {
     /// indirections keep the literal out of a file switchboard derives from
     /// tenant input, and let this and the issuer name one source of truth.
     session_secret: Option<String>,
-    /// Where unauthenticated browsers are redirected — the issuer's login path
-    /// (e.g. `/auth/github/login`). Required. Note the issuer's default
-    /// `/_ephpm/...` paths are unreachable through the router (that namespace is
-    /// reserved and 404s before middleware), so the issuer — and this — must use
-    /// a path outside `/_ephpm/`.
+    /// Where unauthenticated browsers are redirected — the issuer's login path.
+    /// Required. The issuer's default `/_ephpm/auth/github/login` **is**
+    /// reachable: since #487 the router carves `/_ephpm/auth/` out of the
+    /// reserved-namespace 404 and dispatches it to the global middleware chain
+    /// (after site resolution), so the issuer's login/callback endpoints work at
+    /// their defaults. A path outside `/_ephpm/` is still fine if the operator
+    /// prefers one; it just must match the issuer's `login_path`.
     login_url: Option<String>,
+    /// The preview's target repository, `owner/name` (issue #487 per-preview
+    /// gate). Written by switchboard, validated here; surfaced separately on
+    /// [`SiteOverride::preview_gate_repo`] and carried to the OAuth issuer on
+    /// the trusted `request_gate_repo` ABI channel — **never** folded into the
+    /// gate config the verifier sees. A present-but-invalid value fails the site
+    /// closed (503), like any other value this binary understood and rejected.
+    repo: Option<String>,
     /// Session cookie name (must match the issuer's `cookie_name`).
     cookie: Option<String>,
     /// Required `iss` claim.
@@ -459,24 +482,36 @@ pub(crate) fn load(
     // anyone who guessed its hostname. So a section we understood and could not
     // turn into a working gate must fail **closed** (`unusable` → 503), never
     // fall back to serving the preview ungated.
-    let preview_gate = match &raw.preview_auth {
+    let (preview_gate, preview_gate_repo) = match &raw.preview_auth {
         Some(pa) => match resolve_preview_auth(pa) {
-            Ok(config) => Some(config),
+            Ok((config, repo)) => (Some(config), repo),
             Err(reason) => return unusable(reason, &"[preview_auth]"),
         },
-        None => None,
+        None => (None, None),
     };
 
-    SiteOverride { document_root, auto_prepend_file, preview_gate, unknown_keys, unusable: None }
+    SiteOverride {
+        document_root,
+        auto_prepend_file,
+        preview_gate,
+        preview_gate_repo,
+        unknown_keys,
+        unusable: None,
+    }
 }
 
 /// Turn a `[preview_auth]` section into the JSON config the
 /// [`preview-gate`](ephpm_middleware_builtins::preview_gate) builtin accepts,
 /// resolving the session secret indirection.
 ///
-/// Every failure is a `&'static str` reason for [`SiteOverride::unusable`]: a
-/// broken gate takes the one preview out of service rather than serving it open.
-fn resolve_preview_auth(pa: &RawPreviewAuth) -> Result<serde_json::Value, &'static str> {
+/// Returns the gate config **and** the validated per-preview repository (kept
+/// separate — the verifier must not see the repo). Every failure is a
+/// `&'static str` reason for [`SiteOverride::unusable`]: a broken gate, or a
+/// malformed repo, takes the one preview out of service rather than serving it
+/// open or gating it against a bad target.
+fn resolve_preview_auth(
+    pa: &RawPreviewAuth,
+) -> Result<(serde_json::Value, Option<String>), &'static str> {
     let login_url = pa
         .login_url
         .as_deref()
@@ -494,6 +529,16 @@ fn resolve_preview_auth(pa: &RawPreviewAuth) -> Result<serde_json::Value, &'stat
     if secret.len() < MIN_SESSION_SECRET {
         return Err("[preview_auth] `session_secret` resolved to fewer than 32 bytes");
     }
+
+    // The per-preview repository, if declared. Validated to `owner/name`; a
+    // present-but-invalid value fails the site closed, exactly like a broken
+    // `document_root`. It is deliberately NOT inserted into the gate `config`
+    // below — repo authorization is the OAuth issuer's job, and the per-site
+    // verifier this config feeds must never see it (issue #487).
+    let repo = match pa.repo.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(spec) => Some(validate_owner_name(spec)?),
+        None => None,
+    };
 
     // Assemble the builtin's config. Only set keys the operator supplied, so the
     // builtin applies its own documented defaults for the rest.
@@ -526,7 +571,32 @@ fn resolve_preview_auth(pa: &RawPreviewAuth) -> Result<serde_json::Value, &'stat
     if let Some(paths) = &pa.exempt_paths {
         config.insert("exempt_paths".into(), serde_json::Value::from(paths.clone()));
     }
-    Ok(serde_json::Value::Object(config))
+    Ok((serde_json::Value::Object(config), repo))
+}
+
+/// Validate a `[preview_auth] repo` value as `owner/name`.
+///
+/// Mirrors the issuer's `config::repo_from_spec` shape check (both segments
+/// non-empty, no extra `/`, GitHub-name character set, not `.`/`..`) so a value
+/// accepted here is one the issuer accepts when it decodes it back out of the
+/// signed OAuth state. The duplication is forced: `ephpm-middleware-github-auth`
+/// is a `dlopen` module this crate does not link, the same reason `normalize_vhost`
+/// is duplicated there.
+fn validate_owner_name(spec: &str) -> Result<String, &'static str> {
+    let seg_ok = |s: &str| {
+        !s.is_empty()
+            && s.len() <= 100
+            && s != "."
+            && s != ".."
+            && s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    };
+    let Some((owner, name)) = spec.split_once('/') else {
+        return Err("[preview_auth] `repo` must be `owner/name`");
+    };
+    if !seg_ok(owner) || name.contains('/') || !seg_ok(name) {
+        return Err("[preview_auth] `repo` must be exactly `owner/name` (GitHub names)");
+    }
+    Ok(format!("{owner}/{name}"))
 }
 
 /// Resolve a `session_secret` value, following an `env:NAME` or
@@ -1556,6 +1626,91 @@ mod tests {
             over.unknown_keys,
             vec!["preview_auth.a_key_from_a_newer_switchboard".to_string()]
         );
+    }
+
+    /// The per-preview gate (issue #487): a valid `repo` is surfaced on
+    /// `preview_gate_repo` and — the load-bearing property — is NOT folded into
+    /// the gate config the verifier sees. Repo authorization is the issuer's
+    /// job, done once at login; the verifier only checks the session.
+    #[test]
+    fn preview_auth_repo_is_surfaced_separately_never_in_the_gate_config() {
+        let f = fixture();
+        f.write(
+            "[preview_auth]\n\
+             session_secret = \"0123456789abcdef0123456789abcdef\"\n\
+             login_url = \"/auth/github/login\"\n\
+             repo = \"acme/web\"\n",
+        );
+        let over = f.load();
+        assert_eq!(over.unusable, None);
+        assert_eq!(over.preview_gate_repo.as_deref(), Some("acme/web"));
+        let config = over.preview_gate.expect("a valid section resolves to a gate config");
+        assert!(
+            config.get("repo").is_none(),
+            "the repo must never reach the verifier's config: {config}"
+        );
+        // And the config the verifier feeds still parses (repo omission is fine).
+        use ephpm_middleware::Middleware as _;
+        ephpm_middleware_builtins::preview_gate::PreviewGate::init(&config)
+            .expect("the gate must accept the config even with repo carried separately");
+    }
+
+    /// A `[preview_auth]` with no `repo` still resolves a working gate — the key
+    /// is optional (fixed-mode issuers do not need it).
+    #[test]
+    fn preview_auth_without_repo_still_resolves_a_gate() {
+        let f = fixture();
+        f.write(
+            "[preview_auth]\n\
+             session_secret = \"0123456789abcdef0123456789abcdef\"\n\
+             login_url = \"/auth/github/login\"\n",
+        );
+        let over = f.load();
+        assert_eq!(over.unusable, None);
+        assert!(over.preview_gate.is_some());
+        assert_eq!(over.preview_gate_repo, None);
+    }
+
+    /// A present-but-malformed `repo` fails the one site **closed** (503), like a
+    /// broken `document_root` — never gated against a malformed target, never
+    /// served ungated.
+    #[test]
+    fn a_malformed_preview_auth_repo_fails_closed() {
+        for bad in [
+            "acme",
+            "acme/",
+            "/web",
+            "acme/web/x",
+            "../../etc",
+            "acme/we b",
+            "a/b/c",
+            ".",
+            "..",
+            "acme/..",
+        ] {
+            let f = fixture();
+            f.write(&format!(
+                "[preview_auth]\n\
+                 session_secret = \"0123456789abcdef0123456789abcdef\"\n\
+                 login_url = \"/auth/github/login\"\n\
+                 repo = {bad:?}\n",
+            ));
+            let over = f.load();
+            assert!(over.unusable.is_some(), "repo {bad:?} must fail the site closed");
+            assert!(over.preview_gate.is_none(), "repo {bad:?}: no gate on a rejected section");
+            assert_eq!(over.preview_gate_repo, None, "repo {bad:?}: no repo surfaced");
+        }
+    }
+
+    /// `repo` is a **typed** field on the section, not swallowed into the
+    /// section's `unknown` bucket — otherwise it would be reported as an unknown
+    /// key and silently ignored, the exact silent-no-op class #429/#463 forbid.
+    #[test]
+    fn preview_auth_repo_is_a_typed_field_not_an_unknown_key() {
+        let raw: RawPreviewAuth =
+            toml::from_str("session_secret = \"x\"\nrepo = \"acme/web\"\n").unwrap();
+        assert!(raw.unknown.is_empty(), "repo must parse as a typed field, not land in `unknown`");
+        assert_eq!(raw.repo.as_deref(), Some("acme/web"));
     }
 
     /// `preview_auth` is a near-miss suggestion target like the scalar keys.

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -150,6 +150,7 @@ it is a secret in git.
 | `org` | — | organisation login, for `check = "org"` / `"team"` |
 | `team` | — | team slug, for `check = "team"` |
 | `sites` | unset | table mapping each vhost to its own `{ repo \| org \| team }` |
+| `access` | `"fixed"` | `"fixed"`: the configured target (`default_check`/`sites`) is authoritative — today's behaviour. `"per-preview"`: authorize each preview against the `owner/name` the router seals into the OAuth state from its `[preview_auth] repo` override; `default_check`/`sites` become optional and a request with no repo fails closed |
 | `login_path` | `/_ephpm/auth/github/login` | reserved: starts a login. The router routes the `/_ephpm/auth/` sub-namespace to the middleware chain, so this default is reachable; keep custom values under `/_ephpm/auth/` |
 | `callback_path` | `/_ephpm/auth/github/callback` | reserved: receives GitHub's redirect. Register `https://<host>/_ephpm/auth/github/callback` as the GitHub OAuth App's Authorization callback URL |
 | `redirect_uri` | derived | full callback URL sent to GitHub. Defaults to `https://<vhost><callback_path>`. **Set it to a fixed apex** for the wildcard-fleet flow (one App, one callback host) — see below |
@@ -205,6 +206,23 @@ on the wire in clear.
 If `sites` is present it is **authoritative**: a vhost with no entry gets no
 access at all, even when a top-level `repo` is also configured. A hostname
 nobody mapped must not quietly inherit another tenant's rule.
+
+### Per-preview authorization (`access = "per-preview"`)
+
+A dynamic fleet mints a new `<pr>.preview.<domain>` host per PR, so a static
+`sites` map cannot name them and the only fleet-wide `default_check` is coarse
+(e.g. "any member of org `acme`"). `access = "per-preview"` authorizes each
+preview against **its own PR's base repo** instead. switchboard writes
+`repo = "owner/name"` into the preview's `[preview_auth]` override; the router
+carries it to this module on a trusted, non-spoofable channel (the middleware
+ABI's `request_gate_repo`, never a request header); `start_login` seals it into
+the signed OAuth `state` (login always runs on the target host, where the router
+knows the repo); and `handle_callback` — which lands on the apex host, where the
+router no longer does — rebuilds the `Check::Repo` from the signed state. In this
+mode `default_check`/`sites` are optional, and a login or callback with no repo
+fails **closed** (403). The session still binds only to the `site` (#396), never
+the repo. See the
+[Preview Access Gate roadmap page](/roadmap/preview-access-gate/#shipped-per-preview-repository-authorization-issue-487).
 
 ## Which GitHub calls are made
 

--- a/site/content/guides/virtual-hosts.md
+++ b/site/content/guides/virtual-hosts.md
@@ -207,12 +207,14 @@ document_root = "public"
 [preview_auth]
 session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET"   # HS256 key; env:/file:/literal
 login_url      = "/_ephpm/auth/github/login"          # the github-auth issuer's login endpoint
+repo           = "acme/web"                           # per-preview authz target (optional)
 # optional: cookie, issuer, audience, require_https, require_site,
 #           share_param, share_epoch, share_revocation, return_to_param, site_param,
 #           exempt_paths (not needed for the default /_ephpm/auth/ endpoints)
 ```
 
 - **`session_secret`** is the HS256 key ePHPm verifies sessions with — the *same* key the `github-auth` **issuer** (a global `[[middleware]]` mount) signs them with. Use an `env:NAME` or `file:/abs/path` **reference** so the secret is not a literal in this tenant-derived file and both halves name one source of truth. It must resolve to ≥ 32 bytes.
+- **`repo`** (optional, `owner/name`) is this preview's authorization target for the issuer's `access = "per-preview"` mode. The router carries it to the `github-auth` issuer on a trusted channel (never a request header) so the issuer authorizes each preview against its own PR's base repo instead of one coarse fleet-wide check — see the [github-auth guide](/guides/github-auth-middleware/#per-preview-authorization-access--per-preview). It is **not** given to the per-site verifier, and a malformed value fails the site closed (503). Omit it when the issuer is in the default `access = "fixed"` mode.
 - **Only the enforcement half lives here.** The OAuth issuer — and its GitHub App `client_id`/`client_secret` and per-repo access check — stays in the global mount, never in this file. Putting a client secret in a tenant-derived file would defeat the very trust boundary this directory exists for.
 - **Fail-closed.** A missing/short/unresolvable `session_secret`, or a missing `login_url`, takes the one preview **out of service (503)** rather than serving it ungated — the same narrowing rule `document_root` follows. Unknown keys inside the section are tolerated (reported), so a newer provisioning daemon can add one without a fleet outage.
 - **Reachability.** The router routes the `/_ephpm/auth/` sub-namespace to the middleware chain, so `github-auth`'s default endpoints work: login at `/_ephpm/auth/github/login`, callback at `/_ephpm/auth/github/callback` (the URL to register in the GitHub OAuth App). The gate never runs on `/_ephpm/auth/`, so no `exempt_paths` entry is needed for the defaults.

--- a/site/content/roadmap/preview-access-gate.md
+++ b/site/content/roadmap/preview-access-gate.md
@@ -87,7 +87,10 @@ document_root = "public"
 [preview_auth]                                    # turns the gate ON for this vhost
 session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET"   # HS256 key, shared with the issuer
 login_url      = "/_ephpm/auth/github/login"          # the issuer's login endpoint
+repo           = "acme/web"                           # per-preview authz target (see below)
 # cookie / issuer / audience / require_https / require_site / share_* are optional.
+# `repo` is optional too — omit it (and leave the issuer in `access = "fixed"`)
+# to authorize the whole fleet against one coarse org/repo check instead.
 # exempt_paths is NOT needed for the default `/_ephpm/auth/…` endpoints — the
 # router carve-out means the gate never sees them.
 ```
@@ -173,8 +176,10 @@ apex vhost** and carries the target in the signed OAuth `state`:
    apex.
 3. **The apex mints for the target.** The callback lands on the apex, reads the
    `state`, and uses the **target** from it — not its own (apex) vhost — for the
-   repo/org/team authz check (`check_for(<target>)`) and for the session's
-   `site` claim. (`Router::handle_auth_namespace` routes the apex's
+   session's `site` claim and for the access check: the repo/org/team
+   `check_for(<target>)` in `access = "fixed"` mode, or the signed `repo` claim
+   sealed at login in `access = "per-preview"` mode (see "per-preview repository
+   authorization"). (`Router::handle_auth_namespace` routes the apex's
    `/_ephpm/auth/github/callback` to the chain; `github-auth`'s
    `handle_callback` does the target-from-state minting.)
 4. **Domain-scoped cookie + cross-host redirect.** The session cookie is set
@@ -209,6 +214,71 @@ vhost, so the login it starts on `pr-1.preview.ephpm.dev` and the callback it
 handles on the apex are the same mount. The apex (`preview.ephpm.dev`) must
 itself be a served vhost (it is where callbacks land). Substitute your own domain
 throughout.
+
+## Shipped: per-preview repository authorization (issue #487)
+
+The apex flow above funnels every callback through one App, but on its own it
+still authorizes against a **single** target: the issuer's `check_for(<target>)`
+resolves either a `default_check` or a `sites` entry keyed by vhost. A dynamic
+fleet mints a new `<pr>.preview.<domain>` host per PR and cannot enumerate them
+in a static `sites` map, so the only enforceable coarse target was
+`default_check` — "any member of org `acme`", not "read access to *this PR's*
+base repo". Per-preview authorization closes that gap.
+
+The mechanism turns on the **crux** the apex flow created. The OAuth callback
+lands on the apex host, where the router no longer knows which repo the preview
+is for — so the repo cannot be looked up at callback. It is instead captured at
+**login**, which always runs on the target preview host, sealed into the signed
+OAuth `state`, and read back (re-validated) at the callback to build the access
+check:
+
+1. **switchboard writes `repo = "owner/name"`** into the preview's
+   `[preview_auth]` override (validated as `owner/name`, one more field on the
+   file it already writes). A malformed value fails that one preview **closed**
+   (503), exactly like a bad `document_root`.
+2. **The router carries it on a trusted channel.** ePHPm surfaces the value as
+   `SiteRoots::preview_gate_repo` and puts it on each request via the middleware
+   ABI's `request_gate_repo` accessor (ABI **minor 4**) — the same trusted,
+   router-populated channel as the canonical site key, **never** a request
+   header. It is deliberately **not** folded into the per-site verifier's config:
+   the verifier checks the session, and repo authorization is the issuer's job.
+3. **The issuer seals it into `state` at login.** With `access = "per-preview"`,
+   `github-auth`'s `start_login` reads `request_gate_repo` and adds a signed
+   `repo` claim to the OAuth `state` (alongside the existing target `v`, nonce
+   and return path). Both are minted together on the target host and signed
+   together.
+4. **The callback authorizes against the state's repo.** `handle_callback`
+   rebuilds `Check::Repo` from the state's `repo` (re-validated — a signature
+   attests origin, not shape) and runs the normal GitHub read-access check
+   against it. The **signed state wins over the callback host's own channel**, so
+   the apex callback authorizes each preview against its own PR's repo.
+
+### The `access` knob (issuer config, default `fixed`)
+
+```toml
+[[middleware]]
+library = "github-auth"
+config  = { client_id = "Iv1.…", client_secret = "env:GH_CLIENT_SECRET",
+            session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET",
+            redirect_uri = "https://preview.example.com/_ephpm/auth/github/callback",
+            cookie_domain = ".preview.example.com",
+            access = "per-preview" }   # authorize each preview against its own repo
+```
+
+- **`access = "fixed"` (default)** — today's behaviour, unchanged. `default_check`
+  or a `sites` table is **required**, the per-request repo channel is **ignored**,
+  and no `repo` claim is written. Nothing about an existing deployment changes.
+- **`access = "per-preview"`** — `default_check`/`sites` become **optional** (the
+  target arrives per request), and a login or callback that carries **no** repo
+  fails **closed** (403). This is the mode a multi-repo preview fleet uses.
+
+The session is unchanged: it still binds only to the **site** (`site` claim,
+#396), never to the repo. Repo authorization happens once, at login; the hot-path
+verifier is untouched and cross-preview replay is still a `site`-claim mismatch.
+Verified end to end in `github-auth`'s
+`per_preview_gates_on_the_signed_state_repo_not_the_callback_channel` (a hostile
+repo on the callback channel is ignored; the signed state's repo is what GitHub
+is queried for) and its fail-closed siblings.
 
 ## Shipped: temporary shareable URLs (verification + revocation)
 
@@ -307,11 +377,18 @@ build against this, not against the ePHPm internals.
    **issuer** globally in `ephpm.toml` (`[[middleware]] library = "github-auth"`
    — one process config, so it runs on every vhost: login fires on the target
    subdomain, the callback on the apex, from the same mount), with its
-   `client_id`/`client_secret`,
-   the per-repo/org access target (its own `sites` map or `default_check`), and
-   `session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET"`. **For the wildcard
-   fleet, also set the two apex-flow knobs** (see "One GitHub OAuth App for the
-   whole fleet" above):
+   `client_id`/`client_secret` and
+   `session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET"`. Choose the
+   authorization model:
+   - **Per-preview repo (recommended for a multi-repo fleet):** set
+     `access = "per-preview"` and write each preview's `repo` in its
+     `[preview_auth]` override (step 3). No fleet-wide `default_check`/`sites` is
+     needed — each preview authorizes against its own PR's base repo.
+   - **Fixed coarse target:** leave `access` at its default and set a per-repo/org
+     access target (`default_check`, or a `sites` map) on the mount.
+
+   **For the wildcard fleet, also set the two apex-flow knobs** (see "One GitHub
+   OAuth App for the whole fleet" above):
    - `redirect_uri = "https://preview.<domain>/_ephpm/auth/github/callback"` — the
      one fixed callback; a GitHub OAuth App allows a single callback host, **not**
      a wildcard, so register exactly this URL in the App.
@@ -334,10 +411,14 @@ build against this, not against the ePHPm internals.
    [preview_auth]
    session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET"   # the SAME reference the issuer uses
    login_url      = "/_ephpm/auth/github/login"          # the issuer's login endpoint
+   repo           = "owner/name"                         # the PR's base repo (per-preview mode)
    ```
    `cookie` must match the issuer's `cookie_name` (both default `ephpm_session`,
    so usually omit it). No `exempt_paths` is needed for the default
-   `/_ephpm/auth/…` endpoints.
+   `/_ephpm/auth/…` endpoints. Write `repo` only when the issuer is in
+   `access = "per-preview"` mode; a malformed value fails that one preview closed
+   (503), never open. In `access = "fixed"` mode `repo` is ignored (the mount's
+   `default_check`/`sites` decides), so omit it.
 4. **Rollout ordering:** only write `[preview_auth]` once an ePHPm that enforces
    it is deployed. An older ePHPm treats the unknown section leniently (ignored,
    reported) and would serve the preview **ungated** — so a fleet upgrades ePHPm


### PR DESCRIPTION
Authorize each preview against **its own PR base repository** instead of one coarse fleet-wide check. ePHPm half of the approved design; switchboard half merged as ephpm/switchboard#32.

### Contract with switchboard
`[preview_auth]` gains one key: `repo = "owner/name"`. switchboard writes it; ePHPm reads it.

### Mechanism
The OAuth callback lands on the APEX host, not the preview, so the repo is captured at **login** (which runs on the target preview host, where the router knows the repo), sealed into the signed OAuth `state`, and read back (re-validated) at callback to build `Check::Repo`. The repo travels on a **trusted, router-populated ABI channel** (like the site key), never a spoofable request header.

### What changed
- **ABI minor 4** (`ephpm-middleware`): additive `request_gate_repo` accessor (NULL when unset), `Request::gate_repo()`, `RequestCtx::with_gate_repo`. dlopen C-ABI round-trip test still passes.
- **`ephpm-server`**: `[preview_auth] repo` validated `owner/name` (invalid ⇒ that one site 503); surfaced as `SiteOverride::preview_gate_repo`, kept OUT of the verifier's gate config; router carries it and sets `.with_gate_repo` on the request-phase chain (where `start_login` runs). Also fixes the stale `/_ephpm/` doc comment (wrong since #487).
- **`github-auth`**: new `access = "fixed" | "per-preview"` (default `fixed` = no behavior change). In per-preview, `start_login` seals a validated `repo`, `handle_callback` rebuilds `Check::Repo` from the signed state; no-repo fails **closed**; session stays bound to `site` (#396), repo never in the session.

### Security invariants (all test-covered)
- Session for preview A rejected on B (site-claim binding; repo not in session).
- `repo` + target `v` minted together at login on the target host, signed together; forged/mismatched state refused at callback; **signed state wins over the callback channel**.
- Repo channel populated only from the operator-owned override — headers cannot supply it.

### Fail-closed matrix (all test-covered)
per-preview + no repo ⇒ deny · malformed override `repo` ⇒ 503 that site · user-lacks-access (`GET /repos` non-200) ⇒ deny · GitHub API error ⇒ 502.

### Validation
`clippy --all-targets -D warnings` + nightly `fmt --check` clean on the three crates; 84+12 github-auth tests, 638 ephpm-server lib tests, dlopen + response-phase C-ABI round-trip tests pass. Docs updated (roadmap + github-auth/virtual-hosts guides).