### PR TITLE
feat(kv): atomic compare-and-delete (ephpm_kv_del_if_eq / DELIFEQ) for correct lock release

### DIFF
--- a/crates/ephpm-cluster/src/clustered_store.rs
+++ b/crates/ephpm-cluster/src/clustered_store.rs
@@ -497,6 +497,16 @@ impl ClusteredStore {
         gossip_deleted || local_deleted
     }
 
+    /// Per-site publish-only tombstone — the multi-tenant mirror of
+    /// [`gossip_tombstone`](Self::gossip_tombstone). Gossips the
+    /// site-namespaced delete without removing the site store's local copy, so
+    /// a value recreated between `del_if_eq`'s removal and this broadcast
+    /// survives on this node.
+    pub async fn gossip_tombstone_for_site(&self, site: &str, key: &str) -> bool {
+        let transport = crate::site_namespace::encode(site, key);
+        self.cluster.gossip_del(&transport).await
+    }
+
     /// Re-broadcast a per-site key's current value with a new TTL, so peers
     /// pick up the new expiry by the same last-arrival-wins rule the global
     /// path uses. Small-key tier only, matching the global `replicate_expire`.
@@ -739,6 +749,27 @@ impl ClusteredStore {
         }
 
         gossip_deleted || local_deleted
+    }
+
+    /// Broadcast a delete **tombstone only** — fan the removal out on the
+    /// gossip tier without touching this node's local materialized copy.
+    ///
+    /// This is the transport for
+    /// [`ephpm_kv::store::Replicator::replicate_remove_published`], emitted by
+    /// [`Store::del_if_eq`](ephpm_kv::store::Store::del_if_eq) after its
+    /// compare-and-delete has already removed the matching entry locally under
+    /// the key's shard lock. Unlike [`remove`](Self::remove) it must NOT call
+    /// `remove_local`: a concurrent writer may have recreated the key with a
+    /// different value in the gap between that local removal and this call, and
+    /// re-removing here would destroy it — reopening the delete-after-recreate
+    /// race the compare-and-delete exists to close. Peers converge by the
+    /// gossip tier's usual last-arrival-wins rule.
+    pub async fn gossip_tombstone(&self, key: &str) -> bool {
+        let deleted = self.cluster.gossip_del(key).await;
+        if self.config.hot_key_cache {
+            evict_hot_entry(&self.hot_cache, &self.hot_cache_mem, hash_key(key));
+        }
+        deleted
     }
 
     /// Check if a key exists in any tier.
@@ -1157,6 +1188,21 @@ impl ephpm_kv::store::Replicator for KvReplicator {
         });
     }
 
+    fn replicate_remove_published(&self, key: String) {
+        // PUBLISH ONLY — no local removal. `Store::del_if_eq` already removed
+        // the matching entry under its shard lock; a re-removal here (whether
+        // synchronous or via `inner.remove`, which also drops the local copy)
+        // would destroy a value recreated between that removal and this
+        // broadcast. Record our own `write_ms` first so a slow gossip echo of
+        // THIS tombstone cannot clobber a follow-up SET we later accept
+        // locally, then fan the tombstone out on the gossip tier only.
+        self.applied.insert(key.clone(), current_write_ms());
+        let inner = Arc::clone(&self.inner);
+        self.handle.spawn(async move {
+            inner.gossip_tombstone(&key).await;
+        });
+    }
+
     fn replicate_expire(&self, key: &str, ttl: Duration) -> bool {
         // Update the local copy synchronously so this node's readers see
         // the new expiry immediately, then re-broadcast the (unchanged)
@@ -1336,6 +1382,19 @@ impl ephpm_kv::store::Replicator for SiteKvReplicator {
                     "per-site KV: clustered publish returned false — the value did not reach peers"
                 );
             }
+        });
+    }
+
+    fn replicate_remove_published(&self, key: String) {
+        // PUBLISH ONLY — mirrors the global replicator: no local removal, so a
+        // value recreated on this node between `del_if_eq`'s removal and this
+        // broadcast survives. Record `write_ms` keyed by the TRANSPORT key,
+        // then gossip the per-site tombstone only.
+        self.applied.insert(crate::site_namespace::encode(&self.site, &key), current_write_ms());
+        let inner = Arc::clone(&self.inner);
+        let site = Arc::clone(&self.site);
+        self.handle.spawn(async move {
+            inner.gossip_tombstone_for_site(&site, &key).await;
         });
     }
 

--- a/crates/ephpm-kv/src/command.rs
+++ b/crates/ephpm-kv/src/command.rs
@@ -246,6 +246,18 @@ fn execute(store: &Arc<Store>, cmd: &str, argv: &[&[u8]]) -> Frame {
                 .unwrap_or(i64::MAX);
             Frame::integer(removed)
         }
+        "DELIFEQ" => {
+            // Compare-and-delete: `DELIFEQ key token` deletes `key` only while
+            // its current value equals `token`, returning :1 if it did and :0
+            // otherwise. This is the atomic release primitive for KV locks —
+            // the delete-side companion to SETNX. It is deliberately its own
+            // command rather than a `DEL key IFEQ token` variant, because DEL
+            // is variadic over keys and a positional `IFEQ` marker would be
+            // ambiguous with a key literally named "IFEQ".
+            check_args!(cmd, argv, 2);
+            let key = str_from(argv[0]);
+            Frame::integer(i64::from(store.del_if_eq(&key, argv[1])))
+        }
         "EXISTS" => {
             if argv.is_empty() {
                 return Frame::error("ERR wrong number of arguments for 'exists' command");
@@ -789,6 +801,34 @@ mod tests {
         let s = store();
         cmd(&s, &["MSET", "a", "1", "b", "2"]);
         assert_eq!(cmd(&s, &["DEL", "a", "b", "missing"]), Frame::integer(2));
+    }
+
+    // ── DELIFEQ (compare-and-delete) ────────────────────────────────────
+
+    #[test]
+    fn delifeq_deletes_on_matching_token() {
+        let s = store();
+        cmd(&s, &["SET", "lock", "tok"]);
+        assert_eq!(cmd(&s, &["DELIFEQ", "lock", "tok"]), Frame::integer(1));
+        assert_eq!(cmd(&s, &["GET", "lock"]), Frame::Null);
+    }
+
+    #[test]
+    fn delifeq_is_noop_on_mismatch() {
+        let s = store();
+        cmd(&s, &["SET", "lock", "tok"]);
+        assert_eq!(cmd(&s, &["DELIFEQ", "lock", "other"]), Frame::integer(0));
+        assert_eq!(bulk_str(&cmd(&s, &["GET", "lock"])), Some("tok"), "value must survive");
+    }
+
+    #[test]
+    fn delifeq_is_noop_on_absent_key() {
+        assert_eq!(cmd(&store(), &["DELIFEQ", "missing", "tok"]), Frame::integer(0));
+    }
+
+    #[test]
+    fn delifeq_missing_token_is_error() {
+        assert!(matches!(cmd(&store(), &["DELIFEQ", "lock"]), Frame::Error(_)));
     }
 
     #[test]

--- a/crates/ephpm-kv/src/multi_tenant.rs
+++ b/crates/ephpm-kv/src/multi_tenant.rs
@@ -354,6 +354,9 @@ mod tests {
             fn replicate_published(&self, key: String, _v: Vec<u8>, _t: Option<Duration>) {
                 self.sets.lock().unwrap().push(format!("{}:{key}", self.site));
             }
+            fn replicate_remove_published(&self, key: String) {
+                self.sets.lock().unwrap().push(format!("{}:{key}", self.site));
+            }
         }
 
         let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -411,6 +414,9 @@ mod tests {
             fn replicate_published(&self, _k: String, _v: Vec<u8>, _t: Option<Duration>) {
                 self.0.fetch_add(1, Ordering::Relaxed);
             }
+            fn replicate_remove_published(&self, _key: String) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
         }
         let _ = Mutex::new(());
 
@@ -465,6 +471,7 @@ mod tests {
                 true
             }
             fn replicate_published(&self, _k: String, _v: Vec<u8>, _t: Option<Duration>) {}
+            fn replicate_remove_published(&self, _key: String) {}
         }
 
         let done = Arc::new(AtomicBool::new(false));
@@ -528,6 +535,7 @@ mod tests {
                 true
             }
             fn replicate_published(&self, _k: String, _v: Vec<u8>, _t: Option<Duration>) {}
+            fn replicate_remove_published(&self, _key: String) {}
         }
 
         let (tx, rx) = mpsc::channel();

--- a/crates/ephpm-kv/src/store/mod.rs
+++ b/crates/ephpm-kv/src/store/mod.rs
@@ -225,6 +225,37 @@ pub trait Replicator: Send + Sync + std::fmt::Debug {
     /// would silently reintroduce the write-back in every new implementation.
     fn replicate_published(&self, key: String, value: Vec<u8>, ttl: Option<Duration>);
 
+    /// **Publish only** — broadcast a delete that has *already* been applied to
+    /// the local map, dropping the key on every peer.
+    ///
+    /// Called by [`Store::del_if_eq`] after its compare-and-delete has fired
+    /// under the key's shard lock. It is the delete-side mirror of
+    /// [`replicate_published`](Self::replicate_published): the local copy is
+    /// **already gone**, so an implementation MUST NOT call
+    /// [`Store::remove_local`] (or any other local removal) from here.
+    ///
+    /// # Why the local re-removal is forbidden
+    ///
+    /// [`replicate_remove`](Self::replicate_remove) exists to service a plain
+    /// `DEL`, whose contract is "make this key not exist" — so it *does* drop
+    /// the local copy before fanning out. A conditional delete is different:
+    /// its contract is "delete this key **only while it still equals my
+    /// token**". After `del_if_eq` has removed the matching entry, a concurrent
+    /// writer may immediately recreate the key with a *different* value (a fresh
+    /// lock acquisition, say). Re-removing locally here would destroy that new
+    /// value — reintroducing the exact delete-after-recreate race the primitive
+    /// exists to close. Broadcasting a tombstone without touching the local map
+    /// preserves the recreated value locally while letting peers converge by the
+    /// same last-arrival-wins rule as every other write in this tier.
+    ///
+    /// Required rather than defaulted on purpose, for the same reason
+    /// [`replicate_published`](Self::replicate_published) is: a default that
+    /// delegated to `replicate_remove` would silently reintroduce that
+    /// local-re-removal in every new implementation, and a no-op default would
+    /// silently drop the tombstone — leaving a released lock alive on every peer
+    /// until its TTL, an invisible divergence.
+    fn replicate_remove_published(&self, key: String);
+
     /// Handle a public [`Store::set_broadcast`]: put this value on **every**
     /// node, whatever its size.
     ///
@@ -1042,6 +1073,94 @@ impl Store {
             self.replicate_published_value(&key_ref, value, published_expiry);
         }
         SetNxOutcome::Inserted
+    }
+
+    /// Atomically delete a key **only if** its current value equals `token`
+    /// (compare-and-delete). Returns `true` if the key was deleted by this
+    /// call, `false` otherwise.
+    ///
+    /// This is the delete-side companion to [`set_nx`](Self::set_nx): together
+    /// they make a KV lock *safe to release*. A holder acquires the lock with
+    /// `set_nx(key, my_token, ttl)` and releases it with `del_if_eq(key,
+    /// my_token)`. Because the release only fires while the stored value is
+    /// still the holder's own token, a holder that overran its TTL — and whose
+    /// lock was therefore taken over by someone else — can no longer delete the
+    /// **new** owner's lock. A plain [`remove`](Self::remove) release cannot
+    /// make that distinction and will happily unlock a lock it no longer owns.
+    ///
+    /// # Return semantics (precise)
+    ///
+    /// * key present and its value equals `token` → the entry is removed;
+    ///   returns `true`.
+    /// * key present but its value differs from `token` → **no-op**; returns
+    ///   `false` (someone else holds it now).
+    /// * key absent, or present but expired → **no-op**; returns `false` (an
+    ///   expired entry is treated as absent and is left for the normal
+    ///   lazy/proactive reap, exactly as [`get`](Self::get) treats it).
+    ///
+    /// The comparison is byte-exact against the **logical** (post-decompression)
+    /// value, so it is agnostic to whether the entry happens to be stored
+    /// compressed.
+    ///
+    /// # Atomicity
+    ///
+    /// The compare and the delete happen under the **same** per-key shard write
+    /// lock via [`DashMap::remove_if`], whose predicate is evaluated while the
+    /// shard is exclusively locked. A concurrent [`set`](Self::set) /
+    /// [`set_nx`](Self::set_nx) on this key is serialised against it: it either
+    /// lands *before* (the predicate then sees the new value and declines) or
+    /// *after* (we have already removed). There is no window in which a value
+    /// this call did not observe gets deleted — the property `remove` cannot
+    /// offer.
+    ///
+    /// # Clustering
+    ///
+    /// Like [`set_nx`](Self::set_nx), the compare-and-delete is **per-node
+    /// atomic**; cluster-wide it is last-arrival-wins. When a [`Replicator`] is
+    /// installed the deletion is fanned out to peers via
+    /// [`Replicator::replicate_remove_published`] — a *publish-only* tombstone
+    /// that does **not** re-remove the local copy, so a value recreated on this
+    /// node between the removal and the broadcast survives locally. Do not build
+    /// cross-node mutual exclusion on this without an external fence, for the
+    /// same reason spelled out on [`replicate_published_value`](Self::replicate_published_value).
+    pub fn del_if_eq(&self, key: &str, token: &[u8]) -> bool {
+        // Atomic compare-and-delete on the LOCAL map. `remove_if` evaluates the
+        // predicate under the shard write lock and only removes when it returns
+        // true, so the compare and the delete are one indivisible step.
+        let removed = self.data.remove_if(key, |_, entry| {
+            // An expired entry is logically absent: decline, and leave it for
+            // the normal reap rather than counting it as a match.
+            if entry.is_expired() {
+                return false;
+            }
+            if entry.compressed {
+                // Compare against the decompressed logical value. A decode
+                // failure (corrupt/foreign payload) is treated as "does not
+                // match" — never delete on an ambiguous compare.
+                decompress_value(&entry.data, self.config.compression.algo)
+                    .is_some_and(|plain| plain.as_ref() == token)
+            } else {
+                entry.data.as_ref() == token
+            }
+        });
+        let Some((_, old)) = removed else {
+            return false;
+        };
+        // Reconcile the same bookkeeping `remove_local` maintains: memory
+        // accounting, the TTL side index, and watch wakeups (the key is now
+        // absent, so a `wait_for_change` observer must be woken).
+        self.mem_sub(old.mem_size);
+        self.ttl_keys.remove(key);
+        self.notify_write(key);
+        // Clustered: broadcast a publish-only tombstone. The compare already
+        // happened locally under the shard lock; peers drop the key by
+        // last-arrival-wins. Crucially this must NOT re-remove locally (see
+        // `Replicator::replicate_remove_published`) — a value recreated here
+        // between the removal above and this call has to survive on this node.
+        if let Some(rep) = self.active_replicator() {
+            rep.replicate_remove_published(key.to_string());
+        }
+        true
     }
 
     /// Remove a key, returning `true` if it existed. Removes from both
@@ -2257,6 +2376,167 @@ mod tests {
         assert!(s.get("contested").is_some());
     }
 
+    // ── del_if_eq (compare-and-delete) ──────────────────────────────
+
+    #[test]
+    fn del_if_eq_deletes_on_exact_match() {
+        let s = test_store();
+        s.set("lock".into(), b"token-A".to_vec(), None);
+        assert!(s.del_if_eq("lock", b"token-A"), "matching token must delete");
+        assert_eq!(s.get("lock"), None, "key must be gone after a matching delete");
+    }
+
+    #[test]
+    fn del_if_eq_is_noop_on_mismatch() {
+        let s = test_store();
+        s.set("lock".into(), b"token-A".to_vec(), None);
+        assert!(!s.del_if_eq("lock", b"token-B"), "a different token must not delete");
+        assert_eq!(
+            s.get("lock").as_deref(),
+            Some(&b"token-A"[..]),
+            "the value must be untouched on a mismatch"
+        );
+    }
+
+    #[test]
+    fn del_if_eq_is_noop_on_absent_key() {
+        let s = test_store();
+        assert!(!s.del_if_eq("missing", b"whatever"), "an absent key must return false");
+    }
+
+    #[test]
+    fn del_if_eq_treats_expired_as_absent() {
+        let s = test_store();
+        // Insert an already-expired entry directly, then try to CAD it: the
+        // value bytes match, but an expired entry is logically absent, so this
+        // must be a no-op (and must NOT report a delete).
+        let entry = Entry::with_expiry(
+            Bytes::from_static(b"tok"),
+            3,
+            false,
+            Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+            0,
+        );
+        s.data.insert("lock".into(), entry);
+        assert!(!s.del_if_eq("lock", b"tok"), "expired entry must be treated as absent");
+    }
+
+    #[test]
+    fn del_if_eq_release_after_takeover_cannot_unlock_new_owner() {
+        // The motivating safety property. Holder A took the lock, overran its
+        // TTL, and holder B has since acquired it (value now B's token). A's
+        // release must NOT delete B's lock — this is exactly what a plain
+        // `remove()` release gets wrong.
+        let s = test_store();
+        s.set("lock".into(), b"holder-A".to_vec(), None); // A holds it
+        s.set("lock".into(), b"holder-B".to_vec(), None); // TTL lapsed → B took over
+        assert!(!s.del_if_eq("lock", b"holder-A"), "A must not unlock B's lock");
+        assert_eq!(
+            s.get("lock").as_deref(),
+            Some(&b"holder-B"[..]),
+            "B's lock must survive A's stale release"
+        );
+        // B releasing with its own token works.
+        assert!(s.del_if_eq("lock", b"holder-B"));
+        assert_eq!(s.get("lock"), None);
+    }
+
+    #[test]
+    fn del_if_eq_updates_memory_accounting() {
+        let s = test_store();
+        let baseline = s.mem_used();
+        s.set("lock".into(), b"token".to_vec(), None);
+        assert!(s.mem_used() > baseline, "storing a value must charge memory");
+        assert!(s.del_if_eq("lock", b"token"));
+        assert_eq!(s.mem_used(), baseline, "a matching delete must reclaim its bytes");
+    }
+
+    #[test]
+    fn del_if_eq_matches_logical_value_when_compressed() {
+        // With compression on and a low threshold, a large value is stored
+        // compressed. The compare must be against the decompressed logical
+        // bytes, so a matching token still deletes and a mismatch does not.
+        let s = Store::new(StoreConfig {
+            memory_limit: 0,
+            eviction_policy: EvictionPolicy::NoEviction,
+            compression: CompressionConfig { algo: CompressionAlgo::Zstd, level: 6, min_size: 1 },
+        });
+        let token = vec![b'z'; 4096]; // very compressible, well over min_size
+        s.set("lock".into(), token.clone(), None);
+        assert!(!s.del_if_eq("lock", b"z"), "a prefix must not match the logical value");
+        assert!(s.del_if_eq("lock", &token), "the exact logical value must match and delete");
+        assert_eq!(s.get("lock"), None);
+    }
+
+    #[test]
+    fn del_if_eq_wakes_watchers() {
+        // A CAD that fires is a state change (key becomes absent), so a
+        // `wait_for_change` observer must be woken — same contract as remove.
+        let s = test_store();
+        s.set("lock".into(), b"token".to_vec(), None);
+        // Register + snapshot to learn the current version.
+        let (ver, _) = s.wait_for_change("lock", 0, Duration::from_millis(0)).unwrap();
+        assert!(s.del_if_eq("lock", b"token"));
+        let (new_ver, val) =
+            s.wait_for_change("lock", ver, Duration::from_millis(0)).expect("version must advance");
+        assert!(new_ver > ver, "delete must bump the watch version");
+        assert_eq!(val, None, "the woken observer must see the key as absent");
+    }
+
+    #[test]
+    fn del_if_eq_only_one_racing_releaser_wins() {
+        // 32 threads race to release the same lock with the same token; exactly
+        // one CAD may observe true. This is the mirror of the set_nx one-winner
+        // property, and it is what makes double-release harmless.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        let s = test_store();
+        s.set("lock".into(), b"tok".to_vec(), None);
+        let winners = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::with_capacity(32);
+        for _ in 0..32 {
+            let s = Arc::clone(&s);
+            let winners = Arc::clone(&winners);
+            handles.push(thread::spawn(move || {
+                if s.del_if_eq("lock", b"tok") {
+                    winners.fetch_add(1, Ordering::Relaxed);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(winners.load(Ordering::Relaxed), 1, "exactly one releaser may win");
+        assert_eq!(s.get("lock"), None);
+    }
+
+    #[test]
+    fn del_if_eq_broadcasts_publish_only_tombstone_when_replicated() {
+        // In clustered mode a fired CAD must fan a tombstone to peers via the
+        // publish-only hook — and must NOT go through `replicate_remove` (which
+        // re-removes locally). A mismatch must broadcast nothing.
+        let s = test_store();
+        s.set_local("lock".into(), b"tok".to_vec(), None);
+        let rep = Arc::new(RecordingReplicator::default());
+        s.set_replicator(Some(Arc::clone(&rep) as Arc<dyn Replicator>));
+
+        // Mismatch: no delete, no broadcast.
+        assert!(!s.del_if_eq("lock", b"other"));
+        assert!(rep.removes_published.lock().unwrap().is_empty(), "mismatch must not broadcast");
+
+        // Match: exactly one publish-only tombstone, and never the plain
+        // remove hook (that path would re-remove locally and reopen the
+        // delete-after-recreate race).
+        assert!(s.del_if_eq("lock", b"tok"));
+        assert_eq!(rep.removes_published.lock().unwrap().as_slice(), &["lock".to_string()]);
+        assert!(
+            rep.removes.lock().unwrap().is_empty(),
+            "CAD must use the publish-only tombstone, not replicate_remove"
+        );
+    }
+
     #[test]
     fn ttl_expiry() {
         let s = test_store();
@@ -3329,6 +3609,7 @@ mod tests {
         removes: std::sync::Mutex<Vec<String>>,
         expires: std::sync::Mutex<Vec<RecordedExpire>>,
         publishes: std::sync::Mutex<Vec<RecordedSet>>,
+        removes_published: std::sync::Mutex<Vec<String>>,
     }
 
     impl Replicator for RecordingReplicator {
@@ -3346,6 +3627,9 @@ mod tests {
         }
         fn replicate_published(&self, key: String, value: Vec<u8>, ttl: Option<Duration>) {
             self.publishes.lock().unwrap().push((key, value, ttl));
+        }
+        fn replicate_remove_published(&self, key: String) {
+            self.removes_published.lock().unwrap().push(key);
         }
     }
 

--- a/crates/ephpm-php/ephpm_wrapper.c
+++ b/crates/ephpm-php/ephpm_wrapper.c
@@ -3166,10 +3166,14 @@ typedef struct {
     long long (*pttl)(const char *key);
     int  (*flush_all)(void);
     /* Blocking versioned wait. Returns 0 = timeout, 1 = changed with a
-     * value (in the get_result buffer), 2 = changed but key absent.
-     * Must stay LAST-appended: the layout mirrors kv_bridge.rs. */
+     * value (in the get_result buffer), 2 = changed but key absent. */
     int  (*wait)(const char *key, long long last_version, long long timeout_ms,
                  long long *new_version);
+    /* Compare-and-delete: delete key only while its value equals the
+     * token/token_len bytes. Returns 1 if deleted, 0 otherwise. The
+     * safe-release primitive for KV locks (delete-side companion to set_nx).
+     * Must stay LAST-appended: the layout mirrors kv_bridge.rs. */
+    int  (*del_if_eq)(const char *key, const char *token, size_t token_len);
 } EphpmKvOps;
 
 static EphpmKvOps g_kv_ops = {0};
@@ -3238,6 +3242,25 @@ PHP_FUNCTION(ephpm_kv_del)
 
     if (!g_kv_ops.del) { RETURN_LONG(0); }
     RETURN_LONG(g_kv_ops.del(key));
+}
+
+PHP_FUNCTION(ephpm_kv_del_if_eq)
+{
+    char *key; size_t key_len;
+    char *token; size_t token_len;
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_STRING(key, key_len)
+        Z_PARAM_STRING(token, token_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    if (!g_kv_ops.del_if_eq) { RETURN_FALSE; }
+    /* Deletes key only while its stored value still equals `token`; returns
+     * true if this call removed it, false otherwise (mismatch, absent, or
+     * expired). The compare-and-delete is atomic under the KV store's per-key
+     * shard lock — this is the safe-release primitive a lock library pairs
+     * with ephpm_kv_setnx(): a holder that overran its TTL can no longer
+     * delete the new holder's lock. */
+    RETURN_BOOL(g_kv_ops.del_if_eq(key, token, token_len));
 }
 
 PHP_FUNCTION(ephpm_kv_exists)
@@ -3420,6 +3443,11 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_del, 0, 0, 1)
     ZEND_ARG_INFO(0, key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_del_if_eq, 0, 0, 2)
+    ZEND_ARG_INFO(0, key)
+    ZEND_ARG_INFO(0, token)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_ephpm_kv_exists, 0, 0, 1)
@@ -4696,6 +4724,7 @@ ZEND_END_ARG_INFO()
     PHP_FE(ephpm_kv_set,       arginfo_ephpm_kv_set) \
     PHP_FE(ephpm_kv_setnx,     arginfo_ephpm_kv_setnx) \
     PHP_FE(ephpm_kv_del,       arginfo_ephpm_kv_del) \
+    PHP_FE(ephpm_kv_del_if_eq, arginfo_ephpm_kv_del_if_eq) \
     PHP_FE(ephpm_kv_exists,    arginfo_ephpm_kv_exists) \
     PHP_FE(ephpm_kv_incr,      arginfo_ephpm_kv_incr) \
     PHP_FE(ephpm_kv_decr,      arginfo_ephpm_kv_decr) \

--- a/crates/ephpm-php/src/kv_bridge.rs
+++ b/crates/ephpm-php/src/kv_bridge.rs
@@ -188,6 +188,24 @@ pub struct EphpmKvOps {
             new_version: *mut std::os::raw::c_longlong,
         ) -> std::os::raw::c_int,
     >,
+
+    /// Atomically delete `key` only if its current value equals the
+    /// `token`/`token_len` bytes (compare-and-delete). Returns 1 if the key
+    /// was deleted by this call, 0 otherwise (value mismatch, absent, expired,
+    /// or no store registered). The compare and delete happen under the same
+    /// per-key shard lock, so a concurrent overwrite makes this a no-op rather
+    /// than deleting a value it never observed — this is the safe-release
+    /// primitive for KV locks (the delete-side companion to `set_nx`).
+    ///
+    /// Must stay LAST-appended: the layout mirrors `ephpm_wrapper.c`'s
+    /// `EphpmKvOps`.
+    pub del_if_eq: Option<
+        unsafe extern "C" fn(
+            key: *const std::os::raw::c_char,
+            token: *const std::os::raw::c_char,
+            token_len: usize,
+        ) -> std::os::raw::c_int,
+    >,
 }
 
 // ── Callback implementations ────────────────────────────────────────────
@@ -317,6 +335,27 @@ unsafe extern "C" fn kv_del(key: *const std::os::raw::c_char) -> std::os::raw::c
     };
 
     std::os::raw::c_long::from(store.remove(&key_str))
+}
+
+#[cfg(php_linked)]
+unsafe extern "C" fn kv_del_if_eq(
+    key: *const std::os::raw::c_char,
+    token: *const std::os::raw::c_char,
+    token_len: usize,
+) -> std::os::raw::c_int {
+    // Safety: `key` is a null-terminated C string from PHP. `token` is a
+    // pointer to `token_len` bytes from PHP's (binary-safe) string parameter.
+    let key_str = unsafe { CStr::from_ptr(key) };
+    let Ok(key_str) = key_str.to_str() else {
+        return 0;
+    };
+    let Some(store) = effective_store() else {
+        return 0;
+    };
+    // Safety: `token` points to `token_len` bytes of valid memory from PHP.
+    let token_bytes = unsafe { std::slice::from_raw_parts(token.cast::<u8>(), token_len) };
+
+    i32::from(store.del_if_eq(key_str, token_bytes))
 }
 
 #[cfg(php_linked)]
@@ -475,6 +514,7 @@ pub static KV_OPS: EphpmKvOps = EphpmKvOps {
     pttl: Some(kv_pttl),
     flush_all: Some(kv_flush_all),
     wait: Some(kv_wait),
+    del_if_eq: Some(kv_del_if_eq),
 };
 
 // ── Public API ──────────────────────────────────────────────────────────
@@ -655,6 +695,58 @@ mod tests {
         // Safety: key is a valid C string.
         let removed = unsafe { kv_del(key.as_ptr()) };
         assert_eq!(removed, 0);
+    }
+
+    // ── kv_del_if_eq (compare-and-delete) ───────────────────────────────
+
+    #[test]
+    #[serial]
+    fn del_if_eq_matching_token_deletes() {
+        let store = init_store();
+        store.set("bridge_cad_match".into(), b"tok".to_vec(), None);
+        let key = cstr("bridge_cad_match");
+        let token = b"tok";
+        // Safety: key is a valid C string; token is valid for token.len() bytes.
+        let rc = unsafe { kv_del_if_eq(key.as_ptr(), token.as_ptr().cast(), token.len()) };
+        assert_eq!(rc, 1, "a matching token must delete");
+        assert_eq!(store.get("bridge_cad_match"), None);
+    }
+
+    #[test]
+    #[serial]
+    fn del_if_eq_mismatched_token_is_noop() {
+        let store = init_store();
+        store.set("bridge_cad_mismatch".into(), b"tok".to_vec(), None);
+        let key = cstr("bridge_cad_mismatch");
+        let token = b"other";
+        // Safety: key is a valid C string; token is valid for token.len() bytes.
+        let rc = unsafe { kv_del_if_eq(key.as_ptr(), token.as_ptr().cast(), token.len()) };
+        assert_eq!(rc, 0, "a different token must not delete");
+        assert_eq!(store.get("bridge_cad_mismatch").as_deref(), Some(&b"tok"[..]));
+    }
+
+    #[test]
+    #[serial]
+    fn del_if_eq_absent_key_is_noop() {
+        init_store();
+        let key = cstr("bridge_cad_absent");
+        let token = b"tok";
+        // Safety: key is a valid C string; token is valid for token.len() bytes.
+        let rc = unsafe { kv_del_if_eq(key.as_ptr(), token.as_ptr().cast(), token.len()) };
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    #[serial]
+    fn del_if_eq_matches_binary_token() {
+        let store = init_store();
+        let token: &[u8] = &[0x00, 0x01, 0xFF, 0xFE];
+        store.set("bridge_cad_bin".into(), token.to_vec(), None);
+        let key = cstr("bridge_cad_bin");
+        // Safety: key is a valid C string; token is valid for token.len() bytes.
+        let rc = unsafe { kv_del_if_eq(key.as_ptr(), token.as_ptr().cast(), token.len()) };
+        assert_eq!(rc, 1, "a binary token must compare byte-exactly and delete");
+        assert_eq!(store.get("bridge_cad_bin"), None);
     }
 
     // ── kv_exists ───────────────────────────────────────────────────────

--- a/site/content/guides/kv-from-php.md
+++ b/site/content/guides/kv-from-php.md
@@ -25,7 +25,12 @@ ephpm_kv_exists("greeting");                   // false
 
 // setnx is the atomic check-and-set the PHP lock libraries build on
 // (Laravel Cache::lock, Symfony LockFactory)
-ephpm_kv_setnx("lock:job", "owner-1");         // true if it did not exist
+ephpm_kv_setnx("lock:job", "owner-1", 30);     // true if it did not exist (30s TTL)
+
+// del_if_eq is the atomic compare-and-delete that makes the *release* safe:
+// it deletes the key only while its value is still your token, so a holder
+// that overran its TTL cannot delete the new holder's lock.
+ephpm_kv_del_if_eq("lock:job", "owner-1");     // true only if still "owner-1"
 
 // Counters — ephpm_kv_incr takes exactly one argument and always adds 1;
 // use ephpm_kv_incr_by for arbitrary deltas
@@ -44,9 +49,51 @@ ephpm_kv_flush_all();                          // empties the store
 ```
 
 The full set of SAPI functions: `ephpm_kv_get`, `ephpm_kv_set`,
-`ephpm_kv_setnx`, `ephpm_kv_del`, `ephpm_kv_exists`, `ephpm_kv_incr`,
-`ephpm_kv_decr`, `ephpm_kv_incr_by`, `ephpm_kv_expire`, `ephpm_kv_ttl`,
-`ephpm_kv_pttl`, `ephpm_kv_flush_all`, `ephpm_kv_wait`.
+`ephpm_kv_setnx`, `ephpm_kv_del`, `ephpm_kv_del_if_eq`, `ephpm_kv_exists`,
+`ephpm_kv_incr`, `ephpm_kv_decr`, `ephpm_kv_incr_by`, `ephpm_kv_expire`,
+`ephpm_kv_ttl`, `ephpm_kv_pttl`, `ephpm_kv_flush_all`, `ephpm_kv_wait`.
+
+### Safe lock release — `ephpm_kv_del_if_eq()`
+
+```php
+ephpm_kv_del_if_eq(string $key, string $token): bool
+```
+
+Atomically deletes `$key` **only while** its stored value equals `$token`
+(a compare-and-delete), returning `true` if this call removed it and
+`false` otherwise. The compare and the delete happen under the same
+per-key shard lock, so a value written by someone else between your read
+and your delete is never destroyed.
+
+This is the delete-side companion to `ephpm_kv_setnx()` and the primitive
+for **correct lock release**. Acquire with a unique token and a TTL, then
+release with the same token:
+
+```php
+$token = bin2hex(random_bytes(16));
+if (ephpm_kv_setnx("lock:job", $token, 30)) {   // 30s TTL guards a crash
+    try {
+        // ... critical section ...
+    } finally {
+        ephpm_kv_del_if_eq("lock:job", $token);  // releases only if still ours
+    }
+}
+```
+
+Because the release fires only while the value is still *your* token, a
+holder that overran the TTL — and whose lock was therefore taken over by
+another request — can no longer delete the **new** holder's lock. A plain
+`ephpm_kv_del()` release cannot make that distinction and will happily
+unlock a lock it no longer owns.
+
+Return values, precisely: `true` when the key was present, matched, and
+was deleted; `false` when the token differs, the key is absent, or the key
+has expired (an expired entry is treated as absent). Tokens are compared
+byte-exactly and may be binary.
+
+Like `ephpm_kv_setnx()`, the compare-and-delete is atomic **per node**;
+across a cluster it is last-arrival-wins, so do not build cross-node mutual
+exclusion on it without an external fence.
 
 ### Blocking waits — `ephpm_kv_wait()`
 
@@ -66,10 +113,11 @@ Semantics you can rely on:
   always start the protocol with `$last_version = 0`: that first call
   registers the watch and returns the current value + version
   immediately (a race-free snapshot), without blocking.
-- **What bumps the version:** `set`, `setnx` (on insert), `del`, `incr`
-  / `decr` / `incr_by`, `append` (via RESP), expiry reaping, and
-  `flush_all`. TTL-only changes (`expire`) and hash-field ops (RESP
-  `HSET`/`HDEL`) do **not**.
+- **What bumps the version:** `set`, `setnx` (on insert), `del`,
+  `del_if_eq` (only when it actually deletes), `incr` / `decr` /
+  `incr_by`, `append` (via RESP), expiry reaping, and `flush_all`.
+  TTL-only changes (`expire`) and hash-field ops (RESP `HSET`/`HDEL`)
+  do **not**.
 - **Negative arguments clamp to 0**; `$timeout_ms = 0` is a
   non-blocking poll.
 - **Cost when unused: zero.** Writes pay a single atomic load until the
@@ -135,9 +183,11 @@ $count = $redis->incr('page:views');
 | Group | Commands |
 |-------|----------|
 | Strings | `GET`, `SET`, `SETEX`, `MGET`, `MSET`, `SETNX`, `INCR`, `DECR`, `INCRBY`, `DECRBY`, `APPEND`, `STRLEN`, `GETSET` |
-| Keys | `DEL`, `EXISTS`, `EXPIRE`, `PEXPIRE`, `PERSIST`, `TTL`, `PTTL`, `TYPE`, `KEYS`, `DBSIZE`, `FLUSHDB`, `FLUSHALL`, `RENAME` |
+| Keys | `DEL`, `DELIFEQ`, `EXISTS`, `EXPIRE`, `PEXPIRE`, `PERSIST`, `TTL`, `PTTL`, `TYPE`, `KEYS`, `DBSIZE`, `FLUSHDB`, `FLUSHALL`, `RENAME` |
 | Hashes | `HSET`, `HGET`, `HDEL`, `HGETALL`, `HKEYS`, `HVALS`, `HLEN`, `HEXISTS` |
 | Connection | `PING`, `ECHO`, `SELECT`, `QUIT`, `COMMAND`, `INFO`, `AUTH` |
+
+`DELIFEQ key token` is an ePHPm-specific compare-and-delete (not a standard Redis command): it deletes `key` only while its value equals `token`, returning `:1`/`:0`. It is the safe lock-release primitive — reach it over RESP with a raw command (e.g. Predis `$redis->executeRaw(['DELIFEQ', $key, $token])`), or, from in-process PHP, just call `ephpm_kv_del_if_eq()` above. It is a dedicated command rather than a `DEL key IFEQ token` variant because `DEL` is variadic over keys, where a positional marker would be ambiguous with a key named `IFEQ`.
 
 Not implemented: lists, sets, transactions, `SCAN`, pub/sub. ePHPm targets the cache + counter + session use case — if you need full Redis, run actual Redis.
 


### PR DESCRIPTION
Adds an atomic **compare-and-delete** to the KV store — delete a key only while its value still equals a caller-supplied token — at every layer: `Store::del_if_eq` (RESP `DELIFEQ`, SAPI `ephpm_kv_del_if_eq`).

The delete-side companion to `setnx` and the primitive that makes KV lock **release** correct: acquire with `ephpm_kv_setnx(key, token, ttl)`, release with `ephpm_kv_del_if_eq(key, token)`. A holder that overran its TTL (whose lock was taken over) can no longer delete the new holder's lock — a plain `del()` release can't make that distinction.

## Surface
- **Store:** `del_if_eq(key, token) -> bool` — compare-and-delete under one shard write lock (`DashMap::remove_if`), atomic vs concurrent `set`/`set_nx`; expired==absent; byte-exact compare against the logical (decompressed) value.
- **RESP:** `DELIFEQ key token` → `:1`/`:0` (dedicated command, not an ambiguous `DEL … IFEQ` variant).
- **SAPI:** `ephpm_kv_del_if_eq(string $key, string $token): bool` through the wrapper's guards.

## Clustering
A fired CAD broadcasts a **publish-only** tombstone via a new `Replicator::replicate_remove_published` — it must NOT re-remove locally (a value recreated between removal and broadcast has to survive here, else the race reopens). Per-node atomic, cluster-wide last-arrival-wins — same contract as `set_nx`.

## Not included (follow-ons)
- Wiring the PHP lock consumers (Laravel `LockProvider`, `session-handler`, `wp_cache_add`, Symfony Lock) — needs a release first; the in-tree session-handler lock's documented "no compare-and-delete" limitation is now closeable.
- `putOffExpiration` (compare-and-set-expiry) — deferred; CAD stands alone.

## Testing
15 new unit tests (atomicity/mismatch/absent/expired/compressed/takeover-safety/racing-releaser/clustered-tombstone; RESP) + 4 `php_linked` bridge tests (CI). `clippy -p ephpm-kv -p ephpm-cluster -D warnings`, `cargo check -p ephpm-php` under `php_linked`, and nightly `fmt --check` all clean.