### PR TITLE
feat(analyze): baselines, levels, diff-aware, cache, operator-only suppressions, confidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/ephpm-analyze/Cargo.toml
+++ b/crates/ephpm-analyze/Cargo.toml
@@ -12,6 +12,10 @@ anyhow.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 serde_yaml_ng.workspace = true
+# Baseline fingerprints and cache keys hash tenant-controlled adversarial
+# input — a collision-resistant hash is load-bearing there (see the module
+# docs of `baseline` and `cache`), so no fast non-cryptographic hash.
+sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/ephpm-analyze/src/analyzer.rs
+++ b/crates/ephpm-analyze/src/analyzer.rs
@@ -3,15 +3,20 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::baseline::Baseline;
+use crate::cache::FileCache;
 use crate::config::AnalyzeConfig;
 use crate::finding::{Category, Finding};
+use crate::scope::Scope;
 
 /// Everything an analyzer may read about the target under analysis.
 ///
-/// Phase 1 carries the checkout root and the effective configuration. The
-/// fields are private on purpose — analyzers go through accessors — so later
-/// phases can add **lazily populated shared state** without touching any
-/// analyzer's signature:
+/// Carries the checkout root, the effective configuration, and the optional
+/// run-scoped state resolved by [`crate::analyze`]: the diff-aware changed-file
+/// [`Scope`], the incremental [`FileCache`], and the loaded [`Baseline`].
+/// The fields are private on purpose — analyzers go through accessors — so
+/// later phases can add **lazily populated shared state** without touching
+/// any analyzer's signature:
 ///
 /// - *Planned — not yet implemented (Phase 2, opcode analyzers):* a
 ///   `compiled()` accessor returning a lazily built compiled representation
@@ -27,14 +32,38 @@ use crate::finding::{Category, Finding};
 pub struct AnalysisCtx {
     root: PathBuf,
     config: AnalyzeConfig,
+    scope: Option<Scope>,
+    cache: Option<FileCache>,
+    baseline: Option<Baseline>,
 }
 
 impl AnalysisCtx {
     /// Build a context for the checkout at `root` with the given effective
-    /// configuration.
+    /// configuration (no scope, cache, or baseline attached).
     #[must_use]
     pub fn new(root: PathBuf, config: AnalyzeConfig) -> Self {
-        Self { root, config }
+        Self { root, config, scope: None, cache: None, baseline: None }
+    }
+
+    /// Attach a diff-aware changed-file scope (`since:` / `--since`).
+    #[must_use]
+    pub fn with_scope(mut self, scope: Scope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    /// Attach an incremental result cache.
+    #[must_use]
+    pub fn with_cache(mut self, cache: FileCache) -> Self {
+        self.cache = Some(cache);
+        self
+    }
+
+    /// Attach a loaded baseline whose fingerprints suppress known findings.
+    #[must_use]
+    pub fn with_baseline(mut self, baseline: Baseline) -> Self {
+        self.baseline = Some(baseline);
+        self
     }
 
     /// The directory being analyzed.
@@ -47,6 +76,36 @@ impl AnalysisCtx {
     #[must_use]
     pub fn config(&self) -> &AnalyzeConfig {
         &self.config
+    }
+
+    /// The diff-aware changed-file scope, when this is a `since` run.
+    #[must_use]
+    pub fn scope(&self) -> Option<&Scope> {
+        self.scope.as_ref()
+    }
+
+    /// Whether the tree-relative `rel_path` should be analyzed: always true
+    /// on a full run; on a diff-aware run, true only for changed files.
+    /// Per-file analyzers use this to skip unchanged files early — the
+    /// aggregator additionally enforces the same scope on every
+    /// path-anchored finding after the fact.
+    #[must_use]
+    pub fn is_in_scope(&self, rel_path: &Path) -> bool {
+        self.scope.as_ref().is_none_or(|scope| scope.contains(rel_path))
+    }
+
+    /// The incremental result cache, when enabled. Only meaningful for
+    /// per-file analyzers whose result depends solely on the file content
+    /// and the configuration — see `crate::cache` for the contract.
+    #[must_use]
+    pub fn cache(&self) -> Option<&FileCache> {
+        self.cache.as_ref()
+    }
+
+    /// The loaded baseline, when configured.
+    #[must_use]
+    pub fn baseline(&self) -> Option<&Baseline> {
+        self.baseline.as_ref()
     }
 }
 

--- a/crates/ephpm-analyze/src/analyzers/composer_audit.rs
+++ b/crates/ephpm-analyze/src/analyzers/composer_audit.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 use super::tool::{run_tool, stderr_excerpt};
 use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
-use crate::finding::{Category, Finding, Severity};
+use crate::finding::{Category, Confidence, Finding, Severity};
 
 /// See the module docs.
 pub struct ComposerAudit;
@@ -43,6 +43,9 @@ fn advisory_finding(package: &str, advisory: &Value) -> Finding {
         path: Some("composer.lock".into()),
         line: None,
         message: format!("{package}: {title}"),
+        // A published advisory matched against a pinned lockfile version is
+        // definite, not a heuristic.
+        confidence: Confidence::Confirmed,
     }
 }
 
@@ -78,6 +81,7 @@ fn parse_audit_json(json: &Value) -> Vec<Finding> {
                 path: Some("composer.lock".into()),
                 line: None,
                 message: format!("{package} is abandoned{suggestion}"),
+                confidence: Confidence::Confirmed,
             });
         }
     }

--- a/crates/ephpm-analyze/src/analyzers/dangerous_sinks.rs
+++ b/crates/ephpm-analyze/src/analyzers/dangerous_sinks.rs
@@ -20,8 +20,9 @@
 
 use std::path::Path;
 
+use super::php_files::scan_php_tree;
 use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
-use crate::finding::{Category, Finding, Severity};
+use crate::finding::{Category, Confidence, Finding, Severity};
 
 /// See the module docs.
 pub struct DangerousSinks;
@@ -29,19 +30,8 @@ pub struct DangerousSinks;
 /// The analyzer's stable id.
 pub const ID: &str = "dangerous-sinks";
 
-/// Files larger than this are skipped (a minified/vendored blob would drown
-/// the report; the YARA analyzer is the right tool for opaque payloads).
-const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
-
 const SINKS: &[(&str, Severity)] =
     &[("eval", Severity::High), ("system", Severity::High), ("assert", Severity::Medium)];
-
-fn is_php_file(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|e| e.to_str()),
-        Some(ext) if ext.eq_ignore_ascii_case("php") || ext.eq_ignore_ascii_case("phtml")
-    )
-}
 
 /// `true` when the byte before a candidate token rules it out as a direct
 /// function call: part of a longer identifier (`subsystem(`), a variable
@@ -83,36 +73,15 @@ fn scan_text(text: &str, rel_path: &Path) -> Vec<Finding> {
                     path: Some(rel_path.to_path_buf()),
                     line: Some(line_idx as u64 + 1),
                     message: format!("call to {sink}() — dangerous sink"),
+                    // A naive token pass with known false positives (matches
+                    // inside comments/strings) is a hotspot, not proof — the
+                    // Phase-2 opcode analyzer will confirm.
+                    confidence: Confidence::Suspected,
                 });
             }
         }
     }
     findings
-}
-
-/// Recursively walk `dir`, scanning PHP files. Does not follow directory
-/// symlinks; skips `.git`.
-fn walk(root: &Path, dir: &Path, findings: &mut Vec<Finding>) -> Result<(), AnalyzerError> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let path = entry.path();
-        if file_type.is_dir() {
-            if entry.file_name() == ".git" {
-                continue;
-            }
-            walk(root, &path, findings)?;
-        } else if file_type.is_file() && is_php_file(&path) {
-            if entry.metadata()?.len() > MAX_FILE_BYTES {
-                continue;
-            }
-            let bytes = std::fs::read(&path)?;
-            let text = String::from_utf8_lossy(&bytes);
-            let rel = path.strip_prefix(root).unwrap_or(&path);
-            findings.extend(scan_text(&text, rel));
-        }
-    }
-    Ok(())
 }
 
 impl Analyzer for DangerousSinks {
@@ -125,9 +94,7 @@ impl Analyzer for DangerousSinks {
     }
 
     fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
-        let mut findings = Vec::new();
-        walk(ctx.root(), ctx.root(), &mut findings)?;
-        Ok(findings)
+        scan_php_tree(ctx, ID, &scan_text)
     }
 }
 
@@ -166,6 +133,8 @@ mod tests {
         assert_eq!(findings[0].rule_id, "dangerous-sinks/eval");
         assert_eq!(findings[0].line, Some(3));
         assert_eq!(findings[0].severity, Severity::High);
+        // A naive token pass is a hotspot, never confirmed evidence.
+        assert!(findings.iter().all(|f| f.confidence == Confidence::Suspected));
         assert_eq!(findings[1].rule_id, "dangerous-sinks/system");
         assert_eq!(findings[1].line, Some(4));
         assert_eq!(findings[2].rule_id, "dangerous-sinks/assert");

--- a/crates/ephpm-analyze/src/analyzers/mod.rs
+++ b/crates/ephpm-analyze/src/analyzers/mod.rs
@@ -1,19 +1,24 @@
-//! The built-in Phase-1 analyzers.
+//! The built-in analyzers.
 //!
 //! Three wrap external tools as subprocesses and degrade gracefully when the
-//! tool is absent (`composer-audit`, `semgrep-php`, `malware-yara`); one is
-//! native with zero external dependencies (`dangerous-sinks`), exercising
-//! the same path a future opcode analyzer will use.
+//! tool is absent (`composer-audit`, `semgrep-php`, `malware-yara`); two are
+//! native with zero external dependencies (`dangerous-sinks`,
+//! `suppression-scan`), sharing the per-file walker in `php_files` —
+//! diff-aware scope skipping and the incremental cache included — the same
+//! path a future opcode analyzer will use.
 
 mod composer_audit;
 mod dangerous_sinks;
+mod php_files;
 mod semgrep;
+mod suppression_scan;
 mod tool;
 mod yara_scan;
 
 pub use composer_audit::ComposerAudit;
 pub use dangerous_sinks::DangerousSinks;
 pub use semgrep::SemgrepPhp;
+pub use suppression_scan::SuppressionScan;
 pub use yara_scan::MalwareYara;
 
 use crate::analyzer::Analyzer;
@@ -26,5 +31,6 @@ pub fn built_in() -> Vec<Box<dyn Analyzer>> {
         Box::new(SemgrepPhp),
         Box::new(MalwareYara),
         Box::new(DangerousSinks),
+        Box::new(SuppressionScan),
     ]
 }

--- a/crates/ephpm-analyze/src/analyzers/php_files.rs
+++ b/crates/ephpm-analyze/src/analyzers/php_files.rs
@@ -1,0 +1,81 @@
+//! Shared tree walker for the native per-file analyzers.
+//!
+//! Centralizes the concerns every per-file pass shares so `dangerous-sinks`
+//! and `suppression-scan` (and future native analyzers) do not re-implement
+//! them: PHP-file selection, `.git` skipping, the oversized-file cutoff,
+//! diff-aware scope skipping ([`crate::AnalysisCtx::is_in_scope`]), and the
+//! incremental content-hash cache ([`crate::cache`]).
+
+use std::path::Path;
+
+use crate::analyzer::{AnalysisCtx, AnalyzerError};
+use crate::finding::Finding;
+
+/// Files larger than this are skipped (a minified/vendored blob would drown
+/// the report; the YARA analyzer is the right tool for opaque payloads).
+const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Whether `path` names a PHP source file this walker scans.
+fn is_php_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some(ext) if ext.eq_ignore_ascii_case("php") || ext.eq_ignore_ascii_case("phtml")
+    )
+}
+
+/// Walk the tree under `ctx.root()`, running `scan(text, rel_path)` over
+/// every in-scope PHP file and collecting the findings. Does not follow
+/// directory symlinks; skips `.git`. Cached per file when a cache is
+/// attached — `scan` must therefore be a pure function of the file content,
+/// the relative path, and the run configuration.
+///
+/// # Errors
+///
+/// [`AnalyzerError::Io`] on directory-walk or read failures (which gate,
+/// fail-closed).
+pub(crate) fn scan_php_tree(
+    ctx: &AnalysisCtx,
+    analyzer_id: &str,
+    scan: &dyn Fn(&str, &Path) -> Vec<Finding>,
+) -> Result<Vec<Finding>, AnalyzerError> {
+    let mut findings = Vec::new();
+    walk(ctx, analyzer_id, ctx.root(), scan, &mut findings)?;
+    Ok(findings)
+}
+
+fn walk(
+    ctx: &AnalysisCtx,
+    analyzer_id: &str,
+    dir: &Path,
+    scan: &dyn Fn(&str, &Path) -> Vec<Finding>,
+    findings: &mut Vec<Finding>,
+) -> Result<(), AnalyzerError> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            walk(ctx, analyzer_id, &path, scan, findings)?;
+        } else if file_type.is_file() && is_php_file(&path) {
+            let rel = path.strip_prefix(ctx.root()).unwrap_or(&path);
+            if !ctx.is_in_scope(rel) {
+                continue;
+            }
+            if entry.metadata()?.len() > MAX_FILE_BYTES {
+                continue;
+            }
+            let bytes = std::fs::read(&path)?;
+            let file_findings = match ctx.cache() {
+                Some(cache) => cache.get_or_scan(analyzer_id, rel, &bytes, || {
+                    Ok::<_, AnalyzerError>(scan(&String::from_utf8_lossy(&bytes), rel))
+                })?,
+                None => scan(&String::from_utf8_lossy(&bytes), rel),
+            };
+            findings.extend(file_findings);
+        }
+    }
+    Ok(())
+}

--- a/crates/ephpm-analyze/src/analyzers/semgrep.rs
+++ b/crates/ephpm-analyze/src/analyzers/semgrep.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use super::tool::{run_tool, stderr_excerpt};
 use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
-use crate::finding::{Category, Finding, Severity};
+use crate::finding::{Category, Confidence, Finding, Severity};
 
 /// See the module docs.
 pub struct SemgrepPhp;
@@ -59,6 +59,9 @@ fn parse_sarif(doc: &Value) -> Result<Vec<Finding>, AnalyzerError> {
                 path,
                 line,
                 message,
+                // Pattern matches carry false positives by nature — review
+                // signals (hotspots), not confirmed evidence.
+                confidence: Confidence::Suspected,
             });
         }
     }
@@ -77,9 +80,22 @@ impl Analyzer for SemgrepPhp {
     fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
         let config = &ctx.config().analyzers.semgrep_config;
         let timeout = ctx.config().analyzers.tool_timeout_ms;
+        // `--disable-nosem`: Semgrep honors inline `// nosemgrep` comments
+        // by default — a tenant-controlled mute. Suppressions must come only
+        // from operator config (see `crate::suppress`), and the
+        // `suppression-scan` analyzer flags the comment itself; honoring it
+        // here would hollow both out.
         let run = run_tool(
             "semgrep",
-            &["--config", config, "--sarif", "--quiet", "--disable-version-check", "."],
+            &[
+                "--config",
+                config,
+                "--sarif",
+                "--quiet",
+                "--disable-version-check",
+                "--disable-nosem",
+                ".",
+            ],
             ctx.root(),
             timeout,
         )?;

--- a/crates/ephpm-analyze/src/analyzers/suppression_scan.rs
+++ b/crates/ephpm-analyze/src/analyzers/suppression_scan.rs
@@ -1,0 +1,142 @@
+//! `suppression-scan` — flags tenant-authored suppression-shaped comments.
+//!
+//! ePHPm-analyze **never** honors suppression directives found inside the
+//! analyzed code — waivers come exclusively from the operator's config
+//! (`suppress:` — see `crate::suppress`). This analyzer is the enforcement
+//! inversion: instead of obeying an inline `// ephpm-analyze-ignore`,
+//! `@phpstan-ignore`, `// nosemgrep`, `# noqa`, or similar marker, it emits
+//! it as a finding (`suppression-scan/tenant-suppression-attempt`, Medium,
+//! Confirmed) — a tenant trying to silence a scanner is itself a signal.
+//!
+//! Complementarily, the `semgrep-php` analyzer passes `--disable-nosem` so
+//! Semgrep itself cannot be muted by `nosemgrep` comments either — detection
+//! here would be hollow if the underlying tool still obeyed the marker.
+//!
+//! To keep vendored trees (where `@phpstan-ignore` / `phpcs:ignore` are
+//! routine developer hygiene) reviewable rather than overwhelming, findings
+//! are deduplicated to **one per (file, marker)**, anchored at the first
+//! occurrence. Operators who have vetted a tree tune the noise with ordinary
+//! suppressions (e.g. `rule: suppression-scan, path: <vendored file>`) —
+//! which, being operator config, remains the only honored mechanism.
+//!
+//! Matching is case-insensitive over raw lines: this deliberately does not
+//! parse PHP, so a marker inside a string literal is still flagged (an
+//! acceptable false positive for a review-signal rule; the confidence is
+//! about the marker's *presence*, which is a fact).
+
+use std::path::Path;
+
+use super::php_files::scan_php_tree;
+use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+use crate::finding::{Category, Confidence, Finding, Severity};
+
+/// See the module docs.
+pub struct SuppressionScan;
+
+/// The analyzer's stable id.
+pub const ID: &str = "suppression-scan";
+
+/// The single rule id this analyzer emits.
+pub const RULE: &str = "tenant-suppression-attempt";
+
+/// Suppression-shaped markers, lowercase (matched case-insensitively).
+/// `@phpstan-ignore` also covers `@phpstan-ignore-line` / `-next-line`;
+/// `phpcs:` covers `phpcs:ignore` / `phpcs:disable` / `phpcs:ignoreFile`.
+const MARKERS: &[&str] = &[
+    "ephpm-analyze-ignore",
+    "@phpstan-ignore",
+    "@psalm-suppress",
+    "@codingstandardsignore",
+    "phpcs:ignore",
+    "phpcs:disable",
+    "nosemgrep",
+    "noqa",
+    "nosonar",
+];
+
+/// Scan one file's text: one finding per marker present, at its first
+/// occurrence.
+fn scan_text(text: &str, rel_path: &Path) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut remaining: Vec<&str> = MARKERS.to_vec();
+    for (line_idx, line) in text.lines().enumerate() {
+        if remaining.is_empty() {
+            break;
+        }
+        let lower = line.to_ascii_lowercase();
+        remaining.retain(|marker| {
+            if lower.contains(marker) {
+                findings.push(Finding {
+                    rule_id: format!("{ID}/{RULE}"),
+                    severity: Severity::Medium,
+                    category: Category::Security,
+                    path: Some(rel_path.to_path_buf()),
+                    line: Some(line_idx as u64 + 1),
+                    message: format!(
+                        "tenant-authored suppression marker {marker:?} — inline suppression \
+                         directives are never honored; only operator config (`suppress:`) can \
+                         waive findings"
+                    ),
+                    confidence: Confidence::Confirmed,
+                });
+                false
+            } else {
+                true
+            }
+        });
+    }
+    findings
+}
+
+impl Analyzer for SuppressionScan {
+    fn id(&self) -> &str {
+        ID
+    }
+
+    fn category(&self) -> Category {
+        Category::Security
+    }
+
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        scan_php_tree(ctx, ID, &scan_text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan(src: &str) -> Vec<Finding> {
+        scan_text(src, Path::new("t.php"))
+    }
+
+    #[test]
+    fn flags_each_marker_kind() {
+        for marker in
+            ["ephpm-analyze-ignore", "@phpstan-ignore-next-line", "nosemgrep", "NOQA", "NOSONAR"]
+        {
+            let src = format!("<?php\n$x = 1; // {marker}\n");
+            let findings = scan(&src);
+            assert_eq!(findings.len(), 1, "marker {marker} must be flagged");
+            let f = &findings[0];
+            assert_eq!(f.rule_id, "suppression-scan/tenant-suppression-attempt");
+            assert_eq!(f.severity, Severity::Medium);
+            assert_eq!(f.confidence, Confidence::Confirmed);
+            assert_eq!(f.line, Some(2));
+        }
+    }
+
+    #[test]
+    fn dedupes_to_one_finding_per_marker_at_first_occurrence() {
+        let src = "<?php\n// nosemgrep\n// nosemgrep\n/* noqa */\n";
+        let findings = scan(src);
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].line, Some(2));
+        assert_eq!(findings[1].line, Some(4));
+    }
+
+    #[test]
+    fn clean_file_yields_nothing() {
+        assert!(scan("<?php\n// regular comment about ignoring nothing relevant\n").is_empty());
+    }
+}

--- a/crates/ephpm-analyze/src/analyzers/yara_scan.rs
+++ b/crates/ephpm-analyze/src/analyzers/yara_scan.rs
@@ -8,7 +8,7 @@
 
 use super::tool::{run_tool, stderr_excerpt};
 use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
-use crate::finding::{Category, Finding, Severity};
+use crate::finding::{Category, Confidence, Finding, Severity};
 
 /// See the module docs.
 pub struct MalwareYara;
@@ -35,6 +35,10 @@ fn parse_matches(stdout: &str, root: &std::path::Path) -> Vec<Finding> {
                 path: Some(rel.to_path_buf()),
                 line: None,
                 message: format!("YARA rule {rule} matched"),
+                // A signature match from an operator-curated ruleset is
+                // treated as confirmed — pair with `deny_hard: [malware-yara]`
+                // for an instant deny.
+                confidence: Confidence::Confirmed,
             })
         })
         .collect()

--- a/crates/ephpm-analyze/src/baseline.rs
+++ b/crates/ephpm-analyze/src/baseline.rs
@@ -1,0 +1,230 @@
+//! Baseline files — adopt an existing codebase by recording its current
+//! findings, then gate only on *new* ones (the PHPStan model).
+//!
+//! A baseline is a JSON document listing one entry per known finding,
+//! keyed by a **stable fingerprint**: SHA-256 over the finding's rule id,
+//! its path (normalized to `/` separators so Windows and Unix agree), and
+//! its message — deliberately **not** the line number, so reformatting or
+//! unrelated edits that shift a finding vertically do not resurrect it.
+//! Alongside the fingerprint each entry carries the human-readable fields it
+//! was derived from, so a baseline diff in code review is legible.
+//!
+//! SHA-256 rather than a fast non-cryptographic hash on purpose: the
+//! analyzed tree is *tenant-controlled adversarial input*, and with a weak
+//! hash an attacker could craft a malicious finding whose fingerprint
+//! collides with a baselined benign one, silently waiving it.
+//!
+//! Generation is a CLI concern (`ephpm analyze --baseline <file>` writes the
+//! file); consumption is config (`baseline: <path>` suppresses matches). A
+//! configured-but-missing baseline file is a hard error — fail-closed,
+//! consistent with `analyzers.yara_rules`.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::finding::Finding;
+
+/// Format version written to (and required from) baseline files.
+const BASELINE_VERSION: u32 = 1;
+
+/// One remembered finding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BaselineEntry {
+    /// The stable fingerprint — see [`fingerprint`].
+    pub fingerprint: String,
+    /// The rule id at generation time (informational, for reviewability).
+    pub rule_id: String,
+    /// The `/`-normalized path at generation time (informational).
+    #[serde(default)]
+    pub path: Option<String>,
+    /// The message at generation time (informational).
+    pub message: String,
+}
+
+/// A parsed baseline file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Baseline {
+    /// Format version — must equal 1.
+    pub version: u32,
+    /// The remembered findings, sorted by fingerprint for stable diffs.
+    pub findings: Vec<BaselineEntry>,
+}
+
+/// A finding's path normalized to forward slashes, for fingerprinting and
+/// suppression matching that agrees across host platforms.
+#[must_use]
+pub fn normalized_path(finding: &Finding) -> Option<String> {
+    finding.path.as_ref().map(|p| p.to_string_lossy().replace('\\', "/"))
+}
+
+/// The stable fingerprint of a finding: hex SHA-256 over rule id, normalized
+/// path, and message (never the line number — see the module docs). Fields
+/// are length-prefixed so no two distinct triples concatenate identically.
+#[must_use]
+pub fn fingerprint(finding: &Finding) -> String {
+    let path = normalized_path(finding).unwrap_or_default();
+    let mut hasher = Sha256::new();
+    for field in [finding.rule_id.as_str(), path.as_str(), finding.message.as_str()] {
+        hasher.update(u64::try_from(field.len()).unwrap_or(u64::MAX).to_le_bytes());
+        hasher.update(field.as_bytes());
+    }
+    hex(&hasher.finalize())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+impl Baseline {
+    /// Build a baseline from the given findings, deduplicating identical
+    /// fingerprints and sorting for stable diffs.
+    #[must_use]
+    pub fn from_findings(findings: &[Finding]) -> Self {
+        let mut seen = HashSet::new();
+        let mut entries: Vec<BaselineEntry> = findings
+            .iter()
+            .filter_map(|f| {
+                let fingerprint = fingerprint(f);
+                seen.insert(fingerprint.clone()).then(|| BaselineEntry {
+                    fingerprint,
+                    rule_id: f.rule_id.clone(),
+                    path: normalized_path(f),
+                    message: f.message.clone(),
+                })
+            })
+            .collect();
+        entries.sort_by(|a, b| a.fingerprint.cmp(&b.fingerprint));
+        Self { version: BASELINE_VERSION, findings: entries }
+    }
+
+    /// Load and validate a baseline file.
+    ///
+    /// # Errors
+    ///
+    /// On a missing/unreadable file, invalid JSON, unknown fields, or an
+    /// unsupported `version` — all hard errors, so a corrupt baseline never
+    /// silently degrades into a full un-suppressed (or worse, an
+    /// over-suppressed) run.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read baseline {}", path.display()))?;
+        let baseline: Self = serde_json::from_str(&text)
+            .with_context(|| format!("invalid baseline {}", path.display()))?;
+        anyhow::ensure!(
+            baseline.version == BASELINE_VERSION,
+            "baseline {} has unsupported version {} (this build reads version {BASELINE_VERSION})",
+            path.display(),
+            baseline.version
+        );
+        Ok(baseline)
+    }
+
+    /// Write the baseline as pretty JSON.
+    ///
+    /// # Errors
+    ///
+    /// On serialization or write failure.
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        let json = serde_json::to_string_pretty(self).context("failed to serialize baseline")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("failed to write baseline {}", path.display()))
+    }
+
+    /// The set of fingerprints this baseline suppresses.
+    #[must_use]
+    pub fn fingerprints(&self) -> HashSet<&str> {
+        self.findings.iter().map(|e| e.fingerprint.as_str()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::finding::{Category, Confidence, Finding, Severity};
+
+    fn finding(rule_id: &str, path: &str, line: Option<u64>, message: &str) -> Finding {
+        Finding {
+            rule_id: rule_id.to_owned(),
+            severity: Severity::Medium,
+            category: Category::Security,
+            path: (!path.is_empty()).then(|| PathBuf::from(path)),
+            line,
+            message: message.to_owned(),
+            confidence: Confidence::Confirmed,
+        }
+    }
+
+    #[test]
+    fn fingerprint_ignores_line_number() {
+        // The whole point: a finding that moved vertically (reformatting)
+        // keeps its fingerprint.
+        let a = finding("x/r", "src/a.php", Some(10), "msg");
+        let b = finding("x/r", "src/a.php", Some(999), "msg");
+        assert_eq!(fingerprint(&a), fingerprint(&b));
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_rule_path_and_message() {
+        let base = finding("x/r", "src/a.php", None, "msg");
+        assert_ne!(fingerprint(&base), fingerprint(&finding("x/r2", "src/a.php", None, "msg")));
+        assert_ne!(fingerprint(&base), fingerprint(&finding("x/r", "src/b.php", None, "msg")));
+        assert_ne!(fingerprint(&base), fingerprint(&finding("x/r", "src/a.php", None, "msg2")));
+        // Length-prefixing: shifting a byte across a field boundary must not
+        // collide ("ab"+"c" vs "a"+"bc").
+        assert_ne!(
+            fingerprint(&finding("ab", "c", None, "")),
+            fingerprint(&finding("a", "bc", None, ""))
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_platform_agnostic_over_separators() {
+        let unix = finding("x/r", "src/a.php", None, "msg");
+        let windows = finding("x/r", "src\\a.php", None, "msg");
+        assert_eq!(fingerprint(&unix), fingerprint(&windows));
+    }
+
+    #[test]
+    fn roundtrip_and_dedup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("baseline.json");
+        let findings = [
+            finding("x/r", "a.php", Some(1), "m"),
+            finding("x/r", "a.php", Some(2), "m"), // same fingerprint (line differs)
+            finding("y/s", "", None, "n"),
+        ];
+        let baseline = Baseline::from_findings(&findings);
+        assert_eq!(baseline.findings.len(), 2);
+        baseline.save(&path).unwrap();
+        let loaded = Baseline::load(&path).unwrap();
+        assert_eq!(loaded.version, 1);
+        assert_eq!(loaded.fingerprints(), baseline.fingerprints());
+    }
+
+    #[test]
+    fn load_rejects_wrong_version_and_unknown_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("baseline.json");
+        std::fs::write(&path, r#"{"version": 2, "findings": []}"#).unwrap();
+        assert!(format!("{:#}", Baseline::load(&path).unwrap_err()).contains("version"));
+        std::fs::write(&path, r#"{"version": 1, "findings": [], "extra": 1}"#).unwrap();
+        assert!(format!("{:#}", Baseline::load(&path).unwrap_err()).contains("invalid baseline"));
+    }
+
+    #[test]
+    fn load_missing_file_is_an_error() {
+        assert!(Baseline::load(Path::new("Z:/definitely/not/here.json")).is_err());
+    }
+}

--- a/crates/ephpm-analyze/src/cache.rs
+++ b/crates/ephpm-analyze/src/cache.rs
@@ -1,0 +1,235 @@
+//! Incremental content-hash result cache for per-file analyzers.
+//!
+//! # Key model (correctness-safe by construction)
+//!
+//! A cache entry's filename is hex SHA-256 over, length-prefixed:
+//!
+//! 1. this crate's version — a new build never reuses old results,
+//! 2. the analyzer id,
+//! 3. a hash of the **effective configuration** (the whole `AnalyzeConfig`
+//!    serialized to JSON, CLI overrides included) — *any* config change
+//!    invalidates everything,
+//! 4. the file's tree-relative path — same content at a different path is a
+//!    miss, because findings embed the path,
+//! 5. the file's content hash.
+//!
+//! SHA-256 rather than a fast non-cryptographic hash on purpose: the
+//! analyzed tree is tenant-controlled adversarial input, and a weak content
+//! hash would let an attacker craft a malicious file that collides with a
+//! previously scanned benign one, replaying its clean cached findings.
+//!
+//! # Who uses it
+//!
+//! Only the native per-file analyzers (`dangerous-sinks`,
+//! `suppression-scan`) — via [`FileCache::get_or_scan`] through
+//! `AnalysisCtx`. External-tool analyzers are deliberately never cached:
+//! their results depend on state outside the tree (advisory databases,
+//! remote rule packs, ruleset files), so "unchanged file" does not imply
+//! "unchanged result" for them. Phase-2 opcode analyzers are the intended
+//! main beneficiary.
+//!
+//! # Failure and trust model
+//!
+//! Cache *reads* that fail (missing, corrupt, unparseable) are misses; cache
+//! *writes* that fail are logged at debug and ignored — the cache can only
+//! ever cost a rescan, never a wrong verdict, **provided the cache directory
+//! is trusted**. The directory is operator state: whoever can write it can
+//! plant findings (or their absence). The default lives under the system
+//! temp directory (created `0o700` on Unix); on shared hosts point
+//! `cache.dir` / `--cache-dir` at a path only the operator can write.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest as _, Sha256};
+
+use crate::config::AnalyzeConfig;
+use crate::finding::Finding;
+
+/// An open cache handle, scoped to one effective configuration.
+#[derive(Debug)]
+pub struct FileCache {
+    dir: PathBuf,
+    config_hash: [u8; 32],
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+fn update_field(hasher: &mut Sha256, field: &[u8]) {
+    hasher.update(u64::try_from(field.len()).unwrap_or(u64::MAX).to_le_bytes());
+    hasher.update(field);
+}
+
+/// The default cache directory: `ephpm-analyze-cache` under the system temp
+/// directory.
+#[must_use]
+pub fn default_dir() -> PathBuf {
+    std::env::temp_dir().join("ephpm-analyze-cache")
+}
+
+impl FileCache {
+    /// Open (creating if needed) the cache at `dir` for the given effective
+    /// configuration.
+    ///
+    /// # Errors
+    ///
+    /// On failure to create the cache directory or serialize the config.
+    pub fn open(dir: PathBuf, config: &AnalyzeConfig) -> anyhow::Result<Self> {
+        let config_json = serde_json::to_vec(config)
+            .map_err(|e| anyhow::anyhow!("failed to serialize config for cache keying: {e}"))?;
+        let mut hasher = Sha256::new();
+        update_field(&mut hasher, config_json.as_slice());
+        let config_hash: [u8; 32] = hasher.finalize().into();
+
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| anyhow::anyhow!("failed to create cache dir {}: {e}", dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            // Best-effort: keep the default temp-dir cache private to the
+            // invoking user. An existing dir keeps its permissions.
+            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        }
+        Ok(Self { dir, config_hash })
+    }
+
+    /// The entry path for `(analyzer_id, rel_path, content)`.
+    fn entry_path(&self, analyzer_id: &str, rel_path: &Path, content: &[u8]) -> PathBuf {
+        let mut hasher = Sha256::new();
+        update_field(&mut hasher, env!("CARGO_PKG_VERSION").as_bytes());
+        update_field(&mut hasher, analyzer_id.as_bytes());
+        update_field(&mut hasher, &self.config_hash);
+        update_field(&mut hasher, crate::scope::normalize(rel_path).as_bytes());
+        update_field(&mut hasher, content);
+        self.dir.join(format!("{}.json", hex(&hasher.finalize())))
+    }
+
+    /// Return the cached findings for this (analyzer, file, content, config)
+    /// tuple, or run `scan` and cache its result.
+    ///
+    /// # Errors
+    ///
+    /// Only `scan`'s own error, propagated verbatim (and never cached).
+    /// Cache reads that fail are misses; cache writes that fail are logged
+    /// and ignored.
+    pub fn get_or_scan<E>(
+        &self,
+        analyzer_id: &str,
+        rel_path: &Path,
+        content: &[u8],
+        scan: impl FnOnce() -> Result<Vec<Finding>, E>,
+    ) -> Result<Vec<Finding>, E> {
+        let entry = self.entry_path(analyzer_id, rel_path, content);
+        if let Ok(text) = std::fs::read_to_string(&entry)
+            && let Ok(findings) = serde_json::from_str::<Vec<Finding>>(&text)
+        {
+            tracing::trace!(analyzer = analyzer_id, path = %rel_path.display(), "cache hit");
+            return Ok(findings);
+        }
+        let findings = scan()?;
+        match serde_json::to_string(&findings) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&entry, json) {
+                    tracing::debug!(error = %e, entry = %entry.display(), "cache write failed");
+                }
+            }
+            Err(e) => tracing::debug!(error = %e, "cache serialize failed"),
+        }
+        Ok(findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::finding::{Category, Confidence, Severity};
+
+    fn sample_finding() -> Finding {
+        Finding {
+            rule_id: "t/rule".to_owned(),
+            severity: Severity::Medium,
+            category: Category::Security,
+            path: Some(PathBuf::from("a.php")),
+            line: Some(3),
+            message: "m".to_owned(),
+            confidence: Confidence::Suspected,
+        }
+    }
+
+    fn scan_counted(
+        cache: &FileCache,
+        analyzer: &str,
+        rel: &Path,
+        content: &[u8],
+        counter: &AtomicUsize,
+    ) -> Vec<Finding> {
+        cache
+            .get_or_scan(analyzer, rel, content, || {
+                counter.fetch_add(1, Ordering::Relaxed);
+                Ok::<_, Infallible>(vec![sample_finding()])
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn hit_skips_the_scan_and_preserves_findings() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::open(dir.path().to_path_buf(), &AnalyzeConfig::default()).unwrap();
+        let runs = AtomicUsize::new(0);
+        let first = scan_counted(&cache, "a", Path::new("x.php"), b"<?php 1;", &runs);
+        let second = scan_counted(&cache, "a", Path::new("x.php"), b"<?php 1;", &runs);
+        assert_eq!(runs.load(Ordering::Relaxed), 1, "second call must be a cache hit");
+        assert_eq!(first, second);
+        assert_eq!(second[0].confidence, Confidence::Suspected);
+    }
+
+    #[test]
+    fn content_path_and_analyzer_all_key_the_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::open(dir.path().to_path_buf(), &AnalyzeConfig::default()).unwrap();
+        let runs = AtomicUsize::new(0);
+        scan_counted(&cache, "a", Path::new("x.php"), b"one", &runs);
+        scan_counted(&cache, "a", Path::new("x.php"), b"two", &runs); // content differs
+        scan_counted(&cache, "a", Path::new("y.php"), b"one", &runs); // path differs
+        scan_counted(&cache, "b", Path::new("x.php"), b"one", &runs); // analyzer differs
+        assert_eq!(runs.load(Ordering::Relaxed), 4);
+    }
+
+    #[test]
+    fn any_config_change_invalidates() {
+        let dir = tempfile::tempdir().unwrap();
+        let runs = AtomicUsize::new(0);
+        let cache = FileCache::open(dir.path().to_path_buf(), &AnalyzeConfig::default()).unwrap();
+        scan_counted(&cache, "a", Path::new("x.php"), b"c", &runs);
+
+        // Even a config knob irrelevant to this analyzer invalidates —
+        // whole-config hashing is the correctness-safe contract.
+        let mut config = AnalyzeConfig::default();
+        config.policy.deny_score = 51;
+        let cache = FileCache::open(dir.path().to_path_buf(), &config).unwrap();
+        scan_counted(&cache, "a", Path::new("x.php"), b"c", &runs);
+        assert_eq!(runs.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn corrupt_entry_is_a_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileCache::open(dir.path().to_path_buf(), &AnalyzeConfig::default()).unwrap();
+        let runs = AtomicUsize::new(0);
+        scan_counted(&cache, "a", Path::new("x.php"), b"c", &runs);
+        // Corrupt every entry file, then re-query: must rescan, not error.
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            std::fs::write(entry.unwrap().path(), b"{not json").unwrap();
+        }
+        scan_counted(&cache, "a", Path::new("x.php"), b"c", &runs);
+        assert_eq!(runs.load(Ordering::Relaxed), 2);
+    }
+}

--- a/crates/ephpm-analyze/src/config.rs
+++ b/crates/ephpm-analyze/src/config.rs
@@ -6,15 +6,22 @@
 //! set must never be a no-op). Unlike `ephpm.toml` there is no environment
 //! layer feeding this file, so the **root** is strict too.
 //!
+//! Every struct here also derives `Serialize`: the incremental cache
+//! (`crate::cache`) keys entries on a hash of the *effective* configuration,
+//! so any config change — file or CLI override — invalidates cached results.
+//!
 //! ```yaml
 //! profile: security          # security | none
+//! level: 1                   # 0..3 strictness (see crate::policy)
 //! fail_on: quarantine        # allow | quarantine | deny
 //! output: text               # text | sarif
+//! baseline: .ephpm-analyze-baseline.json   # suppress known findings
+//! since: origin/main         # diff-aware: only files changed vs this ref
 //! engine:                    # Phase 4 — parsed but inert today
 //!   detonate: false
 //!   timeout_ms: 30000
 //! analyzers:
-//!   enable: [composer-audit, semgrep-php, malware-yara, dangerous-sinks]
+//!   enable: [composer-audit, semgrep-php, malware-yara, dangerous-sinks, suppression-scan]
 //!   required: [composer-audit]
 //!   deny_hard: [dangerous-sinks/eval]
 //!   yara_rules: rules/malware.yar
@@ -23,6 +30,13 @@
 //! policy:
 //!   quarantine_score: 10
 //!   deny_score: 50
+//! cache:
+//!   enabled: true
+//!   dir: /var/cache/ephpm-analyze
+//! suppress:
+//!   - rule: dangerous-sinks/assert
+//!     path: legacy/compat.php
+//!     reason: vetted 2026-09 — assert() behind a debug flag, not reachable
 //! ```
 
 use std::fmt;
@@ -30,15 +44,15 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::Context as _;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A named preset that supplies the default analyzer set when
 /// `analyzers.enable` is not given explicitly.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Profile {
-    /// The Phase-1 security set: `composer-audit`, `semgrep-php`,
-    /// `malware-yara`, `dangerous-sinks`. The default.
+    /// The default security set: `composer-audit`, `semgrep-php`,
+    /// `malware-yara`, `dangerous-sinks`, `suppression-scan`.
     #[default]
     Security,
     /// No analyzers unless `analyzers.enable` lists them explicitly.
@@ -56,6 +70,7 @@ impl Profile {
                 "semgrep-php".to_owned(),
                 "malware-yara".to_owned(),
                 "dangerous-sinks".to_owned(),
+                "suppression-scan".to_owned(),
             ],
             Self::None => Vec::new(),
         }
@@ -94,7 +109,7 @@ impl fmt::Display for Profile {
 /// `allow` is deliberately "the gate allows everything" (report-only) rather
 /// than the literal "fail at allow-or-worse", which would fail every run and
 /// mean nothing.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FailOn {
     /// Report-only — never fail the exit code on the verdict.
@@ -122,7 +137,7 @@ impl FromStr for FailOn {
 }
 
 /// Output format for the analysis report.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputFormat {
     /// Concise human-readable text. The default.
@@ -149,7 +164,7 @@ impl FromStr for OutputFormat {
 /// **Planned: not yet implemented — parsed but not acted upon.** Both knobs
 /// exist so Phase-4 configs are shaped now; setting either produces a startup
 /// `tracing::warn!` (the workspace's no-silent-no-op rule).
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EngineConfig {
     /// Planned: not yet implemented — parsed but not acted upon. Will opt
@@ -181,7 +196,7 @@ fn default_tool_timeout_ms() -> u64 {
 }
 
 /// `analyzers:` — which analyzers run and how strictly.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnalyzersConfig {
     /// Analyzer ids to run. When omitted, the `profile` supplies the set.
@@ -242,7 +257,7 @@ fn default_deny_score() -> u32 {
 /// See `crate::policy` for the full model. Weights per finding severity:
 /// info 0, low 1, medium 4, high 10, critical 40 (critical also hard-denies
 /// on its own, so its weight only matters for reporting).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PolicyConfig {
     /// Total score at or above which the verdict is at least `Quarantine`.
@@ -260,19 +275,102 @@ impl Default for PolicyConfig {
     }
 }
 
+fn default_cache_enabled() -> bool {
+    true
+}
+
+/// `cache:` — the incremental content-hash result cache.
+///
+/// Only the **native per-file analyzers** (`dangerous-sinks`,
+/// `suppression-scan`) consult the cache; external-tool analyzers are never
+/// cached because their results depend on state outside the analyzed tree
+/// (advisory databases, registry rule packs, ruleset files) — a cache hit
+/// there could hide a newly published advisory. See `crate::cache` for the
+/// key model and the trust boundary of the cache directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CacheConfig {
+    /// Whether the cache is consulted at all. Default `true` — the key
+    /// includes the file content hash, the analyzer id, the effective config
+    /// hash, and the crate version, so a hit is always current.
+    #[serde(default = "default_cache_enabled")]
+    pub enabled: bool,
+    /// Cache directory. Default: `ephpm-analyze-cache` under the system temp
+    /// directory. On shared hosts point this at a path only the operator can
+    /// write — the cache is trusted state.
+    #[serde(default)]
+    pub dir: Option<PathBuf>,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self { enabled: default_cache_enabled(), dir: None }
+    }
+}
+
+/// One operator-side suppression: waive findings matching `rule` (and
+/// optionally `path`) with a documented `reason`.
+///
+/// Suppressions come **only** from this config — never from comments inside
+/// the analyzed code. Tenant-authored suppression-shaped comments are
+/// themselves flagged by the `suppression-scan` analyzer. `reason` is
+/// mandatory and must be non-empty: a waiver without a recorded why is a
+/// config error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SuppressRule {
+    /// Rule id to waive — exact, or a `/`-prefix (`dangerous-sinks` waives
+    /// every `dangerous-sinks/<rule>`), same matching as
+    /// `analyzers.deny_hard`.
+    pub rule: String,
+    /// When set, only findings at exactly this tree-relative path are waived
+    /// (compared with normalized `/` separators). When unset, the rule
+    /// applies at any path.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Why this finding class is acceptable — recorded for the audit trail,
+    /// required non-empty.
+    pub reason: String,
+}
+
+fn default_level() -> u8 {
+    1
+}
+
+/// The highest valid `level:` value — see `crate::policy` for the mapping.
+pub const MAX_LEVEL: u8 = 3;
+
 /// The root of `.ephpm-analyze.yml`.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnalyzeConfig {
     /// Named preset supplying the default analyzer set. Default `security`.
     #[serde(default)]
     pub profile: Profile,
+    /// Strictness level `0..=3` scaling which findings gate — see
+    /// `crate::policy` for the exact mapping. Default `1` (the weighted-score
+    /// model). Composes with `profile`: the profile picks *which* analyzers
+    /// run, the level picks *how strictly* their findings gate.
+    #[serde(default = "default_level")]
+    pub level: u8,
     /// Which verdicts fail the exit code. Default `quarantine`.
     #[serde(default)]
     pub fail_on: FailOn,
     /// Report format. Default `text`.
     #[serde(default)]
     pub output: OutputFormat,
+    /// Baseline file to read: findings whose fingerprint appears in it are
+    /// suppressed, so only *new* findings gate (the PHPStan model). Relative
+    /// paths resolve against the analyzed root. A configured-but-missing
+    /// baseline is a hard error (fail-closed), never a silent full scan.
+    /// Generate the file with `ephpm analyze --baseline <file>`.
+    #[serde(default)]
+    pub baseline: Option<PathBuf>,
+    /// Diff-aware scanning: restrict findings to files changed versus this
+    /// git ref (`git diff --name-only <ref>` plus untracked files). A git
+    /// failure is a hard error (fail-closed), never a silent full pass.
+    #[serde(default)]
+    pub since: Option<String>,
     /// Phase-4 engine section (parsed but inert — see [`EngineConfig`]).
     #[serde(default)]
     pub engine: EngineConfig,
@@ -282,6 +380,32 @@ pub struct AnalyzeConfig {
     /// Scoring thresholds.
     #[serde(default)]
     pub policy: PolicyConfig,
+    /// Incremental result cache — see [`CacheConfig`].
+    #[serde(default)]
+    pub cache: CacheConfig,
+    /// Operator-side finding waivers — see [`SuppressRule`]. The **only**
+    /// suppression mechanism: inline comments in the analyzed code are never
+    /// honored (and are flagged by `suppression-scan`).
+    #[serde(default)]
+    pub suppress: Vec<SuppressRule>,
+}
+
+impl Default for AnalyzeConfig {
+    fn default() -> Self {
+        Self {
+            profile: Profile::default(),
+            level: default_level(),
+            fail_on: FailOn::default(),
+            output: OutputFormat::default(),
+            baseline: None,
+            since: None,
+            engine: EngineConfig::default(),
+            analyzers: AnalyzersConfig::default(),
+            policy: PolicyConfig::default(),
+            cache: CacheConfig::default(),
+            suppress: Vec::new(),
+        }
+    }
 }
 
 impl AnalyzeConfig {
@@ -289,9 +413,38 @@ impl AnalyzeConfig {
     ///
     /// # Errors
     ///
-    /// On invalid YAML or any unknown key (all sections are strict).
+    /// On invalid YAML, any unknown key (all sections are strict), a `level`
+    /// outside `0..=3`, or a `suppress` entry with an empty `rule` or
+    /// `reason`.
     pub fn from_yaml(yaml: &str) -> anyhow::Result<Self> {
-        serde_yaml_ng::from_str(yaml).context("invalid .ephpm-analyze.yml")
+        let config: Self = serde_yaml_ng::from_str(yaml).context("invalid .ephpm-analyze.yml")?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Semantic checks past what serde can express.
+    ///
+    /// # Errors
+    ///
+    /// On an out-of-range `level` or an undocumented/empty suppression.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.level <= MAX_LEVEL,
+            "level {} is out of range (expected 0..={MAX_LEVEL})",
+            self.level
+        );
+        for (idx, rule) in self.suppress.iter().enumerate() {
+            anyhow::ensure!(
+                !rule.rule.trim().is_empty(),
+                "suppress[{idx}] has an empty rule — name the rule id (or prefix) to waive"
+            );
+            anyhow::ensure!(
+                !rule.reason.trim().is_empty(),
+                "suppress[{idx}] ({}) has an empty reason — a waiver must document why",
+                rule.rule
+            );
+        }
+        Ok(())
     }
 
     /// Load from a file.
@@ -321,15 +474,38 @@ mod tests {
     fn empty_document_gets_all_defaults() {
         let cfg = AnalyzeConfig::from_yaml("{}").unwrap();
         assert_eq!(cfg.profile, Profile::Security);
+        assert_eq!(cfg.level, 1);
         assert_eq!(cfg.fail_on, FailOn::Quarantine);
         assert_eq!(cfg.output, OutputFormat::Text);
+        assert_eq!(cfg.baseline, None);
+        assert_eq!(cfg.since, None);
         assert!(!cfg.engine.detonate);
         assert_eq!(cfg.policy.quarantine_score, 10);
         assert_eq!(cfg.policy.deny_score, 50);
+        assert!(cfg.cache.enabled);
+        assert_eq!(cfg.cache.dir, None);
+        assert!(cfg.suppress.is_empty());
         assert_eq!(
             cfg.enabled_analyzers(),
-            vec!["composer-audit", "semgrep-php", "malware-yara", "dangerous-sinks"]
+            vec![
+                "composer-audit",
+                "semgrep-php",
+                "malware-yara",
+                "dangerous-sinks",
+                "suppression-scan"
+            ]
         );
+    }
+
+    #[test]
+    fn parsed_and_derived_defaults_agree() {
+        // `AnalyzeConfig::default()` is used when no config file exists;
+        // parsing `{}` must produce the same effective configuration (this
+        // is where a derived `Default` silently diverging from a serde
+        // default would surface — e.g. `level` defaulting to 0 vs 1).
+        let parsed = AnalyzeConfig::from_yaml("{}").unwrap();
+        let derived = AnalyzeConfig::default();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), serde_json::to_value(&derived).unwrap());
     }
 
     #[test]
@@ -337,8 +513,11 @@ mod tests {
         let cfg = AnalyzeConfig::from_yaml(
             r"
 profile: none
+level: 2
 fail_on: deny
 output: sarif
+baseline: .ephpm-analyze-baseline.json
+since: origin/main
 engine:
   detonate: true
   timeout_ms: 30000
@@ -352,11 +531,31 @@ analyzers:
 policy:
   quarantine_score: 5
   deny_score: 20
+cache:
+  enabled: false
+  dir: /var/cache/ephpm-analyze
+suppress:
+  - rule: dangerous-sinks/assert
+    path: legacy/compat.php
+    reason: vetted
 ",
         )
         .unwrap();
         assert_eq!(cfg.profile, Profile::None);
+        assert_eq!(cfg.level, 2);
         assert_eq!(cfg.fail_on, FailOn::Deny);
+        assert_eq!(cfg.baseline.as_deref(), Some(Path::new(".ephpm-analyze-baseline.json")));
+        assert_eq!(cfg.since.as_deref(), Some("origin/main"));
+        assert!(!cfg.cache.enabled);
+        assert_eq!(cfg.cache.dir.as_deref(), Some(Path::new("/var/cache/ephpm-analyze")));
+        assert_eq!(
+            cfg.suppress,
+            vec![SuppressRule {
+                rule: "dangerous-sinks/assert".to_owned(),
+                path: Some("legacy/compat.php".to_owned()),
+                reason: "vetted".to_owned(),
+            }]
+        );
         assert_eq!(cfg.output, OutputFormat::Sarif);
         assert!(cfg.engine.detonate);
         assert_eq!(cfg.engine.timeout_ms, Some(30_000));
@@ -379,6 +578,8 @@ policy:
             ("engine", "engine:\n  detonate_all: true"),
             ("analyzers", "analyzers:\n  enabled: [x]"), // common typo of `enable`
             ("policy", "policy:\n  deny_treshold: 1"),
+            ("cache", "cache:\n  directory: /tmp"), // common typo of `dir`
+            ("suppress", "suppress:\n  - rule: a/b\n    reason: r\n    line: 3"),
         ];
         for (section, yaml) in cases {
             let err = AnalyzeConfig::from_yaml(yaml)
@@ -386,6 +587,27 @@ policy:
             let msg = format!("{err:#}");
             assert!(msg.contains("unknown field"), "{section}: {msg}");
         }
+    }
+
+    #[test]
+    fn level_out_of_range_is_rejected() {
+        let err = AnalyzeConfig::from_yaml("level: 4").unwrap_err();
+        assert!(format!("{err:#}").contains("out of range"));
+        for level in 0..=3u8 {
+            let cfg = AnalyzeConfig::from_yaml(&format!("level: {level}")).unwrap();
+            assert_eq!(cfg.level, level);
+        }
+    }
+
+    #[test]
+    fn suppress_without_reason_is_rejected() {
+        // A waiver must document why — an empty (or whitespace) reason is a
+        // config error, not a silently accepted suppression.
+        let err = AnalyzeConfig::from_yaml("suppress:\n  - rule: a/b\n    reason: ''").unwrap_err();
+        assert!(format!("{err:#}").contains("empty reason"));
+        let err =
+            AnalyzeConfig::from_yaml("suppress:\n  - rule: ' '\n    reason: why").unwrap_err();
+        assert!(format!("{err:#}").contains("empty rule"));
     }
 
     #[test]

--- a/crates/ephpm-analyze/src/finding.rs
+++ b/crates/ephpm-analyze/src/finding.rs
@@ -74,6 +74,41 @@ impl fmt::Display for Category {
     }
 }
 
+/// How sure the producing analyzer is that a finding is real — the axis that
+/// separates *hotspots* from confirmed problems.
+///
+/// The policy engine (`crate::policy`) treats the two very differently:
+/// `Confirmed` findings can drive a hard `Deny` (deny-hard match, critical
+/// severity, deny-score threshold), while `Suspected` findings are review
+/// signals — they contribute to the score and can floor the verdict at
+/// `Quarantine`, but never force `Deny` on their own. "Definitely malicious →
+/// deny" stays separate from "suspicious → quarantine for review".
+///
+/// The ordering (`Suspected < Confirmed`) is load-bearing for comparisons.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Confidence {
+    /// A heuristic hit that may be a false positive — a hotspot worth human
+    /// review, not proof.
+    Suspected,
+    /// The analyzer is confident the finding is real (a known advisory
+    /// against a pinned lockfile, a malware-signature match, a fact about
+    /// the file's content). The default: absence of doubt is confirmed.
+    #[default]
+    Confirmed,
+}
+
+impl fmt::Display for Confidence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Suspected => "suspected",
+            Self::Confirmed => "confirmed",
+        })
+    }
+}
+
 /// One result produced by an analyzer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Finding {
@@ -94,4 +129,8 @@ pub struct Finding {
     pub line: Option<u64>,
     /// Human-readable description.
     pub message: String,
+    /// How sure the analyzer is — see [`Confidence`] for the policy
+    /// consequences. Defaults to `Confirmed` when absent in serialized form.
+    #[serde(default)]
+    pub confidence: Confidence,
 }

--- a/crates/ephpm-analyze/src/lib.rs
+++ b/crates/ephpm-analyze/src/lib.rs
@@ -1,19 +1,22 @@
 //! ephpm-analyze — static-analysis aggregator and fail-closed deploy gate
 //! for PHP applications (`ephpm analyze`).
 //!
-//! # Architecture (Phase 1)
+//! # Architecture
 //!
 //! ```text
 //!   .ephpm-analyze.yml ──► AnalyzeConfig ──► AnalysisCtx
+//!                             (+ scope, cache, baseline)
 //!                                               │
 //!                     ┌─────────────────────────┼──────────────┐
 //!                     ▼                         ▼              ▼
 //!             external-tool analyzers    native analyzers   (planned:
 //!             composer-audit             dangerous-sinks     opcode/L1,
-//!             semgrep-php                                    engine/L2)
+//!             semgrep-php                suppression-scan    engine/L2)
 //!             malware-yara
 //!                     │                         │
 //!                     └────────► Findings ◄─────┘
+//!                                   │
+//!               scope filter ─► operator suppress ─► baseline
 //!                                   │
 //!                            policy::decide ──► Verdict ──► exit code
 //!                                   │
@@ -21,13 +24,18 @@
 //! ```
 //!
 //! The aggregator runs every enabled [`Analyzer`], merges their
-//! [`Finding`]s, and hands the lot to the policy engine, which produces a
-//! [`Verdict`] (`Allow` / `Quarantine` / `Deny`). The whole pipeline is
-//! **fail-closed**: an analyzer that errors, times out, panics, or is
-//! `required` but cannot run floors the verdict at `Quarantine` — only a run
-//! where everything that should have spoken actually spoke can `Allow`. An
-//! *optional* analyzer whose external tool is simply not installed is
-//! reported as skipped and does not gate (see [`analyzer::AnalyzerError`]).
+//! [`Finding`]s, post-processes them (diff-aware scope filter, operator-only
+//! suppressions, baseline — in that order), and hands the survivors to the
+//! policy engine, which produces a [`Verdict`] (`Allow` / `Quarantine` /
+//! `Deny`). The whole pipeline is **fail-closed**: an analyzer that errors,
+//! times out, panics, or is `required` but cannot run floors the verdict at
+//! `Quarantine` — only a run where everything that should have spoken
+//! actually spoke can `Allow`. An *optional* analyzer whose external tool is
+//! simply not installed is reported as skipped and does not gate (see
+//! [`analyzer::AnalyzerError`]). The same discipline runs through the
+//! supporting features: a `since` git failure, a missing configured
+//! baseline, and an invalid config are all hard errors, never silent
+//! degradations.
 //!
 //! Later phases (opcode-level analysis of compiled PHP, engine-in-the-loop
 //! detonation) slot in as more [`Analyzer`] implementations reading richer
@@ -36,19 +44,24 @@
 
 pub mod analyzer;
 pub mod analyzers;
+pub mod baseline;
+pub mod cache;
 pub mod config;
 pub mod finding;
 pub mod output;
 pub mod policy;
 pub mod report;
+pub mod scope;
+pub mod suppress;
 
 use std::path::Path;
 
 use anyhow::Context as _;
 
 pub use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+pub use crate::baseline::Baseline;
 pub use crate::config::{AnalyzeConfig, FailOn, OutputFormat, Profile};
-pub use crate::finding::{Category, Finding, Severity};
+pub use crate::finding::{Category, Confidence, Finding, Severity};
 pub use crate::policy::Verdict;
 pub use crate::report::{AnalysisReport, AnalyzerState, AnalyzerStatus};
 
@@ -102,6 +115,31 @@ pub fn run_analyzers(ctx: &AnalysisCtx, analyzers: &[Box<dyn Analyzer>]) -> Anal
         statuses.push(AnalyzerStatus { id, state });
     }
 
+    // Post-processing, in a deliberate order:
+    //
+    // 1. Diff-aware scope: on a `since` run, drop findings anchored at a
+    //    path outside the changed set. Pathless findings are always kept —
+    //    an unattributable finding must not be droppable by scoping.
+    let mut out_of_scope = 0;
+    if let Some(scope) = ctx.scope() {
+        let before = findings.len();
+        findings.retain(|f| f.path.as_deref().is_none_or(|p| scope.contains(p)));
+        out_of_scope = before - findings.len();
+    }
+
+    // 2. Operator suppressions — the only waiver mechanism (crate::suppress).
+    let (mut findings, waived) = suppress::apply(findings, &ctx.config().suppress);
+
+    // 3. Baseline: drop findings whose stable fingerprint is remembered, so
+    //    only new findings gate.
+    let mut baseline_suppressed = 0;
+    if let Some(baseline) = ctx.baseline() {
+        let known = baseline.fingerprints();
+        let before = findings.len();
+        findings.retain(|f| !known.contains(baseline::fingerprint(f).as_str()));
+        baseline_suppressed = before - findings.len();
+    }
+
     // Most severe first, then stable by rule id for deterministic output.
     findings.sort_by(|a, b| b.severity.cmp(&a.severity).then_with(|| a.rule_id.cmp(&b.rule_id)));
 
@@ -112,10 +150,13 @@ pub fn run_analyzers(ctx: &AnalysisCtx, analyzers: &[Box<dyn Analyzer>]) -> Anal
         .collect();
     let decision = policy::decide(
         &findings,
-        &ctx.config().analyzers.deny_hard,
-        &failed,
-        ctx.config().policy.quarantine_score,
-        ctx.config().policy.deny_score,
+        &policy::PolicyParams {
+            deny_hard: &ctx.config().analyzers.deny_hard,
+            failed_analyzers: &failed,
+            quarantine_score: ctx.config().policy.quarantine_score,
+            deny_score: ctx.config().policy.deny_score,
+            level: ctx.config().level,
+        },
     );
 
     AnalysisReport {
@@ -124,6 +165,9 @@ pub fn run_analyzers(ctx: &AnalysisCtx, analyzers: &[Box<dyn Analyzer>]) -> Anal
         verdict: decision.verdict,
         score: decision.score,
         reasons: decision.reasons,
+        out_of_scope,
+        waived,
+        baseline_suppressed,
     }
 }
 
@@ -136,11 +180,14 @@ pub fn run_analyzers(ctx: &AnalysisCtx, analyzers: &[Box<dyn Analyzer>]) -> Anal
 ///
 /// # Errors
 ///
-/// On a missing/non-directory `root`, an unknown analyzer id, or a
-/// `required` entry that is not enabled. Individual analyzer failures do
-/// **not** error — they are folded into the report fail-closed.
+/// On a missing/non-directory `root`, an invalid configuration (unknown
+/// analyzer id, `required` entry that is not enabled, out-of-range `level`),
+/// a git failure on a `since` run, or a configured-but-missing baseline —
+/// all fail-closed. Individual analyzer failures do **not** error — they are
+/// folded into the report fail-closed.
 pub fn analyze(root: &Path, config: AnalyzeConfig) -> anyhow::Result<AnalysisReport> {
     anyhow::ensure!(root.is_dir(), "analysis target {} is not a directory", root.display());
+    config.validate()?;
 
     if config.engine.any_set() {
         tracing::warn!(
@@ -175,7 +222,54 @@ pub fn analyze(root: &Path, config: AnalyzeConfig) -> anyhow::Result<AnalysisRep
     let root = root
         .canonicalize()
         .with_context(|| format!("failed to canonicalize {}", root.display()))?;
-    let ctx = AnalysisCtx::new(root, config);
+
+    // Diff-aware scope: any git failure is a hard error (fail-closed).
+    let scope = match &config.since {
+        Some(since_ref) => {
+            let scope = scope::changed_files(&root, since_ref)?;
+            tracing::info!(since = %since_ref, changed_files = scope.len(), "diff-aware scan");
+            Some(scope)
+        }
+        None => None,
+    };
+
+    // Baseline: a configured-but-missing file is a hard error — an operator
+    // asked for baseline gating, so silently gating without one (or with a
+    // stale corrupt one) would be a no-op knob.
+    let baseline = match &config.baseline {
+        Some(path) => {
+            let path = if path.is_absolute() { path.clone() } else { root.join(path) };
+            Some(Baseline::load(&path)?)
+        }
+        None => None,
+    };
+
+    // Cache open failures degrade to an uncached run (warn) — the cache is
+    // an optimization; only its *contents* are correctness-relevant, and
+    // those are keyed safely (see crate::cache).
+    let cache = if config.cache.enabled {
+        let dir = config.cache.dir.clone().unwrap_or_else(cache::default_dir);
+        match cache::FileCache::open(dir, &config) {
+            Ok(cache) => Some(cache),
+            Err(e) => {
+                tracing::warn!(error = %e, "analysis cache unavailable — running uncached");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut ctx = AnalysisCtx::new(root, config);
+    if let Some(scope) = scope {
+        ctx = ctx.with_scope(scope);
+    }
+    if let Some(baseline) = baseline {
+        ctx = ctx.with_baseline(baseline);
+    }
+    if let Some(cache) = cache {
+        ctx = ctx.with_cache(cache);
+    }
     Ok(run_analyzers(&ctx, &selected))
 }
 
@@ -202,6 +296,37 @@ mod tests {
 
     fn ctx_with(config: AnalyzeConfig) -> AnalysisCtx {
         AnalysisCtx::new(std::env::temp_dir(), config)
+    }
+
+    fn test_finding(rule_id: &str, severity: Severity, path: Option<&str>) -> Finding {
+        Finding {
+            rule_id: rule_id.to_owned(),
+            severity,
+            category: Category::Security,
+            path: path.map(std::path::PathBuf::from),
+            line: Some(1),
+            message: format!("finding {rule_id}"),
+            confidence: Confidence::Confirmed,
+        }
+    }
+
+    /// A boxed analyzer emitting a fixed finding set (built per call so the
+    /// `fn()`-pointer shape of `FakeAnalyzer` is not a constraint here).
+    struct EmitAnalyzer(Vec<Finding>);
+
+    impl Analyzer for EmitAnalyzer {
+        // The trait fixes the signature; the literal cannot be
+        // `&'static str` here without diverging from it.
+        #[allow(clippy::unnecessary_literal_bound)]
+        fn id(&self) -> &str {
+            "emit"
+        }
+        fn category(&self) -> Category {
+            Category::Security
+        }
+        fn run(&self, _ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+            Ok(self.0.clone())
+        }
     }
 
     #[test]
@@ -253,22 +378,8 @@ mod tests {
             id: "multi",
             result: || {
                 Ok(vec![
-                    Finding {
-                        rule_id: "multi/low".to_owned(),
-                        severity: Severity::Low,
-                        category: Category::Quality,
-                        path: None,
-                        line: None,
-                        message: "l".to_owned(),
-                    },
-                    Finding {
-                        rule_id: "multi/high".to_owned(),
-                        severity: Severity::High,
-                        category: Category::Security,
-                        path: None,
-                        line: None,
-                        message: "h".to_owned(),
-                    },
+                    test_finding("multi/low", Severity::Low, Some("a.php")),
+                    test_finding("multi/high", Severity::High, Some("a.php")),
                 ])
             },
         })];
@@ -298,5 +409,119 @@ mod tests {
         let err =
             analyze(Path::new("Z:/definitely/not/here"), AnalyzeConfig::default()).unwrap_err();
         assert!(format!("{err:#}").contains("not a directory"));
+    }
+
+    #[test]
+    fn scope_filter_drops_out_of_scope_findings_but_keeps_pathless() {
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(EmitAnalyzer(vec![
+            test_finding("e/changed", Severity::High, Some("changed.php")),
+            test_finding("e/unchanged", Severity::High, Some("unchanged.php")),
+            test_finding("e/pathless", Severity::High, None),
+        ]))];
+        let ctx = ctx_with(AnalyzeConfig::default())
+            .with_scope(scope::Scope::from_paths(vec!["changed.php".to_owned()]));
+        let report = run_analyzers(&ctx, &analyzers);
+        let ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert_eq!(report.out_of_scope, 1);
+        assert!(ids.contains(&"e/changed"));
+        assert!(!ids.contains(&"e/unchanged"));
+        // Pathless findings can never be dropped by scoping (fail-safe).
+        assert!(ids.contains(&"e/pathless"));
+    }
+
+    #[test]
+    fn operator_suppression_waives_and_is_counted() {
+        let mut config = AnalyzeConfig::default();
+        config.suppress = vec![config::SuppressRule {
+            rule: "e/known".to_owned(),
+            path: Some("legacy.php".to_owned()),
+            reason: "vetted".to_owned(),
+        }];
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(EmitAnalyzer(vec![
+            test_finding("e/known", Severity::High, Some("legacy.php")),
+            test_finding("e/other", Severity::Low, Some("legacy.php")),
+        ]))];
+        let report = run_analyzers(&ctx_with(config), &analyzers);
+        assert_eq!(report.waived, 1);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].rule_id, "e/other");
+        assert_eq!(report.verdict, Verdict::Allow);
+    }
+
+    #[test]
+    fn baseline_suppresses_known_findings_and_gates_only_new_ones() {
+        // The baseline remembers e/known at line 5; the current run sees it
+        // at line 50 (reformatted) — still suppressed. e/new gates.
+        let mut known = test_finding("e/known", Severity::High, Some("a.php"));
+        known.line = Some(5);
+        let baseline = Baseline::from_findings(std::slice::from_ref(&known));
+        let mut moved = known.clone();
+        moved.line = Some(50);
+        let analyzers: Vec<Box<dyn Analyzer>> = vec![Box::new(EmitAnalyzer(vec![
+            moved,
+            test_finding("e/new", Severity::High, Some("a.php")),
+        ]))];
+        let ctx = ctx_with(AnalyzeConfig::default()).with_baseline(baseline);
+        let report = run_analyzers(&ctx, &analyzers);
+        assert_eq!(report.baseline_suppressed, 1);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].rule_id, "e/new");
+    }
+
+    #[test]
+    fn analyze_fails_closed_on_missing_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = AnalyzeConfig {
+            baseline: Some(std::path::PathBuf::from("no-such-baseline.json")),
+            ..AnalyzeConfig::default()
+        };
+        let err = analyze(dir.path(), config).unwrap_err();
+        assert!(format!("{err:#}").contains("baseline"));
+    }
+
+    #[test]
+    fn analyze_fails_closed_when_since_git_fails() {
+        // A tempdir is not a git repository — the diff-aware run must error,
+        // never silently degrade to an empty (or full) scan.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config =
+            AnalyzeConfig { since: Some("HEAD".to_owned()), ..AnalyzeConfig::default() };
+        config.cache.enabled = false;
+        assert!(analyze(dir.path(), config).is_err());
+    }
+
+    #[test]
+    fn tenant_suppression_marker_is_flagged_and_never_honored() {
+        // The two halves of operator-only suppression, end to end on a real
+        // tree: (a) a tenant comment shaped like a suppression directive
+        // does NOT waive the finding it sits next to; (b) the comment itself
+        // becomes a finding. Then: (c) an operator suppress rule — the only
+        // honored mechanism — waives the sink finding, while the
+        // tenant-suppression-attempt finding still stands.
+        let dir = tempfile::tempdir().unwrap();
+        // The assert() sink with an inline "ignore" marker (assembled here,
+        // never a webshell-shaped byte sequence — see dangerous_sinks docs).
+        std::fs::write(dir.path().join("t.php"), "<?php\nassert($cond); // ephpm-analyze-ignore\n")
+            .unwrap();
+        let mut config =
+            AnalyzeConfig::from_yaml("analyzers:\n  enable: [dangerous-sinks, suppression-scan]")
+                .unwrap();
+        config.cache.enabled = false;
+
+        let report = analyze(dir.path(), config.clone()).unwrap();
+        let ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert!(ids.contains(&"dangerous-sinks/assert"), "marker must not waive: {ids:?}");
+        assert!(ids.contains(&"suppression-scan/tenant-suppression-attempt"), "{ids:?}");
+
+        config.suppress = vec![config::SuppressRule {
+            rule: "dangerous-sinks/assert".to_owned(),
+            path: Some("t.php".to_owned()),
+            reason: "vetted".to_owned(),
+        }];
+        let report = analyze(dir.path(), config).unwrap();
+        let ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id.as_str()).collect();
+        assert!(!ids.contains(&"dangerous-sinks/assert"), "operator suppress waives: {ids:?}");
+        assert!(ids.contains(&"suppression-scan/tenant-suppression-attempt"), "{ids:?}");
+        assert_eq!(report.waived, 1);
     }
 }

--- a/crates/ephpm-analyze/src/output.rs
+++ b/crates/ephpm-analyze/src/output.rs
@@ -8,7 +8,7 @@ use std::fmt::Write as _;
 
 use serde::Serialize;
 
-use crate::finding::{Finding, Severity};
+use crate::finding::{Confidence, Finding, Severity};
 use crate::report::{AnalysisReport, AnalyzerState};
 
 /// SARIF `level` for a severity.
@@ -17,6 +17,15 @@ fn sarif_level(severity: Severity) -> &'static str {
         Severity::Info | Severity::Low => "note",
         Severity::Medium => "warning",
         Severity::High | Severity::Critical => "error",
+    }
+}
+
+/// SARIF `rank` (0.0–100.0, "importance for triage") from confidence:
+/// confirmed findings outrank suspected hotspots at equal severity.
+fn sarif_rank(confidence: Confidence) -> f64 {
+    match confidence {
+        Confidence::Suspected => 40.0,
+        Confidence::Confirmed => 80.0,
     }
 }
 
@@ -77,6 +86,12 @@ struct SarifRunProperties {
     verdict: String,
     #[serde(rename = "ephpm/score")]
     score: u32,
+    #[serde(rename = "ephpm/outOfScope")]
+    out_of_scope: usize,
+    #[serde(rename = "ephpm/waived")]
+    waived: usize,
+    #[serde(rename = "ephpm/baselineSuppressed")]
+    baseline_suppressed: usize,
 }
 
 #[derive(Serialize)]
@@ -84,6 +99,8 @@ struct SarifResult {
     #[serde(rename = "ruleId")]
     rule_id: String,
     level: &'static str,
+    /// Triage importance derived from confidence — see [`sarif_rank`].
+    rank: f64,
     message: SarifMessage,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     locations: Vec<SarifLocation>,
@@ -96,6 +113,8 @@ struct SarifResultProperties {
     severity: String,
     #[serde(rename = "ephpm/category")]
     category: String,
+    #[serde(rename = "ephpm/confidence")]
+    confidence: String,
 }
 
 #[derive(Serialize)]
@@ -148,11 +167,13 @@ fn sarif_result(finding: &Finding) -> SarifResult {
     SarifResult {
         rule_id: finding.rule_id.clone(),
         level: sarif_level(finding.severity),
+        rank: sarif_rank(finding.confidence),
         message: SarifMessage { text: finding.message.clone() },
         locations,
         properties: SarifResultProperties {
             severity: finding.severity.to_string(),
             category: finding.category.to_string(),
+            confidence: finding.confidence.to_string(),
         },
     }
 }
@@ -210,6 +231,9 @@ pub fn to_sarif(report: &AnalysisReport) -> anyhow::Result<String> {
             properties: SarifRunProperties {
                 verdict: report.verdict.to_string(),
                 score: report.score,
+                out_of_scope: report.out_of_scope,
+                waived: report.waived,
+                baseline_suppressed: report.baseline_suppressed,
             },
         }],
     };
@@ -242,13 +266,29 @@ pub fn to_text(report: &AnalysisReport) -> String {
             (Some(path), None) => path.display().to_string(),
             _ => "-".to_owned(),
         };
+        // Suspected findings are hotspots (review signals); the marker keeps
+        // the common confirmed case visually quiet.
+        let suffix = match finding.confidence {
+            Confidence::Confirmed => "",
+            Confidence::Suspected => " [suspected]",
+        };
         let _ = writeln!(
             out,
-            "  [{:<8}] {:<32} {location}: {}",
+            "  [{:<8}] {:<32} {location}: {}{suffix}",
             finding.severity, finding.rule_id, finding.message
         );
     }
     let _ = writeln!(out);
+    if report.out_of_scope > 0 {
+        let _ = writeln!(out, "out of scope: {} finding(s) (diff-aware run)", report.out_of_scope);
+    }
+    if report.waived > 0 {
+        let _ = writeln!(out, "waived:  {} finding(s) by operator suppressions", report.waived);
+    }
+    if report.baseline_suppressed > 0 {
+        let _ =
+            writeln!(out, "baseline: {} known finding(s) suppressed", report.baseline_suppressed);
+    }
     let _ = writeln!(out, "score:   {}", report.score);
     let _ = writeln!(out, "verdict: {}", report.verdict);
     for reason in &report.reasons {
@@ -276,6 +316,7 @@ mod tests {
                     path: Some(PathBuf::from("src\\index.php")),
                     line: Some(12),
                     message: "eval() call".to_owned(),
+                    confidence: Confidence::Suspected,
                 },
                 Finding {
                     rule_id: "composer-audit/CVE-2024-1".to_owned(),
@@ -284,6 +325,7 @@ mod tests {
                     path: None,
                     line: None,
                     message: "vulnerable dependency".to_owned(),
+                    confidence: Confidence::Confirmed,
                 },
             ],
             statuses: vec![
@@ -303,6 +345,9 @@ mod tests {
             verdict: Verdict::Quarantine,
             score: 14,
             reasons: vec!["score 14 >= quarantine threshold 10".to_owned()],
+            out_of_scope: 3,
+            waived: 2,
+            baseline_suppressed: 1,
         }
     }
 
@@ -324,12 +369,21 @@ mod tests {
         // Pathless finding has no locations key at all.
         assert!(results[1].get("locations").is_none());
         assert_eq!(results[1]["level"], "warning");
+        // Confidence surfaces as rank + a property: suspected hotspots rank
+        // below confirmed findings.
+        assert_eq!(results[0]["rank"], 40.0);
+        assert_eq!(results[0]["properties"]["ephpm/confidence"], "suspected");
+        assert_eq!(results[1]["rank"], 80.0);
+        assert_eq!(results[1]["properties"]["ephpm/confidence"], "confirmed");
         // Rule index covers both rule ids.
         let rules = run["tool"]["driver"]["rules"].as_array().unwrap();
         assert_eq!(rules.len(), 2);
         // Verdict rides in run properties; failed analyzer flips
         // executionSuccessful and produces an error notification.
         assert_eq!(run["properties"]["ephpm/verdict"], "quarantine");
+        assert_eq!(run["properties"]["ephpm/outOfScope"], 3);
+        assert_eq!(run["properties"]["ephpm/waived"], 2);
+        assert_eq!(run["properties"]["ephpm/baselineSuppressed"], 1);
         let invocation = &run["invocations"][0];
         assert_eq!(invocation["executionSuccessful"], false);
         let notes = invocation["toolExecutionNotifications"].as_array().unwrap();
@@ -345,5 +399,24 @@ mod tests {
         assert!(text.contains("verdict: quarantine"));
         assert!(text.contains("score:   14"));
         assert!(text.contains("quarantine threshold"));
+        // Confidence marker only on the suspected finding.
+        assert!(text.contains("eval() call [suspected]"));
+        assert!(text.contains("vulnerable dependency\n"));
+        // Post-processing counters.
+        assert!(text.contains("out of scope: 3"));
+        assert!(text.contains("waived:  2"));
+        assert!(text.contains("baseline: 1 known finding(s)"));
+    }
+
+    #[test]
+    fn text_omits_zero_counters() {
+        let mut report = sample_report();
+        report.out_of_scope = 0;
+        report.waived = 0;
+        report.baseline_suppressed = 0;
+        let text = to_text(&report);
+        assert!(!text.contains("out of scope"));
+        assert!(!text.contains("waived"));
+        assert!(!text.contains("baseline:"));
     }
 }

--- a/crates/ephpm-analyze/src/policy.rs
+++ b/crates/ephpm-analyze/src/policy.rs
@@ -2,31 +2,56 @@
 //!
 //! # The model
 //!
-//! Three layers, evaluated strictest-first; the verdict is the **maximum**
+//! Four layers, evaluated strictest-first; the verdict is the **maximum**
 //! any layer demands (verdicts are ordered `Allow < Quarantine < Deny`):
 //!
 //! 1. **Hard denies.** A finding whose `rule_id` matches an
-//!    `analyzers.deny_hard` entry (exact, or under it as a `/`-prefix), or
-//!    any finding of `Critical` severity, forces `Deny` outright. No score
-//!    can talk its way past these.
+//!    `analyzers.deny_hard` entry (exact, or under it as a `/`-prefix)
+//!    forces `Deny` **regardless of confidence** — `deny_hard` is an
+//!    explicit operator instruction, and the operator who lists a heuristic
+//!    rule there has accepted its false positives (downgrading it would turn
+//!    their instruction into a no-op). A *confirmed* finding of `Critical`
+//!    severity also forces `Deny`; a **suspected** critical floors the
+//!    verdict at `Quarantine` instead — the automatic escalations are where
+//!    confidence separates "definitely malicious → deny" from "suspicious →
+//!    review" (see [`crate::finding::Confidence`]). No score can talk its
+//!    way past a hard deny.
 //! 2. **Fail-closed floor.** Any analyzer *failure* — a tool error, timeout,
 //!    unparseable output, or a `required` analyzer that could not run —
 //!    floors the verdict at `Quarantine`. An analyzer that errored might
 //!    have been about to find something, so the result can never be `Allow`.
-//!    A plain skip (optional tool absent) does **not** floor; it is surfaced
-//!    as a diagnostic instead.
-//! 3. **Weighted score.** Each finding contributes a weight by severity —
-//!    info 0, low 1, medium 4, high 10, critical 40 — and the total is
-//!    compared against the tunable `policy.quarantine_score` (default 10)
-//!    and `policy.deny_score` (default 50) thresholds. The weights are
-//!    deliberately super-additive (one high > two mediums > eight lows) so
-//!    volume of noise cannot outrank a single serious finding class, while a
-//!    large pile of mediums still escalates.
+//!    A plain skip (optional tool absent) does **not** floor. This layer is
+//!    active at **every** strictness level — fail-closed is the framework's
+//!    invariant, and no level relaxes it.
+//! 3. **Weighted score** *(levels 1+)*. Each finding contributes a weight by
+//!    severity — info 0, low 1, medium 4, high 10, critical 40 — and the
+//!    total is compared against the tunable `policy.quarantine_score`
+//!    (default 10) and `policy.deny_score` (default 50) thresholds. The
+//!    weights are deliberately super-additive (one high > two mediums >
+//!    eight lows) so volume of noise cannot outrank a single serious finding
+//!    class, while a large pile of mediums still escalates. Confidence
+//!    splits the thresholds: the **quarantine** threshold compares the total
+//!    score (suspected findings are review signals), while the **deny**
+//!    threshold compares only the confirmed portion (suspected findings
+//!    never add up to a hard stop).
+//! 4. **Severity floors** *(levels 2+)*. At level 2, any single `High`-or-
+//!    worse finding floors the verdict at `Quarantine` regardless of score;
+//!    at level 3 (paranoid), any `Medium`-or-worse finding does. Confidence
+//!    does not matter here — quarantine *is* the review signal.
+//!
+//! # Strictness levels (`level:` in the config)
+//!
+//! | level | name       | score layer | severity floor        |
+//! |-------|------------|-------------|-----------------------|
+//! | 0     | permissive | off         | none — only hard denies (and the fail-closed floor) gate |
+//! | 1     | standard   | on          | none (the default)     |
+//! | 2     | strict     | on          | `High`+ ⇒ quarantine   |
+//! | 3     | paranoid   | on          | `Medium`+ ⇒ quarantine |
 //!
 //! The returned [`PolicyDecision`] carries human-readable reasons for every
 //! layer that fired, so the text output can say *why* a run gated.
 
-use crate::finding::{Finding, Severity};
+use crate::finding::{Confidence, Finding, Severity};
 
 /// The gate's final decision for a run, ordered least to most severe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
@@ -57,10 +82,30 @@ impl std::fmt::Display for Verdict {
 pub struct PolicyDecision {
     /// The final verdict (already the max across all layers).
     pub verdict: Verdict,
-    /// The weighted score across all findings.
+    /// The weighted score across all findings (confirmed **and** suspected).
     pub score: u32,
     /// One line per layer that fired, for the report.
     pub reasons: Vec<String>,
+}
+
+/// Everything [`decide`] needs besides the findings themselves.
+///
+/// A struct rather than positional arguments: the parameter set grew past
+/// five with strictness levels, and a struct keeps call sites readable and
+/// future additions non-breaking at every call site simultaneously.
+#[derive(Debug, Clone, Copy)]
+pub struct PolicyParams<'a> {
+    /// `analyzers.deny_hard` — rule ids (or `/`-prefixes) that force `Deny`.
+    pub deny_hard: &'a [String],
+    /// Analyzers that errored (or were required and could not run) — a
+    /// non-empty list floors the verdict at `Quarantine`.
+    pub failed_analyzers: &'a [String],
+    /// `policy.quarantine_score` — compared against the **total** score.
+    pub quarantine_score: u32,
+    /// `policy.deny_score` — compared against the **confirmed-only** score.
+    pub deny_score: u32,
+    /// Strictness level `0..=3` — see the module docs for the mapping.
+    pub level: u8,
 }
 
 /// Score weight per severity — see the module docs for why super-additive.
@@ -86,24 +131,19 @@ pub fn deny_hard_matches(entry: &str, rule_id: &str) -> bool {
             && rule_id.as_bytes()[entry.len()] == b'/')
 }
 
-/// Evaluate the policy over merged findings.
-///
-/// `failed_analyzers` lists the analyzers that errored (or were required and
-/// could not run) — a non-empty list floors the verdict at `Quarantine`.
+/// Evaluate the policy over merged findings — see the module docs for the
+/// full layer model.
 #[must_use]
-pub fn decide(
-    findings: &[Finding],
-    deny_hard: &[String],
-    failed_analyzers: &[String],
-    quarantine_score: u32,
-    deny_score: u32,
-) -> PolicyDecision {
+pub fn decide(findings: &[Finding], params: &PolicyParams<'_>) -> PolicyDecision {
     let mut reasons = Vec::new();
     let mut verdict = Verdict::Allow;
 
-    // Layer 1: hard denies.
+    // Layer 1a: operator hard denies — explicit instructions, so they fire
+    // regardless of confidence.
     for finding in findings {
-        if let Some(entry) = deny_hard.iter().find(|e| deny_hard_matches(e, &finding.rule_id)) {
+        if let Some(entry) =
+            params.deny_hard.iter().find(|e| deny_hard_matches(e, &finding.rule_id))
+        {
             verdict = Verdict::Deny;
             reasons.push(format!(
                 "hard deny: finding {} matches deny_hard entry {entry:?}",
@@ -111,28 +151,66 @@ pub fn decide(
             ));
         }
     }
-    if let Some(critical) = findings.iter().find(|f| f.severity == Severity::Critical) {
-        verdict = Verdict::Deny;
-        reasons.push(format!("hard deny: critical finding {}", critical.rule_id));
+    // Layer 1b: automatic critical escalation — confidence-gated.
+    for critical in findings.iter().filter(|f| f.severity == Severity::Critical) {
+        if critical.confidence == Confidence::Confirmed {
+            verdict = Verdict::Deny;
+            reasons.push(format!("hard deny: critical finding {}", critical.rule_id));
+        } else {
+            verdict = verdict.max(Verdict::Quarantine);
+            reasons.push(format!(
+                "quarantine: suspected critical finding {} (suspected findings never hard-deny)",
+                critical.rule_id
+            ));
+        }
     }
 
-    // Layer 2: fail-closed floor.
-    if !failed_analyzers.is_empty() {
+    // Layer 2: fail-closed floor — active at every strictness level.
+    if !params.failed_analyzers.is_empty() {
         verdict = verdict.max(Verdict::Quarantine);
         reasons.push(format!(
             "fail-closed: analyzer(s) failed: {} — result cannot be allow",
-            failed_analyzers.join(", ")
+            params.failed_analyzers.join(", ")
         ));
     }
 
-    // Layer 3: weighted score.
+    // Layer 3: weighted score (levels 1+). The total (all confidences) is
+    // always computed for the report; at level 0 it does not gate.
     let score: u32 = findings.iter().map(|f| severity_weight(f.severity)).sum();
-    if score >= deny_score {
-        verdict = Verdict::Deny;
-        reasons.push(format!("score {score} >= deny threshold {deny_score}"));
-    } else if score >= quarantine_score {
+    let confirmed_score: u32 = findings
+        .iter()
+        .filter(|f| f.confidence == Confidence::Confirmed)
+        .map(|f| severity_weight(f.severity))
+        .sum();
+    if params.level >= 1 {
+        if confirmed_score >= params.deny_score {
+            verdict = Verdict::Deny;
+            reasons.push(format!(
+                "confirmed score {confirmed_score} >= deny threshold {}",
+                params.deny_score
+            ));
+        } else if score >= params.quarantine_score {
+            verdict = verdict.max(Verdict::Quarantine);
+            reasons
+                .push(format!("score {score} >= quarantine threshold {}", params.quarantine_score));
+        }
+    }
+
+    // Layer 4: severity floors (levels 2+).
+    let floor = match params.level {
+        0 | 1 => None,
+        2 => Some(Severity::High),
+        _ => Some(Severity::Medium),
+    };
+    if let Some(floor_severity) = floor
+        && let Some(worst) =
+            findings.iter().filter(|f| f.severity >= floor_severity).max_by_key(|f| f.severity)
+    {
         verdict = verdict.max(Verdict::Quarantine);
-        reasons.push(format!("score {score} >= quarantine threshold {quarantine_score}"));
+        reasons.push(format!(
+            "level {} severity floor: {} finding {} is {floor_severity}+",
+            params.level, worst.severity, worst.rule_id
+        ));
     }
 
     PolicyDecision { verdict, score, reasons }
@@ -153,12 +231,27 @@ mod tests {
             path: Some(PathBuf::from("index.php")),
             line: Some(1),
             message: "test".to_owned(),
+            confidence: Confidence::Confirmed,
+        }
+    }
+
+    fn suspected(rule_id: &str, severity: Severity) -> Finding {
+        Finding { confidence: Confidence::Suspected, ..finding(rule_id, severity) }
+    }
+
+    fn params<'a>(deny_hard: &'a [String], failed: &'a [String]) -> PolicyParams<'a> {
+        PolicyParams {
+            deny_hard,
+            failed_analyzers: failed,
+            quarantine_score: 10,
+            deny_score: 50,
+            level: 1,
         }
     }
 
     #[test]
     fn clean_run_allows() {
-        let d = decide(&[], &[], &[], 10, 50);
+        let d = decide(&[], &params(&[], &[]));
         assert_eq!(d.verdict, Verdict::Allow);
         assert_eq!(d.score, 0);
         assert!(d.reasons.is_empty());
@@ -167,7 +260,7 @@ mod tests {
     #[test]
     fn deny_hard_rule_id_forces_deny_even_for_info() {
         let f = [finding("dangerous-sinks/eval", Severity::Info)];
-        let d = decide(&f, &["dangerous-sinks/eval".to_owned()], &[], 10, 50);
+        let d = decide(&f, &params(&["dangerous-sinks/eval".to_owned()], &[]));
         assert_eq!(d.verdict, Verdict::Deny);
     }
 
@@ -182,22 +275,63 @@ mod tests {
     #[test]
     fn critical_finding_forces_deny() {
         let f = [finding("composer-audit/CVE-2024-1", Severity::Critical)];
-        let d = decide(&f, &[], &[], 10, 50);
+        let d = decide(&f, &params(&[], &[]));
         assert_eq!(d.verdict, Verdict::Deny);
+    }
+
+    #[test]
+    fn suspected_findings_quarantine_on_automatic_escalations() {
+        // The confidence split applies to the AUTOMATIC deny triggers: a
+        // suspected critical, and a suspected pile crossing the deny score,
+        // floor at Quarantine instead of Deny.
+        let f = [suspected("x/crit", Severity::Critical)];
+        let d = decide(&f, &params(&[], &[]));
+        assert_eq!(d.verdict, Verdict::Quarantine);
+        assert!(d.reasons.iter().any(|r| r.contains("never hard-deny")));
+
+        // 6 suspected highs = 60 total >= 50, but confirmed score is 0:
+        // quarantine (via the quarantine threshold), not deny.
+        let f: Vec<_> = (0..6).map(|i| suspected(&format!("a/{i}"), Severity::High)).collect();
+        let d = decide(&f, &params(&[], &[]));
+        assert_eq!(d.verdict, Verdict::Quarantine);
+        assert_eq!(d.score, 60);
+    }
+
+    #[test]
+    fn deny_hard_fires_regardless_of_confidence() {
+        // An operator's explicit deny_hard entry is an instruction, not a
+        // heuristic — listing a suspected-producing rule there accepts its
+        // false positives, and downgrading it would make the config a no-op.
+        let deny_hard = ["dangerous-sinks/eval".to_owned()];
+        let f = [suspected("dangerous-sinks/eval", Severity::High)];
+        let d = decide(&f, &params(&deny_hard, &[]));
+        assert_eq!(d.verdict, Verdict::Deny);
+        assert!(d.reasons.iter().any(|r| r.contains("deny_hard")));
+    }
+
+    #[test]
+    fn confirmed_score_still_denies_alongside_suspected_noise() {
+        // 5 confirmed highs = confirmed 50 >= 50 -> deny, regardless of any
+        // suspected findings riding along.
+        let mut f: Vec<_> = (0..5).map(|i| finding(&format!("a/{i}"), Severity::High)).collect();
+        f.push(suspected("b/0", Severity::Medium));
+        assert_eq!(decide(&f, &params(&[], &[])).verdict, Verdict::Deny);
     }
 
     #[test]
     fn analyzer_failure_floors_at_quarantine_with_zero_findings() {
         // The heart of fail-closed: no findings at all, but an analyzer
         // errored — the result must never be Allow.
-        let d = decide(&[], &[], &["semgrep-php".to_owned()], 10, 50);
+        let failed = ["semgrep-php".to_owned()];
+        let d = decide(&[], &params(&[], &failed));
         assert_eq!(d.verdict, Verdict::Quarantine);
     }
 
     #[test]
     fn analyzer_failure_does_not_downgrade_a_deny() {
+        let failed = ["semgrep-php".to_owned()];
         let f = [finding("x/critical", Severity::Critical)];
-        let d = decide(&f, &[], &["semgrep-php".to_owned()], 10, 50);
+        let d = decide(&f, &params(&[], &failed));
         assert_eq!(d.verdict, Verdict::Deny);
     }
 
@@ -205,31 +339,88 @@ mod tests {
     fn score_thresholds_escalate() {
         // 2 mediums = 8 < 10 -> allow
         let f = [finding("a/1", Severity::Medium), finding("a/2", Severity::Medium)];
-        assert_eq!(decide(&f, &[], &[], 10, 50).verdict, Verdict::Allow);
+        assert_eq!(decide(&f, &params(&[], &[])).verdict, Verdict::Allow);
 
         // 1 high = 10 >= 10 -> quarantine
         let f = [finding("a/1", Severity::High)];
-        let d = decide(&f, &[], &[], 10, 50);
+        let d = decide(&f, &params(&[], &[]));
         assert_eq!(d.verdict, Verdict::Quarantine);
         assert_eq!(d.score, 10);
 
         // 5 highs = 50 >= 50 -> deny
         let f: Vec<_> = (0..5).map(|i| finding(&format!("a/{i}"), Severity::High)).collect();
-        assert_eq!(decide(&f, &[], &[], 10, 50).verdict, Verdict::Deny);
+        assert_eq!(decide(&f, &params(&[], &[])).verdict, Verdict::Deny);
     }
 
     #[test]
     fn info_findings_never_gate() {
         let f: Vec<_> = (0..1000).map(|i| finding(&format!("a/{i}"), Severity::Info)).collect();
-        let d = decide(&f, &[], &[], 10, 50);
+        let d = decide(&f, &params(&[], &[]));
         assert_eq!(d.verdict, Verdict::Allow);
         assert_eq!(d.score, 0);
     }
 
     #[test]
-    fn reasons_explain_every_fired_layer() {
+    fn level_zero_gates_only_on_hard_denies() {
+        // A pile of highs that would deny by score at level 1 passes clean
+        // at level 0…
+        let f: Vec<_> = (0..5).map(|i| finding(&format!("a/{i}"), Severity::High)).collect();
+        let mut p = params(&[], &[]);
+        p.level = 0;
+        let d = decide(&f, &p);
+        assert_eq!(d.verdict, Verdict::Allow);
+        // …the score is still reported…
+        assert_eq!(d.score, 50);
+
+        // …but a critical finding or a deny_hard match still denies…
         let f = [finding("x/crit", Severity::Critical)];
-        let d = decide(&f, &["x/crit".to_owned()], &["yara".to_owned()], 10, 50);
+        assert_eq!(decide(&f, &p).verdict, Verdict::Deny);
+
+        // …and the fail-closed floor is NOT relaxed at level 0.
+        let failed = ["yara".to_owned()];
+        let mut p0 = params(&[], &failed);
+        p0.level = 0;
+        assert_eq!(decide(&[], &p0).verdict, Verdict::Quarantine);
+    }
+
+    #[test]
+    fn level_two_floors_any_high_at_quarantine() {
+        // One high scores 10 and already quarantines at defaults, so use a
+        // raised threshold to isolate the floor.
+        let f = [finding("a/1", Severity::High)];
+        let mut p = params(&[], &[]);
+        p.quarantine_score = 100;
+        assert_eq!(decide(&f, &p).verdict, Verdict::Allow);
+        p.level = 2;
+        let d = decide(&f, &p);
+        assert_eq!(d.verdict, Verdict::Quarantine);
+        assert!(d.reasons.iter().any(|r| r.contains("severity floor")));
+
+        // A lone medium does not trip the level-2 floor.
+        let f = [finding("a/1", Severity::Medium)];
+        assert_eq!(decide(&f, &p).verdict, Verdict::Allow);
+    }
+
+    #[test]
+    fn level_three_floors_any_medium_at_quarantine() {
+        let f = [suspected("a/1", Severity::Medium)];
+        let mut p = params(&[], &[]);
+        p.quarantine_score = 100;
+        p.level = 3;
+        // Suspected still trips the floor — quarantine IS the review signal.
+        assert_eq!(decide(&f, &p).verdict, Verdict::Quarantine);
+
+        // Lows never trip a floor, even paranoid.
+        let f = [finding("a/1", Severity::Low)];
+        assert_eq!(decide(&f, &p).verdict, Verdict::Allow);
+    }
+
+    #[test]
+    fn reasons_explain_every_fired_layer() {
+        let deny_hard = ["x/crit".to_owned()];
+        let failed = ["yara".to_owned()];
+        let f = [finding("x/crit", Severity::Critical)];
+        let d = decide(&f, &params(&deny_hard, &failed));
         assert_eq!(d.verdict, Verdict::Deny);
         assert!(d.reasons.iter().any(|r| r.contains("deny_hard")));
         assert!(d.reasons.iter().any(|r| r.contains("critical")));

--- a/crates/ephpm-analyze/src/report.rs
+++ b/crates/ephpm-analyze/src/report.rs
@@ -38,7 +38,8 @@ pub struct AnalyzerStatus {
 /// Everything one `ephpm analyze` run produced.
 #[derive(Debug, Clone)]
 pub struct AnalysisReport {
-    /// All findings across all analyzers, sorted most severe first.
+    /// The findings that gate: post scope-filter, operator suppressions,
+    /// and baseline — sorted most severe first.
     pub findings: Vec<Finding>,
     /// Per-analyzer outcome, in execution order.
     pub statuses: Vec<AnalyzerStatus>,
@@ -48,6 +49,13 @@ pub struct AnalysisReport {
     pub score: u32,
     /// Why the verdict is what it is — one line per policy layer that fired.
     pub reasons: Vec<String>,
+    /// Findings dropped because their path was outside the diff-aware scope
+    /// (`since:` / `--since`). `0` on a full run.
+    pub out_of_scope: usize,
+    /// Findings waived by operator `suppress:` rules.
+    pub waived: usize,
+    /// Findings suppressed by the configured baseline file.
+    pub baseline_suppressed: usize,
 }
 
 impl AnalysisReport {

--- a/crates/ephpm-analyze/src/scope.rs
+++ b/crates/ephpm-analyze/src/scope.rs
@@ -1,0 +1,147 @@
+//! Diff-aware scanning: restrict an analysis run to files changed versus a
+//! git ref (`since:` in the config, `--since` on the CLI) — a fast per-push
+//! gate.
+//!
+//! The changed set is the union of
+//!
+//! - `git diff --name-only --relative <ref>` — tracked files that differ
+//!   between the ref and the working tree, and
+//! - `git ls-files --others --exclude-standard` — untracked files, so a
+//!   brand-new (not yet committed) file cannot dodge the gate by being
+//!   absent from the diff.
+//!
+//! Both run with the analyzed root as working directory; `--relative` keeps
+//! diff paths relative to that root even when it is a subdirectory of the
+//! repository. Paths are compared with `/` separators on every platform.
+//!
+//! **Fail-closed:** any git failure — binary missing, not a repository,
+//! unknown ref — is a hard error that aborts the run. A diff-aware gate
+//! that silently fell back to "scan nothing" would pass everything.
+//!
+//! Enforcement is two-fold: the aggregator drops path-anchored findings
+//! outside the scope after all analyzers ran (uniform across analyzer
+//! kinds), and the native per-file analyzers additionally skip out-of-scope
+//! files up front via [`AnalysisCtx::is_in_scope`](crate::AnalysisCtx) for
+//! speed. Findings with **no** path anchor are always kept — an unattributable
+//! finding must not be droppable by scoping (fail-safe).
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Context as _;
+
+/// The set of tree-relative changed paths, `/`-normalized.
+#[derive(Debug, Clone, Default)]
+pub struct Scope {
+    paths: BTreeSet<String>,
+}
+
+/// Normalize a tree-relative path to the `/`-separated form used for scope
+/// membership tests.
+#[must_use]
+pub fn normalize(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+impl Scope {
+    /// Build a scope from an iterator of `/`-relative path strings (used by
+    /// tests and by [`changed_files`]).
+    #[must_use]
+    pub fn from_paths<I: IntoIterator<Item = String>>(paths: I) -> Self {
+        Self { paths: paths.into_iter().filter(|p| !p.is_empty()).collect() }
+    }
+
+    /// Whether the tree-relative `path` is inside the changed set.
+    #[must_use]
+    pub fn contains(&self, path: &Path) -> bool {
+        self.paths.contains(&normalize(path))
+    }
+
+    /// Number of files in scope.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    /// Whether the changed set is empty (nothing changed since the ref).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+}
+
+fn git_lines(root: &Path, args: &[&str]) -> anyhow::Result<Vec<String>> {
+    let output =
+        Command::new("git").args(args).current_dir(root).output().with_context(|| {
+            format!("failed to run `git {}` (is git installed?)", args.join(" "))
+        })?;
+    anyhow::ensure!(
+        output.status.success(),
+        "`git {}` failed (exit {:?}): {}",
+        args.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|l| l.trim_end().to_owned())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+/// Compute the changed-file scope for `root` versus `since_ref`.
+///
+/// # Errors
+///
+/// On any git failure (missing binary, not a repository, unknown ref) —
+/// fail-closed, see the module docs.
+pub fn changed_files(root: &Path, since_ref: &str) -> anyhow::Result<Scope> {
+    anyhow::ensure!(
+        !since_ref.starts_with('-'),
+        "invalid git ref {since_ref:?} (must not start with '-')"
+    );
+    let mut paths = git_lines(root, &["diff", "--name-only", "--relative", since_ref])
+        .context("diff-aware scan (`since`) could not compute changed files")?;
+    paths.extend(
+        git_lines(root, &["ls-files", "--others", "--exclude-standard"])
+            .context("diff-aware scan (`since`) could not list untracked files")?,
+    );
+    Ok(Scope::from_paths(paths))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_membership_is_separator_agnostic() {
+        let scope = Scope::from_paths(vec!["src/a.php".to_owned(), "b.php".to_owned()]);
+        assert!(scope.contains(Path::new("src/a.php")));
+        assert!(scope.contains(Path::new("src\\a.php")));
+        assert!(scope.contains(Path::new("b.php")));
+        assert!(!scope.contains(Path::new("src/other.php")));
+        assert_eq!(scope.len(), 2);
+        assert!(!scope.is_empty());
+    }
+
+    #[test]
+    fn refs_shaped_like_flags_are_rejected() {
+        // A ref beginning with '-' could smuggle git options.
+        let err = changed_files(Path::new("."), "--output=/tmp/x").unwrap_err();
+        assert!(format!("{err:#}").contains("invalid git ref"));
+    }
+
+    #[test]
+    fn git_failure_is_an_error_not_an_empty_scope() {
+        // Fail-closed: an unknown ref must error, never silently produce an
+        // empty scope. Run inside a real repo checkout (this workspace) so
+        // git itself is exercised; skip when git is unavailable.
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        if Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let err = changed_files(root, "definitely-not-a-ref-9f2c").unwrap_err();
+        assert!(format!("{err:#}").contains("failed"));
+    }
+}

--- a/crates/ephpm-analyze/src/suppress.rs
+++ b/crates/ephpm-analyze/src/suppress.rs
@@ -1,0 +1,129 @@
+//! Operator-side suppressions — the **only** way a finding is waived.
+//!
+//! Suppressions come exclusively from `.ephpm-analyze.yml` (`suppress:`),
+//! which the *operator* controls. Nothing in the pipeline ever reads
+//! suppression directives out of the analyzed code: an inline
+//! `// ephpm-analyze-ignore`, `@phpstan-ignore`, `// nosemgrep`, or similar
+//! comment authored by the tenant is **never honored** — instead the
+//! `suppression-scan` analyzer flags it as a finding
+//! (`suppression-scan/tenant-suppression-attempt`), because an attempt to
+//! silence the scanner is itself a signal. This module is the honoring half;
+//! `crate::analyzers::suppression_scan` is the detecting half.
+
+use crate::baseline::normalized_path;
+use crate::config::SuppressRule;
+use crate::finding::Finding;
+use crate::policy::deny_hard_matches;
+
+/// Whether `rule` waives `finding`: the rule id matches exactly or as a
+/// `/`-prefix (same semantics as `analyzers.deny_hard`), and — when the rule
+/// names a path — the finding is anchored at exactly that `/`-normalized
+/// tree-relative path. A path-scoped rule never waives a pathless finding.
+#[must_use]
+pub fn rule_matches(rule: &SuppressRule, finding: &Finding) -> bool {
+    if !deny_hard_matches(&rule.rule, &finding.rule_id) {
+        return false;
+    }
+    match &rule.path {
+        None => true,
+        Some(rule_path) => {
+            normalized_path(finding).is_some_and(|p| p == rule_path.replace('\\', "/"))
+        }
+    }
+}
+
+/// Drop findings waived by `rules`, returning the survivors and the number
+/// waived.
+#[must_use]
+pub fn apply(findings: Vec<Finding>, rules: &[SuppressRule]) -> (Vec<Finding>, usize) {
+    if rules.is_empty() {
+        return (findings, 0);
+    }
+    let before = findings.len();
+    let kept: Vec<Finding> = findings
+        .into_iter()
+        .filter(|f| {
+            let waived = rules.iter().find(|r| rule_matches(r, f));
+            if let Some(rule) = waived {
+                tracing::debug!(
+                    rule_id = %f.rule_id,
+                    reason = %rule.reason,
+                    "finding waived by operator suppression"
+                );
+            }
+            waived.is_none()
+        })
+        .collect();
+    let waived = before - kept.len();
+    (kept, waived)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::finding::{Category, Confidence, Severity};
+
+    fn finding(rule_id: &str, path: Option<&str>) -> Finding {
+        Finding {
+            rule_id: rule_id.to_owned(),
+            severity: Severity::High,
+            category: Category::Security,
+            path: path.map(PathBuf::from),
+            line: Some(1),
+            message: "m".to_owned(),
+            confidence: Confidence::Confirmed,
+        }
+    }
+
+    fn rule(rule: &str, path: Option<&str>) -> SuppressRule {
+        SuppressRule {
+            rule: rule.to_owned(),
+            path: path.map(str::to_owned),
+            reason: "vetted".to_owned(),
+        }
+    }
+
+    #[test]
+    fn pathless_rule_waives_at_any_path() {
+        let rules = [rule("x/r", None)];
+        let (kept, waived) =
+            apply(vec![finding("x/r", Some("a.php")), finding("x/other", Some("a.php"))], &rules);
+        assert_eq!(waived, 1);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].rule_id, "x/other");
+    }
+
+    #[test]
+    fn path_scoped_rule_waives_only_that_path() {
+        let rules = [rule("x/r", Some("legacy/a.php"))];
+        let findings = vec![
+            finding("x/r", Some("legacy/a.php")),
+            finding("x/r", Some("legacy\\a.php")), // Windows separators
+            finding("x/r", Some("src/b.php")),
+            finding("x/r", None), // pathless never matches a path-scoped rule
+        ];
+        let (kept, waived) = apply(findings, &rules);
+        assert_eq!(waived, 2);
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn prefix_rule_waives_whole_analyzer_namespace() {
+        let rules = [rule("noisy-analyzer", None)];
+        let (kept, waived) = apply(
+            vec![finding("noisy-analyzer/a", None), finding("noisy-analyzer2/a", None)],
+            &rules,
+        );
+        assert_eq!(waived, 1);
+        assert_eq!(kept[0].rule_id, "noisy-analyzer2/a");
+    }
+
+    #[test]
+    fn no_rules_is_a_no_op() {
+        let (kept, waived) = apply(vec![finding("x/r", None)], &[]);
+        assert_eq!(waived, 0);
+        assert_eq!(kept.len(), 1);
+    }
+}

--- a/crates/ephpm-analyze/tests/analyze_e2e.rs
+++ b/crates/ephpm-analyze/tests/analyze_e2e.rs
@@ -10,10 +10,11 @@
 //! already. `assert(` is one of the analyzer's sinks and is AV-benign.
 
 use std::fs;
+use std::path::Path;
 
 use ephpm_analyze::{
-    AnalysisCtx, AnalyzeConfig, Analyzer, AnalyzerError, AnalyzerState, Category, Finding,
-    Severity, Verdict, analyze, analyzers, output, run_analyzers,
+    AnalysisCtx, AnalyzeConfig, Analyzer, AnalyzerError, AnalyzerState, Baseline, Category,
+    Finding, Severity, Verdict, analyze, analyzers, output, run_analyzers,
 };
 
 /// Build a small PHP project fixture with one `assert($cond)` sink call.
@@ -128,6 +129,80 @@ fn failing_external_analyzer_fails_closed_alongside_native_findings() {
     );
     assert!(report.verdict >= Verdict::Quarantine);
     assert!(report.reasons.iter().any(|r| r.contains("fail-closed")));
+}
+
+#[test]
+fn baseline_roundtrip_suppresses_known_findings_end_to_end() {
+    // First run finds the assert() sink and quarantines; a baseline written
+    // from that report makes the second run pass — gate only on NEW
+    // findings. Cache disabled for hermeticity.
+    let dir = fixture();
+    let config = AnalyzeConfig::from_yaml(
+        "analyzers:\n  enable: [dangerous-sinks]\npolicy:\n  quarantine_score: 4\ncache:\n  enabled: false",
+    )
+    .unwrap();
+    let report = analyze(dir.path(), config.clone()).expect("first run");
+    assert_eq!(report.verdict, Verdict::Quarantine);
+
+    let baseline_path = dir.path().join("baseline.json");
+    Baseline::from_findings(&report.findings).save(&baseline_path).unwrap();
+
+    let mut config = config;
+    config.baseline = Some(baseline_path);
+    let report = analyze(dir.path(), config.clone()).expect("baselined run");
+    assert_eq!(report.baseline_suppressed, 1);
+    assert!(report.findings.is_empty());
+    assert_eq!(report.verdict, Verdict::Allow);
+
+    // A NEW finding still gates through the baseline.
+    fs::write(dir.path().join("src/new.php"), "<?php\nassert($x);\n").unwrap();
+    let report = analyze(dir.path(), config).expect("run with new finding");
+    assert_eq!(report.findings.len(), 1);
+    assert_eq!(report.verdict, Verdict::Quarantine);
+}
+
+fn git(root: &Path, args: &[&str]) -> bool {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+#[test]
+fn diff_aware_run_scans_only_changed_files() {
+    // A real git repo: the committed sink is out of scope, the newly added
+    // one gates. Skips silently when git is unavailable on the host.
+    let dir = fixture();
+    if !git(dir.path(), &["init", "-q"]) {
+        eprintln!("git unavailable — skipping diff-aware e2e");
+        return;
+    }
+    assert!(git(dir.path(), &["add", "."]));
+    assert!(git(dir.path(), &["-c", "commit.gpgsign=false", "commit", "-qm", "base"]));
+
+    // An untracked new file with a sink: must be in scope (diff alone would
+    // miss it — the untracked union is load-bearing here).
+    fs::write(dir.path().join("src/new.php"), "<?php\nassert($x);\n").unwrap();
+
+    let config = AnalyzeConfig::from_yaml(
+        "since: HEAD\nanalyzers:\n  enable: [dangerous-sinks]\npolicy:\n  quarantine_score: 4\ncache:\n  enabled: false",
+    )
+    .unwrap();
+    let report = analyze(dir.path(), config).expect("diff-aware run");
+    assert_eq!(report.findings.len(), 1, "{:?}", report.findings);
+    let path = report.findings[0].path.as_ref().unwrap().to_string_lossy().replace('\\', "/");
+    assert_eq!(path, "src/new.php");
+    // The committed upload.php sink never surfaced at all: native analyzers
+    // skip out-of-scope files up front, so nothing needed dropping post-hoc
+    // (the out_of_scope counter tracks only post-filtered findings, e.g.
+    // from external tools that scanned the whole tree).
+    assert_eq!(report.out_of_scope, 0);
+    assert_eq!(report.verdict, Verdict::Quarantine);
 }
 
 #[test]

--- a/crates/ephpm/src/main.rs
+++ b/crates/ephpm/src/main.rs
@@ -123,6 +123,33 @@ enum Commands {
         /// file)
         #[arg(long)]
         fail_on: Option<String>,
+
+        /// Strictness level 0..=3 (overrides the config file): 0 gates only
+        /// on hard denies, 1 is the weighted-score default, 2 quarantines
+        /// any high finding, 3 quarantines any medium finding
+        #[arg(long, value_parser = clap::value_parser!(u8).range(0..=3))]
+        level: Option<u8>,
+
+        /// Write a baseline of the current findings to FILE and exit 0.
+        /// Later runs with `baseline: FILE` in the config suppress those
+        /// findings and gate only on new ones
+        #[arg(long, value_name = "FILE")]
+        baseline: Option<PathBuf>,
+
+        /// Diff-aware scan: analyze only files changed versus this git ref
+        /// (plus untracked files). Fails closed if git errors (overrides the
+        /// config file)
+        #[arg(long, value_name = "GIT_REF")]
+        since: Option<String>,
+
+        /// Directory for the incremental result cache (overrides the config
+        /// file; default: ephpm-analyze-cache under the system temp dir)
+        #[arg(long, value_name = "DIR")]
+        cache_dir: Option<PathBuf>,
+
+        /// Disable the incremental result cache for this run
+        #[arg(long)]
+        no_cache: bool,
     },
 
     /// Run PHP CLI commands using the embedded PHP runtime
@@ -425,8 +452,29 @@ fn run() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Analyze { path, config, format, profile, fail_on }) => {
-            run_analyze(path, config, format, profile, fail_on)
+        Some(Commands::Analyze {
+            path,
+            config,
+            format,
+            profile,
+            fail_on,
+            level,
+            baseline,
+            since,
+            cache_dir,
+            no_cache,
+        }) => {
+            let overrides = AnalyzeOverrides {
+                format,
+                profile,
+                fail_on,
+                level,
+                baseline,
+                since,
+                cache_dir,
+                no_cache,
+            };
+            run_analyze(path, config, overrides)
         }
         Some(Commands::Php { config, site, args }) => run_php(config, site, &php_cli_args(&args)),
         Some(Commands::Exec { config, site, timeout, no_sandbox, command }) => {
@@ -484,20 +532,41 @@ fn run() -> anyhow::Result<ExitCode> {
     }
 }
 
+/// CLI overrides for `ephpm analyze` — each `Some` wins over the config
+/// file (env-var-style precedence).
+#[derive(Default)]
+struct AnalyzeOverrides {
+    format: Option<String>,
+    profile: Option<String>,
+    fail_on: Option<String>,
+    level: Option<u8>,
+    /// Baseline **write** mode: run, write the findings to this file, exit 0.
+    baseline: Option<PathBuf>,
+    since: Option<String>,
+    cache_dir: Option<PathBuf>,
+    no_cache: bool,
+}
+
 /// `ephpm analyze` — load the config, run the aggregator, print the report,
 /// and map the verdict to the exit code.
 ///
 /// Exit codes: `0` when the verdict passes the `fail_on` gate, `2` when a
 /// `quarantine` verdict fails it, `3` when a `deny` verdict fails it, `1`
-/// for internal errors (bad config, unreadable target).
+/// for internal errors (bad config, unreadable target, git failure on a
+/// `--since` run, missing configured baseline).
+///
+/// With `--baseline FILE` the run instead *writes* a baseline of the
+/// current findings to FILE and exits 0 (the generation half of the PHPStan
+/// model; `baseline:` in the config is the consumption half). Operator
+/// suppressions still apply first — permanently waived findings don't
+/// belong in a baseline — while a configured `baseline:` is ignored for the
+/// generating run so the written file is complete.
 fn run_analyze(
     path: Option<PathBuf>,
     config_path: Option<PathBuf>,
-    format: Option<String>,
-    profile: Option<String>,
-    fail_on: Option<String>,
+    overrides: AnalyzeOverrides,
 ) -> anyhow::Result<ExitCode> {
-    use ephpm_analyze::{AnalyzeConfig, FailOn, OutputFormat, Verdict, output};
+    use ephpm_analyze::{AnalyzeConfig, Baseline, FailOn, OutputFormat, Verdict, output};
 
     ensure_cli_tracing();
     let root = match path {
@@ -522,19 +591,46 @@ fn run_analyze(
     };
 
     // CLI flags override the config file.
-    if let Some(profile) = profile {
+    if let Some(profile) = overrides.profile {
         config.profile = profile.parse()?;
     }
-    if let Some(fail_on) = fail_on {
+    if let Some(fail_on) = overrides.fail_on {
         config.fail_on = fail_on.parse()?;
     }
-    if let Some(format) = format {
+    if let Some(format) = overrides.format {
         config.output = format.parse()?;
+    }
+    if let Some(level) = overrides.level {
+        config.level = level;
+    }
+    if let Some(since) = overrides.since {
+        config.since = Some(since);
+    }
+    if let Some(cache_dir) = overrides.cache_dir {
+        config.cache.dir = Some(cache_dir);
+    }
+    if overrides.no_cache {
+        config.cache.enabled = false;
+    }
+    if overrides.baseline.is_some() {
+        // Generating a baseline must see every finding, including the ones a
+        // previously configured baseline would suppress.
+        config.baseline = None;
     }
     let output_format = config.output;
     let gate = config.fail_on;
 
     let report = ephpm_analyze::analyze(&root, config)?;
+
+    if let Some(baseline_path) = overrides.baseline {
+        Baseline::from_findings(&report.findings).save(&baseline_path)?;
+        println!(
+            "baseline written: {} ({} finding(s) recorded)",
+            baseline_path.display(),
+            report.findings.len()
+        );
+        return Ok(ExitCode::SUCCESS);
+    }
 
     match output_format {
         OutputFormat::Sarif => println!("{}", output::to_sarif(&report)?),
@@ -2435,9 +2531,30 @@ mod php_arg_tests {
             "security",
             "--fail-on",
             "deny",
+            "--level",
+            "2",
+            "--baseline",
+            "base.json",
+            "--since",
+            "origin/main",
+            "--cache-dir",
+            "/var/cache/analyze",
+            "--no-cache",
         ])
         .unwrap();
-        let Some(Commands::Analyze { path, config, format, profile, fail_on }) = cli.command else {
+        let Some(Commands::Analyze {
+            path,
+            config,
+            format,
+            profile,
+            fail_on,
+            level,
+            baseline,
+            since,
+            cache_dir,
+            no_cache,
+        }) = cli.command
+        else {
             panic!("expected an analyze command");
         };
         assert_eq!(path.as_deref(), Some(std::path::Path::new("/srv/app")));
@@ -2445,12 +2562,34 @@ mod php_arg_tests {
         assert_eq!(format.as_deref(), Some("sarif"));
         assert_eq!(profile.as_deref(), Some("security"));
         assert_eq!(fail_on.as_deref(), Some("deny"));
+        assert_eq!(level, Some(2));
+        assert_eq!(baseline.as_deref(), Some(std::path::Path::new("base.json")));
+        assert_eq!(since.as_deref(), Some("origin/main"));
+        assert_eq!(cache_dir.as_deref(), Some(std::path::Path::new("/var/cache/analyze")));
+        assert!(no_cache);
+    }
+
+    #[test]
+    fn analyze_rejects_out_of_range_level() {
+        assert!(Cli::try_parse_from(["ephpm", "analyze", "--level", "4"]).is_err());
     }
 
     #[test]
     fn analyze_defaults_to_cwd_and_no_overrides() {
         let cli = Cli::try_parse_from(["ephpm", "analyze"]).unwrap();
-        let Some(Commands::Analyze { path, config, format, profile, fail_on }) = cli.command else {
+        let Some(Commands::Analyze {
+            path,
+            config,
+            format,
+            profile,
+            fail_on,
+            level,
+            baseline,
+            since,
+            cache_dir,
+            no_cache,
+        }) = cli.command
+        else {
             panic!("expected an analyze command");
         };
         assert!(path.is_none());
@@ -2458,6 +2597,11 @@ mod php_arg_tests {
         assert!(format.is_none());
         assert!(profile.is_none());
         assert!(fail_on.is_none());
+        assert!(level.is_none());
+        assert!(baseline.is_none());
+        assert!(since.is_none());
+        assert!(cache_dir.is_none());
+        assert!(!no_cache);
     }
 }
 

--- a/site/content/reference/cli/_index.md
+++ b/site/content/reference/cli/_index.md
@@ -176,7 +176,7 @@ $ ephpm kv del counter temp
 
 ## `ephpm analyze`
 
-Statically analyze a PHP application and gate on the result — external security tools (composer audit, semgrep, yara) wrapped as subprocesses plus native passes, merged under a fail-closed allow/quarantine/deny policy. The exit code reflects the verdict, so it works directly as a CI or deploy-gate step. See the [full `analyze` reference](analyze/).
+Statically analyze a PHP application and gate on the result — external security tools (composer audit, semgrep, yara) wrapped as subprocesses plus native passes, merged under a fail-closed allow/quarantine/deny policy. Supports baselines (gate only on new findings), diff-aware scans (`--since <git-ref>`), strictness levels (`--level 0..3`), an incremental result cache, and operator-only suppressions (inline suppression comments in the scanned code are never honored — they are flagged instead). The exit code reflects the verdict, so it works directly as a CI or deploy-gate step. See the [full `analyze` reference](analyze/).
 
 ```bash
 # Gate the current directory (security profile, fail on quarantine)
@@ -184,6 +184,9 @@ ephpm analyze
 
 # Report-only over a checkout, as SARIF
 ephpm analyze /srv/app --fail-on allow --format sarif
+
+# Fast per-push gate: only files changed vs main
+ephpm analyze /srv/app --since origin/main
 ```
 
 ---
@@ -250,7 +253,8 @@ ephpm serve          Start the production server (--config/--listen/--document-r
 ephpm dev            Development server (--port/--document-root/--sites)
 ephpm php            Run the embedded PHP CLI (pure passthrough)
 ephpm kv             KV store client (keys/get/set/del/incr/ttl/ping)
-ephpm analyze        Static analysis + fail-closed deploy gate (--format/--profile/--fail-on)
+ephpm analyze        Static analysis + fail-closed deploy gate (--format/--profile/--fail-on/
+                     --level/--since/--baseline/--cache-dir/--no-cache)
 
 ephpm install        Install + start the system service
 ephpm uninstall      Remove the system service (--keep-data)

--- a/site/content/reference/cli/analyze.md
+++ b/site/content/reference/cli/analyze.md
@@ -9,6 +9,7 @@ Statically analyze a PHP application and gate on the result. `ephpm analyze` run
 
 ```bash
 ephpm analyze [PATH] [--config FILE] [--format FORMAT] [--profile NAME] [--fail-on VERDICT]
+              [--level N] [--since GIT_REF] [--baseline FILE] [--cache-dir DIR] [--no-cache]
 ```
 
 | Flag | Default | Purpose |
@@ -18,38 +19,121 @@ ephpm analyze [PATH] [--config FILE] [--format FORMAT] [--profile NAME] [--fail-
 | `--format` | `text` | `text` or `sarif` (SARIF v2.1.0 JSON). Overrides the config file. |
 | `--profile` | `security` | `security` or `none`. Overrides the config file. |
 | `--fail-on` | `quarantine` | Least severe verdict that fails the exit code: `allow` (report-only), `quarantine`, or `deny`. Overrides the config file. |
+| `--level` | `1` | Strictness level `0..=3` — see [Strictness levels](#strictness-levels). Overrides the config file. |
+| `--since` | — | Diff-aware scan versus a git ref — see [Diff-aware scanning](#diff-aware-scanning-since). Overrides the config file. |
+| `--baseline` | — | **Write** a baseline of the current findings to FILE and exit 0 — see [Baseline](#baseline-gate-only-on-new-findings). |
+| `--cache-dir` | `ephpm-analyze-cache` under the system temp dir | Directory for the incremental result cache. Overrides the config file. |
+| `--no-cache` | off | Disable the incremental cache for this run. |
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | The verdict passed the `fail_on` gate |
+| `0` | The verdict passed the `fail_on` gate (always, for a `--baseline` write run) |
 | `2` | A `quarantine` verdict failed the gate |
 | `3` | A `deny` verdict failed the gate |
-| `1` | Internal error (unreadable target, invalid configuration) |
+| `1` | Internal error (unreadable target, invalid configuration, git failure on a `--since` run, missing configured baseline) |
 
 `fail_on` semantics: `quarantine` (the default) fails on `quarantine` **or** `deny`; `deny` fails only on `deny`; `allow` is report-only — the verdict never fails the exit code.
 
-## Analyzers (Phase 1)
+## Analyzers
 
-External tools are **not bundled** — ePHPm shells out to them. An analyzer whose tool (or required input) is absent is reported as *skipped* and does not gate, unless listed in `analyzers.required` (see below).
+External tools are **not bundled** — ePHPm shells out to them. An analyzer whose tool (or required input) is absent is reported as *skipped* and does not gate, unless listed in `analyzers.required` (see below). Each finding carries a **confidence**: `confirmed` (the analyzer is sure) or `suspected` (a hotspot worth review) — see [Hotspots vs findings](#hotspots-vs-findings-confidence).
 
-| Analyzer | Kind | Category | Needs | What it does |
-|----------|------|----------|-------|--------------|
-| `composer-audit` | external | supply-chain | `composer` on `PATH`, `composer.json` + `composer.lock` in the target | Runs `composer audit --no-scripts --format=json`; each advisory becomes a finding (severity from the advisory, `critical` hard-denies), abandoned packages become `info` findings. |
-| `semgrep-php` | external | security | `semgrep` on `PATH` (registry configs also need network) | Runs `semgrep --config <analyzers.semgrep_config> --sarif` and maps its SARIF results to findings (`error` → high, `warning` → medium, `note` → low). |
-| `malware-yara` | external | malware | `yara` on `PATH` **and** a ruleset at `analyzers.yara_rules` (none ships with ePHPm — unset means skipped) | Runs `yara -r -w <rules> <target>`; each rule match is a `high` finding. A *configured but missing* ruleset path is an error (fail-closed), not a skip. |
-| `dangerous-sinks` | native | security | nothing | **Phase-1 placeholder**: a naive line/token pass over `*.php` / `*.phtml` flagging direct calls to the `eval` and `system` sinks (high) and `assert` (medium). Deliberately simple — matches inside comments/strings are false positives; dynamic calls are missed. It will be superseded by the opcode-level analyzer (planned). |
+| Analyzer | Kind | Category | Confidence | Needs | What it does |
+|----------|------|----------|------------|-------|--------------|
+| `composer-audit` | external | supply-chain | confirmed | `composer` on `PATH`, `composer.json` + `composer.lock` in the target | Runs `composer audit --no-scripts --format=json`; each advisory becomes a finding (severity from the advisory, `critical` hard-denies), abandoned packages become `info` findings. |
+| `semgrep-php` | external | security | suspected | `semgrep` on `PATH` (registry configs also need network) | Runs `semgrep --config <analyzers.semgrep_config> --sarif --disable-nosem` and maps its SARIF results to findings (`error` → high, `warning` → medium, `note` → low). `--disable-nosem` means inline `// nosemgrep` comments in the analyzed code are **never honored**. |
+| `malware-yara` | external | malware | confirmed | `yara` on `PATH` **and** a ruleset at `analyzers.yara_rules` (none ships with ePHPm — unset means skipped) | Runs `yara -r -w <rules> <target>`; each rule match is a `high` finding. A *configured but missing* ruleset path is an error (fail-closed), not a skip. |
+| `dangerous-sinks` | native | security | suspected | nothing | A naive line/token pass over `*.php` / `*.phtml` flagging direct calls to the `eval` and `system` sinks (high) and `assert` (medium). Deliberately simple — matches inside comments/strings are false positives (hence *suspected*); dynamic calls are missed. It will be superseded by the opcode-level analyzer (planned). |
+| `suppression-scan` | native | security | confirmed | nothing | Flags tenant-authored suppression-shaped comments (`ephpm-analyze-ignore`, `@phpstan-ignore*`, `@psalm-suppress`, `phpcs:ignore`/`phpcs:disable`, `nosemgrep`, `noqa`, `NOSONAR`, `@codingStandardsIgnore`) as `suppression-scan/tenant-suppression-attempt` (medium) — see [Operator-only suppressions](#operator-only-suppressions-suppress). One finding per (file, marker), anchored at the first occurrence. |
 
 ## The verdict model
 
-Three layers; the final verdict is the most severe any layer demands:
+Four layers; the final verdict is the most severe any layer demands:
 
-1. **Hard denies.** A finding whose rule id matches an `analyzers.deny_hard` entry (exactly, or under it as a `/`-prefix — `malware-yara` matches every `malware-yara/<Rule>`), or any finding of `critical` severity, forces `deny`.
-2. **Fail-closed floor.** Any analyzer *failure* — tool error, timeout, unparseable output, panic, or a `required` analyzer that could not run — floors the verdict at `quarantine`. An analyzer that errored might have been about to find something, so the run can never be `allow`. A plain skip of an optional analyzer does not floor.
-3. **Weighted score.** Findings score by severity — info 0, low 1, medium 4, high 10, critical 40 — and the total is compared against `policy.quarantine_score` (default 10) and `policy.deny_score` (default 50). The weights are super-additive on purpose: volume of low-severity noise cannot outrank one serious finding class, while a large pile of mediums still escalates.
+1. **Hard denies.** A finding whose rule id matches an `analyzers.deny_hard` entry (exactly, or under it as a `/`-prefix — `malware-yara` matches every `malware-yara/<Rule>`) forces `deny` regardless of confidence — `deny_hard` is an explicit operator instruction. A **confirmed** finding of `critical` severity also forces `deny`; a *suspected* critical floors the verdict at `quarantine` instead.
+2. **Fail-closed floor.** Any analyzer *failure* — tool error, timeout, unparseable output, panic, or a `required` analyzer that could not run — floors the verdict at `quarantine`. An analyzer that errored might have been about to find something, so the run can never be `allow`. A plain skip of an optional analyzer does not floor. This layer is active at **every** strictness level.
+3. **Weighted score** *(levels 1+)*. Findings score by severity — info 0, low 1, medium 4, high 10, critical 40. The **total** score (confirmed + suspected) is compared against `policy.quarantine_score` (default 10); only the **confirmed** portion is compared against `policy.deny_score` (default 50) — suspected findings never add up to a hard stop. The weights are super-additive on purpose: volume of low-severity noise cannot outrank one serious finding class, while a large pile of mediums still escalates.
+4. **Severity floors** *(levels 2+)*. Level 2: any single high-or-worse finding floors at `quarantine` regardless of score. Level 3: any medium-or-worse finding does.
 
 The text output prints one reason line per layer that fired.
+
+## Strictness levels
+
+`level:` in the config (or `--level`) scales *how strictly* findings gate; it composes with `profile`, which picks *which* analyzers run.
+
+| Level | Name | Score layer | Severity floor |
+|-------|------|-------------|----------------|
+| `0` | permissive | off | none — only `deny_hard` matches and confirmed criticals gate (plus the fail-closed floor, which no level relaxes) |
+| `1` | standard *(default)* | on | none |
+| `2` | strict | on | any `high`+ finding ⇒ at least `quarantine` |
+| `3` | paranoid | on | any `medium`+ finding ⇒ at least `quarantine` |
+
+At level 0 the score is still computed and reported — it just does not gate.
+
+## Baseline: gate only on new findings
+
+Adopting the gate on an existing codebase (the PHPStan model): record the current findings once, then fail only on *new* ones.
+
+```bash
+# 1. Generate: runs the analysis and writes the baseline (exit 0).
+ephpm analyze /srv/app --baseline .ephpm-analyze-baseline.json
+
+# 2. Consume: reference it from the config.
+cat >> /srv/app/.ephpm-analyze.yml <<'EOF'
+baseline: .ephpm-analyze-baseline.json
+EOF
+
+# 3. Later runs suppress the recorded findings and gate only on new ones.
+ephpm analyze /srv/app
+```
+
+Each baseline entry is keyed by a stable fingerprint — SHA-256 over the finding's rule id, `/`-normalized path, and message, deliberately **not** the line number, so reformatting that shifts a finding vertically does not resurrect it. The file also records the human-readable fields, so a baseline diff is reviewable. Fail-closed rules: a configured-but-missing, corrupt, or wrong-version baseline is a hard error (exit 1), never a silent full or over-suppressed run. A `--baseline` write run ignores any configured `baseline:` (so the written file is complete) but does apply `suppress:` rules first (permanently waived findings don't belong in a baseline). Suppressed counts appear in the report (`baseline: N known finding(s) suppressed`; SARIF `ephpm/baselineSuppressed`).
+
+## Diff-aware scanning: `since`
+
+`--since <git-ref>` (or `since:` in the config) restricts the run to files changed versus that ref — a fast per-push gate:
+
+```bash
+ephpm analyze /srv/app --since origin/main
+```
+
+The changed set is `git diff --name-only --relative <ref>` **plus** untracked files (`git ls-files --others --exclude-standard`), so a brand-new uncommitted file cannot dodge the gate. **Fail-closed:** any git failure — no git binary, not a repository, unknown ref — is a hard error (exit 1), never a silent full or empty scan.
+
+Enforcement: the native per-file analyzers skip out-of-scope files up front (the speedup); findings from external tools — which currently still scan the whole tree — are filtered to the changed set afterwards (dropped findings are counted as `out of scope`). Findings with no file anchor are always kept: an unattributable finding must not be droppable by scoping.
+
+## Incremental cache
+
+Results of the native per-file analyzers (`dangerous-sinks`, `suppression-scan`) are cached keyed on the file's content hash, the analyzer id, the effective configuration hash, and the crate version — so unchanged files reuse cached findings, and **any** config change (file or CLI override) invalidates everything. Hashes are SHA-256: the analyzed tree is untrusted input, and a weak content hash would be collision-attackable. External-tool analyzers are deliberately never cached — their results depend on state outside the tree (advisory databases, remote rule packs, ruleset files), so a cache hit could hide a newly published advisory.
+
+On by default (`cache.enabled: true`), directory `ephpm-analyze-cache` under the system temp dir (created `0700` on Unix), overridable with `cache.dir` / `--cache-dir`, off with `cache.enabled: false` / `--no-cache`. Cache read failures are misses and write failures are ignored — the cache can only cost a rescan, never change a verdict, **provided the directory is operator-trusted**: whoever can write it can plant results, so on shared hosts point `--cache-dir` at a path only the operator can write.
+
+## Operator-only suppressions: `suppress`
+
+Findings are waived **only** from the operator-side config — never from comments inside the analyzed (tenant-controlled) code:
+
+```yaml
+suppress:
+  - rule: dangerous-sinks/assert      # exact id, or a /-prefix (dangerous-sinks waives all its rules)
+    path: legacy/compat.php           # optional: waive only at this exact tree-relative path
+    reason: vetted 2026-09 — assert() behind a debug flag, not reachable
+```
+
+`reason` is required and must be non-empty — a waiver without a recorded why is a config error. Waived counts appear in the report (`waived: N finding(s)`; SARIF `ephpm/waived`).
+
+The inversion: a tenant-authored suppression-shaped comment (`// ephpm-analyze-ignore`, `@phpstan-ignore`, `// nosemgrep`, `# noqa`, …) is **never honored** — nothing in the pipeline reads suppression directives from the scanned code, and `semgrep-php` runs with `--disable-nosem` so Semgrep can't be muted inline either. Instead the `suppression-scan` analyzer emits the comment itself as a finding (`suppression-scan/tenant-suppression-attempt`, medium): an attempt to silence the scanner is itself a signal. Vendored code legitimately full of `@phpstan-ignore` / `phpcs:ignore` markers is tuned the operator way — a `suppress:` rule scoped to those paths.
+
+## Hotspots vs findings: confidence
+
+Every finding carries a `confidence`:
+
+- **`confirmed`** — the analyzer is sure (a published advisory against a pinned lockfile, a YARA signature match, the factual presence of a suppression marker). Confirmed findings drive the automatic `deny` escalations: a confirmed critical hard-denies, and only confirmed weight counts toward `policy.deny_score`.
+- **`suspected`** — a heuristic hit that may be a false positive (a semgrep pattern, the naive `dangerous-sinks` token pass). Suspected findings are review signals: they count toward the quarantine threshold and severity floors — they can `quarantine`, but never force `deny` on their own.
+
+The exception is `analyzers.deny_hard`: an explicit operator entry fires regardless of confidence — listing a heuristic rule there means accepting its false positives.
+
+Surfacing: the text output tags suspected findings with `[suspected]`; SARIF results carry `rank` (confirmed 80, suspected 40) and `properties["ephpm/confidence"]`.
 
 ## Configuration: `.ephpm-analyze.yml`
 
@@ -58,9 +142,14 @@ All keys with their defaults. **Every section rejects unknown keys** — a typo 
 ```yaml
 profile: security          # security | none — supplies the analyzer set when
                            # analyzers.enable is not given. `security` enables
-                           # all four Phase-1 analyzers; `none` enables nothing.
+                           # all five analyzers; `none` enables nothing.
+level: 1                   # 0..3 strictness (see the table above)
 fail_on: quarantine        # allow | quarantine | deny (see exit codes above)
 output: text               # text | sarif
+baseline: null             # baseline file to READ (suppress known findings);
+                           # generate one with `--baseline`. Missing file =
+                           # hard error. Relative paths resolve against PATH.
+since: null                # git ref for diff-aware scanning (fail-closed)
 
 engine:                    # Planned: not yet implemented — parsed but not
   detonate: false          # acted upon (engine-in-the-loop analysis, Phase 4).
@@ -72,7 +161,8 @@ analyzers:
   required: []             # analyzers that MUST produce a result: a skip
                            # (tool absent) of a required analyzer gates like a
                            # failure. Must be a subset of the enabled set.
-  deny_hard: []            # rule ids (or `/`-prefixes) that force deny
+  deny_hard: []            # rule ids (or `/`-prefixes) that force deny —
+                           # regardless of confidence
   yara_rules: null         # YARA ruleset path for malware-yara (relative
                            # paths resolve against the analyzed directory)
   semgrep_config: p/php    # semgrep --config value
@@ -80,39 +170,61 @@ analyzers:
                            # it kills the tool and gates (fail-closed)
 
 policy:
-  quarantine_score: 10     # score at/above which the verdict is >= quarantine
-  deny_score: 50           # score at/above which the verdict is deny
+  quarantine_score: 10     # total score at/above which the verdict is
+                           # >= quarantine (levels 1+)
+  deny_score: 50           # CONFIRMED score at/above which the verdict is
+                           # deny (levels 1+)
+
+cache:
+  enabled: true            # incremental cache for the native per-file passes
+  dir: null                # null = ephpm-analyze-cache under the system temp dir
+
+suppress: []               # operator-side waivers — the ONLY suppression
+                           # mechanism; see above. Each entry:
+                           #   rule (required), path (optional), reason (required)
 ```
 
 ## Output formats
 
-**`text`** — per-analyzer status (completed / skipped / FAILED), findings sorted most severe first, then the score, verdict, and reason lines.
+**`text`** — per-analyzer status (completed / skipped / FAILED), findings sorted most severe first (suspected ones tagged `[suspected]`), post-processing counters when non-zero (`out of scope`, `waived`, `baseline`), then the score, verdict, and reason lines.
 
-**`sarif`** — a SARIF v2.1.0 document with one run. Findings map to `results` (severity → level: high/critical → `error`, medium → `warning`, low/info → `note`; the exact severity and category ride in each result's `properties`). Skipped analyzers appear as `note` tool-execution notifications, failed analyzers as `error` notifications with `executionSuccessful: false`, and the verdict and score are on the run's `properties` as `ephpm/verdict` / `ephpm/score`.
+**`sarif`** — a SARIF v2.1.0 document with one run. Findings map to `results` (severity → level: high/critical → `error`, medium → `warning`, low/info → `note`; each result carries `rank` from confidence plus the exact severity, category, and confidence in its `properties`). Skipped analyzers appear as `note` tool-execution notifications, failed analyzers as `error` notifications with `executionSuccessful: false`. The run's `properties` carry `ephpm/verdict`, `ephpm/score`, `ephpm/outOfScope`, `ephpm/waived`, and `ephpm/baselineSuppressed`.
 
 ## Examples
 
 ```bash
-# Gate a checkout in CI with the defaults (security profile, fail on quarantine)
+# Gate a checkout in CI with the defaults (security profile, level 1,
+# fail on quarantine)
 ephpm analyze /srv/app
 
 # Report-only: always exit 0, just print the report
 ephpm analyze /srv/app --fail-on allow
 
+# Fast per-push gate: only files changed vs main, paranoid strictness
+ephpm analyze /srv/app --since origin/main --level 3
+
+# Adopt on a legacy codebase: record today's findings, then gate on new ones
+ephpm analyze /srv/app --baseline .ephpm-analyze-baseline.json
+echo 'baseline: .ephpm-analyze-baseline.json' >> /srv/app/.ephpm-analyze.yml
+
 # SARIF for upload to a code-scanning UI
 ephpm analyze /srv/app --format sarif > analysis.sarif
 
 # Strict deploy gate: composer-audit must actually run, and any YARA hit
-# or eval() call is an instant deny
+# or eval() call is an instant deny; one vetted legacy assert() is waived
 cat > /srv/app/.ephpm-analyze.yml <<'EOF'
 analyzers:
   required: [composer-audit]
   deny_hard: [malware-yara, dangerous-sinks/eval]
   yara_rules: /etc/ephpm/yara/webshells.yar
+suppress:
+  - rule: dangerous-sinks/assert
+    path: legacy/compat.php
+    reason: vetted 2026-09 — debug assertion, unreachable in production
 EOF
 ephpm analyze /srv/app
 ```
 
-## Phase-1 scope
+## Scope
 
-This is the analyzer *framework* release: the aggregator, the fail-closed policy engine, the config/gating surface, both output formats, and the four analyzers above. Planned — not yet implemented: opcode-level analysis of compiled PHP (which replaces the naive `dangerous-sinks` pass), engine-in-the-loop detonation of suspicious inputs (the `engine:` section), and ePHPm-specific rules. The `Analyzer` trait, finding shape, policy engine, and output formats are designed to be stable across those additions.
+Shipped: the aggregator, the fail-closed policy engine (strictness levels, confidence model), the config/gating surface, baselines, diff-aware scanning, the incremental cache, operator-only suppressions with tenant-suppression detection, both output formats, and the five analyzers above. Planned — not yet implemented: opcode-level analysis of compiled PHP (which replaces the naive `dangerous-sinks` pass), engine-in-the-loop detonation of suspicious inputs (the `engine:` section), and ePHPm-specific rules. The `Analyzer` trait, finding shape, policy engine, and output formats are designed to be stable across those additions.


### PR DESCRIPTION
The "now / on the framework" batch (design doc §9) on top of Phase-1 `ephpm-analyze` (#502). Six features, one crate, all extensions of the existing `Analyzer`/`AnalysisCtx`/policy pipeline — no opcode/engine work.

- **Baselines** — `--baseline FILE` writes; `baseline:` suppresses recorded findings so only new ones gate. Fingerprint = SHA-256(rule_id, normalized path, message), no line number.
- **Strictness levels** `level: 0..3` — 0 hard-denies only → 3 Medium+ quarantines; fail-closed floor never relaxed; composes with `profile`.
- **Diff-aware** `--since <ref>` — changed + untracked files; git failure fails the run.
- **Incremental cache** — native-analyzer results SHA-256-keyed on (version, analyzer, whole-config hash, path, content); any config change invalidates; external tools never cached.
- **Operator-only suppressions** — `suppress:` (reason mandatory) is the ONLY waiver; tenant suppression comments are flagged as `tenant-suppression-attempt`; semgrep runs `--disable-nosem`.
- **Confidence** (Confirmed/Suspected) — suspected findings quarantine but never auto-Deny; **`deny_hard` fires regardless of confidence** (an explicit operator instruction, never silently downgraded).

`policy::decide` takes `PolicyParams`; `AnalysisCtx` gains scope/cache/baseline behind accessors (Phase-2/4 seam unchanged). All new config `deny_unknown_fields`. 72 unit + 8 e2e (+28), clippy `-D warnings`, fmt, `cargo deny` clean; `reference/cli/analyze.md` rewritten.