### PR TITLE
feat(analyze): ephpm analyze Phase 1 — analyzer framework + fail-closed gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,6 +1369,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "ephpm-analyze",
  "ephpm-config",
  "ephpm-db",
  "ephpm-kv",
@@ -1389,6 +1390,19 @@ dependencies = [
  "tracing-subscriber",
  "windows-service",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ephpm-analyze"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -4839,6 +4853,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5983,6 +6010,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,14 @@ yamux = "0.14"
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["handshake"] }
 futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 
+# YAML parser for `.ephpm-analyze.yml` (crates/ephpm-analyze). serde_yaml_ng is
+# the maintained continuation of dtolnay's archived serde_yaml — same API, same
+# unsafe-libyaml backend, no new transitive weight. Chosen over the archived
+# serde_yaml so `cargo deny check advisories` stays clean without an ignore.
+serde_yaml_ng = "0.10"
+
 # Internal crates
+ephpm-analyze = { path = "crates/ephpm-analyze" }
 ephpm-cluster = { path = "crates/ephpm-cluster" }
 ephpm-config = { path = "crates/ephpm-config" }
 ephpm-db = { path = "crates/ephpm-db" }

--- a/crates/ephpm-analyze/Cargo.toml
+++ b/crates/ephpm-analyze/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ephpm-analyze"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Static analysis aggregator and fail-closed deploy gate for PHP applications"
+
+[dependencies]
+anyhow.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+serde_yaml_ng.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/ephpm-analyze/src/analyzer.rs
+++ b/crates/ephpm-analyze/src/analyzer.rs
@@ -1,0 +1,121 @@
+//! The `Analyzer` trait, the shared `AnalysisCtx` handed to every analyzer,
+//! and the error taxonomy the aggregator's fail-closed logic keys on.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::AnalyzeConfig;
+use crate::finding::{Category, Finding};
+
+/// Everything an analyzer may read about the target under analysis.
+///
+/// Phase 1 carries the checkout root and the effective configuration. The
+/// fields are private on purpose — analyzers go through accessors — so later
+/// phases can add **lazily populated shared state** without touching any
+/// analyzer's signature:
+///
+/// - *Planned — not yet implemented (Phase 2, opcode analyzers):* a
+///   `compiled()` accessor returning a lazily built compiled representation
+///   of the tree's PHP files (op_array-level), built at most once and shared
+///   by every opcode analyzer.
+/// - *Planned — not yet implemented (Phase 4, engine-in-the-loop):* an
+///   `engine()` accessor exposing a sandboxed embedded-PHP evaluation handle,
+///   gated by `engine.detonate` / `engine.timeout_ms` (parsed today, inert).
+///
+/// Both slot in as additional private fields plus accessors; the `Analyzer`
+/// trait and `run(&self, ctx: &AnalysisCtx)` shape do not change.
+#[derive(Debug)]
+pub struct AnalysisCtx {
+    root: PathBuf,
+    config: AnalyzeConfig,
+}
+
+impl AnalysisCtx {
+    /// Build a context for the checkout at `root` with the given effective
+    /// configuration.
+    #[must_use]
+    pub fn new(root: PathBuf, config: AnalyzeConfig) -> Self {
+        Self { root, config }
+    }
+
+    /// The directory being analyzed.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// The effective (file + CLI-override) configuration.
+    #[must_use]
+    pub fn config(&self) -> &AnalyzeConfig {
+        &self.config
+    }
+}
+
+/// Why an analyzer did not produce a normal result.
+///
+/// The distinction between [`AnalyzerError::Skipped`] and every other variant
+/// is the crux of the fail-closed model: *absence degrades, errors gate*.
+///
+/// - `Skipped` means the analyzer could not meaningfully run at all — its
+///   external tool is not installed, or the target lacks the inputs it needs
+///   (no `composer.json`, no YARA ruleset configured). A skip is reported as
+///   a diagnostic and does **not** floor the verdict — unless the analyzer is
+///   listed in `analyzers.required`, in which case the aggregator upgrades
+///   the skip to a failure.
+/// - Every other variant is a real error on a path that *should* have worked
+///   (tool crashed, unparseable output, timeout, I/O failure) and floors the
+///   verdict at [`crate::policy::Verdict::Quarantine`]: an analyzer that
+///   errored might have been about to find something, so the result can
+///   never be `Allow`.
+#[derive(Debug, thiserror::Error)]
+pub enum AnalyzerError {
+    /// The analyzer cannot run in this environment / against this target.
+    /// Not a failure — see the type-level docs.
+    #[error("skipped: {0}")]
+    Skipped(String),
+    /// The external tool ran but reported a failure the analyzer cannot
+    /// interpret as results.
+    #[error("tool failed: {0}")]
+    ToolFailed(String),
+    /// The external tool exceeded `analyzers.tool_timeout_ms` and was killed.
+    #[error("timed out after {0} ms")]
+    Timeout(u64),
+    /// The tool's output could not be parsed.
+    #[error("output parse error: {0}")]
+    Parse(String),
+    /// An I/O error while walking or reading the target tree.
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl AnalyzerError {
+    /// `true` for the [`AnalyzerError::Skipped`] variant — the only variant
+    /// that does not trip the fail-closed quarantine floor.
+    #[must_use]
+    pub fn is_skip(&self) -> bool {
+        matches!(self, Self::Skipped(_))
+    }
+}
+
+/// A single analysis pass over the target.
+///
+/// Implementations must be side-effect-free with respect to the target tree
+/// (read-only) and must map "my tool / inputs are absent" to
+/// [`AnalyzerError::Skipped`] rather than erroring — see [`AnalyzerError`]
+/// for why the distinction matters.
+pub trait Analyzer {
+    /// Stable identifier, used in `analyzers.enable`, `analyzers.required`,
+    /// diagnostics, and as the namespace prefix of this analyzer's rule ids.
+    fn id(&self) -> &str;
+
+    /// The category this analyzer's findings fall under.
+    fn category(&self) -> Category;
+
+    /// Run the analysis and return findings (possibly none).
+    ///
+    /// # Errors
+    ///
+    /// [`AnalyzerError::Skipped`] when the analyzer cannot run here (tool or
+    /// inputs absent); any other variant for a real failure, which the
+    /// aggregator treats as fail-closed.
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError>;
+}

--- a/crates/ephpm-analyze/src/analyzers/composer_audit.rs
+++ b/crates/ephpm-analyze/src/analyzers/composer_audit.rs
@@ -1,0 +1,179 @@
+//! `composer-audit` — known-advisory scan of Composer dependencies.
+//!
+//! Wraps `composer audit --no-scripts --format=json` as a subprocess (the
+//! Composer binary is an **optional external dependency** — absence skips
+//! this analyzer). Parses the JSON advisory map into findings, one per
+//! advisory, plus `Info` findings for abandoned packages.
+
+use serde_json::Value;
+
+use super::tool::{run_tool, stderr_excerpt};
+use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+use crate::finding::{Category, Finding, Severity};
+
+/// See the module docs.
+pub struct ComposerAudit;
+
+/// The analyzer's stable id.
+pub const ID: &str = "composer-audit";
+
+fn advisory_severity(advisory: &Value) -> Severity {
+    match advisory.get("severity").and_then(Value::as_str) {
+        Some("critical") => Severity::Critical,
+        Some("high") => Severity::High,
+        Some("low") => Severity::Low,
+        // Composer omits the field for some sources; a known advisory with
+        // unknown severity is at least worth a medium.
+        _ => Severity::Medium,
+    }
+}
+
+fn advisory_finding(package: &str, advisory: &Value) -> Finding {
+    let id = advisory
+        .get("cve")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .or_else(|| advisory.get("advisoryId").and_then(Value::as_str))
+        .unwrap_or("unknown");
+    let title = advisory.get("title").and_then(Value::as_str).unwrap_or("known advisory");
+    Finding {
+        rule_id: format!("{ID}/{id}"),
+        severity: advisory_severity(advisory),
+        category: Category::SupplyChain,
+        path: Some("composer.lock".into()),
+        line: None,
+        message: format!("{package}: {title}"),
+    }
+}
+
+/// Parse `composer audit --format=json` output into findings.
+fn parse_audit_json(json: &Value) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    if let Some(advisories) = json.get("advisories").and_then(Value::as_object) {
+        for (package, list) in advisories {
+            // Each value is a list of advisories (or, from some Composer
+            // versions, a map keyed by advisory id).
+            match list {
+                Value::Array(items) => {
+                    findings.extend(items.iter().map(|a| advisory_finding(package, a)));
+                }
+                Value::Object(map) => {
+                    findings.extend(map.values().map(|a| advisory_finding(package, a)));
+                }
+                _ => {}
+            }
+        }
+    }
+    if let Some(abandoned) = json.get("abandoned").and_then(Value::as_object) {
+        for (package, replacement) in abandoned {
+            let suggestion = replacement
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .map(|r| format!(" (suggested replacement: {r})"))
+                .unwrap_or_default();
+            findings.push(Finding {
+                rule_id: format!("{ID}/abandoned"),
+                severity: Severity::Info,
+                category: Category::SupplyChain,
+                path: Some("composer.lock".into()),
+                line: None,
+                message: format!("{package} is abandoned{suggestion}"),
+            });
+        }
+    }
+    findings
+}
+
+impl Analyzer for ComposerAudit {
+    fn id(&self) -> &str {
+        ID
+    }
+
+    fn category(&self) -> Category {
+        Category::SupplyChain
+    }
+
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        let root = ctx.root();
+        if !root.join("composer.json").is_file() {
+            return Err(AnalyzerError::Skipped("no composer.json in target".to_owned()));
+        }
+        if !root.join("composer.lock").is_file() {
+            return Err(AnalyzerError::Skipped(
+                "no composer.lock in target (audit needs a lockfile)".to_owned(),
+            ));
+        }
+        let timeout = ctx.config().analyzers.tool_timeout_ms;
+        let run = run_tool(
+            "composer",
+            &["audit", "--no-scripts", "--format=json", "--no-interaction"],
+            root,
+            timeout,
+        )?;
+        // `composer audit` exits non-zero when it FINDS advisories, so the
+        // exit code alone is not a failure signal — the JSON body is the
+        // authority. Only an unparseable body is a real failure.
+        match serde_json::from_str::<Value>(&run.stdout) {
+            Ok(json) => Ok(parse_audit_json(&json)),
+            Err(_) => Err(AnalyzerError::ToolFailed(format!(
+                "composer audit produced no JSON (exit {:?}): {}",
+                run.exit_code,
+                stderr_excerpt(&run.stderr)
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_advisories_and_abandoned() {
+        let json: Value = serde_json::from_str(
+            r#"{
+              "advisories": {
+                "acme/widget": [
+                  {"advisoryId": "PKSA-x1", "cve": "CVE-2024-1234",
+                   "title": "RCE in widget parser", "severity": "critical"},
+                  {"advisoryId": "PKSA-x2", "cve": "",
+                   "title": "XSS", "severity": "medium"}
+                ]
+              },
+              "abandoned": {"acme/old": "acme/new", "acme/dead": null}
+            }"#,
+        )
+        .unwrap();
+        let findings = parse_audit_json(&json);
+        assert_eq!(findings.len(), 4);
+        let cve = findings.iter().find(|f| f.rule_id == "composer-audit/CVE-2024-1234").unwrap();
+        assert_eq!(cve.severity, Severity::Critical);
+        assert!(cve.message.contains("acme/widget"));
+        // Empty CVE falls back to the advisory id.
+        let xss = findings.iter().find(|f| f.rule_id == "composer-audit/PKSA-x2").unwrap();
+        assert_eq!(xss.severity, Severity::Medium);
+        let abandoned: Vec<_> =
+            findings.iter().filter(|f| f.rule_id == "composer-audit/abandoned").collect();
+        assert_eq!(abandoned.len(), 2);
+        assert!(abandoned.iter().all(|f| f.severity == Severity::Info));
+    }
+
+    #[test]
+    fn advisory_map_form_is_accepted() {
+        // Some Composer versions key advisories by id instead of a list.
+        let json: Value = serde_json::from_str(
+            r#"{"advisories": {"acme/widget": {"PKSA-x1":
+              {"advisoryId": "PKSA-x1", "title": "bug", "severity": "high"}}}}"#,
+        )
+        .unwrap();
+        let findings = parse_audit_json(&json);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::High);
+    }
+
+    #[test]
+    fn clean_audit_yields_no_findings() {
+        let json: Value = serde_json::from_str(r#"{"advisories": {}, "abandoned": {}}"#).unwrap();
+        assert!(parse_audit_json(&json).is_empty());
+    }
+}

--- a/crates/ephpm-analyze/src/analyzers/dangerous_sinks.rs
+++ b/crates/ephpm-analyze/src/analyzers/dangerous_sinks.rs
@@ -1,0 +1,196 @@
+//! `dangerous-sinks` — naive native scan for dangerous PHP call sites.
+//!
+//! **Phase-1 placeholder, deliberately naive.** This is a line-oriented
+//! token pass over `*.php` / `*.phtml` files looking for calls to the
+//! `eval`, `system`, and `assert` sinks. It exists so the *native*-analyzer
+//! path of the framework (no external tool, no subprocess) is exercised end
+//! to end from day one; it will be superseded by the opcode-level analyzer
+//! (Phase 2), which sees through string tricks (a name built by
+//! concatenation), comments, and heredocs that this pass cannot.
+//!
+//! Known false positives (accepted for a placeholder): matches inside
+//! comments and string literals. Known false negatives: dynamic calls,
+//! `call_user_func`, backtick execution operators.
+//!
+//! NOTE for maintainers: keep the sink names in `SINKS` and any test
+//! fixtures free of realistic webshell-shaped payloads (e.g. a sink call
+//! wrapping a request superglobal) — endpoint antivirus quarantines source
+//! files containing those byte sequences, which broke the build once
+//! already.
+
+use std::path::Path;
+
+use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+use crate::finding::{Category, Finding, Severity};
+
+/// See the module docs.
+pub struct DangerousSinks;
+
+/// The analyzer's stable id.
+pub const ID: &str = "dangerous-sinks";
+
+/// Files larger than this are skipped (a minified/vendored blob would drown
+/// the report; the YARA analyzer is the right tool for opaque payloads).
+const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+const SINKS: &[(&str, Severity)] =
+    &[("eval", Severity::High), ("system", Severity::High), ("assert", Severity::Medium)];
+
+fn is_php_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some(ext) if ext.eq_ignore_ascii_case("php") || ext.eq_ignore_ascii_case("phtml")
+    )
+}
+
+/// `true` when the byte before a candidate token rules it out as a direct
+/// function call: part of a longer identifier (`subsystem(`), a variable
+/// (a `$`-prefixed name is a *dynamic* call — out of scope here), or a
+/// method / static access (`->` / `::` — the `>` / `:` byte).
+fn preceded_by_identifier_byte(line: &str, start: usize) -> bool {
+    line[..start]
+        .bytes()
+        .next_back()
+        .is_some_and(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'$' | b'>' | b':'))
+}
+
+/// `true` when the token ending at `after` is immediately followed (modulo
+/// spaces/tabs) by `(`.
+fn followed_by_call_paren(line: &str, after: usize) -> bool {
+    line[after..].bytes().find(|b| !matches!(b, b' ' | b'\t')) == Some(b'(')
+}
+
+/// Scan one file's text, returning findings with 1-based line numbers.
+fn scan_text(text: &str, rel_path: &Path) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for (line_idx, line) in text.lines().enumerate() {
+        for &(sink, severity) in SINKS {
+            let mut search_from = 0;
+            while let Some(pos) = line[search_from..].find(sink) {
+                let start = search_from + pos;
+                let after = start + sink.len();
+                search_from = after;
+                if preceded_by_identifier_byte(line, start) {
+                    continue;
+                }
+                if !followed_by_call_paren(line, after) {
+                    continue;
+                }
+                findings.push(Finding {
+                    rule_id: format!("{ID}/{sink}"),
+                    severity,
+                    category: Category::Security,
+                    path: Some(rel_path.to_path_buf()),
+                    line: Some(line_idx as u64 + 1),
+                    message: format!("call to {sink}() — dangerous sink"),
+                });
+            }
+        }
+    }
+    findings
+}
+
+/// Recursively walk `dir`, scanning PHP files. Does not follow directory
+/// symlinks; skips `.git`.
+fn walk(root: &Path, dir: &Path, findings: &mut Vec<Finding>) -> Result<(), AnalyzerError> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            walk(root, &path, findings)?;
+        } else if file_type.is_file() && is_php_file(&path) {
+            if entry.metadata()?.len() > MAX_FILE_BYTES {
+                continue;
+            }
+            let bytes = std::fs::read(&path)?;
+            let text = String::from_utf8_lossy(&bytes);
+            let rel = path.strip_prefix(root).unwrap_or(&path);
+            findings.extend(scan_text(&text, rel));
+        }
+    }
+    Ok(())
+}
+
+impl Analyzer for DangerousSinks {
+    fn id(&self) -> &str {
+        ID
+    }
+
+    fn category(&self) -> Category {
+        Category::Security
+    }
+
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        let mut findings = Vec::new();
+        walk(ctx.root(), ctx.root(), &mut findings)?;
+        Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan(src: &str) -> Vec<Finding> {
+        scan_text(src, Path::new("t.php"))
+    }
+
+    /// Assemble `<name>(<arg>);` at runtime so the eval/system call byte
+    /// sequences never appear literally in this source file (see the module
+    /// docs' antivirus note — the assembled *strings* only ever live in
+    /// memory here, never on disk).
+    fn call(name: &str, arg: &str) -> String {
+        format!("{name}({arg});")
+    }
+
+    /// The `eval` sink name, split so the identifier + paren never sits in
+    /// the file as one sequence.
+    fn eval_name() -> String {
+        format!("ev{}", "al")
+    }
+
+    #[test]
+    fn finds_direct_sink_calls_with_line_numbers() {
+        let src = format!(
+            "<?php\n$x = 1;\n{}\n{}\n{}\n",
+            call(&eval_name(), "$code"),
+            call("system", "$cmd"),
+            call("assert", "$cond"),
+        );
+        let findings = scan(&src);
+        assert_eq!(findings.len(), 3);
+        assert_eq!(findings[0].rule_id, "dangerous-sinks/eval");
+        assert_eq!(findings[0].line, Some(3));
+        assert_eq!(findings[0].severity, Severity::High);
+        assert_eq!(findings[1].rule_id, "dangerous-sinks/system");
+        assert_eq!(findings[1].line, Some(4));
+        assert_eq!(findings[2].rule_id, "dangerous-sinks/assert");
+        assert_eq!(findings[2].severity, Severity::Medium);
+    }
+
+    #[test]
+    fn ignores_longer_identifiers_and_method_calls() {
+        let findings = scan(
+            "<?php\nsubsystem('x');\n$this->assert(1);\nFoo::assert(1);\n$eval = 2;\nmy_eval(1);\n",
+        );
+        assert!(findings.is_empty(), "{findings:?}");
+    }
+
+    #[test]
+    fn allows_space_before_call_paren() {
+        let src = format!("<?php {} ($x);\n", eval_name());
+        let findings = scan(&src);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn multiple_hits_on_one_line() {
+        let src = format!("<?php {} {}\n", call(&eval_name(), "$a"), call("system", "$b"));
+        let findings = scan(&src);
+        assert_eq!(findings.len(), 2);
+    }
+}

--- a/crates/ephpm-analyze/src/analyzers/mod.rs
+++ b/crates/ephpm-analyze/src/analyzers/mod.rs
@@ -1,0 +1,30 @@
+//! The built-in Phase-1 analyzers.
+//!
+//! Three wrap external tools as subprocesses and degrade gracefully when the
+//! tool is absent (`composer-audit`, `semgrep-php`, `malware-yara`); one is
+//! native with zero external dependencies (`dangerous-sinks`), exercising
+//! the same path a future opcode analyzer will use.
+
+mod composer_audit;
+mod dangerous_sinks;
+mod semgrep;
+mod tool;
+mod yara_scan;
+
+pub use composer_audit::ComposerAudit;
+pub use dangerous_sinks::DangerousSinks;
+pub use semgrep::SemgrepPhp;
+pub use yara_scan::MalwareYara;
+
+use crate::analyzer::Analyzer;
+
+/// All analyzers this binary ships, in their default execution order.
+#[must_use]
+pub fn built_in() -> Vec<Box<dyn Analyzer>> {
+    vec![
+        Box::new(ComposerAudit),
+        Box::new(SemgrepPhp),
+        Box::new(MalwareYara),
+        Box::new(DangerousSinks),
+    ]
+}

--- a/crates/ephpm-analyze/src/analyzers/semgrep.rs
+++ b/crates/ephpm-analyze/src/analyzers/semgrep.rs
@@ -1,0 +1,137 @@
+//! `semgrep-php` — pattern-based PHP security scan.
+//!
+//! Wraps `semgrep --config <ref> --sarif` as a subprocess (Semgrep is an
+//! **optional external dependency** — absence skips this analyzer; the
+//! default `p/php` registry ref needs network access, and a fetch failure is
+//! a real error, which gates). The SARIF it emits is parsed back into
+//! findings.
+
+use serde_json::Value;
+
+use super::tool::{run_tool, stderr_excerpt};
+use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+use crate::finding::{Category, Finding, Severity};
+
+/// See the module docs.
+pub struct SemgrepPhp;
+
+/// The analyzer's stable id.
+pub const ID: &str = "semgrep-php";
+
+fn severity_from_level(level: Option<&str>) -> Severity {
+    match level {
+        Some("error") => Severity::High,
+        Some("note") => Severity::Low,
+        // Semgrep's default level, and the safe middle for anything odd.
+        _ => Severity::Medium,
+    }
+}
+
+/// Parse a SARIF document produced by Semgrep into findings.
+fn parse_sarif(doc: &Value) -> Result<Vec<Finding>, AnalyzerError> {
+    let runs = doc
+        .get("runs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AnalyzerError::Parse("SARIF document has no runs".to_owned()))?;
+    let mut findings = Vec::new();
+    for run in runs {
+        let Some(results) = run.get("results").and_then(Value::as_array) else {
+            continue;
+        };
+        for result in results {
+            let rule = result.get("ruleId").and_then(Value::as_str).unwrap_or("unknown-rule");
+            let message = result
+                .pointer("/message/text")
+                .and_then(Value::as_str)
+                .unwrap_or("semgrep finding")
+                .to_owned();
+            let location = result.pointer("/locations/0/physicalLocation");
+            let path = location
+                .and_then(|l| l.pointer("/artifactLocation/uri"))
+                .and_then(Value::as_str)
+                .map(Into::into);
+            let line =
+                location.and_then(|l| l.pointer("/region/startLine")).and_then(Value::as_u64);
+            findings.push(Finding {
+                rule_id: format!("{ID}/{rule}"),
+                severity: severity_from_level(result.get("level").and_then(Value::as_str)),
+                category: Category::Security,
+                path,
+                line,
+                message,
+            });
+        }
+    }
+    Ok(findings)
+}
+
+impl Analyzer for SemgrepPhp {
+    fn id(&self) -> &str {
+        ID
+    }
+
+    fn category(&self) -> Category {
+        Category::Security
+    }
+
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        let config = &ctx.config().analyzers.semgrep_config;
+        let timeout = ctx.config().analyzers.tool_timeout_ms;
+        let run = run_tool(
+            "semgrep",
+            &["--config", config, "--sarif", "--quiet", "--disable-version-check", "."],
+            ctx.root(),
+            timeout,
+        )?;
+        // Semgrep exits 0 whether or not it has findings; non-zero means the
+        // scan itself broke (bad config ref, registry unreachable, crash).
+        // That is a real failure — fail closed — unless it still produced a
+        // parseable SARIF body, which is then authoritative.
+        match serde_json::from_str::<Value>(&run.stdout) {
+            Ok(doc) => parse_sarif(&doc),
+            Err(_) => Err(AnalyzerError::ToolFailed(format!(
+                "semgrep produced no SARIF (exit {:?}): {}",
+                run.exit_code,
+                stderr_excerpt(&run.stderr)
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_semgrep_sarif_results() {
+        let doc: Value = serde_json::from_str(
+            r#"{"version": "2.1.0", "runs": [{"results": [
+              {"ruleId": "php.lang.security.eval-use",
+               "level": "error",
+               "message": {"text": "eval of user input"},
+               "locations": [{"physicalLocation": {
+                 "artifactLocation": {"uri": "src/handler.php"},
+                 "region": {"startLine": 42}}}]},
+              {"ruleId": "php.lang.best-practice.x",
+               "level": "note",
+               "message": {"text": "style nit"},
+               "locations": []}
+            ]}]}"#,
+        )
+        .unwrap();
+        let findings = parse_sarif(&doc).unwrap();
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].rule_id, "semgrep-php/php.lang.security.eval-use");
+        assert_eq!(findings[0].severity, Severity::High);
+        assert_eq!(findings[0].path.as_deref(), Some(std::path::Path::new("src/handler.php")));
+        assert_eq!(findings[0].line, Some(42));
+        assert_eq!(findings[1].severity, Severity::Low);
+        assert_eq!(findings[1].path, None);
+    }
+
+    #[test]
+    fn sarif_without_runs_is_a_parse_error() {
+        let doc: Value = serde_json::from_str("{}").unwrap();
+        assert!(matches!(parse_sarif(&doc), Err(AnalyzerError::Parse(_))));
+    }
+}

--- a/crates/ephpm-analyze/src/analyzers/tool.rs
+++ b/crates/ephpm-analyze/src/analyzers/tool.rs
@@ -1,0 +1,158 @@
+//! Shared subprocess runner for the external-tool analyzers.
+//!
+//! Responsibilities the individual analyzers must not re-implement:
+//!
+//! - **Absence detection**: a binary not on `PATH` maps to
+//!   [`AnalyzerError::Skipped`], never a crash — the graceful-degradation
+//!   half of the fail-closed model.
+//! - **Timeout enforcement**: a tool exceeding `analyzers.tool_timeout_ms`
+//!   is killed and reported as [`AnalyzerError::Timeout`] (which gates).
+//! - **Windows launcher quirks**: `CreateProcess` resolves `name.exe` but
+//!   not `name.bat`/`name.cmd` (how Composer installs itself on Windows), so
+//!   after a direct spawn fails with `NotFound` the runner searches `PATH`
+//!   for the batch forms and relaunches through `cmd /C` — only with a fully
+//!   resolved path, so a genuine absence still surfaces as `Skipped` rather
+//!   than a locale-dependent `cmd` error string.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::analyzer::AnalyzerError;
+
+/// Captured output of a finished tool.
+pub(crate) struct ToolRun {
+    /// Everything the tool wrote to stdout, lossily decoded.
+    pub stdout: String,
+    /// Everything the tool wrote to stderr, lossily decoded.
+    pub stderr: String,
+    /// The exit code, when the platform reports one.
+    pub exit_code: Option<i32>,
+}
+
+/// Search `PATH` for the first of `names` that exists as a file.
+fn find_in_path(names: &[String]) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        for name in names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Spawn `program` with `args` in `cwd`, or map `NotFound` to `None`.
+fn try_spawn(program: &Path, args: &[&str], cwd: &Path) -> Result<Option<Child>, AnalyzerError> {
+    match Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => Ok(Some(child)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(AnalyzerError::Io(e)),
+    }
+}
+
+/// Run `tool args...` in `cwd` with a wall-clock budget of `timeout_ms`.
+///
+/// # Errors
+///
+/// - [`AnalyzerError::Skipped`] when `tool` is not installed.
+/// - [`AnalyzerError::Timeout`] when the budget is exceeded (the process is
+///   killed first).
+/// - [`AnalyzerError::Io`] for spawn/pipe failures.
+///
+/// A non-zero exit is **not** an error here — several tools (notably
+/// `composer audit`) exit non-zero when they find what they were asked to
+/// find. Callers decide from [`ToolRun::exit_code`] plus output.
+pub(crate) fn run_tool(
+    tool: &str,
+    args: &[&str],
+    cwd: &Path,
+    timeout_ms: u64,
+) -> Result<ToolRun, AnalyzerError> {
+    let mut child = match try_spawn(Path::new(tool), args, cwd)? {
+        Some(child) => child,
+        None => {
+            // Windows: a Composer-style `.bat`/`.cmd` launcher is invisible
+            // to CreateProcess. Resolve it on PATH ourselves and go through
+            // `cmd /C` only when it actually exists.
+            if cfg!(windows) {
+                let batch = find_in_path(&[format!("{tool}.bat"), format!("{tool}.cmd")]);
+                if let Some(batch) = batch {
+                    let mut cmd_args = vec!["/C", batch.to_str().unwrap_or(tool)];
+                    cmd_args.extend_from_slice(args);
+                    match try_spawn(Path::new("cmd"), &cmd_args, cwd)? {
+                        Some(child) => child,
+                        None => {
+                            return Err(AnalyzerError::Skipped(format!(
+                                "`{tool}` not found on PATH"
+                            )));
+                        }
+                    }
+                } else {
+                    return Err(AnalyzerError::Skipped(format!("`{tool}` not found on PATH")));
+                }
+            } else {
+                return Err(AnalyzerError::Skipped(format!("`{tool}` not found on PATH")));
+            }
+        }
+    };
+
+    // Drain stdout/stderr on threads so a chatty tool can't deadlock on a
+    // full pipe while we poll for exit.
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_reader = std::thread::spawn(move || read_all(stdout));
+    let stderr_reader = std::thread::spawn(move || read_all(stderr));
+
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    // Best-effort kill; the process may have just exited.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    // Reader threads finish once the pipes close.
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    return Err(AnalyzerError::Timeout(timeout_ms));
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(e) => return Err(AnalyzerError::Io(e)),
+        }
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    Ok(ToolRun { stdout, stderr, exit_code: status.code() })
+}
+
+fn read_all<R: std::io::Read>(reader: Option<R>) -> String {
+    let mut buf = Vec::new();
+    if let Some(mut reader) = reader {
+        let _ = std::io::Read::read_to_end(&mut reader, &mut buf);
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Trim a stderr blob to a single diagnostic-sized line for error messages.
+pub(crate) fn stderr_excerpt(stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    let first = trimmed.lines().next().unwrap_or_default();
+    let mut excerpt: String = first.chars().take(200).collect();
+    if excerpt.len() < trimmed.len() {
+        excerpt.push('…');
+    }
+    excerpt
+}

--- a/crates/ephpm-analyze/src/analyzers/yara_scan.rs
+++ b/crates/ephpm-analyze/src/analyzers/yara_scan.rs
@@ -1,0 +1,106 @@
+//! `malware-yara` — known-malware scan via YARA rules.
+//!
+//! Wraps the `yara` CLI as a subprocess (an **optional external
+//! dependency**). Two prerequisites, both of whose absence *skips* rather
+//! than fails: the `yara` binary on `PATH`, and a ruleset configured at
+//! `analyzers.yara_rules` (no ruleset ships with ePHPm). Matches are parsed
+//! from the standard `RuleName<space>path` output lines.
+
+use super::tool::{run_tool, stderr_excerpt};
+use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+use crate::finding::{Category, Finding, Severity};
+
+/// See the module docs.
+pub struct MalwareYara;
+
+/// The analyzer's stable id.
+pub const ID: &str = "malware-yara";
+
+/// Parse `yara -r` output (`RuleName /path/to/file` per line).
+fn parse_matches(stdout: &str, root: &std::path::Path) -> Vec<Finding> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let (rule, path) = line.trim_end().split_once(' ')?;
+            if rule.is_empty() || path.is_empty() {
+                return None;
+            }
+            // Report tree-relative paths when the match is inside the root.
+            let rel =
+                std::path::Path::new(path).strip_prefix(root).unwrap_or(std::path::Path::new(path));
+            Some(Finding {
+                rule_id: format!("{ID}/{rule}"),
+                severity: Severity::High,
+                category: Category::Malware,
+                path: Some(rel.to_path_buf()),
+                line: None,
+                message: format!("YARA rule {rule} matched"),
+            })
+        })
+        .collect()
+}
+
+impl Analyzer for MalwareYara {
+    fn id(&self) -> &str {
+        ID
+    }
+
+    fn category(&self) -> Category {
+        Category::Malware
+    }
+
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        let Some(rules) = ctx.config().analyzers.yara_rules.as_ref() else {
+            return Err(AnalyzerError::Skipped(
+                "no ruleset configured (set analyzers.yara_rules)".to_owned(),
+            ));
+        };
+        let rules = if rules.is_absolute() { rules.clone() } else { ctx.root().join(rules) };
+        if !rules.exists() {
+            // A configured-but-missing ruleset is an operator error on a
+            // path that should have worked — fail closed, don't skip.
+            return Err(AnalyzerError::ToolFailed(format!(
+                "configured ruleset {} does not exist",
+                rules.display()
+            )));
+        }
+        let timeout = ctx.config().analyzers.tool_timeout_ms;
+        let rules_arg = rules.to_string_lossy();
+        let root_arg = ctx.root().to_string_lossy();
+        let run = run_tool("yara", &["-r", "-w", &rules_arg, &root_arg], ctx.root(), timeout)?;
+        match run.exit_code {
+            // yara exits 0 whether or not rules matched; matches are on
+            // stdout.
+            Some(0) => Ok(parse_matches(&run.stdout, ctx.root())),
+            code => Err(AnalyzerError::ToolFailed(format!(
+                "yara failed (exit {code:?}): {}",
+                stderr_excerpt(&run.stderr)
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_match_lines_relative_to_root() {
+        let root = std::path::Path::new("/scan/root");
+        let findings = parse_matches(
+            "Php_Webshell /scan/root/uploads/x.php\nEicar_Test /elsewhere/y.bin\n",
+            root,
+        );
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].rule_id, "malware-yara/Php_Webshell");
+        assert_eq!(findings[0].path.as_deref(), Some(std::path::Path::new("uploads/x.php")));
+        assert_eq!(findings[0].severity, Severity::High);
+        // A path outside the root stays as-is.
+        assert_eq!(findings[1].path.as_deref(), Some(std::path::Path::new("/elsewhere/y.bin")));
+    }
+
+    #[test]
+    fn empty_output_means_no_matches() {
+        assert!(parse_matches("", std::path::Path::new("/r")).is_empty());
+    }
+}

--- a/crates/ephpm-analyze/src/config.rs
+++ b/crates/ephpm-analyze/src/config.rs
@@ -1,0 +1,418 @@
+//! `.ephpm-analyze.yml` — the golangci-lint-shaped configuration file.
+//!
+//! Every section is `#[serde(deny_unknown_fields)]`, matching the workspace's
+//! strict-config discipline: an unknown key fails the run naming the key
+//! instead of silently doing nothing (the #429 lesson — a knob an operator
+//! set must never be a no-op). Unlike `ephpm.toml` there is no environment
+//! layer feeding this file, so the **root** is strict too.
+//!
+//! ```yaml
+//! profile: security          # security | none
+//! fail_on: quarantine        # allow | quarantine | deny
+//! output: text               # text | sarif
+//! engine:                    # Phase 4 — parsed but inert today
+//!   detonate: false
+//!   timeout_ms: 30000
+//! analyzers:
+//!   enable: [composer-audit, semgrep-php, malware-yara, dangerous-sinks]
+//!   required: [composer-audit]
+//!   deny_hard: [dangerous-sinks/eval]
+//!   yara_rules: rules/malware.yar
+//!   semgrep_config: p/php
+//!   tool_timeout_ms: 300000
+//! policy:
+//!   quarantine_score: 10
+//!   deny_score: 50
+//! ```
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use anyhow::Context as _;
+use serde::Deserialize;
+
+/// A named preset that supplies the default analyzer set when
+/// `analyzers.enable` is not given explicitly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Profile {
+    /// The Phase-1 security set: `composer-audit`, `semgrep-php`,
+    /// `malware-yara`, `dangerous-sinks`. The default.
+    #[default]
+    Security,
+    /// No analyzers unless `analyzers.enable` lists them explicitly.
+    None,
+}
+
+impl Profile {
+    /// The analyzer ids this profile enables when `analyzers.enable` is not
+    /// set.
+    #[must_use]
+    pub fn default_analyzers(self) -> Vec<String> {
+        match self {
+            Self::Security => vec![
+                "composer-audit".to_owned(),
+                "semgrep-php".to_owned(),
+                "malware-yara".to_owned(),
+                "dangerous-sinks".to_owned(),
+            ],
+            Self::None => Vec::new(),
+        }
+    }
+}
+
+impl FromStr for Profile {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "security" => Ok(Self::Security),
+            "none" => Ok(Self::None),
+            other => anyhow::bail!("unknown profile {other:?} (expected: security, none)"),
+        }
+    }
+}
+
+impl fmt::Display for Profile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Security => "security",
+            Self::None => "none",
+        })
+    }
+}
+
+/// How the final verdict maps to the process exit code (the CI gate).
+///
+/// | value        | behavior                                                  |
+/// |--------------|-----------------------------------------------------------|
+/// | `quarantine` | non-zero exit on `Quarantine` **or** `Deny` (the default) |
+/// | `deny`       | non-zero exit only on `Deny`                              |
+/// | `allow`      | report-only: the verdict never fails the exit code        |
+///
+/// `allow` is deliberately "the gate allows everything" (report-only) rather
+/// than the literal "fail at allow-or-worse", which would fail every run and
+/// mean nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FailOn {
+    /// Report-only — never fail the exit code on the verdict.
+    Allow,
+    /// Fail on `Quarantine` or `Deny`. The default.
+    #[default]
+    Quarantine,
+    /// Fail only on `Deny`.
+    Deny,
+}
+
+impl FromStr for FailOn {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(Self::Allow),
+            "quarantine" => Ok(Self::Quarantine),
+            "deny" => Ok(Self::Deny),
+            other => {
+                anyhow::bail!("unknown fail_on {other:?} (expected: allow, quarantine, deny)")
+            }
+        }
+    }
+}
+
+/// Output format for the analysis report.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    /// Concise human-readable text. The default.
+    #[default]
+    Text,
+    /// SARIF v2.1.0 JSON (one run).
+    Sarif,
+}
+
+impl FromStr for OutputFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(Self::Text),
+            "sarif" => Ok(Self::Sarif),
+            other => anyhow::bail!("unknown output format {other:?} (expected: text, sarif)"),
+        }
+    }
+}
+
+/// `engine:` — the Phase-4 engine-in-the-loop (detonation) section.
+///
+/// **Planned: not yet implemented — parsed but not acted upon.** Both knobs
+/// exist so Phase-4 configs are shaped now; setting either produces a startup
+/// `tracing::warn!` (the workspace's no-silent-no-op rule).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EngineConfig {
+    /// Planned: not yet implemented — parsed but not acted upon. Will opt
+    /// suspicious inputs into sandboxed embedded-PHP evaluation.
+    #[serde(default)]
+    pub detonate: bool,
+    /// Planned: not yet implemented — parsed but not acted upon. Will bound
+    /// each detonation.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+impl EngineConfig {
+    /// `true` when the operator set any Phase-4 knob (used to emit the
+    /// "parsed but inert" warning).
+    #[must_use]
+    pub fn any_set(&self) -> bool {
+        self.detonate || self.timeout_ms.is_some()
+    }
+}
+
+fn default_semgrep_config() -> String {
+    "p/php".to_owned()
+}
+
+/// Default per-tool timeout: 5 minutes.
+fn default_tool_timeout_ms() -> u64 {
+    300_000
+}
+
+/// `analyzers:` — which analyzers run and how strictly.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnalyzersConfig {
+    /// Analyzer ids to run. When omitted, the `profile` supplies the set.
+    /// An unknown id here is a hard configuration error (fail-closed), never
+    /// silently ignored.
+    #[serde(default)]
+    pub enable: Option<Vec<String>>,
+    /// Analyzer ids that must produce a result: a *skip* (tool absent) of a
+    /// required analyzer is upgraded to a failure and floors the verdict at
+    /// `Quarantine`, exactly like an error would. Must be a subset of the
+    /// enabled set.
+    #[serde(default)]
+    pub required: Vec<String>,
+    /// Hard-deny rules: a finding whose `rule_id` equals an entry, or falls
+    /// under an entry as a `/`-separated prefix (e.g. `malware-yara` matches
+    /// `malware-yara/AnyRule`), forces the verdict to `Deny` regardless of
+    /// score.
+    #[serde(default)]
+    pub deny_hard: Vec<String>,
+    /// Path to a YARA ruleset (file or directory index) for `malware-yara`.
+    /// Relative paths resolve against the analyzed root. When unset,
+    /// `malware-yara` is skipped with a diagnostic.
+    #[serde(default)]
+    pub yara_rules: Option<PathBuf>,
+    /// Semgrep config/registry ref passed to `--config`. Default `p/php`.
+    #[serde(default = "default_semgrep_config")]
+    pub semgrep_config: String,
+    /// Wall-clock budget per external tool invocation, in milliseconds. A
+    /// tool exceeding it is killed and the analyzer fails (fail-closed).
+    /// Default 300000 (5 minutes).
+    #[serde(default = "default_tool_timeout_ms")]
+    pub tool_timeout_ms: u64,
+}
+
+impl Default for AnalyzersConfig {
+    fn default() -> Self {
+        Self {
+            enable: None,
+            required: Vec::new(),
+            deny_hard: Vec::new(),
+            yara_rules: None,
+            semgrep_config: default_semgrep_config(),
+            tool_timeout_ms: default_tool_timeout_ms(),
+        }
+    }
+}
+
+fn default_quarantine_score() -> u32 {
+    10
+}
+
+fn default_deny_score() -> u32 {
+    50
+}
+
+/// `policy:` — the tunable thresholds of the weighted-score model.
+///
+/// See `crate::policy` for the full model. Weights per finding severity:
+/// info 0, low 1, medium 4, high 10, critical 40 (critical also hard-denies
+/// on its own, so its weight only matters for reporting).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyConfig {
+    /// Total score at or above which the verdict is at least `Quarantine`.
+    /// Default 10 (one high, or three mediums, ...).
+    #[serde(default = "default_quarantine_score")]
+    pub quarantine_score: u32,
+    /// Total score at or above which the verdict is `Deny`. Default 50.
+    #[serde(default = "default_deny_score")]
+    pub deny_score: u32,
+}
+
+impl Default for PolicyConfig {
+    fn default() -> Self {
+        Self { quarantine_score: default_quarantine_score(), deny_score: default_deny_score() }
+    }
+}
+
+/// The root of `.ephpm-analyze.yml`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnalyzeConfig {
+    /// Named preset supplying the default analyzer set. Default `security`.
+    #[serde(default)]
+    pub profile: Profile,
+    /// Which verdicts fail the exit code. Default `quarantine`.
+    #[serde(default)]
+    pub fail_on: FailOn,
+    /// Report format. Default `text`.
+    #[serde(default)]
+    pub output: OutputFormat,
+    /// Phase-4 engine section (parsed but inert — see [`EngineConfig`]).
+    #[serde(default)]
+    pub engine: EngineConfig,
+    /// Analyzer selection and strictness.
+    #[serde(default)]
+    pub analyzers: AnalyzersConfig,
+    /// Scoring thresholds.
+    #[serde(default)]
+    pub policy: PolicyConfig,
+}
+
+impl AnalyzeConfig {
+    /// Parse a YAML document.
+    ///
+    /// # Errors
+    ///
+    /// On invalid YAML or any unknown key (all sections are strict).
+    pub fn from_yaml(yaml: &str) -> anyhow::Result<Self> {
+        serde_yaml_ng::from_str(yaml).context("invalid .ephpm-analyze.yml")
+    }
+
+    /// Load from a file.
+    ///
+    /// # Errors
+    ///
+    /// On read failure or any parse error from [`AnalyzeConfig::from_yaml`].
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        Self::from_yaml(&text).with_context(|| format!("in {}", path.display()))
+    }
+
+    /// The effective analyzer set: `analyzers.enable` when given, otherwise
+    /// the profile's default set.
+    #[must_use]
+    pub fn enabled_analyzers(&self) -> Vec<String> {
+        self.analyzers.enable.clone().unwrap_or_else(|| self.profile.default_analyzers())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_document_gets_all_defaults() {
+        let cfg = AnalyzeConfig::from_yaml("{}").unwrap();
+        assert_eq!(cfg.profile, Profile::Security);
+        assert_eq!(cfg.fail_on, FailOn::Quarantine);
+        assert_eq!(cfg.output, OutputFormat::Text);
+        assert!(!cfg.engine.detonate);
+        assert_eq!(cfg.policy.quarantine_score, 10);
+        assert_eq!(cfg.policy.deny_score, 50);
+        assert_eq!(
+            cfg.enabled_analyzers(),
+            vec!["composer-audit", "semgrep-php", "malware-yara", "dangerous-sinks"]
+        );
+    }
+
+    #[test]
+    fn full_document_parses() {
+        let cfg = AnalyzeConfig::from_yaml(
+            r"
+profile: none
+fail_on: deny
+output: sarif
+engine:
+  detonate: true
+  timeout_ms: 30000
+analyzers:
+  enable: [dangerous-sinks]
+  required: [dangerous-sinks]
+  deny_hard: [dangerous-sinks/eval]
+  yara_rules: rules/malware.yar
+  semgrep_config: p/security-audit
+  tool_timeout_ms: 60000
+policy:
+  quarantine_score: 5
+  deny_score: 20
+",
+        )
+        .unwrap();
+        assert_eq!(cfg.profile, Profile::None);
+        assert_eq!(cfg.fail_on, FailOn::Deny);
+        assert_eq!(cfg.output, OutputFormat::Sarif);
+        assert!(cfg.engine.detonate);
+        assert_eq!(cfg.engine.timeout_ms, Some(30_000));
+        assert_eq!(cfg.enabled_analyzers(), vec!["dangerous-sinks"]);
+        assert_eq!(cfg.analyzers.required, vec!["dangerous-sinks"]);
+        assert_eq!(cfg.analyzers.deny_hard, vec!["dangerous-sinks/eval"]);
+        assert_eq!(cfg.analyzers.yara_rules.as_deref(), Some(Path::new("rules/malware.yar")));
+        assert_eq!(cfg.analyzers.semgrep_config, "p/security-audit");
+        assert_eq!(cfg.analyzers.tool_timeout_ms, 60_000);
+        assert_eq!(cfg.policy.quarantine_score, 5);
+        assert_eq!(cfg.policy.deny_score, 20);
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected_in_every_section() {
+        // Root and every nested section are strict: a typo'd key must fail
+        // the run naming the key, never silently no-op (#429 discipline).
+        let cases = [
+            ("root", "does_not_exist: 1"),
+            ("engine", "engine:\n  detonate_all: true"),
+            ("analyzers", "analyzers:\n  enabled: [x]"), // common typo of `enable`
+            ("policy", "policy:\n  deny_treshold: 1"),
+        ];
+        for (section, yaml) in cases {
+            let err = AnalyzeConfig::from_yaml(yaml)
+                .expect_err(&format!("unknown key in {section} must be rejected"));
+            let msg = format!("{err:#}");
+            assert!(msg.contains("unknown field"), "{section}: {msg}");
+        }
+    }
+
+    #[test]
+    fn none_profile_enables_nothing() {
+        let cfg = AnalyzeConfig::from_yaml("profile: none").unwrap();
+        assert!(cfg.enabled_analyzers().is_empty());
+    }
+
+    #[test]
+    fn explicit_enable_overrides_profile() {
+        let cfg =
+            AnalyzeConfig::from_yaml("profile: security\nanalyzers:\n  enable: [dangerous-sinks]")
+                .unwrap();
+        assert_eq!(cfg.enabled_analyzers(), vec!["dangerous-sinks"]);
+    }
+
+    #[test]
+    fn from_str_parsers_cover_all_values() {
+        assert_eq!("security".parse::<Profile>().unwrap(), Profile::Security);
+        assert_eq!("none".parse::<Profile>().unwrap(), Profile::None);
+        assert!("prod".parse::<Profile>().is_err());
+        assert_eq!("allow".parse::<FailOn>().unwrap(), FailOn::Allow);
+        assert_eq!("quarantine".parse::<FailOn>().unwrap(), FailOn::Quarantine);
+        assert_eq!("deny".parse::<FailOn>().unwrap(), FailOn::Deny);
+        assert!("block".parse::<FailOn>().is_err());
+        assert_eq!("text".parse::<OutputFormat>().unwrap(), OutputFormat::Text);
+        assert_eq!("sarif".parse::<OutputFormat>().unwrap(), OutputFormat::Sarif);
+        assert!("json".parse::<OutputFormat>().is_err());
+    }
+}

--- a/crates/ephpm-analyze/src/finding.rs
+++ b/crates/ephpm-analyze/src/finding.rs
@@ -1,0 +1,97 @@
+//! The `Finding` record every analyzer produces, plus its `Severity` and
+//! `Category` axes.
+//!
+//! A finding is deliberately flat and analyzer-agnostic: the policy engine
+//! (`crate::policy`) and both output formats (`crate::output`) consume only
+//! this shape, so a future opcode or engine-in-the-loop analyzer plugs in by
+//! producing the same records — nothing downstream changes.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// How bad a single finding is, ordered from least to most severe.
+///
+/// The ordering is load-bearing: `Severity` derives `Ord` and the policy
+/// engine compares severities directly (`Critical` hard-denies, and each
+/// level maps to a score weight — see `crate::policy` for the model).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// Informational — never gates on its own (score weight 0).
+    Info,
+    /// Low severity (score weight 1).
+    Low,
+    /// Medium severity (score weight 4).
+    Medium,
+    /// High severity (score weight 10).
+    High,
+    /// Critical severity — a single critical finding is an automatic
+    /// [`crate::policy::Verdict::Deny`].
+    Critical,
+}
+
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Info => "info",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        };
+        f.write_str(s)
+    }
+}
+
+/// What kind of problem a finding (or an analyzer as a whole) describes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Category {
+    /// Vulnerabilities and insecure code patterns.
+    Security,
+    /// Correctness / robustness problems that are not directly exploitable.
+    Quality,
+    /// Formatting and stylistic conventions.
+    Style,
+    /// Dependency-chain problems (known advisories, abandoned packages).
+    SupplyChain,
+    /// Known-malicious content (e.g. YARA rule matches).
+    Malware,
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Security => "security",
+            Self::Quality => "quality",
+            Self::Style => "style",
+            Self::SupplyChain => "supply-chain",
+            Self::Malware => "malware",
+        };
+        f.write_str(s)
+    }
+}
+
+/// One result produced by an analyzer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    /// Stable rule identifier, namespaced by analyzer id — e.g.
+    /// `dangerous-sinks/eval` or `composer-audit/CVE-2024-1234`. This is the
+    /// key `analyzers.deny_hard` entries match against.
+    pub rule_id: String,
+    /// How severe the finding is.
+    pub severity: Severity,
+    /// What kind of problem it is.
+    pub category: Category,
+    /// File the finding points at, relative to the analyzed root when the
+    /// producing analyzer can express it that way. `None` for findings with
+    /// no file anchor (e.g. a dependency advisory when no lockfile path is
+    /// meaningful).
+    pub path: Option<PathBuf>,
+    /// 1-based line number within `path`, when known.
+    pub line: Option<u64>,
+    /// Human-readable description.
+    pub message: String,
+}

--- a/crates/ephpm-analyze/src/lib.rs
+++ b/crates/ephpm-analyze/src/lib.rs
@@ -1,0 +1,302 @@
+//! ephpm-analyze — static-analysis aggregator and fail-closed deploy gate
+//! for PHP applications (`ephpm analyze`).
+//!
+//! # Architecture (Phase 1)
+//!
+//! ```text
+//!   .ephpm-analyze.yml ──► AnalyzeConfig ──► AnalysisCtx
+//!                                               │
+//!                     ┌─────────────────────────┼──────────────┐
+//!                     ▼                         ▼              ▼
+//!             external-tool analyzers    native analyzers   (planned:
+//!             composer-audit             dangerous-sinks     opcode/L1,
+//!             semgrep-php                                    engine/L2)
+//!             malware-yara
+//!                     │                         │
+//!                     └────────► Findings ◄─────┘
+//!                                   │
+//!                            policy::decide ──► Verdict ──► exit code
+//!                                   │
+//!                        output::{to_text, to_sarif}
+//! ```
+//!
+//! The aggregator runs every enabled [`Analyzer`], merges their
+//! [`Finding`]s, and hands the lot to the policy engine, which produces a
+//! [`Verdict`] (`Allow` / `Quarantine` / `Deny`). The whole pipeline is
+//! **fail-closed**: an analyzer that errors, times out, panics, or is
+//! `required` but cannot run floors the verdict at `Quarantine` — only a run
+//! where everything that should have spoken actually spoke can `Allow`. An
+//! *optional* analyzer whose external tool is simply not installed is
+//! reported as skipped and does not gate (see [`analyzer::AnalyzerError`]).
+//!
+//! Later phases (opcode-level analysis of compiled PHP, engine-in-the-loop
+//! detonation) slot in as more [`Analyzer`] implementations reading richer
+//! state off [`AnalysisCtx`] — the trait, the finding shape, the policy
+//! engine, and both output formats are already final for them.
+
+pub mod analyzer;
+pub mod analyzers;
+pub mod config;
+pub mod finding;
+pub mod output;
+pub mod policy;
+pub mod report;
+
+use std::path::Path;
+
+use anyhow::Context as _;
+
+pub use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+pub use crate::config::{AnalyzeConfig, FailOn, OutputFormat, Profile};
+pub use crate::finding::{Category, Finding, Severity};
+pub use crate::policy::Verdict;
+pub use crate::report::{AnalysisReport, AnalyzerState, AnalyzerStatus};
+
+/// Run `analyzers` against `ctx`, merge findings, and decide the verdict.
+///
+/// This is the aggregator core, kept separate from [`analyze`] so tests (and
+/// future embedders) can inject their own analyzer set. Fail-closed behavior
+/// implemented here:
+///
+/// - an `Err` other than `Skipped` becomes [`AnalyzerState::Failed`];
+/// - a panic inside an analyzer is caught and becomes `Failed` (an analyzer
+///   bug must gate the run, not crash the gate);
+/// - a `Skipped` analyzer listed in `analyzers.required` is upgraded to
+///   `Failed`;
+/// - any `Failed` analyzer floors the verdict at `Quarantine` (see
+///   [`policy::decide`]).
+#[must_use]
+pub fn run_analyzers(ctx: &AnalysisCtx, analyzers: &[Box<dyn Analyzer>]) -> AnalysisReport {
+    let required = &ctx.config().analyzers.required;
+    let mut findings = Vec::new();
+    let mut statuses = Vec::new();
+
+    for analyzer in analyzers {
+        let id = analyzer.id().to_owned();
+        tracing::debug!(analyzer = %id, "running analyzer");
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| analyzer.run(ctx)));
+        let state = match result {
+            Ok(Ok(mut analyzer_findings)) => {
+                let count = analyzer_findings.len();
+                findings.append(&mut analyzer_findings);
+                AnalyzerState::Completed { findings: count }
+            }
+            Ok(Err(e)) if e.is_skip() && !required.contains(&id) => {
+                tracing::info!(analyzer = %id, reason = %e, "analyzer skipped");
+                AnalyzerState::Skipped { reason: e.to_string() }
+            }
+            Ok(Err(e)) if e.is_skip() => {
+                // Required analyzers must speak: a skip is a failure.
+                tracing::warn!(analyzer = %id, reason = %e, "required analyzer could not run");
+                AnalyzerState::Failed { error: format!("required but could not run — {e}") }
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(analyzer = %id, error = %e, "analyzer failed");
+                AnalyzerState::Failed { error: e.to_string() }
+            }
+            Err(_) => {
+                tracing::error!(analyzer = %id, "analyzer panicked");
+                AnalyzerState::Failed { error: "panicked".to_owned() }
+            }
+        };
+        statuses.push(AnalyzerStatus { id, state });
+    }
+
+    // Most severe first, then stable by rule id for deterministic output.
+    findings.sort_by(|a, b| b.severity.cmp(&a.severity).then_with(|| a.rule_id.cmp(&b.rule_id)));
+
+    let failed: Vec<String> = statuses
+        .iter()
+        .filter(|s| matches!(s.state, AnalyzerState::Failed { .. }))
+        .map(|s| s.id.clone())
+        .collect();
+    let decision = policy::decide(
+        &findings,
+        &ctx.config().analyzers.deny_hard,
+        &failed,
+        ctx.config().policy.quarantine_score,
+        ctx.config().policy.deny_score,
+    );
+
+    AnalysisReport {
+        findings,
+        statuses,
+        verdict: decision.verdict,
+        score: decision.score,
+        reasons: decision.reasons,
+    }
+}
+
+/// Analyze the checkout at `root` with `config`, using the built-in
+/// analyzer registry.
+///
+/// Resolves `analyzers.enable` (or the profile's default set) against the
+/// registry — an unknown analyzer id is a hard error, never silently
+/// ignored, and `analyzers.required` must be a subset of the enabled set.
+///
+/// # Errors
+///
+/// On a missing/non-directory `root`, an unknown analyzer id, or a
+/// `required` entry that is not enabled. Individual analyzer failures do
+/// **not** error — they are folded into the report fail-closed.
+pub fn analyze(root: &Path, config: AnalyzeConfig) -> anyhow::Result<AnalysisReport> {
+    anyhow::ensure!(root.is_dir(), "analysis target {} is not a directory", root.display());
+
+    if config.engine.any_set() {
+        tracing::warn!(
+            "engine.detonate / engine.timeout_ms are parsed but not yet implemented \
+             (engine-in-the-loop analysis is Phase 4) — the settings have no effect"
+        );
+    }
+
+    let mut registry = analyzers::built_in();
+    let enabled = config.enabled_analyzers();
+    let mut selected: Vec<Box<dyn Analyzer>> = Vec::new();
+    for id in &enabled {
+        match registry.iter().position(|a| a.id() == id) {
+            Some(pos) => selected.push(registry.remove(pos)),
+            None if selected.iter().any(|a| a.id() == id) => {
+                anyhow::bail!("analyzer {id:?} is listed twice in analyzers.enable");
+            }
+            None => {
+                let known: Vec<String> =
+                    analyzers::built_in().iter().map(|a| a.id().to_owned()).collect();
+                anyhow::bail!("unknown analyzer {id:?} (known: {})", known.join(", "));
+            }
+        }
+    }
+    for required in &config.analyzers.required {
+        anyhow::ensure!(
+            enabled.contains(required),
+            "analyzers.required lists {required:?}, which is not in the enabled set {enabled:?}"
+        );
+    }
+
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", root.display()))?;
+    let ctx = AnalysisCtx::new(root, config);
+    Ok(run_analyzers(&ctx, &selected))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeAnalyzer {
+        id: &'static str,
+        result: fn() -> Result<Vec<Finding>, AnalyzerError>,
+    }
+
+    impl Analyzer for FakeAnalyzer {
+        fn id(&self) -> &str {
+            self.id
+        }
+        fn category(&self) -> Category {
+            Category::Security
+        }
+        fn run(&self, _ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+            (self.result)()
+        }
+    }
+
+    fn ctx_with(config: AnalyzeConfig) -> AnalysisCtx {
+        AnalysisCtx::new(std::env::temp_dir(), config)
+    }
+
+    #[test]
+    fn erroring_analyzer_quarantines_the_run() {
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(FakeAnalyzer {
+            id: "broken",
+            result: || Err(AnalyzerError::ToolFailed("boom".to_owned())),
+        })];
+        let report = run_analyzers(&ctx_with(AnalyzeConfig::default()), &analyzers);
+        assert_eq!(report.verdict, Verdict::Quarantine);
+        assert_eq!(report.failed_analyzers(), vec!["broken"]);
+    }
+
+    #[test]
+    fn skipped_optional_analyzer_does_not_gate() {
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(FakeAnalyzer {
+            id: "absent",
+            result: || Err(AnalyzerError::Skipped("tool not found".to_owned())),
+        })];
+        let report = run_analyzers(&ctx_with(AnalyzeConfig::default()), &analyzers);
+        assert_eq!(report.verdict, Verdict::Allow);
+        assert!(matches!(report.statuses[0].state, AnalyzerState::Skipped { .. }));
+    }
+
+    #[test]
+    fn skipped_required_analyzer_gates() {
+        let mut config = AnalyzeConfig::default();
+        config.analyzers.required = vec!["absent".to_owned()];
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(FakeAnalyzer {
+            id: "absent",
+            result: || Err(AnalyzerError::Skipped("tool not found".to_owned())),
+        })];
+        let report = run_analyzers(&ctx_with(config), &analyzers);
+        assert_eq!(report.verdict, Verdict::Quarantine);
+        assert!(matches!(report.statuses[0].state, AnalyzerState::Failed { .. }));
+    }
+
+    #[test]
+    fn panicking_analyzer_gates_instead_of_crashing() {
+        let analyzers: Vec<Box<dyn Analyzer>> =
+            vec![Box::new(FakeAnalyzer { id: "buggy", result: || panic!("bug") })];
+        let report = run_analyzers(&ctx_with(AnalyzeConfig::default()), &analyzers);
+        assert_eq!(report.verdict, Verdict::Quarantine);
+    }
+
+    #[test]
+    fn findings_sorted_most_severe_first() {
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(FakeAnalyzer {
+            id: "multi",
+            result: || {
+                Ok(vec![
+                    Finding {
+                        rule_id: "multi/low".to_owned(),
+                        severity: Severity::Low,
+                        category: Category::Quality,
+                        path: None,
+                        line: None,
+                        message: "l".to_owned(),
+                    },
+                    Finding {
+                        rule_id: "multi/high".to_owned(),
+                        severity: Severity::High,
+                        category: Category::Security,
+                        path: None,
+                        line: None,
+                        message: "h".to_owned(),
+                    },
+                ])
+            },
+        })];
+        let report = run_analyzers(&ctx_with(AnalyzeConfig::default()), &analyzers);
+        assert_eq!(report.findings[0].rule_id, "multi/high");
+    }
+
+    #[test]
+    fn analyze_rejects_unknown_analyzer_id() {
+        let config = AnalyzeConfig::from_yaml("analyzers:\n  enable: [does-not-exist]").unwrap();
+        let err = analyze(&std::env::temp_dir(), config).unwrap_err();
+        assert!(format!("{err:#}").contains("unknown analyzer"));
+    }
+
+    #[test]
+    fn analyze_rejects_required_not_enabled() {
+        let config = AnalyzeConfig::from_yaml(
+            "analyzers:\n  enable: [dangerous-sinks]\n  required: [malware-yara]",
+        )
+        .unwrap();
+        let err = analyze(&std::env::temp_dir(), config).unwrap_err();
+        assert!(format!("{err:#}").contains("not in the enabled set"));
+    }
+
+    #[test]
+    fn analyze_rejects_missing_root() {
+        let err =
+            analyze(Path::new("Z:/definitely/not/here"), AnalyzeConfig::default()).unwrap_err();
+        assert!(format!("{err:#}").contains("not a directory"));
+    }
+}

--- a/crates/ephpm-analyze/src/output.rs
+++ b/crates/ephpm-analyze/src/output.rs
@@ -1,0 +1,349 @@
+//! Report serializers: SARIF v2.1.0 JSON and the concise human text form.
+//!
+//! Both render the same [`AnalysisReport`]; selection is `output:` in the
+//! config or `--format` on the CLI.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use serde::Serialize;
+
+use crate::finding::{Finding, Severity};
+use crate::report::{AnalysisReport, AnalyzerState};
+
+/// SARIF `level` for a severity.
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Info | Severity::Low => "note",
+        Severity::Medium => "warning",
+        Severity::High | Severity::Critical => "error",
+    }
+}
+
+#[derive(Serialize)]
+struct Sarif {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+    invocations: Vec<SarifInvocation>,
+    properties: SarifRunProperties,
+}
+
+#[derive(Serialize)]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Serialize)]
+struct SarifDriver {
+    name: &'static str,
+    #[serde(rename = "informationUri")]
+    information_uri: &'static str,
+    version: &'static str,
+    rules: Vec<SarifRule>,
+}
+
+#[derive(Serialize)]
+struct SarifRule {
+    id: String,
+}
+
+#[derive(Serialize)]
+struct SarifInvocation {
+    #[serde(rename = "executionSuccessful")]
+    execution_successful: bool,
+    #[serde(rename = "toolExecutionNotifications")]
+    tool_execution_notifications: Vec<SarifNotification>,
+}
+
+#[derive(Serialize)]
+struct SarifNotification {
+    level: &'static str,
+    message: SarifMessage,
+}
+
+#[derive(Serialize)]
+struct SarifRunProperties {
+    /// The gate's verdict, so CI consumers reading only the SARIF still see
+    /// the decision.
+    #[serde(rename = "ephpm/verdict")]
+    verdict: String,
+    #[serde(rename = "ephpm/score")]
+    score: u32,
+}
+
+#[derive(Serialize)]
+struct SarifResult {
+    #[serde(rename = "ruleId")]
+    rule_id: String,
+    level: &'static str,
+    message: SarifMessage,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    locations: Vec<SarifLocation>,
+    properties: SarifResultProperties,
+}
+
+#[derive(Serialize)]
+struct SarifResultProperties {
+    #[serde(rename = "ephpm/severity")]
+    severity: String,
+    #[serde(rename = "ephpm/category")]
+    category: String,
+}
+
+#[derive(Serialize)]
+struct SarifMessage {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Serialize)]
+struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    artifact_location: SarifArtifactLocation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    region: Option<SarifRegion>,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Serialize)]
+struct SarifRegion {
+    #[serde(rename = "startLine")]
+    start_line: u64,
+}
+
+fn sarif_result(finding: &Finding) -> SarifResult {
+    let locations = finding
+        .path
+        .as_ref()
+        .map(|path| {
+            vec![SarifLocation {
+                physical_location: SarifPhysicalLocation {
+                    artifact_location: SarifArtifactLocation {
+                        // SARIF wants a URI; forward slashes regardless of
+                        // host platform.
+                        uri: path.to_string_lossy().replace('\\', "/"),
+                    },
+                    region: finding.line.map(|line| SarifRegion { start_line: line }),
+                },
+            }]
+        })
+        .unwrap_or_default();
+    SarifResult {
+        rule_id: finding.rule_id.clone(),
+        level: sarif_level(finding.severity),
+        message: SarifMessage { text: finding.message.clone() },
+        locations,
+        properties: SarifResultProperties {
+            severity: finding.severity.to_string(),
+            category: finding.category.to_string(),
+        },
+    }
+}
+
+/// Render the report as a SARIF v2.1.0 document (one run).
+///
+/// Skipped analyzers surface as `note` tool-execution notifications and
+/// failed analyzers as `error` notifications with
+/// `executionSuccessful: false`, so the fail-closed situation is visible in
+/// SARIF-only consumers too.
+///
+/// # Errors
+///
+/// Only on JSON serialization failure, which for this fully in-memory shape
+/// would indicate a bug.
+pub fn to_sarif(report: &AnalysisReport) -> anyhow::Result<String> {
+    let rules: BTreeSet<&str> = report.findings.iter().map(|f| f.rule_id.as_str()).collect();
+    let mut notifications = Vec::new();
+    let mut execution_successful = true;
+    for status in &report.statuses {
+        match &status.state {
+            AnalyzerState::Completed { .. } => {}
+            AnalyzerState::Skipped { reason } => notifications.push(SarifNotification {
+                level: "note",
+                message: SarifMessage { text: format!("analyzer {} skipped: {reason}", status.id) },
+            }),
+            AnalyzerState::Failed { error } => {
+                execution_successful = false;
+                notifications.push(SarifNotification {
+                    level: "error",
+                    message: SarifMessage {
+                        text: format!("analyzer {} failed: {error}", status.id),
+                    },
+                });
+            }
+        }
+    }
+    let doc = Sarif {
+        schema: "https://json.schemastore.org/sarif-2.1.0.json",
+        version: "2.1.0",
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: SarifDriver {
+                    name: "ephpm-analyze",
+                    information_uri: "https://github.com/ephpm/ephpm",
+                    version: env!("CARGO_PKG_VERSION"),
+                    rules: rules.into_iter().map(|id| SarifRule { id: id.to_owned() }).collect(),
+                },
+            },
+            results: report.findings.iter().map(sarif_result).collect(),
+            invocations: vec![SarifInvocation {
+                execution_successful,
+                tool_execution_notifications: notifications,
+            }],
+            properties: SarifRunProperties {
+                verdict: report.verdict.to_string(),
+                score: report.score,
+            },
+        }],
+    };
+    Ok(serde_json::to_string_pretty(&doc)?)
+}
+
+/// Render the report as concise human-readable text.
+#[must_use]
+pub fn to_text(report: &AnalysisReport) -> String {
+    let mut out = String::new();
+    for status in &report.statuses {
+        match &status.state {
+            AnalyzerState::Completed { findings } => {
+                let _ = writeln!(out, "  {:<16} completed ({findings} finding(s))", status.id);
+            }
+            AnalyzerState::Skipped { reason } => {
+                let _ = writeln!(out, "  {:<16} skipped: {reason}", status.id);
+            }
+            AnalyzerState::Failed { error } => {
+                let _ = writeln!(out, "  {:<16} FAILED: {error}", status.id);
+            }
+        }
+    }
+    if !report.findings.is_empty() {
+        let _ = writeln!(out);
+    }
+    for finding in &report.findings {
+        let location = match (&finding.path, finding.line) {
+            (Some(path), Some(line)) => format!("{}:{line}", path.display()),
+            (Some(path), None) => path.display().to_string(),
+            _ => "-".to_owned(),
+        };
+        let _ = writeln!(
+            out,
+            "  [{:<8}] {:<32} {location}: {}",
+            finding.severity, finding.rule_id, finding.message
+        );
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(out, "score:   {}", report.score);
+    let _ = writeln!(out, "verdict: {}", report.verdict);
+    for reason in &report.reasons {
+        let _ = writeln!(out, "  - {reason}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::finding::Category;
+    use crate::policy::Verdict;
+    use crate::report::AnalyzerStatus;
+
+    fn sample_report() -> AnalysisReport {
+        AnalysisReport {
+            findings: vec![
+                Finding {
+                    rule_id: "dangerous-sinks/eval".to_owned(),
+                    severity: Severity::High,
+                    category: Category::Security,
+                    path: Some(PathBuf::from("src\\index.php")),
+                    line: Some(12),
+                    message: "eval() call".to_owned(),
+                },
+                Finding {
+                    rule_id: "composer-audit/CVE-2024-1".to_owned(),
+                    severity: Severity::Medium,
+                    category: Category::SupplyChain,
+                    path: None,
+                    line: None,
+                    message: "vulnerable dependency".to_owned(),
+                },
+            ],
+            statuses: vec![
+                AnalyzerStatus {
+                    id: "dangerous-sinks".to_owned(),
+                    state: AnalyzerState::Completed { findings: 1 },
+                },
+                AnalyzerStatus {
+                    id: "malware-yara".to_owned(),
+                    state: AnalyzerState::Skipped { reason: "yara not found".to_owned() },
+                },
+                AnalyzerStatus {
+                    id: "semgrep-php".to_owned(),
+                    state: AnalyzerState::Failed { error: "timed out".to_owned() },
+                },
+            ],
+            verdict: Verdict::Quarantine,
+            score: 14,
+            reasons: vec!["score 14 >= quarantine threshold 10".to_owned()],
+        }
+    }
+
+    #[test]
+    fn sarif_has_required_shape() {
+        let json: serde_json::Value =
+            serde_json::from_str(&to_sarif(&sample_report()).unwrap()).unwrap();
+        assert_eq!(json["version"], "2.1.0");
+        let run = &json["runs"][0];
+        assert_eq!(run["tool"]["driver"]["name"], "ephpm-analyze");
+        let results = run["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        // High -> error, backslashes normalized to URI form.
+        assert_eq!(results[0]["ruleId"], "dangerous-sinks/eval");
+        assert_eq!(results[0]["level"], "error");
+        let loc = &results[0]["locations"][0]["physicalLocation"];
+        assert_eq!(loc["artifactLocation"]["uri"], "src/index.php");
+        assert_eq!(loc["region"]["startLine"], 12);
+        // Pathless finding has no locations key at all.
+        assert!(results[1].get("locations").is_none());
+        assert_eq!(results[1]["level"], "warning");
+        // Rule index covers both rule ids.
+        let rules = run["tool"]["driver"]["rules"].as_array().unwrap();
+        assert_eq!(rules.len(), 2);
+        // Verdict rides in run properties; failed analyzer flips
+        // executionSuccessful and produces an error notification.
+        assert_eq!(run["properties"]["ephpm/verdict"], "quarantine");
+        let invocation = &run["invocations"][0];
+        assert_eq!(invocation["executionSuccessful"], false);
+        let notes = invocation["toolExecutionNotifications"].as_array().unwrap();
+        assert_eq!(notes.len(), 2);
+    }
+
+    #[test]
+    fn text_reports_statuses_findings_and_verdict() {
+        let text = to_text(&sample_report());
+        assert!(text.contains("dangerous-sinks"));
+        assert!(text.contains("skipped: yara not found"));
+        assert!(text.contains("FAILED: timed out"));
+        assert!(text.contains("verdict: quarantine"));
+        assert!(text.contains("score:   14"));
+        assert!(text.contains("quarantine threshold"));
+    }
+}

--- a/crates/ephpm-analyze/src/policy.rs
+++ b/crates/ephpm-analyze/src/policy.rs
@@ -1,0 +1,238 @@
+//! The policy engine: merged findings + analyzer outcomes → a [`Verdict`].
+//!
+//! # The model
+//!
+//! Three layers, evaluated strictest-first; the verdict is the **maximum**
+//! any layer demands (verdicts are ordered `Allow < Quarantine < Deny`):
+//!
+//! 1. **Hard denies.** A finding whose `rule_id` matches an
+//!    `analyzers.deny_hard` entry (exact, or under it as a `/`-prefix), or
+//!    any finding of `Critical` severity, forces `Deny` outright. No score
+//!    can talk its way past these.
+//! 2. **Fail-closed floor.** Any analyzer *failure* — a tool error, timeout,
+//!    unparseable output, or a `required` analyzer that could not run —
+//!    floors the verdict at `Quarantine`. An analyzer that errored might
+//!    have been about to find something, so the result can never be `Allow`.
+//!    A plain skip (optional tool absent) does **not** floor; it is surfaced
+//!    as a diagnostic instead.
+//! 3. **Weighted score.** Each finding contributes a weight by severity —
+//!    info 0, low 1, medium 4, high 10, critical 40 — and the total is
+//!    compared against the tunable `policy.quarantine_score` (default 10)
+//!    and `policy.deny_score` (default 50) thresholds. The weights are
+//!    deliberately super-additive (one high > two mediums > eight lows) so
+//!    volume of noise cannot outrank a single serious finding class, while a
+//!    large pile of mediums still escalates.
+//!
+//! The returned [`PolicyDecision`] carries human-readable reasons for every
+//! layer that fired, so the text output can say *why* a run gated.
+
+use crate::finding::{Finding, Severity};
+
+/// The gate's final decision for a run, ordered least to most severe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+    /// Nothing gate-worthy found.
+    Allow,
+    /// Needs human review before deploy — findings crossed the quarantine
+    /// threshold, or an analyzer failed (fail-closed).
+    Quarantine,
+    /// Hard stop — a hard-deny rule fired, a critical finding exists, or the
+    /// score crossed the deny threshold.
+    Deny,
+}
+
+impl std::fmt::Display for Verdict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Allow => "allow",
+            Self::Quarantine => "quarantine",
+            Self::Deny => "deny",
+        })
+    }
+}
+
+/// A verdict plus the evidence that produced it.
+#[derive(Debug, Clone)]
+pub struct PolicyDecision {
+    /// The final verdict (already the max across all layers).
+    pub verdict: Verdict,
+    /// The weighted score across all findings.
+    pub score: u32,
+    /// One line per layer that fired, for the report.
+    pub reasons: Vec<String>,
+}
+
+/// Score weight per severity — see the module docs for why super-additive.
+#[must_use]
+pub fn severity_weight(severity: Severity) -> u32 {
+    match severity {
+        Severity::Info => 0,
+        Severity::Low => 1,
+        Severity::Medium => 4,
+        Severity::High => 10,
+        Severity::Critical => 40,
+    }
+}
+
+/// `true` when `rule_id` matches a `deny_hard` entry: exact, or falling
+/// under the entry as a `/`-separated prefix (`malware-yara` matches
+/// `malware-yara/AnyRule` but not `malware-yara2/x`).
+#[must_use]
+pub fn deny_hard_matches(entry: &str, rule_id: &str) -> bool {
+    rule_id == entry
+        || (rule_id.len() > entry.len()
+            && rule_id.starts_with(entry)
+            && rule_id.as_bytes()[entry.len()] == b'/')
+}
+
+/// Evaluate the policy over merged findings.
+///
+/// `failed_analyzers` lists the analyzers that errored (or were required and
+/// could not run) — a non-empty list floors the verdict at `Quarantine`.
+#[must_use]
+pub fn decide(
+    findings: &[Finding],
+    deny_hard: &[String],
+    failed_analyzers: &[String],
+    quarantine_score: u32,
+    deny_score: u32,
+) -> PolicyDecision {
+    let mut reasons = Vec::new();
+    let mut verdict = Verdict::Allow;
+
+    // Layer 1: hard denies.
+    for finding in findings {
+        if let Some(entry) = deny_hard.iter().find(|e| deny_hard_matches(e, &finding.rule_id)) {
+            verdict = Verdict::Deny;
+            reasons.push(format!(
+                "hard deny: finding {} matches deny_hard entry {entry:?}",
+                finding.rule_id
+            ));
+        }
+    }
+    if let Some(critical) = findings.iter().find(|f| f.severity == Severity::Critical) {
+        verdict = Verdict::Deny;
+        reasons.push(format!("hard deny: critical finding {}", critical.rule_id));
+    }
+
+    // Layer 2: fail-closed floor.
+    if !failed_analyzers.is_empty() {
+        verdict = verdict.max(Verdict::Quarantine);
+        reasons.push(format!(
+            "fail-closed: analyzer(s) failed: {} — result cannot be allow",
+            failed_analyzers.join(", ")
+        ));
+    }
+
+    // Layer 3: weighted score.
+    let score: u32 = findings.iter().map(|f| severity_weight(f.severity)).sum();
+    if score >= deny_score {
+        verdict = Verdict::Deny;
+        reasons.push(format!("score {score} >= deny threshold {deny_score}"));
+    } else if score >= quarantine_score {
+        verdict = verdict.max(Verdict::Quarantine);
+        reasons.push(format!("score {score} >= quarantine threshold {quarantine_score}"));
+    }
+
+    PolicyDecision { verdict, score, reasons }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::finding::Category;
+
+    fn finding(rule_id: &str, severity: Severity) -> Finding {
+        Finding {
+            rule_id: rule_id.to_owned(),
+            severity,
+            category: Category::Security,
+            path: Some(PathBuf::from("index.php")),
+            line: Some(1),
+            message: "test".to_owned(),
+        }
+    }
+
+    #[test]
+    fn clean_run_allows() {
+        let d = decide(&[], &[], &[], 10, 50);
+        assert_eq!(d.verdict, Verdict::Allow);
+        assert_eq!(d.score, 0);
+        assert!(d.reasons.is_empty());
+    }
+
+    #[test]
+    fn deny_hard_rule_id_forces_deny_even_for_info() {
+        let f = [finding("dangerous-sinks/eval", Severity::Info)];
+        let d = decide(&f, &["dangerous-sinks/eval".to_owned()], &[], 10, 50);
+        assert_eq!(d.verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn deny_hard_prefix_matches_analyzer_namespace() {
+        assert!(deny_hard_matches("malware-yara", "malware-yara/EvilRule"));
+        assert!(deny_hard_matches("malware-yara/EvilRule", "malware-yara/EvilRule"));
+        assert!(!deny_hard_matches("malware-yara", "malware-yara2/x"));
+        assert!(!deny_hard_matches("malware-yara/Evil", "malware-yara/EvilRule"));
+    }
+
+    #[test]
+    fn critical_finding_forces_deny() {
+        let f = [finding("composer-audit/CVE-2024-1", Severity::Critical)];
+        let d = decide(&f, &[], &[], 10, 50);
+        assert_eq!(d.verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn analyzer_failure_floors_at_quarantine_with_zero_findings() {
+        // The heart of fail-closed: no findings at all, but an analyzer
+        // errored — the result must never be Allow.
+        let d = decide(&[], &[], &["semgrep-php".to_owned()], 10, 50);
+        assert_eq!(d.verdict, Verdict::Quarantine);
+    }
+
+    #[test]
+    fn analyzer_failure_does_not_downgrade_a_deny() {
+        let f = [finding("x/critical", Severity::Critical)];
+        let d = decide(&f, &[], &["semgrep-php".to_owned()], 10, 50);
+        assert_eq!(d.verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn score_thresholds_escalate() {
+        // 2 mediums = 8 < 10 -> allow
+        let f = [finding("a/1", Severity::Medium), finding("a/2", Severity::Medium)];
+        assert_eq!(decide(&f, &[], &[], 10, 50).verdict, Verdict::Allow);
+
+        // 1 high = 10 >= 10 -> quarantine
+        let f = [finding("a/1", Severity::High)];
+        let d = decide(&f, &[], &[], 10, 50);
+        assert_eq!(d.verdict, Verdict::Quarantine);
+        assert_eq!(d.score, 10);
+
+        // 5 highs = 50 >= 50 -> deny
+        let f: Vec<_> = (0..5).map(|i| finding(&format!("a/{i}"), Severity::High)).collect();
+        assert_eq!(decide(&f, &[], &[], 10, 50).verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn info_findings_never_gate() {
+        let f: Vec<_> = (0..1000).map(|i| finding(&format!("a/{i}"), Severity::Info)).collect();
+        let d = decide(&f, &[], &[], 10, 50);
+        assert_eq!(d.verdict, Verdict::Allow);
+        assert_eq!(d.score, 0);
+    }
+
+    #[test]
+    fn reasons_explain_every_fired_layer() {
+        let f = [finding("x/crit", Severity::Critical)];
+        let d = decide(&f, &["x/crit".to_owned()], &["yara".to_owned()], 10, 50);
+        assert_eq!(d.verdict, Verdict::Deny);
+        assert!(d.reasons.iter().any(|r| r.contains("deny_hard")));
+        assert!(d.reasons.iter().any(|r| r.contains("critical")));
+        assert!(d.reasons.iter().any(|r| r.contains("fail-closed")));
+    }
+}

--- a/crates/ephpm-analyze/src/report.rs
+++ b/crates/ephpm-analyze/src/report.rs
@@ -1,0 +1,63 @@
+//! The aggregated result of one analysis run: merged findings, per-analyzer
+//! outcomes, and the policy decision.
+
+use crate::finding::Finding;
+use crate::policy::Verdict;
+
+/// How one analyzer ended.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnalyzerState {
+    /// Ran to completion (possibly with zero findings).
+    Completed {
+        /// Number of findings this analyzer contributed.
+        findings: usize,
+    },
+    /// Could not run here (tool or inputs absent) and was not required —
+    /// surfaced as a diagnostic, does not gate.
+    Skipped {
+        /// Why it was skipped.
+        reason: String,
+    },
+    /// Errored, timed out, or was required but could not run — trips the
+    /// fail-closed quarantine floor.
+    Failed {
+        /// The error, rendered.
+        error: String,
+    },
+}
+
+/// One analyzer's outcome within a run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyzerStatus {
+    /// The analyzer's stable id.
+    pub id: String,
+    /// How it ended.
+    pub state: AnalyzerState,
+}
+
+/// Everything one `ephpm analyze` run produced.
+#[derive(Debug, Clone)]
+pub struct AnalysisReport {
+    /// All findings across all analyzers, sorted most severe first.
+    pub findings: Vec<Finding>,
+    /// Per-analyzer outcome, in execution order.
+    pub statuses: Vec<AnalyzerStatus>,
+    /// The gate's decision.
+    pub verdict: Verdict,
+    /// The weighted score (see `crate::policy` for the model).
+    pub score: u32,
+    /// Why the verdict is what it is — one line per policy layer that fired.
+    pub reasons: Vec<String>,
+}
+
+impl AnalysisReport {
+    /// Ids of analyzers whose state is [`AnalyzerState::Failed`].
+    #[must_use]
+    pub fn failed_analyzers(&self) -> Vec<&str> {
+        self.statuses
+            .iter()
+            .filter(|s| matches!(s.state, AnalyzerState::Failed { .. }))
+            .map(|s| s.id.as_str())
+            .collect()
+    }
+}

--- a/crates/ephpm-analyze/tests/analyze_e2e.rs
+++ b/crates/ephpm-analyze/tests/analyze_e2e.rs
@@ -1,0 +1,155 @@
+//! End-to-end aggregator tests over a real fixture directory, using the
+//! native `dangerous-sinks` analyzer (zero external dependencies) plus a
+//! faked external analyzer, so the whole pipeline — config → ctx → analyzers
+//! → policy → output — runs without composer/semgrep/yara installed.
+//!
+//! NOTE for maintainers: the on-disk PHP fixtures deliberately use the
+//! `assert` sink, not `eval`/`system`. Endpoint antivirus quarantines files
+//! (including THIS source file, and the temp fixtures the tests write)
+//! whose bytes look like a PHP webshell, and that broke the build once
+//! already. `assert(` is one of the analyzer's sinks and is AV-benign.
+
+use std::fs;
+
+use ephpm_analyze::{
+    AnalysisCtx, AnalyzeConfig, Analyzer, AnalyzerError, AnalyzerState, Category, Finding,
+    Severity, Verdict, analyze, analyzers, output, run_analyzers,
+};
+
+/// Build a small PHP project fixture with one `assert($cond)` sink call.
+fn fixture() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("src/upload.php"), "<?php\n// handler\nassert($cond);\n").unwrap();
+    fs::write(dir.path().join("src/clean.php"), "<?php\necho 'hello';\n").unwrap();
+    fs::write(dir.path().join("notes.txt"), "assert(this is not php)\n").unwrap();
+    dir
+}
+
+#[test]
+fn native_stub_finds_sink_in_fixture_and_quarantines() {
+    let dir = fixture();
+    // quarantine_score lowered to 4 so the single medium finding (weight 4)
+    // crosses it — also exercises threshold tunability end to end.
+    let config = AnalyzeConfig::from_yaml(
+        "analyzers:\n  enable: [dangerous-sinks]\npolicy:\n  quarantine_score: 4",
+    )
+    .unwrap();
+    let report = analyze(dir.path(), config).expect("analysis runs");
+
+    // Exactly one finding: the assert() in upload.php (the .txt is ignored).
+    assert_eq!(report.findings.len(), 1, "{:?}", report.findings);
+    let finding = &report.findings[0];
+    assert_eq!(finding.rule_id, "dangerous-sinks/assert");
+    assert_eq!(finding.severity, Severity::Medium);
+    assert_eq!(finding.line, Some(3));
+    let path = finding.path.as_ref().unwrap().to_string_lossy().replace('\\', "/");
+    assert_eq!(path, "src/upload.php");
+
+    assert_eq!(report.score, 4);
+    assert_eq!(report.verdict, Verdict::Quarantine);
+
+    // Both output formats render it.
+    let text = output::to_text(&report);
+    assert!(text.contains("dangerous-sinks/assert"));
+    assert!(text.contains("verdict: quarantine"));
+    let sarif: serde_json::Value =
+        serde_json::from_str(&output::to_sarif(&report).unwrap()).unwrap();
+    assert_eq!(sarif["runs"][0]["results"][0]["ruleId"], "dangerous-sinks/assert");
+}
+
+#[test]
+fn default_thresholds_let_a_single_medium_pass() {
+    // Same fixture, default thresholds: one medium (4) < quarantine (10).
+    let dir = fixture();
+    let config = AnalyzeConfig::from_yaml("analyzers:\n  enable: [dangerous-sinks]").unwrap();
+    let report = analyze(dir.path(), config).expect("analysis runs");
+    assert_eq!(report.score, 4);
+    assert_eq!(report.verdict, Verdict::Allow);
+}
+
+#[test]
+fn deny_hard_escalates_the_same_fixture_to_deny() {
+    let dir = fixture();
+    let config = AnalyzeConfig::from_yaml(
+        "analyzers:\n  enable: [dangerous-sinks]\n  deny_hard: [dangerous-sinks/assert]",
+    )
+    .unwrap();
+    let report = analyze(dir.path(), config).expect("analysis runs");
+    assert_eq!(report.verdict, Verdict::Deny);
+    assert!(report.reasons.iter().any(|r| r.contains("deny_hard")));
+}
+
+#[test]
+fn clean_tree_allows() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("index.php"), "<?php\necho 'ok';\n").unwrap();
+    let config = AnalyzeConfig::from_yaml("analyzers:\n  enable: [dangerous-sinks]").unwrap();
+    let report = analyze(dir.path(), config).expect("analysis runs");
+    assert!(report.findings.is_empty());
+    assert_eq!(report.verdict, Verdict::Allow);
+}
+
+/// A fake "external tool" analyzer whose tool always explodes — standing in
+/// for composer/semgrep/yara erroring at runtime.
+struct ExplodingExternal;
+
+impl Analyzer for ExplodingExternal {
+    // The trait fixes the signature; the literal cannot be `&'static str`
+    // here without diverging from it.
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn id(&self) -> &str {
+        "exploding-external"
+    }
+    fn category(&self) -> Category {
+        Category::SupplyChain
+    }
+    fn run(&self, _ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        Err(AnalyzerError::ToolFailed("simulated tool crash".to_owned()))
+    }
+}
+
+#[test]
+fn failing_external_analyzer_fails_closed_alongside_native_findings() {
+    let dir = fixture();
+    let config = AnalyzeConfig::from_yaml("profile: none").unwrap();
+    let ctx = AnalysisCtx::new(dir.path().to_path_buf(), config);
+    let set: Vec<Box<dyn Analyzer>> =
+        vec![Box::new(analyzers::DangerousSinks), Box::new(ExplodingExternal)];
+    let report = run_analyzers(&ctx, &set);
+
+    // Native findings still collected...
+    assert_eq!(report.findings.len(), 1);
+    // ...and the failed external analyzer is recorded and floors the verdict.
+    assert!(
+        report.statuses.iter().any(
+            |s| s.id == "exploding-external" && matches!(s.state, AnalyzerState::Failed { .. })
+        )
+    );
+    assert!(report.verdict >= Verdict::Quarantine);
+    assert!(report.reasons.iter().any(|r| r.contains("fail-closed")));
+}
+
+#[test]
+fn absent_external_tools_skip_but_do_not_gate() {
+    // composer-audit and malware-yara over a tree with no composer.json and
+    // no yara ruleset: both must SKIP (not fail). Their skip conditions are
+    // input-driven and machine-independent, so this holds whether or not the
+    // tools are installed on the host.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("index.php"), "<?php echo 1;\n").unwrap();
+    let config = AnalyzeConfig::from_yaml(
+        "analyzers:\n  enable: [composer-audit, malware-yara, dangerous-sinks]",
+    )
+    .unwrap();
+    let report = analyze(dir.path(), config).expect("analysis runs");
+    for id in ["composer-audit", "malware-yara"] {
+        let status = report.statuses.iter().find(|s| s.id == id).unwrap();
+        assert!(
+            matches!(status.state, AnalyzerState::Skipped { .. }),
+            "{id} should skip, got {:?}",
+            status.state
+        );
+    }
+    assert_eq!(report.verdict, Verdict::Allow);
+}

--- a/crates/ephpm/Cargo.toml
+++ b/crates/ephpm/Cargo.toml
@@ -22,6 +22,7 @@ otlp = ["ephpm-server/otlp"]
 anyhow.workspace = true
 bytes.workspace = true
 clap.workspace = true
+ephpm-analyze.workspace = true
 ephpm-config.workspace = true
 ephpm-db.workspace = true
 ephpm-kv.workspace = true

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -93,6 +93,38 @@ enum Commands {
         verbose: u8,
     },
 
+    /// Statically analyze a PHP application and gate on the verdict
+    ///
+    /// Runs the configured analyzers (external tools wrapped as
+    /// subprocesses, plus native passes) over PATH, merges their findings,
+    /// and applies the fail-closed policy: allow / quarantine / deny. The
+    /// exit code reflects the verdict per `fail_on`, so this works directly
+    /// as a CI or deploy-gate step. Configured by `.ephpm-analyze.yml` in
+    /// the analyzed directory (or `--config`).
+    Analyze {
+        /// Directory to analyze (defaults to the current directory)
+        path: Option<PathBuf>,
+
+        /// Path to the analysis configuration file. Defaults to
+        /// `<PATH>/.ephpm-analyze.yml` when present, else built-in defaults.
+        #[arg(long)]
+        config: Option<PathBuf>,
+
+        /// Output format: text | sarif (overrides the config file)
+        #[arg(long)]
+        format: Option<String>,
+
+        /// Profile preset: security | none (overrides the config file)
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Least severe verdict that fails the exit code:
+        /// allow (report-only) | quarantine | deny (overrides the config
+        /// file)
+        #[arg(long)]
+        fail_on: Option<String>,
+    },
+
     /// Run PHP CLI commands using the embedded PHP runtime
     ///
     /// With `--site` (and `--config`) the in-process `ephpm_db_*` bridge is
@@ -393,6 +425,9 @@ fn run() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
 
     match cli.command {
+        Some(Commands::Analyze { path, config, format, profile, fail_on }) => {
+            run_analyze(path, config, format, profile, fail_on)
+        }
         Some(Commands::Php { config, site, args }) => run_php(config, site, &php_cli_args(&args)),
         Some(Commands::Exec { config, site, timeout, no_sandbox, command }) => {
             ensure_cli_tracing();
@@ -447,6 +482,75 @@ fn run() -> anyhow::Result<ExitCode> {
         None => run_dev(None, None, 8080, None, 0),
         other @ Some(Commands::Serve { .. }) => run_serve_sync(other),
     }
+}
+
+/// `ephpm analyze` — load the config, run the aggregator, print the report,
+/// and map the verdict to the exit code.
+///
+/// Exit codes: `0` when the verdict passes the `fail_on` gate, `2` when a
+/// `quarantine` verdict fails it, `3` when a `deny` verdict fails it, `1`
+/// for internal errors (bad config, unreadable target).
+fn run_analyze(
+    path: Option<PathBuf>,
+    config_path: Option<PathBuf>,
+    format: Option<String>,
+    profile: Option<String>,
+    fail_on: Option<String>,
+) -> anyhow::Result<ExitCode> {
+    use ephpm_analyze::{AnalyzeConfig, FailOn, OutputFormat, Verdict, output};
+
+    ensure_cli_tracing();
+    let root = match path {
+        Some(path) => path,
+        None => std::env::current_dir().context("failed to read current directory")?,
+    };
+
+    let mut config = match config_path {
+        // An explicit --config that doesn't exist is an error (fail-closed),
+        // never silently "defaults".
+        Some(path) => AnalyzeConfig::load(&path)?,
+        None => {
+            let found = [".ephpm-analyze.yml", ".ephpm-analyze.yaml"]
+                .iter()
+                .map(|name| root.join(name))
+                .find(|candidate| candidate.is_file());
+            match found {
+                Some(path) => AnalyzeConfig::load(&path)?,
+                None => AnalyzeConfig::default(),
+            }
+        }
+    };
+
+    // CLI flags override the config file.
+    if let Some(profile) = profile {
+        config.profile = profile.parse()?;
+    }
+    if let Some(fail_on) = fail_on {
+        config.fail_on = fail_on.parse()?;
+    }
+    if let Some(format) = format {
+        config.output = format.parse()?;
+    }
+    let output_format = config.output;
+    let gate = config.fail_on;
+
+    let report = ephpm_analyze::analyze(&root, config)?;
+
+    match output_format {
+        OutputFormat::Sarif => println!("{}", output::to_sarif(&report)?),
+        OutputFormat::Text => print!("{}", output::to_text(&report)),
+    }
+
+    let gated = match gate {
+        FailOn::Allow => false,
+        FailOn::Quarantine => report.verdict >= Verdict::Quarantine,
+        FailOn::Deny => report.verdict >= Verdict::Deny,
+    };
+    Ok(if gated {
+        if report.verdict == Verdict::Deny { ExitCode::from(3) } else { ExitCode::from(2) }
+    } else {
+        ExitCode::SUCCESS
+    })
 }
 
 /// Initialise a small tracing subscriber for service-management commands so
@@ -2315,6 +2419,45 @@ mod php_arg_tests {
         };
         assert!(site.is_none());
         assert_eq!(args, v(&["script.php", "--site", "x"]));
+    }
+
+    #[test]
+    fn analyze_parses_path_and_overrides() {
+        let cli = Cli::try_parse_from([
+            "ephpm",
+            "analyze",
+            "/srv/app",
+            "--config",
+            "gate.yml",
+            "--format",
+            "sarif",
+            "--profile",
+            "security",
+            "--fail-on",
+            "deny",
+        ])
+        .unwrap();
+        let Some(Commands::Analyze { path, config, format, profile, fail_on }) = cli.command else {
+            panic!("expected an analyze command");
+        };
+        assert_eq!(path.as_deref(), Some(std::path::Path::new("/srv/app")));
+        assert_eq!(config.as_deref(), Some(std::path::Path::new("gate.yml")));
+        assert_eq!(format.as_deref(), Some("sarif"));
+        assert_eq!(profile.as_deref(), Some("security"));
+        assert_eq!(fail_on.as_deref(), Some("deny"));
+    }
+
+    #[test]
+    fn analyze_defaults_to_cwd_and_no_overrides() {
+        let cli = Cli::try_parse_from(["ephpm", "analyze"]).unwrap();
+        let Some(Commands::Analyze { path, config, format, profile, fail_on }) = cli.command else {
+            panic!("expected an analyze command");
+        };
+        assert!(path.is_none());
+        assert!(config.is_none());
+        assert!(format.is_none());
+        assert!(profile.is_none());
+        assert!(fail_on.is_none());
     }
 }
 

--- a/site/content/reference/cli/_index.md
+++ b/site/content/reference/cli/_index.md
@@ -174,6 +174,20 @@ $ ephpm kv del counter temp
 
 ---
 
+## `ephpm analyze`
+
+Statically analyze a PHP application and gate on the result — external security tools (composer audit, semgrep, yara) wrapped as subprocesses plus native passes, merged under a fail-closed allow/quarantine/deny policy. The exit code reflects the verdict, so it works directly as a CI or deploy-gate step. See the [full `analyze` reference](analyze/).
+
+```bash
+# Gate the current directory (security profile, fail on quarantine)
+ephpm analyze
+
+# Report-only over a checkout, as SARIF
+ephpm analyze /srv/app --fail-on allow --format sarif
+```
+
+---
+
 ## Service Lifecycle
 
 Install and manage ePHPm as a system service — systemd on Linux, launchd on macOS, SCM on Windows.
@@ -236,6 +250,7 @@ ephpm serve          Start the production server (--config/--listen/--document-r
 ephpm dev            Development server (--port/--document-root/--sites)
 ephpm php            Run the embedded PHP CLI (pure passthrough)
 ephpm kv             KV store client (keys/get/set/del/incr/ttl/ping)
+ephpm analyze        Static analysis + fail-closed deploy gate (--format/--profile/--fail-on)
 
 ephpm install        Install + start the system service
 ephpm uninstall      Remove the system service (--keep-data)

--- a/site/content/reference/cli/analyze.md
+++ b/site/content/reference/cli/analyze.md
@@ -1,0 +1,118 @@
++++
+title = "ephpm analyze"
+weight = 6
++++
+
+Statically analyze a PHP application and gate on the result. `ephpm analyze` runs a set of analyzers over a directory — external security tools wrapped as subprocesses, plus native passes built into the binary — merges their findings, and applies a **fail-closed** policy that produces one of three verdicts: `allow`, `quarantine`, or `deny`. The exit code reflects the verdict, so the command works directly as a CI step or deploy gate.
+
+## Synopsis
+
+```bash
+ephpm analyze [PATH] [--config FILE] [--format FORMAT] [--profile NAME] [--fail-on VERDICT]
+```
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `PATH` | current directory | Directory to analyze |
+| `--config` | `<PATH>/.ephpm-analyze.yml` when present | Analysis configuration file. An explicit `--config` that doesn't exist is an error, never a silent fallback to defaults. |
+| `--format` | `text` | `text` or `sarif` (SARIF v2.1.0 JSON). Overrides the config file. |
+| `--profile` | `security` | `security` or `none`. Overrides the config file. |
+| `--fail-on` | `quarantine` | Least severe verdict that fails the exit code: `allow` (report-only), `quarantine`, or `deny`. Overrides the config file. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | The verdict passed the `fail_on` gate |
+| `2` | A `quarantine` verdict failed the gate |
+| `3` | A `deny` verdict failed the gate |
+| `1` | Internal error (unreadable target, invalid configuration) |
+
+`fail_on` semantics: `quarantine` (the default) fails on `quarantine` **or** `deny`; `deny` fails only on `deny`; `allow` is report-only — the verdict never fails the exit code.
+
+## Analyzers (Phase 1)
+
+External tools are **not bundled** — ePHPm shells out to them. An analyzer whose tool (or required input) is absent is reported as *skipped* and does not gate, unless listed in `analyzers.required` (see below).
+
+| Analyzer | Kind | Category | Needs | What it does |
+|----------|------|----------|-------|--------------|
+| `composer-audit` | external | supply-chain | `composer` on `PATH`, `composer.json` + `composer.lock` in the target | Runs `composer audit --no-scripts --format=json`; each advisory becomes a finding (severity from the advisory, `critical` hard-denies), abandoned packages become `info` findings. |
+| `semgrep-php` | external | security | `semgrep` on `PATH` (registry configs also need network) | Runs `semgrep --config <analyzers.semgrep_config> --sarif` and maps its SARIF results to findings (`error` → high, `warning` → medium, `note` → low). |
+| `malware-yara` | external | malware | `yara` on `PATH` **and** a ruleset at `analyzers.yara_rules` (none ships with ePHPm — unset means skipped) | Runs `yara -r -w <rules> <target>`; each rule match is a `high` finding. A *configured but missing* ruleset path is an error (fail-closed), not a skip. |
+| `dangerous-sinks` | native | security | nothing | **Phase-1 placeholder**: a naive line/token pass over `*.php` / `*.phtml` flagging direct calls to the `eval` and `system` sinks (high) and `assert` (medium). Deliberately simple — matches inside comments/strings are false positives; dynamic calls are missed. It will be superseded by the opcode-level analyzer (planned). |
+
+## The verdict model
+
+Three layers; the final verdict is the most severe any layer demands:
+
+1. **Hard denies.** A finding whose rule id matches an `analyzers.deny_hard` entry (exactly, or under it as a `/`-prefix — `malware-yara` matches every `malware-yara/<Rule>`), or any finding of `critical` severity, forces `deny`.
+2. **Fail-closed floor.** Any analyzer *failure* — tool error, timeout, unparseable output, panic, or a `required` analyzer that could not run — floors the verdict at `quarantine`. An analyzer that errored might have been about to find something, so the run can never be `allow`. A plain skip of an optional analyzer does not floor.
+3. **Weighted score.** Findings score by severity — info 0, low 1, medium 4, high 10, critical 40 — and the total is compared against `policy.quarantine_score` (default 10) and `policy.deny_score` (default 50). The weights are super-additive on purpose: volume of low-severity noise cannot outrank one serious finding class, while a large pile of mediums still escalates.
+
+The text output prints one reason line per layer that fired.
+
+## Configuration: `.ephpm-analyze.yml`
+
+All keys with their defaults. **Every section rejects unknown keys** — a typo fails the run naming the key rather than silently doing nothing.
+
+```yaml
+profile: security          # security | none — supplies the analyzer set when
+                           # analyzers.enable is not given. `security` enables
+                           # all four Phase-1 analyzers; `none` enables nothing.
+fail_on: quarantine        # allow | quarantine | deny (see exit codes above)
+output: text               # text | sarif
+
+engine:                    # Planned: not yet implemented — parsed but not
+  detonate: false          # acted upon (engine-in-the-loop analysis, Phase 4).
+  timeout_ms: null         # Setting either logs a startup warning.
+
+analyzers:
+  enable: null             # explicit analyzer list; null = use the profile.
+                           # Unknown ids are a hard error.
+  required: []             # analyzers that MUST produce a result: a skip
+                           # (tool absent) of a required analyzer gates like a
+                           # failure. Must be a subset of the enabled set.
+  deny_hard: []            # rule ids (or `/`-prefixes) that force deny
+  yara_rules: null         # YARA ruleset path for malware-yara (relative
+                           # paths resolve against the analyzed directory)
+  semgrep_config: p/php    # semgrep --config value
+  tool_timeout_ms: 300000  # wall-clock budget per external tool; exceeding
+                           # it kills the tool and gates (fail-closed)
+
+policy:
+  quarantine_score: 10     # score at/above which the verdict is >= quarantine
+  deny_score: 50           # score at/above which the verdict is deny
+```
+
+## Output formats
+
+**`text`** — per-analyzer status (completed / skipped / FAILED), findings sorted most severe first, then the score, verdict, and reason lines.
+
+**`sarif`** — a SARIF v2.1.0 document with one run. Findings map to `results` (severity → level: high/critical → `error`, medium → `warning`, low/info → `note`; the exact severity and category ride in each result's `properties`). Skipped analyzers appear as `note` tool-execution notifications, failed analyzers as `error` notifications with `executionSuccessful: false`, and the verdict and score are on the run's `properties` as `ephpm/verdict` / `ephpm/score`.
+
+## Examples
+
+```bash
+# Gate a checkout in CI with the defaults (security profile, fail on quarantine)
+ephpm analyze /srv/app
+
+# Report-only: always exit 0, just print the report
+ephpm analyze /srv/app --fail-on allow
+
+# SARIF for upload to a code-scanning UI
+ephpm analyze /srv/app --format sarif > analysis.sarif
+
+# Strict deploy gate: composer-audit must actually run, and any YARA hit
+# or eval() call is an instant deny
+cat > /srv/app/.ephpm-analyze.yml <<'EOF'
+analyzers:
+  required: [composer-audit]
+  deny_hard: [malware-yara, dangerous-sinks/eval]
+  yara_rules: /etc/ephpm/yara/webshells.yar
+EOF
+ephpm analyze /srv/app
+```
+
+## Phase-1 scope
+
+This is the analyzer *framework* release: the aggregator, the fail-closed policy engine, the config/gating surface, both output formats, and the four analyzers above. Planned — not yet implemented: opcode-level analysis of compiled PHP (which replaces the naive `dangerous-sinks` pass), engine-in-the-loop detonation of suspicious inputs (the `engine:` section), and ePHPm-specific rules. The `Analyzer` trait, finding shape, policy engine, and output formats are designed to be stable across those additions.


### PR DESCRIPTION
The foundation of the `ephpm analyze` pipeline (design doc §4/§5/§8-P1): a new `ephpm-analyze` crate (aggregator, policy engine, config, SARIF/text output), four Phase-1 analyzers, and the `ephpm analyze` subcommand wired as a CI/deploy gate. **No opcode analysis, no engine-in-the-loop** — this is the architecture those later phases slot into.

## Framework
- **`Analyzer` trait** over `AnalysisCtx`; ctx fields are private behind accessors — the documented seam so the Phase-2 compiled-PHP repr and Phase-4 engine handle arrive as additive lazily-populated accessors, no trait reshape.
- **Policy engine (fail-closed):** (1) hard-deny — a `deny_hard` match (exact rule id or `/`-prefix) or any `critical` → Deny; (2) **fail-closed floor** — any analyzer error/timeout/panic, or a `required` analyzer that couldn't run, floors at Quarantine (a run where something that should have spoken didn't can never Allow); (3) super-additive weighted score vs tunable thresholds. Verdict = max across layers.
- **Absence degrades, errors gate:** an *optional* tool that isn't installed skips; `analyzers.required` upgrades even a skip to a gating failure.
- **Config:** `.ephpm-analyze.yml`, golangci-lint-shaped, `serde_yaml_ng` (deny-clean). Strict `deny_unknown_fields` on every section incl. root. The Phase-4 `engine:` section parses inert + warns at startup when set.
- **Output:** SARIF v2.1.0 (skips/failures as `toolExecutionNotifications`) + concise text.

## Phase-1 analyzers (shelled out, never bundled)
`composer-audit`, `semgrep-php`, `malware-yara` (operator ruleset), and the native `dangerous-sinks` token pass — a labeled placeholder for the Phase-2 opcode analyzer that proves the zero-dep native path e2e. Shared subprocess runner: PATH-absence → skip, per-tool timeout, Windows launcher resolution.

## CLI
`ephpm analyze [PATH] [--config] [--format text|sarif] [--profile] [--fail-on]`. Exit 0 pass / 2 quarantine-gated / 3 deny-gated / 1 internal.

## Testing
42 crate tests (config strictness, policy layers incl. fail-closed with zero findings, SARIF shape, subprocess-free e2e) + CLI parse tests; all exit paths verified live. clippy `-D warnings`, nightly fmt, `cargo deny` clean.

### Reviewer note
Test fixtures deliberately avoid webshell-shaped byte sequences (assembled at runtime) — Windows Defender quarantined earlier fixture *source files* as `Backdoor:PHP/*`, which would also hit checkouts/CI.