### PR TITLE
feat(analyze): add opt-in PHPStan external-tool analyzer

### DIFF
--- a/crates/ephpm-analyze/src/analyzers/mod.rs
+++ b/crates/ephpm-analyze/src/analyzers/mod.rs
@@ -1,15 +1,20 @@
 //! The built-in analyzers.
 //!
-//! Three wrap external tools as subprocesses and degrade gracefully when the
-//! tool is absent (`composer-audit`, `semgrep-php`, `malware-yara`); two are
-//! native with zero external dependencies (`dangerous-sinks`,
-//! `suppression-scan`), sharing the per-file walker in `php_files` —
-//! diff-aware scope skipping and the incremental cache included — the same
-//! path a future opcode analyzer will use.
+//! Four wrap external tools as subprocesses and degrade gracefully when the
+//! tool is absent (`composer-audit`, `semgrep-php`, `malware-yara`,
+//! `phpstan`); two are native with zero external dependencies
+//! (`dangerous-sinks`, `suppression-scan`), sharing the per-file walker in
+//! `php_files` — diff-aware scope skipping and the incremental cache included
+//! — the same path a future opcode analyzer will use.
+//!
+//! `phpstan` is registered but **not** in the default `security` profile
+//! ([`crate::config::Profile::default_analyzers`]) — it is opt-in via
+//! `analyzers.enable: [phpstan]`.
 
 mod composer_audit;
 mod dangerous_sinks;
 mod php_files;
+mod phpstan;
 mod semgrep;
 mod suppression_scan;
 mod tool;
@@ -17,6 +22,7 @@ mod yara_scan;
 
 pub use composer_audit::ComposerAudit;
 pub use dangerous_sinks::DangerousSinks;
+pub use phpstan::PhpStan;
 pub use semgrep::SemgrepPhp;
 pub use suppression_scan::SuppressionScan;
 pub use yara_scan::MalwareYara;
@@ -30,6 +36,7 @@ pub fn built_in() -> Vec<Box<dyn Analyzer>> {
         Box::new(ComposerAudit),
         Box::new(SemgrepPhp),
         Box::new(MalwareYara),
+        Box::new(PhpStan),
         Box::new(DangerousSinks),
         Box::new(SuppressionScan),
     ]

--- a/crates/ephpm-analyze/src/analyzers/phpstan.rs
+++ b/crates/ephpm-analyze/src/analyzers/phpstan.rs
@@ -1,0 +1,286 @@
+//! `phpstan` — full static analysis of PHP via PHPStan.
+//!
+//! Wraps `phpstan analyse --error-format=json` as a subprocess (PHPStan is an
+//! **optional external dependency** — absence skips this analyzer, the
+//! graceful-degradation half of the fail-closed model). The binary is
+//! resolved first from a project-local Composer install
+//! (`vendor/bin/phpstan`) and otherwise from `PATH`; when neither is present
+//! the shared runner returns [`AnalyzerError::Skipped`], never a crash.
+//!
+//! PHPStan's JSON has three parts: a `totals` block, a `files` map
+//! (path → `{ messages: [ { message, line, identifier, ignorable } ] }`), and
+//! a top-level `errors` array of **non-file** diagnostics — configuration
+//! problems and internal errors. Per-file messages become [`Finding`]s;
+//! a non-empty top-level `errors` array is a *broken run* and gates (a PHPStan
+//! that could not analyse must never look clean).
+//!
+//! Findings are `confidence = Confirmed`: PHPStan is a real static analyzer
+//! reasoning over types, not a heuristic token scan. They are
+//! `category = Quality` — the [`Category::Quality`] variant is documented as
+//! "correctness / robustness problems that are not directly exploitable",
+//! which is exactly what a PHPStan report is (no `Correctness` variant exists,
+//! and `Quality` already means precisely this). Severity is a flat `Medium`:
+//! PHPStan reports bugs, but it does not itself rank them, so the analyzer
+//! does not invent a ranking.
+//!
+//! This analyzer is **not** in the default `security` profile — it is opt-in
+//! via `analyzers.enable: [phpstan]`, so the out-of-the-box gate behaviour is
+//! unchanged.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::tool::{run_tool, stderr_excerpt};
+use crate::analyzer::{AnalysisCtx, Analyzer, AnalyzerError};
+use crate::finding::{Category, Confidence, Finding, Severity};
+
+/// See the module docs.
+pub struct PhpStan;
+
+/// The analyzer's stable id.
+pub const ID: &str = "phpstan";
+
+/// Resolve the PHPStan program name for [`run_tool`].
+///
+/// Prefers a project-local Composer install at `vendor/bin/phpstan` (the file
+/// carries a `#!/usr/bin/env php` shebang and spawns directly on Unix); falls
+/// back to `phpstan` on `PATH`, where the shared runner also handles the
+/// Windows `.bat`/`.cmd` launcher forms. A vendored Windows `.bat` is not
+/// spawned by absolute path (that is [`run_tool`]'s PATH-only concern), so on
+/// Windows a globally installed `phpstan` is used instead — a clean fallback,
+/// never a crash.
+fn resolve_binary(root: &Path) -> String {
+    let vendored = root.join("vendor").join("bin").join("phpstan");
+    if vendored.is_file() {
+        return vendored.to_string_lossy().into_owned();
+    }
+    "phpstan".to_owned()
+}
+
+/// Build the `rule_id` for one message: `phpstan/<identifier>` when PHPStan
+/// emits an `identifier` (1.11+; e.g. `method.notFound`), else the stable
+/// fallback `phpstan/analyse` (PHPStan does not otherwise carry rule ids).
+fn rule_id_for(message: &Value) -> String {
+    match message.get("identifier").and_then(Value::as_str).filter(|s| !s.is_empty()) {
+        Some(identifier) => format!("{ID}/{identifier}"),
+        None => format!("{ID}/analyse"),
+    }
+}
+
+/// Parse a `phpstan analyse --error-format=json` document into findings.
+///
+/// # Errors
+///
+/// [`AnalyzerError::ToolFailed`] when the top-level `errors` array is
+/// non-empty — those are configuration/internal failures, and a run that
+/// could not analyse must gate, not report clean.
+fn parse_phpstan_json(doc: &Value) -> Result<Vec<Finding>, AnalyzerError> {
+    // Top-level `errors` are non-file diagnostics (bad config, internal
+    // error). Any such entry means the analysis itself broke — fail closed.
+    if let Some(errors) = doc.get("errors").and_then(Value::as_array) {
+        if let Some(first) = errors.iter().find_map(Value::as_str) {
+            return Err(AnalyzerError::ToolFailed(format!(
+                "phpstan reported a non-file error: {}",
+                first.chars().take(200).collect::<String>()
+            )));
+        }
+        if !errors.is_empty() {
+            return Err(AnalyzerError::ToolFailed("phpstan reported non-file errors".to_owned()));
+        }
+    }
+
+    let mut findings = Vec::new();
+    let Some(files) = doc.get("files").and_then(Value::as_object) else {
+        return Ok(findings);
+    };
+    for (path, entry) in files {
+        let Some(messages) = entry.get("messages").and_then(Value::as_array) else {
+            continue;
+        };
+        for message in messages {
+            let text = message
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("phpstan finding")
+                .to_owned();
+            // File-level messages carry a null `line`.
+            let line = message.get("line").and_then(Value::as_u64);
+            findings.push(Finding {
+                rule_id: rule_id_for(message),
+                // PHPStan reports bugs but does not itself rank them; keep a
+                // flat medium rather than inventing a severity.
+                severity: Severity::Medium,
+                // "Correctness / robustness problems not directly
+                // exploitable" — see the module docs on the variant choice.
+                category: Category::Quality,
+                path: Some(PathBuf::from(path)),
+                line,
+                message: text,
+                // A type-level static analyzer, not a token heuristic.
+                confidence: Confidence::Confirmed,
+            });
+        }
+    }
+    Ok(findings)
+}
+
+/// Rewrite a finding's path relative to `root` when it is an absolute path
+/// under `root`; leave relative paths (PHPStan's default output) untouched.
+fn relativize(findings: &mut [Finding], root: &Path) {
+    for finding in findings {
+        if let Some(path) = &finding.path
+            && let Ok(rel) = path.strip_prefix(root)
+        {
+            finding.path = Some(rel.to_path_buf());
+        }
+    }
+}
+
+impl Analyzer for PhpStan {
+    fn id(&self) -> &str {
+        ID
+    }
+
+    fn category(&self) -> Category {
+        Category::Quality
+    }
+
+    fn run(&self, ctx: &AnalysisCtx) -> Result<Vec<Finding>, AnalyzerError> {
+        let root = ctx.root();
+        let timeout = ctx.config().analyzers.tool_timeout_ms;
+        let program = resolve_binary(root);
+
+        // Build the argv. `.` because the cwd is the analyzed root (matching
+        // `semgrep-php`). PHPStan auto-discovers `phpstan.neon`/
+        // `phpstan.neon.dist` in the target; the two knobs below only add to
+        // that when the operator sets them.
+        let mut args: Vec<String> = vec![
+            "analyse".to_owned(),
+            "--error-format=json".to_owned(),
+            "--no-progress".to_owned(),
+            "--no-interaction".to_owned(),
+        ];
+        if let Some(config) = &ctx.config().analyzers.phpstan_config {
+            args.push("-c".to_owned());
+            args.push(config.to_string_lossy().into_owned());
+        }
+        if let Some(level) = ctx.config().analyzers.phpstan_level {
+            args.push("--level".to_owned());
+            args.push(level.to_string());
+        }
+        args.push(".".to_owned());
+
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let run = run_tool(&program, &arg_refs, root, timeout)?;
+
+        // PHPStan exits non-zero whenever it finds errors, so the exit code is
+        // not itself a failure signal — the JSON body is the authority
+        // (mirrors `composer-audit` / `semgrep-php`). An unparseable body is a
+        // real failure; a parseable body with a non-empty top-level `errors`
+        // array is a broken run, handled inside `parse_phpstan_json`.
+        match serde_json::from_str::<Value>(&run.stdout) {
+            Ok(doc) => {
+                let mut findings = parse_phpstan_json(&doc)?;
+                relativize(&mut findings, root);
+                Ok(findings)
+            }
+            Err(_) => Err(AnalyzerError::ToolFailed(format!(
+                "phpstan produced no JSON (exit {:?}): {}",
+                run.exit_code,
+                stderr_excerpt(&run.stderr)
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A captured `phpstan analyse --error-format=json` body: two file
+    /// messages (one with an `identifier`, one file-level with a null `line`
+    /// and no `identifier`) and an empty top-level `errors` array.
+    const SAMPLE: &str = r#"{
+      "totals": {"errors": 0, "file_errors": 2},
+      "files": {
+        "src/Controller/UserController.php": {
+          "errors": 1,
+          "messages": [
+            {"message": "Call to an undefined method App\\User::save().",
+             "line": 42, "ignorable": true, "identifier": "method.notFound"}
+          ]
+        },
+        "src/bootstrap.php": {
+          "errors": 1,
+          "messages": [
+            {"message": "Class App\\Kernel not found.",
+             "line": null, "ignorable": false}
+          ]
+        }
+      },
+      "errors": []
+    }"#;
+
+    #[test]
+    fn parses_phpstan_file_messages() {
+        let doc: Value = serde_json::from_str(SAMPLE).unwrap();
+        let findings = parse_phpstan_json(&doc).unwrap();
+        assert_eq!(findings.len(), 2);
+
+        let by_rule = |id: &str| findings.iter().find(|f| f.rule_id == id).unwrap();
+
+        let with_id = by_rule("phpstan/method.notFound");
+        assert_eq!(with_id.severity, Severity::Medium);
+        assert_eq!(with_id.category, Category::Quality);
+        assert_eq!(with_id.confidence, Confidence::Confirmed);
+        assert_eq!(with_id.path.as_deref(), Some(Path::new("src/Controller/UserController.php")));
+        assert_eq!(with_id.line, Some(42));
+        assert!(with_id.message.contains("undefined method"));
+
+        // No `identifier` → the stable fallback rule id; null line → None.
+        let fallback = by_rule("phpstan/analyse");
+        assert_eq!(fallback.path.as_deref(), Some(Path::new("src/bootstrap.php")));
+        assert_eq!(fallback.line, None);
+        assert_eq!(fallback.confidence, Confidence::Confirmed);
+    }
+
+    #[test]
+    fn top_level_errors_gate_instead_of_reporting_clean() {
+        // A config failure: PHPStan emits an empty `files` map but a non-empty
+        // top-level `errors` array. This must be a gating error, never an
+        // empty (clean) result — a broken analysis cannot pass the gate.
+        let doc: Value = serde_json::from_str(
+            r#"{"totals": {"errors": 1, "file_errors": 0},
+                "files": {},
+                "errors": ["Configuration file phpstan.neon does not exist."]}"#,
+        )
+        .unwrap();
+        let result = parse_phpstan_json(&doc);
+        assert!(matches!(result, Err(AnalyzerError::ToolFailed(_))), "{result:?}");
+    }
+
+    #[test]
+    fn clean_run_yields_no_findings() {
+        let doc: Value = serde_json::from_str(
+            r#"{"totals": {"errors": 0, "file_errors": 0}, "files": {}, "errors": []}"#,
+        )
+        .unwrap();
+        assert!(parse_phpstan_json(&doc).unwrap().is_empty());
+    }
+
+    #[test]
+    fn absolute_paths_under_root_are_relativized() {
+        let mut findings = vec![Finding {
+            rule_id: "phpstan/analyse".to_owned(),
+            severity: Severity::Medium,
+            category: Category::Quality,
+            path: Some(PathBuf::from("/srv/app/src/Foo.php")),
+            line: Some(1),
+            message: "x".to_owned(),
+            confidence: Confidence::Confirmed,
+        }];
+        relativize(&mut findings, Path::new("/srv/app"));
+        assert_eq!(findings[0].path.as_deref(), Some(Path::new("src/Foo.php")));
+    }
+}

--- a/crates/ephpm-analyze/src/config.rs
+++ b/crates/ephpm-analyze/src/config.rs
@@ -26,6 +26,8 @@
 //!   deny_hard: [dangerous-sinks/eval]
 //!   yara_rules: rules/malware.yar
 //!   semgrep_config: p/php
+//!   phpstan_config: phpstan.neon   # optional; PHPStan auto-discovers otherwise
+//!   phpstan_level: 6               # optional; else from the target's config
 //!   tool_timeout_ms: 300000
 //! policy:
 //!   quarantine_score: 10
@@ -224,6 +226,19 @@ pub struct AnalyzersConfig {
     /// Semgrep config/registry ref passed to `--config`. Default `p/php`.
     #[serde(default = "default_semgrep_config")]
     pub semgrep_config: String,
+    /// PHPStan configuration file passed to `phpstan analyse -c <path>`.
+    /// Relative paths resolve against the analyzed root (the tool's cwd).
+    /// When unset (the default), PHPStan auto-discovers `phpstan.neon` /
+    /// `phpstan.neon.dist` in the target — the common case, so no knob needed.
+    #[serde(default)]
+    pub phpstan_config: Option<PathBuf>,
+    /// PHPStan rule level passed to `phpstan analyse --level <n>` (0 is
+    /// loosest, `max` is expressed as `9`). When unset (the default), the
+    /// level comes from the target's PHPStan config; PHPStan itself errors if
+    /// neither this nor a config supplies one, which surfaces as a gating
+    /// analyzer failure (fail-closed), never a silent clean run.
+    #[serde(default)]
+    pub phpstan_level: Option<u8>,
     /// Wall-clock budget per external tool invocation, in milliseconds. A
     /// tool exceeding it is killed and the analyzer fails (fail-closed).
     /// Default 300000 (5 minutes).
@@ -239,6 +254,8 @@ impl Default for AnalyzersConfig {
             deny_hard: Vec::new(),
             yara_rules: None,
             semgrep_config: default_semgrep_config(),
+            phpstan_config: None,
+            phpstan_level: None,
             tool_timeout_ms: default_tool_timeout_ms(),
         }
     }
@@ -527,6 +544,8 @@ analyzers:
   deny_hard: [dangerous-sinks/eval]
   yara_rules: rules/malware.yar
   semgrep_config: p/security-audit
+  phpstan_config: phpstan.neon
+  phpstan_level: 8
   tool_timeout_ms: 60000
 policy:
   quarantine_score: 5
@@ -564,6 +583,8 @@ suppress:
         assert_eq!(cfg.analyzers.deny_hard, vec!["dangerous-sinks/eval"]);
         assert_eq!(cfg.analyzers.yara_rules.as_deref(), Some(Path::new("rules/malware.yar")));
         assert_eq!(cfg.analyzers.semgrep_config, "p/security-audit");
+        assert_eq!(cfg.analyzers.phpstan_config.as_deref(), Some(Path::new("phpstan.neon")));
+        assert_eq!(cfg.analyzers.phpstan_level, Some(8));
         assert_eq!(cfg.analyzers.tool_timeout_ms, 60_000);
         assert_eq!(cfg.policy.quarantine_score, 5);
         assert_eq!(cfg.policy.deny_score, 20);

--- a/site/content/reference/cli/analyze.md
+++ b/site/content/reference/cli/analyze.md
@@ -40,6 +40,8 @@ ephpm analyze [PATH] [--config FILE] [--format FORMAT] [--profile NAME] [--fail-
 
 External tools are **not bundled** — ePHPm shells out to them. An analyzer whose tool (or required input) is absent is reported as *skipped* and does not gate, unless listed in `analyzers.required` (see below). Each finding carries a **confidence**: `confirmed` (the analyzer is sure) or `suspected` (a hotspot worth review) — see [Hotspots vs findings](#hotspots-vs-findings-confidence).
 
+The `security` profile enables the first five analyzers below (`composer-audit`, `semgrep-php`, `malware-yara`, `dangerous-sinks`, `suppression-scan`). `phpstan` is registered but **opt-in** — it runs only when named explicitly in `analyzers.enable`, so the default gate behaviour is unchanged.
+
 | Analyzer | Kind | Category | Confidence | Needs | What it does |
 |----------|------|----------|------------|-------|--------------|
 | `composer-audit` | external | supply-chain | confirmed | `composer` on `PATH`, `composer.json` + `composer.lock` in the target | Runs `composer audit --no-scripts --format=json`; each advisory becomes a finding (severity from the advisory, `critical` hard-denies), abandoned packages become `info` findings. |
@@ -47,6 +49,7 @@ External tools are **not bundled** — ePHPm shells out to them. An analyzer who
 | `malware-yara` | external | malware | confirmed | `yara` on `PATH` **and** a ruleset at `analyzers.yara_rules` (none ships with ePHPm — unset means skipped) | Runs `yara -r -w <rules> <target>`; each rule match is a `high` finding. A *configured but missing* ruleset path is an error (fail-closed), not a skip. |
 | `dangerous-sinks` | native | security | suspected | nothing | A naive line/token pass over `*.php` / `*.phtml` flagging direct calls to the `eval` and `system` sinks (high) and `assert` (medium). Deliberately simple — matches inside comments/strings are false positives (hence *suspected*); dynamic calls are missed. It will be superseded by the opcode-level analyzer (planned). |
 | `suppression-scan` | native | security | confirmed | nothing | Flags tenant-authored suppression-shaped comments (`ephpm-analyze-ignore`, `@phpstan-ignore*`, `@psalm-suppress`, `phpcs:ignore`/`phpcs:disable`, `nosemgrep`, `noqa`, `NOSONAR`, `@codingStandardsIgnore`) as `suppression-scan/tenant-suppression-attempt` (medium) — see [Operator-only suppressions](#operator-only-suppressions-suppress). One finding per (file, marker), anchored at the first occurrence. |
+| `phpstan` | external, **opt-in** | quality | confirmed | `phpstan` on `PATH` **or** a vendored `vendor/bin/phpstan`; a rule level (from `analyzers.phpstan_level` or a `phpstan.neon`/`phpstan.neon.dist` in the target) | Runs `phpstan analyse --error-format=json --no-progress --no-interaction`; each per-file message becomes a `medium` **quality** finding (`rule_id` = `phpstan/<identifier>` when PHPStan emits one, else `phpstan/analyse`). A non-empty top-level `errors` array (bad config, internal error) is a broken run and **gates** (fail-closed), never a clean result. Not in the `security` profile — enable it with `analyzers.enable: [phpstan]`. |
 
 ## The verdict model
 
@@ -166,6 +169,11 @@ analyzers:
   yara_rules: null         # YARA ruleset path for malware-yara (relative
                            # paths resolve against the analyzed directory)
   semgrep_config: p/php    # semgrep --config value
+  phpstan_config: null     # phpstan `analyse -c <path>` (relative to the
+                           # target). null = PHPStan auto-discovers
+                           # phpstan.neon / phpstan.neon.dist
+  phpstan_level: null      # phpstan `analyse --level <n>` (0..=9). null =
+                           # level comes from the target's PHPStan config
   tool_timeout_ms: 300000  # wall-clock budget per external tool; exceeding
                            # it kills the tool and gates (fail-closed)
 
@@ -227,4 +235,4 @@ ephpm analyze /srv/app
 
 ## Scope
 
-Shipped: the aggregator, the fail-closed policy engine (strictness levels, confidence model), the config/gating surface, baselines, diff-aware scanning, the incremental cache, operator-only suppressions with tenant-suppression detection, both output formats, and the five analyzers above. Planned — not yet implemented: opcode-level analysis of compiled PHP (which replaces the naive `dangerous-sinks` pass), engine-in-the-loop detonation of suspicious inputs (the `engine:` section), and ePHPm-specific rules. The `Analyzer` trait, finding shape, policy engine, and output formats are designed to be stable across those additions.
+Shipped: the aggregator, the fail-closed policy engine (strictness levels, confidence model), the config/gating surface, baselines, diff-aware scanning, the incremental cache, operator-only suppressions with tenant-suppression detection, both output formats, the five default-profile analyzers above, and the opt-in `phpstan` analyzer. Planned — not yet implemented: opcode-level analysis of compiled PHP (which replaces the naive `dangerous-sinks` pass), engine-in-the-loop detonation of suspicious inputs (the `engine:` section), and ePHPm-specific rules. The `Analyzer` trait, finding shape, policy engine, and output formats are designed to be stable across those additions.


### PR DESCRIPTION
## Summary

Adds a **PHPStan** analyzer (`id = "phpstan"`) to `ephpm-analyze`, modelled exactly on the existing `semgrep-php` analyzer. It wraps `phpstan analyse --error-format=json --no-progress --no-interaction .` as a subprocess through the shared `analyzers/tool.rs` runner, so absence of the binary degrades to `Skipped` and a timeout gates as `Timeout` — none of those quirks are re-implemented.

- **Binary resolution:** prefers a project-local `vendor/bin/phpstan` (Composer install), otherwise `phpstan` on `PATH` (where `tool.rs` also handles the Windows `.bat`/`.cmd` launcher forms).
- **Per-file messages → `Finding`:** `severity = Medium`, `confidence = Confirmed` (a real type-level static analyzer, not a token heuristic), `category = Quality`, `path`, `line`.
- **`rule_id = phpstan/<identifier>`** when PHPStan emits an `identifier` (1.11+/2.x, e.g. `method.notFound`), else the stable fallback `phpstan/analyse`.
- **Broken run gates:** the top-level `errors` array (config/internal failures — an array of strings) surfaces as a gating `AnalyzerError::ToolFailed`, never a clean result. Mirrors how `semgrep-php`/`composer-audit` treat the JSON body as authoritative and the exit code alone as non-signal.

### Registration / profile
Registered in `analyzers::built_in()` so `analyzers.enable: [phpstan]` resolves it, but **not** added to `Profile::default_analyzers` (the `security` profile) — it stays opt-in, so the default gate behaviour is unchanged.

### Category decision — no new variant added
The task suggested `Category::Correctness`. `finding.rs` has no such variant, and the existing **`Category::Quality`** is documented verbatim as *"Correctness / robustness problems that are not directly exploitable"* — exactly a PHPStan report. Adding a `Correctness` variant would ripple through `Display`, the policy engine, and the SARIF mapping to express something `Quality` already means, so this PR reuses `Quality`. **No new `Category`/`Severity` variant was needed.**

### Config knobs (both opt-in, default `None`)
Added to `AnalyzersConfig` (strict `deny_unknown_fields` preserved; serde defaults; `Default` impl, docstring example, and `full_document_parses` test all updated):

- `phpstan_config: Option<PathBuf>` → `phpstan analyse -c <path>` (relative to the target).
- `phpstan_level: Option<u8>` → `phpstan analyse --level <n>`.

Both default to unset, deferring to the target's `phpstan.neon`/`phpstan.neon.dist` auto-discovery. If neither a level nor a config is available, PHPStan errors — which surfaces as a gating analyzer failure (fail-closed), not a silent clean run.

### PHPStan JSON schema (verified, matches the task)
Top-level `{ totals, files, errors }`; `files` maps path → `{ errors, messages: [ { message, line, ignorable, identifier? } ] }`; the top-level `errors` is an **array of strings** (non-file diagnostics). `line` is `null` for file-level messages (handled → `line = None`). `identifier` is present on 1.11+/2.x; the `phpstan/analyse` fallback covers older versions that omit it.

## Tests (do **not** require phpstan installed)
In `crates/ephpm-analyze/src/analyzers/phpstan.rs`:
- `parses_phpstan_file_messages` — captured JSON fixture with two file messages (one with `identifier`, one file-level with null `line`/no identifier); asserts count, both rule ids, severity, category, path, line, `confidence = Confirmed`.
- `top_level_errors_gate_instead_of_reporting_clean` — a config-failure JSON (empty `files`, non-empty top-level `errors`) yields a gating `ToolFailed`, not an empty clean result.
- `clean_run_yields_no_findings`.
- `absolute_paths_under_root_are_relativized` — absolute paths under the analyzed root are rewritten tree-relative (PHPStan may emit either form; relative paths untouched).

The absence path (binary not found → `Skipped`) is covered by `tool.rs` / the existing `absent_external_tools_skip_but_do_not_gate` e2e test.

## Docs
`site/content/reference/cli/analyze.md`: new `phpstan` row in the analyzer table (opt-in, quality, confirmed, skipped when absent, gates on top-level errors), the two new config keys in the config block, and the profile/scope prose updated.

## Gates
`cargo build --workspace --lib --examples`, `cargo test -p ephpm-analyze` (80 tests, incl. the 4 new), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check` — all pass.