### PR TITLE
feat(github-auth): add passive endpoints-only issuer mode

### DIFF
--- a/crates/ephpm-middleware-github-auth/src/config.rs
+++ b/crates/ephpm-middleware-github-auth/src/config.rs
@@ -175,6 +175,20 @@ pub struct Config {
     /// Session lifetime, seconds.
     pub session_ttl_secs: u64,
 
+    /// Serve only the gate's own endpoints and never gate content.
+    ///
+    /// When `true`, an unauthenticated content request passes through
+    /// (`CONTINUE`) instead of being redirected to login. `login_path`,
+    /// `callback_path`, a request already carrying a session cookie, and a
+    /// valid bypass token still behave exactly as they do in the default
+    /// (content-gating) mode — so the login flow still runs and still needs an
+    /// access target. This is the passive-issuer mode that lets one global
+    /// mount coexist with per-site `preview-gate` verifiers: a public preview
+    /// (no verifier) stays open, while a private one's verifier redirects
+    /// unauthenticated requests to the login this issuer serves. Defaults to
+    /// `false`, which preserves the original content-gating behaviour.
+    pub endpoints_only: bool,
+
     /// `iss` claim written into issued tokens.
     pub issuer: String,
     /// `aud` claim written into issued tokens, when configured.
@@ -492,6 +506,10 @@ impl Config {
             );
         }
 
+        // Passive-issuer mode: serve the OAuth endpoints, gate nothing. Off by
+        // default so existing content-gating mounts are unchanged.
+        let endpoints_only = opt_bool(config, "endpoints_only", false)?;
+
         let bypass_token = secret(config, "bypass_token", env)?;
         if let Some(t) = &bypass_token
             && t.expose().len() < MIN_SESSION_SECRET
@@ -575,6 +593,7 @@ impl Config {
                 domain: cookie_domain,
             },
             session_ttl_secs,
+            endpoints_only,
             issuer: opt_str(config, "issuer")?.unwrap_or_else(|| DEFAULT_ISSUER.to_owned()),
             audience: opt_str(config, "audience")?,
             bypass_token,
@@ -692,6 +711,28 @@ mod tests {
         assert!(c.scopes.is_empty(), "empty scopes is correct for a GitHub App");
         assert_eq!(c.http_timeout_secs, 10);
         assert_eq!(c.default_check, Some(Check::Repo { owner: "acme".into(), name: "web".into() }));
+        assert!(!c.endpoints_only, "endpoints_only defaults to false (content-gating)");
+    }
+
+    #[test]
+    fn endpoints_only_parses_and_still_requires_a_target() {
+        let mut v = base();
+        v["endpoints_only"] = serde_json::json!(true);
+        assert!(parse(v).expect("parse").endpoints_only);
+
+        // Passive mode still runs the login flow, so a target is still required.
+        let mut v = base();
+        v.as_object_mut().expect("object").remove("repo");
+        v["endpoints_only"] = serde_json::json!(true);
+        assert!(
+            parse(v).expect_err("no target").contains("every GitHub user in the world"),
+            "endpoints_only must not waive the access-target requirement"
+        );
+
+        // And it is a boolean.
+        let mut v = base();
+        v["endpoints_only"] = serde_json::json!("yes");
+        assert!(parse(v).is_err(), "a non-boolean endpoints_only must be refused");
     }
 
     #[test]

--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -185,6 +185,11 @@ pub enum Route {
     Bypass,
     /// A session cookie is present: hand off to the verifier. No network.
     HasSession,
+    /// Endpoints-only mode: an unauthenticated content request is passed
+    /// through untouched instead of being redirected to login, so a passive
+    /// global issuer serves only its own endpoints and leaves content
+    /// enforcement to a per-site verifier. No network.
+    Passthrough,
 }
 
 /// The gate.
@@ -231,6 +236,13 @@ impl GithubAuth {
             )
         {
             return Route::Bypass;
+        }
+        // An unauthenticated content request. In endpoints-only mode the issuer
+        // is passive — it serves login/callback and lets content through, so a
+        // single global mount can coexist with per-site verifiers that gate
+        // only the previews that opt in. Otherwise it gates content itself.
+        if self.config.endpoints_only {
+            return Route::Passthrough;
         }
         Route::StartLogin { return_to: redirect::sanitize_return_to(&here(path, query), &reserved) }
     }
@@ -747,7 +759,7 @@ impl Middleware for GithubAuth {
         let now = unix_now();
 
         match self.route(req.path(), req.query(), cookies, bypass.as_deref()) {
-            Route::HasSession => Response::cont(),
+            Route::HasSession | Route::Passthrough => Response::cont(),
             Route::StartLogin { return_to } => self.start_login(req, vhost, &return_to, now),
             Route::Callback => self.handle_callback(req, vhost, now),
             Route::Bypass => {
@@ -1001,6 +1013,68 @@ mod tests {
                 "{hostile} must not survive"
             );
         }
+    }
+
+    // ── endpoints-only (passive issuer) mode ────────────────────────────
+
+    #[test]
+    fn endpoints_only_passes_unauthenticated_content_through() {
+        // A passive global issuer serves its own endpoints and lets content
+        // through, so a per-site verifier — not the issuer — decides whether a
+        // given preview is gated. An unauthenticated content request that would
+        // normally 302 to GitHub instead routes to Passthrough…
+        let mw = gate(serde_json::json!({ "endpoints_only": true }));
+        for (path, query) in [("/", ""), ("/index.php", "a=b"), ("/wp-admin/edit.php", "post=7")] {
+            assert_eq!(
+                mw.route(path, query, "", None),
+                Route::Passthrough,
+                "{path} must pass through in endpoints-only mode"
+            );
+        }
+        // …and invoke() turns that into a CONTINUE, not a 302/403.
+        let resp = invoke(&mw, "/", "", &[]);
+        assert_eq!(resp.__action(), ACTION_CONTINUE, "content must be let through, not redirected");
+        assert!(resp.__headers().is_empty(), "a pass-through adds no headers");
+    }
+
+    #[test]
+    fn endpoints_only_still_serves_its_own_endpoints() {
+        // The passive issuer is passive about *content* only — its own
+        // endpoints, an existing session, and the bypass all behave exactly as
+        // they do in the default mode.
+        let mw = gate(serde_json::json!({ "endpoints_only": true }));
+        assert_eq!(
+            mw.route("/_ephpm/auth/github/login", "", "", None),
+            Route::StartLogin { return_to: "/".into() },
+            "login must still start"
+        );
+        assert_eq!(
+            mw.route("/_ephpm/auth/github/callback", "code=x&state=y", "", None),
+            Route::Callback,
+            "the callback must still be handled"
+        );
+        assert_eq!(
+            mw.route("/", "", "ephpm_session=tok", None),
+            Route::HasSession,
+            "a session cookie must still hand off to the verifier"
+        );
+        // And a real login started at the login endpoint still 302s to GitHub.
+        let resp = invoke(&mw, "/_ephpm/auth/github/login", "", &[]);
+        assert_eq!(resp.__action(), ACTION_RESPOND);
+        assert_eq!(resp.__status(), 302);
+    }
+
+    #[test]
+    fn endpoints_only_defaults_off_and_gates_content_as_before() {
+        // Regression: with the knob omitted (the default) an unauthenticated
+        // content request is gated exactly as it always was.
+        let mw = gate(serde_json::json!({}));
+        assert!(!mw.config.endpoints_only, "the default must be false");
+        assert_eq!(
+            mw.route("/wp-admin/edit.php", "post=7", "", None),
+            Route::StartLogin { return_to: "/wp-admin/edit.php?post=7".into() },
+            "default mode still redirects unauthenticated content to login"
+        );
     }
 
     // ── the 302 to GitHub ───────────────────────────────────────────────

--- a/site/content/guides/github-auth-middleware.md
+++ b/site/content/guides/github-auth-middleware.md
@@ -158,6 +158,7 @@ it is a secret in git.
 | `org` | — | organisation login, for `check = "org"` / `"team"` |
 | `team` | — | team slug, for `check = "team"` |
 | `sites` | unset | table mapping each vhost to its own `{ repo \| org \| team }` |
+| `endpoints_only` | `false` | passive-issuer mode: serve only login/callback and let unauthenticated **content** through (`CONTINUE`) instead of redirecting it to login. A session cookie, the bypass, and the two reserved paths behave exactly as in the default mode, so the login flow still runs and a target is still required. Use it for one global issuer alongside per-site verifiers (see [Passive issuer for public-open, private-gated fleets](#passive-issuer-for-public-open-private-gated-fleets)) |
 | `access` | `"fixed"` | `"fixed"`: the configured target (`default_check`/`sites`) is authoritative — today's behaviour. `"per-preview"`: authorize each preview against the `owner/name` the router seals into the OAuth state from its `[preview_auth] repo` override; `default_check`/`sites` become optional and a request with no repo fails closed |
 | `login_path` | `/_ephpm/auth/github/login` | reserved: starts a login. The router routes the `/_ephpm/auth/` sub-namespace to the middleware chain, so this default is reachable; keep custom values under `/_ephpm/auth/` |
 | `callback_path` | `/_ephpm/auth/github/callback` | reserved: receives GitHub's redirect. Register `https://<host>/_ephpm/auth/github/callback` as the GitHub OAuth App's Authorization callback URL |
@@ -231,6 +232,35 @@ mode `default_check`/`sites` are optional, and a login or callback with no repo
 fails **closed** (403). The session still binds only to the `site` (#396), never
 the repo. See the
 [Preview Access Gate roadmap page](/roadmap/preview-access-gate/#shipped-per-preview-repository-authorization-issue-487).
+
+### Passive issuer for public-open, private-gated fleets
+
+By default the issuer gates content itself: an unauthenticated request that is
+not a login, callback, session, or bypass is redirected to GitHub. That is
+correct when every vhost the mount serves is private. On a mixed fleet — some
+previews public, some private — it is too much: a **single global issuer holds
+the OAuth client secret and must serve login on every subdomain and the callback
+on the apex**, so it necessarily runs on public previews too, where redirecting
+every visitor to login is wrong.
+
+`endpoints_only = true` makes the issuer **passive**. It still serves its own
+endpoints — login starts, the callback is handled, a session cookie hands off to
+the verifier, a bypass token still mints — but an unauthenticated **content**
+request is passed straight through (`CONTINUE`) instead of being redirected. The
+gating decision then belongs entirely to a **per-site verifier**
+([`preview-gate`](/guides/native-middleware/#preview-gate), activated per preview
+by a `[preview_auth]` override):
+
+- a **private** preview has a verifier, which redirects its unauthenticated
+  requests to this issuer's `login_url` — the passive issuer serves that login
+  and mints the session;
+- a **public** preview has no verifier, so the passive issuer lets its content
+  through and the preview is open.
+
+A target is still required in this mode (the login flow runs when someone hits
+the login path), so the "no access target" startup error is unchanged. Pair it
+with the apex-flow knobs above for a wildcard fleet. The full topology is on the
+[Preview Access Gate roadmap page](/roadmap/preview-access-gate/#public-open-private-gated-one-passive-global-issuer).
 
 ## Which GitHub calls are made
 

--- a/site/content/roadmap/preview-access-gate.md
+++ b/site/content/roadmap/preview-access-gate.md
@@ -215,6 +215,59 @@ handles on the apex are the same mount. The apex (`preview.ephpm.dev`) must
 itself be a served vhost (it is where callbacks land). Substitute your own domain
 throughout.
 
+Note the wording above assumes the issuer also **content-gates** — the mode it
+ships in by default, where an unauthenticated content request on any vhost is
+redirected to login. That is correct only when every vhost the mount serves is
+private. To run a fleet where some previews are public and some private, set the
+issuer's `endpoints_only = true` and let per-site verifiers do all content
+enforcement — see the next section.
+
+## Public open, private gated: one passive global issuer
+
+The single-global-issuer requirement above is in tension with a fleet that
+serves **public** previews next to private ones. The issuer must be global (it
+holds the OAuth client secret and serves login on every subdomain plus the
+callback on the apex), but a global content-gating issuer redirects *every*
+visitor to login — including on a public preview that was never meant to be
+gated. `[preview_auth]` cannot rescue this: it activates the per-site *verifier*,
+which only ever runs where it is written, whereas the issuer's own final "no
+session → redirect to login" fires on every vhost regardless.
+
+`endpoints_only = true` on the issuer resolves it. The issuer becomes **passive**
+— it still serves login, the callback, honours an existing session, and mints on
+a bypass token, but an unauthenticated **content** request passes through
+(`CONTINUE`) instead of being redirected. Content enforcement moves entirely to
+the per-site verifier:
+
+| Preview | `[preview_auth]` verifier? | Unauth content request | Result |
+|---|---|---|---|
+| **private** | yes | verifier redirects it to the issuer's `login_url`; the passive issuer serves login and mints the session | gated |
+| **public** | no | no verifier runs; the passive issuer passes it through | open |
+
+The two halves still couple exactly as before — the shared `session_secret`, the
+matching cookie name, and the per-tenant `site` claim binding (#396) — so a
+session minted at login verifies only on the preview it was for. `endpoints_only`
+changes **only** what the issuer does with an unauthenticated content request; it
+does not waive the access-target requirement (login still runs, so a `repo` /
+`org` / `team` / `sites` target — or `access = "per-preview"` — is still
+mandatory) and it does not touch the verifier's fail-closed behaviour. Combine it
+with the apex-flow knobs (`redirect_uri`, `cookie_domain`) for a wildcard fleet.
+
+```toml
+# ephpm.toml — one global, passive issuer for the whole fleet
+[[middleware]]
+library = "github-auth"
+config  = { client_id = "Iv1.…", client_secret = "env:GH_CLIENT_SECRET",
+            session_secret = "env:EPHPM_PREVIEW_SESSION_SECRET",
+            redirect_uri  = "https://preview.ephpm.dev/_ephpm/auth/github/callback",
+            cookie_domain = ".preview.ephpm.dev",
+            org = "acme",                           # target still required — login runs here
+            endpoints_only = true }                 # passive: gate nothing, serve endpoints
+```
+
+Only the private previews then get a `[preview_auth]` override; the public ones
+get none and stay open.
+
 ## Shipped: per-preview repository authorization (issue #487)
 
 The apex flow above funnels every callback through one App, but on its own it


### PR DESCRIPTION
## What

Adds a boolean config knob **`endpoints_only`** (default **`false`**) to the `github-auth` issuer middleware. When `true`, the issuer becomes a **passive** issuer: it serves only its own OAuth endpoints and never gates content.

| Request | `endpoints_only = false` (default, unchanged) | `endpoints_only = true` |
|---|---|---|
| `login_path` | `Route::StartLogin` | `Route::StartLogin` |
| `callback_path` | `Route::Callback` | `Route::Callback` |
| session cookie present | `Route::HasSession` → `CONTINUE` | `Route::HasSession` → `CONTINUE` |
| valid bypass token | `Route::Bypass` | `Route::Bypass` |
| **unauthenticated content** | `Route::StartLogin` (302 → GitHub) | **`Route::Passthrough` → `CONTINUE`** |

The default preserves today's behaviour exactly (backward compatible).

## Why

The preview cluster gates private-repo previews with a per-site `preview-gate` verifier, turned on per preview via a `[preview_auth]` override. But the `github-auth` **issuer** must be a single **global** `[[middleware]]` mount — it holds the OAuth client secret and serves login on every subdomain plus the callback on the apex.

The problem: a global content-gating issuer sends *every* unauthenticated request on *every* vhost to login, so a **public** preview (one with no `[preview_auth]` verifier) also gets redirected/403'd. There was no way to run "public previews open, only private gated" with a global issuer.

With `endpoints_only = true`, a private preview's verifier redirects unauthenticated requests to the passive issuer's `login_url` (which it still serves), while a public preview has no verifier, so the passive issuer passes its content straight through → open.

## Implementation

- `config.rs`: new `pub endpoints_only: bool`, parsed via the existing `opt_bool(config, "endpoints_only", false)` helper, documented with `///`. The "no access target configured" error is **unchanged** — passive mode still runs the login flow (`start_login`/`check_for`) and so still requires a target.
- `lib.rs`: new `Route::Passthrough` variant; `route()`'s final `else` returns it when `endpoints_only`, else `Route::StartLogin` as before; `invoke()` maps `Route::Passthrough` to `Response::cont()` (folded into the existing `HasSession` arm, both `CONTINUE`).

## CONFIG_KEYS

`github_auth` does **not** declare `Middleware::CONFIG_KEYS` (it returns the trait default `None` → unchecked), so no allowlist update was needed. Verified in `crates/ephpm-middleware/src/lib.rs` (`init_checked` only enforces when `CONFIG_KEYS` is `Some`).

## Tests added

`crates/ephpm-middleware-github-auth`:
- `tests::endpoints_only_passes_unauthenticated_content_through` — content requests → `Route::Passthrough`; `invoke()` returns `CONTINUE`, no headers.
- `tests::endpoints_only_still_serves_its_own_endpoints` — `login_path` → `StartLogin`, `callback_path` → `Callback`, session cookie → `HasSession`, and a login still 302s.
- `tests::endpoints_only_defaults_off_and_gates_content_as_before` — regression: default is `false`; unauthenticated content still → `StartLogin`.
- `config::tests::endpoints_only_parses_and_still_requires_a_target` — parses `true`; still errors with no target; rejects a non-boolean.

## Docs (same PR — Docs-Must-Match-Code)

- `site/content/roadmap/preview-access-gate.md` — new "Public open, private gated: one passive global issuer" section + reconciled the "single global mount" text (it assumed content-gating).
- `site/content/guides/github-auth-middleware.md` — `endpoints_only` row in the config table + a "Passive issuer" subsection.

## Gates

- `cargo build --workspace --lib --examples` ✅
- `cargo test -p ephpm-middleware-github-auth` ✅ (88 unit + 12 integration)
- `cargo test -p ephpm-server --test middleware_dlopen --test middleware_response_phase` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo +nightly fmt --all -- --check` ✅