### PR TITLE
docs(analyze): acme-portal worked example + walkthrough

### DIFF
--- a/examples/analyze-demo/.ephpm-analyze.yml
+++ b/examples/analyze-demo/.ephpm-analyze.yml
@@ -1,0 +1,20 @@
+# ephpm analyze — configuration for the acme-portal demo.
+# Any key ephpm does not recognize fails startup (deny_unknown_fields), so a
+# typo can never silently disable a check.
+
+profile: security          # runs: composer-audit, semgrep-php, malware-yara,
+                           #       dangerous-sinks, suppression-scan
+
+fail_on: quarantine        # deploy gate: a "quarantine" verdict (or worse)
+                           # makes `ephpm analyze` exit non-zero. Use "deny"
+                           # to gate only on the most severe verdict, or
+                           # "allow" for report-only.
+
+level: 1                   # 0 = gate only on hard denies
+                           # 1 = weighted-score default (this demo)
+                           # 2 = quarantine any High finding
+                           # 3 = quarantine any Medium finding
+
+analyzers:
+  # A malware-yara hit is always fatal, regardless of the weighted score.
+  deny_hard: [malware-yara]

--- a/examples/analyze-demo/README.md
+++ b/examples/analyze-demo/README.md
@@ -1,0 +1,90 @@
+# `ephpm analyze` demo — acme-portal
+
+A tiny, **deliberately-insecure** PHP app used to show what `ephpm analyze`
+reports and how the fail-closed deploy gate behaves. **Do not model real code on
+this** — every "finding" below is an intentional plant.
+
+## Run it
+
+From this directory (or point `ephpm analyze` at the path):
+
+```console
+$ ephpm analyze .
+```
+
+`ephpm analyze` reads `.ephpm-analyze.yml` here (or falls back to built-in
+defaults), runs the configured analyzers, prints a report, and **exits non-zero
+when the verdict trips the gate** — so it drops straight into a CI or deploy
+step.
+
+## What you get
+
+With the bundled config (`profile: security`, `fail_on: quarantine`), a run on a
+box where the external tools aren't installed looks like this:
+
+```text
+  composer-audit   skipped: no composer.lock in target (audit needs a lockfile)
+  semgrep-php      skipped: `semgrep` not found on PATH
+  malware-yara     skipped: no ruleset configured (set analyzers.yara_rules)
+  dangerous-sinks  completed (3 finding(s))
+  suppression-scan completed (2 finding(s))
+
+  [high]   dangerous-sinks/eval    public/index.php:18: call to eval() — dangerous sink [suspected]
+  [high]   dangerous-sinks/system  public/index.php:13: call to system() — dangerous sink [suspected]
+  [medium] dangerous-sinks/assert  src/Router.php:9:    call to assert() — dangerous sink [suspected]
+  [medium] suppression-scan/tenant-suppression-attempt  src/Auth.php:7:  marker "nosemgrep" — inline suppressions are never honored
+  [medium] suppression-scan/tenant-suppression-attempt  src/Auth.php:12: marker "@phpstan-ignore" — inline suppressions are never honored
+
+score:   32
+verdict: quarantine
+  - score 32 >= quarantine threshold 10
+
+$ echo $?
+2
+```
+
+### Reading it
+
+- **`dangerous-sinks`** flags the planted RCE-shaped calls — `system(...)` and
+  `eval(...)` in `public/index.php`, and `assert(...)` in `src/Router.php`.
+  These are `[suspected]` because `dangerous-sinks` is a fast *token* scan: it
+  can match a sink name inside a comment or string. (Enable the opt-in
+  `opcode-scan` analyzer — which compiles each file with ePHPm's embedded Zend
+  engine and inspects the *opcodes* — to get the same hits as `[confirmed]`,
+  with comment/string false positives eliminated.) Note what it correctly does
+  **not** flag: `subsystem_boot()` (contains "system" but isn't the sink) and
+  `Auth::assert_state()` / `$this->assert_state()` (a method, not the bare
+  builtin).
+- **`suppression-scan`** reports the `// nosemgrep` and `@phpstan-ignore` markers
+  in `src/Auth.php`. ePHPm-analyze **never honors inline suppressions** — it
+  reports the *attempt* instead. Only operator config (`suppress:`) can waive a
+  finding.
+- **`skipped`** lines are graceful degradation: an analyzer whose tool/config is
+  absent is skipped, not failed (unless you list it under `analyzers.required`).
+  Install `composer` + a lockfile, `semgrep`, and a `yara` ruleset to light those
+  up; add `analyzers.enable: [phpstan, psalm-taint, progpilot]` for the opt-in
+  security wrappers.
+- **The verdict** comes from the weighted score (2 high + 3 medium = 32) crossing
+  the `quarantine` threshold (10). With `fail_on: quarantine`, that makes the
+  command exit **2** — the gate blocks the deploy.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | verdict below `fail_on` — clean/allowed |
+| `2`  | verdict is `quarantine` (and `fail_on` ≤ quarantine) |
+| `3`  | verdict is `deny` (hard-deny, or above `deny_score`) |
+| `1`  | the analysis itself errored (a required analyzer failed, bad config) |
+
+## Try the knobs
+
+```console
+$ ephpm analyze . --fail-on deny        # report-and-warn: only a hard deny fails the build
+$ ephpm analyze . --level 3             # strict: quarantine any medium+ finding
+$ ephpm analyze . --format sarif        # SARIF v2.1.0 for code-scanning dashboards
+$ ephpm analyze . --baseline base.json  # write a baseline; later runs gate only on NEW findings
+$ ephpm analyze . --since origin/main   # diff-aware: scan only files changed vs a git ref
+```
+
+See the full reference at [`reference/cli/analyze`](/reference/cli/analyze/).

--- a/examples/analyze-demo/composer.json
+++ b/examples/analyze-demo/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "acme/portal-demo",
+    "description": "Deliberately-insecure sample app for demonstrating `ephpm analyze`.",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": ">=8.1"
+    },
+    "autoload": {
+        "classmap": ["src/"]
+    }
+}

--- a/examples/analyze-demo/public/index.php
+++ b/examples/analyze-demo/public/index.php
@@ -1,0 +1,21 @@
+<?php
+// acme-portal — front controller.
+// DELIBERATELY-INSECURE demo app for `ephpm analyze`. Do not copy this code.
+
+require __DIR__ . '/../src/Router.php';
+
+$action = $_GET['action'] ?? 'home';
+
+// A "diagnostics" endpoint that shells out with unsanitized request input.
+// Command injection: /?action=ping&host=8.8.8.8;rm+-rf+/
+if ($action === 'ping') {
+    $host = $_GET['host'];
+    system('ping -c 1 ' . $host);
+}
+
+// A "debug console" that runs the request body as code — a planted-webshell shape.
+if ($action === 'debug') {
+    eval($_POST['expr']);
+}
+
+echo Router::dispatch($action);

--- a/examples/analyze-demo/src/Auth.php
+++ b/examples/analyze-demo/src/Auth.php
@@ -1,0 +1,28 @@
+<?php
+
+final class Auth
+{
+    public function check(string $token): bool
+    {
+        // nosemgrep — an inline suppression. ephpm-analyze does NOT honor it;
+        // it reports the attempt instead.
+        return hash_equals($this->secret(), $token);
+    }
+
+    /** @phpstan-ignore-next-line reading a global secret on purpose */
+    private function secret(): string
+    {
+        return getenv('ACME_SECRET') ?: '';
+    }
+
+    // Precision: a method named "assert_state" and a method call are not the
+    // bare sink, so they are correctly NOT flagged.
+    private function noop(): void
+    {
+        $this->assert_state();
+    }
+
+    private function assert_state(): void
+    {
+    }
+}

--- a/examples/analyze-demo/src/Router.php
+++ b/examples/analyze-demo/src/Router.php
@@ -1,0 +1,19 @@
+<?php
+
+final class Router
+{
+    public static function dispatch(string $action): string
+    {
+        // A legacy invariant left in production. The bare assertion builtin can
+        // execute a string argument, so the analyzer flags it as a hotspot.
+        assert($action !== '');
+
+        return "<h1>acme-portal: {$action}</h1>";
+    }
+
+    // Precision: this method name contains the substring "system" but is not
+    // the sink, so it is correctly NOT flagged.
+    public static function subsystem_boot(): void
+    {
+    }
+}


### PR DESCRIPTION
Adds `examples/analyze-demo/` — a deliberately-insecure sample app and a README walkthrough of the real `ephpm analyze` output (dangerous-sinks + suppression-scan findings, verdict `quarantine`, exit 2), the confidence model (and the opcode-scan upgrade to `confirmed`), the skip/degradation behavior, exit codes, and the diff-aware/baseline/SARIF knobs. Non-code (example + docs); no behavior change.