### PR TITLE
fix(github-auth): apex OAuth login fails under sites_domain_suffix

### DIFF
--- a/crates/ephpm-middleware-github-auth/src/lib.rs
+++ b/crates/ephpm-middleware-github-auth/src/lib.rs
@@ -407,11 +407,29 @@ impl GithubAuth {
             }
         };
 
+        // The full request host this login is running on. `vhost` is the
+        // canonical *site key*, which with `sites_domain_suffix` set is
+        // suffix-stripped (host `pr-1.preview.example.com` → key `pr-1`) — a bare
+        // label the apex callback cannot use for its fleet-membership check, an
+        // outbound `redirect_uri`, or the absolute bounce-back. `http_host()` is
+        // the real host, normalized (port/dot stripped, lowercased). We seal both
+        // into the state: `v` stays the site key (the session's `site` claim and
+        // the per-tenant binding of issue #396), and `vh` carries the full host
+        // for everything host-shaped. On a host too old to expose `http_host`
+        // (`""`) fall back to the site key — where a suffix could not have been
+        // stripped either (that normalization arrived in the same ABI minor), so
+        // the two are identical anyway.
+        let full_host = {
+            let h = req.http_host();
+            if h.is_empty() { vhost } else { h }
+        };
+
         let nonce = token::random_nonce();
         let mut state_claims = serde_json::json!({
             "n": nonce,
             "rt": return_to,
             "v": vhost,
+            "vh": full_host,
             "exp": now.saturating_add(STATE_TTL_SECS),
         });
         // Seal the per-preview repository into the state so the apex callback can
@@ -426,11 +444,17 @@ impl GithubAuth {
             return deny(500, "Login could not be started.");
         };
 
+        // The `redirect_uri` must key off the full host, not the site key: with a
+        // fixed apex `redirect_uri` configured (the apex flow) the argument is
+        // ignored, but a per-vhost-derived `redirect_uri` under a
+        // `sites_domain_suffix` would otherwise build the unreachable
+        // `https://pr-1/callback`. The code exchange re-derives it from `vh`
+        // below, so the two byte-match as OAuth requires.
         let mut url = format!(
             "{}/login/oauth/authorize?client_id={}&redirect_uri={}&state={}&response_type=code",
             self.config.github_base,
             encode_query(&self.config.client_id),
-            encode_query(&self.redirect_uri(vhost)),
+            encode_query(&self.redirect_uri(full_host)),
             encode_query(&nonce),
         );
         if !self.config.scopes.is_empty() {
@@ -515,23 +539,49 @@ impl GithubAuth {
                 .header("Set-Cookie", clear_state);
         }
         // The **target** preview is whatever host the login was started on,
-        // carried (signed) in the state's `v` — NOT the host this callback
-        // landed on. They are the same in a single-host deployment; in the
-        // single-OAuth-App apex flow the callback always lands on the apex vhost
-        // while the target is a `*.preview` subdomain. The target is
-        // authoritative from here: the access check, the session's `site` claim,
-        // and the redirect all key off it.
-        let target = state_claims.get("v").and_then(serde_json::Value::as_str).unwrap_or_default();
-        // `v` was set by us to a router-validated site key, and the state is
-        // signed — but re-validate (defense in depth: it becomes an outbound
-        // `redirect_uri` and an absolute redirect Location) and confirm it is a
-        // host this callback may complete for: itself, or — with a fleet
-        // `cookie_domain` — any host under it. Without a `cookie_domain` only
-        // the callback's own host is allowed, which is the strict per-vhost
-        // binding this replaced (a state minted for another tenant is refused).
-        if target.is_empty()
-            || config::validate_vhost(target).is_err()
-            || !self.target_is_allowed(target, vhost)
+        // carried (signed) in the state — NOT the host this callback landed on.
+        // They are the same in a single-host deployment; in the single-OAuth-App
+        // apex flow the callback always lands on the apex vhost while the target
+        // is a `*.preview` subdomain. The state carries two facets of the target,
+        // which must not be conflated:
+        //
+        //   * `target_site` (`v`) — the canonical **site key**. Under a
+        //     `sites_domain_suffix` this is suffix-stripped (`pr-1`), so it is a
+        //     tenant identity, not a host. It is authoritative for the access
+        //     check, the session's `site` claim (the per-tenant binding of issue
+        //     #396 — the verifier compares that claim to `req.vhost_id()`), and
+        //     the `sites` lookup.
+        //   * `target_host` (`vh`) — the **full host** login ran on. It is
+        //     authoritative for everything host-shaped: fleet-membership, the
+        //     outbound `redirect_uri`, and the absolute bounce-back `Location`.
+        //     Fall back to `v` for a state minted before `vh` existed and for a
+        //     no-suffix deployment, where the two are identical by construction.
+        let target_site =
+            state_claims.get("v").and_then(serde_json::Value::as_str).unwrap_or_default();
+        let target_host = state_claims
+            .get("vh")
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(target_site);
+        // The host this callback actually landed on — the apex in the fleet flow.
+        // Fleet membership and the absolute bounce are host comparisons, so use
+        // the full request host, not the (possibly suffix-stripped) site key
+        // `vhost`; fall back to `vhost` on a host too old to expose `http_host`.
+        let callback_host = {
+            let h = req.http_host();
+            if h.is_empty() { vhost } else { h }
+        };
+        // Both facets were set by us and the state is signed — but re-validate
+        // the full host (defense in depth: it becomes an outbound `redirect_uri`
+        // and an absolute redirect Location) and confirm it is a host this
+        // callback may complete for: itself, or — with a fleet `cookie_domain` —
+        // any host under it. Without a `cookie_domain` only the callback's own
+        // host is allowed, which is the strict per-vhost binding this replaced (a
+        // state minted for another tenant is refused). `target_site` must also be
+        // present, since it becomes the session's `site` claim.
+        if target_site.is_empty()
+            || config::validate_vhost(target_host).is_err()
+            || !self.target_is_allowed(target_host, callback_host)
         {
             log(
                 req,
@@ -581,7 +631,7 @@ impl GithubAuth {
                 }
             }
             Access::Fixed => {
-                let Some(c) = self.config.check_for(target) else {
+                let Some(c) = self.config.check_for(target_site) else {
                     return deny(403, "This preview is not configured for GitHub access control.")
                         .header("Set-Cookie", clear_state);
                 };
@@ -597,10 +647,11 @@ impl GithubAuth {
 
         // ── The only network calls in the module ─────────────────────────
         // The exchange's `redirect_uri` must byte-match the one sent at
-        // `authorize` (which used `redirect_uri(target)`); with a fixed apex
-        // `redirect_uri` configured, both are the apex regardless of argument.
+        // `authorize` (which used `redirect_uri(full_host)`, i.e. `vh` =
+        // `target_host`); with a fixed apex `redirect_uri` configured, both are
+        // the apex regardless of argument.
         let outcome =
-            self.github.exchange_code(&code, &self.redirect_uri(target)).and_then(|access| {
+            self.github.exchange_code(&code, &self.redirect_uri(target_host)).and_then(|access| {
                 let user = self.github.current_user(&access)?;
                 let allowed = self.github.check_access(&access, &check, &user)?;
                 Ok((user, allowed))
@@ -622,7 +673,7 @@ impl GithubAuth {
                 req,
                 LOG_INFO,
                 &format!(
-                    "github-auth: denied {} on target vhost {target:?} — no access to {}",
+                    "github-auth: denied {} on target vhost {target_site:?} — no access to {}",
                     user.login,
                     check.describe()
                 ),
@@ -631,14 +682,15 @@ impl GithubAuth {
                 .header("Set-Cookie", clear_state);
         }
 
-        // Mint the session for the TARGET (its `site` claim), and redirect the
-        // browser back to the target — absolute when the callback ran on a
-        // different host (the apex flow), so it lands on the right preview. The
-        // domain-scoped session cookie `issue` sets travels with it.
-        let final_return = self.return_location(target, vhost, &return_to);
+        // Mint the session bound to the TARGET SITE KEY (its `site` claim — the
+        // per-tenant binding of issue #396), and redirect the browser back to the
+        // target's FULL HOST — absolute when the callback ran on a different host
+        // (the apex flow), so it lands on the right preview. The domain-scoped
+        // session cookie `issue` sets travels with it.
+        let final_return = self.return_location(target_host, callback_host, &return_to);
         self.issue(
             req,
-            target,
+            target_site,
             &user.login,
             "github",
             Some(user.id),

--- a/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
+++ b/crates/ephpm-middleware-github-auth/tests/oauth_round_trip.rs
@@ -216,6 +216,27 @@ fn call_on(
     mw.invoke(&req)
 }
 
+/// Like [`call_on`] but sets the canonical **site key** and the normalized
+/// **full request host** independently — the exact split a `sites_domain_suffix`
+/// deployment produces, where `vhost_id()` is the suffix-stripped key (`pr-1`)
+/// while `http_host()` is the real host (`pr-1.preview.test`). `call_on` passes
+/// one string as both, which is only faithful to a deployment with no suffix.
+fn call_on_full(
+    mw: &GithubAuth,
+    site_key: &str,
+    full_host: &str,
+    path: &str,
+    query: &str,
+    headers: &[(String, String)],
+) -> Response {
+    let ctx =
+        RequestCtx::new("GET", path, query, "203.0.113.9", site_key, headers).with_host(full_host);
+    // SAFETY: `ctx` outlives the borrow and `host_table()` is 'static — the
+    // exact contract `Request::from_raw` documents.
+    let req = unsafe { Request::from_raw(ctx.as_abi(), host_table()) };
+    mw.invoke(&req)
+}
+
 fn header(resp: &Response, name: &str) -> Option<String> {
     resp.__headers().iter().find(|(n, _)| n.eq_ignore_ascii_case(name)).map(|(_, v)| v.clone())
 }
@@ -583,6 +604,123 @@ fn apex_flow_one_app_serves_the_whole_wildcard_fleet() {
         policy.verify(token, now, Some(APEX)).is_none(),
         "and it is not a session for the apex"
     );
+}
+
+/// The apex flow **with `sites_domain_suffix` configured** — the real
+/// production preview config, and the one CI never exercised. When the router
+/// strips a `sites_domain_suffix`, `req.vhost_id()` is the bare **site key**
+/// (`pr-1`), NOT the full host (`pr-1.preview.test`); `req.http_host()` carries
+/// the full host. The bug: `handle_callback` sealed the site key into the state
+/// as the target and then treated that bare label as a host — checking
+/// `host_in_domain("pr-1", ".preview.test")` (false) and, had it passed,
+/// redirecting to the unreachable `https://pr-1/…`. Every login 400'd with
+/// "This login link is not valid here."
+///
+/// The fix seals the full host separately (`vh`) and uses it for the fleet
+/// check, the outbound `redirect_uri` and the absolute bounce, while `v` stays
+/// the site key that binds the session (#396). This drives the end-to-end apex
+/// flow with the site-key/full-host split and asserts the login completes: the
+/// callback is NOT a 400, the session's `site` claim is the SITE KEY (not the
+/// full host, so the hot-path verifier still matches it), and the redirect
+/// lands on the full host.
+///
+/// Falsification: revert the fix (`git stash` the `src/` change) and this test
+/// fails at the callback with `400` instead of `302`.
+#[test]
+fn apex_flow_with_a_sites_domain_suffix_stripped_site_key() {
+    // The suffix-stripped site keys (what `req.vhost_id()` returns in prod), and
+    // the full hosts (what `req.http_host()` returns). The `sites` map is keyed
+    // by SITE KEY — the same value `check_for` has always looked up.
+    const TARGET_KEY: &str = "pr-1";
+    const TARGET_HOST: &str = "pr-1.preview.test";
+    const APEX_KEY: &str = "preview.test"; // suffix `.preview.test` does not strip the apex
+    const APEX_HOST: &str = "preview.test";
+
+    let stub = Stub::start();
+    // Distinct repos per site key prove the callback gates on the TARGET site
+    // key, not the apex it landed on: the target maps to a readable repo, the
+    // apex to a denied one.
+    let mw = gate(
+        &stub,
+        serde_json::json!({
+            "repo": null,
+            "sites": {
+                TARGET_KEY: { "repo": "acme/web" },     // target → readable
+                APEX_KEY:   { "repo": "acme/noread" },  // apex → read denied
+            },
+            "redirect_uri": format!("https://{APEX_HOST}/_ephpm/auth/github/callback"),
+            "cookie_domain": ".preview.test",
+        }),
+    );
+
+    // 1. Login on the TARGET: site key `pr-1`, full host `pr-1.preview.test`.
+    let login = call_on_full(&mw, TARGET_KEY, TARGET_HOST, "/wp-admin/", "", &[]);
+    assert_eq!(login.__status(), 302);
+    let loc = header(&login, "Location").expect("Location");
+    let qs = loc.split_once('?').expect("query").1;
+    assert_eq!(
+        query_param(qs, "redirect_uri").expect("redirect_uri"),
+        format!("https://{APEX_HOST}/_ephpm/auth/github/callback"),
+        "authorize must send the ONE fixed apex redirect_uri"
+    );
+    let state = query_param(qs, "state").expect("state");
+    let state_cookie = set_cookies(&login)
+        .into_iter()
+        .find(|c| c.starts_with("ephpm_session_oauth="))
+        .expect("state cookie")
+        .split(';')
+        .next()
+        .expect("pair")
+        .to_owned();
+
+    // 2. GitHub redirects to the APEX callback (a different host, site key
+    //    `preview.test`). On the buggy code the bare `pr-1` target failed the
+    //    fleet check here → 400. The fix reads the sealed full host instead.
+    let resp = call_on_full(
+        &mw,
+        APEX_KEY,
+        APEX_HOST,
+        "/_ephpm/auth/github/callback",
+        &format!("code={GOOD_CODE}&state={state}"),
+        &[("Cookie".to_owned(), state_cookie)],
+    );
+    assert_ne!(
+        resp.__status(),
+        400,
+        "the suffix-stripped site key must not read as an out-of-fleet host — this is the bug"
+    );
+    assert_eq!(resp.__status(), 302, "the apex callback completes the login");
+
+    // 3. The redirect lands on the TARGET's FULL HOST, not the bare site key.
+    assert_eq!(
+        header(&resp, "Location").as_deref(),
+        Some("https://pr-1.preview.test/wp-admin/"),
+        "the browser must bounce back to the full host, never the unreachable bare `pr-1`"
+    );
+
+    // 4. The access check gated on the TARGET site key's repo (acme/web).
+    let seen = stub.seen();
+    assert!(seen.requests.iter().any(|r| r == "GET /repos/acme/web"), "must check the target repo");
+    assert!(
+        !seen.requests.iter().any(|r| r == "GET /repos/acme/noread"),
+        "must NOT check the apex's repo"
+    );
+    drop(seen);
+
+    // 5. The minted session's `site` claim is the SITE KEY `pr-1` — NOT the full
+    //    host. The hot-path verifier compares `site` to `req.vhost_id()` (the
+    //    site key) per #396; a full host there would break every request.
+    let session = session_value(&resp);
+    let payload =
+        session.strip_prefix("ephpm_session=").expect("prefix").split('.').nth(1).expect("payload");
+    let json: serde_json::Value =
+        serde_json::from_slice(&base64_url_decode(payload).expect("base64url")).expect("json");
+    assert_eq!(
+        json["site"], TARGET_KEY,
+        "the session must bind to the site key (#396), not the full host {TARGET_HOST}"
+    );
+    assert_eq!(json["via"], "github");
+    assert_eq!(json["check"], "repo acme/web");
 }
 
 // ── per-preview repo gate (issue #487) ─────────────────────────────────────


### PR DESCRIPTION
## The bug (confirmed live on the preview fleet)

The apex OAuth flow rejected **every** login with *"This login link is not valid here. Start again."* whenever `sites_domain_suffix` is configured — the production multi-tenant preview config.

`start_login` sealed `req.vhost_id()` into the signed OAuth state as the `v` claim. With `sites_domain_suffix` set, `vhost_id()` is the canonical **site key** — the suffix-stripped bare label (host `ephpm-preview-gate-test-pr-1.preview.ephpm.dev` → key `ephpm-preview-gate-test-pr-1`), **not** a host.

`handle_callback` then read `v` as the target **host**:
- it passed the bare key to `target_is_allowed`, whose `host_in_domain("<bare-key>", ".preview.ephpm.dev")` is `false` → the callback returned `400` before any network call;
- and had that passed, `return_location` would have built the unreachable `https://<bare-key>/…`.

**Why CI missed it:** the apex unit/integration tests (`apex_flow_one_app_serves_the_whole_wildcard_fleet`, the router composition tests) set no `sites_domain_suffix`, so their `vhost_id` was already a full host and the check passed. Public previews never exercise login, so only the real prod config hit it.

## The fix

Seal the full request host separately, and keep the site key for the session binding.

- `start_login` adds a **`vh`** claim from `req.http_host()` (the normalized full host the login ran on) and derives the outbound `redirect_uri` from it. `v` still carries the site key.
- `handle_callback` splits the target into two facets:
  - **`target_site`** (`v`, the site key) — authoritative for the access check, the `sites` lookup, and the session's `site` claim. That claim is what the hot-path `session-cookie`/`preview-gate` verifier compares to `req.vhost_id()` per **#396**, so it must stay the site key.
  - **`target_host`** (`vh`, falling back to `v` for pre-`vh` states and no-suffix deployments) — drives the fleet-membership check (`target_is_allowed`), the code-exchange `redirect_uri` (byte-matches the authorize one), and the absolute bounce-back `Location`.
  - the callback host is likewise taken from `req.http_host()`, not the (possibly suffix-stripped) site key.

### Approach chosen: sealed `vh`, not reconstruct

The `Request` ABI already exposes a reliable full host at login — `Request::http_host()` (normalized: port/dot stripped, lowercased; ABI minor 2, and the router advertises minor 4). Login always runs on the target preview host, so `http_host()` is exactly the host needed. Sealing it is robust and, unlike reconstructing `site_key + cookie_domain` at the callback, does **not** assume `cookie_domain == sites_domain_suffix`. Fallback to `v` handles hosts too old to expose `http_host` (where a suffix could not have been stripped anyway, so the two are identical).

The CSRF nonce (`n`), `exp`, state-cookie verification, and the per-preview `repo` claim are unchanged. `#396` binding is intact (the `site` claim remains the site key).

## Regression test

`apex_flow_with_a_sites_domain_suffix_stripped_site_key` (in `tests/oauth_round_trip.rs`, against the existing stub GitHub) drives the end-to-end apex flow with the site-key/full-host split — the exact prod scenario. It asserts the callback is **not** a `400`, completes with `302`, mints a session whose `site` claim is the **site key** (not the full host), and redirects to the **full host**.

**Falsification:** reverting only the `src/` change makes it fail at the callback with `400` (`assert_ne!(status, 400)` — the "not valid here" path). With the fix it is `302`.

## Gates

- `cargo build --workspace --lib --examples` ✓
- `cargo test -p ephpm-middleware-github-auth` — 88 unit + 13 integration ✓
- `cargo test -p ephpm-server --test middleware_dlopen --test middleware_response_phase` — 9 + 4 ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo +nightly fmt --all -- --check` ✓
